### PR TITLE
feat(parity): vendor anchors + visual-similarity scripts to the remaining 4 converters (all 9 now covered)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/source-anchors.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/source-anchors.md
@@ -1,0 +1,163 @@
+# Source-value anchors — the measured value bar
+
+## Why this exists
+
+Two field migrations shipped dashboards whose **numbers were wrong** while every
+judgment gate recorded "pass":
+
+1. **The 10x/ranking failure.** A "top members" ranked panel showed *different
+   members* with values ~10x off — the migrated dashboard rendered **"$1.8T"**
+   where the source printed **"18,037B"** (≈ $18.0T). A multi-region YoY panel
+   collapsed to **one bar where the source showed six**, and a trend line
+   crashed to zero on a partial final period. The run followed the pipeline,
+   executed a real 3-pass RCF loop *reading* the render PNGs — and still
+   recorded `--verdict pass`.
+2. **The waiver-stacking failure.** A second workbook "passed" by combining
+   `--skip-parity-gate` with `--allow-missing-tiles 6`, discovered by grepping
+   `--help` for skip flags. Nothing measured the values; every gate that could
+   have was waived.
+
+The lesson: **every judgment gate is an attestation, and lenient models attest
+generously.** Visual verdicts, RCF scoring, and parity waivers are all places
+where "looks right" substitutes for "is right." Anchors replace that judgment
+with a **measurement**: printed values transcribed from the source image either
+appear in the live workbook's exports at the printed precision, or they don't.
+
+A printed source value that appears **nowhere** in the workbook exports is the
+loudest possible signal the data is wrong — wrong unit (10x), wrong aggregate,
+missing filter, collapsed buckets, or the wrong column entirely.
+
+## The contract
+
+### `source-anchors.json` — authored BY THE AGENT at Phase 1d
+
+Written **while reading the source dashboard PNG** (the same read that produces
+`png-read.json`). Never generated from CSVs — the whole point is transcribing
+what the source *renders*.
+
+```json
+{
+  "source_image": "views/<dashboardViewId>.png",
+  "transcribed_at": "2026-07-08T12:00:00Z",
+  "anchors": [
+    { "id": "a1",
+      "panel": "TOP COUNTRIES",
+      "label": "United States GDP",
+      "raw": "18,037B",
+      "kind": "currency",
+      "sigma_element_hint": "Top Countries" }
+  ]
+}
+```
+
+- `raw` — the value **EXACTLY as printed**. Keep the raw string: `"18,037B"`,
+  never `18037`; `"(12.3%)"`, never `-0.123`; `"$733,215.26"` with the `$` and
+  commas. The printed form *is* the precision contract.
+- `kind` — `currency` | `number` | `percent` | **`text`** (alias `roster`/`member`).
+  A `text` anchor's `raw` is a **displayed LABEL** (case-insensitive cell match),
+  not a value — use it for ranked/top-N tiles so a wrongly-selected or dropped
+  member fails loudly (a top-15 materialized from the wrong rank, a renamed
+  category, a missing path label). Scope: exports carry the element's full
+  underlying data, so `text` anchors can't catch an UNFILTERED tile that merely
+  windows the wrong first-N on screen — gate 9b (shape identity) owns that class.
+- `sigma_element_hint` — optional; the Sigma element name the value should land
+  in. When present it wins over fuzzy matching.
+- **Minimum anchors (the gate requires ≥ 5):** every KPI value, the **top 3
+  values of every ranked list/table**, **one representative bucket value
+  per chart**, and — for every ranked/top-N tile — **2–3 `text` roster anchors**
+  naming members the source actually displays (include at least one from the
+  BOTTOM half of the list: top members often survive a wrong ranking, bottom
+  members don't). Top-of-ranked-list anchors are what catch the
+  different-members-with-different-values failure.
+
+### `anchors-verdict.json` — written by `scripts/verify-anchors.rb`
+
+```json
+{ "checked": 9, "matched": 8,
+  "missing": [ { "id": "a1", "label": "United States GDP", "raw": "18,037B",
+                 "best_candidate": { "value": 1.8e12, "element": "Top Countries" } } ],
+  "pass": false }
+```
+
+`verify-anchors.rb --workdir <W> --workbook-id <id>` pools the live workbook's
+element CSV exports (the same export→poll→download flow
+`collect-parity-actuals.rb` uses), searches each anchor in the element whose
+name best matches its label/panel (token overlap; the hint wins), then searches
+every other export before declaring a miss. Found-elsewhere still matches (the
+value exists; only the label→element mapping was fuzzy) and is noted. It also
+stamps an `anchors` summary into `parity-final.json` when present. Exit 0 all
+matched / 1 with a per-miss report naming each miss and its closest candidate.
+
+## Canonicalization rules (`scripts/lib/anchor_values.rb`)
+
+**Match rule:** a printed value MATCHES a real number when the real number
+**rounds to the printed form at the printed precision** — i.e.
+`|actual − printed| ≤ half of the last printed digit's place value`, scaled by
+any suffix.
+
+| Printed | Canonical value | Tolerance | Notes |
+|---|---|---|---|
+| `18,037B` | 1.8037e13 | ±0.5e9 | last digit = units of B |
+| `$1.8T` | 1.8e12 | ±0.05e12 | currency; one decimal of T |
+| `46.5M` | 4.65e7 | ±0.05e6 | |
+| `-2%` | −2 points | ±0.5 | also matches the fraction −0.02 ± 0.005 |
+| `1,687` | 1687 | ±0.5 | |
+| `$733,215.26` | 733215.26 | ±0.005 | cents precision |
+| `(12.3%)` | −12.3 points | ±0.05 | accounting-paren negative |
+| `12.3k` | 12300 | ±50 | lowercase suffixes accepted |
+
+Extra interpretations checked (they never weaken 10x detection):
+
+- Suffixed forms also match the **unscaled face value** (`18,037B` ↔ a column
+  already denominated in billions storing `18037`).
+- Percents match both **points** (−2) and **fraction** (−0.02) storage.
+
+So `1.8e12` does **not** match `18,037B` under any interpretation — the exact
+field failure — while `18,036,800,000,000` (rounds to 18,037B) does.
+
+## Worked example
+
+Source image shows a KPI `$86.5T`, a TOP COUNTRIES list headed by
+`United States 18,037B`, `China 13,608B`, `Japan 4,971B`, and a YoY panel with
+`-2%` on one bucket:
+
+```json
+{ "source_image": "views/abc123.png", "transcribed_at": "2026-07-08T15:04:00Z",
+  "anchors": [
+    { "id": "a1", "panel": "KPI",           "label": "World GDP total", "raw": "$86.5T",  "kind": "currency" },
+    { "id": "a2", "panel": "TOP COUNTRIES", "label": "United States",   "raw": "18,037B", "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a3", "panel": "TOP COUNTRIES", "label": "China",           "raw": "13,608B", "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a4", "panel": "TOP COUNTRIES", "label": "Japan",           "raw": "4,971B",  "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a5", "panel": "YOY BY REGION", "label": "largest decline bucket", "raw": "-2%", "kind": "percent" }
+  ] }
+```
+
+If the built workbook's Top Countries element exports `1.8e12` for the top row,
+`verify-anchors.rb` reports:
+
+```
+MISSING  a2 "United States" raw="18,037B" — closest candidate 1.8e12 in "Top Countries"
+```
+
+— the 10x failure caught mechanically, before any visual verdict is consulted.
+
+## Gate wiring (`assert-phase6-ran.rb`)
+
+- **Gate 13 (exit 18):** whenever the workdir carries a source dashboard PNG
+  (the Phase 1d artifact — `png-read.json` `source_png`, `views/*.png`, or
+  `dashboards/*.png`), `source-anchors.json` must exist with ≥ 5 anchors AND
+  `anchors-verdict.json` must pass with every anchor checked (a stale verdict —
+  fewer checked than transcribed — fails). No source PNG → stated SKIP.
+  Escape: `--skip-anchors-gate "<reason>"` (counted against the waiver budget).
+- **Conditional `--skip-parity-gate` (exit 18):** waiving source parity is
+  REJECTED unless `anchors-verdict.json` exists and passes. The anchors oracle
+  replaces parity — never nothing. This is the no-standalone-views path's
+  contract too: parity oracle = anchors + warehouse (`verify-warehouse.rb`).
+- **Data-class RCF residuals (exit 15):** any unresolved `data`-class entry in
+  `fidelity-ledger.json` blocks GREEN whenever the ledger exists —
+  `--accept-residuals` does not apply. The numbers are wrong; fix or reclassify
+  with evidence.
+- **Waiver budget (exit 19):** more than 2 quality waivers → GREEN unavailable
+  (YELLOW cap). Anchors and similarity skips count; `--skip-telemetry-gate`
+  (policy) and the sanctioned builder→verifier `--skip-visual-comparison`
+  handoff do not.

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/visual-similarity.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/visual-similarity.md
@@ -1,0 +1,82 @@
+# Visual-similarity floor — the deterministic gate under the visual verdict
+
+`scripts/visual-similarity.py` is a deterministic sanity floor that runs before any
+model-judged visual verdict counts. Its job is narrow: make it **impossible to record a
+passing visual verdict over a render that is structurally nothing like the source**. It is
+NOT a match-scorer and it does not measure migration quality — the RCF loop
+(`refs/phase-5g-rcf.md`, `refs/fidelity-rubric.md`) and Phase 6 parity own that. A floor
+pass means only "these two images are plausibly the same dashboard"; the real visual QA
+still happens on top of it.
+
+## Contract
+
+```
+python3 scripts/visual-similarity.py --source <src.png> --render <render.png> --json-out <out.json>
+```
+
+Exit codes: `0` = pass, `1` = fail, `2` = dependencies missing or input unreadable.
+**Exit 2 is never a pass** — treat it as a blocked gate: fix the environment
+(`pip install pillow numpy`) or re-export the image, then re-run. The gate wiring must
+propagate 2 as a hard stop, not fall through to the model verdict.
+
+JSON written to `--json-out`:
+
+| field           | meaning                                                                 |
+|-----------------|-------------------------------------------------------------------------|
+| `score_ink`     | 0–1. Render mark density (edges: text, bars, lines) as a fraction of the source's. Asymmetric — extra ink is never penalized; missing ink is. |
+| `score_layout`  | 0–1. Spatial distribution agreement: worst-band ink balance over row/column thirds (dominant term), plus coarse ink-pattern and row/column profile correlations. |
+| `score_overall` | 0–1. `aspect_factor * (0.42*score_ink + 0.58*score_layout)`.            |
+| `threshold`     | The calibrated pass line for `score_overall` (currently **0.45**).      |
+| `pass`          | `score_overall >= threshold` AND `score_ink >= 0.40` AND band balance `>= 0.10`. The two sub-floors catch sparse-marks and emptied-region failures even when the blend stays high. |
+| `notes`         | Human-readable reasons for any failure or anomaly (blank source, aspect mismatch, tripped sub-floor). |
+| `components`    | Diagnostic sub-signals (coverage, band_balance, pattern_corr, profile_corr, aspect_factor). |
+
+The comparison is fully deterministic: same two files in → byte-identical JSON out. No
+randomness, no model calls, no network.
+
+## What the floor catches
+
+- **Blank / mostly-empty pages** — render draws little or none of the source's ink.
+- **One-bar-vs-six-bars panels** — panel chrome survives but the marks are gone
+  (`score_ink` sub-floor at 0.40).
+- **Missing whole columns / sections / tables** — a page region that holds content in the
+  source is near-empty in the render (band-balance sub-floor at 0.10).
+- **Single-column stacks** — a grid dashboard collapsed into one long column; the page's
+  extreme aspect-ratio mismatch (>2.2x) zeroes the score.
+
+## What the floor deliberately tolerates
+
+Different fonts, colors, themes, padding, spacing, and margins; different aspect ratios
+(landscape source → longer Sigma page is normal); moderate panel rearrangement and re-flow
+(verified-faithful migrations in the calibration set include a 2x3 grid re-flowed to 4x3
+and landscape→portrait re-stacks — all pass with margin). If a render passes the floor but
+looks off, that is exactly what the RCF rubric is for.
+
+## Threshold provenance — do not tune it
+
+Threshold 0.45 and the sub-floors were calibrated on **20 verified-faithful migration
+pairs** (real Tableau dashboard exports vs their accepted Sigma renders, spanning dense
+KPI dashboards, app-style layouts, dark themes, text-heavy pages, and 10 chart-gallery
+pages) plus **17 failure-mode negatives** (1 real failed field migration with 1-bar-vs-6
+panels and whitespace, plus synthesized blank-page, half-page-empty, quarter-content, and
+single-column-stack renders). Every positive clears the threshold by ≥ 0.08 and every
+negative misses it by ≥ 0.10; the sub-floors clear their nearest positive by ≥ 0.10. The
+per-pair table is embedded as a comment block in `scripts/visual-similarity.py`.
+
+**If the floor fails, the render's STRUCTURE diverges from the source.** The fix is always
+in the workbook: re-run the RCF loop, restore the missing sections/marks, and re-render.
+Never raise `--threshold`-style knobs, edit the constants, or re-crop the screenshots to
+squeeze a failing render through — a tuned floor is worse than no floor, because it
+launders a broken render into a recorded visual pass.
+
+## Dependencies
+
+Pillow + numpy only (no OpenCV/scikit). If either is missing the script prints
+`pip install pillow numpy` and exits 2. Runtime is well under a second per pair.
+
+## Tests
+
+`python3 scripts/test_visual_similarity.py` — offline synthetic-fixture suite covering the
+scoring behaviors (identical ≈ 1.0, recolored/shifted copy passes, blank / half-empty /
+sparse / stacked renders fail) and the full CLI exit-code contract, including a
+missing-dependency simulation.

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/anchor_values.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/anchor_values.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+#
+# anchor_values.rb — PURE canonicalization of printed dashboard values.
+#
+# WHY. Two field migrations shipped dashboards whose NUMBERS were wrong while
+# every judgment gate recorded "pass": a ranked list showed different members
+# with 10x-off values ("$1.8T" where the source printed "18,037B"), and panels
+# collapsed to a fraction of the source's buckets. The fix is a MEASURED value
+# bar: the agent transcribes the source's printed values EXACTLY as printed
+# (Phase 1d, source-anchors.json), and verify-anchors.rb checks each printed
+# value against the live workbook's element CSV exports. This module is the
+# arithmetic core of that check: it parses a printed form ("18,037B", "$1.8T",
+# "-2%", "(12.3%)", "$733,215.26", "12.3k") into a (value, precision) pair and
+# decides whether a real number could have RENDERED as that printed form.
+#
+# MATCH RULE. A printed value MATCHES a real number when the real number rounds
+# to the printed form at the printed precision — i.e. |actual - printed_value|
+# <= half of the last printed digit's place value (scaled by any K/M/B/T
+# suffix). "18,037B" therefore matches any real in [18,036.5B, 18,037.5B]
+# (tolerance ±0.5e9), and 1.8e12 ("$1.8T") is a loud 10x MISS.
+#
+# CANDIDATE INTERPRETATIONS (all checked by match?):
+#   - suffixed values ("18,037B") also match the UNSCALED face value (18037)
+#     because some warehouses store the column already in that display unit;
+#   - percents ("-2%") match both percent POINTS (-2) and the FRACTION (-0.02).
+# Neither weakens the 10x/regrouping detection — the wrong values seen in the
+# field match none of the interpretations.
+#
+# Pure, stdlib-only, no IO. Unit tests: scripts/test-anchor-values.rb.
+
+module AnchorValues
+  KINDS = %w[currency number percent].freeze
+
+  SUFFIXES = {
+    'k' => 1e3, 'm' => 1e6, 'b' => 1e9, 't' => 1e12
+  }.freeze
+
+  CURRENCY_SYMBOLS = %w[$ € £ ¥].freeze
+
+  module_function
+
+  # Parse a printed form into its PRIMARY canonical interpretation.
+  # Returns { value: Float, tol: Float, kind: 'currency'|'number'|'percent',
+  #           negative: Boolean } or nil when the string is not a printed number.
+  # For percents the primary value is in percent POINTS ("-2%" → -2.0 ± 0.5);
+  # candidates() adds the fraction form.
+  def parse(raw)
+    s = raw.to_s.strip
+    return nil if s.empty?
+
+    negative = false
+    # Accounting-style parenthesized negative: "(12.3%)", "($4,120)".
+    if s.start_with?('(') && s.end_with?(')')
+      negative = true
+      s = s[1..-2].to_s.strip
+    end
+    # Leading minus (ASCII or unicode), possibly before OR after a currency symbol.
+    if s.start_with?('-', '−', '–')
+      negative = true
+      s = s[1..].to_s.strip
+    end
+
+    kind = 'number'
+    if CURRENCY_SYMBOLS.include?(s[0])
+      kind = 'currency'
+      s = s[1..].to_s.strip
+      if s.start_with?('-', '−', '–') # "$-12.4"
+        negative = true
+        s = s[1..].to_s.strip
+      end
+    end
+
+    percent = false
+    if s.end_with?('%')
+      percent = true
+      kind = 'percent'
+      s = s[0..-2].to_s.strip
+    end
+
+    multiplier = 1.0
+    if !percent && s =~ /\A(.*?)\s*([kKmMbBtT])\z/ && !Regexp.last_match(1).to_s.strip.empty?
+      body = Regexp.last_match(1).strip
+      suf  = Regexp.last_match(2).downcase
+      multiplier = SUFFIXES[suf]
+      s = body
+    end
+
+    digits = s.delete(',')
+    return nil unless digits =~ /\A(?:\d+(?:\.\d+)?|\.\d+)\z/
+
+    decimals = digits.include?('.') ? digits.split('.', 2)[1].length : 0
+    face = Float(digits)
+    step = 10.0**-decimals
+    value = face * multiplier
+    value = -value if negative
+    { value: value, tol: (step / 2.0) * multiplier, kind: kind, negative: negative }
+  end
+
+  # All acceptable (value, tol) interpretations of a printed form, primary first.
+  # Returns an Array of [value, tol] pairs, or [] when unparseable.
+  def candidates(raw)
+    p = parse(raw)
+    return [] if p.nil?
+    out = [[p[:value], p[:tol]]]
+    if p[:kind] == 'percent'
+      # Fraction form: exports often carry 0.02 where the dashboard prints "2%".
+      out << [p[:value] / 100.0, p[:tol] / 100.0]
+    else
+      # Unscaled face value for suffixed forms ("18,037B" ↔ a column already
+      # denominated in billions). Only differs when a suffix was present.
+      pr = parse(strip_suffix(raw))
+      out << [pr[:value], pr[:tol]] if pr && (pr[:value] - p[:value]).abs > Float::EPSILON
+    end
+    out
+  end
+
+  # Does a real number match the printed form? (See MATCH RULE above.)
+  def match?(raw, actual)
+    return false if actual.nil?
+    a = begin
+      Float(actual)
+    rescue ArgumentError, TypeError
+      return false
+    end
+    candidates(raw).any? do |value, tol|
+      (a - value).abs <= tol + (1e-9 * [value.abs, 1.0].max)
+    end
+  end
+
+  # The schema `kind` of a printed form ('currency'|'number'|'percent'), or nil.
+  def kind(raw)
+    p = parse(raw)
+    p && p[:kind]
+  end
+
+  # Relative distance between a real number and the printed form's primary
+  # value — used to rank "closest miss" candidates in reports. Float::INFINITY
+  # when the form is unparseable.
+  def relative_distance(raw, actual)
+    p = parse(raw)
+    return Float::INFINITY if p.nil? || actual.nil?
+    a = begin
+      Float(actual)
+    rescue ArgumentError, TypeError
+      return Float::INFINITY
+    end
+    # Best (smallest) distance across all interpretations, so a fraction-form
+    # percent ranks as close as its points form.
+    candidates(raw).map { |v, _| (a - v).abs / [v.abs, 1e-9].max }.min
+  end
+
+  # Remove a trailing K/M/B/T suffix (keeps sign/currency/percent decorations).
+  def strip_suffix(raw)
+    raw.to_s.sub(/\s*[kKmMbBtT](\)?)\z/, '\1')
+  end
+end

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-verify-anchors.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Tests for scripts/verify-anchors.rb — the measured value bar.
+#
+#   1. Pure core (AnchorVerify): label→element fuzzy match by token overlap,
+#      sigma_element_hint priority, found-elsewhere-still-matches, missing
+#      anchors carry a best_candidate, cell parsing ($/,/%/parens).
+#   2. CLI offline mode (--workbook-spec + --exports-dir): verdict file shape
+#      (checked/matched/missing/pass), exit codes (0 all matched / 1 miss /
+#      2 usage), and the parity-final.json `anchors` stamp.
+#
+# Offline, no network. Usage: ruby scripts/test-verify-anchors.rb
+
+require 'json'
+require 'csv'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+ENV['VERIFY_ANCHORS_CLI'] = nil
+require_relative 'verify-anchors' # loads AnchorVerify (CLI guarded out)
+
+SCRIPT = File.join(__dir__, 'verify-anchors.rb')
+
+$fails = []
+def ok(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '-- pure core: element ranking --'
+els = ['Top Countries', 'GDP Trend', 'YoY Growth by Region', 'KPI Row']
+a_label = { 'id' => 'a1', 'panel' => 'TOP COUNTRIES', 'label' => 'United States GDP', 'raw' => '18,037B' }
+ok(AnchorVerify.ranked_elements(a_label, els).first == 'Top Countries',
+   'panel/label token overlap ranks the right element first')
+ok(AnchorVerify.ranked_elements(a_label, els).length == els.length,
+   'zero-score elements are appended (search everywhere)')
+a_hint = a_label.merge('sigma_element_hint' => 'YoY Growth by Region')
+ok(AnchorVerify.ranked_elements(a_hint, els).first == 'YoY Growth by Region',
+   'sigma_element_hint wins over panel/label overlap')
+a_hint_fuzzy = a_label.merge('sigma_element_hint' => 'yoy region growth')
+ok(AnchorVerify.ranked_elements(a_hint_fuzzy, els).first == 'YoY Growth by Region',
+   'non-exact hint still matches by token overlap')
+
+puts '-- pure core: cell parsing --'
+ok(AnchorVerify.cell_numbers('$1,234.50') == [1234.5], 'currency + commas parse')
+ok(AnchorVerify.cell_numbers('(42)') == [-42.0], 'paren negative parses')
+ok(AnchorVerify.cell_numbers('12%') == [12.0, 0.12], 'percent cell keeps points + fraction')
+ok(AnchorVerify.cell_numbers('United States').empty?, 'non-numeric cell yields nothing')
+ok(AnchorVerify.cell_numbers('').empty? && AnchorVerify.cell_numbers(nil).empty?, 'empty/nil cells yield nothing')
+
+puts '-- pure core: verify() verdicts --'
+exports = {
+  'Top Countries' => [['Country', 'GDP'], ['United States', '18037000000000'], ['China', '13608000000000']],
+  'GDP Trend'     => [['Year', 'GDP'], ['2024', '1.75e12'], ['2025', '1.8e12']],
+  'KPI Row'       => [['Total GDP', 'YoY'], ['86500000000000', '-0.02']]
+}
+anchors = [
+  { 'id' => 'a1', 'panel' => 'TOP COUNTRIES', 'label' => 'United States GDP', 'raw' => '18,037B' },
+  { 'id' => 'a2', 'panel' => 'KPI', 'label' => 'YoY change', 'raw' => '-2%', 'sigma_element_hint' => 'KPI Row' },
+  { 'id' => 'a3', 'panel' => 'KPI', 'label' => 'Total GDP', 'raw' => '86.5T' }
+]
+v = AnchorVerify.verify(anchors, exports)
+ok(v['pass'] == true && v['matched'] == 3 && v['checked'] == 3, 'all-matched verdict passes 3/3')
+ok(v['missing'].empty?, 'no missing entries when all matched')
+
+# The field failure: the workbook renders 1.8T where the source printed 18,037B.
+bad_exports = exports.merge('Top Countries' => [['Country', 'GDP'], ['United Kingdom', '1.8e12']])
+v2 = AnchorVerify.verify(anchors, bad_exports)
+ok(v2['pass'] == false && v2['matched'] == 2, '10x-off value fails the anchor (2/3)')
+miss = v2['missing'].first
+ok(miss['id'] == 'a1' && miss['raw'] == '18,037B', 'missing entry carries id + raw')
+ok(miss['best_candidate'].is_a?(Hash) && miss['best_candidate']['value'] == 1.8e12,
+   'best_candidate reports the closest wrong value (the 1.8T impostor)')
+
+# found-elsewhere: value lives in a differently-named element → matched + noted
+elsewhere = { 'Some Renamed Tile' => [['GDP'], ['18037000000000']] }
+v3 = AnchorVerify.verify([anchors[0]], elsewhere)
+ok(v3['pass'] == true, 'value found in a non-best-match element still matches')
+ok(v3['detail'].first['matched_in'] == 'Some Renamed Tile', 'detail names where it was found')
+
+# hint discipline: a HINTED numeric anchor whose value appears ONLY in a
+# hint-UNRELATED element is a MISS — NOT a false match. Field-caught in the
+# PowerBI port pilot: a KPI's wrong value (10x-unit / wrong-aggregate) that
+# coincidentally lived in a big detail table silently passed the old
+# search-everywhere fallback. (Hint-LESS anchors keep that fallback — see v3.)
+hinted_exports = {
+  'Total Stores' => [['Total Stores'], ['104']],
+  'Sales Detail' => [['SLS'], ['1040'], ['1600000']]
+}
+v4 = AnchorVerify.verify(
+  [{ 'id' => 'h1', 'label' => 'Total Stores', 'raw' => '1,040', 'sigma_element_hint' => 'Total Stores' }],
+  hinted_exports
+)
+ok(v4['pass'] == false && v4['missing'].first && v4['missing'].first['id'] == 'h1',
+   'hinted numeric found only OUTSIDE the hinted element is a MISS (not a false match)')
+ok(v4['missing'].first['best_candidate'] && v4['missing'].first['best_candidate']['value'] == 104.0,
+   'the miss surfaces the real value (104 in the hinted element) as closest candidate')
+v5 = AnchorVerify.verify(
+  [{ 'id' => 'h2', 'label' => 'Total Stores', 'raw' => '104', 'sigma_element_hint' => 'Total Stores' }],
+  hinted_exports
+)
+ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
+
+puts '-- CLI offline mode --'
+def write_fixture(dir, exports_rows, anchors)
+  spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>
+    exports_rows.each_with_index.map { |(name, _), i| { 'id' => "el#{i}", 'name' => name, 'kind' => 'table' } } }] }
+  File.write(File.join(dir, 'wb-spec.json'), JSON.pretty_generate(spec))
+  exp = File.join(dir, 'exports')
+  Dir.mkdir(exp)
+  exports_rows.each_with_index do |(_, rows), i|
+    CSV.open(File.join(exp, "el#{i}.csv"), 'w') { |c| rows.each { |r| c << r } }
+  end
+  File.write(File.join(dir, 'source-anchors.json'),
+             JSON.pretty_generate('source_image' => 'views/dash.png',
+                                  'transcribed_at' => '2026-07-08T00:00:00Z',
+                                  'anchors' => anchors))
+  [File.join(dir, 'wb-spec.json'), exp]
+end
+
+def run_cli(dir, spec, exp)
+  Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--workbook-spec', spec, '--exports-dir', exp)
+end
+
+Dir.mktmpdir do |dir|
+  spec, exp = write_fixture(dir, exports, anchors)
+  File.write(File.join(dir, 'parity-final.json'),
+             JSON.pretty_generate('status' => 'PASS', 'charts_total' => 3, 'charts_pass' => 3))
+  out, _err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus.zero?, "all matched → exit 0 (got #{st.exitstatus})")
+  ok(out.include?('3/3'), 'summary reports 3/3 matched')
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  ok(vd['pass'] == true && vd['checked'] == 3 && vd['matched'] == 3 && vd['missing'] == [],
+     'anchors-verdict.json carries the contract shape (checked/matched/missing/pass)')
+  pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
+  ok(pf['anchors'].is_a?(Hash) && pf['anchors']['pass'] == true && pf['anchors']['checked'] == 3,
+     'anchors summary stamped into parity-final.json')
+end
+
+Dir.mktmpdir do |dir|
+  spec, exp = write_fixture(dir, bad_exports, anchors)
+  _out, err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus == 1, "missing anchor → exit 1 (got #{st.exitstatus})")
+  ok(err.include?('MISSING') && err.include?('18,037B'), 'per-miss report names the anchor raw value')
+  ok(err.include?('closest candidate'), 'per-miss report shows the best candidate')
+  ok(err.include?('loudest possible signal'), 'failure explains what a total miss means')
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  ok(vd['pass'] == false && vd['missing'].length == 1 && vd['missing'][0]['id'] == 'a1',
+     'failing verdict written with the missing anchor')
+end
+
+Dir.mktmpdir do |dir|
+  # no source-anchors.json at all → usage error, points at Phase 1d
+  _out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir,
+                                 '--workbook-spec', '/nonexistent', '--exports-dir', dir)
+  ok(st.exitstatus == 2, "missing source-anchors.json → exit 2 (got #{st.exitstatus})")
+  ok(err.include?('Phase 1d'), 'missing-anchors error points at the Phase 1d transcription step')
+end
+
+Dir.mktmpdir do |dir|
+  # unparseable raw → usage error (transcription contract violated)
+  spec, exp = write_fixture(dir, exports, [{ 'id' => 'a1', 'label' => 'x', 'raw' => 'about twenty' }])
+  _out, err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus == 2, "unparseable raw → exit 2 (got #{st.exitstatus})")
+  ok(err.include?('EXACTLY as printed'), 'unparseable-raw error restates the transcription rule')
+end
+
+puts
+if $fails.empty?
+  puts 'ALL PASS — verify-anchors core + offline CLI'
+  exit 0
+else
+  puts "FAILURES (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test_visual_similarity.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test_visual_similarity.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Offline tests for visual-similarity.py (synthetic fixtures only).
+
+Run: python3 scripts/test_visual_similarity.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "visual-similarity.py")
+
+try:
+    from PIL import Image, ImageDraw
+except ImportError:  # pragma: no cover
+    sys.stderr.write("tests require Pillow/numpy: pip install pillow numpy\n")
+    sys.exit(2)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("visual_similarity", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+VS = _load_module()
+
+# --- synthetic dashboard fixtures -------------------------------------------
+
+BAR_HEIGHTS = [0.55, 0.8, 0.35, 0.95, 0.6, 0.45]
+
+
+def draw_card(d, x0, y0, x1, y1, chrome, ink, accent, bars=6, lines=False):
+    """One dashboard 'card': faint border, title bar, bar chart or text rows.
+
+    bars < 6 models the mid-tier failure mode seen in the field: the panel
+    chrome survives, but a single small bar sits where six categories should
+    be, or a dense table collapses to a few stub rows, leaving whitespace
+    (bar slots are always sized for six, so fewer bars = emptier panel).
+    """
+    d.rectangle([x0, y0, x1, y1], outline=chrome, width=1)
+    d.rectangle([x0 + 8, y0 + 8, x1 - 8, y0 + 22], fill=accent)
+    body_top, body_bot = y0 + 36, y1 - 12
+    if lines:  # table-ish card; sparse variant drops most rows
+        y = body_top
+        step = 12 if bars >= 6 else 12 * 6 // max(1, bars)
+        while y < body_bot - 6:
+            d.rectangle([x0 + 12, y, x1 - 20, y + 4], fill=ink)
+            y += step
+        return
+    span = (x1 - x0 - 24) / 6.0  # slot width is ALWAYS six-across
+    scale = 1.0 if bars >= 6 else 0.5  # degenerate charts come out small too
+    for i in range(bars):
+        h = BAR_HEIGHTS[i % len(BAR_HEIGHTS)] * (body_bot - body_top) * scale
+        bx0 = x0 + 12 + i * span
+        bx1 = bx0 + span * 0.62
+        d.rectangle([bx0, body_bot - h, bx1, body_bot], fill=accent)
+
+
+def make_dashboard(w=1200, h=800, bg=(255, 255, 255), ink=(40, 40, 60),
+                   accent=(46, 84, 158), bars=6, shift=0):
+    """Deterministic synthetic dashboard: header + KPI row + 3x2 card grid.
+
+    Card borders are drawn just above the background (delta < ink threshold),
+    like modern borderless-card dashboards, so marks dominate the ink budget.
+    """
+    chrome = tuple(max(0, c - 10) for c in bg)
+    im = Image.new("RGB", (w, h), bg)
+    d = ImageDraw.Draw(im)
+    s = shift
+    d.rectangle([20 + s, 15 + s, w - 20 + s, 45 + s], fill=accent)  # header
+    for k in range(4):  # KPI strip: value block + sparkline zigzag
+        kx = 20 + s + k * (w - 40) // 4
+        kx1 = kx + (w - 40) // 4 - 12
+        d.rectangle([kx, 60 + s, kx1, 110 + s], outline=chrome, width=1)
+        if bars >= 6:  # degenerate renders lose KPI innards, keep the frame
+            d.rectangle([kx + 10, 70 + s, kx + 70, 86 + s], fill=ink)
+            pts = [(kx + 10 + 7 * i, 100 + s - 8 * (i % 3)) for i in range(12)]
+            d.line(pts, fill=accent, width=2)
+    grid_top = 130 + s
+    cw, ch = (w - 60) // 3, (h - grid_top - 30) // 2
+    for r in range(2):
+        for c in range(3):
+            x0 = 20 + s + c * (cw + 10)
+            y0 = grid_top + r * (ch + 10)
+            draw_card(d, x0, y0, x0 + cw, y0 + ch, chrome, ink, accent,
+                      bars=bars, lines=(c == 2))
+    return im
+
+
+def make_stack(src):
+    """Catastrophe: the six grid cards restacked into one narrow column."""
+    w, h = src.size
+    cw, ch = (w - 60) // 3, (h - 130 - 30) // 2
+    tiles = []
+    for r in range(2):
+        for c in range(3):
+            x0, y0 = 20 + c * (cw + 10), 130 + r * (ch + 10)
+            tiles.append(src.crop((x0, y0, x0 + cw, y0 + ch)))
+    out = Image.new("RGB", (cw + 20, (ch + 10) * 6 + 20), (255, 255, 255))
+    y = 10
+    for t in tiles:
+        out.paste(t, (10, y))
+        y += ch + 10
+    return out
+
+
+class FixtureMixin:
+    @classmethod
+    def setUpClass(cls):
+        cls.dir = tempfile.mkdtemp(prefix="vissim-test-")
+        cls.paths = {}
+
+        def save(name, im):
+            p = os.path.join(cls.dir, name + ".png")
+            im.save(p)
+            cls.paths[name] = p
+            return p
+
+        src = make_dashboard()
+        save("source", src)
+        save("identical", src.copy())
+        # recolored + font/padding-shifted copy: different palette, offset
+        save("recolored", make_dashboard(bg=(244, 241, 252), ink=(70, 60, 90),
+                                         accent=(180, 120, 60), shift=6))
+        save("blank", Image.new("RGB", (1600, 900), (255, 255, 255)))
+        half = src.copy()
+        half.paste(Image.new("RGB", (src.width, src.height // 2),
+                             (255, 255, 255)), (0, src.height // 2))
+        save("halfempty", half)
+        save("sparse", make_dashboard(bars=1))       # one bar vs six per panel
+        save("stack", make_stack(src))               # single-column stack
+        corrupt = os.path.join(cls.dir, "corrupt.png")
+        with open(corrupt, "wb") as fh:
+            fh.write(b"this is not a png file")
+        cls.paths["corrupt"] = corrupt
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.dir, ignore_errors=True)
+
+    def run_cli(self, source, render, json_out=None, env=None):
+        json_out = json_out or os.path.join(self.dir, "out.json")
+        proc = subprocess.run(
+            [sys.executable, SCRIPT, "--source", source, "--render", render,
+             "--json-out", json_out],
+            capture_output=True, text=True, env=env,
+        )
+        data = None
+        if os.path.isfile(json_out) and proc.returncode in (0, 1):
+            with open(json_out) as fh:
+                data = json.load(fh)
+        return proc, data
+
+
+class TestScoring(FixtureMixin, unittest.TestCase):
+    def test_identical_scores_near_one(self):
+        res = VS.compare(self.paths["source"], self.paths["identical"])
+        self.assertTrue(res["pass"])
+        self.assertGreaterEqual(res["score_overall"], 0.98)
+        self.assertGreaterEqual(res["score_ink"], 0.98)
+        self.assertGreaterEqual(res["score_layout"], 0.98)
+
+    def test_recolored_font_shifted_copy_passes(self):
+        res = VS.compare(self.paths["source"], self.paths["recolored"])
+        self.assertTrue(res["pass"], res)
+        self.assertGreaterEqual(
+            res["score_overall"], res["threshold"] + 0.05,
+            "legit restyle must clear the threshold with margin",
+        )
+
+    def test_blank_render_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["blank"])
+        self.assertFalse(res["pass"])
+        self.assertLessEqual(res["score_overall"], res["threshold"] - 0.05)
+
+    def test_half_empty_render_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["halfempty"])
+        self.assertFalse(res["pass"])
+        self.assertLessEqual(res["score_overall"], res["threshold"] - 0.05)
+
+    def test_one_bar_vs_six_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["sparse"])
+        self.assertFalse(res["pass"], res)
+        self.assertLess(res["score_ink"], 0.40,
+                        "mark-density floor should catch sparse panels")
+
+    def test_single_column_stack_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["stack"])
+        self.assertFalse(res["pass"], res)
+
+    def test_symmetric_blank_source_noted(self):
+        res = VS.compare(self.paths["blank"], self.paths["blank"])
+        self.assertTrue(any("source appears blank" in n for n in res["notes"]))
+
+
+class TestCLIContract(FixtureMixin, unittest.TestCase):
+    def test_pass_exit_0_and_json_schema(self):
+        out = os.path.join(self.dir, "nested", "dir", "verdict.json")
+        proc, data = self.run_cli(self.paths["source"], self.paths["recolored"],
+                                  json_out=out)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        for key, typ in (("score_layout", float), ("score_ink", float),
+                         ("score_overall", float), ("pass", bool),
+                         ("threshold", float), ("notes", list)):
+            self.assertIn(key, data)
+            self.assertIsInstance(data[key], typ)
+        for key in ("score_layout", "score_ink", "score_overall"):
+            self.assertGreaterEqual(data[key], 0.0)
+            self.assertLessEqual(data[key], 1.0)
+
+    def test_fail_exit_1(self):
+        proc, data = self.run_cli(self.paths["source"], self.paths["blank"])
+        self.assertEqual(proc.returncode, 1)
+        self.assertFalse(data["pass"])
+        self.assertTrue(data["notes"], "failure must carry explanatory notes")
+
+    def test_deterministic_output(self):
+        out1 = os.path.join(self.dir, "det1.json")
+        out2 = os.path.join(self.dir, "det2.json")
+        self.run_cli(self.paths["source"], self.paths["recolored"], json_out=out1)
+        self.run_cli(self.paths["source"], self.paths["recolored"], json_out=out2)
+        with open(out1, "rb") as a, open(out2, "rb") as b:
+            self.assertEqual(a.read(), b.read())
+
+    def test_missing_input_exit_2(self):
+        proc, _ = self.run_cli(os.path.join(self.dir, "nope.png"),
+                               self.paths["source"])
+        self.assertEqual(proc.returncode, 2)
+        proc, _ = self.run_cli(self.paths["source"],
+                               os.path.join(self.dir, "nope.png"))
+        self.assertEqual(proc.returncode, 2)
+
+    def test_corrupt_input_exit_2(self):
+        proc, _ = self.run_cli(self.paths["source"], self.paths["corrupt"])
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("could not analyze", proc.stderr)
+
+    def test_missing_deps_exit_2_with_remediation(self):
+        shim = os.path.join(self.dir, "shim")
+        os.makedirs(shim, exist_ok=True)
+        for mod in ("PIL", "numpy"):
+            with open(os.path.join(shim, mod + ".py"), "w") as fh:
+                fh.write("raise ImportError('simulated missing %s')\n" % mod)
+        env = dict(os.environ)
+        env["PYTHONPATH"] = shim
+        proc, _ = self.run_cli(self.paths["source"], self.paths["identical"],
+                               env=env)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("pip install pillow numpy", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-anchors.rb
@@ -1,0 +1,483 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-anchors.rb — the MEASURED value bar for a converted workbook.
+#
+# WHY. Two field migrations recorded passing visual verdicts over dashboards
+# whose NUMBERS were wrong: a ranked list showed different members with 10x-off
+# values ("$1.8T" rendered where the source printed "18,037B"), and a
+# multi-bucket panel collapsed to a single bar. Every judgment gate is an
+# attestation, and lenient models attest generously — so this script replaces
+# the judgment with a MEASUREMENT: each printed value the agent transcribed
+# from the SOURCE dashboard image (Phase 1d, <workdir>/source-anchors.json)
+# must literally appear in the LIVE Sigma workbook's element CSV exports, at
+# the printed precision (scripts/lib/anchor_values.rb). An anchor value that
+# appears NOWHERE in the workbook exports is the loudest possible signal the
+# data is wrong.
+#
+# INPUT  <workdir>/source-anchors.json — authored by the AGENT at Phase 1d
+#        while reading the source dashboard PNG (schema: SKILL.md Phase 1d,
+#        refs/source-anchors.md):
+#          { "source_image": "views/<id>.png", "transcribed_at": "...",
+#            "anchors": [ { "id": "a1", "panel": "TOP COUNTRIES",
+#                           "label": "United States GDP", "raw": "18,037B",
+#                           "kind": "currency",
+#                           "sigma_element_hint": "Top Countries" } ] }
+# OUTPUT <workdir>/anchors-verdict.json:
+#          { "checked": N, "matched": M,
+#            "missing": [ { "id", "label", "raw", "best_candidate" } ],
+#            "pass": true|false }
+#        Also stamps an `anchors` summary into parity-final.json when present.
+#
+# HOW. Fetches the live workbook spec for element names, then pools element
+# CSV exports (the same POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download flow collect-parity-actuals.rb uses). Each anchor
+# is searched in the element whose name best matches its label/panel (token
+# overlap; `sigma_element_hint` wins when present); when the matched element
+# doesn't carry the value, every other export is searched before declaring the
+# anchor MISSING — found-elsewhere still counts as matched (the value exists;
+# only the label→element mapping was fuzzy) and is noted in the verdict.
+#
+# Usage (live):
+#   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+# Usage (offline — tests / pre-collected exports):
+#   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
+#     --exports-dir <dir-with-<elementId>.csv>
+#
+# Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
+# per-miss report names each, with its closest candidate); 2 = usage / missing
+# inputs.
+
+require 'json'
+require 'csv'
+require 'set'
+require 'optparse'
+require_relative 'lib/anchor_values'
+
+# ---------------------------------------------------------------------------
+# Pure core — unit-tested offline in test-verify-anchors.rb.
+# ---------------------------------------------------------------------------
+module AnchorVerify
+  STOPWORDS = %w[the a an of by per and or in on for to vs].freeze
+
+  module_function
+
+  def tokens(s)
+    s.to_s.downcase.scan(/[a-z0-9]+/) - STOPWORDS
+  end
+
+  # Overlap score between an anchor and an element name. sigma_element_hint,
+  # when present, is the only signal; otherwise panel+label tokens are used.
+  def element_score(anchor, el_name)
+    hint = anchor['sigma_element_hint'].to_s
+    name_toks = tokens(el_name)
+    return 0 if name_toks.empty?
+    if !hint.strip.empty?
+      return 1_000 if hint.strip.casecmp?(el_name.to_s.strip)
+      return (tokens(hint) & name_toks).length
+    end
+    ((tokens(anchor['panel']) | tokens(anchor['label'])) & name_toks).length
+  end
+
+  # Element names ordered best-match-first for this anchor; zero-score names
+  # are appended (search everywhere before declaring a value missing).
+  def ranked_elements(anchor, el_names)
+    scored = el_names.map { |n| [n, element_score(anchor, n)] }
+    hits = scored.select { |_, s| s.positive? }.sort_by { |n, s| [-s, n.to_s] }.map(&:first)
+    hits + (el_names - hits)
+  end
+
+  # Numeric face values of a CSV cell (both percent interpretations kept so
+  # AnchorValues candidate matching sees whichever the export carried).
+  def cell_numbers(cell)
+    s = cell.to_s
+    # Export bytes arrive as ASCII-8BIT off the HTTP body; a UTF-8 regexp match
+    # on that raises Encoding::CompatibilityError (live-caught). Normalize first.
+    s = s.dup.force_encoding(Encoding::UTF_8) unless s.encoding == Encoding::UTF_8
+    s = s.scrub('') unless s.valid_encoding?
+    s = s.strip
+    return [] if s.empty?
+    neg = s.start_with?('(') && s.end_with?(')')
+    s = s[1..-2] if neg
+    body = s.gsub(/[,$€£¥\s]/, '')
+    pct = body.end_with?('%')
+    body = body.chomp('%')
+    f = begin
+      Float(body)
+    rescue ArgumentError, TypeError
+      return []
+    end
+    f = -f if neg
+    pct ? [f, f / 100.0] : [f]
+  end
+
+  def rows_numbers(rows)
+    rows.flat_map { |r| Array(r).flat_map { |c| cell_numbers(c) } }
+  end
+
+  # Normalized text cells of an export (for kind:"text" roster anchors).
+  def rows_texts(rows)
+    # (map+compact, not filter_map — the skill's floor is the system Ruby 2.6)
+    rows.flat_map { |r| Array(r) }.map do |c|
+      s = c.to_s
+      s = s.dup.force_encoding(Encoding::UTF_8) unless s.encoding == Encoding::UTF_8
+      s = s.scrub('') unless s.valid_encoding?
+      s = s.strip.downcase
+      s.empty? ? nil : s
+    end.compact.to_set
+  end
+
+  # Verify anchors against { element_name => [[cell, ...], ...] } exports.
+  # Returns the verdict Hash (contract shape + per-anchor detail).
+  #
+  # Two anchor kinds:
+  #   numeric (default) — `raw` is a printed VALUE; matches any export cell at
+  #     printed precision.
+  #   kind: "text" (aka "roster") — `raw` is a LABEL that must appear as a cell
+  #     (case-insensitive, trimmed). Use these on ranked/top-N tiles so a
+  #     WRONGLY-SELECTED or dropped member fails loudly (a materialized top-15
+  #     built from the wrong rank, a renamed category, a missing path label).
+  #     Scope note: exports carry the element's full underlying data, so a
+  #     roster anchor canNOT catch an UNFILTERED tile that merely WINDOWS the
+  #     wrong first-N on screen — that class is caught by gate 9b (shape
+  #     identity: the reviewer sees the wrong columns) and by the render-bisect
+  #     playbook (unbounded pivots kill the renderer). Use both.
+  def verify(anchors, exports)
+    el_names = exports.keys
+    numbers = exports.transform_values { |rows| rows_numbers(rows) }
+    texts = exports.transform_values { |rows| rows_texts(rows) }
+    detail = []
+    missing = []
+    anchors.each do |a|
+      raw = a['raw'].to_s
+      order = ranked_elements(a, el_names)
+      if %w[text roster member].include?(a['kind'].to_s)
+        want = raw.strip.downcase
+        found_in = order.find { |n| texts[n].include?(want) }
+        if found_in
+          detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
+        else
+          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+        end
+        next
+      end
+      # A HINTED numeric anchor asserts WHERE its value must live. A match found
+      # only in a hint-UNRELATED element (e.g. a raw detail table that merely
+      # happens to contain the number) is NOT acceptance — that loophole silently
+      # passed 10x-unit and wrong-aggregate defects in field testing (a KPI whose
+      # value coincidentally appears in a big detail element). Restrict a hinted
+      # numeric anchor's search to hint-scored elements; found-only-outside is a
+      # MISS. Hint-less anchors keep the search-everywhere fallback (no asserted
+      # location to enforce); text/roster anchors are unchanged (a member label
+      # appearing anywhere is meaningful on its own).
+      search_order =
+        if a['sigma_element_hint'].to_s.strip.empty?
+          order
+        else
+          scoped = order.select { |n| element_score(a, n).positive? }
+          scoped.empty? ? order : scoped # defensive: hint matched no element name
+        end
+      found_in = search_order.find { |n| numbers[n].any? { |v| AnchorValues.match?(raw, v) } }
+      if found_in
+        primary = order.first
+        detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in,
+                    'note' => (found_in == primary ? nil : "found outside best-match element #{primary.inspect}") }.compact
+      else
+        # Closest candidate WITHIN the best-matching element that carries any
+        # numbers (walking down the ranking until one does) — the wrong value
+        # almost always lives in the anchor's own panel, so this surfaces the
+        # impostor ("$1.8T where the source printed 18,037B") rather than a
+        # coincidentally-near number from an unrelated tile.
+        best = nil
+        order.each do |n|
+          numbers[n].each do |v|
+            d = AnchorValues.relative_distance(raw, v)
+            best = { 'value' => v, 'element' => n, 'distance' => d.round(6) } if best.nil? || d < best['distance']
+          end
+          break if best
+        end
+        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                     'best_candidate' => best }
+      end
+    end
+    { 'checked' => anchors.length,
+      'matched' => anchors.length - missing.length,
+      'missing' => missing,
+      'pass' => missing.empty?,
+      'detail' => detail }
+  end
+end
+
+# ---------------------------------------------------------------------------
+# CLI (IO / REST) — thin wrapper around the pure core above.
+# ---------------------------------------------------------------------------
+return if $PROGRAM_NAME != __FILE__ && !ENV['VERIFY_ANCHORS_CLI'] # allow `require` in tests
+
+# Element display name for export keys. put-layout replaces `name` with a
+# visibility hash on hidden-title elements — every such element would
+# stringify to the SAME key and overwrite each other's exports (false RED on
+# any anchor living in the clobbered tile). Fall back to text, then the id
+# slug (unique by construction; token matching still ranks it).
+def el_display_name(el)
+  n = el['name']
+  return n.to_s unless n.is_a?(Hash)
+  t = n['text'].to_s
+  t.empty? ? el['id'].to_s.sub(/\Ael-/, '').tr('-', ' ') : t
+end
+
+opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+OptionParser.new do |p|
+  p.on('--workdir DIR')        { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
+  p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
+  p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
+end.parse!
+abort('--workdir required') unless opts[:dir]
+
+anchors_path = opts[:anchors] || File.join(opts[:dir], 'source-anchors.json')
+out_path     = opts[:out]     || File.join(opts[:dir], 'anchors-verdict.json')
+
+unless File.exist?(anchors_path)
+  warn "FATAL: #{anchors_path} not found — transcribe the source dashboard's printed values"
+  warn '       at Phase 1d (every KPI, top-3 of every ranked list/table, one bucket value per'
+  warn '       chart; EXACTLY as printed). Schema: SKILL.md Phase 1d / refs/source-anchors.md.'
+  exit 2
+end
+doc = begin
+  JSON.parse(File.read(anchors_path))
+rescue JSON::ParserError => e
+  warn "FATAL: #{anchors_path} is malformed JSON: #{e.message}"
+  exit 2
+end
+anchors = Array(doc['anchors'])
+if anchors.empty?
+  warn "FATAL: #{anchors_path} has no anchors[] — nothing to verify."
+  exit 2
+end
+# kind:"text"/"roster"/"member" anchors carry a LABEL in `raw` (displayed-set
+# membership for ranked tiles) — only NUMERIC anchors must parse as values.
+bad = anchors.reject do |a|
+  next false unless a.is_a?(Hash)
+  %w[text roster member].include?(a['kind'].to_s) ? !a['raw'].to_s.strip.empty? : AnchorValues.parse(a['raw'])
+end
+unless bad.empty?
+  warn "FATAL: #{bad.length} anchor(s) have an unparseable `raw` printed value:"
+  bad.first(10).each { |a| warn "         #{a.is_a?(Hash) ? a['id'] : '(bad entry)'}: raw=#{(a['raw'] rescue nil).inspect}" }
+  warn '       `raw` must be the value EXACTLY as printed on the source image ("18,037B", "-2%",'
+  warn '       "$733,215.26") — or, for kind:"text" roster anchors, a non-empty displayed label.'
+  exit 2
+end
+
+# --- element names + rows: offline (spec+exports dir) or live (REST) ---------
+exports = {} # element name => rows (arrays of cells)
+
+if opts[:exports]
+  spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
+  unless File.exist?(spec_path)
+    warn "FATAL: offline mode needs --workbook-spec (or <workdir>/wb-readback.json); #{spec_path} not found."
+    exit 2
+  end
+  spec = JSON.parse(File.read(spec_path))
+  elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  elements.each do |el|
+    csv = File.join(opts[:exports], "#{el['id']}.csv")
+    next unless File.exist?(csv)
+    exports[el_display_name(el)] = CSV.read(csv)
+  end
+else
+  # Live: resolve workbook id, GET the spec, pool the element CSV exports —
+  # the same export → poll → download flow collect-parity-actuals.rb uses.
+  wb = opts[:wb]
+  if wb.nil?
+    ids = File.join(opts[:dir], 'wb-ids.json')
+    wb = (JSON.parse(File.read(ids))['workbookId'] rescue nil) if File.exist?(ids)
+  end
+  abort('--workbook-id required (or a <workdir>/wb-ids.json with workbookId)') if wb.to_s.empty?
+
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
+  spec = begin
+    JSON.parse(body)
+  rescue JSON::ParserError, TypeError
+    require 'yaml'
+    require 'date'
+    body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
+  end
+  elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
+
+  # v5.4 PIVOT-TOTALS CEILING: a pivot carrying a `totals` key 500s its CSV
+  # export (probe-isolated: the key's PRESENCE is the sole trigger — value type
+  # irrelevant), so a totals-bearing pivot's anchor values would read as MISSING
+  # here through no fault of the data. Bracket the exports: capture + STRIP each
+  # pivot's totals (one PUT), export against totals-free pivots, then RESTORE the
+  # captured totals (ensure). Renders keep their hidden grand totals before and
+  # after — only the brief export window is totals-free. The shipped hide state
+  # is re-guaranteed by `put-layout.rb --apply-pivot-totals` at the finalize ship
+  # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
+  READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
+  put_spec = lambda do |s|
+    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
+  end
+  captured_totals = {}
+  queryable.each do |el|
+    next unless el['kind'] == 'pivot-table' && el.is_a?(Hash) && el.key?('totals')
+    captured_totals[el['id'].to_s] = el.delete('totals')
+  end
+  # v5.4.9 review fix: persist the captured totals to a *-pivot-totals.json
+  # sidecar BEFORE the strip PUT. If this process dies (or the restore PUT
+  # fails) between strip and restore, the finalize ship step (put-layout.rb
+  # --apply-pivot-totals, which globs the workdir) re-applies the FULL captured
+  # totals — including showSubtotals — instead of stamping the lossy
+  # showGrandTotals-only default. Deleted again after a successful restore.
+  totals_sidecar = File.join(opts[:dir], 'anchors-restore-pivot-totals.json')
+  if captured_totals.any?
+    begin
+      File.write(totals_sidecar, JSON.pretty_generate({ 'workbook' => wb, 'totals' => captured_totals }))
+    rescue StandardError => e
+      warn "  [WARN] could not write totals restore sidecar (#{e.class}: #{e.message.to_s[0, 80]})"
+    end
+  end
+
+  export_one = lambda do |el|
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return nil unless qid
+    t0 = Time.now
+    loop do
+      return nil if Time.now - t0 > opts[:timeout]
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        next if b.to_s.empty? # still rendering
+        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
+        return CSV.parse(b)
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
+      end
+    end
+  rescue Sigma::Error, CSV::MalformedCSVError => e
+    msg = e.message.lines.first.to_s.strip[0, 120]
+    ceiling = (el['kind'] == 'pivot-table' && e.is_a?(Sigma::Error) && msg =~ /\b500\b/) ?
+      ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
+      'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
+    warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
+    nil
+  end
+
+  require 'thread'
+  begin
+    # The strip PUT runs INSIDE this begin/ensure (v5.4.9 review fix): a
+    # network-level exception on the PUT (Net::ReadTimeout, Errno::ECONNRESET,
+    # SocketError — raised raw by Sigma.request, which only wraps HTTP-status
+    # failures in Sigma::Error) can fire AFTER the server applied the strip;
+    # previously it propagated before the restore bracket existed and left the
+    # live workbook totals-stripped (grand totals visible). Restoring when the
+    # strip never landed is an idempotent no-op PUT, so the ensure always
+    # attempts it.
+    if captured_totals.any?
+      begin
+        put_spec.call(spec)
+        warn "  [totals-ceiling] stripped grand-total key from #{captured_totals.size} pivot(s) for CSV export (restored after)"
+      rescue StandardError => e
+        warn "  [WARN] could not strip pivot totals (#{e.class}: #{e.message.lines.first.to_s.strip[0, 100]}) — " \
+             'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
+      end
+    end
+    queue = Queue.new
+    queryable.each { |el| queue << el }
+    mutex = Mutex.new
+    Array.new([opts[:pool], queryable.size].min.clamp(1, 8)) do
+      Thread.new do
+        loop do
+          el = begin
+            queue.pop(true)
+          rescue ThreadError
+            break
+          end
+          rows = export_one.call(el)
+          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+        end
+      end
+    end.each(&:join)
+  ensure
+    # Restore the grand-total keys stripped for the export window so renders
+    # (and the shipped workbook) keep hidden grand totals — even if the strip
+    # PUT or an export above raised (network-level errors included). On
+    # restore failure the sidecar written above survives, and the finalize
+    # ship step re-applies the FULL captured totals (incl. showSubtotals).
+    if captured_totals.any?
+      begin
+        elements.each { |el| (t = captured_totals[el['id'].to_s]) && el['totals'] = t }
+        put_spec.call(spec)
+        warn "  [totals-ceiling] restored grand-total key on #{captured_totals.size} pivot(s)"
+        begin
+          File.delete(totals_sidecar) if File.exist?(totals_sidecar)
+        rescue StandardError
+          nil # stale sidecar is harmless: it re-applies the same captured totals
+        end
+      rescue StandardError => e
+        warn "  [WARN] pivot totals RESTORE failed (#{e.class}: #{e.message.lines.first.to_s.strip[0, 100]}) — " \
+             "captured totals kept in #{File.basename(totals_sidecar)}; the finalize ship step " \
+             '(put-layout.rb --apply-pivot-totals) re-applies them, incl. showSubtotals'
+      end
+    end
+  end
+end
+
+if exports.empty?
+  warn 'FATAL: no element exports could be collected — cannot verify anchors.'
+  warn '       (live: check SIGMA_* credentials and the workbook id; offline: check --exports-dir)'
+  exit 2
+end
+
+verdict = AnchorVerify.verify(anchors, exports)
+verdict['source_anchors'] = anchors_path
+verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+File.write(out_path, JSON.pretty_generate(verdict))
+
+# Stamp the summary into parity-final.json when Phase 6 already finalized —
+# the anchors result travels with the parity verdict the final gate reads.
+pf = File.join(opts[:dir], 'parity-final.json')
+if File.exist?(pf)
+  begin
+    s = JSON.parse(File.read(pf))
+    s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
+                     'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    File.write(pf, JSON.pretty_generate(s))
+  rescue JSON::ParserError
+    warn "[WARN] #{pf} is malformed — anchors summary not stamped."
+  end
+end
+
+puts "verify-anchors: #{verdict['matched']}/#{verdict['checked']} anchor(s) matched " \
+     "across #{exports.length} element export(s) → #{out_path}"
+verdict['detail'].each do |d|
+  puts "  MATCHED  #{d['id']} #{d['raw'].inspect} in #{d['matched_in'].inspect}#{d['note'] ? " (#{d['note']})" : ''}"
+end
+if verdict['pass']
+  puts '[OK] every source anchor value is present in the live workbook exports.'
+  exit 0
+end
+warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+verdict['missing'].each do |m|
+  bc = m['best_candidate']
+  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+end
+warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+exit 1

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/visual-similarity.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/visual-similarity.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Deterministic visual-similarity floor for Phase 6 parity verification.
+
+Compares a source dashboard screenshot against a Sigma render and decides
+whether the render is structurally in the same universe as the source. This
+is a FLOOR, not a match-scorer: it exists so a passing "visual verdict" can
+never be recorded over a render that is structurally nothing like the source
+(blank/mostly-empty pages, one-bar-vs-six-bars panels, missing whole
+columns/sections, single-column stacks). It deliberately tolerates font,
+color, padding, spacing, and aspect-ratio differences, and even wholesale
+panel rearrangement, as long as the render carries a comparable amount of
+content distributed across the whole page.
+
+Contract (consumed by the Phase 6 gate):
+
+    python3 scripts/visual-similarity.py \
+        --source <src.png> --render <render.png> --json-out <out.json>
+
+Writes JSON: {"score_layout": float, "score_ink": float,
+              "score_overall": float, "pass": bool, "threshold": float,
+              "notes": [str, ...]}
+Exit codes: 0 = pass, 1 = fail, 2 = deps missing or unreadable input.
+Exit 2 must NEVER be treated as a pass.
+
+Method (fully deterministic — no randomness, no model calls):
+  1. Normalize: flatten alpha onto white, grayscale, downsample to <=384px.
+  2. Two binary "ink" maps per image: deviation from the page background
+     (histogram mode) and local gradient (catches light-on-light text).
+  3. Trim outer margins (capped at 12% per side, so real emptiness survives).
+  4. Signals, each in 0..1:
+       cov  - render edge-ink density as a fraction of the source's
+              (missing marks; asymmetric: extra ink is not penalized)
+       bal  - worst-band ink share ratio over row/column thirds
+              (an entire source-inked region empty in the render -> 0)
+       patt - Pearson correlation of 12x12 ink-density grids
+       prof - best of row/column 48-bin edge-ink profile correlations
+       asp  - soft penalty only for extreme aspect-ratio mismatch (>2.2x),
+              the page-geometry signature of a single-column stack
+  5. score_ink = cov;  score_layout = (0.46*bal + 0.06*patt + 0.06*prof)/0.58
+     score_overall = asp * (0.42*score_ink + 0.58*score_layout)
+     pass = score_overall >= 0.45  AND  score_ink >= 0.40  AND  bal >= 0.10
+
+Threshold provenance: calibrated on 20 verified-faithful migration pairs
+from the skills-test corpus plus 17 failure-mode negatives (1 real failed
+field migration + synthesized blank / half-empty / quarter-content /
+single-column-stack pages). Do NOT tune the threshold to make a failing
+render pass — a failure means STRUCTURE diverges; re-run the RCF loop.
+
+# ---------------------------------------------------------------------------
+# CALIBRATION SUMMARY (2026-07: 20 positives, 17 negatives; threshold 0.45)
+# All positives >= threshold + 0.05; all negatives <= threshold - 0.05.
+#
+# POSITIVES (must pass)            overall   NEGATIVES (must fail)      overall
+#   call-center                      0.780     field-failure (1-bar-vs-6) 0.311
+#   dynamic-zoning-kpi               0.702     blank-page x4              0.000
+#   ecommerce-admin                  0.534     single-column-stack x4  <= 0.001
+#   er-visits                        0.872     half-page-empty x4      <= 0.343
+#   social-media-campaign            0.692     quarter-content x4      <= 0.199
+#   supermart-sales                  0.554
+#   superstore-perf-overview         0.731   min positive 0.534 (+0.084)
+#   superstore-perf-order-detail     0.834   max negative 0.343 (-0.107)
+#   superstore-viz-extensions        0.629
+#   udemy-course-analysis            0.774   Sub-floors also verified:
+#   visual-vocabulary x10 pages   >= 0.553     min positive cov 0.506
+#                                              (ink floor 0.40, +0.106)
+#                                              min positive bal 0.234
+#                                              (bal floor 0.10, +0.134)
+# ---------------------------------------------------------------------------
+"""
+
+import argparse
+import json
+import os
+import sys
+
+REMEDIATION = (
+    "visual-similarity.py requires Pillow and numpy. "
+    "Install with: pip install pillow numpy"
+)
+
+try:
+    import numpy as np
+    from PIL import Image
+except ImportError:
+    sys.stderr.write(REMEDIATION + "\n")
+    sys.exit(2)
+
+# --- tunables (calibrated; see module docstring — do not tune per-run) ------
+WORK = 384          # max working dimension after downsample
+COARSE = 12         # coarse occupancy/pattern grid
+FINE = 48           # fine profile grid
+TRIM_CAP = 0.12     # max fraction of each side trimmed as outer margin
+LUM_DELTA = 24      # luminance deviation from page background counted as ink
+EDGE_DELTA = 20     # local gradient magnitude counted as edge ink
+BAND_N = 3          # row/column bands for the balance signal
+BAND_MIN_SHARE = 0.05   # source band must hold >=5% of ink to be scored
+ASPECT_SOFT = 2.2   # aspect-ratio mismatch tolerated up to this factor
+ASPECT_RAMP = 1.8   # penalty ramp width beyond ASPECT_SOFT
+
+W_INK = 0.42
+W_BAL = 0.46
+W_PATT = 0.06
+W_PROF = 0.06
+W_LAYOUT = W_BAL + W_PATT + W_PROF   # 0.58
+
+THRESHOLD = 0.45
+INK_FLOOR = 0.40    # hard sub-floor on score_ink (mark coverage)
+BAL_FLOOR = 0.10    # hard sub-floor on band balance
+
+
+def _load_gray(path):
+    """Return (grayscale float array downsampled to <=WORK, aspect ratio)."""
+    im = Image.open(path)
+    im.load()
+    if im.mode in ("RGBA", "LA") or (im.mode == "P" and "transparency" in im.info):
+        rgba = im.convert("RGBA")
+        flat = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+        im = Image.alpha_composite(flat, rgba)
+    im = im.convert("L")
+    w, h = im.size
+    if w < 4 or h < 4:
+        raise ValueError("image too small to analyze (%dx%d)" % (w, h))
+    aspect = w / h
+    scale = WORK / max(w, h)
+    if scale < 1:
+        im = im.resize(
+            (max(1, round(w * scale)), max(1, round(h * scale))), Image.BILINEAR
+        )
+    return np.asarray(im, dtype=np.float32), aspect
+
+
+def _ink_maps(gray):
+    """Return (combined ink map, edge-only ink map) as float 0/1 arrays."""
+    # explicit float64 edges: np.histogram(x, bins=16, range=(0,256)) hits a
+    # broadcast regression on numpy 2.2.x with real image arrays (A/B-report
+    # reproduced; fine on 2.3+). Edges are version-robust on both.
+    hist, edges = np.histogram(np.asarray(gray, dtype=np.float64).ravel(),
+                               bins=np.linspace(0.0, 256.0, 17))
+    mode = int(np.argmax(hist))
+    background = (edges[mode] + edges[mode + 1]) / 2.0
+    deviation = np.abs(gray - background) > LUM_DELTA
+    gx = np.abs(np.diff(gray, axis=1, prepend=gray[:, :1]))
+    gy = np.abs(np.diff(gray, axis=0, prepend=gray[:1, :]))
+    edge = (gx + gy) > EDGE_DELTA
+    return (deviation | edge).astype(np.float32), edge.astype(np.float32)
+
+
+def _capped_trim(ink, edge):
+    """Trim near-empty outer margins, at most TRIM_CAP per side.
+
+    The cap matters: it normalizes letterboxing/browser chrome without
+    letting a half-empty page crop itself back into looking complete.
+    """
+    h, w = ink.shape
+    rows = ink.sum(axis=1)
+    cols = ink.sum(axis=0)
+    rnz = np.nonzero(rows > w * 0.005)[0]
+    cnz = np.nonzero(cols > h * 0.005)[0]
+    if len(rnz) == 0 or len(cnz) == 0:
+        return ink, edge
+    r0 = min(int(rnz[0]), int(h * TRIM_CAP))
+    r1 = max(int(rnz[-1]) + 1, h - int(h * TRIM_CAP))
+    c0 = min(int(cnz[0]), int(w * TRIM_CAP))
+    c1 = max(int(cnz[-1]) + 1, w - int(w * TRIM_CAP))
+    return ink[r0:r1, c0:c1], edge[r0:r1, c0:c1]
+
+
+def _grid(m, n):
+    """Reduce a 2-D map to an n x n grid of cell means (stretch-normalized)."""
+    h, w = m.shape
+    ys = np.linspace(0, h, n + 1).astype(int)
+    xs = np.linspace(0, w, n + 1).astype(int)
+    out = np.zeros((n, n), dtype=np.float64)
+    for i in range(n):
+        for j in range(n):
+            cell = m[ys[i]:ys[i + 1], xs[j]:xs[j + 1]]
+            if cell.size:
+                out[i, j] = float(cell.mean())
+    return out
+
+
+def _corr(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    if a.std() < 1e-9 or b.std() < 1e-9:
+        return 0.0
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def _band_shares(ink, n=BAND_N):
+    """Fraction of total ink in each of n row bands and n column bands."""
+    h, w = ink.shape
+    total = float(ink.sum()) or 1.0
+    shares = []
+    for i in range(n):
+        shares.append(float(ink[i * h // n:(i + 1) * h // n, :].sum()) / total)
+    for j in range(n):
+        shares.append(float(ink[:, j * w // n:(j + 1) * w // n].sum()) / total)
+    return shares
+
+
+def _band_balance(src_map, ren_map):
+    """Worst-case render/source ink-share ratio over row+column bands."""
+    src_shares = _band_shares(src_map)
+    ren_shares = _band_shares(ren_map)
+    worst = 1.0
+    for s, r in zip(src_shares, ren_shares):
+        if s > BAND_MIN_SHARE:
+            worst = min(worst, min(1.0, r / s))
+    return worst
+
+
+def compare(source_path, render_path):
+    """Compute the similarity-floor verdict for one source/render pair."""
+    gray_s, aspect_s = _load_gray(source_path)
+    gray_r, aspect_r = _load_gray(render_path)
+    ink_s, edge_s = _ink_maps(gray_s)
+    ink_r, edge_r = _ink_maps(gray_r)
+    ink_s, edge_s = _capped_trim(ink_s, edge_s)
+    ink_r, edge_r = _capped_trim(ink_r, edge_r)
+
+    notes = []
+
+    # -- ink coverage (asymmetric: only missing marks are penalized) --------
+    dens_s = float(edge_s.mean())
+    dens_r = float(edge_r.mean())
+    if dens_s > 1e-6:
+        cov = min(1.0, dens_r / dens_s)
+    else:
+        cov = 1.0 if dens_r <= 1e-6 else 0.0
+        notes.append("source appears blank — verify the source export")
+
+    # -- band balance: is any whole page region emptied out? ----------------
+    bal = min(_band_balance(ink_s, ink_r), _band_balance(edge_s, edge_r))
+
+    # -- structure agreement -------------------------------------------------
+    coarse_s, coarse_r = _grid(ink_s, COARSE), _grid(ink_r, COARSE)
+    fine_s, fine_r = _grid(edge_s, FINE), _grid(edge_r, FINE)
+    patt = max(0.0, _corr(coarse_s, coarse_r))
+    prof = max(
+        max(0.0, _corr(fine_s.sum(axis=1), fine_r.sum(axis=1))),
+        max(0.0, _corr(fine_s.sum(axis=0), fine_r.sum(axis=0))),
+    )
+
+    # -- aspect-ratio sanity (single-column-stack page geometry) ------------
+    ratio = max(aspect_s, aspect_r) / min(aspect_s, aspect_r)
+    if ratio <= ASPECT_SOFT:
+        asp = 1.0
+    else:
+        asp = max(0.0, 1.0 - (ratio - ASPECT_SOFT) / ASPECT_RAMP)
+        notes.append(
+            "extreme aspect-ratio mismatch (x%.1f): render page geometry "
+            "suggests content collapsed into a single column" % ratio
+        )
+
+    score_ink = round(cov, 4)
+    score_layout = round((W_BAL * bal + W_PATT * patt + W_PROF * prof) / W_LAYOUT, 4)
+    score_overall = round(asp * (W_INK * score_ink + W_LAYOUT * score_layout), 4)
+
+    passed = score_overall >= THRESHOLD
+    if score_ink < INK_FLOOR:
+        passed = False
+        notes.append(
+            "render draws only %.0f%% of the source's mark density "
+            "(floor %.0f%%): charts/text are likely missing or degenerate"
+            % (score_ink * 100, INK_FLOOR * 100)
+        )
+    if bal < BAL_FLOOR:
+        passed = False
+        notes.append(
+            "band balance %.2f (floor %.2f): a page region that holds "
+            "content in the source is (near-)empty in the render" % (bal, BAL_FLOOR)
+        )
+    if not passed and score_overall < THRESHOLD:
+        notes.append(
+            "overall %.3f below threshold %.2f: render structure diverges "
+            "from the source — re-run the RCF loop; do not tune the threshold"
+            % (score_overall, THRESHOLD)
+        )
+
+    return {
+        "score_layout": score_layout,
+        "score_ink": score_ink,
+        "score_overall": score_overall,
+        "pass": passed,
+        "threshold": THRESHOLD,
+        "notes": notes,
+        "components": {
+            "coverage": round(cov, 4),
+            "band_balance": round(bal, 4),
+            "pattern_corr": round(patt, 4),
+            "profile_corr": round(prof, 4),
+            "aspect_factor": round(asp, 4),
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Deterministic visual-similarity floor (source vs render)."
+    )
+    parser.add_argument("--source", required=True, help="source dashboard PNG")
+    parser.add_argument("--render", required=True, help="Sigma render PNG")
+    parser.add_argument("--json-out", required=True, help="verdict JSON path")
+    args = parser.parse_args(argv)
+
+    for label, path in (("source", args.source), ("render", args.render)):
+        if not os.path.isfile(path):
+            sys.stderr.write("%s image not found: %s\n" % (label, path))
+            return 2
+
+    try:
+        result = compare(args.source, args.render)
+    except Exception as exc:  # unreadable/corrupt input — never a pass
+        sys.stderr.write("could not analyze images: %s\n" % exc)
+        return 2
+
+    out_dir = os.path.dirname(os.path.abspath(args.json_out))
+    os.makedirs(out_dir, exist_ok=True)
+    with open(args.json_out, "w") as fh:
+        json.dump(result, fh, indent=2)
+        fh.write("\n")
+
+    verdict = "PASS" if result["pass"] else "FAIL"
+    print(
+        "visual-similarity: %s  overall=%.3f (threshold %.2f)  "
+        "ink=%.3f layout=%.3f"
+        % (
+            verdict,
+            result["score_overall"],
+            result["threshold"],
+            result["score_ink"],
+            result["score_layout"],
+        )
+    )
+    for note in result["notes"]:
+        print("  note: %s" % note)
+    return 0 if result["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/source-anchors.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/source-anchors.md
@@ -1,0 +1,163 @@
+# Source-value anchors — the measured value bar
+
+## Why this exists
+
+Two field migrations shipped dashboards whose **numbers were wrong** while every
+judgment gate recorded "pass":
+
+1. **The 10x/ranking failure.** A "top members" ranked panel showed *different
+   members* with values ~10x off — the migrated dashboard rendered **"$1.8T"**
+   where the source printed **"18,037B"** (≈ $18.0T). A multi-region YoY panel
+   collapsed to **one bar where the source showed six**, and a trend line
+   crashed to zero on a partial final period. The run followed the pipeline,
+   executed a real 3-pass RCF loop *reading* the render PNGs — and still
+   recorded `--verdict pass`.
+2. **The waiver-stacking failure.** A second workbook "passed" by combining
+   `--skip-parity-gate` with `--allow-missing-tiles 6`, discovered by grepping
+   `--help` for skip flags. Nothing measured the values; every gate that could
+   have was waived.
+
+The lesson: **every judgment gate is an attestation, and lenient models attest
+generously.** Visual verdicts, RCF scoring, and parity waivers are all places
+where "looks right" substitutes for "is right." Anchors replace that judgment
+with a **measurement**: printed values transcribed from the source image either
+appear in the live workbook's exports at the printed precision, or they don't.
+
+A printed source value that appears **nowhere** in the workbook exports is the
+loudest possible signal the data is wrong — wrong unit (10x), wrong aggregate,
+missing filter, collapsed buckets, or the wrong column entirely.
+
+## The contract
+
+### `source-anchors.json` — authored BY THE AGENT at Phase 1d
+
+Written **while reading the source dashboard PNG** (the same read that produces
+`png-read.json`). Never generated from CSVs — the whole point is transcribing
+what the source *renders*.
+
+```json
+{
+  "source_image": "views/<dashboardViewId>.png",
+  "transcribed_at": "2026-07-08T12:00:00Z",
+  "anchors": [
+    { "id": "a1",
+      "panel": "TOP COUNTRIES",
+      "label": "United States GDP",
+      "raw": "18,037B",
+      "kind": "currency",
+      "sigma_element_hint": "Top Countries" }
+  ]
+}
+```
+
+- `raw` — the value **EXACTLY as printed**. Keep the raw string: `"18,037B"`,
+  never `18037`; `"(12.3%)"`, never `-0.123`; `"$733,215.26"` with the `$` and
+  commas. The printed form *is* the precision contract.
+- `kind` — `currency` | `number` | `percent` | **`text`** (alias `roster`/`member`).
+  A `text` anchor's `raw` is a **displayed LABEL** (case-insensitive cell match),
+  not a value — use it for ranked/top-N tiles so a wrongly-selected or dropped
+  member fails loudly (a top-15 materialized from the wrong rank, a renamed
+  category, a missing path label). Scope: exports carry the element's full
+  underlying data, so `text` anchors can't catch an UNFILTERED tile that merely
+  windows the wrong first-N on screen — gate 9b (shape identity) owns that class.
+- `sigma_element_hint` — optional; the Sigma element name the value should land
+  in. When present it wins over fuzzy matching.
+- **Minimum anchors (the gate requires ≥ 5):** every KPI value, the **top 3
+  values of every ranked list/table**, **one representative bucket value
+  per chart**, and — for every ranked/top-N tile — **2–3 `text` roster anchors**
+  naming members the source actually displays (include at least one from the
+  BOTTOM half of the list: top members often survive a wrong ranking, bottom
+  members don't). Top-of-ranked-list anchors are what catch the
+  different-members-with-different-values failure.
+
+### `anchors-verdict.json` — written by `scripts/verify-anchors.rb`
+
+```json
+{ "checked": 9, "matched": 8,
+  "missing": [ { "id": "a1", "label": "United States GDP", "raw": "18,037B",
+                 "best_candidate": { "value": 1.8e12, "element": "Top Countries" } } ],
+  "pass": false }
+```
+
+`verify-anchors.rb --workdir <W> --workbook-id <id>` pools the live workbook's
+element CSV exports (the same export→poll→download flow
+`collect-parity-actuals.rb` uses), searches each anchor in the element whose
+name best matches its label/panel (token overlap; the hint wins), then searches
+every other export before declaring a miss. Found-elsewhere still matches (the
+value exists; only the label→element mapping was fuzzy) and is noted. It also
+stamps an `anchors` summary into `parity-final.json` when present. Exit 0 all
+matched / 1 with a per-miss report naming each miss and its closest candidate.
+
+## Canonicalization rules (`scripts/lib/anchor_values.rb`)
+
+**Match rule:** a printed value MATCHES a real number when the real number
+**rounds to the printed form at the printed precision** — i.e.
+`|actual − printed| ≤ half of the last printed digit's place value`, scaled by
+any suffix.
+
+| Printed | Canonical value | Tolerance | Notes |
+|---|---|---|---|
+| `18,037B` | 1.8037e13 | ±0.5e9 | last digit = units of B |
+| `$1.8T` | 1.8e12 | ±0.05e12 | currency; one decimal of T |
+| `46.5M` | 4.65e7 | ±0.05e6 | |
+| `-2%` | −2 points | ±0.5 | also matches the fraction −0.02 ± 0.005 |
+| `1,687` | 1687 | ±0.5 | |
+| `$733,215.26` | 733215.26 | ±0.005 | cents precision |
+| `(12.3%)` | −12.3 points | ±0.05 | accounting-paren negative |
+| `12.3k` | 12300 | ±50 | lowercase suffixes accepted |
+
+Extra interpretations checked (they never weaken 10x detection):
+
+- Suffixed forms also match the **unscaled face value** (`18,037B` ↔ a column
+  already denominated in billions storing `18037`).
+- Percents match both **points** (−2) and **fraction** (−0.02) storage.
+
+So `1.8e12` does **not** match `18,037B` under any interpretation — the exact
+field failure — while `18,036,800,000,000` (rounds to 18,037B) does.
+
+## Worked example
+
+Source image shows a KPI `$86.5T`, a TOP COUNTRIES list headed by
+`United States 18,037B`, `China 13,608B`, `Japan 4,971B`, and a YoY panel with
+`-2%` on one bucket:
+
+```json
+{ "source_image": "views/abc123.png", "transcribed_at": "2026-07-08T15:04:00Z",
+  "anchors": [
+    { "id": "a1", "panel": "KPI",           "label": "World GDP total", "raw": "$86.5T",  "kind": "currency" },
+    { "id": "a2", "panel": "TOP COUNTRIES", "label": "United States",   "raw": "18,037B", "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a3", "panel": "TOP COUNTRIES", "label": "China",           "raw": "13,608B", "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a4", "panel": "TOP COUNTRIES", "label": "Japan",           "raw": "4,971B",  "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a5", "panel": "YOY BY REGION", "label": "largest decline bucket", "raw": "-2%", "kind": "percent" }
+  ] }
+```
+
+If the built workbook's Top Countries element exports `1.8e12` for the top row,
+`verify-anchors.rb` reports:
+
+```
+MISSING  a2 "United States" raw="18,037B" — closest candidate 1.8e12 in "Top Countries"
+```
+
+— the 10x failure caught mechanically, before any visual verdict is consulted.
+
+## Gate wiring (`assert-phase6-ran.rb`)
+
+- **Gate 13 (exit 18):** whenever the workdir carries a source dashboard PNG
+  (the Phase 1d artifact — `png-read.json` `source_png`, `views/*.png`, or
+  `dashboards/*.png`), `source-anchors.json` must exist with ≥ 5 anchors AND
+  `anchors-verdict.json` must pass with every anchor checked (a stale verdict —
+  fewer checked than transcribed — fails). No source PNG → stated SKIP.
+  Escape: `--skip-anchors-gate "<reason>"` (counted against the waiver budget).
+- **Conditional `--skip-parity-gate` (exit 18):** waiving source parity is
+  REJECTED unless `anchors-verdict.json` exists and passes. The anchors oracle
+  replaces parity — never nothing. This is the no-standalone-views path's
+  contract too: parity oracle = anchors + warehouse (`verify-warehouse.rb`).
+- **Data-class RCF residuals (exit 15):** any unresolved `data`-class entry in
+  `fidelity-ledger.json` blocks GREEN whenever the ledger exists —
+  `--accept-residuals` does not apply. The numbers are wrong; fix or reclassify
+  with evidence.
+- **Waiver budget (exit 19):** more than 2 quality waivers → GREEN unavailable
+  (YELLOW cap). Anchors and similarity skips count; `--skip-telemetry-gate`
+  (policy) and the sanctioned builder→verifier `--skip-visual-comparison`
+  handoff do not.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/visual-similarity.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/visual-similarity.md
@@ -1,0 +1,82 @@
+# Visual-similarity floor — the deterministic gate under the visual verdict
+
+`scripts/visual-similarity.py` is a deterministic sanity floor that runs before any
+model-judged visual verdict counts. Its job is narrow: make it **impossible to record a
+passing visual verdict over a render that is structurally nothing like the source**. It is
+NOT a match-scorer and it does not measure migration quality — the RCF loop
+(`refs/phase-5g-rcf.md`, `refs/fidelity-rubric.md`) and Phase 6 parity own that. A floor
+pass means only "these two images are plausibly the same dashboard"; the real visual QA
+still happens on top of it.
+
+## Contract
+
+```
+python3 scripts/visual-similarity.py --source <src.png> --render <render.png> --json-out <out.json>
+```
+
+Exit codes: `0` = pass, `1` = fail, `2` = dependencies missing or input unreadable.
+**Exit 2 is never a pass** — treat it as a blocked gate: fix the environment
+(`pip install pillow numpy`) or re-export the image, then re-run. The gate wiring must
+propagate 2 as a hard stop, not fall through to the model verdict.
+
+JSON written to `--json-out`:
+
+| field           | meaning                                                                 |
+|-----------------|-------------------------------------------------------------------------|
+| `score_ink`     | 0–1. Render mark density (edges: text, bars, lines) as a fraction of the source's. Asymmetric — extra ink is never penalized; missing ink is. |
+| `score_layout`  | 0–1. Spatial distribution agreement: worst-band ink balance over row/column thirds (dominant term), plus coarse ink-pattern and row/column profile correlations. |
+| `score_overall` | 0–1. `aspect_factor * (0.42*score_ink + 0.58*score_layout)`.            |
+| `threshold`     | The calibrated pass line for `score_overall` (currently **0.45**).      |
+| `pass`          | `score_overall >= threshold` AND `score_ink >= 0.40` AND band balance `>= 0.10`. The two sub-floors catch sparse-marks and emptied-region failures even when the blend stays high. |
+| `notes`         | Human-readable reasons for any failure or anomaly (blank source, aspect mismatch, tripped sub-floor). |
+| `components`    | Diagnostic sub-signals (coverage, band_balance, pattern_corr, profile_corr, aspect_factor). |
+
+The comparison is fully deterministic: same two files in → byte-identical JSON out. No
+randomness, no model calls, no network.
+
+## What the floor catches
+
+- **Blank / mostly-empty pages** — render draws little or none of the source's ink.
+- **One-bar-vs-six-bars panels** — panel chrome survives but the marks are gone
+  (`score_ink` sub-floor at 0.40).
+- **Missing whole columns / sections / tables** — a page region that holds content in the
+  source is near-empty in the render (band-balance sub-floor at 0.10).
+- **Single-column stacks** — a grid dashboard collapsed into one long column; the page's
+  extreme aspect-ratio mismatch (>2.2x) zeroes the score.
+
+## What the floor deliberately tolerates
+
+Different fonts, colors, themes, padding, spacing, and margins; different aspect ratios
+(landscape source → longer Sigma page is normal); moderate panel rearrangement and re-flow
+(verified-faithful migrations in the calibration set include a 2x3 grid re-flowed to 4x3
+and landscape→portrait re-stacks — all pass with margin). If a render passes the floor but
+looks off, that is exactly what the RCF rubric is for.
+
+## Threshold provenance — do not tune it
+
+Threshold 0.45 and the sub-floors were calibrated on **20 verified-faithful migration
+pairs** (real Tableau dashboard exports vs their accepted Sigma renders, spanning dense
+KPI dashboards, app-style layouts, dark themes, text-heavy pages, and 10 chart-gallery
+pages) plus **17 failure-mode negatives** (1 real failed field migration with 1-bar-vs-6
+panels and whitespace, plus synthesized blank-page, half-page-empty, quarter-content, and
+single-column-stack renders). Every positive clears the threshold by ≥ 0.08 and every
+negative misses it by ≥ 0.10; the sub-floors clear their nearest positive by ≥ 0.10. The
+per-pair table is embedded as a comment block in `scripts/visual-similarity.py`.
+
+**If the floor fails, the render's STRUCTURE diverges from the source.** The fix is always
+in the workbook: re-run the RCF loop, restore the missing sections/marks, and re-render.
+Never raise `--threshold`-style knobs, edit the constants, or re-crop the screenshots to
+squeeze a failing render through — a tuned floor is worse than no floor, because it
+launders a broken render into a recorded visual pass.
+
+## Dependencies
+
+Pillow + numpy only (no OpenCV/scikit). If either is missing the script prints
+`pip install pillow numpy` and exits 2. Runtime is well under a second per pair.
+
+## Tests
+
+`python3 scripts/test_visual_similarity.py` — offline synthetic-fixture suite covering the
+scoring behaviors (identical ≈ 1.0, recolored/shifted copy passes, blank / half-empty /
+sparse / stacked renders fail) and the full CLI exit-code contract, including a
+missing-dependency simulation.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/anchor_values.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/anchor_values.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+#
+# anchor_values.rb — PURE canonicalization of printed dashboard values.
+#
+# WHY. Two field migrations shipped dashboards whose NUMBERS were wrong while
+# every judgment gate recorded "pass": a ranked list showed different members
+# with 10x-off values ("$1.8T" where the source printed "18,037B"), and panels
+# collapsed to a fraction of the source's buckets. The fix is a MEASURED value
+# bar: the agent transcribes the source's printed values EXACTLY as printed
+# (Phase 1d, source-anchors.json), and verify-anchors.rb checks each printed
+# value against the live workbook's element CSV exports. This module is the
+# arithmetic core of that check: it parses a printed form ("18,037B", "$1.8T",
+# "-2%", "(12.3%)", "$733,215.26", "12.3k") into a (value, precision) pair and
+# decides whether a real number could have RENDERED as that printed form.
+#
+# MATCH RULE. A printed value MATCHES a real number when the real number rounds
+# to the printed form at the printed precision — i.e. |actual - printed_value|
+# <= half of the last printed digit's place value (scaled by any K/M/B/T
+# suffix). "18,037B" therefore matches any real in [18,036.5B, 18,037.5B]
+# (tolerance ±0.5e9), and 1.8e12 ("$1.8T") is a loud 10x MISS.
+#
+# CANDIDATE INTERPRETATIONS (all checked by match?):
+#   - suffixed values ("18,037B") also match the UNSCALED face value (18037)
+#     because some warehouses store the column already in that display unit;
+#   - percents ("-2%") match both percent POINTS (-2) and the FRACTION (-0.02).
+# Neither weakens the 10x/regrouping detection — the wrong values seen in the
+# field match none of the interpretations.
+#
+# Pure, stdlib-only, no IO. Unit tests: scripts/test-anchor-values.rb.
+
+module AnchorValues
+  KINDS = %w[currency number percent].freeze
+
+  SUFFIXES = {
+    'k' => 1e3, 'm' => 1e6, 'b' => 1e9, 't' => 1e12
+  }.freeze
+
+  CURRENCY_SYMBOLS = %w[$ € £ ¥].freeze
+
+  module_function
+
+  # Parse a printed form into its PRIMARY canonical interpretation.
+  # Returns { value: Float, tol: Float, kind: 'currency'|'number'|'percent',
+  #           negative: Boolean } or nil when the string is not a printed number.
+  # For percents the primary value is in percent POINTS ("-2%" → -2.0 ± 0.5);
+  # candidates() adds the fraction form.
+  def parse(raw)
+    s = raw.to_s.strip
+    return nil if s.empty?
+
+    negative = false
+    # Accounting-style parenthesized negative: "(12.3%)", "($4,120)".
+    if s.start_with?('(') && s.end_with?(')')
+      negative = true
+      s = s[1..-2].to_s.strip
+    end
+    # Leading minus (ASCII or unicode), possibly before OR after a currency symbol.
+    if s.start_with?('-', '−', '–')
+      negative = true
+      s = s[1..].to_s.strip
+    end
+
+    kind = 'number'
+    if CURRENCY_SYMBOLS.include?(s[0])
+      kind = 'currency'
+      s = s[1..].to_s.strip
+      if s.start_with?('-', '−', '–') # "$-12.4"
+        negative = true
+        s = s[1..].to_s.strip
+      end
+    end
+
+    percent = false
+    if s.end_with?('%')
+      percent = true
+      kind = 'percent'
+      s = s[0..-2].to_s.strip
+    end
+
+    multiplier = 1.0
+    if !percent && s =~ /\A(.*?)\s*([kKmMbBtT])\z/ && !Regexp.last_match(1).to_s.strip.empty?
+      body = Regexp.last_match(1).strip
+      suf  = Regexp.last_match(2).downcase
+      multiplier = SUFFIXES[suf]
+      s = body
+    end
+
+    digits = s.delete(',')
+    return nil unless digits =~ /\A(?:\d+(?:\.\d+)?|\.\d+)\z/
+
+    decimals = digits.include?('.') ? digits.split('.', 2)[1].length : 0
+    face = Float(digits)
+    step = 10.0**-decimals
+    value = face * multiplier
+    value = -value if negative
+    { value: value, tol: (step / 2.0) * multiplier, kind: kind, negative: negative }
+  end
+
+  # All acceptable (value, tol) interpretations of a printed form, primary first.
+  # Returns an Array of [value, tol] pairs, or [] when unparseable.
+  def candidates(raw)
+    p = parse(raw)
+    return [] if p.nil?
+    out = [[p[:value], p[:tol]]]
+    if p[:kind] == 'percent'
+      # Fraction form: exports often carry 0.02 where the dashboard prints "2%".
+      out << [p[:value] / 100.0, p[:tol] / 100.0]
+    else
+      # Unscaled face value for suffixed forms ("18,037B" ↔ a column already
+      # denominated in billions). Only differs when a suffix was present.
+      pr = parse(strip_suffix(raw))
+      out << [pr[:value], pr[:tol]] if pr && (pr[:value] - p[:value]).abs > Float::EPSILON
+    end
+    out
+  end
+
+  # Does a real number match the printed form? (See MATCH RULE above.)
+  def match?(raw, actual)
+    return false if actual.nil?
+    a = begin
+      Float(actual)
+    rescue ArgumentError, TypeError
+      return false
+    end
+    candidates(raw).any? do |value, tol|
+      (a - value).abs <= tol + (1e-9 * [value.abs, 1.0].max)
+    end
+  end
+
+  # The schema `kind` of a printed form ('currency'|'number'|'percent'), or nil.
+  def kind(raw)
+    p = parse(raw)
+    p && p[:kind]
+  end
+
+  # Relative distance between a real number and the printed form's primary
+  # value — used to rank "closest miss" candidates in reports. Float::INFINITY
+  # when the form is unparseable.
+  def relative_distance(raw, actual)
+    p = parse(raw)
+    return Float::INFINITY if p.nil? || actual.nil?
+    a = begin
+      Float(actual)
+    rescue ArgumentError, TypeError
+      return Float::INFINITY
+    end
+    # Best (smallest) distance across all interpretations, so a fraction-form
+    # percent ranks as close as its points form.
+    candidates(raw).map { |v, _| (a - v).abs / [v.abs, 1e-9].max }.min
+  end
+
+  # Remove a trailing K/M/B/T suffix (keeps sign/currency/percent decorations).
+  def strip_suffix(raw)
+    raw.to_s.sub(/\s*[kKmMbBtT](\)?)\z/, '\1')
+  end
+end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test-verify-anchors.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Tests for scripts/verify-anchors.rb — the measured value bar.
+#
+#   1. Pure core (AnchorVerify): label→element fuzzy match by token overlap,
+#      sigma_element_hint priority, found-elsewhere-still-matches, missing
+#      anchors carry a best_candidate, cell parsing ($/,/%/parens).
+#   2. CLI offline mode (--workbook-spec + --exports-dir): verdict file shape
+#      (checked/matched/missing/pass), exit codes (0 all matched / 1 miss /
+#      2 usage), and the parity-final.json `anchors` stamp.
+#
+# Offline, no network. Usage: ruby scripts/test-verify-anchors.rb
+
+require 'json'
+require 'csv'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+ENV['VERIFY_ANCHORS_CLI'] = nil
+require_relative 'verify-anchors' # loads AnchorVerify (CLI guarded out)
+
+SCRIPT = File.join(__dir__, 'verify-anchors.rb')
+
+$fails = []
+def ok(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '-- pure core: element ranking --'
+els = ['Top Countries', 'GDP Trend', 'YoY Growth by Region', 'KPI Row']
+a_label = { 'id' => 'a1', 'panel' => 'TOP COUNTRIES', 'label' => 'United States GDP', 'raw' => '18,037B' }
+ok(AnchorVerify.ranked_elements(a_label, els).first == 'Top Countries',
+   'panel/label token overlap ranks the right element first')
+ok(AnchorVerify.ranked_elements(a_label, els).length == els.length,
+   'zero-score elements are appended (search everywhere)')
+a_hint = a_label.merge('sigma_element_hint' => 'YoY Growth by Region')
+ok(AnchorVerify.ranked_elements(a_hint, els).first == 'YoY Growth by Region',
+   'sigma_element_hint wins over panel/label overlap')
+a_hint_fuzzy = a_label.merge('sigma_element_hint' => 'yoy region growth')
+ok(AnchorVerify.ranked_elements(a_hint_fuzzy, els).first == 'YoY Growth by Region',
+   'non-exact hint still matches by token overlap')
+
+puts '-- pure core: cell parsing --'
+ok(AnchorVerify.cell_numbers('$1,234.50') == [1234.5], 'currency + commas parse')
+ok(AnchorVerify.cell_numbers('(42)') == [-42.0], 'paren negative parses')
+ok(AnchorVerify.cell_numbers('12%') == [12.0, 0.12], 'percent cell keeps points + fraction')
+ok(AnchorVerify.cell_numbers('United States').empty?, 'non-numeric cell yields nothing')
+ok(AnchorVerify.cell_numbers('').empty? && AnchorVerify.cell_numbers(nil).empty?, 'empty/nil cells yield nothing')
+
+puts '-- pure core: verify() verdicts --'
+exports = {
+  'Top Countries' => [['Country', 'GDP'], ['United States', '18037000000000'], ['China', '13608000000000']],
+  'GDP Trend'     => [['Year', 'GDP'], ['2024', '1.75e12'], ['2025', '1.8e12']],
+  'KPI Row'       => [['Total GDP', 'YoY'], ['86500000000000', '-0.02']]
+}
+anchors = [
+  { 'id' => 'a1', 'panel' => 'TOP COUNTRIES', 'label' => 'United States GDP', 'raw' => '18,037B' },
+  { 'id' => 'a2', 'panel' => 'KPI', 'label' => 'YoY change', 'raw' => '-2%', 'sigma_element_hint' => 'KPI Row' },
+  { 'id' => 'a3', 'panel' => 'KPI', 'label' => 'Total GDP', 'raw' => '86.5T' }
+]
+v = AnchorVerify.verify(anchors, exports)
+ok(v['pass'] == true && v['matched'] == 3 && v['checked'] == 3, 'all-matched verdict passes 3/3')
+ok(v['missing'].empty?, 'no missing entries when all matched')
+
+# The field failure: the workbook renders 1.8T where the source printed 18,037B.
+bad_exports = exports.merge('Top Countries' => [['Country', 'GDP'], ['United Kingdom', '1.8e12']])
+v2 = AnchorVerify.verify(anchors, bad_exports)
+ok(v2['pass'] == false && v2['matched'] == 2, '10x-off value fails the anchor (2/3)')
+miss = v2['missing'].first
+ok(miss['id'] == 'a1' && miss['raw'] == '18,037B', 'missing entry carries id + raw')
+ok(miss['best_candidate'].is_a?(Hash) && miss['best_candidate']['value'] == 1.8e12,
+   'best_candidate reports the closest wrong value (the 1.8T impostor)')
+
+# found-elsewhere: value lives in a differently-named element → matched + noted
+elsewhere = { 'Some Renamed Tile' => [['GDP'], ['18037000000000']] }
+v3 = AnchorVerify.verify([anchors[0]], elsewhere)
+ok(v3['pass'] == true, 'value found in a non-best-match element still matches')
+ok(v3['detail'].first['matched_in'] == 'Some Renamed Tile', 'detail names where it was found')
+
+# hint discipline: a HINTED numeric anchor whose value appears ONLY in a
+# hint-UNRELATED element is a MISS — NOT a false match. Field-caught in the
+# PowerBI port pilot: a KPI's wrong value (10x-unit / wrong-aggregate) that
+# coincidentally lived in a big detail table silently passed the old
+# search-everywhere fallback. (Hint-LESS anchors keep that fallback — see v3.)
+hinted_exports = {
+  'Total Stores' => [['Total Stores'], ['104']],
+  'Sales Detail' => [['SLS'], ['1040'], ['1600000']]
+}
+v4 = AnchorVerify.verify(
+  [{ 'id' => 'h1', 'label' => 'Total Stores', 'raw' => '1,040', 'sigma_element_hint' => 'Total Stores' }],
+  hinted_exports
+)
+ok(v4['pass'] == false && v4['missing'].first && v4['missing'].first['id'] == 'h1',
+   'hinted numeric found only OUTSIDE the hinted element is a MISS (not a false match)')
+ok(v4['missing'].first['best_candidate'] && v4['missing'].first['best_candidate']['value'] == 104.0,
+   'the miss surfaces the real value (104 in the hinted element) as closest candidate')
+v5 = AnchorVerify.verify(
+  [{ 'id' => 'h2', 'label' => 'Total Stores', 'raw' => '104', 'sigma_element_hint' => 'Total Stores' }],
+  hinted_exports
+)
+ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
+
+puts '-- CLI offline mode --'
+def write_fixture(dir, exports_rows, anchors)
+  spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>
+    exports_rows.each_with_index.map { |(name, _), i| { 'id' => "el#{i}", 'name' => name, 'kind' => 'table' } } }] }
+  File.write(File.join(dir, 'wb-spec.json'), JSON.pretty_generate(spec))
+  exp = File.join(dir, 'exports')
+  Dir.mkdir(exp)
+  exports_rows.each_with_index do |(_, rows), i|
+    CSV.open(File.join(exp, "el#{i}.csv"), 'w') { |c| rows.each { |r| c << r } }
+  end
+  File.write(File.join(dir, 'source-anchors.json'),
+             JSON.pretty_generate('source_image' => 'views/dash.png',
+                                  'transcribed_at' => '2026-07-08T00:00:00Z',
+                                  'anchors' => anchors))
+  [File.join(dir, 'wb-spec.json'), exp]
+end
+
+def run_cli(dir, spec, exp)
+  Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--workbook-spec', spec, '--exports-dir', exp)
+end
+
+Dir.mktmpdir do |dir|
+  spec, exp = write_fixture(dir, exports, anchors)
+  File.write(File.join(dir, 'parity-final.json'),
+             JSON.pretty_generate('status' => 'PASS', 'charts_total' => 3, 'charts_pass' => 3))
+  out, _err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus.zero?, "all matched → exit 0 (got #{st.exitstatus})")
+  ok(out.include?('3/3'), 'summary reports 3/3 matched')
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  ok(vd['pass'] == true && vd['checked'] == 3 && vd['matched'] == 3 && vd['missing'] == [],
+     'anchors-verdict.json carries the contract shape (checked/matched/missing/pass)')
+  pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
+  ok(pf['anchors'].is_a?(Hash) && pf['anchors']['pass'] == true && pf['anchors']['checked'] == 3,
+     'anchors summary stamped into parity-final.json')
+end
+
+Dir.mktmpdir do |dir|
+  spec, exp = write_fixture(dir, bad_exports, anchors)
+  _out, err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus == 1, "missing anchor → exit 1 (got #{st.exitstatus})")
+  ok(err.include?('MISSING') && err.include?('18,037B'), 'per-miss report names the anchor raw value')
+  ok(err.include?('closest candidate'), 'per-miss report shows the best candidate')
+  ok(err.include?('loudest possible signal'), 'failure explains what a total miss means')
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  ok(vd['pass'] == false && vd['missing'].length == 1 && vd['missing'][0]['id'] == 'a1',
+     'failing verdict written with the missing anchor')
+end
+
+Dir.mktmpdir do |dir|
+  # no source-anchors.json at all → usage error, points at Phase 1d
+  _out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir,
+                                 '--workbook-spec', '/nonexistent', '--exports-dir', dir)
+  ok(st.exitstatus == 2, "missing source-anchors.json → exit 2 (got #{st.exitstatus})")
+  ok(err.include?('Phase 1d'), 'missing-anchors error points at the Phase 1d transcription step')
+end
+
+Dir.mktmpdir do |dir|
+  # unparseable raw → usage error (transcription contract violated)
+  spec, exp = write_fixture(dir, exports, [{ 'id' => 'a1', 'label' => 'x', 'raw' => 'about twenty' }])
+  _out, err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus == 2, "unparseable raw → exit 2 (got #{st.exitstatus})")
+  ok(err.include?('EXACTLY as printed'), 'unparseable-raw error restates the transcription rule')
+end
+
+puts
+if $fails.empty?
+  puts 'ALL PASS — verify-anchors core + offline CLI'
+  exit 0
+else
+  puts "FAILURES (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test_visual_similarity.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test_visual_similarity.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Offline tests for visual-similarity.py (synthetic fixtures only).
+
+Run: python3 scripts/test_visual_similarity.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "visual-similarity.py")
+
+try:
+    from PIL import Image, ImageDraw
+except ImportError:  # pragma: no cover
+    sys.stderr.write("tests require Pillow/numpy: pip install pillow numpy\n")
+    sys.exit(2)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("visual_similarity", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+VS = _load_module()
+
+# --- synthetic dashboard fixtures -------------------------------------------
+
+BAR_HEIGHTS = [0.55, 0.8, 0.35, 0.95, 0.6, 0.45]
+
+
+def draw_card(d, x0, y0, x1, y1, chrome, ink, accent, bars=6, lines=False):
+    """One dashboard 'card': faint border, title bar, bar chart or text rows.
+
+    bars < 6 models the mid-tier failure mode seen in the field: the panel
+    chrome survives, but a single small bar sits where six categories should
+    be, or a dense table collapses to a few stub rows, leaving whitespace
+    (bar slots are always sized for six, so fewer bars = emptier panel).
+    """
+    d.rectangle([x0, y0, x1, y1], outline=chrome, width=1)
+    d.rectangle([x0 + 8, y0 + 8, x1 - 8, y0 + 22], fill=accent)
+    body_top, body_bot = y0 + 36, y1 - 12
+    if lines:  # table-ish card; sparse variant drops most rows
+        y = body_top
+        step = 12 if bars >= 6 else 12 * 6 // max(1, bars)
+        while y < body_bot - 6:
+            d.rectangle([x0 + 12, y, x1 - 20, y + 4], fill=ink)
+            y += step
+        return
+    span = (x1 - x0 - 24) / 6.0  # slot width is ALWAYS six-across
+    scale = 1.0 if bars >= 6 else 0.5  # degenerate charts come out small too
+    for i in range(bars):
+        h = BAR_HEIGHTS[i % len(BAR_HEIGHTS)] * (body_bot - body_top) * scale
+        bx0 = x0 + 12 + i * span
+        bx1 = bx0 + span * 0.62
+        d.rectangle([bx0, body_bot - h, bx1, body_bot], fill=accent)
+
+
+def make_dashboard(w=1200, h=800, bg=(255, 255, 255), ink=(40, 40, 60),
+                   accent=(46, 84, 158), bars=6, shift=0):
+    """Deterministic synthetic dashboard: header + KPI row + 3x2 card grid.
+
+    Card borders are drawn just above the background (delta < ink threshold),
+    like modern borderless-card dashboards, so marks dominate the ink budget.
+    """
+    chrome = tuple(max(0, c - 10) for c in bg)
+    im = Image.new("RGB", (w, h), bg)
+    d = ImageDraw.Draw(im)
+    s = shift
+    d.rectangle([20 + s, 15 + s, w - 20 + s, 45 + s], fill=accent)  # header
+    for k in range(4):  # KPI strip: value block + sparkline zigzag
+        kx = 20 + s + k * (w - 40) // 4
+        kx1 = kx + (w - 40) // 4 - 12
+        d.rectangle([kx, 60 + s, kx1, 110 + s], outline=chrome, width=1)
+        if bars >= 6:  # degenerate renders lose KPI innards, keep the frame
+            d.rectangle([kx + 10, 70 + s, kx + 70, 86 + s], fill=ink)
+            pts = [(kx + 10 + 7 * i, 100 + s - 8 * (i % 3)) for i in range(12)]
+            d.line(pts, fill=accent, width=2)
+    grid_top = 130 + s
+    cw, ch = (w - 60) // 3, (h - grid_top - 30) // 2
+    for r in range(2):
+        for c in range(3):
+            x0 = 20 + s + c * (cw + 10)
+            y0 = grid_top + r * (ch + 10)
+            draw_card(d, x0, y0, x0 + cw, y0 + ch, chrome, ink, accent,
+                      bars=bars, lines=(c == 2))
+    return im
+
+
+def make_stack(src):
+    """Catastrophe: the six grid cards restacked into one narrow column."""
+    w, h = src.size
+    cw, ch = (w - 60) // 3, (h - 130 - 30) // 2
+    tiles = []
+    for r in range(2):
+        for c in range(3):
+            x0, y0 = 20 + c * (cw + 10), 130 + r * (ch + 10)
+            tiles.append(src.crop((x0, y0, x0 + cw, y0 + ch)))
+    out = Image.new("RGB", (cw + 20, (ch + 10) * 6 + 20), (255, 255, 255))
+    y = 10
+    for t in tiles:
+        out.paste(t, (10, y))
+        y += ch + 10
+    return out
+
+
+class FixtureMixin:
+    @classmethod
+    def setUpClass(cls):
+        cls.dir = tempfile.mkdtemp(prefix="vissim-test-")
+        cls.paths = {}
+
+        def save(name, im):
+            p = os.path.join(cls.dir, name + ".png")
+            im.save(p)
+            cls.paths[name] = p
+            return p
+
+        src = make_dashboard()
+        save("source", src)
+        save("identical", src.copy())
+        # recolored + font/padding-shifted copy: different palette, offset
+        save("recolored", make_dashboard(bg=(244, 241, 252), ink=(70, 60, 90),
+                                         accent=(180, 120, 60), shift=6))
+        save("blank", Image.new("RGB", (1600, 900), (255, 255, 255)))
+        half = src.copy()
+        half.paste(Image.new("RGB", (src.width, src.height // 2),
+                             (255, 255, 255)), (0, src.height // 2))
+        save("halfempty", half)
+        save("sparse", make_dashboard(bars=1))       # one bar vs six per panel
+        save("stack", make_stack(src))               # single-column stack
+        corrupt = os.path.join(cls.dir, "corrupt.png")
+        with open(corrupt, "wb") as fh:
+            fh.write(b"this is not a png file")
+        cls.paths["corrupt"] = corrupt
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.dir, ignore_errors=True)
+
+    def run_cli(self, source, render, json_out=None, env=None):
+        json_out = json_out or os.path.join(self.dir, "out.json")
+        proc = subprocess.run(
+            [sys.executable, SCRIPT, "--source", source, "--render", render,
+             "--json-out", json_out],
+            capture_output=True, text=True, env=env,
+        )
+        data = None
+        if os.path.isfile(json_out) and proc.returncode in (0, 1):
+            with open(json_out) as fh:
+                data = json.load(fh)
+        return proc, data
+
+
+class TestScoring(FixtureMixin, unittest.TestCase):
+    def test_identical_scores_near_one(self):
+        res = VS.compare(self.paths["source"], self.paths["identical"])
+        self.assertTrue(res["pass"])
+        self.assertGreaterEqual(res["score_overall"], 0.98)
+        self.assertGreaterEqual(res["score_ink"], 0.98)
+        self.assertGreaterEqual(res["score_layout"], 0.98)
+
+    def test_recolored_font_shifted_copy_passes(self):
+        res = VS.compare(self.paths["source"], self.paths["recolored"])
+        self.assertTrue(res["pass"], res)
+        self.assertGreaterEqual(
+            res["score_overall"], res["threshold"] + 0.05,
+            "legit restyle must clear the threshold with margin",
+        )
+
+    def test_blank_render_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["blank"])
+        self.assertFalse(res["pass"])
+        self.assertLessEqual(res["score_overall"], res["threshold"] - 0.05)
+
+    def test_half_empty_render_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["halfempty"])
+        self.assertFalse(res["pass"])
+        self.assertLessEqual(res["score_overall"], res["threshold"] - 0.05)
+
+    def test_one_bar_vs_six_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["sparse"])
+        self.assertFalse(res["pass"], res)
+        self.assertLess(res["score_ink"], 0.40,
+                        "mark-density floor should catch sparse panels")
+
+    def test_single_column_stack_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["stack"])
+        self.assertFalse(res["pass"], res)
+
+    def test_symmetric_blank_source_noted(self):
+        res = VS.compare(self.paths["blank"], self.paths["blank"])
+        self.assertTrue(any("source appears blank" in n for n in res["notes"]))
+
+
+class TestCLIContract(FixtureMixin, unittest.TestCase):
+    def test_pass_exit_0_and_json_schema(self):
+        out = os.path.join(self.dir, "nested", "dir", "verdict.json")
+        proc, data = self.run_cli(self.paths["source"], self.paths["recolored"],
+                                  json_out=out)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        for key, typ in (("score_layout", float), ("score_ink", float),
+                         ("score_overall", float), ("pass", bool),
+                         ("threshold", float), ("notes", list)):
+            self.assertIn(key, data)
+            self.assertIsInstance(data[key], typ)
+        for key in ("score_layout", "score_ink", "score_overall"):
+            self.assertGreaterEqual(data[key], 0.0)
+            self.assertLessEqual(data[key], 1.0)
+
+    def test_fail_exit_1(self):
+        proc, data = self.run_cli(self.paths["source"], self.paths["blank"])
+        self.assertEqual(proc.returncode, 1)
+        self.assertFalse(data["pass"])
+        self.assertTrue(data["notes"], "failure must carry explanatory notes")
+
+    def test_deterministic_output(self):
+        out1 = os.path.join(self.dir, "det1.json")
+        out2 = os.path.join(self.dir, "det2.json")
+        self.run_cli(self.paths["source"], self.paths["recolored"], json_out=out1)
+        self.run_cli(self.paths["source"], self.paths["recolored"], json_out=out2)
+        with open(out1, "rb") as a, open(out2, "rb") as b:
+            self.assertEqual(a.read(), b.read())
+
+    def test_missing_input_exit_2(self):
+        proc, _ = self.run_cli(os.path.join(self.dir, "nope.png"),
+                               self.paths["source"])
+        self.assertEqual(proc.returncode, 2)
+        proc, _ = self.run_cli(self.paths["source"],
+                               os.path.join(self.dir, "nope.png"))
+        self.assertEqual(proc.returncode, 2)
+
+    def test_corrupt_input_exit_2(self):
+        proc, _ = self.run_cli(self.paths["source"], self.paths["corrupt"])
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("could not analyze", proc.stderr)
+
+    def test_missing_deps_exit_2_with_remediation(self):
+        shim = os.path.join(self.dir, "shim")
+        os.makedirs(shim, exist_ok=True)
+        for mod in ("PIL", "numpy"):
+            with open(os.path.join(shim, mod + ".py"), "w") as fh:
+                fh.write("raise ImportError('simulated missing %s')\n" % mod)
+        env = dict(os.environ)
+        env["PYTHONPATH"] = shim
+        proc, _ = self.run_cli(self.paths["source"], self.paths["identical"],
+                               env=env)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("pip install pillow numpy", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-anchors.rb
@@ -1,0 +1,483 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-anchors.rb — the MEASURED value bar for a converted workbook.
+#
+# WHY. Two field migrations recorded passing visual verdicts over dashboards
+# whose NUMBERS were wrong: a ranked list showed different members with 10x-off
+# values ("$1.8T" rendered where the source printed "18,037B"), and a
+# multi-bucket panel collapsed to a single bar. Every judgment gate is an
+# attestation, and lenient models attest generously — so this script replaces
+# the judgment with a MEASUREMENT: each printed value the agent transcribed
+# from the SOURCE dashboard image (Phase 1d, <workdir>/source-anchors.json)
+# must literally appear in the LIVE Sigma workbook's element CSV exports, at
+# the printed precision (scripts/lib/anchor_values.rb). An anchor value that
+# appears NOWHERE in the workbook exports is the loudest possible signal the
+# data is wrong.
+#
+# INPUT  <workdir>/source-anchors.json — authored by the AGENT at Phase 1d
+#        while reading the source dashboard PNG (schema: SKILL.md Phase 1d,
+#        refs/source-anchors.md):
+#          { "source_image": "views/<id>.png", "transcribed_at": "...",
+#            "anchors": [ { "id": "a1", "panel": "TOP COUNTRIES",
+#                           "label": "United States GDP", "raw": "18,037B",
+#                           "kind": "currency",
+#                           "sigma_element_hint": "Top Countries" } ] }
+# OUTPUT <workdir>/anchors-verdict.json:
+#          { "checked": N, "matched": M,
+#            "missing": [ { "id", "label", "raw", "best_candidate" } ],
+#            "pass": true|false }
+#        Also stamps an `anchors` summary into parity-final.json when present.
+#
+# HOW. Fetches the live workbook spec for element names, then pools element
+# CSV exports (the same POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download flow collect-parity-actuals.rb uses). Each anchor
+# is searched in the element whose name best matches its label/panel (token
+# overlap; `sigma_element_hint` wins when present); when the matched element
+# doesn't carry the value, every other export is searched before declaring the
+# anchor MISSING — found-elsewhere still counts as matched (the value exists;
+# only the label→element mapping was fuzzy) and is noted in the verdict.
+#
+# Usage (live):
+#   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+# Usage (offline — tests / pre-collected exports):
+#   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
+#     --exports-dir <dir-with-<elementId>.csv>
+#
+# Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
+# per-miss report names each, with its closest candidate); 2 = usage / missing
+# inputs.
+
+require 'json'
+require 'csv'
+require 'set'
+require 'optparse'
+require_relative 'lib/anchor_values'
+
+# ---------------------------------------------------------------------------
+# Pure core — unit-tested offline in test-verify-anchors.rb.
+# ---------------------------------------------------------------------------
+module AnchorVerify
+  STOPWORDS = %w[the a an of by per and or in on for to vs].freeze
+
+  module_function
+
+  def tokens(s)
+    s.to_s.downcase.scan(/[a-z0-9]+/) - STOPWORDS
+  end
+
+  # Overlap score between an anchor and an element name. sigma_element_hint,
+  # when present, is the only signal; otherwise panel+label tokens are used.
+  def element_score(anchor, el_name)
+    hint = anchor['sigma_element_hint'].to_s
+    name_toks = tokens(el_name)
+    return 0 if name_toks.empty?
+    if !hint.strip.empty?
+      return 1_000 if hint.strip.casecmp?(el_name.to_s.strip)
+      return (tokens(hint) & name_toks).length
+    end
+    ((tokens(anchor['panel']) | tokens(anchor['label'])) & name_toks).length
+  end
+
+  # Element names ordered best-match-first for this anchor; zero-score names
+  # are appended (search everywhere before declaring a value missing).
+  def ranked_elements(anchor, el_names)
+    scored = el_names.map { |n| [n, element_score(anchor, n)] }
+    hits = scored.select { |_, s| s.positive? }.sort_by { |n, s| [-s, n.to_s] }.map(&:first)
+    hits + (el_names - hits)
+  end
+
+  # Numeric face values of a CSV cell (both percent interpretations kept so
+  # AnchorValues candidate matching sees whichever the export carried).
+  def cell_numbers(cell)
+    s = cell.to_s
+    # Export bytes arrive as ASCII-8BIT off the HTTP body; a UTF-8 regexp match
+    # on that raises Encoding::CompatibilityError (live-caught). Normalize first.
+    s = s.dup.force_encoding(Encoding::UTF_8) unless s.encoding == Encoding::UTF_8
+    s = s.scrub('') unless s.valid_encoding?
+    s = s.strip
+    return [] if s.empty?
+    neg = s.start_with?('(') && s.end_with?(')')
+    s = s[1..-2] if neg
+    body = s.gsub(/[,$€£¥\s]/, '')
+    pct = body.end_with?('%')
+    body = body.chomp('%')
+    f = begin
+      Float(body)
+    rescue ArgumentError, TypeError
+      return []
+    end
+    f = -f if neg
+    pct ? [f, f / 100.0] : [f]
+  end
+
+  def rows_numbers(rows)
+    rows.flat_map { |r| Array(r).flat_map { |c| cell_numbers(c) } }
+  end
+
+  # Normalized text cells of an export (for kind:"text" roster anchors).
+  def rows_texts(rows)
+    # (map+compact, not filter_map — the skill's floor is the system Ruby 2.6)
+    rows.flat_map { |r| Array(r) }.map do |c|
+      s = c.to_s
+      s = s.dup.force_encoding(Encoding::UTF_8) unless s.encoding == Encoding::UTF_8
+      s = s.scrub('') unless s.valid_encoding?
+      s = s.strip.downcase
+      s.empty? ? nil : s
+    end.compact.to_set
+  end
+
+  # Verify anchors against { element_name => [[cell, ...], ...] } exports.
+  # Returns the verdict Hash (contract shape + per-anchor detail).
+  #
+  # Two anchor kinds:
+  #   numeric (default) — `raw` is a printed VALUE; matches any export cell at
+  #     printed precision.
+  #   kind: "text" (aka "roster") — `raw` is a LABEL that must appear as a cell
+  #     (case-insensitive, trimmed). Use these on ranked/top-N tiles so a
+  #     WRONGLY-SELECTED or dropped member fails loudly (a materialized top-15
+  #     built from the wrong rank, a renamed category, a missing path label).
+  #     Scope note: exports carry the element's full underlying data, so a
+  #     roster anchor canNOT catch an UNFILTERED tile that merely WINDOWS the
+  #     wrong first-N on screen — that class is caught by gate 9b (shape
+  #     identity: the reviewer sees the wrong columns) and by the render-bisect
+  #     playbook (unbounded pivots kill the renderer). Use both.
+  def verify(anchors, exports)
+    el_names = exports.keys
+    numbers = exports.transform_values { |rows| rows_numbers(rows) }
+    texts = exports.transform_values { |rows| rows_texts(rows) }
+    detail = []
+    missing = []
+    anchors.each do |a|
+      raw = a['raw'].to_s
+      order = ranked_elements(a, el_names)
+      if %w[text roster member].include?(a['kind'].to_s)
+        want = raw.strip.downcase
+        found_in = order.find { |n| texts[n].include?(want) }
+        if found_in
+          detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
+        else
+          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+        end
+        next
+      end
+      # A HINTED numeric anchor asserts WHERE its value must live. A match found
+      # only in a hint-UNRELATED element (e.g. a raw detail table that merely
+      # happens to contain the number) is NOT acceptance — that loophole silently
+      # passed 10x-unit and wrong-aggregate defects in field testing (a KPI whose
+      # value coincidentally appears in a big detail element). Restrict a hinted
+      # numeric anchor's search to hint-scored elements; found-only-outside is a
+      # MISS. Hint-less anchors keep the search-everywhere fallback (no asserted
+      # location to enforce); text/roster anchors are unchanged (a member label
+      # appearing anywhere is meaningful on its own).
+      search_order =
+        if a['sigma_element_hint'].to_s.strip.empty?
+          order
+        else
+          scoped = order.select { |n| element_score(a, n).positive? }
+          scoped.empty? ? order : scoped # defensive: hint matched no element name
+        end
+      found_in = search_order.find { |n| numbers[n].any? { |v| AnchorValues.match?(raw, v) } }
+      if found_in
+        primary = order.first
+        detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in,
+                    'note' => (found_in == primary ? nil : "found outside best-match element #{primary.inspect}") }.compact
+      else
+        # Closest candidate WITHIN the best-matching element that carries any
+        # numbers (walking down the ranking until one does) — the wrong value
+        # almost always lives in the anchor's own panel, so this surfaces the
+        # impostor ("$1.8T where the source printed 18,037B") rather than a
+        # coincidentally-near number from an unrelated tile.
+        best = nil
+        order.each do |n|
+          numbers[n].each do |v|
+            d = AnchorValues.relative_distance(raw, v)
+            best = { 'value' => v, 'element' => n, 'distance' => d.round(6) } if best.nil? || d < best['distance']
+          end
+          break if best
+        end
+        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                     'best_candidate' => best }
+      end
+    end
+    { 'checked' => anchors.length,
+      'matched' => anchors.length - missing.length,
+      'missing' => missing,
+      'pass' => missing.empty?,
+      'detail' => detail }
+  end
+end
+
+# ---------------------------------------------------------------------------
+# CLI (IO / REST) — thin wrapper around the pure core above.
+# ---------------------------------------------------------------------------
+return if $PROGRAM_NAME != __FILE__ && !ENV['VERIFY_ANCHORS_CLI'] # allow `require` in tests
+
+# Element display name for export keys. put-layout replaces `name` with a
+# visibility hash on hidden-title elements — every such element would
+# stringify to the SAME key and overwrite each other's exports (false RED on
+# any anchor living in the clobbered tile). Fall back to text, then the id
+# slug (unique by construction; token matching still ranks it).
+def el_display_name(el)
+  n = el['name']
+  return n.to_s unless n.is_a?(Hash)
+  t = n['text'].to_s
+  t.empty? ? el['id'].to_s.sub(/\Ael-/, '').tr('-', ' ') : t
+end
+
+opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+OptionParser.new do |p|
+  p.on('--workdir DIR')        { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
+  p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
+  p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
+end.parse!
+abort('--workdir required') unless opts[:dir]
+
+anchors_path = opts[:anchors] || File.join(opts[:dir], 'source-anchors.json')
+out_path     = opts[:out]     || File.join(opts[:dir], 'anchors-verdict.json')
+
+unless File.exist?(anchors_path)
+  warn "FATAL: #{anchors_path} not found — transcribe the source dashboard's printed values"
+  warn '       at Phase 1d (every KPI, top-3 of every ranked list/table, one bucket value per'
+  warn '       chart; EXACTLY as printed). Schema: SKILL.md Phase 1d / refs/source-anchors.md.'
+  exit 2
+end
+doc = begin
+  JSON.parse(File.read(anchors_path))
+rescue JSON::ParserError => e
+  warn "FATAL: #{anchors_path} is malformed JSON: #{e.message}"
+  exit 2
+end
+anchors = Array(doc['anchors'])
+if anchors.empty?
+  warn "FATAL: #{anchors_path} has no anchors[] — nothing to verify."
+  exit 2
+end
+# kind:"text"/"roster"/"member" anchors carry a LABEL in `raw` (displayed-set
+# membership for ranked tiles) — only NUMERIC anchors must parse as values.
+bad = anchors.reject do |a|
+  next false unless a.is_a?(Hash)
+  %w[text roster member].include?(a['kind'].to_s) ? !a['raw'].to_s.strip.empty? : AnchorValues.parse(a['raw'])
+end
+unless bad.empty?
+  warn "FATAL: #{bad.length} anchor(s) have an unparseable `raw` printed value:"
+  bad.first(10).each { |a| warn "         #{a.is_a?(Hash) ? a['id'] : '(bad entry)'}: raw=#{(a['raw'] rescue nil).inspect}" }
+  warn '       `raw` must be the value EXACTLY as printed on the source image ("18,037B", "-2%",'
+  warn '       "$733,215.26") — or, for kind:"text" roster anchors, a non-empty displayed label.'
+  exit 2
+end
+
+# --- element names + rows: offline (spec+exports dir) or live (REST) ---------
+exports = {} # element name => rows (arrays of cells)
+
+if opts[:exports]
+  spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
+  unless File.exist?(spec_path)
+    warn "FATAL: offline mode needs --workbook-spec (or <workdir>/wb-readback.json); #{spec_path} not found."
+    exit 2
+  end
+  spec = JSON.parse(File.read(spec_path))
+  elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  elements.each do |el|
+    csv = File.join(opts[:exports], "#{el['id']}.csv")
+    next unless File.exist?(csv)
+    exports[el_display_name(el)] = CSV.read(csv)
+  end
+else
+  # Live: resolve workbook id, GET the spec, pool the element CSV exports —
+  # the same export → poll → download flow collect-parity-actuals.rb uses.
+  wb = opts[:wb]
+  if wb.nil?
+    ids = File.join(opts[:dir], 'wb-ids.json')
+    wb = (JSON.parse(File.read(ids))['workbookId'] rescue nil) if File.exist?(ids)
+  end
+  abort('--workbook-id required (or a <workdir>/wb-ids.json with workbookId)') if wb.to_s.empty?
+
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
+  spec = begin
+    JSON.parse(body)
+  rescue JSON::ParserError, TypeError
+    require 'yaml'
+    require 'date'
+    body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
+  end
+  elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
+
+  # v5.4 PIVOT-TOTALS CEILING: a pivot carrying a `totals` key 500s its CSV
+  # export (probe-isolated: the key's PRESENCE is the sole trigger — value type
+  # irrelevant), so a totals-bearing pivot's anchor values would read as MISSING
+  # here through no fault of the data. Bracket the exports: capture + STRIP each
+  # pivot's totals (one PUT), export against totals-free pivots, then RESTORE the
+  # captured totals (ensure). Renders keep their hidden grand totals before and
+  # after — only the brief export window is totals-free. The shipped hide state
+  # is re-guaranteed by `put-layout.rb --apply-pivot-totals` at the finalize ship
+  # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
+  READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
+  put_spec = lambda do |s|
+    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
+  end
+  captured_totals = {}
+  queryable.each do |el|
+    next unless el['kind'] == 'pivot-table' && el.is_a?(Hash) && el.key?('totals')
+    captured_totals[el['id'].to_s] = el.delete('totals')
+  end
+  # v5.4.9 review fix: persist the captured totals to a *-pivot-totals.json
+  # sidecar BEFORE the strip PUT. If this process dies (or the restore PUT
+  # fails) between strip and restore, the finalize ship step (put-layout.rb
+  # --apply-pivot-totals, which globs the workdir) re-applies the FULL captured
+  # totals — including showSubtotals — instead of stamping the lossy
+  # showGrandTotals-only default. Deleted again after a successful restore.
+  totals_sidecar = File.join(opts[:dir], 'anchors-restore-pivot-totals.json')
+  if captured_totals.any?
+    begin
+      File.write(totals_sidecar, JSON.pretty_generate({ 'workbook' => wb, 'totals' => captured_totals }))
+    rescue StandardError => e
+      warn "  [WARN] could not write totals restore sidecar (#{e.class}: #{e.message.to_s[0, 80]})"
+    end
+  end
+
+  export_one = lambda do |el|
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return nil unless qid
+    t0 = Time.now
+    loop do
+      return nil if Time.now - t0 > opts[:timeout]
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        next if b.to_s.empty? # still rendering
+        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
+        return CSV.parse(b)
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
+      end
+    end
+  rescue Sigma::Error, CSV::MalformedCSVError => e
+    msg = e.message.lines.first.to_s.strip[0, 120]
+    ceiling = (el['kind'] == 'pivot-table' && e.is_a?(Sigma::Error) && msg =~ /\b500\b/) ?
+      ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
+      'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
+    warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
+    nil
+  end
+
+  require 'thread'
+  begin
+    # The strip PUT runs INSIDE this begin/ensure (v5.4.9 review fix): a
+    # network-level exception on the PUT (Net::ReadTimeout, Errno::ECONNRESET,
+    # SocketError — raised raw by Sigma.request, which only wraps HTTP-status
+    # failures in Sigma::Error) can fire AFTER the server applied the strip;
+    # previously it propagated before the restore bracket existed and left the
+    # live workbook totals-stripped (grand totals visible). Restoring when the
+    # strip never landed is an idempotent no-op PUT, so the ensure always
+    # attempts it.
+    if captured_totals.any?
+      begin
+        put_spec.call(spec)
+        warn "  [totals-ceiling] stripped grand-total key from #{captured_totals.size} pivot(s) for CSV export (restored after)"
+      rescue StandardError => e
+        warn "  [WARN] could not strip pivot totals (#{e.class}: #{e.message.lines.first.to_s.strip[0, 100]}) — " \
+             'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
+      end
+    end
+    queue = Queue.new
+    queryable.each { |el| queue << el }
+    mutex = Mutex.new
+    Array.new([opts[:pool], queryable.size].min.clamp(1, 8)) do
+      Thread.new do
+        loop do
+          el = begin
+            queue.pop(true)
+          rescue ThreadError
+            break
+          end
+          rows = export_one.call(el)
+          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+        end
+      end
+    end.each(&:join)
+  ensure
+    # Restore the grand-total keys stripped for the export window so renders
+    # (and the shipped workbook) keep hidden grand totals — even if the strip
+    # PUT or an export above raised (network-level errors included). On
+    # restore failure the sidecar written above survives, and the finalize
+    # ship step re-applies the FULL captured totals (incl. showSubtotals).
+    if captured_totals.any?
+      begin
+        elements.each { |el| (t = captured_totals[el['id'].to_s]) && el['totals'] = t }
+        put_spec.call(spec)
+        warn "  [totals-ceiling] restored grand-total key on #{captured_totals.size} pivot(s)"
+        begin
+          File.delete(totals_sidecar) if File.exist?(totals_sidecar)
+        rescue StandardError
+          nil # stale sidecar is harmless: it re-applies the same captured totals
+        end
+      rescue StandardError => e
+        warn "  [WARN] pivot totals RESTORE failed (#{e.class}: #{e.message.lines.first.to_s.strip[0, 100]}) — " \
+             "captured totals kept in #{File.basename(totals_sidecar)}; the finalize ship step " \
+             '(put-layout.rb --apply-pivot-totals) re-applies them, incl. showSubtotals'
+      end
+    end
+  end
+end
+
+if exports.empty?
+  warn 'FATAL: no element exports could be collected — cannot verify anchors.'
+  warn '       (live: check SIGMA_* credentials and the workbook id; offline: check --exports-dir)'
+  exit 2
+end
+
+verdict = AnchorVerify.verify(anchors, exports)
+verdict['source_anchors'] = anchors_path
+verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+File.write(out_path, JSON.pretty_generate(verdict))
+
+# Stamp the summary into parity-final.json when Phase 6 already finalized —
+# the anchors result travels with the parity verdict the final gate reads.
+pf = File.join(opts[:dir], 'parity-final.json')
+if File.exist?(pf)
+  begin
+    s = JSON.parse(File.read(pf))
+    s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
+                     'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    File.write(pf, JSON.pretty_generate(s))
+  rescue JSON::ParserError
+    warn "[WARN] #{pf} is malformed — anchors summary not stamped."
+  end
+end
+
+puts "verify-anchors: #{verdict['matched']}/#{verdict['checked']} anchor(s) matched " \
+     "across #{exports.length} element export(s) → #{out_path}"
+verdict['detail'].each do |d|
+  puts "  MATCHED  #{d['id']} #{d['raw'].inspect} in #{d['matched_in'].inspect}#{d['note'] ? " (#{d['note']})" : ''}"
+end
+if verdict['pass']
+  puts '[OK] every source anchor value is present in the live workbook exports.'
+  exit 0
+end
+warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+verdict['missing'].each do |m|
+  bc = m['best_candidate']
+  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+end
+warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+exit 1

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/visual-similarity.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/visual-similarity.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Deterministic visual-similarity floor for Phase 6 parity verification.
+
+Compares a source dashboard screenshot against a Sigma render and decides
+whether the render is structurally in the same universe as the source. This
+is a FLOOR, not a match-scorer: it exists so a passing "visual verdict" can
+never be recorded over a render that is structurally nothing like the source
+(blank/mostly-empty pages, one-bar-vs-six-bars panels, missing whole
+columns/sections, single-column stacks). It deliberately tolerates font,
+color, padding, spacing, and aspect-ratio differences, and even wholesale
+panel rearrangement, as long as the render carries a comparable amount of
+content distributed across the whole page.
+
+Contract (consumed by the Phase 6 gate):
+
+    python3 scripts/visual-similarity.py \
+        --source <src.png> --render <render.png> --json-out <out.json>
+
+Writes JSON: {"score_layout": float, "score_ink": float,
+              "score_overall": float, "pass": bool, "threshold": float,
+              "notes": [str, ...]}
+Exit codes: 0 = pass, 1 = fail, 2 = deps missing or unreadable input.
+Exit 2 must NEVER be treated as a pass.
+
+Method (fully deterministic — no randomness, no model calls):
+  1. Normalize: flatten alpha onto white, grayscale, downsample to <=384px.
+  2. Two binary "ink" maps per image: deviation from the page background
+     (histogram mode) and local gradient (catches light-on-light text).
+  3. Trim outer margins (capped at 12% per side, so real emptiness survives).
+  4. Signals, each in 0..1:
+       cov  - render edge-ink density as a fraction of the source's
+              (missing marks; asymmetric: extra ink is not penalized)
+       bal  - worst-band ink share ratio over row/column thirds
+              (an entire source-inked region empty in the render -> 0)
+       patt - Pearson correlation of 12x12 ink-density grids
+       prof - best of row/column 48-bin edge-ink profile correlations
+       asp  - soft penalty only for extreme aspect-ratio mismatch (>2.2x),
+              the page-geometry signature of a single-column stack
+  5. score_ink = cov;  score_layout = (0.46*bal + 0.06*patt + 0.06*prof)/0.58
+     score_overall = asp * (0.42*score_ink + 0.58*score_layout)
+     pass = score_overall >= 0.45  AND  score_ink >= 0.40  AND  bal >= 0.10
+
+Threshold provenance: calibrated on 20 verified-faithful migration pairs
+from the skills-test corpus plus 17 failure-mode negatives (1 real failed
+field migration + synthesized blank / half-empty / quarter-content /
+single-column-stack pages). Do NOT tune the threshold to make a failing
+render pass — a failure means STRUCTURE diverges; re-run the RCF loop.
+
+# ---------------------------------------------------------------------------
+# CALIBRATION SUMMARY (2026-07: 20 positives, 17 negatives; threshold 0.45)
+# All positives >= threshold + 0.05; all negatives <= threshold - 0.05.
+#
+# POSITIVES (must pass)            overall   NEGATIVES (must fail)      overall
+#   call-center                      0.780     field-failure (1-bar-vs-6) 0.311
+#   dynamic-zoning-kpi               0.702     blank-page x4              0.000
+#   ecommerce-admin                  0.534     single-column-stack x4  <= 0.001
+#   er-visits                        0.872     half-page-empty x4      <= 0.343
+#   social-media-campaign            0.692     quarter-content x4      <= 0.199
+#   supermart-sales                  0.554
+#   superstore-perf-overview         0.731   min positive 0.534 (+0.084)
+#   superstore-perf-order-detail     0.834   max negative 0.343 (-0.107)
+#   superstore-viz-extensions        0.629
+#   udemy-course-analysis            0.774   Sub-floors also verified:
+#   visual-vocabulary x10 pages   >= 0.553     min positive cov 0.506
+#                                              (ink floor 0.40, +0.106)
+#                                              min positive bal 0.234
+#                                              (bal floor 0.10, +0.134)
+# ---------------------------------------------------------------------------
+"""
+
+import argparse
+import json
+import os
+import sys
+
+REMEDIATION = (
+    "visual-similarity.py requires Pillow and numpy. "
+    "Install with: pip install pillow numpy"
+)
+
+try:
+    import numpy as np
+    from PIL import Image
+except ImportError:
+    sys.stderr.write(REMEDIATION + "\n")
+    sys.exit(2)
+
+# --- tunables (calibrated; see module docstring — do not tune per-run) ------
+WORK = 384          # max working dimension after downsample
+COARSE = 12         # coarse occupancy/pattern grid
+FINE = 48           # fine profile grid
+TRIM_CAP = 0.12     # max fraction of each side trimmed as outer margin
+LUM_DELTA = 24      # luminance deviation from page background counted as ink
+EDGE_DELTA = 20     # local gradient magnitude counted as edge ink
+BAND_N = 3          # row/column bands for the balance signal
+BAND_MIN_SHARE = 0.05   # source band must hold >=5% of ink to be scored
+ASPECT_SOFT = 2.2   # aspect-ratio mismatch tolerated up to this factor
+ASPECT_RAMP = 1.8   # penalty ramp width beyond ASPECT_SOFT
+
+W_INK = 0.42
+W_BAL = 0.46
+W_PATT = 0.06
+W_PROF = 0.06
+W_LAYOUT = W_BAL + W_PATT + W_PROF   # 0.58
+
+THRESHOLD = 0.45
+INK_FLOOR = 0.40    # hard sub-floor on score_ink (mark coverage)
+BAL_FLOOR = 0.10    # hard sub-floor on band balance
+
+
+def _load_gray(path):
+    """Return (grayscale float array downsampled to <=WORK, aspect ratio)."""
+    im = Image.open(path)
+    im.load()
+    if im.mode in ("RGBA", "LA") or (im.mode == "P" and "transparency" in im.info):
+        rgba = im.convert("RGBA")
+        flat = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+        im = Image.alpha_composite(flat, rgba)
+    im = im.convert("L")
+    w, h = im.size
+    if w < 4 or h < 4:
+        raise ValueError("image too small to analyze (%dx%d)" % (w, h))
+    aspect = w / h
+    scale = WORK / max(w, h)
+    if scale < 1:
+        im = im.resize(
+            (max(1, round(w * scale)), max(1, round(h * scale))), Image.BILINEAR
+        )
+    return np.asarray(im, dtype=np.float32), aspect
+
+
+def _ink_maps(gray):
+    """Return (combined ink map, edge-only ink map) as float 0/1 arrays."""
+    # explicit float64 edges: np.histogram(x, bins=16, range=(0,256)) hits a
+    # broadcast regression on numpy 2.2.x with real image arrays (A/B-report
+    # reproduced; fine on 2.3+). Edges are version-robust on both.
+    hist, edges = np.histogram(np.asarray(gray, dtype=np.float64).ravel(),
+                               bins=np.linspace(0.0, 256.0, 17))
+    mode = int(np.argmax(hist))
+    background = (edges[mode] + edges[mode + 1]) / 2.0
+    deviation = np.abs(gray - background) > LUM_DELTA
+    gx = np.abs(np.diff(gray, axis=1, prepend=gray[:, :1]))
+    gy = np.abs(np.diff(gray, axis=0, prepend=gray[:1, :]))
+    edge = (gx + gy) > EDGE_DELTA
+    return (deviation | edge).astype(np.float32), edge.astype(np.float32)
+
+
+def _capped_trim(ink, edge):
+    """Trim near-empty outer margins, at most TRIM_CAP per side.
+
+    The cap matters: it normalizes letterboxing/browser chrome without
+    letting a half-empty page crop itself back into looking complete.
+    """
+    h, w = ink.shape
+    rows = ink.sum(axis=1)
+    cols = ink.sum(axis=0)
+    rnz = np.nonzero(rows > w * 0.005)[0]
+    cnz = np.nonzero(cols > h * 0.005)[0]
+    if len(rnz) == 0 or len(cnz) == 0:
+        return ink, edge
+    r0 = min(int(rnz[0]), int(h * TRIM_CAP))
+    r1 = max(int(rnz[-1]) + 1, h - int(h * TRIM_CAP))
+    c0 = min(int(cnz[0]), int(w * TRIM_CAP))
+    c1 = max(int(cnz[-1]) + 1, w - int(w * TRIM_CAP))
+    return ink[r0:r1, c0:c1], edge[r0:r1, c0:c1]
+
+
+def _grid(m, n):
+    """Reduce a 2-D map to an n x n grid of cell means (stretch-normalized)."""
+    h, w = m.shape
+    ys = np.linspace(0, h, n + 1).astype(int)
+    xs = np.linspace(0, w, n + 1).astype(int)
+    out = np.zeros((n, n), dtype=np.float64)
+    for i in range(n):
+        for j in range(n):
+            cell = m[ys[i]:ys[i + 1], xs[j]:xs[j + 1]]
+            if cell.size:
+                out[i, j] = float(cell.mean())
+    return out
+
+
+def _corr(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    if a.std() < 1e-9 or b.std() < 1e-9:
+        return 0.0
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def _band_shares(ink, n=BAND_N):
+    """Fraction of total ink in each of n row bands and n column bands."""
+    h, w = ink.shape
+    total = float(ink.sum()) or 1.0
+    shares = []
+    for i in range(n):
+        shares.append(float(ink[i * h // n:(i + 1) * h // n, :].sum()) / total)
+    for j in range(n):
+        shares.append(float(ink[:, j * w // n:(j + 1) * w // n].sum()) / total)
+    return shares
+
+
+def _band_balance(src_map, ren_map):
+    """Worst-case render/source ink-share ratio over row+column bands."""
+    src_shares = _band_shares(src_map)
+    ren_shares = _band_shares(ren_map)
+    worst = 1.0
+    for s, r in zip(src_shares, ren_shares):
+        if s > BAND_MIN_SHARE:
+            worst = min(worst, min(1.0, r / s))
+    return worst
+
+
+def compare(source_path, render_path):
+    """Compute the similarity-floor verdict for one source/render pair."""
+    gray_s, aspect_s = _load_gray(source_path)
+    gray_r, aspect_r = _load_gray(render_path)
+    ink_s, edge_s = _ink_maps(gray_s)
+    ink_r, edge_r = _ink_maps(gray_r)
+    ink_s, edge_s = _capped_trim(ink_s, edge_s)
+    ink_r, edge_r = _capped_trim(ink_r, edge_r)
+
+    notes = []
+
+    # -- ink coverage (asymmetric: only missing marks are penalized) --------
+    dens_s = float(edge_s.mean())
+    dens_r = float(edge_r.mean())
+    if dens_s > 1e-6:
+        cov = min(1.0, dens_r / dens_s)
+    else:
+        cov = 1.0 if dens_r <= 1e-6 else 0.0
+        notes.append("source appears blank — verify the source export")
+
+    # -- band balance: is any whole page region emptied out? ----------------
+    bal = min(_band_balance(ink_s, ink_r), _band_balance(edge_s, edge_r))
+
+    # -- structure agreement -------------------------------------------------
+    coarse_s, coarse_r = _grid(ink_s, COARSE), _grid(ink_r, COARSE)
+    fine_s, fine_r = _grid(edge_s, FINE), _grid(edge_r, FINE)
+    patt = max(0.0, _corr(coarse_s, coarse_r))
+    prof = max(
+        max(0.0, _corr(fine_s.sum(axis=1), fine_r.sum(axis=1))),
+        max(0.0, _corr(fine_s.sum(axis=0), fine_r.sum(axis=0))),
+    )
+
+    # -- aspect-ratio sanity (single-column-stack page geometry) ------------
+    ratio = max(aspect_s, aspect_r) / min(aspect_s, aspect_r)
+    if ratio <= ASPECT_SOFT:
+        asp = 1.0
+    else:
+        asp = max(0.0, 1.0 - (ratio - ASPECT_SOFT) / ASPECT_RAMP)
+        notes.append(
+            "extreme aspect-ratio mismatch (x%.1f): render page geometry "
+            "suggests content collapsed into a single column" % ratio
+        )
+
+    score_ink = round(cov, 4)
+    score_layout = round((W_BAL * bal + W_PATT * patt + W_PROF * prof) / W_LAYOUT, 4)
+    score_overall = round(asp * (W_INK * score_ink + W_LAYOUT * score_layout), 4)
+
+    passed = score_overall >= THRESHOLD
+    if score_ink < INK_FLOOR:
+        passed = False
+        notes.append(
+            "render draws only %.0f%% of the source's mark density "
+            "(floor %.0f%%): charts/text are likely missing or degenerate"
+            % (score_ink * 100, INK_FLOOR * 100)
+        )
+    if bal < BAL_FLOOR:
+        passed = False
+        notes.append(
+            "band balance %.2f (floor %.2f): a page region that holds "
+            "content in the source is (near-)empty in the render" % (bal, BAL_FLOOR)
+        )
+    if not passed and score_overall < THRESHOLD:
+        notes.append(
+            "overall %.3f below threshold %.2f: render structure diverges "
+            "from the source — re-run the RCF loop; do not tune the threshold"
+            % (score_overall, THRESHOLD)
+        )
+
+    return {
+        "score_layout": score_layout,
+        "score_ink": score_ink,
+        "score_overall": score_overall,
+        "pass": passed,
+        "threshold": THRESHOLD,
+        "notes": notes,
+        "components": {
+            "coverage": round(cov, 4),
+            "band_balance": round(bal, 4),
+            "pattern_corr": round(patt, 4),
+            "profile_corr": round(prof, 4),
+            "aspect_factor": round(asp, 4),
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Deterministic visual-similarity floor (source vs render)."
+    )
+    parser.add_argument("--source", required=True, help="source dashboard PNG")
+    parser.add_argument("--render", required=True, help="Sigma render PNG")
+    parser.add_argument("--json-out", required=True, help="verdict JSON path")
+    args = parser.parse_args(argv)
+
+    for label, path in (("source", args.source), ("render", args.render)):
+        if not os.path.isfile(path):
+            sys.stderr.write("%s image not found: %s\n" % (label, path))
+            return 2
+
+    try:
+        result = compare(args.source, args.render)
+    except Exception as exc:  # unreadable/corrupt input — never a pass
+        sys.stderr.write("could not analyze images: %s\n" % exc)
+        return 2
+
+    out_dir = os.path.dirname(os.path.abspath(args.json_out))
+    os.makedirs(out_dir, exist_ok=True)
+    with open(args.json_out, "w") as fh:
+        json.dump(result, fh, indent=2)
+        fh.write("\n")
+
+    verdict = "PASS" if result["pass"] else "FAIL"
+    print(
+        "visual-similarity: %s  overall=%.3f (threshold %.2f)  "
+        "ink=%.3f layout=%.3f"
+        % (
+            verdict,
+            result["score_overall"],
+            result["threshold"],
+            result["score_ink"],
+            result["score_layout"],
+        )
+    )
+    for note in result["notes"]:
+        print("  note: %s" % note)
+    return 0 if result["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/source-anchors.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/source-anchors.md
@@ -1,0 +1,163 @@
+# Source-value anchors — the measured value bar
+
+## Why this exists
+
+Two field migrations shipped dashboards whose **numbers were wrong** while every
+judgment gate recorded "pass":
+
+1. **The 10x/ranking failure.** A "top members" ranked panel showed *different
+   members* with values ~10x off — the migrated dashboard rendered **"$1.8T"**
+   where the source printed **"18,037B"** (≈ $18.0T). A multi-region YoY panel
+   collapsed to **one bar where the source showed six**, and a trend line
+   crashed to zero on a partial final period. The run followed the pipeline,
+   executed a real 3-pass RCF loop *reading* the render PNGs — and still
+   recorded `--verdict pass`.
+2. **The waiver-stacking failure.** A second workbook "passed" by combining
+   `--skip-parity-gate` with `--allow-missing-tiles 6`, discovered by grepping
+   `--help` for skip flags. Nothing measured the values; every gate that could
+   have was waived.
+
+The lesson: **every judgment gate is an attestation, and lenient models attest
+generously.** Visual verdicts, RCF scoring, and parity waivers are all places
+where "looks right" substitutes for "is right." Anchors replace that judgment
+with a **measurement**: printed values transcribed from the source image either
+appear in the live workbook's exports at the printed precision, or they don't.
+
+A printed source value that appears **nowhere** in the workbook exports is the
+loudest possible signal the data is wrong — wrong unit (10x), wrong aggregate,
+missing filter, collapsed buckets, or the wrong column entirely.
+
+## The contract
+
+### `source-anchors.json` — authored BY THE AGENT at Phase 1d
+
+Written **while reading the source dashboard PNG** (the same read that produces
+`png-read.json`). Never generated from CSVs — the whole point is transcribing
+what the source *renders*.
+
+```json
+{
+  "source_image": "views/<dashboardViewId>.png",
+  "transcribed_at": "2026-07-08T12:00:00Z",
+  "anchors": [
+    { "id": "a1",
+      "panel": "TOP COUNTRIES",
+      "label": "United States GDP",
+      "raw": "18,037B",
+      "kind": "currency",
+      "sigma_element_hint": "Top Countries" }
+  ]
+}
+```
+
+- `raw` — the value **EXACTLY as printed**. Keep the raw string: `"18,037B"`,
+  never `18037`; `"(12.3%)"`, never `-0.123`; `"$733,215.26"` with the `$` and
+  commas. The printed form *is* the precision contract.
+- `kind` — `currency` | `number` | `percent` | **`text`** (alias `roster`/`member`).
+  A `text` anchor's `raw` is a **displayed LABEL** (case-insensitive cell match),
+  not a value — use it for ranked/top-N tiles so a wrongly-selected or dropped
+  member fails loudly (a top-15 materialized from the wrong rank, a renamed
+  category, a missing path label). Scope: exports carry the element's full
+  underlying data, so `text` anchors can't catch an UNFILTERED tile that merely
+  windows the wrong first-N on screen — gate 9b (shape identity) owns that class.
+- `sigma_element_hint` — optional; the Sigma element name the value should land
+  in. When present it wins over fuzzy matching.
+- **Minimum anchors (the gate requires ≥ 5):** every KPI value, the **top 3
+  values of every ranked list/table**, **one representative bucket value
+  per chart**, and — for every ranked/top-N tile — **2–3 `text` roster anchors**
+  naming members the source actually displays (include at least one from the
+  BOTTOM half of the list: top members often survive a wrong ranking, bottom
+  members don't). Top-of-ranked-list anchors are what catch the
+  different-members-with-different-values failure.
+
+### `anchors-verdict.json` — written by `scripts/verify-anchors.rb`
+
+```json
+{ "checked": 9, "matched": 8,
+  "missing": [ { "id": "a1", "label": "United States GDP", "raw": "18,037B",
+                 "best_candidate": { "value": 1.8e12, "element": "Top Countries" } } ],
+  "pass": false }
+```
+
+`verify-anchors.rb --workdir <W> --workbook-id <id>` pools the live workbook's
+element CSV exports (the same export→poll→download flow
+`collect-parity-actuals.rb` uses), searches each anchor in the element whose
+name best matches its label/panel (token overlap; the hint wins), then searches
+every other export before declaring a miss. Found-elsewhere still matches (the
+value exists; only the label→element mapping was fuzzy) and is noted. It also
+stamps an `anchors` summary into `parity-final.json` when present. Exit 0 all
+matched / 1 with a per-miss report naming each miss and its closest candidate.
+
+## Canonicalization rules (`scripts/lib/anchor_values.rb`)
+
+**Match rule:** a printed value MATCHES a real number when the real number
+**rounds to the printed form at the printed precision** — i.e.
+`|actual − printed| ≤ half of the last printed digit's place value`, scaled by
+any suffix.
+
+| Printed | Canonical value | Tolerance | Notes |
+|---|---|---|---|
+| `18,037B` | 1.8037e13 | ±0.5e9 | last digit = units of B |
+| `$1.8T` | 1.8e12 | ±0.05e12 | currency; one decimal of T |
+| `46.5M` | 4.65e7 | ±0.05e6 | |
+| `-2%` | −2 points | ±0.5 | also matches the fraction −0.02 ± 0.005 |
+| `1,687` | 1687 | ±0.5 | |
+| `$733,215.26` | 733215.26 | ±0.005 | cents precision |
+| `(12.3%)` | −12.3 points | ±0.05 | accounting-paren negative |
+| `12.3k` | 12300 | ±50 | lowercase suffixes accepted |
+
+Extra interpretations checked (they never weaken 10x detection):
+
+- Suffixed forms also match the **unscaled face value** (`18,037B` ↔ a column
+  already denominated in billions storing `18037`).
+- Percents match both **points** (−2) and **fraction** (−0.02) storage.
+
+So `1.8e12` does **not** match `18,037B` under any interpretation — the exact
+field failure — while `18,036,800,000,000` (rounds to 18,037B) does.
+
+## Worked example
+
+Source image shows a KPI `$86.5T`, a TOP COUNTRIES list headed by
+`United States 18,037B`, `China 13,608B`, `Japan 4,971B`, and a YoY panel with
+`-2%` on one bucket:
+
+```json
+{ "source_image": "views/abc123.png", "transcribed_at": "2026-07-08T15:04:00Z",
+  "anchors": [
+    { "id": "a1", "panel": "KPI",           "label": "World GDP total", "raw": "$86.5T",  "kind": "currency" },
+    { "id": "a2", "panel": "TOP COUNTRIES", "label": "United States",   "raw": "18,037B", "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a3", "panel": "TOP COUNTRIES", "label": "China",           "raw": "13,608B", "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a4", "panel": "TOP COUNTRIES", "label": "Japan",           "raw": "4,971B",  "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a5", "panel": "YOY BY REGION", "label": "largest decline bucket", "raw": "-2%", "kind": "percent" }
+  ] }
+```
+
+If the built workbook's Top Countries element exports `1.8e12` for the top row,
+`verify-anchors.rb` reports:
+
+```
+MISSING  a2 "United States" raw="18,037B" — closest candidate 1.8e12 in "Top Countries"
+```
+
+— the 10x failure caught mechanically, before any visual verdict is consulted.
+
+## Gate wiring (`assert-phase6-ran.rb`)
+
+- **Gate 13 (exit 18):** whenever the workdir carries a source dashboard PNG
+  (the Phase 1d artifact — `png-read.json` `source_png`, `views/*.png`, or
+  `dashboards/*.png`), `source-anchors.json` must exist with ≥ 5 anchors AND
+  `anchors-verdict.json` must pass with every anchor checked (a stale verdict —
+  fewer checked than transcribed — fails). No source PNG → stated SKIP.
+  Escape: `--skip-anchors-gate "<reason>"` (counted against the waiver budget).
+- **Conditional `--skip-parity-gate` (exit 18):** waiving source parity is
+  REJECTED unless `anchors-verdict.json` exists and passes. The anchors oracle
+  replaces parity — never nothing. This is the no-standalone-views path's
+  contract too: parity oracle = anchors + warehouse (`verify-warehouse.rb`).
+- **Data-class RCF residuals (exit 15):** any unresolved `data`-class entry in
+  `fidelity-ledger.json` blocks GREEN whenever the ledger exists —
+  `--accept-residuals` does not apply. The numbers are wrong; fix or reclassify
+  with evidence.
+- **Waiver budget (exit 19):** more than 2 quality waivers → GREEN unavailable
+  (YELLOW cap). Anchors and similarity skips count; `--skip-telemetry-gate`
+  (policy) and the sanctioned builder→verifier `--skip-visual-comparison`
+  handoff do not.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/visual-similarity.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/visual-similarity.md
@@ -1,0 +1,82 @@
+# Visual-similarity floor — the deterministic gate under the visual verdict
+
+`scripts/visual-similarity.py` is a deterministic sanity floor that runs before any
+model-judged visual verdict counts. Its job is narrow: make it **impossible to record a
+passing visual verdict over a render that is structurally nothing like the source**. It is
+NOT a match-scorer and it does not measure migration quality — the RCF loop
+(`refs/phase-5g-rcf.md`, `refs/fidelity-rubric.md`) and Phase 6 parity own that. A floor
+pass means only "these two images are plausibly the same dashboard"; the real visual QA
+still happens on top of it.
+
+## Contract
+
+```
+python3 scripts/visual-similarity.py --source <src.png> --render <render.png> --json-out <out.json>
+```
+
+Exit codes: `0` = pass, `1` = fail, `2` = dependencies missing or input unreadable.
+**Exit 2 is never a pass** — treat it as a blocked gate: fix the environment
+(`pip install pillow numpy`) or re-export the image, then re-run. The gate wiring must
+propagate 2 as a hard stop, not fall through to the model verdict.
+
+JSON written to `--json-out`:
+
+| field           | meaning                                                                 |
+|-----------------|-------------------------------------------------------------------------|
+| `score_ink`     | 0–1. Render mark density (edges: text, bars, lines) as a fraction of the source's. Asymmetric — extra ink is never penalized; missing ink is. |
+| `score_layout`  | 0–1. Spatial distribution agreement: worst-band ink balance over row/column thirds (dominant term), plus coarse ink-pattern and row/column profile correlations. |
+| `score_overall` | 0–1. `aspect_factor * (0.42*score_ink + 0.58*score_layout)`.            |
+| `threshold`     | The calibrated pass line for `score_overall` (currently **0.45**).      |
+| `pass`          | `score_overall >= threshold` AND `score_ink >= 0.40` AND band balance `>= 0.10`. The two sub-floors catch sparse-marks and emptied-region failures even when the blend stays high. |
+| `notes`         | Human-readable reasons for any failure or anomaly (blank source, aspect mismatch, tripped sub-floor). |
+| `components`    | Diagnostic sub-signals (coverage, band_balance, pattern_corr, profile_corr, aspect_factor). |
+
+The comparison is fully deterministic: same two files in → byte-identical JSON out. No
+randomness, no model calls, no network.
+
+## What the floor catches
+
+- **Blank / mostly-empty pages** — render draws little or none of the source's ink.
+- **One-bar-vs-six-bars panels** — panel chrome survives but the marks are gone
+  (`score_ink` sub-floor at 0.40).
+- **Missing whole columns / sections / tables** — a page region that holds content in the
+  source is near-empty in the render (band-balance sub-floor at 0.10).
+- **Single-column stacks** — a grid dashboard collapsed into one long column; the page's
+  extreme aspect-ratio mismatch (>2.2x) zeroes the score.
+
+## What the floor deliberately tolerates
+
+Different fonts, colors, themes, padding, spacing, and margins; different aspect ratios
+(landscape source → longer Sigma page is normal); moderate panel rearrangement and re-flow
+(verified-faithful migrations in the calibration set include a 2x3 grid re-flowed to 4x3
+and landscape→portrait re-stacks — all pass with margin). If a render passes the floor but
+looks off, that is exactly what the RCF rubric is for.
+
+## Threshold provenance — do not tune it
+
+Threshold 0.45 and the sub-floors were calibrated on **20 verified-faithful migration
+pairs** (real Tableau dashboard exports vs their accepted Sigma renders, spanning dense
+KPI dashboards, app-style layouts, dark themes, text-heavy pages, and 10 chart-gallery
+pages) plus **17 failure-mode negatives** (1 real failed field migration with 1-bar-vs-6
+panels and whitespace, plus synthesized blank-page, half-page-empty, quarter-content, and
+single-column-stack renders). Every positive clears the threshold by ≥ 0.08 and every
+negative misses it by ≥ 0.10; the sub-floors clear their nearest positive by ≥ 0.10. The
+per-pair table is embedded as a comment block in `scripts/visual-similarity.py`.
+
+**If the floor fails, the render's STRUCTURE diverges from the source.** The fix is always
+in the workbook: re-run the RCF loop, restore the missing sections/marks, and re-render.
+Never raise `--threshold`-style knobs, edit the constants, or re-crop the screenshots to
+squeeze a failing render through — a tuned floor is worse than no floor, because it
+launders a broken render into a recorded visual pass.
+
+## Dependencies
+
+Pillow + numpy only (no OpenCV/scikit). If either is missing the script prints
+`pip install pillow numpy` and exits 2. Runtime is well under a second per pair.
+
+## Tests
+
+`python3 scripts/test_visual_similarity.py` — offline synthetic-fixture suite covering the
+scoring behaviors (identical ≈ 1.0, recolored/shifted copy passes, blank / half-empty /
+sparse / stacked renders fail) and the full CLI exit-code contract, including a
+missing-dependency simulation.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/anchor_values.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/anchor_values.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+#
+# anchor_values.rb — PURE canonicalization of printed dashboard values.
+#
+# WHY. Two field migrations shipped dashboards whose NUMBERS were wrong while
+# every judgment gate recorded "pass": a ranked list showed different members
+# with 10x-off values ("$1.8T" where the source printed "18,037B"), and panels
+# collapsed to a fraction of the source's buckets. The fix is a MEASURED value
+# bar: the agent transcribes the source's printed values EXACTLY as printed
+# (Phase 1d, source-anchors.json), and verify-anchors.rb checks each printed
+# value against the live workbook's element CSV exports. This module is the
+# arithmetic core of that check: it parses a printed form ("18,037B", "$1.8T",
+# "-2%", "(12.3%)", "$733,215.26", "12.3k") into a (value, precision) pair and
+# decides whether a real number could have RENDERED as that printed form.
+#
+# MATCH RULE. A printed value MATCHES a real number when the real number rounds
+# to the printed form at the printed precision — i.e. |actual - printed_value|
+# <= half of the last printed digit's place value (scaled by any K/M/B/T
+# suffix). "18,037B" therefore matches any real in [18,036.5B, 18,037.5B]
+# (tolerance ±0.5e9), and 1.8e12 ("$1.8T") is a loud 10x MISS.
+#
+# CANDIDATE INTERPRETATIONS (all checked by match?):
+#   - suffixed values ("18,037B") also match the UNSCALED face value (18037)
+#     because some warehouses store the column already in that display unit;
+#   - percents ("-2%") match both percent POINTS (-2) and the FRACTION (-0.02).
+# Neither weakens the 10x/regrouping detection — the wrong values seen in the
+# field match none of the interpretations.
+#
+# Pure, stdlib-only, no IO. Unit tests: scripts/test-anchor-values.rb.
+
+module AnchorValues
+  KINDS = %w[currency number percent].freeze
+
+  SUFFIXES = {
+    'k' => 1e3, 'm' => 1e6, 'b' => 1e9, 't' => 1e12
+  }.freeze
+
+  CURRENCY_SYMBOLS = %w[$ € £ ¥].freeze
+
+  module_function
+
+  # Parse a printed form into its PRIMARY canonical interpretation.
+  # Returns { value: Float, tol: Float, kind: 'currency'|'number'|'percent',
+  #           negative: Boolean } or nil when the string is not a printed number.
+  # For percents the primary value is in percent POINTS ("-2%" → -2.0 ± 0.5);
+  # candidates() adds the fraction form.
+  def parse(raw)
+    s = raw.to_s.strip
+    return nil if s.empty?
+
+    negative = false
+    # Accounting-style parenthesized negative: "(12.3%)", "($4,120)".
+    if s.start_with?('(') && s.end_with?(')')
+      negative = true
+      s = s[1..-2].to_s.strip
+    end
+    # Leading minus (ASCII or unicode), possibly before OR after a currency symbol.
+    if s.start_with?('-', '−', '–')
+      negative = true
+      s = s[1..].to_s.strip
+    end
+
+    kind = 'number'
+    if CURRENCY_SYMBOLS.include?(s[0])
+      kind = 'currency'
+      s = s[1..].to_s.strip
+      if s.start_with?('-', '−', '–') # "$-12.4"
+        negative = true
+        s = s[1..].to_s.strip
+      end
+    end
+
+    percent = false
+    if s.end_with?('%')
+      percent = true
+      kind = 'percent'
+      s = s[0..-2].to_s.strip
+    end
+
+    multiplier = 1.0
+    if !percent && s =~ /\A(.*?)\s*([kKmMbBtT])\z/ && !Regexp.last_match(1).to_s.strip.empty?
+      body = Regexp.last_match(1).strip
+      suf  = Regexp.last_match(2).downcase
+      multiplier = SUFFIXES[suf]
+      s = body
+    end
+
+    digits = s.delete(',')
+    return nil unless digits =~ /\A(?:\d+(?:\.\d+)?|\.\d+)\z/
+
+    decimals = digits.include?('.') ? digits.split('.', 2)[1].length : 0
+    face = Float(digits)
+    step = 10.0**-decimals
+    value = face * multiplier
+    value = -value if negative
+    { value: value, tol: (step / 2.0) * multiplier, kind: kind, negative: negative }
+  end
+
+  # All acceptable (value, tol) interpretations of a printed form, primary first.
+  # Returns an Array of [value, tol] pairs, or [] when unparseable.
+  def candidates(raw)
+    p = parse(raw)
+    return [] if p.nil?
+    out = [[p[:value], p[:tol]]]
+    if p[:kind] == 'percent'
+      # Fraction form: exports often carry 0.02 where the dashboard prints "2%".
+      out << [p[:value] / 100.0, p[:tol] / 100.0]
+    else
+      # Unscaled face value for suffixed forms ("18,037B" ↔ a column already
+      # denominated in billions). Only differs when a suffix was present.
+      pr = parse(strip_suffix(raw))
+      out << [pr[:value], pr[:tol]] if pr && (pr[:value] - p[:value]).abs > Float::EPSILON
+    end
+    out
+  end
+
+  # Does a real number match the printed form? (See MATCH RULE above.)
+  def match?(raw, actual)
+    return false if actual.nil?
+    a = begin
+      Float(actual)
+    rescue ArgumentError, TypeError
+      return false
+    end
+    candidates(raw).any? do |value, tol|
+      (a - value).abs <= tol + (1e-9 * [value.abs, 1.0].max)
+    end
+  end
+
+  # The schema `kind` of a printed form ('currency'|'number'|'percent'), or nil.
+  def kind(raw)
+    p = parse(raw)
+    p && p[:kind]
+  end
+
+  # Relative distance between a real number and the printed form's primary
+  # value — used to rank "closest miss" candidates in reports. Float::INFINITY
+  # when the form is unparseable.
+  def relative_distance(raw, actual)
+    p = parse(raw)
+    return Float::INFINITY if p.nil? || actual.nil?
+    a = begin
+      Float(actual)
+    rescue ArgumentError, TypeError
+      return Float::INFINITY
+    end
+    # Best (smallest) distance across all interpretations, so a fraction-form
+    # percent ranks as close as its points form.
+    candidates(raw).map { |v, _| (a - v).abs / [v.abs, 1e-9].max }.min
+  end
+
+  # Remove a trailing K/M/B/T suffix (keeps sign/currency/percent decorations).
+  def strip_suffix(raw)
+    raw.to_s.sub(/\s*[kKmMbBtT](\)?)\z/, '\1')
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-anchors.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Tests for scripts/verify-anchors.rb — the measured value bar.
+#
+#   1. Pure core (AnchorVerify): label→element fuzzy match by token overlap,
+#      sigma_element_hint priority, found-elsewhere-still-matches, missing
+#      anchors carry a best_candidate, cell parsing ($/,/%/parens).
+#   2. CLI offline mode (--workbook-spec + --exports-dir): verdict file shape
+#      (checked/matched/missing/pass), exit codes (0 all matched / 1 miss /
+#      2 usage), and the parity-final.json `anchors` stamp.
+#
+# Offline, no network. Usage: ruby scripts/test-verify-anchors.rb
+
+require 'json'
+require 'csv'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+ENV['VERIFY_ANCHORS_CLI'] = nil
+require_relative 'verify-anchors' # loads AnchorVerify (CLI guarded out)
+
+SCRIPT = File.join(__dir__, 'verify-anchors.rb')
+
+$fails = []
+def ok(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '-- pure core: element ranking --'
+els = ['Top Countries', 'GDP Trend', 'YoY Growth by Region', 'KPI Row']
+a_label = { 'id' => 'a1', 'panel' => 'TOP COUNTRIES', 'label' => 'United States GDP', 'raw' => '18,037B' }
+ok(AnchorVerify.ranked_elements(a_label, els).first == 'Top Countries',
+   'panel/label token overlap ranks the right element first')
+ok(AnchorVerify.ranked_elements(a_label, els).length == els.length,
+   'zero-score elements are appended (search everywhere)')
+a_hint = a_label.merge('sigma_element_hint' => 'YoY Growth by Region')
+ok(AnchorVerify.ranked_elements(a_hint, els).first == 'YoY Growth by Region',
+   'sigma_element_hint wins over panel/label overlap')
+a_hint_fuzzy = a_label.merge('sigma_element_hint' => 'yoy region growth')
+ok(AnchorVerify.ranked_elements(a_hint_fuzzy, els).first == 'YoY Growth by Region',
+   'non-exact hint still matches by token overlap')
+
+puts '-- pure core: cell parsing --'
+ok(AnchorVerify.cell_numbers('$1,234.50') == [1234.5], 'currency + commas parse')
+ok(AnchorVerify.cell_numbers('(42)') == [-42.0], 'paren negative parses')
+ok(AnchorVerify.cell_numbers('12%') == [12.0, 0.12], 'percent cell keeps points + fraction')
+ok(AnchorVerify.cell_numbers('United States').empty?, 'non-numeric cell yields nothing')
+ok(AnchorVerify.cell_numbers('').empty? && AnchorVerify.cell_numbers(nil).empty?, 'empty/nil cells yield nothing')
+
+puts '-- pure core: verify() verdicts --'
+exports = {
+  'Top Countries' => [['Country', 'GDP'], ['United States', '18037000000000'], ['China', '13608000000000']],
+  'GDP Trend'     => [['Year', 'GDP'], ['2024', '1.75e12'], ['2025', '1.8e12']],
+  'KPI Row'       => [['Total GDP', 'YoY'], ['86500000000000', '-0.02']]
+}
+anchors = [
+  { 'id' => 'a1', 'panel' => 'TOP COUNTRIES', 'label' => 'United States GDP', 'raw' => '18,037B' },
+  { 'id' => 'a2', 'panel' => 'KPI', 'label' => 'YoY change', 'raw' => '-2%', 'sigma_element_hint' => 'KPI Row' },
+  { 'id' => 'a3', 'panel' => 'KPI', 'label' => 'Total GDP', 'raw' => '86.5T' }
+]
+v = AnchorVerify.verify(anchors, exports)
+ok(v['pass'] == true && v['matched'] == 3 && v['checked'] == 3, 'all-matched verdict passes 3/3')
+ok(v['missing'].empty?, 'no missing entries when all matched')
+
+# The field failure: the workbook renders 1.8T where the source printed 18,037B.
+bad_exports = exports.merge('Top Countries' => [['Country', 'GDP'], ['United Kingdom', '1.8e12']])
+v2 = AnchorVerify.verify(anchors, bad_exports)
+ok(v2['pass'] == false && v2['matched'] == 2, '10x-off value fails the anchor (2/3)')
+miss = v2['missing'].first
+ok(miss['id'] == 'a1' && miss['raw'] == '18,037B', 'missing entry carries id + raw')
+ok(miss['best_candidate'].is_a?(Hash) && miss['best_candidate']['value'] == 1.8e12,
+   'best_candidate reports the closest wrong value (the 1.8T impostor)')
+
+# found-elsewhere: value lives in a differently-named element → matched + noted
+elsewhere = { 'Some Renamed Tile' => [['GDP'], ['18037000000000']] }
+v3 = AnchorVerify.verify([anchors[0]], elsewhere)
+ok(v3['pass'] == true, 'value found in a non-best-match element still matches')
+ok(v3['detail'].first['matched_in'] == 'Some Renamed Tile', 'detail names where it was found')
+
+# hint discipline: a HINTED numeric anchor whose value appears ONLY in a
+# hint-UNRELATED element is a MISS — NOT a false match. Field-caught in the
+# PowerBI port pilot: a KPI's wrong value (10x-unit / wrong-aggregate) that
+# coincidentally lived in a big detail table silently passed the old
+# search-everywhere fallback. (Hint-LESS anchors keep that fallback — see v3.)
+hinted_exports = {
+  'Total Stores' => [['Total Stores'], ['104']],
+  'Sales Detail' => [['SLS'], ['1040'], ['1600000']]
+}
+v4 = AnchorVerify.verify(
+  [{ 'id' => 'h1', 'label' => 'Total Stores', 'raw' => '1,040', 'sigma_element_hint' => 'Total Stores' }],
+  hinted_exports
+)
+ok(v4['pass'] == false && v4['missing'].first && v4['missing'].first['id'] == 'h1',
+   'hinted numeric found only OUTSIDE the hinted element is a MISS (not a false match)')
+ok(v4['missing'].first['best_candidate'] && v4['missing'].first['best_candidate']['value'] == 104.0,
+   'the miss surfaces the real value (104 in the hinted element) as closest candidate')
+v5 = AnchorVerify.verify(
+  [{ 'id' => 'h2', 'label' => 'Total Stores', 'raw' => '104', 'sigma_element_hint' => 'Total Stores' }],
+  hinted_exports
+)
+ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
+
+puts '-- CLI offline mode --'
+def write_fixture(dir, exports_rows, anchors)
+  spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>
+    exports_rows.each_with_index.map { |(name, _), i| { 'id' => "el#{i}", 'name' => name, 'kind' => 'table' } } }] }
+  File.write(File.join(dir, 'wb-spec.json'), JSON.pretty_generate(spec))
+  exp = File.join(dir, 'exports')
+  Dir.mkdir(exp)
+  exports_rows.each_with_index do |(_, rows), i|
+    CSV.open(File.join(exp, "el#{i}.csv"), 'w') { |c| rows.each { |r| c << r } }
+  end
+  File.write(File.join(dir, 'source-anchors.json'),
+             JSON.pretty_generate('source_image' => 'views/dash.png',
+                                  'transcribed_at' => '2026-07-08T00:00:00Z',
+                                  'anchors' => anchors))
+  [File.join(dir, 'wb-spec.json'), exp]
+end
+
+def run_cli(dir, spec, exp)
+  Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--workbook-spec', spec, '--exports-dir', exp)
+end
+
+Dir.mktmpdir do |dir|
+  spec, exp = write_fixture(dir, exports, anchors)
+  File.write(File.join(dir, 'parity-final.json'),
+             JSON.pretty_generate('status' => 'PASS', 'charts_total' => 3, 'charts_pass' => 3))
+  out, _err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus.zero?, "all matched → exit 0 (got #{st.exitstatus})")
+  ok(out.include?('3/3'), 'summary reports 3/3 matched')
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  ok(vd['pass'] == true && vd['checked'] == 3 && vd['matched'] == 3 && vd['missing'] == [],
+     'anchors-verdict.json carries the contract shape (checked/matched/missing/pass)')
+  pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
+  ok(pf['anchors'].is_a?(Hash) && pf['anchors']['pass'] == true && pf['anchors']['checked'] == 3,
+     'anchors summary stamped into parity-final.json')
+end
+
+Dir.mktmpdir do |dir|
+  spec, exp = write_fixture(dir, bad_exports, anchors)
+  _out, err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus == 1, "missing anchor → exit 1 (got #{st.exitstatus})")
+  ok(err.include?('MISSING') && err.include?('18,037B'), 'per-miss report names the anchor raw value')
+  ok(err.include?('closest candidate'), 'per-miss report shows the best candidate')
+  ok(err.include?('loudest possible signal'), 'failure explains what a total miss means')
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  ok(vd['pass'] == false && vd['missing'].length == 1 && vd['missing'][0]['id'] == 'a1',
+     'failing verdict written with the missing anchor')
+end
+
+Dir.mktmpdir do |dir|
+  # no source-anchors.json at all → usage error, points at Phase 1d
+  _out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir,
+                                 '--workbook-spec', '/nonexistent', '--exports-dir', dir)
+  ok(st.exitstatus == 2, "missing source-anchors.json → exit 2 (got #{st.exitstatus})")
+  ok(err.include?('Phase 1d'), 'missing-anchors error points at the Phase 1d transcription step')
+end
+
+Dir.mktmpdir do |dir|
+  # unparseable raw → usage error (transcription contract violated)
+  spec, exp = write_fixture(dir, exports, [{ 'id' => 'a1', 'label' => 'x', 'raw' => 'about twenty' }])
+  _out, err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus == 2, "unparseable raw → exit 2 (got #{st.exitstatus})")
+  ok(err.include?('EXACTLY as printed'), 'unparseable-raw error restates the transcription rule')
+end
+
+puts
+if $fails.empty?
+  puts 'ALL PASS — verify-anchors core + offline CLI'
+  exit 0
+else
+  puts "FAILURES (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test_visual_similarity.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test_visual_similarity.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Offline tests for visual-similarity.py (synthetic fixtures only).
+
+Run: python3 scripts/test_visual_similarity.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "visual-similarity.py")
+
+try:
+    from PIL import Image, ImageDraw
+except ImportError:  # pragma: no cover
+    sys.stderr.write("tests require Pillow/numpy: pip install pillow numpy\n")
+    sys.exit(2)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("visual_similarity", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+VS = _load_module()
+
+# --- synthetic dashboard fixtures -------------------------------------------
+
+BAR_HEIGHTS = [0.55, 0.8, 0.35, 0.95, 0.6, 0.45]
+
+
+def draw_card(d, x0, y0, x1, y1, chrome, ink, accent, bars=6, lines=False):
+    """One dashboard 'card': faint border, title bar, bar chart or text rows.
+
+    bars < 6 models the mid-tier failure mode seen in the field: the panel
+    chrome survives, but a single small bar sits where six categories should
+    be, or a dense table collapses to a few stub rows, leaving whitespace
+    (bar slots are always sized for six, so fewer bars = emptier panel).
+    """
+    d.rectangle([x0, y0, x1, y1], outline=chrome, width=1)
+    d.rectangle([x0 + 8, y0 + 8, x1 - 8, y0 + 22], fill=accent)
+    body_top, body_bot = y0 + 36, y1 - 12
+    if lines:  # table-ish card; sparse variant drops most rows
+        y = body_top
+        step = 12 if bars >= 6 else 12 * 6 // max(1, bars)
+        while y < body_bot - 6:
+            d.rectangle([x0 + 12, y, x1 - 20, y + 4], fill=ink)
+            y += step
+        return
+    span = (x1 - x0 - 24) / 6.0  # slot width is ALWAYS six-across
+    scale = 1.0 if bars >= 6 else 0.5  # degenerate charts come out small too
+    for i in range(bars):
+        h = BAR_HEIGHTS[i % len(BAR_HEIGHTS)] * (body_bot - body_top) * scale
+        bx0 = x0 + 12 + i * span
+        bx1 = bx0 + span * 0.62
+        d.rectangle([bx0, body_bot - h, bx1, body_bot], fill=accent)
+
+
+def make_dashboard(w=1200, h=800, bg=(255, 255, 255), ink=(40, 40, 60),
+                   accent=(46, 84, 158), bars=6, shift=0):
+    """Deterministic synthetic dashboard: header + KPI row + 3x2 card grid.
+
+    Card borders are drawn just above the background (delta < ink threshold),
+    like modern borderless-card dashboards, so marks dominate the ink budget.
+    """
+    chrome = tuple(max(0, c - 10) for c in bg)
+    im = Image.new("RGB", (w, h), bg)
+    d = ImageDraw.Draw(im)
+    s = shift
+    d.rectangle([20 + s, 15 + s, w - 20 + s, 45 + s], fill=accent)  # header
+    for k in range(4):  # KPI strip: value block + sparkline zigzag
+        kx = 20 + s + k * (w - 40) // 4
+        kx1 = kx + (w - 40) // 4 - 12
+        d.rectangle([kx, 60 + s, kx1, 110 + s], outline=chrome, width=1)
+        if bars >= 6:  # degenerate renders lose KPI innards, keep the frame
+            d.rectangle([kx + 10, 70 + s, kx + 70, 86 + s], fill=ink)
+            pts = [(kx + 10 + 7 * i, 100 + s - 8 * (i % 3)) for i in range(12)]
+            d.line(pts, fill=accent, width=2)
+    grid_top = 130 + s
+    cw, ch = (w - 60) // 3, (h - grid_top - 30) // 2
+    for r in range(2):
+        for c in range(3):
+            x0 = 20 + s + c * (cw + 10)
+            y0 = grid_top + r * (ch + 10)
+            draw_card(d, x0, y0, x0 + cw, y0 + ch, chrome, ink, accent,
+                      bars=bars, lines=(c == 2))
+    return im
+
+
+def make_stack(src):
+    """Catastrophe: the six grid cards restacked into one narrow column."""
+    w, h = src.size
+    cw, ch = (w - 60) // 3, (h - 130 - 30) // 2
+    tiles = []
+    for r in range(2):
+        for c in range(3):
+            x0, y0 = 20 + c * (cw + 10), 130 + r * (ch + 10)
+            tiles.append(src.crop((x0, y0, x0 + cw, y0 + ch)))
+    out = Image.new("RGB", (cw + 20, (ch + 10) * 6 + 20), (255, 255, 255))
+    y = 10
+    for t in tiles:
+        out.paste(t, (10, y))
+        y += ch + 10
+    return out
+
+
+class FixtureMixin:
+    @classmethod
+    def setUpClass(cls):
+        cls.dir = tempfile.mkdtemp(prefix="vissim-test-")
+        cls.paths = {}
+
+        def save(name, im):
+            p = os.path.join(cls.dir, name + ".png")
+            im.save(p)
+            cls.paths[name] = p
+            return p
+
+        src = make_dashboard()
+        save("source", src)
+        save("identical", src.copy())
+        # recolored + font/padding-shifted copy: different palette, offset
+        save("recolored", make_dashboard(bg=(244, 241, 252), ink=(70, 60, 90),
+                                         accent=(180, 120, 60), shift=6))
+        save("blank", Image.new("RGB", (1600, 900), (255, 255, 255)))
+        half = src.copy()
+        half.paste(Image.new("RGB", (src.width, src.height // 2),
+                             (255, 255, 255)), (0, src.height // 2))
+        save("halfempty", half)
+        save("sparse", make_dashboard(bars=1))       # one bar vs six per panel
+        save("stack", make_stack(src))               # single-column stack
+        corrupt = os.path.join(cls.dir, "corrupt.png")
+        with open(corrupt, "wb") as fh:
+            fh.write(b"this is not a png file")
+        cls.paths["corrupt"] = corrupt
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.dir, ignore_errors=True)
+
+    def run_cli(self, source, render, json_out=None, env=None):
+        json_out = json_out or os.path.join(self.dir, "out.json")
+        proc = subprocess.run(
+            [sys.executable, SCRIPT, "--source", source, "--render", render,
+             "--json-out", json_out],
+            capture_output=True, text=True, env=env,
+        )
+        data = None
+        if os.path.isfile(json_out) and proc.returncode in (0, 1):
+            with open(json_out) as fh:
+                data = json.load(fh)
+        return proc, data
+
+
+class TestScoring(FixtureMixin, unittest.TestCase):
+    def test_identical_scores_near_one(self):
+        res = VS.compare(self.paths["source"], self.paths["identical"])
+        self.assertTrue(res["pass"])
+        self.assertGreaterEqual(res["score_overall"], 0.98)
+        self.assertGreaterEqual(res["score_ink"], 0.98)
+        self.assertGreaterEqual(res["score_layout"], 0.98)
+
+    def test_recolored_font_shifted_copy_passes(self):
+        res = VS.compare(self.paths["source"], self.paths["recolored"])
+        self.assertTrue(res["pass"], res)
+        self.assertGreaterEqual(
+            res["score_overall"], res["threshold"] + 0.05,
+            "legit restyle must clear the threshold with margin",
+        )
+
+    def test_blank_render_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["blank"])
+        self.assertFalse(res["pass"])
+        self.assertLessEqual(res["score_overall"], res["threshold"] - 0.05)
+
+    def test_half_empty_render_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["halfempty"])
+        self.assertFalse(res["pass"])
+        self.assertLessEqual(res["score_overall"], res["threshold"] - 0.05)
+
+    def test_one_bar_vs_six_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["sparse"])
+        self.assertFalse(res["pass"], res)
+        self.assertLess(res["score_ink"], 0.40,
+                        "mark-density floor should catch sparse panels")
+
+    def test_single_column_stack_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["stack"])
+        self.assertFalse(res["pass"], res)
+
+    def test_symmetric_blank_source_noted(self):
+        res = VS.compare(self.paths["blank"], self.paths["blank"])
+        self.assertTrue(any("source appears blank" in n for n in res["notes"]))
+
+
+class TestCLIContract(FixtureMixin, unittest.TestCase):
+    def test_pass_exit_0_and_json_schema(self):
+        out = os.path.join(self.dir, "nested", "dir", "verdict.json")
+        proc, data = self.run_cli(self.paths["source"], self.paths["recolored"],
+                                  json_out=out)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        for key, typ in (("score_layout", float), ("score_ink", float),
+                         ("score_overall", float), ("pass", bool),
+                         ("threshold", float), ("notes", list)):
+            self.assertIn(key, data)
+            self.assertIsInstance(data[key], typ)
+        for key in ("score_layout", "score_ink", "score_overall"):
+            self.assertGreaterEqual(data[key], 0.0)
+            self.assertLessEqual(data[key], 1.0)
+
+    def test_fail_exit_1(self):
+        proc, data = self.run_cli(self.paths["source"], self.paths["blank"])
+        self.assertEqual(proc.returncode, 1)
+        self.assertFalse(data["pass"])
+        self.assertTrue(data["notes"], "failure must carry explanatory notes")
+
+    def test_deterministic_output(self):
+        out1 = os.path.join(self.dir, "det1.json")
+        out2 = os.path.join(self.dir, "det2.json")
+        self.run_cli(self.paths["source"], self.paths["recolored"], json_out=out1)
+        self.run_cli(self.paths["source"], self.paths["recolored"], json_out=out2)
+        with open(out1, "rb") as a, open(out2, "rb") as b:
+            self.assertEqual(a.read(), b.read())
+
+    def test_missing_input_exit_2(self):
+        proc, _ = self.run_cli(os.path.join(self.dir, "nope.png"),
+                               self.paths["source"])
+        self.assertEqual(proc.returncode, 2)
+        proc, _ = self.run_cli(self.paths["source"],
+                               os.path.join(self.dir, "nope.png"))
+        self.assertEqual(proc.returncode, 2)
+
+    def test_corrupt_input_exit_2(self):
+        proc, _ = self.run_cli(self.paths["source"], self.paths["corrupt"])
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("could not analyze", proc.stderr)
+
+    def test_missing_deps_exit_2_with_remediation(self):
+        shim = os.path.join(self.dir, "shim")
+        os.makedirs(shim, exist_ok=True)
+        for mod in ("PIL", "numpy"):
+            with open(os.path.join(shim, mod + ".py"), "w") as fh:
+                fh.write("raise ImportError('simulated missing %s')\n" % mod)
+        env = dict(os.environ)
+        env["PYTHONPATH"] = shim
+        proc, _ = self.run_cli(self.paths["source"], self.paths["identical"],
+                               env=env)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("pip install pillow numpy", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-anchors.rb
@@ -1,0 +1,483 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-anchors.rb — the MEASURED value bar for a converted workbook.
+#
+# WHY. Two field migrations recorded passing visual verdicts over dashboards
+# whose NUMBERS were wrong: a ranked list showed different members with 10x-off
+# values ("$1.8T" rendered where the source printed "18,037B"), and a
+# multi-bucket panel collapsed to a single bar. Every judgment gate is an
+# attestation, and lenient models attest generously — so this script replaces
+# the judgment with a MEASUREMENT: each printed value the agent transcribed
+# from the SOURCE dashboard image (Phase 1d, <workdir>/source-anchors.json)
+# must literally appear in the LIVE Sigma workbook's element CSV exports, at
+# the printed precision (scripts/lib/anchor_values.rb). An anchor value that
+# appears NOWHERE in the workbook exports is the loudest possible signal the
+# data is wrong.
+#
+# INPUT  <workdir>/source-anchors.json — authored by the AGENT at Phase 1d
+#        while reading the source dashboard PNG (schema: SKILL.md Phase 1d,
+#        refs/source-anchors.md):
+#          { "source_image": "views/<id>.png", "transcribed_at": "...",
+#            "anchors": [ { "id": "a1", "panel": "TOP COUNTRIES",
+#                           "label": "United States GDP", "raw": "18,037B",
+#                           "kind": "currency",
+#                           "sigma_element_hint": "Top Countries" } ] }
+# OUTPUT <workdir>/anchors-verdict.json:
+#          { "checked": N, "matched": M,
+#            "missing": [ { "id", "label", "raw", "best_candidate" } ],
+#            "pass": true|false }
+#        Also stamps an `anchors` summary into parity-final.json when present.
+#
+# HOW. Fetches the live workbook spec for element names, then pools element
+# CSV exports (the same POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download flow collect-parity-actuals.rb uses). Each anchor
+# is searched in the element whose name best matches its label/panel (token
+# overlap; `sigma_element_hint` wins when present); when the matched element
+# doesn't carry the value, every other export is searched before declaring the
+# anchor MISSING — found-elsewhere still counts as matched (the value exists;
+# only the label→element mapping was fuzzy) and is noted in the verdict.
+#
+# Usage (live):
+#   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+# Usage (offline — tests / pre-collected exports):
+#   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
+#     --exports-dir <dir-with-<elementId>.csv>
+#
+# Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
+# per-miss report names each, with its closest candidate); 2 = usage / missing
+# inputs.
+
+require 'json'
+require 'csv'
+require 'set'
+require 'optparse'
+require_relative 'lib/anchor_values'
+
+# ---------------------------------------------------------------------------
+# Pure core — unit-tested offline in test-verify-anchors.rb.
+# ---------------------------------------------------------------------------
+module AnchorVerify
+  STOPWORDS = %w[the a an of by per and or in on for to vs].freeze
+
+  module_function
+
+  def tokens(s)
+    s.to_s.downcase.scan(/[a-z0-9]+/) - STOPWORDS
+  end
+
+  # Overlap score between an anchor and an element name. sigma_element_hint,
+  # when present, is the only signal; otherwise panel+label tokens are used.
+  def element_score(anchor, el_name)
+    hint = anchor['sigma_element_hint'].to_s
+    name_toks = tokens(el_name)
+    return 0 if name_toks.empty?
+    if !hint.strip.empty?
+      return 1_000 if hint.strip.casecmp?(el_name.to_s.strip)
+      return (tokens(hint) & name_toks).length
+    end
+    ((tokens(anchor['panel']) | tokens(anchor['label'])) & name_toks).length
+  end
+
+  # Element names ordered best-match-first for this anchor; zero-score names
+  # are appended (search everywhere before declaring a value missing).
+  def ranked_elements(anchor, el_names)
+    scored = el_names.map { |n| [n, element_score(anchor, n)] }
+    hits = scored.select { |_, s| s.positive? }.sort_by { |n, s| [-s, n.to_s] }.map(&:first)
+    hits + (el_names - hits)
+  end
+
+  # Numeric face values of a CSV cell (both percent interpretations kept so
+  # AnchorValues candidate matching sees whichever the export carried).
+  def cell_numbers(cell)
+    s = cell.to_s
+    # Export bytes arrive as ASCII-8BIT off the HTTP body; a UTF-8 regexp match
+    # on that raises Encoding::CompatibilityError (live-caught). Normalize first.
+    s = s.dup.force_encoding(Encoding::UTF_8) unless s.encoding == Encoding::UTF_8
+    s = s.scrub('') unless s.valid_encoding?
+    s = s.strip
+    return [] if s.empty?
+    neg = s.start_with?('(') && s.end_with?(')')
+    s = s[1..-2] if neg
+    body = s.gsub(/[,$€£¥\s]/, '')
+    pct = body.end_with?('%')
+    body = body.chomp('%')
+    f = begin
+      Float(body)
+    rescue ArgumentError, TypeError
+      return []
+    end
+    f = -f if neg
+    pct ? [f, f / 100.0] : [f]
+  end
+
+  def rows_numbers(rows)
+    rows.flat_map { |r| Array(r).flat_map { |c| cell_numbers(c) } }
+  end
+
+  # Normalized text cells of an export (for kind:"text" roster anchors).
+  def rows_texts(rows)
+    # (map+compact, not filter_map — the skill's floor is the system Ruby 2.6)
+    rows.flat_map { |r| Array(r) }.map do |c|
+      s = c.to_s
+      s = s.dup.force_encoding(Encoding::UTF_8) unless s.encoding == Encoding::UTF_8
+      s = s.scrub('') unless s.valid_encoding?
+      s = s.strip.downcase
+      s.empty? ? nil : s
+    end.compact.to_set
+  end
+
+  # Verify anchors against { element_name => [[cell, ...], ...] } exports.
+  # Returns the verdict Hash (contract shape + per-anchor detail).
+  #
+  # Two anchor kinds:
+  #   numeric (default) — `raw` is a printed VALUE; matches any export cell at
+  #     printed precision.
+  #   kind: "text" (aka "roster") — `raw` is a LABEL that must appear as a cell
+  #     (case-insensitive, trimmed). Use these on ranked/top-N tiles so a
+  #     WRONGLY-SELECTED or dropped member fails loudly (a materialized top-15
+  #     built from the wrong rank, a renamed category, a missing path label).
+  #     Scope note: exports carry the element's full underlying data, so a
+  #     roster anchor canNOT catch an UNFILTERED tile that merely WINDOWS the
+  #     wrong first-N on screen — that class is caught by gate 9b (shape
+  #     identity: the reviewer sees the wrong columns) and by the render-bisect
+  #     playbook (unbounded pivots kill the renderer). Use both.
+  def verify(anchors, exports)
+    el_names = exports.keys
+    numbers = exports.transform_values { |rows| rows_numbers(rows) }
+    texts = exports.transform_values { |rows| rows_texts(rows) }
+    detail = []
+    missing = []
+    anchors.each do |a|
+      raw = a['raw'].to_s
+      order = ranked_elements(a, el_names)
+      if %w[text roster member].include?(a['kind'].to_s)
+        want = raw.strip.downcase
+        found_in = order.find { |n| texts[n].include?(want) }
+        if found_in
+          detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
+        else
+          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+        end
+        next
+      end
+      # A HINTED numeric anchor asserts WHERE its value must live. A match found
+      # only in a hint-UNRELATED element (e.g. a raw detail table that merely
+      # happens to contain the number) is NOT acceptance — that loophole silently
+      # passed 10x-unit and wrong-aggregate defects in field testing (a KPI whose
+      # value coincidentally appears in a big detail element). Restrict a hinted
+      # numeric anchor's search to hint-scored elements; found-only-outside is a
+      # MISS. Hint-less anchors keep the search-everywhere fallback (no asserted
+      # location to enforce); text/roster anchors are unchanged (a member label
+      # appearing anywhere is meaningful on its own).
+      search_order =
+        if a['sigma_element_hint'].to_s.strip.empty?
+          order
+        else
+          scoped = order.select { |n| element_score(a, n).positive? }
+          scoped.empty? ? order : scoped # defensive: hint matched no element name
+        end
+      found_in = search_order.find { |n| numbers[n].any? { |v| AnchorValues.match?(raw, v) } }
+      if found_in
+        primary = order.first
+        detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in,
+                    'note' => (found_in == primary ? nil : "found outside best-match element #{primary.inspect}") }.compact
+      else
+        # Closest candidate WITHIN the best-matching element that carries any
+        # numbers (walking down the ranking until one does) — the wrong value
+        # almost always lives in the anchor's own panel, so this surfaces the
+        # impostor ("$1.8T where the source printed 18,037B") rather than a
+        # coincidentally-near number from an unrelated tile.
+        best = nil
+        order.each do |n|
+          numbers[n].each do |v|
+            d = AnchorValues.relative_distance(raw, v)
+            best = { 'value' => v, 'element' => n, 'distance' => d.round(6) } if best.nil? || d < best['distance']
+          end
+          break if best
+        end
+        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                     'best_candidate' => best }
+      end
+    end
+    { 'checked' => anchors.length,
+      'matched' => anchors.length - missing.length,
+      'missing' => missing,
+      'pass' => missing.empty?,
+      'detail' => detail }
+  end
+end
+
+# ---------------------------------------------------------------------------
+# CLI (IO / REST) — thin wrapper around the pure core above.
+# ---------------------------------------------------------------------------
+return if $PROGRAM_NAME != __FILE__ && !ENV['VERIFY_ANCHORS_CLI'] # allow `require` in tests
+
+# Element display name for export keys. put-layout replaces `name` with a
+# visibility hash on hidden-title elements — every such element would
+# stringify to the SAME key and overwrite each other's exports (false RED on
+# any anchor living in the clobbered tile). Fall back to text, then the id
+# slug (unique by construction; token matching still ranks it).
+def el_display_name(el)
+  n = el['name']
+  return n.to_s unless n.is_a?(Hash)
+  t = n['text'].to_s
+  t.empty? ? el['id'].to_s.sub(/\Ael-/, '').tr('-', ' ') : t
+end
+
+opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+OptionParser.new do |p|
+  p.on('--workdir DIR')        { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
+  p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
+  p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
+end.parse!
+abort('--workdir required') unless opts[:dir]
+
+anchors_path = opts[:anchors] || File.join(opts[:dir], 'source-anchors.json')
+out_path     = opts[:out]     || File.join(opts[:dir], 'anchors-verdict.json')
+
+unless File.exist?(anchors_path)
+  warn "FATAL: #{anchors_path} not found — transcribe the source dashboard's printed values"
+  warn '       at Phase 1d (every KPI, top-3 of every ranked list/table, one bucket value per'
+  warn '       chart; EXACTLY as printed). Schema: SKILL.md Phase 1d / refs/source-anchors.md.'
+  exit 2
+end
+doc = begin
+  JSON.parse(File.read(anchors_path))
+rescue JSON::ParserError => e
+  warn "FATAL: #{anchors_path} is malformed JSON: #{e.message}"
+  exit 2
+end
+anchors = Array(doc['anchors'])
+if anchors.empty?
+  warn "FATAL: #{anchors_path} has no anchors[] — nothing to verify."
+  exit 2
+end
+# kind:"text"/"roster"/"member" anchors carry a LABEL in `raw` (displayed-set
+# membership for ranked tiles) — only NUMERIC anchors must parse as values.
+bad = anchors.reject do |a|
+  next false unless a.is_a?(Hash)
+  %w[text roster member].include?(a['kind'].to_s) ? !a['raw'].to_s.strip.empty? : AnchorValues.parse(a['raw'])
+end
+unless bad.empty?
+  warn "FATAL: #{bad.length} anchor(s) have an unparseable `raw` printed value:"
+  bad.first(10).each { |a| warn "         #{a.is_a?(Hash) ? a['id'] : '(bad entry)'}: raw=#{(a['raw'] rescue nil).inspect}" }
+  warn '       `raw` must be the value EXACTLY as printed on the source image ("18,037B", "-2%",'
+  warn '       "$733,215.26") — or, for kind:"text" roster anchors, a non-empty displayed label.'
+  exit 2
+end
+
+# --- element names + rows: offline (spec+exports dir) or live (REST) ---------
+exports = {} # element name => rows (arrays of cells)
+
+if opts[:exports]
+  spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
+  unless File.exist?(spec_path)
+    warn "FATAL: offline mode needs --workbook-spec (or <workdir>/wb-readback.json); #{spec_path} not found."
+    exit 2
+  end
+  spec = JSON.parse(File.read(spec_path))
+  elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  elements.each do |el|
+    csv = File.join(opts[:exports], "#{el['id']}.csv")
+    next unless File.exist?(csv)
+    exports[el_display_name(el)] = CSV.read(csv)
+  end
+else
+  # Live: resolve workbook id, GET the spec, pool the element CSV exports —
+  # the same export → poll → download flow collect-parity-actuals.rb uses.
+  wb = opts[:wb]
+  if wb.nil?
+    ids = File.join(opts[:dir], 'wb-ids.json')
+    wb = (JSON.parse(File.read(ids))['workbookId'] rescue nil) if File.exist?(ids)
+  end
+  abort('--workbook-id required (or a <workdir>/wb-ids.json with workbookId)') if wb.to_s.empty?
+
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
+  spec = begin
+    JSON.parse(body)
+  rescue JSON::ParserError, TypeError
+    require 'yaml'
+    require 'date'
+    body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
+  end
+  elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
+
+  # v5.4 PIVOT-TOTALS CEILING: a pivot carrying a `totals` key 500s its CSV
+  # export (probe-isolated: the key's PRESENCE is the sole trigger — value type
+  # irrelevant), so a totals-bearing pivot's anchor values would read as MISSING
+  # here through no fault of the data. Bracket the exports: capture + STRIP each
+  # pivot's totals (one PUT), export against totals-free pivots, then RESTORE the
+  # captured totals (ensure). Renders keep their hidden grand totals before and
+  # after — only the brief export window is totals-free. The shipped hide state
+  # is re-guaranteed by `put-layout.rb --apply-pivot-totals` at the finalize ship
+  # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
+  READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
+  put_spec = lambda do |s|
+    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
+  end
+  captured_totals = {}
+  queryable.each do |el|
+    next unless el['kind'] == 'pivot-table' && el.is_a?(Hash) && el.key?('totals')
+    captured_totals[el['id'].to_s] = el.delete('totals')
+  end
+  # v5.4.9 review fix: persist the captured totals to a *-pivot-totals.json
+  # sidecar BEFORE the strip PUT. If this process dies (or the restore PUT
+  # fails) between strip and restore, the finalize ship step (put-layout.rb
+  # --apply-pivot-totals, which globs the workdir) re-applies the FULL captured
+  # totals — including showSubtotals — instead of stamping the lossy
+  # showGrandTotals-only default. Deleted again after a successful restore.
+  totals_sidecar = File.join(opts[:dir], 'anchors-restore-pivot-totals.json')
+  if captured_totals.any?
+    begin
+      File.write(totals_sidecar, JSON.pretty_generate({ 'workbook' => wb, 'totals' => captured_totals }))
+    rescue StandardError => e
+      warn "  [WARN] could not write totals restore sidecar (#{e.class}: #{e.message.to_s[0, 80]})"
+    end
+  end
+
+  export_one = lambda do |el|
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return nil unless qid
+    t0 = Time.now
+    loop do
+      return nil if Time.now - t0 > opts[:timeout]
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        next if b.to_s.empty? # still rendering
+        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
+        return CSV.parse(b)
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
+      end
+    end
+  rescue Sigma::Error, CSV::MalformedCSVError => e
+    msg = e.message.lines.first.to_s.strip[0, 120]
+    ceiling = (el['kind'] == 'pivot-table' && e.is_a?(Sigma::Error) && msg =~ /\b500\b/) ?
+      ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
+      'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
+    warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
+    nil
+  end
+
+  require 'thread'
+  begin
+    # The strip PUT runs INSIDE this begin/ensure (v5.4.9 review fix): a
+    # network-level exception on the PUT (Net::ReadTimeout, Errno::ECONNRESET,
+    # SocketError — raised raw by Sigma.request, which only wraps HTTP-status
+    # failures in Sigma::Error) can fire AFTER the server applied the strip;
+    # previously it propagated before the restore bracket existed and left the
+    # live workbook totals-stripped (grand totals visible). Restoring when the
+    # strip never landed is an idempotent no-op PUT, so the ensure always
+    # attempts it.
+    if captured_totals.any?
+      begin
+        put_spec.call(spec)
+        warn "  [totals-ceiling] stripped grand-total key from #{captured_totals.size} pivot(s) for CSV export (restored after)"
+      rescue StandardError => e
+        warn "  [WARN] could not strip pivot totals (#{e.class}: #{e.message.lines.first.to_s.strip[0, 100]}) — " \
+             'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
+      end
+    end
+    queue = Queue.new
+    queryable.each { |el| queue << el }
+    mutex = Mutex.new
+    Array.new([opts[:pool], queryable.size].min.clamp(1, 8)) do
+      Thread.new do
+        loop do
+          el = begin
+            queue.pop(true)
+          rescue ThreadError
+            break
+          end
+          rows = export_one.call(el)
+          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+        end
+      end
+    end.each(&:join)
+  ensure
+    # Restore the grand-total keys stripped for the export window so renders
+    # (and the shipped workbook) keep hidden grand totals — even if the strip
+    # PUT or an export above raised (network-level errors included). On
+    # restore failure the sidecar written above survives, and the finalize
+    # ship step re-applies the FULL captured totals (incl. showSubtotals).
+    if captured_totals.any?
+      begin
+        elements.each { |el| (t = captured_totals[el['id'].to_s]) && el['totals'] = t }
+        put_spec.call(spec)
+        warn "  [totals-ceiling] restored grand-total key on #{captured_totals.size} pivot(s)"
+        begin
+          File.delete(totals_sidecar) if File.exist?(totals_sidecar)
+        rescue StandardError
+          nil # stale sidecar is harmless: it re-applies the same captured totals
+        end
+      rescue StandardError => e
+        warn "  [WARN] pivot totals RESTORE failed (#{e.class}: #{e.message.lines.first.to_s.strip[0, 100]}) — " \
+             "captured totals kept in #{File.basename(totals_sidecar)}; the finalize ship step " \
+             '(put-layout.rb --apply-pivot-totals) re-applies them, incl. showSubtotals'
+      end
+    end
+  end
+end
+
+if exports.empty?
+  warn 'FATAL: no element exports could be collected — cannot verify anchors.'
+  warn '       (live: check SIGMA_* credentials and the workbook id; offline: check --exports-dir)'
+  exit 2
+end
+
+verdict = AnchorVerify.verify(anchors, exports)
+verdict['source_anchors'] = anchors_path
+verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+File.write(out_path, JSON.pretty_generate(verdict))
+
+# Stamp the summary into parity-final.json when Phase 6 already finalized —
+# the anchors result travels with the parity verdict the final gate reads.
+pf = File.join(opts[:dir], 'parity-final.json')
+if File.exist?(pf)
+  begin
+    s = JSON.parse(File.read(pf))
+    s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
+                     'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    File.write(pf, JSON.pretty_generate(s))
+  rescue JSON::ParserError
+    warn "[WARN] #{pf} is malformed — anchors summary not stamped."
+  end
+end
+
+puts "verify-anchors: #{verdict['matched']}/#{verdict['checked']} anchor(s) matched " \
+     "across #{exports.length} element export(s) → #{out_path}"
+verdict['detail'].each do |d|
+  puts "  MATCHED  #{d['id']} #{d['raw'].inspect} in #{d['matched_in'].inspect}#{d['note'] ? " (#{d['note']})" : ''}"
+end
+if verdict['pass']
+  puts '[OK] every source anchor value is present in the live workbook exports.'
+  exit 0
+end
+warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+verdict['missing'].each do |m|
+  bc = m['best_candidate']
+  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+end
+warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+exit 1

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/visual-similarity.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/visual-similarity.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Deterministic visual-similarity floor for Phase 6 parity verification.
+
+Compares a source dashboard screenshot against a Sigma render and decides
+whether the render is structurally in the same universe as the source. This
+is a FLOOR, not a match-scorer: it exists so a passing "visual verdict" can
+never be recorded over a render that is structurally nothing like the source
+(blank/mostly-empty pages, one-bar-vs-six-bars panels, missing whole
+columns/sections, single-column stacks). It deliberately tolerates font,
+color, padding, spacing, and aspect-ratio differences, and even wholesale
+panel rearrangement, as long as the render carries a comparable amount of
+content distributed across the whole page.
+
+Contract (consumed by the Phase 6 gate):
+
+    python3 scripts/visual-similarity.py \
+        --source <src.png> --render <render.png> --json-out <out.json>
+
+Writes JSON: {"score_layout": float, "score_ink": float,
+              "score_overall": float, "pass": bool, "threshold": float,
+              "notes": [str, ...]}
+Exit codes: 0 = pass, 1 = fail, 2 = deps missing or unreadable input.
+Exit 2 must NEVER be treated as a pass.
+
+Method (fully deterministic — no randomness, no model calls):
+  1. Normalize: flatten alpha onto white, grayscale, downsample to <=384px.
+  2. Two binary "ink" maps per image: deviation from the page background
+     (histogram mode) and local gradient (catches light-on-light text).
+  3. Trim outer margins (capped at 12% per side, so real emptiness survives).
+  4. Signals, each in 0..1:
+       cov  - render edge-ink density as a fraction of the source's
+              (missing marks; asymmetric: extra ink is not penalized)
+       bal  - worst-band ink share ratio over row/column thirds
+              (an entire source-inked region empty in the render -> 0)
+       patt - Pearson correlation of 12x12 ink-density grids
+       prof - best of row/column 48-bin edge-ink profile correlations
+       asp  - soft penalty only for extreme aspect-ratio mismatch (>2.2x),
+              the page-geometry signature of a single-column stack
+  5. score_ink = cov;  score_layout = (0.46*bal + 0.06*patt + 0.06*prof)/0.58
+     score_overall = asp * (0.42*score_ink + 0.58*score_layout)
+     pass = score_overall >= 0.45  AND  score_ink >= 0.40  AND  bal >= 0.10
+
+Threshold provenance: calibrated on 20 verified-faithful migration pairs
+from the skills-test corpus plus 17 failure-mode negatives (1 real failed
+field migration + synthesized blank / half-empty / quarter-content /
+single-column-stack pages). Do NOT tune the threshold to make a failing
+render pass — a failure means STRUCTURE diverges; re-run the RCF loop.
+
+# ---------------------------------------------------------------------------
+# CALIBRATION SUMMARY (2026-07: 20 positives, 17 negatives; threshold 0.45)
+# All positives >= threshold + 0.05; all negatives <= threshold - 0.05.
+#
+# POSITIVES (must pass)            overall   NEGATIVES (must fail)      overall
+#   call-center                      0.780     field-failure (1-bar-vs-6) 0.311
+#   dynamic-zoning-kpi               0.702     blank-page x4              0.000
+#   ecommerce-admin                  0.534     single-column-stack x4  <= 0.001
+#   er-visits                        0.872     half-page-empty x4      <= 0.343
+#   social-media-campaign            0.692     quarter-content x4      <= 0.199
+#   supermart-sales                  0.554
+#   superstore-perf-overview         0.731   min positive 0.534 (+0.084)
+#   superstore-perf-order-detail     0.834   max negative 0.343 (-0.107)
+#   superstore-viz-extensions        0.629
+#   udemy-course-analysis            0.774   Sub-floors also verified:
+#   visual-vocabulary x10 pages   >= 0.553     min positive cov 0.506
+#                                              (ink floor 0.40, +0.106)
+#                                              min positive bal 0.234
+#                                              (bal floor 0.10, +0.134)
+# ---------------------------------------------------------------------------
+"""
+
+import argparse
+import json
+import os
+import sys
+
+REMEDIATION = (
+    "visual-similarity.py requires Pillow and numpy. "
+    "Install with: pip install pillow numpy"
+)
+
+try:
+    import numpy as np
+    from PIL import Image
+except ImportError:
+    sys.stderr.write(REMEDIATION + "\n")
+    sys.exit(2)
+
+# --- tunables (calibrated; see module docstring — do not tune per-run) ------
+WORK = 384          # max working dimension after downsample
+COARSE = 12         # coarse occupancy/pattern grid
+FINE = 48           # fine profile grid
+TRIM_CAP = 0.12     # max fraction of each side trimmed as outer margin
+LUM_DELTA = 24      # luminance deviation from page background counted as ink
+EDGE_DELTA = 20     # local gradient magnitude counted as edge ink
+BAND_N = 3          # row/column bands for the balance signal
+BAND_MIN_SHARE = 0.05   # source band must hold >=5% of ink to be scored
+ASPECT_SOFT = 2.2   # aspect-ratio mismatch tolerated up to this factor
+ASPECT_RAMP = 1.8   # penalty ramp width beyond ASPECT_SOFT
+
+W_INK = 0.42
+W_BAL = 0.46
+W_PATT = 0.06
+W_PROF = 0.06
+W_LAYOUT = W_BAL + W_PATT + W_PROF   # 0.58
+
+THRESHOLD = 0.45
+INK_FLOOR = 0.40    # hard sub-floor on score_ink (mark coverage)
+BAL_FLOOR = 0.10    # hard sub-floor on band balance
+
+
+def _load_gray(path):
+    """Return (grayscale float array downsampled to <=WORK, aspect ratio)."""
+    im = Image.open(path)
+    im.load()
+    if im.mode in ("RGBA", "LA") or (im.mode == "P" and "transparency" in im.info):
+        rgba = im.convert("RGBA")
+        flat = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+        im = Image.alpha_composite(flat, rgba)
+    im = im.convert("L")
+    w, h = im.size
+    if w < 4 or h < 4:
+        raise ValueError("image too small to analyze (%dx%d)" % (w, h))
+    aspect = w / h
+    scale = WORK / max(w, h)
+    if scale < 1:
+        im = im.resize(
+            (max(1, round(w * scale)), max(1, round(h * scale))), Image.BILINEAR
+        )
+    return np.asarray(im, dtype=np.float32), aspect
+
+
+def _ink_maps(gray):
+    """Return (combined ink map, edge-only ink map) as float 0/1 arrays."""
+    # explicit float64 edges: np.histogram(x, bins=16, range=(0,256)) hits a
+    # broadcast regression on numpy 2.2.x with real image arrays (A/B-report
+    # reproduced; fine on 2.3+). Edges are version-robust on both.
+    hist, edges = np.histogram(np.asarray(gray, dtype=np.float64).ravel(),
+                               bins=np.linspace(0.0, 256.0, 17))
+    mode = int(np.argmax(hist))
+    background = (edges[mode] + edges[mode + 1]) / 2.0
+    deviation = np.abs(gray - background) > LUM_DELTA
+    gx = np.abs(np.diff(gray, axis=1, prepend=gray[:, :1]))
+    gy = np.abs(np.diff(gray, axis=0, prepend=gray[:1, :]))
+    edge = (gx + gy) > EDGE_DELTA
+    return (deviation | edge).astype(np.float32), edge.astype(np.float32)
+
+
+def _capped_trim(ink, edge):
+    """Trim near-empty outer margins, at most TRIM_CAP per side.
+
+    The cap matters: it normalizes letterboxing/browser chrome without
+    letting a half-empty page crop itself back into looking complete.
+    """
+    h, w = ink.shape
+    rows = ink.sum(axis=1)
+    cols = ink.sum(axis=0)
+    rnz = np.nonzero(rows > w * 0.005)[0]
+    cnz = np.nonzero(cols > h * 0.005)[0]
+    if len(rnz) == 0 or len(cnz) == 0:
+        return ink, edge
+    r0 = min(int(rnz[0]), int(h * TRIM_CAP))
+    r1 = max(int(rnz[-1]) + 1, h - int(h * TRIM_CAP))
+    c0 = min(int(cnz[0]), int(w * TRIM_CAP))
+    c1 = max(int(cnz[-1]) + 1, w - int(w * TRIM_CAP))
+    return ink[r0:r1, c0:c1], edge[r0:r1, c0:c1]
+
+
+def _grid(m, n):
+    """Reduce a 2-D map to an n x n grid of cell means (stretch-normalized)."""
+    h, w = m.shape
+    ys = np.linspace(0, h, n + 1).astype(int)
+    xs = np.linspace(0, w, n + 1).astype(int)
+    out = np.zeros((n, n), dtype=np.float64)
+    for i in range(n):
+        for j in range(n):
+            cell = m[ys[i]:ys[i + 1], xs[j]:xs[j + 1]]
+            if cell.size:
+                out[i, j] = float(cell.mean())
+    return out
+
+
+def _corr(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    if a.std() < 1e-9 or b.std() < 1e-9:
+        return 0.0
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def _band_shares(ink, n=BAND_N):
+    """Fraction of total ink in each of n row bands and n column bands."""
+    h, w = ink.shape
+    total = float(ink.sum()) or 1.0
+    shares = []
+    for i in range(n):
+        shares.append(float(ink[i * h // n:(i + 1) * h // n, :].sum()) / total)
+    for j in range(n):
+        shares.append(float(ink[:, j * w // n:(j + 1) * w // n].sum()) / total)
+    return shares
+
+
+def _band_balance(src_map, ren_map):
+    """Worst-case render/source ink-share ratio over row+column bands."""
+    src_shares = _band_shares(src_map)
+    ren_shares = _band_shares(ren_map)
+    worst = 1.0
+    for s, r in zip(src_shares, ren_shares):
+        if s > BAND_MIN_SHARE:
+            worst = min(worst, min(1.0, r / s))
+    return worst
+
+
+def compare(source_path, render_path):
+    """Compute the similarity-floor verdict for one source/render pair."""
+    gray_s, aspect_s = _load_gray(source_path)
+    gray_r, aspect_r = _load_gray(render_path)
+    ink_s, edge_s = _ink_maps(gray_s)
+    ink_r, edge_r = _ink_maps(gray_r)
+    ink_s, edge_s = _capped_trim(ink_s, edge_s)
+    ink_r, edge_r = _capped_trim(ink_r, edge_r)
+
+    notes = []
+
+    # -- ink coverage (asymmetric: only missing marks are penalized) --------
+    dens_s = float(edge_s.mean())
+    dens_r = float(edge_r.mean())
+    if dens_s > 1e-6:
+        cov = min(1.0, dens_r / dens_s)
+    else:
+        cov = 1.0 if dens_r <= 1e-6 else 0.0
+        notes.append("source appears blank — verify the source export")
+
+    # -- band balance: is any whole page region emptied out? ----------------
+    bal = min(_band_balance(ink_s, ink_r), _band_balance(edge_s, edge_r))
+
+    # -- structure agreement -------------------------------------------------
+    coarse_s, coarse_r = _grid(ink_s, COARSE), _grid(ink_r, COARSE)
+    fine_s, fine_r = _grid(edge_s, FINE), _grid(edge_r, FINE)
+    patt = max(0.0, _corr(coarse_s, coarse_r))
+    prof = max(
+        max(0.0, _corr(fine_s.sum(axis=1), fine_r.sum(axis=1))),
+        max(0.0, _corr(fine_s.sum(axis=0), fine_r.sum(axis=0))),
+    )
+
+    # -- aspect-ratio sanity (single-column-stack page geometry) ------------
+    ratio = max(aspect_s, aspect_r) / min(aspect_s, aspect_r)
+    if ratio <= ASPECT_SOFT:
+        asp = 1.0
+    else:
+        asp = max(0.0, 1.0 - (ratio - ASPECT_SOFT) / ASPECT_RAMP)
+        notes.append(
+            "extreme aspect-ratio mismatch (x%.1f): render page geometry "
+            "suggests content collapsed into a single column" % ratio
+        )
+
+    score_ink = round(cov, 4)
+    score_layout = round((W_BAL * bal + W_PATT * patt + W_PROF * prof) / W_LAYOUT, 4)
+    score_overall = round(asp * (W_INK * score_ink + W_LAYOUT * score_layout), 4)
+
+    passed = score_overall >= THRESHOLD
+    if score_ink < INK_FLOOR:
+        passed = False
+        notes.append(
+            "render draws only %.0f%% of the source's mark density "
+            "(floor %.0f%%): charts/text are likely missing or degenerate"
+            % (score_ink * 100, INK_FLOOR * 100)
+        )
+    if bal < BAL_FLOOR:
+        passed = False
+        notes.append(
+            "band balance %.2f (floor %.2f): a page region that holds "
+            "content in the source is (near-)empty in the render" % (bal, BAL_FLOOR)
+        )
+    if not passed and score_overall < THRESHOLD:
+        notes.append(
+            "overall %.3f below threshold %.2f: render structure diverges "
+            "from the source — re-run the RCF loop; do not tune the threshold"
+            % (score_overall, THRESHOLD)
+        )
+
+    return {
+        "score_layout": score_layout,
+        "score_ink": score_ink,
+        "score_overall": score_overall,
+        "pass": passed,
+        "threshold": THRESHOLD,
+        "notes": notes,
+        "components": {
+            "coverage": round(cov, 4),
+            "band_balance": round(bal, 4),
+            "pattern_corr": round(patt, 4),
+            "profile_corr": round(prof, 4),
+            "aspect_factor": round(asp, 4),
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Deterministic visual-similarity floor (source vs render)."
+    )
+    parser.add_argument("--source", required=True, help="source dashboard PNG")
+    parser.add_argument("--render", required=True, help="Sigma render PNG")
+    parser.add_argument("--json-out", required=True, help="verdict JSON path")
+    args = parser.parse_args(argv)
+
+    for label, path in (("source", args.source), ("render", args.render)):
+        if not os.path.isfile(path):
+            sys.stderr.write("%s image not found: %s\n" % (label, path))
+            return 2
+
+    try:
+        result = compare(args.source, args.render)
+    except Exception as exc:  # unreadable/corrupt input — never a pass
+        sys.stderr.write("could not analyze images: %s\n" % exc)
+        return 2
+
+    out_dir = os.path.dirname(os.path.abspath(args.json_out))
+    os.makedirs(out_dir, exist_ok=True)
+    with open(args.json_out, "w") as fh:
+        json.dump(result, fh, indent=2)
+        fh.write("\n")
+
+    verdict = "PASS" if result["pass"] else "FAIL"
+    print(
+        "visual-similarity: %s  overall=%.3f (threshold %.2f)  "
+        "ink=%.3f layout=%.3f"
+        % (
+            verdict,
+            result["score_overall"],
+            result["threshold"],
+            result["score_ink"],
+            result["score_layout"],
+        )
+    )
+    for note in result["notes"]:
+        print("  note: %s" % note)
+    return 0 if result["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/source-anchors.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/source-anchors.md
@@ -1,0 +1,163 @@
+# Source-value anchors — the measured value bar
+
+## Why this exists
+
+Two field migrations shipped dashboards whose **numbers were wrong** while every
+judgment gate recorded "pass":
+
+1. **The 10x/ranking failure.** A "top members" ranked panel showed *different
+   members* with values ~10x off — the migrated dashboard rendered **"$1.8T"**
+   where the source printed **"18,037B"** (≈ $18.0T). A multi-region YoY panel
+   collapsed to **one bar where the source showed six**, and a trend line
+   crashed to zero on a partial final period. The run followed the pipeline,
+   executed a real 3-pass RCF loop *reading* the render PNGs — and still
+   recorded `--verdict pass`.
+2. **The waiver-stacking failure.** A second workbook "passed" by combining
+   `--skip-parity-gate` with `--allow-missing-tiles 6`, discovered by grepping
+   `--help` for skip flags. Nothing measured the values; every gate that could
+   have was waived.
+
+The lesson: **every judgment gate is an attestation, and lenient models attest
+generously.** Visual verdicts, RCF scoring, and parity waivers are all places
+where "looks right" substitutes for "is right." Anchors replace that judgment
+with a **measurement**: printed values transcribed from the source image either
+appear in the live workbook's exports at the printed precision, or they don't.
+
+A printed source value that appears **nowhere** in the workbook exports is the
+loudest possible signal the data is wrong — wrong unit (10x), wrong aggregate,
+missing filter, collapsed buckets, or the wrong column entirely.
+
+## The contract
+
+### `source-anchors.json` — authored BY THE AGENT at Phase 1d
+
+Written **while reading the source dashboard PNG** (the same read that produces
+`png-read.json`). Never generated from CSVs — the whole point is transcribing
+what the source *renders*.
+
+```json
+{
+  "source_image": "views/<dashboardViewId>.png",
+  "transcribed_at": "2026-07-08T12:00:00Z",
+  "anchors": [
+    { "id": "a1",
+      "panel": "TOP COUNTRIES",
+      "label": "United States GDP",
+      "raw": "18,037B",
+      "kind": "currency",
+      "sigma_element_hint": "Top Countries" }
+  ]
+}
+```
+
+- `raw` — the value **EXACTLY as printed**. Keep the raw string: `"18,037B"`,
+  never `18037`; `"(12.3%)"`, never `-0.123`; `"$733,215.26"` with the `$` and
+  commas. The printed form *is* the precision contract.
+- `kind` — `currency` | `number` | `percent` | **`text`** (alias `roster`/`member`).
+  A `text` anchor's `raw` is a **displayed LABEL** (case-insensitive cell match),
+  not a value — use it for ranked/top-N tiles so a wrongly-selected or dropped
+  member fails loudly (a top-15 materialized from the wrong rank, a renamed
+  category, a missing path label). Scope: exports carry the element's full
+  underlying data, so `text` anchors can't catch an UNFILTERED tile that merely
+  windows the wrong first-N on screen — gate 9b (shape identity) owns that class.
+- `sigma_element_hint` — optional; the Sigma element name the value should land
+  in. When present it wins over fuzzy matching.
+- **Minimum anchors (the gate requires ≥ 5):** every KPI value, the **top 3
+  values of every ranked list/table**, **one representative bucket value
+  per chart**, and — for every ranked/top-N tile — **2–3 `text` roster anchors**
+  naming members the source actually displays (include at least one from the
+  BOTTOM half of the list: top members often survive a wrong ranking, bottom
+  members don't). Top-of-ranked-list anchors are what catch the
+  different-members-with-different-values failure.
+
+### `anchors-verdict.json` — written by `scripts/verify-anchors.rb`
+
+```json
+{ "checked": 9, "matched": 8,
+  "missing": [ { "id": "a1", "label": "United States GDP", "raw": "18,037B",
+                 "best_candidate": { "value": 1.8e12, "element": "Top Countries" } } ],
+  "pass": false }
+```
+
+`verify-anchors.rb --workdir <W> --workbook-id <id>` pools the live workbook's
+element CSV exports (the same export→poll→download flow
+`collect-parity-actuals.rb` uses), searches each anchor in the element whose
+name best matches its label/panel (token overlap; the hint wins), then searches
+every other export before declaring a miss. Found-elsewhere still matches (the
+value exists; only the label→element mapping was fuzzy) and is noted. It also
+stamps an `anchors` summary into `parity-final.json` when present. Exit 0 all
+matched / 1 with a per-miss report naming each miss and its closest candidate.
+
+## Canonicalization rules (`scripts/lib/anchor_values.rb`)
+
+**Match rule:** a printed value MATCHES a real number when the real number
+**rounds to the printed form at the printed precision** — i.e.
+`|actual − printed| ≤ half of the last printed digit's place value`, scaled by
+any suffix.
+
+| Printed | Canonical value | Tolerance | Notes |
+|---|---|---|---|
+| `18,037B` | 1.8037e13 | ±0.5e9 | last digit = units of B |
+| `$1.8T` | 1.8e12 | ±0.05e12 | currency; one decimal of T |
+| `46.5M` | 4.65e7 | ±0.05e6 | |
+| `-2%` | −2 points | ±0.5 | also matches the fraction −0.02 ± 0.005 |
+| `1,687` | 1687 | ±0.5 | |
+| `$733,215.26` | 733215.26 | ±0.005 | cents precision |
+| `(12.3%)` | −12.3 points | ±0.05 | accounting-paren negative |
+| `12.3k` | 12300 | ±50 | lowercase suffixes accepted |
+
+Extra interpretations checked (they never weaken 10x detection):
+
+- Suffixed forms also match the **unscaled face value** (`18,037B` ↔ a column
+  already denominated in billions storing `18037`).
+- Percents match both **points** (−2) and **fraction** (−0.02) storage.
+
+So `1.8e12` does **not** match `18,037B` under any interpretation — the exact
+field failure — while `18,036,800,000,000` (rounds to 18,037B) does.
+
+## Worked example
+
+Source image shows a KPI `$86.5T`, a TOP COUNTRIES list headed by
+`United States 18,037B`, `China 13,608B`, `Japan 4,971B`, and a YoY panel with
+`-2%` on one bucket:
+
+```json
+{ "source_image": "views/abc123.png", "transcribed_at": "2026-07-08T15:04:00Z",
+  "anchors": [
+    { "id": "a1", "panel": "KPI",           "label": "World GDP total", "raw": "$86.5T",  "kind": "currency" },
+    { "id": "a2", "panel": "TOP COUNTRIES", "label": "United States",   "raw": "18,037B", "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a3", "panel": "TOP COUNTRIES", "label": "China",           "raw": "13,608B", "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a4", "panel": "TOP COUNTRIES", "label": "Japan",           "raw": "4,971B",  "kind": "number", "sigma_element_hint": "Top Countries" },
+    { "id": "a5", "panel": "YOY BY REGION", "label": "largest decline bucket", "raw": "-2%", "kind": "percent" }
+  ] }
+```
+
+If the built workbook's Top Countries element exports `1.8e12` for the top row,
+`verify-anchors.rb` reports:
+
+```
+MISSING  a2 "United States" raw="18,037B" — closest candidate 1.8e12 in "Top Countries"
+```
+
+— the 10x failure caught mechanically, before any visual verdict is consulted.
+
+## Gate wiring (`assert-phase6-ran.rb`)
+
+- **Gate 13 (exit 18):** whenever the workdir carries a source dashboard PNG
+  (the Phase 1d artifact — `png-read.json` `source_png`, `views/*.png`, or
+  `dashboards/*.png`), `source-anchors.json` must exist with ≥ 5 anchors AND
+  `anchors-verdict.json` must pass with every anchor checked (a stale verdict —
+  fewer checked than transcribed — fails). No source PNG → stated SKIP.
+  Escape: `--skip-anchors-gate "<reason>"` (counted against the waiver budget).
+- **Conditional `--skip-parity-gate` (exit 18):** waiving source parity is
+  REJECTED unless `anchors-verdict.json` exists and passes. The anchors oracle
+  replaces parity — never nothing. This is the no-standalone-views path's
+  contract too: parity oracle = anchors + warehouse (`verify-warehouse.rb`).
+- **Data-class RCF residuals (exit 15):** any unresolved `data`-class entry in
+  `fidelity-ledger.json` blocks GREEN whenever the ledger exists —
+  `--accept-residuals` does not apply. The numbers are wrong; fix or reclassify
+  with evidence.
+- **Waiver budget (exit 19):** more than 2 quality waivers → GREEN unavailable
+  (YELLOW cap). Anchors and similarity skips count; `--skip-telemetry-gate`
+  (policy) and the sanctioned builder→verifier `--skip-visual-comparison`
+  handoff do not.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/visual-similarity.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/visual-similarity.md
@@ -1,0 +1,82 @@
+# Visual-similarity floor — the deterministic gate under the visual verdict
+
+`scripts/visual-similarity.py` is a deterministic sanity floor that runs before any
+model-judged visual verdict counts. Its job is narrow: make it **impossible to record a
+passing visual verdict over a render that is structurally nothing like the source**. It is
+NOT a match-scorer and it does not measure migration quality — the RCF loop
+(`refs/phase-5g-rcf.md`, `refs/fidelity-rubric.md`) and Phase 6 parity own that. A floor
+pass means only "these two images are plausibly the same dashboard"; the real visual QA
+still happens on top of it.
+
+## Contract
+
+```
+python3 scripts/visual-similarity.py --source <src.png> --render <render.png> --json-out <out.json>
+```
+
+Exit codes: `0` = pass, `1` = fail, `2` = dependencies missing or input unreadable.
+**Exit 2 is never a pass** — treat it as a blocked gate: fix the environment
+(`pip install pillow numpy`) or re-export the image, then re-run. The gate wiring must
+propagate 2 as a hard stop, not fall through to the model verdict.
+
+JSON written to `--json-out`:
+
+| field           | meaning                                                                 |
+|-----------------|-------------------------------------------------------------------------|
+| `score_ink`     | 0–1. Render mark density (edges: text, bars, lines) as a fraction of the source's. Asymmetric — extra ink is never penalized; missing ink is. |
+| `score_layout`  | 0–1. Spatial distribution agreement: worst-band ink balance over row/column thirds (dominant term), plus coarse ink-pattern and row/column profile correlations. |
+| `score_overall` | 0–1. `aspect_factor * (0.42*score_ink + 0.58*score_layout)`.            |
+| `threshold`     | The calibrated pass line for `score_overall` (currently **0.45**).      |
+| `pass`          | `score_overall >= threshold` AND `score_ink >= 0.40` AND band balance `>= 0.10`. The two sub-floors catch sparse-marks and emptied-region failures even when the blend stays high. |
+| `notes`         | Human-readable reasons for any failure or anomaly (blank source, aspect mismatch, tripped sub-floor). |
+| `components`    | Diagnostic sub-signals (coverage, band_balance, pattern_corr, profile_corr, aspect_factor). |
+
+The comparison is fully deterministic: same two files in → byte-identical JSON out. No
+randomness, no model calls, no network.
+
+## What the floor catches
+
+- **Blank / mostly-empty pages** — render draws little or none of the source's ink.
+- **One-bar-vs-six-bars panels** — panel chrome survives but the marks are gone
+  (`score_ink` sub-floor at 0.40).
+- **Missing whole columns / sections / tables** — a page region that holds content in the
+  source is near-empty in the render (band-balance sub-floor at 0.10).
+- **Single-column stacks** — a grid dashboard collapsed into one long column; the page's
+  extreme aspect-ratio mismatch (>2.2x) zeroes the score.
+
+## What the floor deliberately tolerates
+
+Different fonts, colors, themes, padding, spacing, and margins; different aspect ratios
+(landscape source → longer Sigma page is normal); moderate panel rearrangement and re-flow
+(verified-faithful migrations in the calibration set include a 2x3 grid re-flowed to 4x3
+and landscape→portrait re-stacks — all pass with margin). If a render passes the floor but
+looks off, that is exactly what the RCF rubric is for.
+
+## Threshold provenance — do not tune it
+
+Threshold 0.45 and the sub-floors were calibrated on **20 verified-faithful migration
+pairs** (real Tableau dashboard exports vs their accepted Sigma renders, spanning dense
+KPI dashboards, app-style layouts, dark themes, text-heavy pages, and 10 chart-gallery
+pages) plus **17 failure-mode negatives** (1 real failed field migration with 1-bar-vs-6
+panels and whitespace, plus synthesized blank-page, half-page-empty, quarter-content, and
+single-column-stack renders). Every positive clears the threshold by ≥ 0.08 and every
+negative misses it by ≥ 0.10; the sub-floors clear their nearest positive by ≥ 0.10. The
+per-pair table is embedded as a comment block in `scripts/visual-similarity.py`.
+
+**If the floor fails, the render's STRUCTURE diverges from the source.** The fix is always
+in the workbook: re-run the RCF loop, restore the missing sections/marks, and re-render.
+Never raise `--threshold`-style knobs, edit the constants, or re-crop the screenshots to
+squeeze a failing render through — a tuned floor is worse than no floor, because it
+launders a broken render into a recorded visual pass.
+
+## Dependencies
+
+Pillow + numpy only (no OpenCV/scikit). If either is missing the script prints
+`pip install pillow numpy` and exits 2. Runtime is well under a second per pair.
+
+## Tests
+
+`python3 scripts/test_visual_similarity.py` — offline synthetic-fixture suite covering the
+scoring behaviors (identical ≈ 1.0, recolored/shifted copy passes, blank / half-empty /
+sparse / stacked renders fail) and the full CLI exit-code contract, including a
+missing-dependency simulation.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/anchor_values.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/anchor_values.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+#
+# anchor_values.rb — PURE canonicalization of printed dashboard values.
+#
+# WHY. Two field migrations shipped dashboards whose NUMBERS were wrong while
+# every judgment gate recorded "pass": a ranked list showed different members
+# with 10x-off values ("$1.8T" where the source printed "18,037B"), and panels
+# collapsed to a fraction of the source's buckets. The fix is a MEASURED value
+# bar: the agent transcribes the source's printed values EXACTLY as printed
+# (Phase 1d, source-anchors.json), and verify-anchors.rb checks each printed
+# value against the live workbook's element CSV exports. This module is the
+# arithmetic core of that check: it parses a printed form ("18,037B", "$1.8T",
+# "-2%", "(12.3%)", "$733,215.26", "12.3k") into a (value, precision) pair and
+# decides whether a real number could have RENDERED as that printed form.
+#
+# MATCH RULE. A printed value MATCHES a real number when the real number rounds
+# to the printed form at the printed precision — i.e. |actual - printed_value|
+# <= half of the last printed digit's place value (scaled by any K/M/B/T
+# suffix). "18,037B" therefore matches any real in [18,036.5B, 18,037.5B]
+# (tolerance ±0.5e9), and 1.8e12 ("$1.8T") is a loud 10x MISS.
+#
+# CANDIDATE INTERPRETATIONS (all checked by match?):
+#   - suffixed values ("18,037B") also match the UNSCALED face value (18037)
+#     because some warehouses store the column already in that display unit;
+#   - percents ("-2%") match both percent POINTS (-2) and the FRACTION (-0.02).
+# Neither weakens the 10x/regrouping detection — the wrong values seen in the
+# field match none of the interpretations.
+#
+# Pure, stdlib-only, no IO. Unit tests: scripts/test-anchor-values.rb.
+
+module AnchorValues
+  KINDS = %w[currency number percent].freeze
+
+  SUFFIXES = {
+    'k' => 1e3, 'm' => 1e6, 'b' => 1e9, 't' => 1e12
+  }.freeze
+
+  CURRENCY_SYMBOLS = %w[$ € £ ¥].freeze
+
+  module_function
+
+  # Parse a printed form into its PRIMARY canonical interpretation.
+  # Returns { value: Float, tol: Float, kind: 'currency'|'number'|'percent',
+  #           negative: Boolean } or nil when the string is not a printed number.
+  # For percents the primary value is in percent POINTS ("-2%" → -2.0 ± 0.5);
+  # candidates() adds the fraction form.
+  def parse(raw)
+    s = raw.to_s.strip
+    return nil if s.empty?
+
+    negative = false
+    # Accounting-style parenthesized negative: "(12.3%)", "($4,120)".
+    if s.start_with?('(') && s.end_with?(')')
+      negative = true
+      s = s[1..-2].to_s.strip
+    end
+    # Leading minus (ASCII or unicode), possibly before OR after a currency symbol.
+    if s.start_with?('-', '−', '–')
+      negative = true
+      s = s[1..].to_s.strip
+    end
+
+    kind = 'number'
+    if CURRENCY_SYMBOLS.include?(s[0])
+      kind = 'currency'
+      s = s[1..].to_s.strip
+      if s.start_with?('-', '−', '–') # "$-12.4"
+        negative = true
+        s = s[1..].to_s.strip
+      end
+    end
+
+    percent = false
+    if s.end_with?('%')
+      percent = true
+      kind = 'percent'
+      s = s[0..-2].to_s.strip
+    end
+
+    multiplier = 1.0
+    if !percent && s =~ /\A(.*?)\s*([kKmMbBtT])\z/ && !Regexp.last_match(1).to_s.strip.empty?
+      body = Regexp.last_match(1).strip
+      suf  = Regexp.last_match(2).downcase
+      multiplier = SUFFIXES[suf]
+      s = body
+    end
+
+    digits = s.delete(',')
+    return nil unless digits =~ /\A(?:\d+(?:\.\d+)?|\.\d+)\z/
+
+    decimals = digits.include?('.') ? digits.split('.', 2)[1].length : 0
+    face = Float(digits)
+    step = 10.0**-decimals
+    value = face * multiplier
+    value = -value if negative
+    { value: value, tol: (step / 2.0) * multiplier, kind: kind, negative: negative }
+  end
+
+  # All acceptable (value, tol) interpretations of a printed form, primary first.
+  # Returns an Array of [value, tol] pairs, or [] when unparseable.
+  def candidates(raw)
+    p = parse(raw)
+    return [] if p.nil?
+    out = [[p[:value], p[:tol]]]
+    if p[:kind] == 'percent'
+      # Fraction form: exports often carry 0.02 where the dashboard prints "2%".
+      out << [p[:value] / 100.0, p[:tol] / 100.0]
+    else
+      # Unscaled face value for suffixed forms ("18,037B" ↔ a column already
+      # denominated in billions). Only differs when a suffix was present.
+      pr = parse(strip_suffix(raw))
+      out << [pr[:value], pr[:tol]] if pr && (pr[:value] - p[:value]).abs > Float::EPSILON
+    end
+    out
+  end
+
+  # Does a real number match the printed form? (See MATCH RULE above.)
+  def match?(raw, actual)
+    return false if actual.nil?
+    a = begin
+      Float(actual)
+    rescue ArgumentError, TypeError
+      return false
+    end
+    candidates(raw).any? do |value, tol|
+      (a - value).abs <= tol + (1e-9 * [value.abs, 1.0].max)
+    end
+  end
+
+  # The schema `kind` of a printed form ('currency'|'number'|'percent'), or nil.
+  def kind(raw)
+    p = parse(raw)
+    p && p[:kind]
+  end
+
+  # Relative distance between a real number and the printed form's primary
+  # value — used to rank "closest miss" candidates in reports. Float::INFINITY
+  # when the form is unparseable.
+  def relative_distance(raw, actual)
+    p = parse(raw)
+    return Float::INFINITY if p.nil? || actual.nil?
+    a = begin
+      Float(actual)
+    rescue ArgumentError, TypeError
+      return Float::INFINITY
+    end
+    # Best (smallest) distance across all interpretations, so a fraction-form
+    # percent ranks as close as its points form.
+    candidates(raw).map { |v, _| (a - v).abs / [v.abs, 1e-9].max }.min
+  end
+
+  # Remove a trailing K/M/B/T suffix (keeps sign/currency/percent decorations).
+  def strip_suffix(raw)
+    raw.to_s.sub(/\s*[kKmMbBtT](\)?)\z/, '\1')
+  end
+end

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,218 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.auth_token`             — age-aware: re-mints automatically when
+#                                       the token is older than TOKEN_TTL_SECONDS
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Token-freshness semantics (field lesson: sessions repeatedly hit 401s at
+# ~+25min-past-expiry because `auth_token` kept returning the stale env token):
+#   - A token minted by THIS process carries an in-memory minted_at stamp; when
+#     it ages past TOKEN_TTL_SECONDS (50 min), auth_token re-mints proactively.
+#   - The mint time is also surfaced as SIGMA_TOKEN_MINTED_AT (iso8601) so
+#     child processes inherit the token's AGE along with the token itself.
+#   - A token loaded from <WORK>/auth.json is aged by the file's mtime
+#     (get_token.py writes it at mint time, so mtime == mint time).
+#   - A bare env SIGMA_API_TOKEN with no known age is honored as-is
+#     (age-unknown) — the request helper's 401 handler re-mints ONCE and
+#     retries, then fails loudly.
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+require 'time'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env, encoding: 'UTF-8') do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
+      if _auth['SIGMA_API_TOKEN']
+        ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN']
+        # get_token.py writes auth.json at mint time, so the file's mtime IS
+        # the token's mint time — record it so auth_token can age the token
+        # out proactively instead of discovering staleness via a mid-phase 401.
+        ENV['SIGMA_TOKEN_MINTED_AT'] ||= File.mtime(_auth_path).utc.iso8601
+      end
+      ENV['SIGMA_BASE_URL'] ||= _auth['SIGMA_BASE_URL'] if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  # Sigma bearer tokens live ~60 minutes. Any token older than this is treated
+  # as stale and re-minted proactively (50 min leaves a safety margin), so long
+  # phases stop tripping over mid-run 401s from a token that quietly expired.
+  TOKEN_TTL_SECONDS = 50 * 60
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @minted_at = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  # Return a token that is safe to use RIGHT NOW.
+  #   - No token anywhere → mint one.
+  #   - Known mint time (this process minted it, a parent surfaced
+  #     SIGMA_TOKEN_MINTED_AT, or auth.json's mtime) and age > TTL → re-mint
+  #     (requires SIGMA_CLIENT_ID; without creds the stale token is returned
+  #     and the 401 path surfaces the failure loudly).
+  #   - Age unknown (bare env SIGMA_API_TOKEN) → honored as-is; the request
+  #     helper's 401 handler re-mints once and retries.
+  def auth_token
+    tok = @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN']
+    return refresh_token! if tok.nil? || tok.empty?
+    return refresh_token! if token_stale? && ENV['SIGMA_CLIENT_ID']
+    tok
+  end
+
+  # When the current token was minted, if known. The in-memory stamp (set by
+  # refresh_token! in this process) wins; else SIGMA_TOKEN_MINTED_AT (iso8601,
+  # set by a parent process's mint or by the auth.json bootstrap from mtime).
+  # nil = age unknown.
+  def token_minted_at
+    m = @token_mutex.synchronize { @minted_at }
+    return m if m
+    ts = ENV['SIGMA_TOKEN_MINTED_AT'].to_s
+    return nil if ts.empty?
+    begin
+      Time.parse(ts)
+    rescue ArgumentError
+      nil
+    end
+  end
+
+  def token_stale?
+    minted = token_minted_at
+    !minted.nil? && (Time.now - minted) > TOKEN_TTL_SECONDS
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      now = Time.now
+      @token_mutex.synchronize do
+        @token_override = tok
+        @minted_at = now
+      end
+      # Surface the refreshed token — and its mint time, so child processes
+      # inherit the token's AGE and re-mint on schedule too — to child
+      # processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      ENV['SIGMA_TOKEN_MINTED_AT'] = now.utc.iso8601
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/test-verify-anchors.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Tests for scripts/verify-anchors.rb — the measured value bar.
+#
+#   1. Pure core (AnchorVerify): label→element fuzzy match by token overlap,
+#      sigma_element_hint priority, found-elsewhere-still-matches, missing
+#      anchors carry a best_candidate, cell parsing ($/,/%/parens).
+#   2. CLI offline mode (--workbook-spec + --exports-dir): verdict file shape
+#      (checked/matched/missing/pass), exit codes (0 all matched / 1 miss /
+#      2 usage), and the parity-final.json `anchors` stamp.
+#
+# Offline, no network. Usage: ruby scripts/test-verify-anchors.rb
+
+require 'json'
+require 'csv'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+ENV['VERIFY_ANCHORS_CLI'] = nil
+require_relative 'verify-anchors' # loads AnchorVerify (CLI guarded out)
+
+SCRIPT = File.join(__dir__, 'verify-anchors.rb')
+
+$fails = []
+def ok(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '-- pure core: element ranking --'
+els = ['Top Countries', 'GDP Trend', 'YoY Growth by Region', 'KPI Row']
+a_label = { 'id' => 'a1', 'panel' => 'TOP COUNTRIES', 'label' => 'United States GDP', 'raw' => '18,037B' }
+ok(AnchorVerify.ranked_elements(a_label, els).first == 'Top Countries',
+   'panel/label token overlap ranks the right element first')
+ok(AnchorVerify.ranked_elements(a_label, els).length == els.length,
+   'zero-score elements are appended (search everywhere)')
+a_hint = a_label.merge('sigma_element_hint' => 'YoY Growth by Region')
+ok(AnchorVerify.ranked_elements(a_hint, els).first == 'YoY Growth by Region',
+   'sigma_element_hint wins over panel/label overlap')
+a_hint_fuzzy = a_label.merge('sigma_element_hint' => 'yoy region growth')
+ok(AnchorVerify.ranked_elements(a_hint_fuzzy, els).first == 'YoY Growth by Region',
+   'non-exact hint still matches by token overlap')
+
+puts '-- pure core: cell parsing --'
+ok(AnchorVerify.cell_numbers('$1,234.50') == [1234.5], 'currency + commas parse')
+ok(AnchorVerify.cell_numbers('(42)') == [-42.0], 'paren negative parses')
+ok(AnchorVerify.cell_numbers('12%') == [12.0, 0.12], 'percent cell keeps points + fraction')
+ok(AnchorVerify.cell_numbers('United States').empty?, 'non-numeric cell yields nothing')
+ok(AnchorVerify.cell_numbers('').empty? && AnchorVerify.cell_numbers(nil).empty?, 'empty/nil cells yield nothing')
+
+puts '-- pure core: verify() verdicts --'
+exports = {
+  'Top Countries' => [['Country', 'GDP'], ['United States', '18037000000000'], ['China', '13608000000000']],
+  'GDP Trend'     => [['Year', 'GDP'], ['2024', '1.75e12'], ['2025', '1.8e12']],
+  'KPI Row'       => [['Total GDP', 'YoY'], ['86500000000000', '-0.02']]
+}
+anchors = [
+  { 'id' => 'a1', 'panel' => 'TOP COUNTRIES', 'label' => 'United States GDP', 'raw' => '18,037B' },
+  { 'id' => 'a2', 'panel' => 'KPI', 'label' => 'YoY change', 'raw' => '-2%', 'sigma_element_hint' => 'KPI Row' },
+  { 'id' => 'a3', 'panel' => 'KPI', 'label' => 'Total GDP', 'raw' => '86.5T' }
+]
+v = AnchorVerify.verify(anchors, exports)
+ok(v['pass'] == true && v['matched'] == 3 && v['checked'] == 3, 'all-matched verdict passes 3/3')
+ok(v['missing'].empty?, 'no missing entries when all matched')
+
+# The field failure: the workbook renders 1.8T where the source printed 18,037B.
+bad_exports = exports.merge('Top Countries' => [['Country', 'GDP'], ['United Kingdom', '1.8e12']])
+v2 = AnchorVerify.verify(anchors, bad_exports)
+ok(v2['pass'] == false && v2['matched'] == 2, '10x-off value fails the anchor (2/3)')
+miss = v2['missing'].first
+ok(miss['id'] == 'a1' && miss['raw'] == '18,037B', 'missing entry carries id + raw')
+ok(miss['best_candidate'].is_a?(Hash) && miss['best_candidate']['value'] == 1.8e12,
+   'best_candidate reports the closest wrong value (the 1.8T impostor)')
+
+# found-elsewhere: value lives in a differently-named element → matched + noted
+elsewhere = { 'Some Renamed Tile' => [['GDP'], ['18037000000000']] }
+v3 = AnchorVerify.verify([anchors[0]], elsewhere)
+ok(v3['pass'] == true, 'value found in a non-best-match element still matches')
+ok(v3['detail'].first['matched_in'] == 'Some Renamed Tile', 'detail names where it was found')
+
+# hint discipline: a HINTED numeric anchor whose value appears ONLY in a
+# hint-UNRELATED element is a MISS — NOT a false match. Field-caught in the
+# PowerBI port pilot: a KPI's wrong value (10x-unit / wrong-aggregate) that
+# coincidentally lived in a big detail table silently passed the old
+# search-everywhere fallback. (Hint-LESS anchors keep that fallback — see v3.)
+hinted_exports = {
+  'Total Stores' => [['Total Stores'], ['104']],
+  'Sales Detail' => [['SLS'], ['1040'], ['1600000']]
+}
+v4 = AnchorVerify.verify(
+  [{ 'id' => 'h1', 'label' => 'Total Stores', 'raw' => '1,040', 'sigma_element_hint' => 'Total Stores' }],
+  hinted_exports
+)
+ok(v4['pass'] == false && v4['missing'].first && v4['missing'].first['id'] == 'h1',
+   'hinted numeric found only OUTSIDE the hinted element is a MISS (not a false match)')
+ok(v4['missing'].first['best_candidate'] && v4['missing'].first['best_candidate']['value'] == 104.0,
+   'the miss surfaces the real value (104 in the hinted element) as closest candidate')
+v5 = AnchorVerify.verify(
+  [{ 'id' => 'h2', 'label' => 'Total Stores', 'raw' => '104', 'sigma_element_hint' => 'Total Stores' }],
+  hinted_exports
+)
+ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
+
+puts '-- CLI offline mode --'
+def write_fixture(dir, exports_rows, anchors)
+  spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>
+    exports_rows.each_with_index.map { |(name, _), i| { 'id' => "el#{i}", 'name' => name, 'kind' => 'table' } } }] }
+  File.write(File.join(dir, 'wb-spec.json'), JSON.pretty_generate(spec))
+  exp = File.join(dir, 'exports')
+  Dir.mkdir(exp)
+  exports_rows.each_with_index do |(_, rows), i|
+    CSV.open(File.join(exp, "el#{i}.csv"), 'w') { |c| rows.each { |r| c << r } }
+  end
+  File.write(File.join(dir, 'source-anchors.json'),
+             JSON.pretty_generate('source_image' => 'views/dash.png',
+                                  'transcribed_at' => '2026-07-08T00:00:00Z',
+                                  'anchors' => anchors))
+  [File.join(dir, 'wb-spec.json'), exp]
+end
+
+def run_cli(dir, spec, exp)
+  Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--workbook-spec', spec, '--exports-dir', exp)
+end
+
+Dir.mktmpdir do |dir|
+  spec, exp = write_fixture(dir, exports, anchors)
+  File.write(File.join(dir, 'parity-final.json'),
+             JSON.pretty_generate('status' => 'PASS', 'charts_total' => 3, 'charts_pass' => 3))
+  out, _err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus.zero?, "all matched → exit 0 (got #{st.exitstatus})")
+  ok(out.include?('3/3'), 'summary reports 3/3 matched')
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  ok(vd['pass'] == true && vd['checked'] == 3 && vd['matched'] == 3 && vd['missing'] == [],
+     'anchors-verdict.json carries the contract shape (checked/matched/missing/pass)')
+  pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
+  ok(pf['anchors'].is_a?(Hash) && pf['anchors']['pass'] == true && pf['anchors']['checked'] == 3,
+     'anchors summary stamped into parity-final.json')
+end
+
+Dir.mktmpdir do |dir|
+  spec, exp = write_fixture(dir, bad_exports, anchors)
+  _out, err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus == 1, "missing anchor → exit 1 (got #{st.exitstatus})")
+  ok(err.include?('MISSING') && err.include?('18,037B'), 'per-miss report names the anchor raw value')
+  ok(err.include?('closest candidate'), 'per-miss report shows the best candidate')
+  ok(err.include?('loudest possible signal'), 'failure explains what a total miss means')
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  ok(vd['pass'] == false && vd['missing'].length == 1 && vd['missing'][0]['id'] == 'a1',
+     'failing verdict written with the missing anchor')
+end
+
+Dir.mktmpdir do |dir|
+  # no source-anchors.json at all → usage error, points at Phase 1d
+  _out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir,
+                                 '--workbook-spec', '/nonexistent', '--exports-dir', dir)
+  ok(st.exitstatus == 2, "missing source-anchors.json → exit 2 (got #{st.exitstatus})")
+  ok(err.include?('Phase 1d'), 'missing-anchors error points at the Phase 1d transcription step')
+end
+
+Dir.mktmpdir do |dir|
+  # unparseable raw → usage error (transcription contract violated)
+  spec, exp = write_fixture(dir, exports, [{ 'id' => 'a1', 'label' => 'x', 'raw' => 'about twenty' }])
+  _out, err, st = run_cli(dir, spec, exp)
+  ok(st.exitstatus == 2, "unparseable raw → exit 2 (got #{st.exitstatus})")
+  ok(err.include?('EXACTLY as printed'), 'unparseable-raw error restates the transcription rule')
+end
+
+puts
+if $fails.empty?
+  puts 'ALL PASS — verify-anchors core + offline CLI'
+  exit 0
+else
+  puts "FAILURES (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/test_visual_similarity.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/test_visual_similarity.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Offline tests for visual-similarity.py (synthetic fixtures only).
+
+Run: python3 scripts/test_visual_similarity.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "visual-similarity.py")
+
+try:
+    from PIL import Image, ImageDraw
+except ImportError:  # pragma: no cover
+    sys.stderr.write("tests require Pillow/numpy: pip install pillow numpy\n")
+    sys.exit(2)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("visual_similarity", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+VS = _load_module()
+
+# --- synthetic dashboard fixtures -------------------------------------------
+
+BAR_HEIGHTS = [0.55, 0.8, 0.35, 0.95, 0.6, 0.45]
+
+
+def draw_card(d, x0, y0, x1, y1, chrome, ink, accent, bars=6, lines=False):
+    """One dashboard 'card': faint border, title bar, bar chart or text rows.
+
+    bars < 6 models the mid-tier failure mode seen in the field: the panel
+    chrome survives, but a single small bar sits where six categories should
+    be, or a dense table collapses to a few stub rows, leaving whitespace
+    (bar slots are always sized for six, so fewer bars = emptier panel).
+    """
+    d.rectangle([x0, y0, x1, y1], outline=chrome, width=1)
+    d.rectangle([x0 + 8, y0 + 8, x1 - 8, y0 + 22], fill=accent)
+    body_top, body_bot = y0 + 36, y1 - 12
+    if lines:  # table-ish card; sparse variant drops most rows
+        y = body_top
+        step = 12 if bars >= 6 else 12 * 6 // max(1, bars)
+        while y < body_bot - 6:
+            d.rectangle([x0 + 12, y, x1 - 20, y + 4], fill=ink)
+            y += step
+        return
+    span = (x1 - x0 - 24) / 6.0  # slot width is ALWAYS six-across
+    scale = 1.0 if bars >= 6 else 0.5  # degenerate charts come out small too
+    for i in range(bars):
+        h = BAR_HEIGHTS[i % len(BAR_HEIGHTS)] * (body_bot - body_top) * scale
+        bx0 = x0 + 12 + i * span
+        bx1 = bx0 + span * 0.62
+        d.rectangle([bx0, body_bot - h, bx1, body_bot], fill=accent)
+
+
+def make_dashboard(w=1200, h=800, bg=(255, 255, 255), ink=(40, 40, 60),
+                   accent=(46, 84, 158), bars=6, shift=0):
+    """Deterministic synthetic dashboard: header + KPI row + 3x2 card grid.
+
+    Card borders are drawn just above the background (delta < ink threshold),
+    like modern borderless-card dashboards, so marks dominate the ink budget.
+    """
+    chrome = tuple(max(0, c - 10) for c in bg)
+    im = Image.new("RGB", (w, h), bg)
+    d = ImageDraw.Draw(im)
+    s = shift
+    d.rectangle([20 + s, 15 + s, w - 20 + s, 45 + s], fill=accent)  # header
+    for k in range(4):  # KPI strip: value block + sparkline zigzag
+        kx = 20 + s + k * (w - 40) // 4
+        kx1 = kx + (w - 40) // 4 - 12
+        d.rectangle([kx, 60 + s, kx1, 110 + s], outline=chrome, width=1)
+        if bars >= 6:  # degenerate renders lose KPI innards, keep the frame
+            d.rectangle([kx + 10, 70 + s, kx + 70, 86 + s], fill=ink)
+            pts = [(kx + 10 + 7 * i, 100 + s - 8 * (i % 3)) for i in range(12)]
+            d.line(pts, fill=accent, width=2)
+    grid_top = 130 + s
+    cw, ch = (w - 60) // 3, (h - grid_top - 30) // 2
+    for r in range(2):
+        for c in range(3):
+            x0 = 20 + s + c * (cw + 10)
+            y0 = grid_top + r * (ch + 10)
+            draw_card(d, x0, y0, x0 + cw, y0 + ch, chrome, ink, accent,
+                      bars=bars, lines=(c == 2))
+    return im
+
+
+def make_stack(src):
+    """Catastrophe: the six grid cards restacked into one narrow column."""
+    w, h = src.size
+    cw, ch = (w - 60) // 3, (h - 130 - 30) // 2
+    tiles = []
+    for r in range(2):
+        for c in range(3):
+            x0, y0 = 20 + c * (cw + 10), 130 + r * (ch + 10)
+            tiles.append(src.crop((x0, y0, x0 + cw, y0 + ch)))
+    out = Image.new("RGB", (cw + 20, (ch + 10) * 6 + 20), (255, 255, 255))
+    y = 10
+    for t in tiles:
+        out.paste(t, (10, y))
+        y += ch + 10
+    return out
+
+
+class FixtureMixin:
+    @classmethod
+    def setUpClass(cls):
+        cls.dir = tempfile.mkdtemp(prefix="vissim-test-")
+        cls.paths = {}
+
+        def save(name, im):
+            p = os.path.join(cls.dir, name + ".png")
+            im.save(p)
+            cls.paths[name] = p
+            return p
+
+        src = make_dashboard()
+        save("source", src)
+        save("identical", src.copy())
+        # recolored + font/padding-shifted copy: different palette, offset
+        save("recolored", make_dashboard(bg=(244, 241, 252), ink=(70, 60, 90),
+                                         accent=(180, 120, 60), shift=6))
+        save("blank", Image.new("RGB", (1600, 900), (255, 255, 255)))
+        half = src.copy()
+        half.paste(Image.new("RGB", (src.width, src.height // 2),
+                             (255, 255, 255)), (0, src.height // 2))
+        save("halfempty", half)
+        save("sparse", make_dashboard(bars=1))       # one bar vs six per panel
+        save("stack", make_stack(src))               # single-column stack
+        corrupt = os.path.join(cls.dir, "corrupt.png")
+        with open(corrupt, "wb") as fh:
+            fh.write(b"this is not a png file")
+        cls.paths["corrupt"] = corrupt
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.dir, ignore_errors=True)
+
+    def run_cli(self, source, render, json_out=None, env=None):
+        json_out = json_out or os.path.join(self.dir, "out.json")
+        proc = subprocess.run(
+            [sys.executable, SCRIPT, "--source", source, "--render", render,
+             "--json-out", json_out],
+            capture_output=True, text=True, env=env,
+        )
+        data = None
+        if os.path.isfile(json_out) and proc.returncode in (0, 1):
+            with open(json_out) as fh:
+                data = json.load(fh)
+        return proc, data
+
+
+class TestScoring(FixtureMixin, unittest.TestCase):
+    def test_identical_scores_near_one(self):
+        res = VS.compare(self.paths["source"], self.paths["identical"])
+        self.assertTrue(res["pass"])
+        self.assertGreaterEqual(res["score_overall"], 0.98)
+        self.assertGreaterEqual(res["score_ink"], 0.98)
+        self.assertGreaterEqual(res["score_layout"], 0.98)
+
+    def test_recolored_font_shifted_copy_passes(self):
+        res = VS.compare(self.paths["source"], self.paths["recolored"])
+        self.assertTrue(res["pass"], res)
+        self.assertGreaterEqual(
+            res["score_overall"], res["threshold"] + 0.05,
+            "legit restyle must clear the threshold with margin",
+        )
+
+    def test_blank_render_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["blank"])
+        self.assertFalse(res["pass"])
+        self.assertLessEqual(res["score_overall"], res["threshold"] - 0.05)
+
+    def test_half_empty_render_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["halfempty"])
+        self.assertFalse(res["pass"])
+        self.assertLessEqual(res["score_overall"], res["threshold"] - 0.05)
+
+    def test_one_bar_vs_six_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["sparse"])
+        self.assertFalse(res["pass"], res)
+        self.assertLess(res["score_ink"], 0.40,
+                        "mark-density floor should catch sparse panels")
+
+    def test_single_column_stack_fails(self):
+        res = VS.compare(self.paths["source"], self.paths["stack"])
+        self.assertFalse(res["pass"], res)
+
+    def test_symmetric_blank_source_noted(self):
+        res = VS.compare(self.paths["blank"], self.paths["blank"])
+        self.assertTrue(any("source appears blank" in n for n in res["notes"]))
+
+
+class TestCLIContract(FixtureMixin, unittest.TestCase):
+    def test_pass_exit_0_and_json_schema(self):
+        out = os.path.join(self.dir, "nested", "dir", "verdict.json")
+        proc, data = self.run_cli(self.paths["source"], self.paths["recolored"],
+                                  json_out=out)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        for key, typ in (("score_layout", float), ("score_ink", float),
+                         ("score_overall", float), ("pass", bool),
+                         ("threshold", float), ("notes", list)):
+            self.assertIn(key, data)
+            self.assertIsInstance(data[key], typ)
+        for key in ("score_layout", "score_ink", "score_overall"):
+            self.assertGreaterEqual(data[key], 0.0)
+            self.assertLessEqual(data[key], 1.0)
+
+    def test_fail_exit_1(self):
+        proc, data = self.run_cli(self.paths["source"], self.paths["blank"])
+        self.assertEqual(proc.returncode, 1)
+        self.assertFalse(data["pass"])
+        self.assertTrue(data["notes"], "failure must carry explanatory notes")
+
+    def test_deterministic_output(self):
+        out1 = os.path.join(self.dir, "det1.json")
+        out2 = os.path.join(self.dir, "det2.json")
+        self.run_cli(self.paths["source"], self.paths["recolored"], json_out=out1)
+        self.run_cli(self.paths["source"], self.paths["recolored"], json_out=out2)
+        with open(out1, "rb") as a, open(out2, "rb") as b:
+            self.assertEqual(a.read(), b.read())
+
+    def test_missing_input_exit_2(self):
+        proc, _ = self.run_cli(os.path.join(self.dir, "nope.png"),
+                               self.paths["source"])
+        self.assertEqual(proc.returncode, 2)
+        proc, _ = self.run_cli(self.paths["source"],
+                               os.path.join(self.dir, "nope.png"))
+        self.assertEqual(proc.returncode, 2)
+
+    def test_corrupt_input_exit_2(self):
+        proc, _ = self.run_cli(self.paths["source"], self.paths["corrupt"])
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("could not analyze", proc.stderr)
+
+    def test_missing_deps_exit_2_with_remediation(self):
+        shim = os.path.join(self.dir, "shim")
+        os.makedirs(shim, exist_ok=True)
+        for mod in ("PIL", "numpy"):
+            with open(os.path.join(shim, mod + ".py"), "w") as fh:
+                fh.write("raise ImportError('simulated missing %s')\n" % mod)
+        env = dict(os.environ)
+        env["PYTHONPATH"] = shim
+        proc, _ = self.run_cli(self.paths["source"], self.paths["identical"],
+                               env=env)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("pip install pillow numpy", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-anchors.rb
@@ -1,0 +1,483 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-anchors.rb — the MEASURED value bar for a converted workbook.
+#
+# WHY. Two field migrations recorded passing visual verdicts over dashboards
+# whose NUMBERS were wrong: a ranked list showed different members with 10x-off
+# values ("$1.8T" rendered where the source printed "18,037B"), and a
+# multi-bucket panel collapsed to a single bar. Every judgment gate is an
+# attestation, and lenient models attest generously — so this script replaces
+# the judgment with a MEASUREMENT: each printed value the agent transcribed
+# from the SOURCE dashboard image (Phase 1d, <workdir>/source-anchors.json)
+# must literally appear in the LIVE Sigma workbook's element CSV exports, at
+# the printed precision (scripts/lib/anchor_values.rb). An anchor value that
+# appears NOWHERE in the workbook exports is the loudest possible signal the
+# data is wrong.
+#
+# INPUT  <workdir>/source-anchors.json — authored by the AGENT at Phase 1d
+#        while reading the source dashboard PNG (schema: SKILL.md Phase 1d,
+#        refs/source-anchors.md):
+#          { "source_image": "views/<id>.png", "transcribed_at": "...",
+#            "anchors": [ { "id": "a1", "panel": "TOP COUNTRIES",
+#                           "label": "United States GDP", "raw": "18,037B",
+#                           "kind": "currency",
+#                           "sigma_element_hint": "Top Countries" } ] }
+# OUTPUT <workdir>/anchors-verdict.json:
+#          { "checked": N, "matched": M,
+#            "missing": [ { "id", "label", "raw", "best_candidate" } ],
+#            "pass": true|false }
+#        Also stamps an `anchors` summary into parity-final.json when present.
+#
+# HOW. Fetches the live workbook spec for element names, then pools element
+# CSV exports (the same POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download flow collect-parity-actuals.rb uses). Each anchor
+# is searched in the element whose name best matches its label/panel (token
+# overlap; `sigma_element_hint` wins when present); when the matched element
+# doesn't carry the value, every other export is searched before declaring the
+# anchor MISSING — found-elsewhere still counts as matched (the value exists;
+# only the label→element mapping was fuzzy) and is noted in the verdict.
+#
+# Usage (live):
+#   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+# Usage (offline — tests / pre-collected exports):
+#   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
+#     --exports-dir <dir-with-<elementId>.csv>
+#
+# Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
+# per-miss report names each, with its closest candidate); 2 = usage / missing
+# inputs.
+
+require 'json'
+require 'csv'
+require 'set'
+require 'optparse'
+require_relative 'lib/anchor_values'
+
+# ---------------------------------------------------------------------------
+# Pure core — unit-tested offline in test-verify-anchors.rb.
+# ---------------------------------------------------------------------------
+module AnchorVerify
+  STOPWORDS = %w[the a an of by per and or in on for to vs].freeze
+
+  module_function
+
+  def tokens(s)
+    s.to_s.downcase.scan(/[a-z0-9]+/) - STOPWORDS
+  end
+
+  # Overlap score between an anchor and an element name. sigma_element_hint,
+  # when present, is the only signal; otherwise panel+label tokens are used.
+  def element_score(anchor, el_name)
+    hint = anchor['sigma_element_hint'].to_s
+    name_toks = tokens(el_name)
+    return 0 if name_toks.empty?
+    if !hint.strip.empty?
+      return 1_000 if hint.strip.casecmp?(el_name.to_s.strip)
+      return (tokens(hint) & name_toks).length
+    end
+    ((tokens(anchor['panel']) | tokens(anchor['label'])) & name_toks).length
+  end
+
+  # Element names ordered best-match-first for this anchor; zero-score names
+  # are appended (search everywhere before declaring a value missing).
+  def ranked_elements(anchor, el_names)
+    scored = el_names.map { |n| [n, element_score(anchor, n)] }
+    hits = scored.select { |_, s| s.positive? }.sort_by { |n, s| [-s, n.to_s] }.map(&:first)
+    hits + (el_names - hits)
+  end
+
+  # Numeric face values of a CSV cell (both percent interpretations kept so
+  # AnchorValues candidate matching sees whichever the export carried).
+  def cell_numbers(cell)
+    s = cell.to_s
+    # Export bytes arrive as ASCII-8BIT off the HTTP body; a UTF-8 regexp match
+    # on that raises Encoding::CompatibilityError (live-caught). Normalize first.
+    s = s.dup.force_encoding(Encoding::UTF_8) unless s.encoding == Encoding::UTF_8
+    s = s.scrub('') unless s.valid_encoding?
+    s = s.strip
+    return [] if s.empty?
+    neg = s.start_with?('(') && s.end_with?(')')
+    s = s[1..-2] if neg
+    body = s.gsub(/[,$€£¥\s]/, '')
+    pct = body.end_with?('%')
+    body = body.chomp('%')
+    f = begin
+      Float(body)
+    rescue ArgumentError, TypeError
+      return []
+    end
+    f = -f if neg
+    pct ? [f, f / 100.0] : [f]
+  end
+
+  def rows_numbers(rows)
+    rows.flat_map { |r| Array(r).flat_map { |c| cell_numbers(c) } }
+  end
+
+  # Normalized text cells of an export (for kind:"text" roster anchors).
+  def rows_texts(rows)
+    # (map+compact, not filter_map — the skill's floor is the system Ruby 2.6)
+    rows.flat_map { |r| Array(r) }.map do |c|
+      s = c.to_s
+      s = s.dup.force_encoding(Encoding::UTF_8) unless s.encoding == Encoding::UTF_8
+      s = s.scrub('') unless s.valid_encoding?
+      s = s.strip.downcase
+      s.empty? ? nil : s
+    end.compact.to_set
+  end
+
+  # Verify anchors against { element_name => [[cell, ...], ...] } exports.
+  # Returns the verdict Hash (contract shape + per-anchor detail).
+  #
+  # Two anchor kinds:
+  #   numeric (default) — `raw` is a printed VALUE; matches any export cell at
+  #     printed precision.
+  #   kind: "text" (aka "roster") — `raw` is a LABEL that must appear as a cell
+  #     (case-insensitive, trimmed). Use these on ranked/top-N tiles so a
+  #     WRONGLY-SELECTED or dropped member fails loudly (a materialized top-15
+  #     built from the wrong rank, a renamed category, a missing path label).
+  #     Scope note: exports carry the element's full underlying data, so a
+  #     roster anchor canNOT catch an UNFILTERED tile that merely WINDOWS the
+  #     wrong first-N on screen — that class is caught by gate 9b (shape
+  #     identity: the reviewer sees the wrong columns) and by the render-bisect
+  #     playbook (unbounded pivots kill the renderer). Use both.
+  def verify(anchors, exports)
+    el_names = exports.keys
+    numbers = exports.transform_values { |rows| rows_numbers(rows) }
+    texts = exports.transform_values { |rows| rows_texts(rows) }
+    detail = []
+    missing = []
+    anchors.each do |a|
+      raw = a['raw'].to_s
+      order = ranked_elements(a, el_names)
+      if %w[text roster member].include?(a['kind'].to_s)
+        want = raw.strip.downcase
+        found_in = order.find { |n| texts[n].include?(want) }
+        if found_in
+          detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
+        else
+          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+        end
+        next
+      end
+      # A HINTED numeric anchor asserts WHERE its value must live. A match found
+      # only in a hint-UNRELATED element (e.g. a raw detail table that merely
+      # happens to contain the number) is NOT acceptance — that loophole silently
+      # passed 10x-unit and wrong-aggregate defects in field testing (a KPI whose
+      # value coincidentally appears in a big detail element). Restrict a hinted
+      # numeric anchor's search to hint-scored elements; found-only-outside is a
+      # MISS. Hint-less anchors keep the search-everywhere fallback (no asserted
+      # location to enforce); text/roster anchors are unchanged (a member label
+      # appearing anywhere is meaningful on its own).
+      search_order =
+        if a['sigma_element_hint'].to_s.strip.empty?
+          order
+        else
+          scoped = order.select { |n| element_score(a, n).positive? }
+          scoped.empty? ? order : scoped # defensive: hint matched no element name
+        end
+      found_in = search_order.find { |n| numbers[n].any? { |v| AnchorValues.match?(raw, v) } }
+      if found_in
+        primary = order.first
+        detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in,
+                    'note' => (found_in == primary ? nil : "found outside best-match element #{primary.inspect}") }.compact
+      else
+        # Closest candidate WITHIN the best-matching element that carries any
+        # numbers (walking down the ranking until one does) — the wrong value
+        # almost always lives in the anchor's own panel, so this surfaces the
+        # impostor ("$1.8T where the source printed 18,037B") rather than a
+        # coincidentally-near number from an unrelated tile.
+        best = nil
+        order.each do |n|
+          numbers[n].each do |v|
+            d = AnchorValues.relative_distance(raw, v)
+            best = { 'value' => v, 'element' => n, 'distance' => d.round(6) } if best.nil? || d < best['distance']
+          end
+          break if best
+        end
+        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                     'best_candidate' => best }
+      end
+    end
+    { 'checked' => anchors.length,
+      'matched' => anchors.length - missing.length,
+      'missing' => missing,
+      'pass' => missing.empty?,
+      'detail' => detail }
+  end
+end
+
+# ---------------------------------------------------------------------------
+# CLI (IO / REST) — thin wrapper around the pure core above.
+# ---------------------------------------------------------------------------
+return if $PROGRAM_NAME != __FILE__ && !ENV['VERIFY_ANCHORS_CLI'] # allow `require` in tests
+
+# Element display name for export keys. put-layout replaces `name` with a
+# visibility hash on hidden-title elements — every such element would
+# stringify to the SAME key and overwrite each other's exports (false RED on
+# any anchor living in the clobbered tile). Fall back to text, then the id
+# slug (unique by construction; token matching still ranks it).
+def el_display_name(el)
+  n = el['name']
+  return n.to_s unless n.is_a?(Hash)
+  t = n['text'].to_s
+  t.empty? ? el['id'].to_s.sub(/\Ael-/, '').tr('-', ' ') : t
+end
+
+opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+OptionParser.new do |p|
+  p.on('--workdir DIR')        { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
+  p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
+  p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
+end.parse!
+abort('--workdir required') unless opts[:dir]
+
+anchors_path = opts[:anchors] || File.join(opts[:dir], 'source-anchors.json')
+out_path     = opts[:out]     || File.join(opts[:dir], 'anchors-verdict.json')
+
+unless File.exist?(anchors_path)
+  warn "FATAL: #{anchors_path} not found — transcribe the source dashboard's printed values"
+  warn '       at Phase 1d (every KPI, top-3 of every ranked list/table, one bucket value per'
+  warn '       chart; EXACTLY as printed). Schema: SKILL.md Phase 1d / refs/source-anchors.md.'
+  exit 2
+end
+doc = begin
+  JSON.parse(File.read(anchors_path))
+rescue JSON::ParserError => e
+  warn "FATAL: #{anchors_path} is malformed JSON: #{e.message}"
+  exit 2
+end
+anchors = Array(doc['anchors'])
+if anchors.empty?
+  warn "FATAL: #{anchors_path} has no anchors[] — nothing to verify."
+  exit 2
+end
+# kind:"text"/"roster"/"member" anchors carry a LABEL in `raw` (displayed-set
+# membership for ranked tiles) — only NUMERIC anchors must parse as values.
+bad = anchors.reject do |a|
+  next false unless a.is_a?(Hash)
+  %w[text roster member].include?(a['kind'].to_s) ? !a['raw'].to_s.strip.empty? : AnchorValues.parse(a['raw'])
+end
+unless bad.empty?
+  warn "FATAL: #{bad.length} anchor(s) have an unparseable `raw` printed value:"
+  bad.first(10).each { |a| warn "         #{a.is_a?(Hash) ? a['id'] : '(bad entry)'}: raw=#{(a['raw'] rescue nil).inspect}" }
+  warn '       `raw` must be the value EXACTLY as printed on the source image ("18,037B", "-2%",'
+  warn '       "$733,215.26") — or, for kind:"text" roster anchors, a non-empty displayed label.'
+  exit 2
+end
+
+# --- element names + rows: offline (spec+exports dir) or live (REST) ---------
+exports = {} # element name => rows (arrays of cells)
+
+if opts[:exports]
+  spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
+  unless File.exist?(spec_path)
+    warn "FATAL: offline mode needs --workbook-spec (or <workdir>/wb-readback.json); #{spec_path} not found."
+    exit 2
+  end
+  spec = JSON.parse(File.read(spec_path))
+  elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  elements.each do |el|
+    csv = File.join(opts[:exports], "#{el['id']}.csv")
+    next unless File.exist?(csv)
+    exports[el_display_name(el)] = CSV.read(csv)
+  end
+else
+  # Live: resolve workbook id, GET the spec, pool the element CSV exports —
+  # the same export → poll → download flow collect-parity-actuals.rb uses.
+  wb = opts[:wb]
+  if wb.nil?
+    ids = File.join(opts[:dir], 'wb-ids.json')
+    wb = (JSON.parse(File.read(ids))['workbookId'] rescue nil) if File.exist?(ids)
+  end
+  abort('--workbook-id required (or a <workdir>/wb-ids.json with workbookId)') if wb.to_s.empty?
+
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
+  spec = begin
+    JSON.parse(body)
+  rescue JSON::ParserError, TypeError
+    require 'yaml'
+    require 'date'
+    body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
+  end
+  elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
+
+  # v5.4 PIVOT-TOTALS CEILING: a pivot carrying a `totals` key 500s its CSV
+  # export (probe-isolated: the key's PRESENCE is the sole trigger — value type
+  # irrelevant), so a totals-bearing pivot's anchor values would read as MISSING
+  # here through no fault of the data. Bracket the exports: capture + STRIP each
+  # pivot's totals (one PUT), export against totals-free pivots, then RESTORE the
+  # captured totals (ensure). Renders keep their hidden grand totals before and
+  # after — only the brief export window is totals-free. The shipped hide state
+  # is re-guaranteed by `put-layout.rb --apply-pivot-totals` at the finalize ship
+  # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
+  READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
+  put_spec = lambda do |s|
+    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
+  end
+  captured_totals = {}
+  queryable.each do |el|
+    next unless el['kind'] == 'pivot-table' && el.is_a?(Hash) && el.key?('totals')
+    captured_totals[el['id'].to_s] = el.delete('totals')
+  end
+  # v5.4.9 review fix: persist the captured totals to a *-pivot-totals.json
+  # sidecar BEFORE the strip PUT. If this process dies (or the restore PUT
+  # fails) between strip and restore, the finalize ship step (put-layout.rb
+  # --apply-pivot-totals, which globs the workdir) re-applies the FULL captured
+  # totals — including showSubtotals — instead of stamping the lossy
+  # showGrandTotals-only default. Deleted again after a successful restore.
+  totals_sidecar = File.join(opts[:dir], 'anchors-restore-pivot-totals.json')
+  if captured_totals.any?
+    begin
+      File.write(totals_sidecar, JSON.pretty_generate({ 'workbook' => wb, 'totals' => captured_totals }))
+    rescue StandardError => e
+      warn "  [WARN] could not write totals restore sidecar (#{e.class}: #{e.message.to_s[0, 80]})"
+    end
+  end
+
+  export_one = lambda do |el|
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return nil unless qid
+    t0 = Time.now
+    loop do
+      return nil if Time.now - t0 > opts[:timeout]
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        next if b.to_s.empty? # still rendering
+        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
+        return CSV.parse(b)
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
+      end
+    end
+  rescue Sigma::Error, CSV::MalformedCSVError => e
+    msg = e.message.lines.first.to_s.strip[0, 120]
+    ceiling = (el['kind'] == 'pivot-table' && e.is_a?(Sigma::Error) && msg =~ /\b500\b/) ?
+      ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
+      'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
+    warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
+    nil
+  end
+
+  require 'thread'
+  begin
+    # The strip PUT runs INSIDE this begin/ensure (v5.4.9 review fix): a
+    # network-level exception on the PUT (Net::ReadTimeout, Errno::ECONNRESET,
+    # SocketError — raised raw by Sigma.request, which only wraps HTTP-status
+    # failures in Sigma::Error) can fire AFTER the server applied the strip;
+    # previously it propagated before the restore bracket existed and left the
+    # live workbook totals-stripped (grand totals visible). Restoring when the
+    # strip never landed is an idempotent no-op PUT, so the ensure always
+    # attempts it.
+    if captured_totals.any?
+      begin
+        put_spec.call(spec)
+        warn "  [totals-ceiling] stripped grand-total key from #{captured_totals.size} pivot(s) for CSV export (restored after)"
+      rescue StandardError => e
+        warn "  [WARN] could not strip pivot totals (#{e.class}: #{e.message.lines.first.to_s.strip[0, 100]}) — " \
+             'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
+      end
+    end
+    queue = Queue.new
+    queryable.each { |el| queue << el }
+    mutex = Mutex.new
+    Array.new([opts[:pool], queryable.size].min.clamp(1, 8)) do
+      Thread.new do
+        loop do
+          el = begin
+            queue.pop(true)
+          rescue ThreadError
+            break
+          end
+          rows = export_one.call(el)
+          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+        end
+      end
+    end.each(&:join)
+  ensure
+    # Restore the grand-total keys stripped for the export window so renders
+    # (and the shipped workbook) keep hidden grand totals — even if the strip
+    # PUT or an export above raised (network-level errors included). On
+    # restore failure the sidecar written above survives, and the finalize
+    # ship step re-applies the FULL captured totals (incl. showSubtotals).
+    if captured_totals.any?
+      begin
+        elements.each { |el| (t = captured_totals[el['id'].to_s]) && el['totals'] = t }
+        put_spec.call(spec)
+        warn "  [totals-ceiling] restored grand-total key on #{captured_totals.size} pivot(s)"
+        begin
+          File.delete(totals_sidecar) if File.exist?(totals_sidecar)
+        rescue StandardError
+          nil # stale sidecar is harmless: it re-applies the same captured totals
+        end
+      rescue StandardError => e
+        warn "  [WARN] pivot totals RESTORE failed (#{e.class}: #{e.message.lines.first.to_s.strip[0, 100]}) — " \
+             "captured totals kept in #{File.basename(totals_sidecar)}; the finalize ship step " \
+             '(put-layout.rb --apply-pivot-totals) re-applies them, incl. showSubtotals'
+      end
+    end
+  end
+end
+
+if exports.empty?
+  warn 'FATAL: no element exports could be collected — cannot verify anchors.'
+  warn '       (live: check SIGMA_* credentials and the workbook id; offline: check --exports-dir)'
+  exit 2
+end
+
+verdict = AnchorVerify.verify(anchors, exports)
+verdict['source_anchors'] = anchors_path
+verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+File.write(out_path, JSON.pretty_generate(verdict))
+
+# Stamp the summary into parity-final.json when Phase 6 already finalized —
+# the anchors result travels with the parity verdict the final gate reads.
+pf = File.join(opts[:dir], 'parity-final.json')
+if File.exist?(pf)
+  begin
+    s = JSON.parse(File.read(pf))
+    s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
+                     'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    File.write(pf, JSON.pretty_generate(s))
+  rescue JSON::ParserError
+    warn "[WARN] #{pf} is malformed — anchors summary not stamped."
+  end
+end
+
+puts "verify-anchors: #{verdict['matched']}/#{verdict['checked']} anchor(s) matched " \
+     "across #{exports.length} element export(s) → #{out_path}"
+verdict['detail'].each do |d|
+  puts "  MATCHED  #{d['id']} #{d['raw'].inspect} in #{d['matched_in'].inspect}#{d['note'] ? " (#{d['note']})" : ''}"
+end
+if verdict['pass']
+  puts '[OK] every source anchor value is present in the live workbook exports.'
+  exit 0
+end
+warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+verdict['missing'].each do |m|
+  bc = m['best_candidate']
+  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+end
+warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+exit 1

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/visual-similarity.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/visual-similarity.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Deterministic visual-similarity floor for Phase 6 parity verification.
+
+Compares a source dashboard screenshot against a Sigma render and decides
+whether the render is structurally in the same universe as the source. This
+is a FLOOR, not a match-scorer: it exists so a passing "visual verdict" can
+never be recorded over a render that is structurally nothing like the source
+(blank/mostly-empty pages, one-bar-vs-six-bars panels, missing whole
+columns/sections, single-column stacks). It deliberately tolerates font,
+color, padding, spacing, and aspect-ratio differences, and even wholesale
+panel rearrangement, as long as the render carries a comparable amount of
+content distributed across the whole page.
+
+Contract (consumed by the Phase 6 gate):
+
+    python3 scripts/visual-similarity.py \
+        --source <src.png> --render <render.png> --json-out <out.json>
+
+Writes JSON: {"score_layout": float, "score_ink": float,
+              "score_overall": float, "pass": bool, "threshold": float,
+              "notes": [str, ...]}
+Exit codes: 0 = pass, 1 = fail, 2 = deps missing or unreadable input.
+Exit 2 must NEVER be treated as a pass.
+
+Method (fully deterministic — no randomness, no model calls):
+  1. Normalize: flatten alpha onto white, grayscale, downsample to <=384px.
+  2. Two binary "ink" maps per image: deviation from the page background
+     (histogram mode) and local gradient (catches light-on-light text).
+  3. Trim outer margins (capped at 12% per side, so real emptiness survives).
+  4. Signals, each in 0..1:
+       cov  - render edge-ink density as a fraction of the source's
+              (missing marks; asymmetric: extra ink is not penalized)
+       bal  - worst-band ink share ratio over row/column thirds
+              (an entire source-inked region empty in the render -> 0)
+       patt - Pearson correlation of 12x12 ink-density grids
+       prof - best of row/column 48-bin edge-ink profile correlations
+       asp  - soft penalty only for extreme aspect-ratio mismatch (>2.2x),
+              the page-geometry signature of a single-column stack
+  5. score_ink = cov;  score_layout = (0.46*bal + 0.06*patt + 0.06*prof)/0.58
+     score_overall = asp * (0.42*score_ink + 0.58*score_layout)
+     pass = score_overall >= 0.45  AND  score_ink >= 0.40  AND  bal >= 0.10
+
+Threshold provenance: calibrated on 20 verified-faithful migration pairs
+from the skills-test corpus plus 17 failure-mode negatives (1 real failed
+field migration + synthesized blank / half-empty / quarter-content /
+single-column-stack pages). Do NOT tune the threshold to make a failing
+render pass — a failure means STRUCTURE diverges; re-run the RCF loop.
+
+# ---------------------------------------------------------------------------
+# CALIBRATION SUMMARY (2026-07: 20 positives, 17 negatives; threshold 0.45)
+# All positives >= threshold + 0.05; all negatives <= threshold - 0.05.
+#
+# POSITIVES (must pass)            overall   NEGATIVES (must fail)      overall
+#   call-center                      0.780     field-failure (1-bar-vs-6) 0.311
+#   dynamic-zoning-kpi               0.702     blank-page x4              0.000
+#   ecommerce-admin                  0.534     single-column-stack x4  <= 0.001
+#   er-visits                        0.872     half-page-empty x4      <= 0.343
+#   social-media-campaign            0.692     quarter-content x4      <= 0.199
+#   supermart-sales                  0.554
+#   superstore-perf-overview         0.731   min positive 0.534 (+0.084)
+#   superstore-perf-order-detail     0.834   max negative 0.343 (-0.107)
+#   superstore-viz-extensions        0.629
+#   udemy-course-analysis            0.774   Sub-floors also verified:
+#   visual-vocabulary x10 pages   >= 0.553     min positive cov 0.506
+#                                              (ink floor 0.40, +0.106)
+#                                              min positive bal 0.234
+#                                              (bal floor 0.10, +0.134)
+# ---------------------------------------------------------------------------
+"""
+
+import argparse
+import json
+import os
+import sys
+
+REMEDIATION = (
+    "visual-similarity.py requires Pillow and numpy. "
+    "Install with: pip install pillow numpy"
+)
+
+try:
+    import numpy as np
+    from PIL import Image
+except ImportError:
+    sys.stderr.write(REMEDIATION + "\n")
+    sys.exit(2)
+
+# --- tunables (calibrated; see module docstring — do not tune per-run) ------
+WORK = 384          # max working dimension after downsample
+COARSE = 12         # coarse occupancy/pattern grid
+FINE = 48           # fine profile grid
+TRIM_CAP = 0.12     # max fraction of each side trimmed as outer margin
+LUM_DELTA = 24      # luminance deviation from page background counted as ink
+EDGE_DELTA = 20     # local gradient magnitude counted as edge ink
+BAND_N = 3          # row/column bands for the balance signal
+BAND_MIN_SHARE = 0.05   # source band must hold >=5% of ink to be scored
+ASPECT_SOFT = 2.2   # aspect-ratio mismatch tolerated up to this factor
+ASPECT_RAMP = 1.8   # penalty ramp width beyond ASPECT_SOFT
+
+W_INK = 0.42
+W_BAL = 0.46
+W_PATT = 0.06
+W_PROF = 0.06
+W_LAYOUT = W_BAL + W_PATT + W_PROF   # 0.58
+
+THRESHOLD = 0.45
+INK_FLOOR = 0.40    # hard sub-floor on score_ink (mark coverage)
+BAL_FLOOR = 0.10    # hard sub-floor on band balance
+
+
+def _load_gray(path):
+    """Return (grayscale float array downsampled to <=WORK, aspect ratio)."""
+    im = Image.open(path)
+    im.load()
+    if im.mode in ("RGBA", "LA") or (im.mode == "P" and "transparency" in im.info):
+        rgba = im.convert("RGBA")
+        flat = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+        im = Image.alpha_composite(flat, rgba)
+    im = im.convert("L")
+    w, h = im.size
+    if w < 4 or h < 4:
+        raise ValueError("image too small to analyze (%dx%d)" % (w, h))
+    aspect = w / h
+    scale = WORK / max(w, h)
+    if scale < 1:
+        im = im.resize(
+            (max(1, round(w * scale)), max(1, round(h * scale))), Image.BILINEAR
+        )
+    return np.asarray(im, dtype=np.float32), aspect
+
+
+def _ink_maps(gray):
+    """Return (combined ink map, edge-only ink map) as float 0/1 arrays."""
+    # explicit float64 edges: np.histogram(x, bins=16, range=(0,256)) hits a
+    # broadcast regression on numpy 2.2.x with real image arrays (A/B-report
+    # reproduced; fine on 2.3+). Edges are version-robust on both.
+    hist, edges = np.histogram(np.asarray(gray, dtype=np.float64).ravel(),
+                               bins=np.linspace(0.0, 256.0, 17))
+    mode = int(np.argmax(hist))
+    background = (edges[mode] + edges[mode + 1]) / 2.0
+    deviation = np.abs(gray - background) > LUM_DELTA
+    gx = np.abs(np.diff(gray, axis=1, prepend=gray[:, :1]))
+    gy = np.abs(np.diff(gray, axis=0, prepend=gray[:1, :]))
+    edge = (gx + gy) > EDGE_DELTA
+    return (deviation | edge).astype(np.float32), edge.astype(np.float32)
+
+
+def _capped_trim(ink, edge):
+    """Trim near-empty outer margins, at most TRIM_CAP per side.
+
+    The cap matters: it normalizes letterboxing/browser chrome without
+    letting a half-empty page crop itself back into looking complete.
+    """
+    h, w = ink.shape
+    rows = ink.sum(axis=1)
+    cols = ink.sum(axis=0)
+    rnz = np.nonzero(rows > w * 0.005)[0]
+    cnz = np.nonzero(cols > h * 0.005)[0]
+    if len(rnz) == 0 or len(cnz) == 0:
+        return ink, edge
+    r0 = min(int(rnz[0]), int(h * TRIM_CAP))
+    r1 = max(int(rnz[-1]) + 1, h - int(h * TRIM_CAP))
+    c0 = min(int(cnz[0]), int(w * TRIM_CAP))
+    c1 = max(int(cnz[-1]) + 1, w - int(w * TRIM_CAP))
+    return ink[r0:r1, c0:c1], edge[r0:r1, c0:c1]
+
+
+def _grid(m, n):
+    """Reduce a 2-D map to an n x n grid of cell means (stretch-normalized)."""
+    h, w = m.shape
+    ys = np.linspace(0, h, n + 1).astype(int)
+    xs = np.linspace(0, w, n + 1).astype(int)
+    out = np.zeros((n, n), dtype=np.float64)
+    for i in range(n):
+        for j in range(n):
+            cell = m[ys[i]:ys[i + 1], xs[j]:xs[j + 1]]
+            if cell.size:
+                out[i, j] = float(cell.mean())
+    return out
+
+
+def _corr(a, b):
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    if a.std() < 1e-9 or b.std() < 1e-9:
+        return 0.0
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def _band_shares(ink, n=BAND_N):
+    """Fraction of total ink in each of n row bands and n column bands."""
+    h, w = ink.shape
+    total = float(ink.sum()) or 1.0
+    shares = []
+    for i in range(n):
+        shares.append(float(ink[i * h // n:(i + 1) * h // n, :].sum()) / total)
+    for j in range(n):
+        shares.append(float(ink[:, j * w // n:(j + 1) * w // n].sum()) / total)
+    return shares
+
+
+def _band_balance(src_map, ren_map):
+    """Worst-case render/source ink-share ratio over row+column bands."""
+    src_shares = _band_shares(src_map)
+    ren_shares = _band_shares(ren_map)
+    worst = 1.0
+    for s, r in zip(src_shares, ren_shares):
+        if s > BAND_MIN_SHARE:
+            worst = min(worst, min(1.0, r / s))
+    return worst
+
+
+def compare(source_path, render_path):
+    """Compute the similarity-floor verdict for one source/render pair."""
+    gray_s, aspect_s = _load_gray(source_path)
+    gray_r, aspect_r = _load_gray(render_path)
+    ink_s, edge_s = _ink_maps(gray_s)
+    ink_r, edge_r = _ink_maps(gray_r)
+    ink_s, edge_s = _capped_trim(ink_s, edge_s)
+    ink_r, edge_r = _capped_trim(ink_r, edge_r)
+
+    notes = []
+
+    # -- ink coverage (asymmetric: only missing marks are penalized) --------
+    dens_s = float(edge_s.mean())
+    dens_r = float(edge_r.mean())
+    if dens_s > 1e-6:
+        cov = min(1.0, dens_r / dens_s)
+    else:
+        cov = 1.0 if dens_r <= 1e-6 else 0.0
+        notes.append("source appears blank — verify the source export")
+
+    # -- band balance: is any whole page region emptied out? ----------------
+    bal = min(_band_balance(ink_s, ink_r), _band_balance(edge_s, edge_r))
+
+    # -- structure agreement -------------------------------------------------
+    coarse_s, coarse_r = _grid(ink_s, COARSE), _grid(ink_r, COARSE)
+    fine_s, fine_r = _grid(edge_s, FINE), _grid(edge_r, FINE)
+    patt = max(0.0, _corr(coarse_s, coarse_r))
+    prof = max(
+        max(0.0, _corr(fine_s.sum(axis=1), fine_r.sum(axis=1))),
+        max(0.0, _corr(fine_s.sum(axis=0), fine_r.sum(axis=0))),
+    )
+
+    # -- aspect-ratio sanity (single-column-stack page geometry) ------------
+    ratio = max(aspect_s, aspect_r) / min(aspect_s, aspect_r)
+    if ratio <= ASPECT_SOFT:
+        asp = 1.0
+    else:
+        asp = max(0.0, 1.0 - (ratio - ASPECT_SOFT) / ASPECT_RAMP)
+        notes.append(
+            "extreme aspect-ratio mismatch (x%.1f): render page geometry "
+            "suggests content collapsed into a single column" % ratio
+        )
+
+    score_ink = round(cov, 4)
+    score_layout = round((W_BAL * bal + W_PATT * patt + W_PROF * prof) / W_LAYOUT, 4)
+    score_overall = round(asp * (W_INK * score_ink + W_LAYOUT * score_layout), 4)
+
+    passed = score_overall >= THRESHOLD
+    if score_ink < INK_FLOOR:
+        passed = False
+        notes.append(
+            "render draws only %.0f%% of the source's mark density "
+            "(floor %.0f%%): charts/text are likely missing or degenerate"
+            % (score_ink * 100, INK_FLOOR * 100)
+        )
+    if bal < BAL_FLOOR:
+        passed = False
+        notes.append(
+            "band balance %.2f (floor %.2f): a page region that holds "
+            "content in the source is (near-)empty in the render" % (bal, BAL_FLOOR)
+        )
+    if not passed and score_overall < THRESHOLD:
+        notes.append(
+            "overall %.3f below threshold %.2f: render structure diverges "
+            "from the source — re-run the RCF loop; do not tune the threshold"
+            % (score_overall, THRESHOLD)
+        )
+
+    return {
+        "score_layout": score_layout,
+        "score_ink": score_ink,
+        "score_overall": score_overall,
+        "pass": passed,
+        "threshold": THRESHOLD,
+        "notes": notes,
+        "components": {
+            "coverage": round(cov, 4),
+            "band_balance": round(bal, 4),
+            "pattern_corr": round(patt, 4),
+            "profile_corr": round(prof, 4),
+            "aspect_factor": round(asp, 4),
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Deterministic visual-similarity floor (source vs render)."
+    )
+    parser.add_argument("--source", required=True, help="source dashboard PNG")
+    parser.add_argument("--render", required=True, help="Sigma render PNG")
+    parser.add_argument("--json-out", required=True, help="verdict JSON path")
+    args = parser.parse_args(argv)
+
+    for label, path in (("source", args.source), ("render", args.render)):
+        if not os.path.isfile(path):
+            sys.stderr.write("%s image not found: %s\n" % (label, path))
+            return 2
+
+    try:
+        result = compare(args.source, args.render)
+    except Exception as exc:  # unreadable/corrupt input — never a pass
+        sys.stderr.write("could not analyze images: %s\n" % exc)
+        return 2
+
+    out_dir = os.path.dirname(os.path.abspath(args.json_out))
+    os.makedirs(out_dir, exist_ok=True)
+    with open(args.json_out, "w") as fh:
+        json.dump(result, fh, indent=2)
+        fh.write("\n")
+
+    verdict = "PASS" if result["pass"] else "FAIL"
+    print(
+        "visual-similarity: %s  overall=%.3f (threshold %.2f)  "
+        "ink=%.3f layout=%.3f"
+        % (
+            verdict,
+            result["score_overall"],
+            result["threshold"],
+            result["score_ink"],
+            result["score_layout"],
+        )
+    )
+    for note in result["notes"]:
+        print("  note: %s" % note)
+    return 0 if result["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -56,7 +56,8 @@
     "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb",
     "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb",
     "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb",
-    "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb"
+    "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb"
    ]
   },
   {
@@ -509,7 +510,11 @@
     "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-anchors.rb",
     "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-anchors.rb",
     "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-anchors.rb",
-    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-anchors.rb"
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-anchors.rb",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-anchors.rb",
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-anchors.rb",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-anchors.rb",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-anchors.rb"
    ]
   },
   {
@@ -520,7 +525,11 @@
     "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-verify-anchors.rb",
     "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-verify-anchors.rb",
     "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test-verify-anchors.rb",
-    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test-verify-anchors.rb"
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test-verify-anchors.rb",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-anchors.rb",
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-verify-anchors.rb",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test-verify-anchors.rb",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/test-verify-anchors.rb"
    ]
   },
   {
@@ -531,7 +540,11 @@
     "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/anchor_values.rb",
     "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/anchor_values.rb",
     "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/anchor_values.rb",
-    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/anchor_values.rb"
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/anchor_values.rb",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/anchor_values.rb",
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/anchor_values.rb",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/anchor_values.rb",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/anchor_values.rb"
    ]
   },
   {
@@ -542,7 +555,11 @@
     "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/visual-similarity.py",
     "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/visual-similarity.py",
     "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/visual-similarity.py",
-    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/visual-similarity.py"
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/visual-similarity.py",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/visual-similarity.py",
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/visual-similarity.py",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/visual-similarity.py",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/visual-similarity.py"
    ]
   },
   {
@@ -553,7 +570,11 @@
     "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_visual_similarity.py",
     "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test_visual_similarity.py",
     "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_visual_similarity.py",
-    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test_visual_similarity.py"
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test_visual_similarity.py",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test_visual_similarity.py",
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test_visual_similarity.py",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test_visual_similarity.py",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/test_visual_similarity.py"
    ]
   },
   {
@@ -564,7 +585,11 @@
     "plugins/looker-to-sigma/skills/looker-to-sigma/refs/source-anchors.md",
     "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/source-anchors.md",
     "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/source-anchors.md",
-    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/source-anchors.md"
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/source-anchors.md",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/source-anchors.md",
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/source-anchors.md",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/source-anchors.md",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/source-anchors.md"
    ]
   },
   {
@@ -575,7 +600,11 @@
     "plugins/looker-to-sigma/skills/looker-to-sigma/refs/visual-similarity.md",
     "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/visual-similarity.md",
     "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/visual-similarity.md",
-    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/visual-similarity.md"
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/visual-similarity.md",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/visual-similarity.md",
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/visual-similarity.md",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/visual-similarity.md",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/visual-similarity.md"
    ]
   }
  ]


### PR DESCRIPTION
## Summary

Completes the **script-level** rollout of the measured parity toolkit (follow-up to #370/#371). Vendors `verify-anchors.rb` + `lib/anchor_values.rb` + `visual-similarity.py` (+ tests + `refs/source-anchors.md`, `refs/visual-similarity.md`) as shared twins into the **4 remaining converters**: qlik, cognos, gooddata, sisense (sisense also gets `lib/sigma_rest.rb`, the ruby dep it lacked).

**All 9 Sigma converters now carry the anchors + visual-similarity toolkit** (canonical = tableau; `check-shared`: 367 copies match).

## Safe + inert on these 4
None of qlik/cognos/gooddata/sisense has `assert-phase6-ran.rb` yet, so the gates don't arm here — this is purely the **prerequisite** so the per-skill gate-host wiring can land later without a script gap (and avoids the gate-13 armed-but-scriptless exit-18 landmine when a source PNG is introduced).

## Verification
- Vendored `verify-anchors` unit suite passes in the qlik copy.
- All new ruby/python copies syntax-clean; `test_visual_similarity` skips cleanly without Pillow/numpy.
- `check-shared` 367/367; SKILL conformance, ESM-import, agent-variant gates all green.

## Rollout status & staged follow-ups (from the per-skill blueprint)
| bucket | skills | this PR | next |
|---|---|---|---|
| scripts vendored | **all 9** | ✅ | — |
| gates live (host + wiring) | powerbi, looker, quicksight, thoughtspot, microstrategy | scripts+host present (#371) | SKILL.md Phase-1d/Phase-6 wiring |
| source-PNG bridge | quicksight, microstrategy, thoughtspot | — | PDF→PNG / screenshot convention |
| gate-host port | qlik, cognos, gooddata | scripts present | inline (qlik) / Node→Ruby (cognos) / host drop-in (gooddata) |
| defer | sisense | scripts present (scoped fallback) | python re-platform |

🤖 Generated with [Claude Code](https://claude.com/claude-code)