### PR TITLE
feat(parity): wire anchors + visual-similarity gates into powerbi & looker SKILL.md

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -747,6 +747,9 @@ ruby scripts/phase6-parity-looker.rb --workdir /tmp/<name> --workbook-id <wb>   
 #   (Looker POST /queries/run/json, or the warehouse re-aggregation offline) …
 #   → write parity-expected.json + parity-actuals.json (shape: {"<chart>": [[dim,val],…]})
 ruby scripts/phase6-parity-looker.rb --workdir /tmp/<name> --finalize           # PASS 2: sentinel
+# MEASURED bars — Phase 4a must have authored source-anchors.json (>=5) + landed a source PNG on disk:
+ruby scripts/verify-anchors.rb      --workdir /tmp/<name> --workbook-id <wb>    # -> anchors-verdict.json (gate 13)
+python3 scripts/visual-similarity.py --source /tmp/<name>/dashboards/looker-<dash>.png --render /tmp/<name>/sigma-<dash>.png --json-out /tmp/<name>/visual-similarity.json  # gate 14
 ruby scripts/assert-phase6-ran.rb   --workdir /tmp/<name> --workbook-id <wb>    # must exit 0
 ```
 
@@ -754,8 +757,12 @@ The finalize pass writes the **`parity-final.json` sentinel**; `assert-phase6-ra
 (hard gate, vendored byte-identical across the 5 plugins) refuses GREEN unless
 parity ran + PASSed, no orphan workbooks were left, the live workbook has no
 `type=error` columns, a real layout is applied, the layout lint passes (gate 6),
-and the control lint passes (gate 7 — dead/ghost/partial controls; see
-`refs/control-parity.md`). Optional runtime follow-up when controls exist:
+the control lint passes (gate 7 — dead/ghost/partial controls; see
+`refs/control-parity.md`), **the source-anchor values verify (gate 13** — needs
+`source-anchors.json` ≥5 + a passing `anchors-verdict.json`; arms when a source
+PNG is on disk; `--skip-anchors-gate "<reason>"`**)**, and **the visual-similarity
+floor holds (gate 14** — `visual-similarity.json`; `--skip-visual-similarity "<reason>"`**)**;
+no source PNG on disk → both self-SKIP (stated), never a silent pass. Optional runtime follow-up when controls exist:
 `ruby scripts/probe-controls.rb --workbook-id <wb> --check-out-of-closure`
 (flip test — in-closure export must change under a non-default control value,
 out-of-closure must not). `migrate-looker.py` automates
@@ -780,8 +787,13 @@ where Looker showed `$`/`%`). After POSTing, render **both** the Looker source d
 migrated Sigma workbook to PNG and inspect them side-by-side:
 
 ```bash
-# (1) SOURCE — render the live Looker dashboard (reads ~/.looker/looker.ini)
-python3 scripts/looker-render-dashboard.py <dashboardId> /tmp/<name>/looker-<dash>.png
+# (1) SOURCE — render the live Looker dashboard (reads ~/.looker/looker.ini).
+#     Land it under dashboards/ (a gate-discovered path) so the anchors bar (gate 13) arms:
+mkdir -p /tmp/<name>/dashboards
+python3 scripts/looker-render-dashboard.py <dashboardId> /tmp/<name>/dashboards/looker-<dash>.png
+#     Then READ that PNG and transcribe its printed values into /tmp/<name>/source-anchors.json
+#     (>=5 anchors, EXACTLY as printed — every KPI, top-3 of each ranked list/table, one bucket
+#     per chart; schema: refs/source-anchors.md). Verified in 4-pre (gate 13) + fed to gate 14.
 
 # (2) MIGRATED — render the Sigma workbook page
 bash -c 'eval "$(scripts/get-token.sh)" && python3 scripts/sigma-export-png.py \

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -213,6 +213,20 @@ pages next to the Power BI renders. Do this BEFORE Phase 6, every run:
    Phase 5c ledger: every **recoverable** gap must be acknowledged — its visual
    named in a page's `deltas[]` (or an explicit `acceptedGaps` list) — so a
    recoverable drop can never ship unnoticed.
+6. **Measured bars (feed the Phase-6 anchors + visual-similarity gates 13/14).**
+   Steps 3–5 are human judgment; these two are deterministic and MUST also run:
+   - **Source anchors.** While reading each source page, transcribe its printed
+     values into `$WORK/source-anchors.json` — **≥5 anchors, EXACTLY as printed**
+     (every KPI, the top-3 of each ranked list/table, one representative bucket
+     per chart; schema: `refs/source-anchors.md`). Land the source page PNG at a
+     path the gate discovers so the bar arms: set it as `source_png` in
+     `png-read.json`, **or** copy it to `$WORK/dashboards/source.png` (if the
+     source export is a PDF, convert one page first: `sips -s format png in.pdf --out out.png` / `pdftoppm -png`).
+     Then verify against the live workbook:
+     `ruby scripts/verify-anchors.rb --workdir $WORK --workbook-id <wbId>` → `anchors-verdict.json` (must pass).
+   - **Visual-similarity floor.** `"$PY" scripts/visual-similarity.py --source <sourcePagePng> --render $WORK/visual-qa/sigma-<page>.png --json-out $WORK/visual-similarity.json` — a deterministic ink/layout floor beneath the human compare.
+   A genuinely stale or untranscribable source is waived at the Phase-6 gate with
+   `--skip-anchors-gate`/`--skip-visual-similarity "<reason>"` (waiver-budgeted). See `refs/source-anchors.md`, `refs/visual-similarity.md`.
 
 Layout escalation if the compare fails on arrangement: the builder's default
 `--layout clean` preserves the source positions inside a normalized grid; use
@@ -240,7 +254,7 @@ A workbook that POSTs 200 and passes numeric parity can still be visually broken
   - **Online DAX (high-fidelity / import-only models):** PBI `POST /v1.0/myorg/groups/{ws}/datasets/{id}/executeQueries` (DAX) via `--emit-dax`, vs the same Sigma aggregation. DAX-only; breaks under service-principal if RLS; needs the workspace/dataset (auto-wired from `freshness.json`).
     - **XMLA fallback (when `executeQueries` REST is blocked but the model is on capacity):** run the same measure through the Power BI Modeling MCP — `dax_query_operations Execute` on an `Initial Catalog`-bound connection — and diff against the Sigma actuals identically. Recipe in `refs/pbi-modeling-mcp.md`. This also catches **silently mis-modeled source measures** (e.g. time-intel over an inactive date relationship returns a flat total in Power BI) that a SQL oracle wouldn't flag.
 - **Finalize (both paths):** `ruby scripts/phase6-parity-pbi.rb --finalize --plan plan.json --actuals parity-actuals.json --out-dir <dir>` → writes `parity-final.json` (`source` records which oracle was used).
-- Hard gate: `ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>` — 7 gates incl. layout lint (6) and **control lint (7**: dead controls / ghost targets / partial same-page reach / `control-scope.json` coverage; `--skip-control-lint` escape; see `refs/control-parity.md`**)**.
+- Hard gate: `ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>` — incl. layout lint (6), **control lint (7**: dead controls / ghost targets / partial same-page reach / `control-scope.json` coverage; `--skip-control-lint` escape; see `refs/control-parity.md`**)**, and the MEASURED bars wired in Phase 5e: **gate 13 (source-anchor values** — arms when a source PNG is on disk; needs `source-anchors.json` ≥5 + a passing `anchors-verdict.json`; `--skip-anchors-gate "<reason>"`**)** and **gate 14 (visual-similarity floor** — `visual-similarity.json`; `--skip-visual-similarity "<reason>"`**)**. No source PNG on disk → both self-SKIP (stated), never a silent pass.
 - Optional flip test when the report has slicers→controls: `ruby scripts/probe-controls.rb --workbook-id <wb> --check-out-of-closure` — runtime proof a control actually filters (in-closure export changes under a non-default `parameters` value, out-of-closure doesn't). MCP query can NOT flip controls (defaults only) — export API `parameters` is the only mechanism.
 
 ## Phase 7 — Bookmarks → per-bookmark workbooks (optional)


### PR DESCRIPTION
## Summary

Third step of the parity rollout (after #371 vendored the scripts+gate code to these two, and #372 covered the rest). Wires the **powerbi** and **looker** migration flows to actually PRODUCE the measured gates' inputs, so gate 13 (source-anchor values) and gate 14 (visual-similarity floor) *run* instead of self-SKIPping.

**powerbi** — Phase 5e (already renders source + Sigma pages): author `source-anchors.json` (≥5, exactly-as-printed), land a source PNG at a gate-discovered path (`png-read.json` `source_png` / `dashboards/`), run `verify-anchors.rb` + `visual-similarity.py`; Phase 6 hard-gate note now documents gates 13/14 + their waivers.

**looker** — Phase 4a: render the Looker source into `<W>/dashboards/` (a discovered path) + transcribe `source-anchors.json`; Phase 4-pre: run `verify-anchors.rb` + `visual-similarity.py` before `assert-phase6-ran.rb`; gate description documents 13/14.

## Safe by construction
Gate 13 arms only when a source PNG is on disk **and** the wired steps author `source-anchors.json` + a passing `anchors-verdict.json` together — so no armed-but-scriptless exit-18. A genuinely stale/untranscribable source waives with `--skip-anchors-gate`/`--skip-visual-similarity "<reason>"` (waiver-budgeted).

## Validation
Exercised the actual `assert-phase6-ran.rb` against the **live PBI retail workbook `d66c3253`**: the gate recognized the wired artifacts — the conditional `--skip-parity-gate` was **accepted because `anchors-verdict.json` passed 8/8** (the anchors oracle standing in), gates 3/4/6/7/8 clean, **no exit-18/20**. `lint-skills` (conformance + portability), `check-agent-variants`, `check-shared` (367) all green.

## Rollout status
| bucket | skills | status |
|---|---|---|
| scripts vendored | all 9 | ✅ #371/#372 |
| gates wired live | **powerbi, looker** | ✅ this PR |
| source-PNG bridge | quicksight, microstrategy, thoughtspot | next |
| gate-host port | qlik, cognos, gooddata | next |
| defer | sisense | python re-platform |

🤖 Generated with [Claude Code](https://claude.com/claude-code)