### PR TITLE
feat(parity): source-PNG capture + gate wiring for quicksight, microstrategy, thoughtspot

### DIFF
--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -156,6 +156,10 @@ captures:
 ```bash
 # (a) Pixel-faithful PDF of the live dossier — the layout/branding/arrangement reference.
 python3 scripts/export-dossier-pdf.py <dossierId> source_dossier.pdf
+# (a2) Source dashboard PNG at a gate-discovered path — arms the Phase-6 MEASURED gates 13/14:
+python3 scripts/microstrategy-render-source.py <dossierId> --workdir <WORK>   # -> <WORK>/dashboards/source.png (dossier PDF -> page-1 PNG; needs pdftoppm/magick/sips)
+#      Then READ that PNG and transcribe >=5 anchors EXACTLY as printed into <WORK>/source-anchors.json
+#      (every KPI, top-3 of each ranked list/table, one bucket per chart; schema: refs/source-anchors.md).
 ```
 
 **READ `source_dossier.pdf`** before composing anything. Note, per page: the
@@ -375,16 +379,22 @@ top-level layout the workbook renders as a single-column stack).
 ## Phase 6 — Finalize (hard gate before declaring GREEN)
 
 ```bash
+ruby scripts/verify-anchors.rb    --workdir <dir> --workbook-id <workbookId>   # -> anchors-verdict.json (gate 13; Phase 1.1 landed dashboards/source.png + source-anchors.json)
 ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <workbookId>
 ```
 
-Seven independent gates (shared, vendored byte-identical): parity ran + PASS,
+The shared gates (vendored byte-identical): parity ran + PASS,
 no orphan workbooks, no live `type=error` columns, layout applied, tile
 census (skipped — this converter does not emit one), **layout lint** (gate 6:
 no raw-id titles, no orphan controls, no dead zones, no generic "Page N"
 header, no under-filled bands), and **control lint** (gate 7: no dead
 controls, no ghost targets, full declared reach, `control-scope.json`
-coverage — an interactive dossier converting to zero controls FAILS).
+coverage — an interactive dossier converting to zero controls FAILS), **plus the
+measured bars from Phase 1.1: gate 13 (source-anchor values** — `source-anchors.json`
+≥5 + a passing `anchors-verdict.json`; arms once `dashboards/source.png` is on disk;
+`--skip-anchors-gate "<reason>"`**) and gate 14 (visual-similarity floor** — measured
+vs the source PNG; `--skip-visual-similarity "<reason>"`**)**; no source PNG → both
+self-SKIP (stated), never a silent pass.
 Exit 0 = GREEN. Optional runtime proof after the lint passes:
 
 ```bash

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/microstrategy-render-source.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/microstrategy-render-source.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""microstrategy-render-source.py — render a MicroStrategy dossier to a single
+source dashboard PNG for the Phase-6 MEASURED parity gates in assert-phase6-ran.rb:
+gate 13 (source-anchor value verification) + gate 14 (visual-similarity floor).
+Those gates arm the moment a source dashboard PNG is on disk under
+<workdir>/dashboards/*.png (or views/*.png, or png-read.json source_png); this
+script lands that image.
+
+API (MicroStrategy REST — same session-bound flow export-dossier-pdf.py already uses):
+  POST /api/dossiers/{id}/instances            -> { "mid": <instanceId> }
+  POST /api/documents/{id}/instances/{mid}/pdf -> { "data": <base64 PDF> }
+  (v1 path; /v2/dossiers/.../pdf 404s on the validated build.)
+  Docs: https://github.com/MicroStrategy/rest-api-docs/blob/public/docs/common-workflows/analytics/export-to-pdf.md
+
+MicroStrategy has no native whole-dossier PNG endpoint, so we export the dossier
+to PDF (always supported) and convert page 1 -> PNG with whatever rasterizer is
+on PATH (pdftoppm > magick/convert > sips). Best-effort: if none is installed the
+script says exactly that and exits non-zero rather than land a bad image.
+
+Auth: reuses lib/mstr.py Session (same credential path as export-dossier-pdf.py /
+migrate) — no new credential source. Output: <workdir>/dashboards/source.png,
+auto-discovered by gate 13/14. A multi-page dossier's PDF has one page per
+chapter/page — page 1 is captured; pick another with --page.
+
+Usage:
+  python3 microstrategy-render-source.py <dossierId> [--workdir DIR] [--out PATH] [--page N]
+Env: whatever lib/mstr.py Session reads (MSTR base URL + auth).
+"""
+import argparse
+import base64
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import mstr  # noqa: E402  — same Session/auth as export-dossier-pdf.py
+
+
+def export_pdf(dossier_id):
+    """Return the dossier's rendered PDF bytes (instance + export in ONE session)."""
+    s = mstr.Session()
+    iid = s.post(f"/dossiers/{dossier_id}/instances", {})["mid"]
+    resp = s.post(f"/documents/{dossier_id}/instances/{iid}/pdf", {})
+    if "data" not in resp:
+        raise RuntimeError(f"PDF export returned no data: {str(resp)[:200]}")
+    return base64.b64decode(resp["data"])
+
+
+def pdf_to_png(pdf_bytes, out_path, page=1):
+    """Best-effort PDF page -> PNG using whatever converter is on PATH."""
+    with tempfile.TemporaryDirectory() as td:
+        pdf = os.path.join(td, "src.pdf")
+        with open(pdf, "wb") as fh:
+            fh.write(pdf_bytes)
+        if shutil.which("pdftoppm"):
+            base = os.path.join(td, "pg")
+            subprocess.run(["pdftoppm", "-png", "-r", "150", "-f", str(page),
+                            "-l", str(page), "-singlefile", pdf, base], check=True)
+            os.replace(base + ".png", out_path)
+            return
+        for tool in ("magick", "convert"):
+            if shutil.which(tool):
+                subprocess.run([tool, "-density", "150", f"{pdf}[{page - 1}]", out_path],
+                               check=True)
+                return
+        if shutil.which("sips") and page == 1:  # sips can't select a page
+            subprocess.run(["sips", "-s", "format", "png", pdf, "--out", out_path], check=True)
+            return
+    raise RuntimeError(
+        "PDF->PNG needs a converter on PATH (pdftoppm / magick / convert / sips) — "
+        "none found (or --page>1 with only sips). Install poppler (pdftoppm) or "
+        "ImageMagick, or drop the source PNG manually into <workdir>/dashboards/source.png.")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Render a MicroStrategy dossier to a source dashboard PNG.")
+    ap.add_argument("dossier_id", help="dossier GUID to render")
+    ap.add_argument("--workdir", default=os.environ.get("MSTR_WORKDIR") or os.getcwd(),
+                    help="run dir; PNG lands in <workdir>/dashboards/ (default $MSTR_WORKDIR or cwd)")
+    ap.add_argument("--out", help="explicit output PNG path (default <workdir>/dashboards/source.png)")
+    ap.add_argument("--page", type=int, default=1, help="PDF page to rasterize (default 1)")
+    a = ap.parse_args()
+
+    out = a.out or os.path.join(a.workdir, "dashboards", "source.png")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+
+    try:
+        pdf = export_pdf(a.dossier_id)
+    except Exception as e:  # noqa: BLE001 — surface, never crash a migration
+        sys.exit(f"FATAL: dossier PDF export failed for {a.dossier_id}: {e}")
+    if pdf[:5] != b"%PDF-":
+        sys.exit(f"FATAL: export did not return a PDF (error body?): {pdf[:200]!r}")
+    pdf_to_png(pdf, out, a.page)
+    if not os.path.exists(out) or os.path.getsize(out) < 1000:
+        sys.exit(f"FATAL: rendered PNG missing/too small at {out} — check the PDF converter.")
+    print(f"wrote {out} ({os.path.getsize(out)} bytes) — READ it, transcribe >=5 "
+          "anchors into <workdir>/source-anchors.json (refs/source-anchors.md)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -115,6 +115,31 @@ Pulls `describe-analysis-definition` (or `-dashboard-definition`) + `describe-da
 - `signals.json` — normalized: per-sheet visuals (type + VisualId + title + referenced ColumnNames), calc fields, parameters, datasets, sources. Drives the convert + workbook + layout phases.
 - `timings.json` — per-call wall clock + transport; **always written**.
 
+### Phase 1d — Capture the source dashboard PNG + author value anchors (arms Phase-6 gates 13 + 14)
+
+QuickSight has **no server-side PNG render**, so the source image comes from the async
+**Snapshot Export** job (`StartDashboardSnapshotJob` → PDF → poll → presigned S3 → PDF→PNG
+stitch). Capture it into the SAME workdir right after discovery — it reuses
+`quicksight-discover.py`'s boto3/AWS-CLI auth (same `--profile`/`--region`):
+
+```bash
+python3 scripts/quicksight-render-source.py \
+  --account-id <ACCOUNT_ID> --region <REGION> --profile <PROFILE> \
+  --dashboard-id <DASHBOARD_ID> --workdir <WORK>
+# → <WORK>/dashboards/source.png  (the exact path the Phase-6 gate scans to arm gates 13/14)
+```
+
+- Needs a **published DASHBOARD id** (snapshots don't run on analyses), **Enterprise edition + the Pixel Perfect Report add-on** (required for PDF snapshot export), and one PDF→PNG backend (`brew install poppler` / `apt-get install poppler-utils` / `pip install pymupdf`). If the job genuinely can't run (Standard edition, no add-on, anonymous-snapshot capacity not enabled), drop a **customer screenshot** at `<WORK>/dashboards/source.png` instead — the gate accepts any PNG there.
+
+Then **Read `<WORK>/dashboards/source.png`** and, in that same pass, transcribe the printed
+numbers into **`<WORK>/source-anchors.json` — EXACTLY as printed** (keep the raw string:
+`"18,037B"`, never `18037`; `"(12.3%)"`, never `-0.123`). Minimum **≥ 5 anchors**: every KPI
+value, the top 3 values of each ranked list/table, one representative bucket value per chart,
+and 2–3 `text` roster anchors (include at least one from the BOTTOM of any ranked list — top
+members survive a wrong ranking, bottom members don't). Also write `png-read.json`
+(`{"source_png": "dashboards/source.png", ...}`) if you keep a per-tile read. Schema,
+canonicalization rules, and a worked example: `refs/source-anchors.md`.
+
 ### Fast discovery (designed for 20-40 dashboard estates sharing datasets)
 - **In-process boto3 transport.** Each `aws` CLI subprocess pays a 0.4-0.7s interpreter-startup tax (measured ~0.7s wall); a 1-analysis discovery makes 4-5 calls and an estate re-pays it per dashboard. With boto3 importable, ONE session serves every call; the CLI fallback keeps zero-dependency installs working (identical call/response shapes — boto3 responses are normalized: datetimes → ISO strings, `ResponseMetadata` stripped).
 - **Estate-level dataset cache** (`/tmp/qs-estate-cache/<acct>__<region>/`, override `QS_ESTATE_CACHE`): describe responses cached keyed **DataSetArn + LastUpdatedTime** — shared datasets are described ONCE per estate, not per dashboard. Freshness is validated against ONE `list-data-sets` call per process; any LastUpdatedTime mismatch (or a denied/empty listing) re-describes. **Data sources are described once, lazily** and cached without a probe (they change rarely). `--no-cache` bypasses, `--refresh-cache` forces re-describe.
@@ -239,6 +264,11 @@ ruby scripts/phase6-parity-quicksight.rb --workdir /tmp/<name> --workbook-id <WO
 #     writing parity-actuals.json + parity-expected.json into the workdir ...
 # PASS 2 — verify + write the parity-final.json sentinel
 ruby scripts/phase6-parity-quicksight.rb --workdir /tmp/<name> --finalize
+# MEASURED value bar (gate 13) — Phase-1d anchors must appear in the live element exports
+ruby scripts/verify-anchors.rb --workdir /tmp/<name> --workbook-id <WORKBOOK_ID>
+# MEASURED visual floor (gate 14) — the Sigma render must be structurally like the source PNG
+python3 scripts/visual-similarity.py --source /tmp/<name>/dashboards/source.png \
+  --render /tmp/<name>/sigma-render.png --json-out /tmp/<name>/visual-similarity.json
 # hard gate — must exit 0 before declaring GREEN
 ruby scripts/assert-phase6-ran.rb --workdir /tmp/<name> --workbook-id <WORKBOOK_ID>
 ```
@@ -247,6 +277,7 @@ ruby scripts/assert-phase6-ran.rb --workdir /tmp/<name> --workbook-id <WORKBOOK_
 - `sigma-mcp-v2 query` each element → confirm real rows (not blank / not all `error`).
 - True parity: compare each Sigma aggregation against the same aggregation computed from the QuickSight side (or the warehouse). `assert-phase6-ran.rb` is a hard gate — a subagent must run it and it must pass before reporting success.
 - `assert-phase6-ran.rb` runs 7 gates incl. layout lint (gate 6) and **control lint** (gate 7 — dead controls / ghost targets / partial same-page reach / `control-scope.json` coverage; `--skip-control-lint` escape; see `refs/control-parity.md`).
+- **Measured source gates (armed only when `<WORK>/dashboards/source.png` — or `views/*.png` / `png-read.json.source_png` — exists):** **gate 13 (exit 18)** requires `source-anchors.json` with ≥ 5 anchors AND a passing `anchors-verdict.json` (from `verify-anchors.rb`) — every printed source value must appear in the live element exports at its printed precision (catches the 10x/wrong-unit/collapsed-bucket failures a visual verdict misses); it also fires if `--skip-parity-gate` is used without a passing anchors verdict (the anchors oracle replaces parity, never nothing). **Gate 14 (exit 20)** runs the deterministic `visual-similarity.py` floor (source PNG vs Sigma render); exit 2 (missing Pillow/numpy) is a hard stop, never a pass. No source PNG → both gates state a SKIP. Escapes (each counts against the waiver budget, exit 19 at >2): `--skip-anchors-gate "<reason>"`, `--skip-visual-similarity "<reason>"`. See `refs/source-anchors.md` + `refs/visual-similarity.md`.
 - Optional flip test when the dashboard had parameters/filter controls: `ruby scripts/probe-controls.rb --workbook-id <wb> --check-out-of-closure` — runtime proof controls actually filter (export API `parameters` is the only way to set a control programmatically; MCP queries see saved defaults only).
 - **mcp-v2 warehouse-side (EXPECTED) queries can NOT use the raw warehouse FQN**
   (`SELECT … FROM DB.SCHEMA.TABLE` fails): with `type=connection` the table must
@@ -274,7 +305,7 @@ ruby scripts/assert-phase6-ran.rb --workdir /tmp/<name> --workbook-id <WORKBOOK_
 - **Verify without MCP via the Export API**: when the customer org isn't wired to `sigma-mcp-v2`, query an element with `POST /v2/workbooks/{wb}/export {elementId, format:{type:csv}}` → poll `GET /v2/query/{queryId}/download`. This is how you confirm real values (and filtered parity) on any org.
 
 ## Reuse, don't reinvent
-These vendor-agnostic Sigma-side scripts are reused across the migration skills: `get-token.sh`, `lib/sigma_rest.rb`, `post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `validate-spec.rb`, `verify-parity.rb`, `cleanup-orphan-workbooks.rb`. Only the QuickSight-specific stages (`quicksight-discover.py`, `convert-model.rb`, `build-workbook-from-quicksight.rb`, `build-quicksight-layout.rb`, `phase6-parity-quicksight.rb`, `qs-dm-signature.py`) are new. `scripts/sigma-export-png.py` renders a workbook page to PNG for the mandatory **Visual QA** gate (read each image against `refs/layout-visual-qa.md`).
+These vendor-agnostic Sigma-side scripts are reused across the migration skills: `get-token.sh`, `lib/sigma_rest.rb`, `post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `validate-spec.rb`, `verify-parity.rb`, `cleanup-orphan-workbooks.rb`. Only the QuickSight-specific stages (`quicksight-discover.py`, `quicksight-render-source.py`, `convert-model.rb`, `build-workbook-from-quicksight.rb`, `build-quicksight-layout.rb`, `phase6-parity-quicksight.rb`, `qs-dm-signature.py`) are new. `scripts/sigma-export-png.py` renders a workbook page to PNG for the mandatory **Visual QA** gate (read each image against `refs/layout-visual-qa.md`); `scripts/quicksight-render-source.py` renders the SOURCE dashboard to `<WORK>/dashboards/source.png` (Snapshot Export PDF→PNG) so the measured Phase-6 gates 13/14 (`verify-anchors.rb` + `visual-similarity.py`) can run.
 
 
 ## Security: Row- & Column-Level Security (RLS/CLS)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/quicksight-render-source.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/quicksight-render-source.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""quicksight-render-source.py — render a LIVE QuickSight dashboard to a single
+source PNG for the Phase-1d / Phase-6 measured visual gates.
+
+QuickSight has NO server-side PNG render. The only server-side, whole-dashboard
+image path is the async **Snapshot Export** job, which emits PDF/CSV/EXCEL (never
+PNG). So this script:
+
+  1. StartDashboardSnapshotJob  — kick off an async PDF snapshot of the whole
+     dashboard (one FileGroup, FormatType=PDF, SheetSelections =
+     {SheetId, SelectionScope: ALL_VISUALS} for every sheet).
+       https://docs.aws.amazon.com/quicksight/latest/APIReference/API_StartDashboardSnapshotJob.html
+       https://docs.aws.amazon.com/boto3/latest/reference/services/quicksight/client/start_dashboard_snapshot_job.html
+     Returns {Arn, SnapshotJobId, RequestId, Status}. PDF requires ALL_VISUALS
+     scope. UserConfiguration.AnonymousUsers=[{RowLevelPermissionTags:[]}] is the
+     default; pass --identity-enhanced to send UserConfiguration=null instead
+     (required when the caller uses identity-enhanced session credentials).
+  2. DescribeDashboardSnapshotJob — poll JobStatus until COMPLETED / FAILED
+     (QUEUED | RUNNING | COMPLETED | FAILED).
+       https://docs.aws.amazon.com/boto3/latest/reference/services/quicksight/client/describe_dashboard_snapshot_job.html
+  3. DescribeDashboardSnapshotJobResult — read the finished result's S3Uri:
+     Result.AnonymousUsers[].FileGroups[].S3Results[].S3Uri (+ ErrorInfo).
+       https://docs.aws.amazon.com/boto3/latest/reference/services/quicksight/client/describe_dashboard_snapshot_job_result.html
+     When NO custom DestinationConfiguration is supplied (the default here), the
+     S3Uri is a short-lived **presigned HTTPS URL** that downloads directly (AWS
+     BI blog "Automate financial statements using QuickSight Snapshot Export
+     APIs":  https://aws.amazon.com/blogs/business-intelligence/automate-financial-statements-using-amazon-quicksight-snapshot-export-apis/ ).
+     With --s3-bucket the S3Uri is an s3:// path fetched via `aws s3 cp`/boto3.
+  4. PDF -> PNG — render each PDF page (poppler `pdftoppm`, else PyMuPDF `fitz`,
+     else `pdf2image`) and stitch the pages into one tall PNG with Pillow.
+  5. Write the PNG to <workdir>/dashboards/source.png — the exact path the
+     Phase-6 hard gate scans (assert-phase6-ran.rb `find_source_png`:
+     png-read.json.source_png -> views/*.png -> dashboards/*.png), which ARMS
+     gate 13 (source-value anchors) and gate 14 (visual-similarity floor).
+
+REQUIREMENTS / CAVEATS (state these to the user if the job fails):
+  * QuickSight **Enterprise edition** AND the **Pixel Perfect Report add-on** are
+    required for PDF snapshot export. Standard edition / no add-on -> the job
+    FAILS; fall back to a customer screenshot dropped at
+    <workdir>/dashboards/source.png (the gate accepts any PNG there).
+  * Snapshots run against a **published DASHBOARD**, not an analysis — pass
+    --dashboard-id (an analysis has no snapshot endpoint).
+  * Anonymous snapshot users require the account's **capacity (session) pricing**
+    plan; without it use --identity-enhanced or provide registered-user config.
+  * The S3 bucket (custom or the QuickSight-managed default) must be in the SAME
+    region as the API call.
+
+Auth is REUSED from quicksight-discover.py's QSApi (in-process boto3 Session with
+--profile/--region when boto3 is importable; `aws quicksight ...` CLI fallback
+otherwise) — the same credential source Phase-2 discovery uses. No new auth path.
+
+Usage:
+  python3 scripts/quicksight-render-source.py \
+    --account-id <ACCT> --region us-east-1 --profile <P> \
+    --dashboard-id <DASHBOARD_ID> --workdir <WORK>
+  # -> <WORK>/dashboards/source.png  (+ <WORK>/dashboards/source.pdf, render-source.json)
+
+  # explicit sheet(s) (default: all sheets on the dashboard):
+  #   --sheet-id SHEET_A --sheet-id SHEET_B
+  # custom S3 bucket instead of the presigned default:
+  #   --s3-bucket my-bkt --s3-prefix qs-snapshots [--s3-region us-east-1]
+"""
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Reuse the discovery transport (boto3 session / profile / region + CLI fallback)
+# — quicksight-discover.py is hyphenated, so load it by path (mirrors
+# tests/test-quicksight-discover.py).
+_spec = importlib.util.spec_from_file_location(
+    "qsdisc", os.path.join(HERE, "quicksight-discover.py"))
+qsdisc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(qsdisc)  # noqa: E402
+
+
+def _sanitize_job_id(raw):
+    """SnapshotJobId accepts [\\w-]; keep it short + unique per run."""
+    safe = "".join(c if (c.isalnum() or c in "-_") else "-" for c in raw)
+    return f"qs-src-{safe}-{int(time.time())}"[:490]
+
+
+def _sheet_ids(api, dashboard_id, workdir, explicit):
+    """Sheet ids to snapshot. Explicit --sheet-id wins; else read the Phase-2
+    discovery artifacts in <workdir> (signals.json / analysis.json); else ask
+    QuickSight via describe-dashboard-definition."""
+    if explicit:
+        return list(explicit)
+    for name, dig in (("signals.json", lambda j: [s.get("sheetId") for s in j.get("sheets", [])]),
+                      ("analysis.json", lambda j: [s.get("SheetId")
+                                                   for s in j.get("Definition", {}).get("Sheets", [])])):
+        p = os.path.join(workdir, name)
+        if os.path.isfile(p):
+            try:
+                ids = [s for s in dig(json.load(open(p))) if s]
+                if ids:
+                    return ids
+            except (ValueError, OSError):
+                pass
+    # last resort: live describe (Enterprise only; simple params -> QSApi.call ok)
+    d = api.call("describe-dashboard-definition", DashboardId=dashboard_id)
+    return [s.get("SheetId") for s in d.get("Definition", {}).get("Sheets", []) if s.get("SheetId")]
+
+
+def _start_job(api, region, profile, request):
+    """StartDashboardSnapshotJob with nested params. boto3 takes the dict kwargs
+    directly; the CLI fallback needs the whole request as --cli-input-json
+    (QSApi.call str()-ifies dicts, which the CLI can't parse)."""
+    if api.boto is not None:
+        return qsdisc._jsonable(api.boto.start_dashboard_snapshot_job(**request))
+    cmd = ["aws", "quicksight", "start-dashboard-snapshot-job",
+           "--region", region, "--output", "json",
+           "--cli-input-json", json.dumps(request)]
+    if profile:
+        cmd += ["--profile", profile]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        sys.exit(f"start-dashboard-snapshot-job failed: {p.stderr.strip() or p.stdout.strip()}")
+    return json.loads(p.stdout or "{}")
+
+
+def _download(uri, out_path, region, profile):
+    """Presigned HTTPS S3Uri -> fetch directly; s3:// (custom bucket) -> aws s3 cp
+    (falls back to boto3 s3 when the CLI is absent)."""
+    if uri.startswith("s3://"):
+        cmd = ["aws", "s3", "cp", uri, out_path, "--region", region]
+        if profile:
+            cmd += ["--profile", profile]
+        p = subprocess.run(cmd, capture_output=True, text=True)
+        if p.returncode == 0:
+            return
+        try:  # boto3 fallback
+            import boto3
+            bkt, key = uri[5:].split("/", 1)
+            sess = boto3.Session(profile_name=profile, region_name=region)
+            sess.client("s3").download_file(bkt, key, out_path)
+            return
+        except Exception as e:  # noqa: BLE001
+            sys.exit(f"could not download {uri}: {p.stderr.strip() or e}")
+    else:  # presigned HTTPS — no auth header needed
+        req = urllib.request.Request(uri, headers={"Accept": "application/pdf"})
+        try:
+            with urllib.request.urlopen(req, timeout=120) as r:
+                data = r.read()
+        except urllib.error.HTTPError as e:
+            sys.exit(f"presigned download {e.code}: {e.read()[:300].decode('utf-8', 'replace')}")
+        with open(out_path, "wb") as f:
+            f.write(data)
+
+
+def _pdf_to_pngs(pdf_path, out_dir, dpi):
+    """Render every PDF page to a PNG. Try poppler `pdftoppm`, then PyMuPDF
+    (`fitz`), then `pdf2image`. Returns the ordered page-PNG paths, or [] if no
+    backend is available."""
+    prefix = os.path.join(out_dir, "source-page")
+    # 1. poppler pdftoppm (fast, no python dep)
+    from shutil import which
+    if which("pdftoppm"):
+        r = subprocess.run(["pdftoppm", "-png", "-r", str(dpi), pdf_path, prefix],
+                           capture_output=True, text=True)
+        if r.returncode == 0:
+            pages = sorted(p for p in
+                           (os.path.join(out_dir, f) for f in os.listdir(out_dir))
+                           if os.path.basename(p).startswith("source-page") and p.endswith(".png"))
+            if pages:
+                return pages
+    # 2. PyMuPDF
+    try:
+        import fitz  # PyMuPDF
+        doc = fitz.open(pdf_path)
+        pages = []
+        for i, page in enumerate(doc):
+            out = f"{prefix}-{i + 1:03d}.png"
+            page.get_pixmap(dpi=dpi).save(out)
+            pages.append(out)
+        doc.close()
+        if pages:
+            return pages
+    except Exception:  # noqa: BLE001
+        pass
+    # 3. pdf2image (wraps poppler)
+    try:
+        from pdf2image import convert_from_path
+        pages = []
+        for i, img in enumerate(convert_from_path(pdf_path, dpi=dpi)):
+            out = f"{prefix}-{i + 1:03d}.png"
+            img.save(out, "PNG")
+            pages.append(out)
+        if pages:
+            return pages
+    except Exception:  # noqa: BLE001
+        pass
+    return []
+
+
+def _stitch(page_pngs, out_path):
+    """Vertically concatenate page PNGs into one tall image (Pillow, already a
+    visual-similarity dep). Single page -> just move it."""
+    if len(page_pngs) == 1:
+        os.replace(page_pngs[0], out_path)
+        return
+    try:
+        from PIL import Image
+    except ImportError:
+        os.replace(page_pngs[0], out_path)  # no Pillow -> first page only
+        print("[warn] Pillow missing — wrote page 1 only (pip install pillow to stitch)")
+        return
+    imgs = [Image.open(p).convert("RGB") for p in page_pngs]
+    w = max(i.width for i in imgs)
+    h = sum(i.height for i in imgs)
+    canvas = Image.new("RGB", (w, h), "white")
+    y = 0
+    for im in imgs:
+        canvas.paste(im, (0, y))
+        y += im.height
+    canvas.save(out_path, "PNG")
+
+
+def render(args):
+    api = qsdisc.QSApi(args.account_id, args.region, args.profile)
+    print(f"[transport] {api.transport}")
+
+    sheet_ids = _sheet_ids(api, args.dashboard_id, args.workdir, args.sheet_id)
+    if not sheet_ids:
+        sys.exit("no sheet ids found (pass --sheet-id, or run discovery into --workdir first)")
+    print(f"[render] dashboard {args.dashboard_id}: {len(sheet_ids)} sheet(s) -> PDF")
+
+    job_id = _sanitize_job_id(args.dashboard_id)
+    file_group = {
+        "Files": [{
+            "SheetSelections": [{"SheetId": sid, "SelectionScope": "ALL_VISUALS"} for sid in sheet_ids],
+            "FormatType": "PDF",
+        }]
+    }
+    snap = {"FileGroups": [file_group]}
+    if args.s3_bucket:
+        snap["DestinationConfiguration"] = {"S3Destinations": [{"BucketConfiguration": {
+            "BucketName": args.s3_bucket,
+            "BucketPrefix": args.s3_prefix or "quicksight-source-snapshots",
+            "BucketRegion": args.s3_region or args.region,
+        }}]}
+
+    request = {
+        "AwsAccountId": args.account_id,
+        "DashboardId": args.dashboard_id,
+        "SnapshotJobId": job_id,
+        "SnapshotConfiguration": snap,
+    }
+    if not args.identity_enhanced:
+        request["UserConfiguration"] = {"AnonymousUsers": [{"RowLevelPermissionTags": []}]}
+
+    started = _start_job(api, args.region, args.profile, request)
+    print(f"[render] snapshot job {job_id} started (HTTP {started.get('Status')})")
+
+    # poll
+    deadline = time.time() + args.timeout
+    status = None
+    while time.time() < deadline:
+        js = api.call("describe-dashboard-snapshot-job",
+                      DashboardId=args.dashboard_id, SnapshotJobId=job_id)
+        status = js.get("JobStatus")
+        print(f"[render]   status={status}")
+        if status in ("COMPLETED", "FAILED"):
+            break
+        time.sleep(args.poll)
+    if status != "COMPLETED":
+        sys.exit(f"snapshot job {job_id} ended status={status or 'TIMEOUT'} "
+                 f"(Enterprise + Pixel Perfect Report add-on required for PDF; "
+                 f"fall back to a customer screenshot at {os.path.join(args.workdir, 'dashboards', 'source.png')})")
+
+    result = api.call("describe-dashboard-snapshot-job-result",
+                      DashboardId=args.dashboard_id, SnapshotJobId=job_id)
+    # pull the first PDF S3Uri out of the (Anonymous|Registered)Users tree
+    uri, err = None, None
+    res = result.get("Result", {}) or {}
+    for group in (res.get("AnonymousUsers") or []) + (res.get("RegisteredUsers") or []):
+        for fg in group.get("FileGroups", []):
+            for s3 in fg.get("S3Results", []):
+                if s3.get("ErrorInfo"):
+                    err = s3["ErrorInfo"]
+                if s3.get("S3Uri"):
+                    uri = s3["S3Uri"]
+                    break
+            if uri:
+                break
+        if uri:
+            break
+    if not uri:
+        sys.exit(f"no S3Uri in snapshot result (errors: {json.dumps(err)})")
+
+    dash_dir = os.path.join(args.workdir, "dashboards")
+    os.makedirs(dash_dir, exist_ok=True)
+    pdf_path = os.path.join(dash_dir, "source.pdf")
+    _download(uri, pdf_path, args.region, args.profile)
+    print(f"[render] downloaded PDF -> {pdf_path} ({os.path.getsize(pdf_path)} bytes)")
+
+    pages = _pdf_to_pngs(pdf_path, dash_dir, args.dpi)
+    out_png = args.out or os.path.join(dash_dir, "source.png")
+    if not pages:
+        sys.exit("PDF downloaded but no PDF->PNG backend available. Install ONE of:\n"
+                 "  brew install poppler   (macOS)  |  apt-get install poppler-utils (Linux)\n"
+                 "  pip install pymupdf    |  pip install pdf2image\n"
+                 f"then re-run, or hand-convert {pdf_path} -> {out_png}.")
+    _stitch(pages, out_png)
+    # tidy intermediate page PNGs that survived the stitch
+    for p in pages:
+        if os.path.abspath(p) != os.path.abspath(out_png) and os.path.exists(p):
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+    print(f"[render] source dashboard PNG -> {out_png}  (arms Phase-6 gates 13 + 14)")
+
+    json.dump({"dashboardId": args.dashboard_id, "snapshotJobId": job_id,
+               "sheets": sheet_ids, "pages": len(pages), "pdf": pdf_path,
+               "source_png": os.path.relpath(out_png, args.workdir),
+               "transport": api.transport},
+              open(os.path.join(args.workdir, "render-source.json"), "w"), indent=2)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render a QuickSight dashboard to a source PNG (Phase-6 gates 13/14).")
+    ap.add_argument("--account-id", required=True)
+    ap.add_argument("--region", required=True)
+    ap.add_argument("--profile")
+    ap.add_argument("--dashboard-id", required=True,
+                    help="PUBLISHED dashboard id (snapshots do not run on analyses)")
+    ap.add_argument("--workdir", required=True,
+                    help="migration workdir; PNG lands at <workdir>/dashboards/source.png")
+    ap.add_argument("--sheet-id", action="append",
+                    help="sheet(s) to snapshot (repeatable); default = all sheets on the dashboard")
+    ap.add_argument("--out", help="output PNG path (default <workdir>/dashboards/source.png)")
+    ap.add_argument("--s3-bucket", help="custom S3 bucket (default: QuickSight-managed presigned URL)")
+    ap.add_argument("--s3-prefix")
+    ap.add_argument("--s3-region")
+    ap.add_argument("--identity-enhanced", action="store_true",
+                    help="send UserConfiguration=null (required with identity-enhanced session creds)")
+    ap.add_argument("--dpi", type=int, default=130, help="PDF->PNG render DPI (default 130)")
+    ap.add_argument("--poll", type=int, default=5, help="poll interval seconds (default 5)")
+    ap.add_argument("--timeout", type=int, default=600, help="max seconds to wait (default 600)")
+    args = ap.parse_args()
+    args.workdir = os.path.expanduser(args.workdir)
+    render(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -43,6 +43,30 @@ POST `username`+`secret_key` to `auth/token/full`. Sigma side uses
 Trials often sit behind corp TLS — the Python helpers use an unverified SSL
 context (curl uses the system store and works).
 
+## Source dashboard PNG + value anchors (Phase 1d — MANDATORY for the measured gates)
+
+Before parity, capture the WHOLE source Liveboard as one image and transcribe its
+printed values. This arms the Phase-6 measured gates (step 6 + `refs/source-anchors.md`):
+
+1. **Render the source dashboard PNG** (whole Liveboard, one image):
+   ```bash
+   python3 scripts/thoughtspot-render-source.py <LIVEBOARD_ID> --workdir <WORK>
+   # → <WORK>/dashboards/source.png
+   #   POST /api/rest/2.0/report/liveboard  {file_format:"PNG", png_options:{...}}  with NO
+   #   visualization_identifiers = the WHOLE Liveboard; the response IS the PNG bytes
+   #   (synchronous — no async task / S3). Reuses TS_HOST/TS_TOKEN (same auth as ts_lib);
+   #   older orgs fall back to whole-Liveboard PDF→PNG. Blank/placeholder renders fail loudly.
+   ```
+   For a multi-Liveboard run, use that Liveboard's parity dir (`<WORK>/parity-<n>`) as
+   `--workdir` so the image lands where its gate runs. `--tab <guid>` renders one tab.
+2. **READ that PNG and transcribe ≥ 5 anchors** into `<WORK>/source-anchors.json`, EXACTLY as
+   printed (keep the raw string: `"18,037B"`, never `18037`): every KPI value, the top 3 values
+   of every ranked list/table, one representative bucket value per chart, and 2–3 `text` roster
+   anchors per ranked tile (include one from the BOTTOM half). Schema + canonicalization rules:
+   `refs/source-anchors.md`.
+
+Skipping either step leaves the migration UNVERIFIED (gates 13/14 SKIP), not "done".
+
 ## ONE COMMAND (preferred): migrate-thoughtspot.py
 
 > ## ⛔ THE ONE PATH (do not improvise a workbook)
@@ -215,6 +239,25 @@ python3 scripts/migrate.py --model-tml fixtures/retail-analytics-model.tml \
    `verify-parity.rb` and writes the `parity-final.json` sentinel. Then run
    `ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>` —
    it must **exit 0** before declaring the migration GREEN.
+
+   **Measured value + visual gates (13 & 14).** Once the source PNG (see the *Source
+   dashboard PNG + value anchors* section) is on disk, `assert-phase6-ran.rb` arms two
+   measured gates. Verify the transcribed anchors against the LIVE workbook first, then let
+   the hard gate run:
+   ```bash
+   ruby scripts/verify-anchors.rb --workdir <dir> --workbook-id <wb>   # → anchors-verdict.json
+   ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>
+   ```
+   - **Gate 13 (exit 18) — source-anchor values:** every printed value in `source-anchors.json`
+     (≥ 5) must appear in the live element exports at printed precision (`anchors-verdict.json`
+     `pass:true`, all anchors checked — a stale verdict fails). Catches the 10x / wrong-member /
+     collapsed-bucket failures a visual verdict misses. No source PNG → stated SKIP; genuine
+     escape only via `--skip-anchors-gate "<reason>"`.
+   - **Gate 14 (exit 20) — visual-similarity floor:** `assert-phase6-ran.rb` runs
+     `scripts/visual-similarity.py --source <dir>/dashboards/source.png --render <sigma render>`
+     and requires `visual-similarity.json` `pass:true`. Below the floor → fix layout/kind/palette
+     in the visual-QA loop (step 7) and re-render; escape `--skip-visual-similarity "<reason>"`
+     (counts against the waiver budget). Details: `refs/source-anchors.md`, `refs/visual-similarity.md`.
 7. **Visual QA (HARD GATE)** — **never skip, never declare done on HTTP 200.** A
    workbook that POSTs cleanly and passes parity can still be visually broken
    (overlapping tiles, clipped KPI titles, dead zones, orphaned filters; Sigma's
@@ -293,6 +336,15 @@ driving the picker by hand:
 - `ts_screenshot.py` — per-viz PNG export from ThoughtSpot; detects blank /
   connection-error placeholder renders (near-uniform image or non-PNG error
   body) and reports them as ✗ failures, never ✓
+- `thoughtspot-render-source.py` — **source-side WHOLE-Liveboard PNG** for the
+  measured Phase-6 gates: `POST /api/rest/2.0/report/liveboard` (`file_format PNG`,
+  no `visualization_identifiers`) → synchronous bytes → `<workdir>/dashboards/source.png`
+  (blank-render guarded via `ts_screenshot.png_health`; whole-Liveboard PDF→PNG fallback for
+  older orgs). Reuses `TS_HOST`/`TS_TOKEN`
+- `verify-anchors.rb` — gate 13: checks the ≥ 5 anchors transcribed from the source PNG appear
+  in the live workbook element exports at printed precision → `anchors-verdict.json`
+- `visual-similarity.py` — gate 14: scores `dashboards/source.png` vs the Sigma render →
+  `visual-similarity.json` (invoked by `assert-phase6-ran.rb`)
 - `gap-scout.md` + `scout-validate.py` + `learned-rules.py` — formula gap-scout (validate + persist unhandled-TML translations)
 - `get-token.sh` — Sigma token; `get-ts-token.sh` — ThoughtSpot Trusted-Auth service token
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/thoughtspot-render-source.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/thoughtspot-render-source.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""thoughtspot-render-source.py — render a WHOLE ThoughtSpot Liveboard to a single
+source dashboard PNG, for the Phase-6 MEASURED parity gates in
+assert-phase6-ran.rb: gate 13 (source-anchor value verification) + gate 14
+(visual-similarity floor). Those gates arm the moment a source dashboard PNG is
+on disk under <workdir>/dashboards/*.png (or views/*.png, or png-read.json
+source_png); this script lands that image.
+
+API (ThoughtSpot REST v2.0 — verified against the developer docs, 2026-07):
+  POST {TS_HOST}/api/rest/2.0/report/liveboard
+    Authorization: Bearer <TS_TOKEN>
+    Content-Type: application/json
+    { "metadata_identifier": "<liveboard-guid-or-name>",
+      "file_format": "PNG",
+      "png_options": { "image_resolution": 1920, "image_scale": 100,
+                       "include_header": true } }
+
+  * SYNCHRONOUS — the response body IS the raw PNG bytes (an extensionless
+    binary/octet-stream file). There is NO async task, no S3 URL to poll
+    (unlike the older /callosum PDF export or Looker's render-task API), so a
+    single request → write is all that's needed.
+  * Omitting "visualization_identifiers" renders the ENTIRE Liveboard (all
+    tiles) as one tall PNG — the whole-dashboard source image the anchors +
+    visual-similarity gates compare against. (Passing visualization_identifiers
+    is the per-viz path used by ts_screenshot.py.)
+  * "png_options" (image_resolution / image_scale / include_header) were added
+    in 10.9.0.cl (June 2025); older orgs are handled by an automatic minimal-body
+    retry, then a whole-Liveboard PDF→PNG fallback.
+  * "tab_identifiers" restricts the render to one tab of a multi-tab Liveboard.
+  Docs: https://developers.thoughtspot.com/docs/liveboard-export-api
+        https://developers.thoughtspot.com/docs/fetch-data-and-report-apis
+        https://developers.thoughtspot.com/docs/rest-apiv2-reference  (POST /report/liveboard)
+
+Auth: the SAME bearer path every other TS script uses — TS_HOST + TS_TOKEN.
+ts_lib.py reads them from the environment (get-ts-token.sh mints a service token
+via Trusted Auth, or copy one from Develop → REST Playground). No new credential
+source is introduced.
+
+Blank-render guard: reuses ts_screenshot.png_health — when the Liveboard's
+warehouse connection is down, ThoughtSpot still returns HTTP 200 with a
+near-uniform placeholder PNG (or a JSON/HTML error body under a 200). Those are
+reported as failures (exit 1) and NEVER written as a valid source image, so a
+dead render can't silently arm the gate with a blank picture.
+
+Fallback (older orgs that don't serve whole-Liveboard PNG): request the whole
+Liveboard as PDF (always supported) and convert page 1 → PNG with whatever
+converter is on PATH (pdftoppm > magick/convert > sips). Best-effort; if none is
+installed the script says exactly that and exits non-zero rather than land a bad
+image. (A multi-tab Liveboard's PDF has one page per tab — the fallback captures
+page 1; use --tab to target a specific tab, or prefer the native PNG path.)
+
+Output: <workdir>/dashboards/source.png  (auto-discovered by gate 13/14 via the
+dashboards/*.png glob). Default workdir = $TS_WORKDIR or ./ts-migration; for a
+multi-Liveboard run point --workdir at that Liveboard's parity dir
+(<wd>/parity-<n>) so the image lands where its gate runs.
+
+Usage:
+  python3 thoughtspot-render-source.py <LIVEBOARD_ID> [--workdir DIR] [--out PATH]
+  python3 thoughtspot-render-source.py <LIVEBOARD_ID> --tab <tabGuidOrName>
+Env: TS_HOST, TS_TOKEN, TS_WORKDIR.
+"""
+import argparse
+import json
+import os
+import shutil
+import ssl
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ts_lib  # noqa: E402  — TS_HOST / TS_TOKEN, same auth as every TS script
+
+try:
+    from ts_screenshot import png_health  # reuse the blank/placeholder detector
+except Exception:  # ts_screenshot imports yaml at module load; guard the dep
+    def png_health(data):
+        """Minimal signature+size guard (full blank heuristic lives in ts_screenshot)."""
+        if len(data) < 1000:
+            return False, f"suspiciously small response ({len(data)} bytes)"
+        if data[:8] != b"\x89PNG\r\n\x1a\n":
+            return False, "not a PNG (error body?)"
+        return True, "png signature ok"
+
+_SSL = ssl._create_unverified_context()
+ENDPOINT = "/api/rest/2.0/report/liveboard"
+
+
+def _post_report(body, timeout=180):
+    """POST the report/liveboard export and return the raw response bytes."""
+    req = urllib.request.Request(
+        ts_lib.HOST + ENDPOINT, data=json.dumps(body).encode(), method="POST",
+        headers={"Authorization": f"Bearer {ts_lib.TOKEN}",
+                 "Content-Type": "application/json",
+                 # The TS Cloud edge WAF rejects UA-less requests with an HTML 403.
+                 "User-Agent": "thoughtspot-to-sigma/1.0"})
+    with urllib.request.urlopen(req, context=_SSL, timeout=timeout) as r:
+        return r.read()
+
+
+def render_png(lb_id, tab=None, options=True):
+    body = {"metadata_identifier": lb_id, "file_format": "PNG"}
+    if options:
+        body["png_options"] = {"image_resolution": 1920, "image_scale": 100,
+                               "include_header": True}
+    if tab:
+        body["tab_identifiers"] = [tab]
+    return _post_report(body)
+
+
+def render_pdf(lb_id, tab=None):
+    body = {"metadata_identifier": lb_id, "file_format": "PDF"}
+    if tab:
+        body["tab_identifiers"] = [tab]
+    return _post_report(body)
+
+
+def _pdf_to_png(pdf_bytes, out_path):
+    """Best-effort PDF page-1 → PNG using whatever converter is on PATH."""
+    with tempfile.TemporaryDirectory() as td:
+        pdf = os.path.join(td, "src.pdf")
+        with open(pdf, "wb") as fh:
+            fh.write(pdf_bytes)
+        if shutil.which("pdftoppm"):
+            base = os.path.join(td, "pg")
+            subprocess.run(["pdftoppm", "-png", "-singlefile", "-r", "150", pdf, base],
+                           check=True)
+            os.replace(base + ".png", out_path)
+            return
+        for tool in ("magick", "convert"):
+            if shutil.which(tool):
+                subprocess.run([tool, "-density", "150", pdf + "[0]", out_path], check=True)
+                return
+        if shutil.which("sips"):
+            subprocess.run(["sips", "-s", "format", "png", pdf, "--out", out_path], check=True)
+            return
+    raise RuntimeError(
+        "PDF fallback needs a PDF→PNG converter on PATH (pdftoppm / magick / "
+        "convert / sips) — none found. Install poppler (pdftoppm) or ImageMagick, "
+        "or capture the source PNG manually into <workdir>/dashboards/source.png.")
+
+
+def _write_sidecar(out, lb_id, mode, nbytes, reason):
+    """Provenance next to the image (does NOT touch the agent's png-read.json)."""
+    workdir = os.path.dirname(os.path.dirname(out))
+    side = os.path.join(os.path.dirname(out), "source-render.json")
+    with open(side, "w") as fh:
+        json.dump({"source_png": os.path.relpath(out, workdir),
+                   "liveboard_id": lb_id, "mode": mode, "bytes": nbytes,
+                   "health": reason,
+                   "endpoint": "POST /api/rest/2.0/report/liveboard"}, fh, indent=2)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Render a whole ThoughtSpot Liveboard to a source dashboard PNG.")
+    ap.add_argument("liveboard_id", help="Liveboard GUID (or name) to render")
+    ap.add_argument("--workdir",
+                    default=os.environ.get("TS_WORKDIR")
+                    or os.path.join(os.getcwd(), "ts-migration"),
+                    help="run dir; PNG lands in <workdir>/dashboards/ (default $TS_WORKDIR or ./ts-migration)")
+    ap.add_argument("--out", help="explicit output PNG path (default <workdir>/dashboards/source.png)")
+    ap.add_argument("--tab", help="render only this tab GUID/name (default = whole Liveboard)")
+    a = ap.parse_args()
+
+    if not ts_lib.HOST or not ts_lib.TOKEN:
+        sys.exit("FATAL: set TS_HOST and TS_TOKEN (scripts/get-ts-token.sh, or copy a "
+                 "token from Develop → REST Playground). Same auth as every TS script.")
+
+    out = a.out or os.path.join(a.workdir, "dashboards", "source.png")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+
+    # ── Primary: whole-Liveboard PNG (synchronous bytes) ─────────────────────
+    data = None
+    try:
+        try:
+            data = render_png(a.liveboard_id, a.tab, options=True)
+        except urllib.error.HTTPError as e:
+            if e.code in (400, 422):  # older org rejects png_options → minimal body
+                print("  png_options rejected; retrying minimal PNG body", file=sys.stderr)
+                data = render_png(a.liveboard_id, a.tab, options=False)
+            else:
+                raise
+    except urllib.error.HTTPError as e:
+        body = e.read()[:300].decode("utf-8", "replace")
+        print(f"  whole-Liveboard PNG failed ({e.code} {e.reason}: {body}); "
+              "trying PDF→PNG fallback", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 — any transport failure → try the fallback
+        print(f"  whole-Liveboard PNG failed ({e}); trying PDF→PNG fallback", file=sys.stderr)
+
+    if data is not None:
+        ok, reason = png_health(data)
+        if ok:
+            with open(out, "wb") as fh:
+                fh.write(data)
+            print(f"✓ whole-Liveboard PNG {len(data)} bytes ({reason}) -> {out}")
+            _write_sidecar(out, a.liveboard_id, "png", len(data), reason)
+            return 0
+        print(f"  whole-Liveboard PNG unusable ({reason}); trying PDF→PNG fallback",
+              file=sys.stderr)
+
+    # ── Fallback: whole-Liveboard PDF → PNG ──────────────────────────────────
+    try:
+        pdf = render_pdf(a.liveboard_id, a.tab)
+    except Exception as e:  # noqa: BLE001
+        sys.exit(f"FATAL: both PNG and PDF export failed for {a.liveboard_id}: {e}")
+    if pdf[:5] != b"%PDF-":
+        head = pdf[:200].decode("utf-8", "replace")
+        sys.exit(f"FATAL: PDF export did not return a PDF (error body?): {head}")
+    _pdf_to_png(pdf, out)
+    with open(out, "rb") as fh:
+        ok, reason = png_health(fh.read())
+    if not ok:
+        sys.exit(f"FATAL: converted PDF page rendered blank/invalid ({reason}) — "
+                 "the source dashboard may be disconnected from its warehouse.")
+    nbytes = os.path.getsize(out)
+    print(f"✓ Liveboard PDF→PNG {nbytes} bytes ({reason}) -> {out}")
+    _write_sidecar(out, a.liveboard_id, "pdf->png", nbytes, reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Wires the measured gates (13 source-anchors, 14 visual-similarity — shipped to these 3 in #371) into their migration flows: each gets a way to land a **source dashboard PNG** at a gate-discovered path + SKILL.md steps to author `source-anchors.json` and run the gates.

**New per-tool capture scripts** (plugin-local; reuse existing auth; cite the API; fail-clean — never crash a migration, gate self-SKIPs without a PNG):
- **quicksight** — `StartDashboardSnapshotJob` (async → PDF → presigned S3 → PDF→PNG stitch); reuses `quicksight-discover.py` QSApi. Needs Enterprise + Pixel Perfect add-on; documented customer-screenshot fallback.
- **microstrategy** — dossier PDF export (same flow as `export-dossier-pdf.py`) → page-1 PNG; reuses `lib/mstr.py` Session.
- **thoughtspot** — `POST /api/rest/2.0/report/liveboard` (whole-Liveboard PNG, synchronous) + `png_options` retry + PDF→PNG fallback; reuses `ts_lib` auth + `png_health` blank-guard.

**SKILL.md**: each gets a Phase-1d/source step (render → author `source-anchors.json` ≥5 exactly-as-printed) + a Phase-6 step (`verify-anchors.rb` + `visual-similarity.py` before `assert-phase6-ran.rb`) documenting gates 13/14 + waivers.

## Validation
All 3 `py_compile` clean; `lint-skills` (conformance + portability), `check-agent-variants`, `check-shared` (367) green.

⚠️ **Not smoke-tested against live QuickSight / MicroStrategy / ThoughtSpot orgs** (no access). A maintainer with access must confirm capture succeeds on their org version (esp. QS Enterprise + Pixel Perfect add-on; TS `png_options` requires ≥10.9.0.cl; PDF→PNG needs poppler/ImageMagick/sips). Until then the scripts fail-clean and the gates self-SKIP — no regression to existing flows.

## Rollout after this
Ready-to-wire (live-validated): tableau ✅, powerbi ✅, looker ✅. Wired-from-docs (this PR): quicksight, microstrategy, thoughtspot. Remaining: gate-host ports for qlik / cognos / gooddata; sisense deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)