### PR TITLE
docs: list powerbi-import-to-snowflake in README + AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ reading the relevant `SKILL.md` and executing its scripts.
 | Convert a GoodData Cloud / .CN workspace (LDM + MAQL + insights + dashboards) → Sigma | `gooddata-to-sigma` | `plugins/gooddata-to-sigma/skills/gooddata-to-sigma/` |
 | Scope/assess a GoodData workspace | `gooddata-assessment` | `plugins/gooddata-to-sigma/skills/gooddata-assessment/` |
 | Land a Tableau published-datasource/extract in Snowflake or Databricks | `tableau-vds-to-cdw` | `plugins/tableau-to-sigma/skills/tableau-vds-to-cdw/` |
+| Land an Import-mode Power BI model's data in Snowflake (before converting) | `powerbi-import-to-snowflake` | `plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/` |
 
 Assessments are read-only (never write to the source or post to Sigma); run one
 to pick what to convert, then hand off to the matching converter.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ and the skill drives discovery → translation → build → parity.
 | Plugin | Source tool | Skills it installs |
 |---|---|---|
 | [`tableau-to-sigma`](plugins/tableau-to-sigma/) | Tableau | `tableau-to-sigma`, `tableau-assessment`, `tableau-vds-to-cdw` |
-| [`powerbi-to-sigma`](plugins/powerbi-to-sigma/) | Power BI | `powerbi-to-sigma`, `powerbi-assessment` |
+| [`powerbi-to-sigma`](plugins/powerbi-to-sigma/) | Power BI | `powerbi-to-sigma`, `powerbi-assessment`, `powerbi-import-to-snowflake` |
 | [`qlik-to-sigma`](plugins/qlik-to-sigma/) | Qlik Sense / Cloud | `qlik-to-sigma`, `qlik-assessment` |
 | [`thoughtspot-to-sigma`](plugins/thoughtspot-to-sigma/) | ThoughtSpot | `thoughtspot-to-sigma`, `thoughtspot-assessment` |
 | [`quicksight-to-sigma`](plugins/quicksight-to-sigma/) | Amazon QuickSight | `quicksight-to-sigma`, `quicksight-assessment` |
@@ -70,6 +70,14 @@ published extract / VDS feed) and isn't yet in the warehouse Sigma reads. It pul
 via the VizQL Data Service API and lands it in your cloud warehouse — **Snowflake** or **Databricks**, optionally on a schedule —
 so the converter has a warehouse-native table to build on. `tableau-assessment` flags the
 datasources that need it.
+
+The `powerbi-to-sigma` plugin bundles the equivalent bridge, **`powerbi-import-to-snowflake`** —
+for **Import-mode** Power BI models whose data lives inside the `.pbix` / semantic model
+(Excel, Power Query, flat files) rather than a live warehouse. It reads the model definition
+via Fabric `getDefinition`, extracts the stored table rows through the Power BI
+`executeQueries` API, and lands them as typed tables in **Snowflake** — the data track that
+runs *before* `powerbi-to-sigma` converts the model logic. DirectQuery models already point
+at a warehouse and don't need it.
 
 ## The shared shape
 


### PR DESCRIPTION
## What

The `powerbi-import-to-snowflake` skill shipped in #281 (merged 2026-07-07) and is bundled in `marketplace.json` under the `powerbi-to-sigma` plugin — but it was never added to the two human-facing index tables, so the Power BI plugin's third skill was effectively invisible in the docs.

## Changes

- **README "What's in the marketplace" table** — add `powerbi-import-to-snowflake` to the Power BI row (previously only `powerbi-to-sigma`, `powerbi-assessment`).
- **README explainer** — add a paragraph describing the Import-mode → Snowflake data-landing bridge, paralleling the existing `tableau-vds-to-cdw` paragraph.
- **AGENTS.md intent→skill table** — add a row for landing an Import-mode Power BI model's data in Snowflake, mirroring the existing `tableau-vds-to-cdw` row.

Docs-only; no script or shared-file changes. Pre-commit gates (shared-file parity, SKILL gate docs, ESM import lint, agent-variant sync) passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)