### PR TITLE
docs(README): converter is bundled/local by default, not a required MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ corpus/run-corpus.sh --check      # no creds needed; CI-safe
 
 - **A coding agent that runs skills** (Claude Code, Cursor, Cortex Code, …).
 - The **[Sigma MCP server](https://help.sigmacomputing.com/docs/use-sigma-mcp-server)** connected in your agent — how the agent reads/queries your Sigma org and builds + validates the migrated data model and workbook. Follow Sigma's setup guide.
-- The **[Sigma data model converter MCP](https://github.com/twells89/sigma-data-model-mcp)** available (provides the `convert_*_to_sigma` tools that translate the source spec).
+- **No converter to install** — each skill bundles its data-model converter (`convert_*_to_sigma`) and runs it **locally by default** (no network, no data egress). A [hosted converter MCP](https://github.com/twells89/sigma-data-model-mcp) is available as an **optional, opt-in fallback** that sends the source spec off-machine.
 - A **Sigma API token** and a Sigma **connection** pointing at the same warehouse as the source content (needed for the parity gate).
 - Per-tool source access — see each plugin's `refs/connection.md` (e.g. `qlik-cli` for Qlik; device-code / Fabric `getDefinition` for Power BI).
 


### PR DESCRIPTION
## What

The **Requirements** list in `README.md` said the *Sigma data model converter MCP* must be "available." That's stale — it makes customers set up an MCP they don't need and implies their source data has to leave their environment.

**Reality (verified against current code):** each skill vendors its converter (`converter/*.mjs`) and runs it **locally by default** — zero config, no network, no data egress:
- `shared/refs/environment.md`: *"the converters need no clone, no npm install, no network, no MCP."*
- each converter `SKILL.md`: *"Converter backend — LOCAL by default, zero config, never upload customer data silently."*
- `migrate-tableau.rb` auto-resolves the vendored bundle and prints `converter: LOCAL build … (no data leaves this machine)`.

The hosted converter MCP is now an **opt-in fallback** that uploads the source spec off-machine.

## Change

One bullet in `## Requirements`: reword so the converter is described as bundled/local-by-default, with the hosted MCP called out as an optional, opt-in fallback.

## Scope

Docs only — one line. No code, no shared-file changes (pre-commit governance checks passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)