### PR TITLE
fix(skills): correct window-fn placement claim across pbi/qlik/quicksight + sigma-data-models

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-charts-from-signals.rb
@@ -240,8 +240,8 @@ end
 # ---- Tableau table-calc translators ---------------------------------------
 # Translate Tableau table-calculation functions to their Sigma equivalents.
 # Returns the translated formula, plus a hint about Sigma-specific caveats
-# (e.g., "window functions silently error in grouping-table charts — add to a
-# non-grouping context or Custom SQL DM element").
+# (e.g., "the *Over family — SumOver/CountOver/... — is Unknown-function in
+# every spec context; the native window family works in calc columns").
 #
 # Function mappings (Sigma names):
 #   INDEX()                  → RowNumber()
@@ -405,7 +405,7 @@ def translate_tableau_tc(formula)
 
   return [nil, nil] unless changed
   hints.uniq!
-  hints << 'NOTE: Sigma window functions (Rank/Lag/Lead/Cumulative*) silently error in grouping-table charts and DM-element calc cols — add to a workbook-master non-grouping context OR a Custom SQL DM element' if hints.any? { |h| h =~ /Rank|Lag|Lead|RowNumber/ }
+  hints << 'NOTE: Sigma-native window functions (Rank/RankDense/Lag/Lead/RowNumber/Cumulative*/Moving*/PercentOfTotal) resolve to real OVER() in calc columns of DM elements AND workbook tables (grouped or ungrouped) — live-verified 2026-07-15 (tableau probe-window-contexts.rb). Only the *Over family (SumOver/CountOver/...) is Unknown-function in every spec context — never emit those.' if hints.any? { |h| h =~ /Rank|Lag|Lead|RowNumber/ }
   [s, hints.join('; ')]
 end
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/converter/qlik.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/converter/qlik.mjs
@@ -445,7 +445,7 @@ function convertQlikToSigma(rawJson, options = {}) {
         ...ctx.verify ? { verify: true } : {},
         note: ctx.notes?.length ? ctx.notes.join(" ") : "Translated Qlik inter-record expression."
       });
-      warnings.push(`\u2139 "${title}": inter-record/window expression \u2192 ready Sigma formula in result.workbookPatterns \u2014 place as a calculation in a GROUPED workbook element (group by the chart's dimension); not emitted as a DM metric (window functions silently error there).`);
+      warnings.push(`\u2139 "${title}": inter-record/window expression \u2192 ready Sigma formula in result.workbookPatterns \u2014 place as a calculation in a GROUPED workbook element (group by the chart's dimension); not emitted as a DM metric (a metric aggregates across rows, so it can't express a per-row window; native window funcs belong in a workbook element or a DM-element calc column).`);
       continue;
     }
     if (!measuresByElement[bestElementId])
@@ -572,7 +572,7 @@ function convertQlikToSigma(rawJson, options = {}) {
         ...ctx.verify ? { verify: true } : {},
         note: (ctx.notes?.length ? ctx.notes.join(" ") : "Translated Qlik inter-record expression.") + " (Qlik master dimension.)"
       });
-      warnings.push(`\u2139 Calc dimension "${title}": inter-record/window expression \u2192 ready Sigma formula in result.workbookPatterns \u2014 place in a GROUPED workbook element; not emitted as a DM column (window functions silently error there).`);
+      warnings.push(`\u2139 Calc dimension "${title}": inter-record/window expression \u2192 ready Sigma formula in result.workbookPatterns \u2014 place in a GROUPED workbook element; not emitted as a DM column (native window funcs also resolve in a DM-element calc column; grouped here for the partition/order that match the Qlik chart).`);
       continue;
     }
     const distinctElIds = Object.keys(elementHits);
@@ -1134,7 +1134,7 @@ var QLIK_FSV_SENTINEL = "__QLIK_FSV__";
 function tidyFormula(f) {
   return f.replace(/\(\s+/g, "(").replace(/\s+\)/g, ")").replace(/\s+,/g, ",").replace(/ {2,}/g, " ").trim();
 }
-var QLIK_GROUPED_REQUIRES = "Place as a calculation in a GROUPED workbook element: group by the Qlik chart's dimension(s), sort the element to match the chart's sort order, and put this formula at the grouping level. (Spec gotcha, live-verified 2026-06-11: the element-level `sort` field 400s on grouped tables \u2014 'Sort column not found' \u2014 so a grouped element computes Lag/Lead over the group key ASCENDING at POST time; apply any other sort in the UI afterwards, or pick the grouping key so ascending order matches the Qlik chart.) When placing in a workbook element, prefix base-column refs with the source element name ([Element/Col]). Window functions (Rank/RankDense/Lag/Lead) silently error in data-model calc columns/metrics and in workbook master calc columns \u2014 they only work in grouped workbook elements.";
+var QLIK_GROUPED_REQUIRES = "Place as a calculation in a GROUPED workbook element: group by the Qlik chart's dimension(s), sort the element to match the chart's sort order, and put this formula at the grouping level. (Spec gotcha, live-verified 2026-06-11: the element-level `sort` field 400s on grouped tables \u2014 'Sort column not found' \u2014 so a grouped element computes Lag/Lead over the group key ASCENDING at POST time; apply any other sort in the UI afterwards, or pick the grouping key so ascending order matches the Qlik chart.) When placing in a workbook element, prefix base-column refs with the source element name ([Element/Col]). Native window functions (Rank/RankDense/Lag/Lead/RowNumber/Cumulative*/Moving*) resolve in DM-element calc columns and in workbook tables (grouped OR ungrouped/master) \u2014 live-verified 2026-07-15; only the *Over family (SumOver/CountOver/...) errors in every spec context. A GROUPED element is still the recommended placement here because it gives Lag/Lead the partition + ordering that match the Qlik chart.";
 var QLIK_IR_RE = /\b(Rank|HRank|VRank|Above|Below|Before|After|Top|Bottom|Previous|Peek)\s*\(/i;
 function lowerInterRecordFns(f, warnings, name, original, ctx) {
   const flagUnsupported = (note2) => {

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/converter/quicksight.mjs
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/converter/quicksight.mjs
@@ -1599,8 +1599,8 @@ function quicksightFormulaToSigmaEx(expr, warnings) {
   ];
   const windowRe = new RegExp(`\\b(${windowFns.join("|")})\\s*\\(`, "i");
   if (windowRe.test(s)) {
-    warnings.push(`\u26A0 Formula uses a QuickSight table-calculation function (${s.match(windowRe)[1]}) \u2014 Sigma DM calc columns silently error on window functions. Degraded to a Null calc column with the original expression in its description; re-author as a Custom SQL element or a workbook-layer calculation.`);
-    return { formula: "Null", description: `QuickSight table-calc (re-author in Sigma): ${expr}` };
+    warnings.push(`\u26A0 Formula uses a QuickSight table-calculation function (${s.match(windowRe)[1]}) \u2014 not auto-mapped to a native Sigma window function yet (converter follow-up). Degraded to a Null calc column with the original expression in its description; re-author with the native Sigma equivalent (CumulativeSum/MovingAvg/MovingSum/PercentOfTotal/Rank/Lag/Lead), which DOES resolve in DM-element and workbook calc columns (verified 2026-07-15) \u2014 only the *Over family errors.`);
+    return { formula: "Null", description: `QuickSight table-calc \u2014 re-author with the native Sigma window fn (NOT the *Over family): ${expr}` };
   }
   const paramRe = /\$\{([^{}]+)\}/;
   if (paramRe.test(s)) {

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-charts-from-signals.rb
@@ -240,8 +240,8 @@ end
 # ---- Tableau table-calc translators ---------------------------------------
 # Translate Tableau table-calculation functions to their Sigma equivalents.
 # Returns the translated formula, plus a hint about Sigma-specific caveats
-# (e.g., "window functions silently error in grouping-table charts — add to a
-# non-grouping context or Custom SQL DM element").
+# (e.g., "the *Over family — SumOver/CountOver/... — is Unknown-function in
+# every spec context; the native window family works in calc columns").
 #
 # Function mappings (Sigma names):
 #   INDEX()                  → RowNumber()
@@ -405,7 +405,7 @@ def translate_tableau_tc(formula)
 
   return [nil, nil] unless changed
   hints.uniq!
-  hints << 'NOTE: Sigma window functions (Rank/Lag/Lead/Cumulative*) silently error in grouping-table charts and DM-element calc cols — add to a workbook-master non-grouping context OR a Custom SQL DM element' if hints.any? { |h| h =~ /Rank|Lag|Lead|RowNumber/ }
+  hints << 'NOTE: Sigma-native window functions (Rank/RankDense/Lag/Lead/RowNumber/Cumulative*/Moving*/PercentOfTotal) resolve to real OVER() in calc columns of DM elements AND workbook tables (grouped or ungrouped) — live-verified 2026-07-15 (tableau probe-window-contexts.rb). Only the *Over family (SumOver/CountOver/...) is Unknown-function in every spec context — never emit those.' if hints.any? { |h| h =~ /Rank|Lag|Lead|RowNumber/ }
   [s, hints.join('; ')]
 end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gap-scout.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gap-scout.md
@@ -39,9 +39,11 @@ PROCEDURE
    - scripts/lib/sigma_functions.rb (the whitelist — anything outside ALL_SET
      silently errors)
 2. Propose ONE candidate Sigma formula. Prefer functions in the whitelist.
-   For window/running/percentOfTotal functions, remember they silently error in
-   workbook-master grouping-table calc cols AND in DM-element calc cols — route
-   to a non-grouping context or a Custom SQL DM element with explicit OVER(...).
+   For window/running/percentOfTotal functions: the native Sigma forms
+   (CumulativeSum/MovingAvg/PercentOfTotal/Rank/RankDense/Lag/Lead/RowNumber)
+   resolve in DM-element AND workbook table calc cols (grouped OR ungrouped) —
+   verified 2026-07-15. Only the *Over family (SumOver/CountOver/...) errors in
+   every context; for those, use a Custom SQL DM element with explicit OVER(...).
 3. Run:
    ruby scripts/scout-validate-and-persist.rb \
      --feature '<feature>' \

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/learned-rules.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/learned-rules.rb
@@ -14,7 +14,7 @@
 #       description: "Tableau WINDOW_AVG(SUM(x)) → Sigma MovingAvg"
 #       tableau_pattern: '\bWINDOW_AVG\s*\(\s*SUM\s*\(\[([^\]]+)\]\)\s*\)'
 #       sigma_template: 'MovingAvg(Sum([Master/\1]), -10, 10)'
-#       hint: "Sigma window functions silently error in grouping-table charts"
+#       hint: "Native window fns resolve in calc columns; only the *Over family errors"
 #       validated_at: "2026-05-19T16:42:00Z"
 #       validated_workbook: "wb-id-here"
 #       example_from: "workbook.twb line 1234"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/scout-validate-and-persist.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/scout-validate-and-persist.rb
@@ -17,7 +17,7 @@
 #     --master-element-id master \
 #     [--folder-id <folder-id>] \
 #     [--description "..."] \
-#     [--hint "Sigma window functions silently error in grouping-table charts"] \
+#     [--hint "Native window fns resolve in calc columns; only the *Over family errors"] \
 #     [--example-from "workbook.twb line 123"] \
 #     [--max-attempts 3]
 #

--- a/plugins/sigma-authoring/skills/sigma-data-models/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/SKILL.md
@@ -66,7 +66,7 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/cline/sigma-data-models.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/cline/sigma-data-models.md
@@ -57,7 +57,7 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/codex/AGENTS.md
@@ -57,7 +57,7 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/continue/sigma-data-models.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/continue/sigma-data-models.md
@@ -57,7 +57,7 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
@@ -62,7 +62,7 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/calc-columns.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/calc-columns.md
@@ -22,19 +22,19 @@ A calc column has no warehouse-column ID prefix — its `id` is a generated shor
 
 A calc column **cannot reference itself**, even transitively — the server rejects circular references.
 
-## Window functions don't work in DM element calc columns
+## The `*Over` window functions don't work — but the native family does
 
-`CountOver`, `SumOver`, `RowNumberOver`, `RankOver`, and other window-style functions silently fail when used as a formula on a calculated column **inside a data model element**. The column's `error` flag flips on without a clear UI signal, and any downstream chart that references the column blanks out.
+The `*Over` family — `CountOver`, `SumOver`, `RowNumberOver`, `RankOver`, `MaxOver`, `MinOver` — is **not a valid spec formula**. In a data-model element calc column a DM-spec POST **hard-rejects** them (400 Bad Request); in a workbook calc column they resolve to `Unknown function` at query time. Never emit the `*Over` names from a spec.
 
-This is independent of the underlying SQL — the same formula works fine in a workbook calc column on most element types, but **not** on a workbook master table that's sourced from a data model (the workbook table inherits the DM-side restriction).
+The Sigma-**native** window family — `CumulativeSum` / `CumulativeAvg` / `CumulativeMax` / `CumulativeMin` / `CumulativeCount`, `MovingSum` / `MovingAvg` / `MovingMax` / `MovingMin` / `MovingStdDev`, `Rank` / `RankDense` / `RankPercentile`, `RowNumber`, `Lag`, `Lead`, `PercentOfTotal` — **does** work. Live-verified 2026-07-15: each compiles to real warehouse `OVER(...)` in a DM-element calc column, in a grouped workbook table, and in an ungrouped workbook "master" table sourced from a data model. There is **no** inherited DM-side restriction on DM-sourced workbook tables. Prefer these over the `*Over` names.
 
-### Workarounds
+### Workarounds (only when there is no native equivalent)
 
 | If you need… | Do this |
 |---|---|
-| A running total or rank by group on warehouse data | Push the calculation to a `sql` source — write the window function in SQL once, expose the result as a regular warehouse column. |
-| A row-number-by-group at view time | Move the calc to a workbook-level table that's **not** sourced from the DM (i.e., sources directly from warehouse-table). Window functions are allowed in those contexts. |
-| A simple cumulative metric | Express it as a metric on the model with `Sum / Count / etc.` — metrics aggregate across rows, which gets you most of what `SumOver` would. |
+| A running total, moving window, rank, or row number | Use the native form (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) — it works directly in a DM-element or workbook calc column. |
+| An `*Over`-only construct with no native equivalent | Push it to a `sql` source — write the window function in SQL once, expose the result as a regular warehouse column. |
+| A simple cumulative metric | `CumulativeSum(...)` in a calc column, or a model metric with `Sum / Count / etc.` |
 
 ### Side effect to know about
 
@@ -43,7 +43,7 @@ When a calc column on a DM element is set to an unsupported formula and the mode
 ## Common errors
 
 - **"Invalid column reference"** — bare `[col]` where a prefix was needed, or a misspelling. Re-check column names against the source via `discover.md`.
-- **Column shows `error` icon, formula looks fine** — likely a window function. Try a simpler aggregation; if that works, the window function is the issue.
+- **Column shows `error` icon, formula looks fine** — likely an `*Over` function (`SumOver`/`CountOver`/…). Switch to the native window function (`CumulativeSum`/`MovingAvg`/`Rank`/`Lag`/…), which resolves in calc columns.
 - **Chart that references this column blanks out** — the calc column is in error state. Fix the formula; the chart will recover on the next render.
 
 See `formulas.md` (in the `sigma-workbooks` skill) for the full formula language reference, including the function list. The data-model side uses the same formula syntax with the constraints noted here.


### PR DESCRIPTION
## What & why

Follow-up to #379 (tableau). The window-function correction there was a **Sigma-platform fact**, not a Tableau one — so the same over-generalization ("Sigma-native window functions silently error outside a chart yAxis / in DM & table calc columns") was wrong everywhere it was repeated. A repo sweep found it in **four other plugins**.

Verified 2026-07-15 (tableau `probe-window-contexts.rb`, 9 fns × 3 contexts): the **native** family (`Cumulative*`/`Moving*`/`Rank`/`RankDense`/`RowNumber`/`Lag`/`Lead`/`PercentOfTotal`) resolves to real `OVER(...)` in DM-element calc columns **and** workbook tables (grouped + ungrouped/master). Only the **`*Over`** family fails: `Unknown function` at query, and a hard **400** on a DM-spec POST.

## Changes (claim corrected; correct `*Over` statements + verified gotchas preserved)
- **powerbi** & **quicksight** `build-charts-from-signals.rb` — window hint + comment
- **qlik** `qlik.mjs` (×3) — kept the live-verified `sort`-400 gotcha, the `[Element/Col]` bare-ref rule, and the grouped-element routing as the *recommended* placement; corrected only the false capability claim
- **quicksight** `quicksight.mjs` — corrected the warning **text** (native funcs DO resolve); **left the `Null`-degradation logic as a flagged follow-up** (mapping QS window fns → native Sigma equivalents is its own change)
- **quicksight** `gap-scout.md` / `scout-validate-and-persist.rb` / `learned-rules.rb` — hint strings
- **sigma-data-models** (vendored) `SKILL.md` + `reference/calc-columns.md` — rewrote the window section as an `*Over`-vs-native distinction; **regenerated the 4 agent variants**

## Not touched / flagged
- ✅ **thoughtspot** `liveboard-to-workbook.md` — already correct (names only `CountOver`/`SumOver`)
- 🚩 **qlik** `gap-scout.md:25` recommends emitting `*Over` functions (dead in every context) — a converter-strategy question, out of scope here
- 📌 Canonical `sigma-data-models` fix is mirrored upstream in `twells89/sigma-skills` (separate PR). A full re-vendor (upstream moved past the pinned SHA) is separate housekeeping.

## Verification
`check-shared`, `lint-skills`, `lint-esm-imports`, `check-agent-variants` all green; `node --check` on both edited `.mjs`; `ruby -c` on edited `.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)