### PR TITLE
feat(quicksight): map self-contained window fns to native Sigma (beads-sigma-7lw8)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -217,6 +217,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-element-match.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb
+            plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/converter/quicksight.mjs
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/converter/quicksight.mjs
@@ -1544,10 +1544,52 @@ function buildDerivedView(srcEl, allElements) {
     order: viewOrder
   };
 }
+function qsSafeWindowToNative(rawExpr, warnings) {
+  // SAFE inline mapping for SELF-CONTAINED QuickSight window fns ONLY:
+  // unpartitioned rank / denseRank / percentileRank and unpartitioned
+  // percentOfTotal. These fully specify their own ordering/scope, so they
+  // translate faithfully to a native Sigma window formula in a calc column
+  // (which resolves — live-verified 2026-07-15). Order/partition-DEPENDENT
+  // windows (running*/lag/lead/difference/period*/window*/*Over) are NOT mapped
+  // here: the native fns inherit the element's sort/partition, so an inline map
+  // would silently drop the QuickSight PARTITION BY / ORDER BY. Those fall
+  // through to the loud Null-degrade (or the SQL OVER() helper path). bd 7lw8.
+  warnings = warnings || [];
+  const m = (rawExpr || "").trim().match(/^(rank|denseRank|percentileRank|percentOfTotal)\s*\(([\s\S]*)\)$/i);
+  if (!m) return null;
+  const fn = m[1].toLowerCase();
+  const args = splitTopLevel(m[2], ",");
+  if (args.length === 0 || !args[0].trim()) return null;
+  if (args.length >= 2 && args[1].trim()) return null; // partitioned → not self-contained → bail to loud degrade
+  const toSigma = (qs) => {
+    const r = quicksightFormulaToSigmaEx(qs, []);
+    return r && r.formula && r.formula !== "Null" ? r.formula : null;
+  };
+  if (fn === "percentoftotal") {
+    const agg = toSigma(args[0]);
+    if (!agg) return null;
+    warnings.push(`ℹ QuickSight percentOfTotal → native PercentOfTotal(_, "grand_total") (resolves in a calc column). Verify against the QuickSight total.`);
+    return `PercentOfTotal(${agg}, "grand_total")`;
+  }
+  const sortTok = args[0].trim().replace(/^\[/, "").replace(/\]$/, "").trim();
+  const dm = sortTok.match(/^([\s\S]*?)\s+(ASC|DESC)\s*$/i);
+  const exprPart = dm ? dm[1].trim() : sortTok;
+  const dir = (dm && dm[2] ? dm[2] : (fn === "percentilerank" ? "ASC" : "DESC")).toLowerCase();
+  const sigExpr = toSigma(exprPart);
+  if (!sigExpr) return null;
+  const sigFn = fn === "rank" ? "Rank" : fn === "denserank" ? "RankDense" : "RankPercentile";
+  warnings.push(`ℹ QuickSight ${m[1]} → native ${sigFn}(_, "${dir}") (resolves in a calc column). Verify ranking direction/tie handling.`);
+  return `${sigFn}(${sigExpr}, "${dir}")`;
+}
 function quicksightFormulaToSigmaEx(expr, warnings) {
   if (!expr || typeof expr !== "string")
     return { formula: "" };
   let s = expr.trim();
+  // Self-contained window fns (unpartitioned rank family + percentOfTotal) map
+  // to a faithful native Sigma window formula; order/partition-dependent ones
+  // fall through to the loud degrade below. See qsSafeWindowToNative / bd 7lw8.
+  const _nativeWin = qsSafeWindowToNative(s, warnings);
+  if (_nativeWin) return { formula: _nativeWin };
   const strings = [];
   s = s.replace(/'((?:[^'\\]|\\.)*)'/g, (_, body) => {
     const idx = strings.length;
@@ -1599,8 +1641,8 @@ function quicksightFormulaToSigmaEx(expr, warnings) {
   ];
   const windowRe = new RegExp(`\\b(${windowFns.join("|")})\\s*\\(`, "i");
   if (windowRe.test(s)) {
-    warnings.push(`\u26A0 Formula uses a QuickSight table-calculation function (${s.match(windowRe)[1]}) \u2014 not auto-mapped to a native Sigma window function yet (converter follow-up). Degraded to a Null calc column with the original expression in its description; re-author with the native Sigma equivalent (CumulativeSum/MovingAvg/MovingSum/PercentOfTotal/Rank/Lag/Lead), which DOES resolve in DM-element and workbook calc columns (verified 2026-07-15) \u2014 only the *Over family errors.`);
-    return { formula: "Null", description: `QuickSight table-calc \u2014 re-author with the native Sigma window fn (NOT the *Over family): ${expr}` };
+    warnings.push(`\u26A0 Formula uses an order/partition-DEPENDENT QuickSight table-calc (${s.match(windowRe)[1]}) \u2014 not auto-mapped inline, because the native Sigma equivalent (CumulativeSum/MovingAvg/Lag/Lead/\u2026) inherits the element's sort+partition and would silently drop the QuickSight PARTITION BY/ORDER BY. Degraded to a Null calc column with the original expression in its description; re-author it in a GROUPED, SORTED workbook element with the native window fn (which resolves there), or as a Custom SQL element with explicit OVER(...). (Self-contained rank/denseRank/percentileRank/percentOfTotal ARE auto-mapped; the *Over family is invalid everywhere.)`);
+    return { formula: "Null", description: `QuickSight order/partition-dependent table-calc \u2014 re-author in a grouped/sorted workbook element with the native window fn (NOT the *Over family): ${expr}` };
   }
   const paramRe = /\$\{([^{}]+)\}/;
   if (paramRe.test(s)) {

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-window-native.rb — regression for the safe inline QuickSight window-fn →
+# native Sigma mapping (beads-sigma-7lw8). Guards the invariant:
+#
+#   SELF-CONTAINED windows (unpartitioned rank / denseRank / percentileRank +
+#   unpartitioned percentOfTotal) map to a native Sigma window fn — they fully
+#   specify their own ordering/scope, so they resolve faithfully in a calc column
+#   (live-verified 2026-07-15).
+#
+#   Order/partition-DEPENDENT windows (running*/lag/lead/difference/period*/
+#   window*/*Over), PARTITIONED rank/percentOfTotal, and NESTED window exprs must
+#   still degrade to Null — mapping them inline would silently drop the
+#   QuickSight PARTITION BY / ORDER BY (native fns inherit the element's grain).
+#
+# Creds-free, network-free. Shells to node (preinstalled on the CI runner).
+
+require 'open3'
+require 'json'
+
+conv = File.expand_path('../converter/quicksight.mjs', __dir__)
+abort "converter not found: #{conv}" unless File.exist?(conv)
+
+node_script = <<~JS
+  const { quicksightFormulaToSigma } = await import(#{"file://#{conv}".to_json});
+  const cases = [
+    // [expr, expectation, optional shape regex]
+    ["rank([sum({Sales}) DESC])",        "map",  /^Rank\\(Sum\\(\\[Sales\\]\\), "desc"\\)$/],
+    ["rank([sum({Sales})])",             "map",  /"desc"\\)$/],
+    ["denseRank([sum({Profit}) ASC])",   "map",  /^RankDense\\(.*"asc"\\)$/],
+    ["percentileRank([sum({X})])",       "map",  /^RankPercentile\\(.*"asc"\\)$/],
+    ["percentOfTotal(sum({Sales}))",     "map",  /^PercentOfTotal\\(.*"grand_total"\\)$/],
+    ["runningSum(sum({Sales}), [{OrderDate} ASC])", "null"],
+    ["rank([sum({Sales}) DESC], [{Region}])",       "null"],
+    ["percentOfTotal(sum({Sales}), [{Region}])",    "null"],
+    ["sumOver(sum({Sales}), [{Region}])",           "null"],
+    ["lag(sum({Sales}), [{OrderDate} ASC], 1)",     "null"],
+    ["rank([sum({Sales})]) + 1",                    "null"],
+  ];
+  let fail = 0;
+  for (const [expr, want, re] of cases) {
+    const out = quicksightFormulaToSigma(expr, []);
+    const isNull = out === "Null";
+    const ok = want === "null" ? isNull : (!isNull && (!re || re.test(out)));
+    if (!ok) { fail++; console.error(`  FAIL [${want}] ${expr}  =>  ${out}`); }
+  }
+  process.exit(fail === 0 ? 0 : 1);
+JS
+
+out, status = Open3.capture2e('node', '--input-type=module', stdin_data: node_script)
+if status.success?
+  puts 'PASS: QuickSight safe-window → native mapping (11 cases; self-contained map, order/partition-dependent degrade)'
+  exit 0
+else
+  warn out
+  warn 'FAIL: test-window-native.rb — window-fn mapping regression'
+  exit 1
+end


### PR DESCRIPTION
## What

The quicksight converter's inline formula translator degraded **all** window functions to `Null`. This maps the **self-contained** ones to a native Sigma window function that resolves in a calc column (per #379/#380, verified 2026-07-15):

| QuickSight | Sigma |
|---|---|
| `rank([<agg> DESC])` | `Rank(<agg>, "desc")` |
| `denseRank([<agg> ASC])` | `RankDense(<agg>, "asc")` |
| `percentileRank([<agg>])` | `RankPercentile(<agg>, "asc")` |
| `percentOfTotal(<agg>)` | `PercentOfTotal(<agg>, "grand_total")` |

These fully specify their own ordering/scope, so the inline map is faithful.

## Deliberately still degraded to Null (never-silent)

Order/partition-**dependent** windows (`running*`/`lag`/`lead`/`difference`/`period*`/`window*`/`*Over`), **partitioned** `rank`/`percentOfTotal`, and **nested** window exprs. A native inline map would inherit the consuming element's grain and **silently drop** the QuickSight `PARTITION BY` / `ORDER BY`. These keep the loud degrade (message rewritten to explain why + point at a grouped/sorted workbook element or a SQL `OVER()` element). Note: quicksight's **primary** path already builds faithful SQL `OVER()` helpers; routing this *fallback* through that helper is deferred to a follow-up bead.

## Verification
- `scripts/test-window-native.rb` — 11-case regression (safe→native, unsafe→Null), added to the corpus-check unit-test allow-list
- Live-verified `RankPercentile` resolves in a grouped calc column (`0.75`)
- 14/14 corpus goldens pass; all gates green (check-shared, lint-skills, lint-esm-imports, check-agent-variants)

Implements the **safe-slice** (option A) of `beads-sigma-7lw8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)