### PR TITLE
feat(gate): opt-in runtime control flip test (gate 7b)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -45,6 +45,14 @@
 #      an interactive source = FAIL, the Qlik class) and per-control
 #      scope:[...] allowlists (intentional single-chart switchers like grain
 #      controls). See the lib header CONTRACT.
+#   7b. Runtime control flip test (OPT-IN via --require-control-flip) — gate 7's
+#      control-scope.json sidecar is derived by build_workbook.py from the same
+#      `listen` data it used to wire the spec, so a builder-level mis-mapping
+#      makes spec and sidecar AGREE and gate 7 passes. This gate proves the
+#      wiring INDEPENDENTLY at runtime: scripts/probe-controls.rb flips each
+#      auto-probeable control via the REST export API and requires its targets'
+#      output to actually change (wired-but-inert = FAIL, exit 21). Offline runs
+#      (no creds / no workbook) SKIP. See lib/flip_gate.rb.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -63,6 +71,11 @@
 #                              # in your report
 #     [--control-scope PATH]   # control-scope.json sidecar for gate 7
 #                              # (default: <workdir>/control-scope.json)
+#     [--require-control-flip] # gate 7b (OPT-IN): prove control wiring at runtime
+#                              # via probe-controls.rb (looker-to-sigma opts in)
+#     [--skip-control-flip R]  # waive gate 7b — name the reason in your report
+#     [--flip-check-leaks]     # gate 7b: also assert flips don't leak
+#                              # (probe --check-out-of-closure; doubles exports)
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -172,6 +185,15 @@
 #      pass=false. Script absent → gate is invisible; inputs absent → stated
 #      SKIP. Escape hatch: --skip-visual-similarity "<reason>" (counted against
 #      the waiver budget).
+#  21  Runtime control flip test failed (gate 7b; OPT-IN via --require-control-flip)
+#      — a control passed the static wiring lint (gate 7) but does NOT actually
+#      filter its targets at runtime (wired-but-inert / builder-level listen->
+#      column mis-mapping), proven by scripts/probe-controls.rb; OR the probe
+#      could not run at all on an opted-in gate (fail-closed). Fix the listen
+#      mapping in build_workbook.py + re-PUT, or re-run once the export API is
+#      reachable. Un-probeable control types (date-range / slider) are an
+#      advisory WARN + control-flip-unverified.json marker, not this failure.
+#      Escape hatch: --skip-control-flip "<reason>" (counts against the budget).
 #
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
@@ -206,6 +228,9 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
   p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--require-control-flip', 'gate 7b (OPT-IN, off by default): after control lint, PROVE each auto-probeable control actually filters its targets at runtime via scripts/probe-controls.rb (live REST export flip test). Closes the self-referential-sidecar hole in gate 7. Adopters (looker-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_control_flip] = true }
+  p.on('--skip-control-flip [REASON]', 'waive gate 7b (runtime control flip test) — the reason MUST be named in your migration report.') { |v| opts[:skip_control_flip] = v || true }
+  p.on('--flip-check-leaks', 'gate 7b: also run probe --check-out-of-closure (asserts a flip does NOT leak to out-of-closure elements; doubles exports). Off by default.') { opts[:flip_check_leaks] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
@@ -294,6 +319,7 @@ WAIVER_HIDES = {
   '--allow-missing-tiles'      => 'gate 5: source tiles absent from the build were accepted',
   '--skip-layout-lint'         => 'gate 6: layout quality never linted',
   '--skip-control-lint'        => 'gate 7: control wiring never linted',
+  '--skip-control-flip'        => 'gate 7b: control wiring never proven at runtime',
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
@@ -321,6 +347,7 @@ waiver_flags << '--skip-layout-check'        if opts[:skip_layout]
 waiver_flags << '--allow-missing-tiles'      if opts[:allow_missing_tiles].to_i.positive?
 waiver_flags << '--skip-layout-lint'         if opts[:skip_lint]
 waiver_flags << '--skip-control-lint'        if opts[:skip_control_lint]
+waiver_flags << '--skip-control-flip'        if opts[:skip_control_flip] && opts[:require_control_flip]
 waiver_flags << '--skip-visual-gate'         if opts[:skip_visual]
 waiver_flags << '--skip-visual-comparison'   if opts[:skip_visual_cmp]
 waiver_flags << '--skip-layout-fill'         if opts[:skip_layout_fill]
@@ -953,6 +980,110 @@ else
              "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
       else
         warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7b — runtime control flip test (exit 21; OPT-IN via --require-control-flip)
+# Gate 7 proves control wiring against the LIVE spec + control-scope.json — but
+# that sidecar is derived by build_workbook.py from the SAME `listen` data it
+# used to wire the spec, so a BUILDER-level mis-mapping yields a spec and a
+# sidecar that AGREE and gate 7 passes. The only independent proof is runtime:
+# flip a control via the REST export API and confirm its targets' output
+# actually changes. This gate shells out to scripts/probe-controls.rb (which
+# already does exactly that) and turns its verdict into a hard gate. Opt-in so
+# converters adopt it deliberately (looker-to-sigma passes --require-control-flip);
+# offline runs (no creds / no workbook) SKIP, never false-fail. See lib/flip_gate.rb.
+# ---------------------------------------------------------------------------
+if !opts[:require_control_flip]
+  puts '[SKIP] gate 7b: runtime control flip test not opted in (pass --require-control-flip to enable)'
+elsif opts[:skip_control_flip]
+  record_waiver.call('--skip-control-flip', 'gate 7b (runtime control flip test)', opts[:skip_control_flip])
+else
+  flip_wb = opts[:wb]
+  if flip_wb.nil?
+    _p = File.join(opts[:tab], 'wb-ids.json')
+    flip_wb = (JSON.parse(File.read(_p))['workbookId'] rescue nil) if File.exist?(_p)
+  end
+  flip_base = ENV['SIGMA_BASE_URL']
+  flip_tok  = ENV['SIGMA_API_TOKEN']
+  probe = File.join(__dir__, 'probe-controls.rb')
+  if flip_wb.nil? || flip_wb.to_s.empty?
+    puts '[SKIP] gate 7b: no workbook ID resolvable for the flip test'
+  elsif flip_base.nil? || flip_base.empty? || flip_tok.nil? || flip_tok.empty?
+    warn '[SKIP] gate 7b: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot exercise controls'
+  elsif !File.exist?(probe)
+    warn '[SKIP] gate 7b: scripts/probe-controls.rb not vendored alongside this script — re-vendor (SHA-1 discipline)'
+  else
+    # Only meaningful when the workbook actually has controls. Reuse gate 7's
+    # spec fetch + ControlLint to count them; 0 controls -> nothing to prove.
+    begin
+      require_relative 'lib/control_lint'
+      require_relative 'lib/flip_gate'
+    rescue LoadError => e
+      warn "[SKIP] gate 7b: #{e.message} — re-vendor scripts/lib (SHA-1 discipline)"
+    end
+    n_controls = nil
+    if defined?(ControlLint) && defined?(FlipGate)
+      uri = URI("#{flip_base}/v2/workbooks/#{flip_wb}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{flip_tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        n_controls = ControlLint.controls_report(spec).length
+      else
+        warn "[SKIP] gate 7b: GET /v2/workbooks/#{flip_wb}/spec returned HTTP #{res.code} — cannot count controls"
+      end
+    end
+    if n_controls == 0
+      puts '[OK] gate 7b: workbook has no controls — nothing to flip-test'
+    elsif !n_controls.nil?
+      out = File.join(opts[:tab], 'probe-controls')
+      cmd = [RbConfig.ruby, probe, '--workbook-id', flip_wb, '--out', out]
+      cmd << '--check-out-of-closure' if opts[:flip_check_leaks]
+      system(*cmd) # inherits stdout — the operator sees the per-control PASS/FAIL/SKIP table
+      probe_rc = $?.exitstatus
+      results = (JSON.parse(File.read(File.join(out, 'probe-results.json'))) rescue nil)
+      decision, info = FlipGate.decide(probe_rc, results)
+      case decision
+      when :ok
+        puts "[OK] gate 7b: #{info[:passes].length} control(s) proven live (in-closure export changes when flipped)" \
+             "#{info[:skips].any? ? "; #{info[:skips].length} un-probeable type(s) skipped" : ''}"
+      when :fail
+        warn "[FAIL] gate 7b: #{info[:fails].length} control(s) wired but INERT on live workbook #{flip_wb}:"
+        info[:fails].each { |cid, note| warn "         - #{cid}: #{note}" }
+        warn '       The control passed the static lint (gate 7) but does not actually filter its'
+        warn '       targets — a builder-level listen->column mis-mapping. Re-check the tile `listen`'
+        warn '       mapping in build_workbook.py, re-PUT the spec, then re-run.'
+        warn "       Reproduce: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
+      when :advisory
+        warn "[WARN] gate 7b: no control could be auto-flipped (#{info[:skips].length} date-range / slider / " \
+             'unlabeled control(s) need an explicit flip value) — runtime wiring is UNVERIFIED.'
+        info[:skips].each { |cid, note| warn "         - #{cid}: #{note}" }
+        marker = File.join(opts[:tab], 'control-flip-unverified.json')
+        File.write(marker, JSON.pretty_generate('workbookId' => flip_wb,
+                                                'unprobed' => info[:skips].map { |c, n| { 'control' => c, 'note' => n } })) rescue nil
+        warn "       Recorded to #{marker}. Prove them with: ruby scripts/probe-controls.rb --workbook-id " \
+             "#{flip_wb} --value <controlId>=<value>  (or waive with --skip-control-flip \"<reason>\")."
+      when :error
+        warn "[FAIL] gate 7b: probe-controls.rb could not verify the wiring (exit #{probe_rc}) on workbook #{flip_wb}."
+        warn '       An opted-in gate that could not run must not pass silently. Re-run once the export'
+        warn "       API is reachable: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
       end
     end
   end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/flip_gate.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -1078,7 +1078,15 @@ console.error('stats:', JSON.stringify(res.stats));
     rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-looker.rb"),
                  "--workdir", wd, "--finalize"], check=False)
     gate_cmd = ["ruby", os.path.join(HERE, "assert-phase6-ran.rb"),
-                "--workdir", wd, "--workbook-id", wb]
+                "--workdir", wd, "--workbook-id", wb,
+                # Opt into gate 7b (runtime control flip test). Gate 7's static
+                # control lint checks the spec against a builder-derived
+                # control-scope.json sidecar — it cannot catch a builder-level
+                # listen->column mis-mapping (spec + sidecar agree). Gate 7b
+                # flips each control live (probe-controls.rb) and proves its
+                # targets change. Looker is the first adopter; other converters
+                # are unaffected until they pass this flag too.
+                "--require-control-flip"]
     # Wire the Phase-4c render to gate 8 (visual render). We render to
     # visual-qa/<pageId>.png, but the gate defaults to looking for
     # <workdir>/sigma-render.png — without this the gate never finds the PNG and

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-flip-gate.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-flip-gate.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Tests for lib/flip_gate.rb — the pure decision logic behind gate 7b (the
+# runtime control flip test in assert-phase6-ran.rb). Turns probe-controls.rb's
+# exit code + parsed probe-results.json into :ok / :fail / :advisory / :error
+# WITHOUT touching a live workbook, so the branch table is unit-verifiable.
+#
+# Offline, no network. Usage: ruby scripts/test-flip-gate.rb
+
+require_relative 'lib/flip_gate'
+
+$fails = []
+def ok(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# A probe-results.json as parsed from disk (string keys).
+PASS_ROW = { 'control' => 'ctl-region', 'result' => 'PASS', 'note' => '3 -> 1 rows' }
+FAIL_ROW = { 'control' => 'ctl-tier', 'result' => 'FAIL', 'note' => 'export IDENTICAL — wired but inert' }
+SKIP_ROW = { 'control' => 'ctl-date', 'result' => 'SKIP', 'note' => 'date range — pass --value' }
+
+puts '-- rc=0 (probe reports every probeable control flipped) --'
+dec, info = FlipGate.decide(0, [PASS_ROW])
+ok(dec == :ok, "rc=0 + a PASS row → :ok (got #{dec})")
+ok(info[:passes] == ['ctl-region'], 'ok: passes list carries the control id')
+
+dec, info = FlipGate.decide(0, [PASS_ROW, SKIP_ROW])
+ok(dec == :ok, 'rc=0 with a PASS and a SKIP → :ok (skips allowed)')
+ok(info[:skips].first == ['ctl-date', 'date range — pass --value'], 'ok: skips carry [id, note]')
+
+dec, = FlipGate.decide(0, [SKIP_ROW])
+ok(dec == :advisory, 'rc=0 but ONLY skips (no PASS) → :advisory, never a silent green')
+
+puts '-- rc=1 (probe reports a failure) --'
+dec, info = FlipGate.decide(1, [PASS_ROW, FAIL_ROW])
+ok(dec == :fail, "rc=1 + a FAIL row → :fail (got #{dec})")
+ok(info[:fails].first == ['ctl-tier', 'export IDENTICAL — wired but inert'],
+   'fail: fails carry [id, note] for the operator message')
+
+dec, = FlipGate.decide(1, nil)
+ok(dec == :error, 'rc=1 with NO results file (probe aborted / bad args) → :error, not a false :fail')
+dec, = FlipGate.decide(1, [])
+ok(dec == :error, 'rc=1 with an empty results array → :error (nothing actually failed to report)')
+
+puts '-- rc=2 (nothing was auto-probeable) --'
+dec, info = FlipGate.decide(2, [SKIP_ROW])
+ok(dec == :advisory, 'rc=2 → :advisory (date/slider controls need --value; do not block)')
+ok(info[:skips].length == 1, 'advisory: the un-probeable controls are reported for the marker')
+
+puts '-- unexpected probe exit → fail-closed --'
+dec, = FlipGate.decide(3, nil)
+ok(dec == :error, 'rc=3 (probe crashed unexpectedly) → :error (fail-closed, never silent pass)')
+
+puts '-- symbol-keyed rows (results built in-process, not parsed from JSON) --'
+dec, info = FlipGate.decide(0, [{ control: 'c1', result: 'PASS', note: 'ok' }])
+ok(dec == :ok, 'symbol keys resolve identically to string keys → :ok')
+ok(info[:passes] == ['c1'], 'symbol-keyed control id extracted')
+
+puts '-- defensive: garbage results shape --'
+dec, = FlipGate.decide(0, 'not-an-array')
+ok(dec == :advisory, 'non-array results at rc=0 → :advisory (no PASS rows found)')
+
+puts
+if $fails.empty?
+  puts 'ALL PASS — flip_gate decision table'
+  exit 0
+else
+  puts "FAILURES (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -45,6 +45,14 @@
 #      an interactive source = FAIL, the Qlik class) and per-control
 #      scope:[...] allowlists (intentional single-chart switchers like grain
 #      controls). See the lib header CONTRACT.
+#   7b. Runtime control flip test (OPT-IN via --require-control-flip) — gate 7's
+#      control-scope.json sidecar is derived by build_workbook.py from the same
+#      `listen` data it used to wire the spec, so a builder-level mis-mapping
+#      makes spec and sidecar AGREE and gate 7 passes. This gate proves the
+#      wiring INDEPENDENTLY at runtime: scripts/probe-controls.rb flips each
+#      auto-probeable control via the REST export API and requires its targets'
+#      output to actually change (wired-but-inert = FAIL, exit 21). Offline runs
+#      (no creds / no workbook) SKIP. See lib/flip_gate.rb.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -63,6 +71,11 @@
 #                              # in your report
 #     [--control-scope PATH]   # control-scope.json sidecar for gate 7
 #                              # (default: <workdir>/control-scope.json)
+#     [--require-control-flip] # gate 7b (OPT-IN): prove control wiring at runtime
+#                              # via probe-controls.rb (looker-to-sigma opts in)
+#     [--skip-control-flip R]  # waive gate 7b — name the reason in your report
+#     [--flip-check-leaks]     # gate 7b: also assert flips don't leak
+#                              # (probe --check-out-of-closure; doubles exports)
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -172,6 +185,15 @@
 #      pass=false. Script absent → gate is invisible; inputs absent → stated
 #      SKIP. Escape hatch: --skip-visual-similarity "<reason>" (counted against
 #      the waiver budget).
+#  21  Runtime control flip test failed (gate 7b; OPT-IN via --require-control-flip)
+#      — a control passed the static wiring lint (gate 7) but does NOT actually
+#      filter its targets at runtime (wired-but-inert / builder-level listen->
+#      column mis-mapping), proven by scripts/probe-controls.rb; OR the probe
+#      could not run at all on an opted-in gate (fail-closed). Fix the listen
+#      mapping in build_workbook.py + re-PUT, or re-run once the export API is
+#      reachable. Un-probeable control types (date-range / slider) are an
+#      advisory WARN + control-flip-unverified.json marker, not this failure.
+#      Escape hatch: --skip-control-flip "<reason>" (counts against the budget).
 #
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
@@ -206,6 +228,9 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
   p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--require-control-flip', 'gate 7b (OPT-IN, off by default): after control lint, PROVE each auto-probeable control actually filters its targets at runtime via scripts/probe-controls.rb (live REST export flip test). Closes the self-referential-sidecar hole in gate 7. Adopters (looker-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_control_flip] = true }
+  p.on('--skip-control-flip [REASON]', 'waive gate 7b (runtime control flip test) — the reason MUST be named in your migration report.') { |v| opts[:skip_control_flip] = v || true }
+  p.on('--flip-check-leaks', 'gate 7b: also run probe --check-out-of-closure (asserts a flip does NOT leak to out-of-closure elements; doubles exports). Off by default.') { opts[:flip_check_leaks] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
@@ -294,6 +319,7 @@ WAIVER_HIDES = {
   '--allow-missing-tiles'      => 'gate 5: source tiles absent from the build were accepted',
   '--skip-layout-lint'         => 'gate 6: layout quality never linted',
   '--skip-control-lint'        => 'gate 7: control wiring never linted',
+  '--skip-control-flip'        => 'gate 7b: control wiring never proven at runtime',
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
@@ -321,6 +347,7 @@ waiver_flags << '--skip-layout-check'        if opts[:skip_layout]
 waiver_flags << '--allow-missing-tiles'      if opts[:allow_missing_tiles].to_i.positive?
 waiver_flags << '--skip-layout-lint'         if opts[:skip_lint]
 waiver_flags << '--skip-control-lint'        if opts[:skip_control_lint]
+waiver_flags << '--skip-control-flip'        if opts[:skip_control_flip] && opts[:require_control_flip]
 waiver_flags << '--skip-visual-gate'         if opts[:skip_visual]
 waiver_flags << '--skip-visual-comparison'   if opts[:skip_visual_cmp]
 waiver_flags << '--skip-layout-fill'         if opts[:skip_layout_fill]
@@ -953,6 +980,110 @@ else
              "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
       else
         warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7b — runtime control flip test (exit 21; OPT-IN via --require-control-flip)
+# Gate 7 proves control wiring against the LIVE spec + control-scope.json — but
+# that sidecar is derived by build_workbook.py from the SAME `listen` data it
+# used to wire the spec, so a BUILDER-level mis-mapping yields a spec and a
+# sidecar that AGREE and gate 7 passes. The only independent proof is runtime:
+# flip a control via the REST export API and confirm its targets' output
+# actually changes. This gate shells out to scripts/probe-controls.rb (which
+# already does exactly that) and turns its verdict into a hard gate. Opt-in so
+# converters adopt it deliberately (looker-to-sigma passes --require-control-flip);
+# offline runs (no creds / no workbook) SKIP, never false-fail. See lib/flip_gate.rb.
+# ---------------------------------------------------------------------------
+if !opts[:require_control_flip]
+  puts '[SKIP] gate 7b: runtime control flip test not opted in (pass --require-control-flip to enable)'
+elsif opts[:skip_control_flip]
+  record_waiver.call('--skip-control-flip', 'gate 7b (runtime control flip test)', opts[:skip_control_flip])
+else
+  flip_wb = opts[:wb]
+  if flip_wb.nil?
+    _p = File.join(opts[:tab], 'wb-ids.json')
+    flip_wb = (JSON.parse(File.read(_p))['workbookId'] rescue nil) if File.exist?(_p)
+  end
+  flip_base = ENV['SIGMA_BASE_URL']
+  flip_tok  = ENV['SIGMA_API_TOKEN']
+  probe = File.join(__dir__, 'probe-controls.rb')
+  if flip_wb.nil? || flip_wb.to_s.empty?
+    puts '[SKIP] gate 7b: no workbook ID resolvable for the flip test'
+  elsif flip_base.nil? || flip_base.empty? || flip_tok.nil? || flip_tok.empty?
+    warn '[SKIP] gate 7b: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot exercise controls'
+  elsif !File.exist?(probe)
+    warn '[SKIP] gate 7b: scripts/probe-controls.rb not vendored alongside this script — re-vendor (SHA-1 discipline)'
+  else
+    # Only meaningful when the workbook actually has controls. Reuse gate 7's
+    # spec fetch + ControlLint to count them; 0 controls -> nothing to prove.
+    begin
+      require_relative 'lib/control_lint'
+      require_relative 'lib/flip_gate'
+    rescue LoadError => e
+      warn "[SKIP] gate 7b: #{e.message} — re-vendor scripts/lib (SHA-1 discipline)"
+    end
+    n_controls = nil
+    if defined?(ControlLint) && defined?(FlipGate)
+      uri = URI("#{flip_base}/v2/workbooks/#{flip_wb}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{flip_tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        n_controls = ControlLint.controls_report(spec).length
+      else
+        warn "[SKIP] gate 7b: GET /v2/workbooks/#{flip_wb}/spec returned HTTP #{res.code} — cannot count controls"
+      end
+    end
+    if n_controls == 0
+      puts '[OK] gate 7b: workbook has no controls — nothing to flip-test'
+    elsif !n_controls.nil?
+      out = File.join(opts[:tab], 'probe-controls')
+      cmd = [RbConfig.ruby, probe, '--workbook-id', flip_wb, '--out', out]
+      cmd << '--check-out-of-closure' if opts[:flip_check_leaks]
+      system(*cmd) # inherits stdout — the operator sees the per-control PASS/FAIL/SKIP table
+      probe_rc = $?.exitstatus
+      results = (JSON.parse(File.read(File.join(out, 'probe-results.json'))) rescue nil)
+      decision, info = FlipGate.decide(probe_rc, results)
+      case decision
+      when :ok
+        puts "[OK] gate 7b: #{info[:passes].length} control(s) proven live (in-closure export changes when flipped)" \
+             "#{info[:skips].any? ? "; #{info[:skips].length} un-probeable type(s) skipped" : ''}"
+      when :fail
+        warn "[FAIL] gate 7b: #{info[:fails].length} control(s) wired but INERT on live workbook #{flip_wb}:"
+        info[:fails].each { |cid, note| warn "         - #{cid}: #{note}" }
+        warn '       The control passed the static lint (gate 7) but does not actually filter its'
+        warn '       targets — a builder-level listen->column mis-mapping. Re-check the tile `listen`'
+        warn '       mapping in build_workbook.py, re-PUT the spec, then re-run.'
+        warn "       Reproduce: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
+      when :advisory
+        warn "[WARN] gate 7b: no control could be auto-flipped (#{info[:skips].length} date-range / slider / " \
+             'unlabeled control(s) need an explicit flip value) — runtime wiring is UNVERIFIED.'
+        info[:skips].each { |cid, note| warn "         - #{cid}: #{note}" }
+        marker = File.join(opts[:tab], 'control-flip-unverified.json')
+        File.write(marker, JSON.pretty_generate('workbookId' => flip_wb,
+                                                'unprobed' => info[:skips].map { |c, n| { 'control' => c, 'note' => n } })) rescue nil
+        warn "       Recorded to #{marker}. Prove them with: ruby scripts/probe-controls.rb --workbook-id " \
+             "#{flip_wb} --value <controlId>=<value>  (or waive with --skip-control-flip \"<reason>\")."
+      when :error
+        warn "[FAIL] gate 7b: probe-controls.rb could not verify the wiring (exit #{probe_rc}) on workbook #{flip_wb}."
+        warn '       An opted-in gate that could not run must not pass silently. Re-run once the export'
+        warn "       API is reachable: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
       end
     end
   end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/flip_gate.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -45,6 +45,14 @@
 #      an interactive source = FAIL, the Qlik class) and per-control
 #      scope:[...] allowlists (intentional single-chart switchers like grain
 #      controls). See the lib header CONTRACT.
+#   7b. Runtime control flip test (OPT-IN via --require-control-flip) — gate 7's
+#      control-scope.json sidecar is derived by build_workbook.py from the same
+#      `listen` data it used to wire the spec, so a builder-level mis-mapping
+#      makes spec and sidecar AGREE and gate 7 passes. This gate proves the
+#      wiring INDEPENDENTLY at runtime: scripts/probe-controls.rb flips each
+#      auto-probeable control via the REST export API and requires its targets'
+#      output to actually change (wired-but-inert = FAIL, exit 21). Offline runs
+#      (no creds / no workbook) SKIP. See lib/flip_gate.rb.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -63,6 +71,11 @@
 #                              # in your report
 #     [--control-scope PATH]   # control-scope.json sidecar for gate 7
 #                              # (default: <workdir>/control-scope.json)
+#     [--require-control-flip] # gate 7b (OPT-IN): prove control wiring at runtime
+#                              # via probe-controls.rb (looker-to-sigma opts in)
+#     [--skip-control-flip R]  # waive gate 7b — name the reason in your report
+#     [--flip-check-leaks]     # gate 7b: also assert flips don't leak
+#                              # (probe --check-out-of-closure; doubles exports)
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -172,6 +185,15 @@
 #      pass=false. Script absent → gate is invisible; inputs absent → stated
 #      SKIP. Escape hatch: --skip-visual-similarity "<reason>" (counted against
 #      the waiver budget).
+#  21  Runtime control flip test failed (gate 7b; OPT-IN via --require-control-flip)
+#      — a control passed the static wiring lint (gate 7) but does NOT actually
+#      filter its targets at runtime (wired-but-inert / builder-level listen->
+#      column mis-mapping), proven by scripts/probe-controls.rb; OR the probe
+#      could not run at all on an opted-in gate (fail-closed). Fix the listen
+#      mapping in build_workbook.py + re-PUT, or re-run once the export API is
+#      reachable. Un-probeable control types (date-range / slider) are an
+#      advisory WARN + control-flip-unverified.json marker, not this failure.
+#      Escape hatch: --skip-control-flip "<reason>" (counts against the budget).
 #
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
@@ -206,6 +228,9 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
   p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--require-control-flip', 'gate 7b (OPT-IN, off by default): after control lint, PROVE each auto-probeable control actually filters its targets at runtime via scripts/probe-controls.rb (live REST export flip test). Closes the self-referential-sidecar hole in gate 7. Adopters (looker-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_control_flip] = true }
+  p.on('--skip-control-flip [REASON]', 'waive gate 7b (runtime control flip test) — the reason MUST be named in your migration report.') { |v| opts[:skip_control_flip] = v || true }
+  p.on('--flip-check-leaks', 'gate 7b: also run probe --check-out-of-closure (asserts a flip does NOT leak to out-of-closure elements; doubles exports). Off by default.') { opts[:flip_check_leaks] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
@@ -294,6 +319,7 @@ WAIVER_HIDES = {
   '--allow-missing-tiles'      => 'gate 5: source tiles absent from the build were accepted',
   '--skip-layout-lint'         => 'gate 6: layout quality never linted',
   '--skip-control-lint'        => 'gate 7: control wiring never linted',
+  '--skip-control-flip'        => 'gate 7b: control wiring never proven at runtime',
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
@@ -321,6 +347,7 @@ waiver_flags << '--skip-layout-check'        if opts[:skip_layout]
 waiver_flags << '--allow-missing-tiles'      if opts[:allow_missing_tiles].to_i.positive?
 waiver_flags << '--skip-layout-lint'         if opts[:skip_lint]
 waiver_flags << '--skip-control-lint'        if opts[:skip_control_lint]
+waiver_flags << '--skip-control-flip'        if opts[:skip_control_flip] && opts[:require_control_flip]
 waiver_flags << '--skip-visual-gate'         if opts[:skip_visual]
 waiver_flags << '--skip-visual-comparison'   if opts[:skip_visual_cmp]
 waiver_flags << '--skip-layout-fill'         if opts[:skip_layout_fill]
@@ -953,6 +980,110 @@ else
              "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
       else
         warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7b — runtime control flip test (exit 21; OPT-IN via --require-control-flip)
+# Gate 7 proves control wiring against the LIVE spec + control-scope.json — but
+# that sidecar is derived by build_workbook.py from the SAME `listen` data it
+# used to wire the spec, so a BUILDER-level mis-mapping yields a spec and a
+# sidecar that AGREE and gate 7 passes. The only independent proof is runtime:
+# flip a control via the REST export API and confirm its targets' output
+# actually changes. This gate shells out to scripts/probe-controls.rb (which
+# already does exactly that) and turns its verdict into a hard gate. Opt-in so
+# converters adopt it deliberately (looker-to-sigma passes --require-control-flip);
+# offline runs (no creds / no workbook) SKIP, never false-fail. See lib/flip_gate.rb.
+# ---------------------------------------------------------------------------
+if !opts[:require_control_flip]
+  puts '[SKIP] gate 7b: runtime control flip test not opted in (pass --require-control-flip to enable)'
+elsif opts[:skip_control_flip]
+  record_waiver.call('--skip-control-flip', 'gate 7b (runtime control flip test)', opts[:skip_control_flip])
+else
+  flip_wb = opts[:wb]
+  if flip_wb.nil?
+    _p = File.join(opts[:tab], 'wb-ids.json')
+    flip_wb = (JSON.parse(File.read(_p))['workbookId'] rescue nil) if File.exist?(_p)
+  end
+  flip_base = ENV['SIGMA_BASE_URL']
+  flip_tok  = ENV['SIGMA_API_TOKEN']
+  probe = File.join(__dir__, 'probe-controls.rb')
+  if flip_wb.nil? || flip_wb.to_s.empty?
+    puts '[SKIP] gate 7b: no workbook ID resolvable for the flip test'
+  elsif flip_base.nil? || flip_base.empty? || flip_tok.nil? || flip_tok.empty?
+    warn '[SKIP] gate 7b: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot exercise controls'
+  elsif !File.exist?(probe)
+    warn '[SKIP] gate 7b: scripts/probe-controls.rb not vendored alongside this script — re-vendor (SHA-1 discipline)'
+  else
+    # Only meaningful when the workbook actually has controls. Reuse gate 7's
+    # spec fetch + ControlLint to count them; 0 controls -> nothing to prove.
+    begin
+      require_relative 'lib/control_lint'
+      require_relative 'lib/flip_gate'
+    rescue LoadError => e
+      warn "[SKIP] gate 7b: #{e.message} — re-vendor scripts/lib (SHA-1 discipline)"
+    end
+    n_controls = nil
+    if defined?(ControlLint) && defined?(FlipGate)
+      uri = URI("#{flip_base}/v2/workbooks/#{flip_wb}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{flip_tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        n_controls = ControlLint.controls_report(spec).length
+      else
+        warn "[SKIP] gate 7b: GET /v2/workbooks/#{flip_wb}/spec returned HTTP #{res.code} — cannot count controls"
+      end
+    end
+    if n_controls == 0
+      puts '[OK] gate 7b: workbook has no controls — nothing to flip-test'
+    elsif !n_controls.nil?
+      out = File.join(opts[:tab], 'probe-controls')
+      cmd = [RbConfig.ruby, probe, '--workbook-id', flip_wb, '--out', out]
+      cmd << '--check-out-of-closure' if opts[:flip_check_leaks]
+      system(*cmd) # inherits stdout — the operator sees the per-control PASS/FAIL/SKIP table
+      probe_rc = $?.exitstatus
+      results = (JSON.parse(File.read(File.join(out, 'probe-results.json'))) rescue nil)
+      decision, info = FlipGate.decide(probe_rc, results)
+      case decision
+      when :ok
+        puts "[OK] gate 7b: #{info[:passes].length} control(s) proven live (in-closure export changes when flipped)" \
+             "#{info[:skips].any? ? "; #{info[:skips].length} un-probeable type(s) skipped" : ''}"
+      when :fail
+        warn "[FAIL] gate 7b: #{info[:fails].length} control(s) wired but INERT on live workbook #{flip_wb}:"
+        info[:fails].each { |cid, note| warn "         - #{cid}: #{note}" }
+        warn '       The control passed the static lint (gate 7) but does not actually filter its'
+        warn '       targets — a builder-level listen->column mis-mapping. Re-check the tile `listen`'
+        warn '       mapping in build_workbook.py, re-PUT the spec, then re-run.'
+        warn "       Reproduce: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
+      when :advisory
+        warn "[WARN] gate 7b: no control could be auto-flipped (#{info[:skips].length} date-range / slider / " \
+             'unlabeled control(s) need an explicit flip value) — runtime wiring is UNVERIFIED.'
+        info[:skips].each { |cid, note| warn "         - #{cid}: #{note}" }
+        marker = File.join(opts[:tab], 'control-flip-unverified.json')
+        File.write(marker, JSON.pretty_generate('workbookId' => flip_wb,
+                                                'unprobed' => info[:skips].map { |c, n| { 'control' => c, 'note' => n } })) rescue nil
+        warn "       Recorded to #{marker}. Prove them with: ruby scripts/probe-controls.rb --workbook-id " \
+             "#{flip_wb} --value <controlId>=<value>  (or waive with --skip-control-flip \"<reason>\")."
+      when :error
+        warn "[FAIL] gate 7b: probe-controls.rb could not verify the wiring (exit #{probe_rc}) on workbook #{flip_wb}."
+        warn '       An opted-in gate that could not run must not pass silently. Re-run once the export'
+        warn "       API is reachable: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
       end
     end
   end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/flip_gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -45,6 +45,14 @@
 #      an interactive source = FAIL, the Qlik class) and per-control
 #      scope:[...] allowlists (intentional single-chart switchers like grain
 #      controls). See the lib header CONTRACT.
+#   7b. Runtime control flip test (OPT-IN via --require-control-flip) — gate 7's
+#      control-scope.json sidecar is derived by build_workbook.py from the same
+#      `listen` data it used to wire the spec, so a builder-level mis-mapping
+#      makes spec and sidecar AGREE and gate 7 passes. This gate proves the
+#      wiring INDEPENDENTLY at runtime: scripts/probe-controls.rb flips each
+#      auto-probeable control via the REST export API and requires its targets'
+#      output to actually change (wired-but-inert = FAIL, exit 21). Offline runs
+#      (no creds / no workbook) SKIP. See lib/flip_gate.rb.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -63,6 +71,11 @@
 #                              # in your report
 #     [--control-scope PATH]   # control-scope.json sidecar for gate 7
 #                              # (default: <workdir>/control-scope.json)
+#     [--require-control-flip] # gate 7b (OPT-IN): prove control wiring at runtime
+#                              # via probe-controls.rb (looker-to-sigma opts in)
+#     [--skip-control-flip R]  # waive gate 7b — name the reason in your report
+#     [--flip-check-leaks]     # gate 7b: also assert flips don't leak
+#                              # (probe --check-out-of-closure; doubles exports)
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -172,6 +185,15 @@
 #      pass=false. Script absent → gate is invisible; inputs absent → stated
 #      SKIP. Escape hatch: --skip-visual-similarity "<reason>" (counted against
 #      the waiver budget).
+#  21  Runtime control flip test failed (gate 7b; OPT-IN via --require-control-flip)
+#      — a control passed the static wiring lint (gate 7) but does NOT actually
+#      filter its targets at runtime (wired-but-inert / builder-level listen->
+#      column mis-mapping), proven by scripts/probe-controls.rb; OR the probe
+#      could not run at all on an opted-in gate (fail-closed). Fix the listen
+#      mapping in build_workbook.py + re-PUT, or re-run once the export API is
+#      reachable. Un-probeable control types (date-range / slider) are an
+#      advisory WARN + control-flip-unverified.json marker, not this failure.
+#      Escape hatch: --skip-control-flip "<reason>" (counts against the budget).
 #
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
@@ -206,6 +228,9 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
   p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--require-control-flip', 'gate 7b (OPT-IN, off by default): after control lint, PROVE each auto-probeable control actually filters its targets at runtime via scripts/probe-controls.rb (live REST export flip test). Closes the self-referential-sidecar hole in gate 7. Adopters (looker-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_control_flip] = true }
+  p.on('--skip-control-flip [REASON]', 'waive gate 7b (runtime control flip test) — the reason MUST be named in your migration report.') { |v| opts[:skip_control_flip] = v || true }
+  p.on('--flip-check-leaks', 'gate 7b: also run probe --check-out-of-closure (asserts a flip does NOT leak to out-of-closure elements; doubles exports). Off by default.') { opts[:flip_check_leaks] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
@@ -294,6 +319,7 @@ WAIVER_HIDES = {
   '--allow-missing-tiles'      => 'gate 5: source tiles absent from the build were accepted',
   '--skip-layout-lint'         => 'gate 6: layout quality never linted',
   '--skip-control-lint'        => 'gate 7: control wiring never linted',
+  '--skip-control-flip'        => 'gate 7b: control wiring never proven at runtime',
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
@@ -321,6 +347,7 @@ waiver_flags << '--skip-layout-check'        if opts[:skip_layout]
 waiver_flags << '--allow-missing-tiles'      if opts[:allow_missing_tiles].to_i.positive?
 waiver_flags << '--skip-layout-lint'         if opts[:skip_lint]
 waiver_flags << '--skip-control-lint'        if opts[:skip_control_lint]
+waiver_flags << '--skip-control-flip'        if opts[:skip_control_flip] && opts[:require_control_flip]
 waiver_flags << '--skip-visual-gate'         if opts[:skip_visual]
 waiver_flags << '--skip-visual-comparison'   if opts[:skip_visual_cmp]
 waiver_flags << '--skip-layout-fill'         if opts[:skip_layout_fill]
@@ -953,6 +980,110 @@ else
              "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
       else
         warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7b — runtime control flip test (exit 21; OPT-IN via --require-control-flip)
+# Gate 7 proves control wiring against the LIVE spec + control-scope.json — but
+# that sidecar is derived by build_workbook.py from the SAME `listen` data it
+# used to wire the spec, so a BUILDER-level mis-mapping yields a spec and a
+# sidecar that AGREE and gate 7 passes. The only independent proof is runtime:
+# flip a control via the REST export API and confirm its targets' output
+# actually changes. This gate shells out to scripts/probe-controls.rb (which
+# already does exactly that) and turns its verdict into a hard gate. Opt-in so
+# converters adopt it deliberately (looker-to-sigma passes --require-control-flip);
+# offline runs (no creds / no workbook) SKIP, never false-fail. See lib/flip_gate.rb.
+# ---------------------------------------------------------------------------
+if !opts[:require_control_flip]
+  puts '[SKIP] gate 7b: runtime control flip test not opted in (pass --require-control-flip to enable)'
+elsif opts[:skip_control_flip]
+  record_waiver.call('--skip-control-flip', 'gate 7b (runtime control flip test)', opts[:skip_control_flip])
+else
+  flip_wb = opts[:wb]
+  if flip_wb.nil?
+    _p = File.join(opts[:tab], 'wb-ids.json')
+    flip_wb = (JSON.parse(File.read(_p))['workbookId'] rescue nil) if File.exist?(_p)
+  end
+  flip_base = ENV['SIGMA_BASE_URL']
+  flip_tok  = ENV['SIGMA_API_TOKEN']
+  probe = File.join(__dir__, 'probe-controls.rb')
+  if flip_wb.nil? || flip_wb.to_s.empty?
+    puts '[SKIP] gate 7b: no workbook ID resolvable for the flip test'
+  elsif flip_base.nil? || flip_base.empty? || flip_tok.nil? || flip_tok.empty?
+    warn '[SKIP] gate 7b: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot exercise controls'
+  elsif !File.exist?(probe)
+    warn '[SKIP] gate 7b: scripts/probe-controls.rb not vendored alongside this script — re-vendor (SHA-1 discipline)'
+  else
+    # Only meaningful when the workbook actually has controls. Reuse gate 7's
+    # spec fetch + ControlLint to count them; 0 controls -> nothing to prove.
+    begin
+      require_relative 'lib/control_lint'
+      require_relative 'lib/flip_gate'
+    rescue LoadError => e
+      warn "[SKIP] gate 7b: #{e.message} — re-vendor scripts/lib (SHA-1 discipline)"
+    end
+    n_controls = nil
+    if defined?(ControlLint) && defined?(FlipGate)
+      uri = URI("#{flip_base}/v2/workbooks/#{flip_wb}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{flip_tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        n_controls = ControlLint.controls_report(spec).length
+      else
+        warn "[SKIP] gate 7b: GET /v2/workbooks/#{flip_wb}/spec returned HTTP #{res.code} — cannot count controls"
+      end
+    end
+    if n_controls == 0
+      puts '[OK] gate 7b: workbook has no controls — nothing to flip-test'
+    elsif !n_controls.nil?
+      out = File.join(opts[:tab], 'probe-controls')
+      cmd = [RbConfig.ruby, probe, '--workbook-id', flip_wb, '--out', out]
+      cmd << '--check-out-of-closure' if opts[:flip_check_leaks]
+      system(*cmd) # inherits stdout — the operator sees the per-control PASS/FAIL/SKIP table
+      probe_rc = $?.exitstatus
+      results = (JSON.parse(File.read(File.join(out, 'probe-results.json'))) rescue nil)
+      decision, info = FlipGate.decide(probe_rc, results)
+      case decision
+      when :ok
+        puts "[OK] gate 7b: #{info[:passes].length} control(s) proven live (in-closure export changes when flipped)" \
+             "#{info[:skips].any? ? "; #{info[:skips].length} un-probeable type(s) skipped" : ''}"
+      when :fail
+        warn "[FAIL] gate 7b: #{info[:fails].length} control(s) wired but INERT on live workbook #{flip_wb}:"
+        info[:fails].each { |cid, note| warn "         - #{cid}: #{note}" }
+        warn '       The control passed the static lint (gate 7) but does not actually filter its'
+        warn '       targets — a builder-level listen->column mis-mapping. Re-check the tile `listen`'
+        warn '       mapping in build_workbook.py, re-PUT the spec, then re-run.'
+        warn "       Reproduce: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
+      when :advisory
+        warn "[WARN] gate 7b: no control could be auto-flipped (#{info[:skips].length} date-range / slider / " \
+             'unlabeled control(s) need an explicit flip value) — runtime wiring is UNVERIFIED.'
+        info[:skips].each { |cid, note| warn "         - #{cid}: #{note}" }
+        marker = File.join(opts[:tab], 'control-flip-unverified.json')
+        File.write(marker, JSON.pretty_generate('workbookId' => flip_wb,
+                                                'unprobed' => info[:skips].map { |c, n| { 'control' => c, 'note' => n } })) rescue nil
+        warn "       Recorded to #{marker}. Prove them with: ruby scripts/probe-controls.rb --workbook-id " \
+             "#{flip_wb} --value <controlId>=<value>  (or waive with --skip-control-flip \"<reason>\")."
+      when :error
+        warn "[FAIL] gate 7b: probe-controls.rb could not verify the wiring (exit #{probe_rc}) on workbook #{flip_wb}."
+        warn '       An opted-in gate that could not run must not pass silently. Re-run once the export'
+        warn "       API is reachable: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
       end
     end
   end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/flip_gate.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -45,6 +45,14 @@
 #      an interactive source = FAIL, the Qlik class) and per-control
 #      scope:[...] allowlists (intentional single-chart switchers like grain
 #      controls). See the lib header CONTRACT.
+#   7b. Runtime control flip test (OPT-IN via --require-control-flip) — gate 7's
+#      control-scope.json sidecar is derived by build_workbook.py from the same
+#      `listen` data it used to wire the spec, so a builder-level mis-mapping
+#      makes spec and sidecar AGREE and gate 7 passes. This gate proves the
+#      wiring INDEPENDENTLY at runtime: scripts/probe-controls.rb flips each
+#      auto-probeable control via the REST export API and requires its targets'
+#      output to actually change (wired-but-inert = FAIL, exit 21). Offline runs
+#      (no creds / no workbook) SKIP. See lib/flip_gate.rb.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -63,6 +71,11 @@
 #                              # in your report
 #     [--control-scope PATH]   # control-scope.json sidecar for gate 7
 #                              # (default: <workdir>/control-scope.json)
+#     [--require-control-flip] # gate 7b (OPT-IN): prove control wiring at runtime
+#                              # via probe-controls.rb (looker-to-sigma opts in)
+#     [--skip-control-flip R]  # waive gate 7b — name the reason in your report
+#     [--flip-check-leaks]     # gate 7b: also assert flips don't leak
+#                              # (probe --check-out-of-closure; doubles exports)
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -172,6 +185,15 @@
 #      pass=false. Script absent → gate is invisible; inputs absent → stated
 #      SKIP. Escape hatch: --skip-visual-similarity "<reason>" (counted against
 #      the waiver budget).
+#  21  Runtime control flip test failed (gate 7b; OPT-IN via --require-control-flip)
+#      — a control passed the static wiring lint (gate 7) but does NOT actually
+#      filter its targets at runtime (wired-but-inert / builder-level listen->
+#      column mis-mapping), proven by scripts/probe-controls.rb; OR the probe
+#      could not run at all on an opted-in gate (fail-closed). Fix the listen
+#      mapping in build_workbook.py + re-PUT, or re-run once the export API is
+#      reachable. Un-probeable control types (date-range / slider) are an
+#      advisory WARN + control-flip-unverified.json marker, not this failure.
+#      Escape hatch: --skip-control-flip "<reason>" (counts against the budget).
 #
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
@@ -206,6 +228,9 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
   p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--require-control-flip', 'gate 7b (OPT-IN, off by default): after control lint, PROVE each auto-probeable control actually filters its targets at runtime via scripts/probe-controls.rb (live REST export flip test). Closes the self-referential-sidecar hole in gate 7. Adopters (looker-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_control_flip] = true }
+  p.on('--skip-control-flip [REASON]', 'waive gate 7b (runtime control flip test) — the reason MUST be named in your migration report.') { |v| opts[:skip_control_flip] = v || true }
+  p.on('--flip-check-leaks', 'gate 7b: also run probe --check-out-of-closure (asserts a flip does NOT leak to out-of-closure elements; doubles exports). Off by default.') { opts[:flip_check_leaks] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
@@ -294,6 +319,7 @@ WAIVER_HIDES = {
   '--allow-missing-tiles'      => 'gate 5: source tiles absent from the build were accepted',
   '--skip-layout-lint'         => 'gate 6: layout quality never linted',
   '--skip-control-lint'        => 'gate 7: control wiring never linted',
+  '--skip-control-flip'        => 'gate 7b: control wiring never proven at runtime',
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
@@ -321,6 +347,7 @@ waiver_flags << '--skip-layout-check'        if opts[:skip_layout]
 waiver_flags << '--allow-missing-tiles'      if opts[:allow_missing_tiles].to_i.positive?
 waiver_flags << '--skip-layout-lint'         if opts[:skip_lint]
 waiver_flags << '--skip-control-lint'        if opts[:skip_control_lint]
+waiver_flags << '--skip-control-flip'        if opts[:skip_control_flip] && opts[:require_control_flip]
 waiver_flags << '--skip-visual-gate'         if opts[:skip_visual]
 waiver_flags << '--skip-visual-comparison'   if opts[:skip_visual_cmp]
 waiver_flags << '--skip-layout-fill'         if opts[:skip_layout_fill]
@@ -953,6 +980,110 @@ else
              "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
       else
         warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7b — runtime control flip test (exit 21; OPT-IN via --require-control-flip)
+# Gate 7 proves control wiring against the LIVE spec + control-scope.json — but
+# that sidecar is derived by build_workbook.py from the SAME `listen` data it
+# used to wire the spec, so a BUILDER-level mis-mapping yields a spec and a
+# sidecar that AGREE and gate 7 passes. The only independent proof is runtime:
+# flip a control via the REST export API and confirm its targets' output
+# actually changes. This gate shells out to scripts/probe-controls.rb (which
+# already does exactly that) and turns its verdict into a hard gate. Opt-in so
+# converters adopt it deliberately (looker-to-sigma passes --require-control-flip);
+# offline runs (no creds / no workbook) SKIP, never false-fail. See lib/flip_gate.rb.
+# ---------------------------------------------------------------------------
+if !opts[:require_control_flip]
+  puts '[SKIP] gate 7b: runtime control flip test not opted in (pass --require-control-flip to enable)'
+elsif opts[:skip_control_flip]
+  record_waiver.call('--skip-control-flip', 'gate 7b (runtime control flip test)', opts[:skip_control_flip])
+else
+  flip_wb = opts[:wb]
+  if flip_wb.nil?
+    _p = File.join(opts[:tab], 'wb-ids.json')
+    flip_wb = (JSON.parse(File.read(_p))['workbookId'] rescue nil) if File.exist?(_p)
+  end
+  flip_base = ENV['SIGMA_BASE_URL']
+  flip_tok  = ENV['SIGMA_API_TOKEN']
+  probe = File.join(__dir__, 'probe-controls.rb')
+  if flip_wb.nil? || flip_wb.to_s.empty?
+    puts '[SKIP] gate 7b: no workbook ID resolvable for the flip test'
+  elsif flip_base.nil? || flip_base.empty? || flip_tok.nil? || flip_tok.empty?
+    warn '[SKIP] gate 7b: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot exercise controls'
+  elsif !File.exist?(probe)
+    warn '[SKIP] gate 7b: scripts/probe-controls.rb not vendored alongside this script — re-vendor (SHA-1 discipline)'
+  else
+    # Only meaningful when the workbook actually has controls. Reuse gate 7's
+    # spec fetch + ControlLint to count them; 0 controls -> nothing to prove.
+    begin
+      require_relative 'lib/control_lint'
+      require_relative 'lib/flip_gate'
+    rescue LoadError => e
+      warn "[SKIP] gate 7b: #{e.message} — re-vendor scripts/lib (SHA-1 discipline)"
+    end
+    n_controls = nil
+    if defined?(ControlLint) && defined?(FlipGate)
+      uri = URI("#{flip_base}/v2/workbooks/#{flip_wb}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{flip_tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        n_controls = ControlLint.controls_report(spec).length
+      else
+        warn "[SKIP] gate 7b: GET /v2/workbooks/#{flip_wb}/spec returned HTTP #{res.code} — cannot count controls"
+      end
+    end
+    if n_controls == 0
+      puts '[OK] gate 7b: workbook has no controls — nothing to flip-test'
+    elsif !n_controls.nil?
+      out = File.join(opts[:tab], 'probe-controls')
+      cmd = [RbConfig.ruby, probe, '--workbook-id', flip_wb, '--out', out]
+      cmd << '--check-out-of-closure' if opts[:flip_check_leaks]
+      system(*cmd) # inherits stdout — the operator sees the per-control PASS/FAIL/SKIP table
+      probe_rc = $?.exitstatus
+      results = (JSON.parse(File.read(File.join(out, 'probe-results.json'))) rescue nil)
+      decision, info = FlipGate.decide(probe_rc, results)
+      case decision
+      when :ok
+        puts "[OK] gate 7b: #{info[:passes].length} control(s) proven live (in-closure export changes when flipped)" \
+             "#{info[:skips].any? ? "; #{info[:skips].length} un-probeable type(s) skipped" : ''}"
+      when :fail
+        warn "[FAIL] gate 7b: #{info[:fails].length} control(s) wired but INERT on live workbook #{flip_wb}:"
+        info[:fails].each { |cid, note| warn "         - #{cid}: #{note}" }
+        warn '       The control passed the static lint (gate 7) but does not actually filter its'
+        warn '       targets — a builder-level listen->column mis-mapping. Re-check the tile `listen`'
+        warn '       mapping in build_workbook.py, re-PUT the spec, then re-run.'
+        warn "       Reproduce: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
+      when :advisory
+        warn "[WARN] gate 7b: no control could be auto-flipped (#{info[:skips].length} date-range / slider / " \
+             'unlabeled control(s) need an explicit flip value) — runtime wiring is UNVERIFIED.'
+        info[:skips].each { |cid, note| warn "         - #{cid}: #{note}" }
+        marker = File.join(opts[:tab], 'control-flip-unverified.json')
+        File.write(marker, JSON.pretty_generate('workbookId' => flip_wb,
+                                                'unprobed' => info[:skips].map { |c, n| { 'control' => c, 'note' => n } })) rescue nil
+        warn "       Recorded to #{marker}. Prove them with: ruby scripts/probe-controls.rb --workbook-id " \
+             "#{flip_wb} --value <controlId>=<value>  (or waive with --skip-control-flip \"<reason>\")."
+      when :error
+        warn "[FAIL] gate 7b: probe-controls.rb could not verify the wiring (exit #{probe_rc}) on workbook #{flip_wb}."
+        warn '       An opted-in gate that could not run must not pass silently. Re-run once the export'
+        warn "       API is reachable: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
       end
     end
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/flip_gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -45,6 +45,14 @@
 #      an interactive source = FAIL, the Qlik class) and per-control
 #      scope:[...] allowlists (intentional single-chart switchers like grain
 #      controls). See the lib header CONTRACT.
+#   7b. Runtime control flip test (OPT-IN via --require-control-flip) — gate 7's
+#      control-scope.json sidecar is derived by build_workbook.py from the same
+#      `listen` data it used to wire the spec, so a builder-level mis-mapping
+#      makes spec and sidecar AGREE and gate 7 passes. This gate proves the
+#      wiring INDEPENDENTLY at runtime: scripts/probe-controls.rb flips each
+#      auto-probeable control via the REST export API and requires its targets'
+#      output to actually change (wired-but-inert = FAIL, exit 21). Offline runs
+#      (no creds / no workbook) SKIP. See lib/flip_gate.rb.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -63,6 +71,11 @@
 #                              # in your report
 #     [--control-scope PATH]   # control-scope.json sidecar for gate 7
 #                              # (default: <workdir>/control-scope.json)
+#     [--require-control-flip] # gate 7b (OPT-IN): prove control wiring at runtime
+#                              # via probe-controls.rb (looker-to-sigma opts in)
+#     [--skip-control-flip R]  # waive gate 7b — name the reason in your report
+#     [--flip-check-leaks]     # gate 7b: also assert flips don't leak
+#                              # (probe --check-out-of-closure; doubles exports)
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -172,6 +185,15 @@
 #      pass=false. Script absent → gate is invisible; inputs absent → stated
 #      SKIP. Escape hatch: --skip-visual-similarity "<reason>" (counted against
 #      the waiver budget).
+#  21  Runtime control flip test failed (gate 7b; OPT-IN via --require-control-flip)
+#      — a control passed the static wiring lint (gate 7) but does NOT actually
+#      filter its targets at runtime (wired-but-inert / builder-level listen->
+#      column mis-mapping), proven by scripts/probe-controls.rb; OR the probe
+#      could not run at all on an opted-in gate (fail-closed). Fix the listen
+#      mapping in build_workbook.py + re-PUT, or re-run once the export API is
+#      reachable. Un-probeable control types (date-range / slider) are an
+#      advisory WARN + control-flip-unverified.json marker, not this failure.
+#      Escape hatch: --skip-control-flip "<reason>" (counts against the budget).
 #
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
@@ -206,6 +228,9 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
   p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--require-control-flip', 'gate 7b (OPT-IN, off by default): after control lint, PROVE each auto-probeable control actually filters its targets at runtime via scripts/probe-controls.rb (live REST export flip test). Closes the self-referential-sidecar hole in gate 7. Adopters (looker-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_control_flip] = true }
+  p.on('--skip-control-flip [REASON]', 'waive gate 7b (runtime control flip test) — the reason MUST be named in your migration report.') { |v| opts[:skip_control_flip] = v || true }
+  p.on('--flip-check-leaks', 'gate 7b: also run probe --check-out-of-closure (asserts a flip does NOT leak to out-of-closure elements; doubles exports). Off by default.') { opts[:flip_check_leaks] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
@@ -294,6 +319,7 @@ WAIVER_HIDES = {
   '--allow-missing-tiles'      => 'gate 5: source tiles absent from the build were accepted',
   '--skip-layout-lint'         => 'gate 6: layout quality never linted',
   '--skip-control-lint'        => 'gate 7: control wiring never linted',
+  '--skip-control-flip'        => 'gate 7b: control wiring never proven at runtime',
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
@@ -321,6 +347,7 @@ waiver_flags << '--skip-layout-check'        if opts[:skip_layout]
 waiver_flags << '--allow-missing-tiles'      if opts[:allow_missing_tiles].to_i.positive?
 waiver_flags << '--skip-layout-lint'         if opts[:skip_lint]
 waiver_flags << '--skip-control-lint'        if opts[:skip_control_lint]
+waiver_flags << '--skip-control-flip'        if opts[:skip_control_flip] && opts[:require_control_flip]
 waiver_flags << '--skip-visual-gate'         if opts[:skip_visual]
 waiver_flags << '--skip-visual-comparison'   if opts[:skip_visual_cmp]
 waiver_flags << '--skip-layout-fill'         if opts[:skip_layout_fill]
@@ -953,6 +980,110 @@ else
              "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
       else
         warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7b — runtime control flip test (exit 21; OPT-IN via --require-control-flip)
+# Gate 7 proves control wiring against the LIVE spec + control-scope.json — but
+# that sidecar is derived by build_workbook.py from the SAME `listen` data it
+# used to wire the spec, so a BUILDER-level mis-mapping yields a spec and a
+# sidecar that AGREE and gate 7 passes. The only independent proof is runtime:
+# flip a control via the REST export API and confirm its targets' output
+# actually changes. This gate shells out to scripts/probe-controls.rb (which
+# already does exactly that) and turns its verdict into a hard gate. Opt-in so
+# converters adopt it deliberately (looker-to-sigma passes --require-control-flip);
+# offline runs (no creds / no workbook) SKIP, never false-fail. See lib/flip_gate.rb.
+# ---------------------------------------------------------------------------
+if !opts[:require_control_flip]
+  puts '[SKIP] gate 7b: runtime control flip test not opted in (pass --require-control-flip to enable)'
+elsif opts[:skip_control_flip]
+  record_waiver.call('--skip-control-flip', 'gate 7b (runtime control flip test)', opts[:skip_control_flip])
+else
+  flip_wb = opts[:wb]
+  if flip_wb.nil?
+    _p = File.join(opts[:tab], 'wb-ids.json')
+    flip_wb = (JSON.parse(File.read(_p))['workbookId'] rescue nil) if File.exist?(_p)
+  end
+  flip_base = ENV['SIGMA_BASE_URL']
+  flip_tok  = ENV['SIGMA_API_TOKEN']
+  probe = File.join(__dir__, 'probe-controls.rb')
+  if flip_wb.nil? || flip_wb.to_s.empty?
+    puts '[SKIP] gate 7b: no workbook ID resolvable for the flip test'
+  elsif flip_base.nil? || flip_base.empty? || flip_tok.nil? || flip_tok.empty?
+    warn '[SKIP] gate 7b: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot exercise controls'
+  elsif !File.exist?(probe)
+    warn '[SKIP] gate 7b: scripts/probe-controls.rb not vendored alongside this script — re-vendor (SHA-1 discipline)'
+  else
+    # Only meaningful when the workbook actually has controls. Reuse gate 7's
+    # spec fetch + ControlLint to count them; 0 controls -> nothing to prove.
+    begin
+      require_relative 'lib/control_lint'
+      require_relative 'lib/flip_gate'
+    rescue LoadError => e
+      warn "[SKIP] gate 7b: #{e.message} — re-vendor scripts/lib (SHA-1 discipline)"
+    end
+    n_controls = nil
+    if defined?(ControlLint) && defined?(FlipGate)
+      uri = URI("#{flip_base}/v2/workbooks/#{flip_wb}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{flip_tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        n_controls = ControlLint.controls_report(spec).length
+      else
+        warn "[SKIP] gate 7b: GET /v2/workbooks/#{flip_wb}/spec returned HTTP #{res.code} — cannot count controls"
+      end
+    end
+    if n_controls == 0
+      puts '[OK] gate 7b: workbook has no controls — nothing to flip-test'
+    elsif !n_controls.nil?
+      out = File.join(opts[:tab], 'probe-controls')
+      cmd = [RbConfig.ruby, probe, '--workbook-id', flip_wb, '--out', out]
+      cmd << '--check-out-of-closure' if opts[:flip_check_leaks]
+      system(*cmd) # inherits stdout — the operator sees the per-control PASS/FAIL/SKIP table
+      probe_rc = $?.exitstatus
+      results = (JSON.parse(File.read(File.join(out, 'probe-results.json'))) rescue nil)
+      decision, info = FlipGate.decide(probe_rc, results)
+      case decision
+      when :ok
+        puts "[OK] gate 7b: #{info[:passes].length} control(s) proven live (in-closure export changes when flipped)" \
+             "#{info[:skips].any? ? "; #{info[:skips].length} un-probeable type(s) skipped" : ''}"
+      when :fail
+        warn "[FAIL] gate 7b: #{info[:fails].length} control(s) wired but INERT on live workbook #{flip_wb}:"
+        info[:fails].each { |cid, note| warn "         - #{cid}: #{note}" }
+        warn '       The control passed the static lint (gate 7) but does not actually filter its'
+        warn '       targets — a builder-level listen->column mis-mapping. Re-check the tile `listen`'
+        warn '       mapping in build_workbook.py, re-PUT the spec, then re-run.'
+        warn "       Reproduce: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
+      when :advisory
+        warn "[WARN] gate 7b: no control could be auto-flipped (#{info[:skips].length} date-range / slider / " \
+             'unlabeled control(s) need an explicit flip value) — runtime wiring is UNVERIFIED.'
+        info[:skips].each { |cid, note| warn "         - #{cid}: #{note}" }
+        marker = File.join(opts[:tab], 'control-flip-unverified.json')
+        File.write(marker, JSON.pretty_generate('workbookId' => flip_wb,
+                                                'unprobed' => info[:skips].map { |c, n| { 'control' => c, 'note' => n } })) rescue nil
+        warn "       Recorded to #{marker}. Prove them with: ruby scripts/probe-controls.rb --workbook-id " \
+             "#{flip_wb} --value <controlId>=<value>  (or waive with --skip-control-flip \"<reason>\")."
+      when :error
+        warn "[FAIL] gate 7b: probe-controls.rb could not verify the wiring (exit #{probe_rc}) on workbook #{flip_wb}."
+        warn '       An opted-in gate that could not run must not pass silently. Re-run once the export'
+        warn "       API is reachable: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
       end
     end
   end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/flip_gate.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/shared/lib/flip_gate.rb
+++ b/shared/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -89,6 +89,17 @@
    ]
   },
   {
+   "canonical": "shared/lib/flip_gate.rb",
+   "targets": [
+    "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/flip_gate.rb",
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/flip_gate.rb",
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/flip_gate.rb",
+    "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/flip_gate.rb",
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/flip_gate.rb",
+    "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/flip_gate.rb"
+   ]
+  },
+  {
    "canonical": "shared/lib/control_lint.rb",
    "targets": [
     "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb",

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -45,6 +45,14 @@
 #      an interactive source = FAIL, the Qlik class) and per-control
 #      scope:[...] allowlists (intentional single-chart switchers like grain
 #      controls). See the lib header CONTRACT.
+#   7b. Runtime control flip test (OPT-IN via --require-control-flip) — gate 7's
+#      control-scope.json sidecar is derived by build_workbook.py from the same
+#      `listen` data it used to wire the spec, so a builder-level mis-mapping
+#      makes spec and sidecar AGREE and gate 7 passes. This gate proves the
+#      wiring INDEPENDENTLY at runtime: scripts/probe-controls.rb flips each
+#      auto-probeable control via the REST export API and requires its targets'
+#      output to actually change (wired-but-inert = FAIL, exit 21). Offline runs
+#      (no creds / no workbook) SKIP. See lib/flip_gate.rb.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -63,6 +71,11 @@
 #                              # in your report
 #     [--control-scope PATH]   # control-scope.json sidecar for gate 7
 #                              # (default: <workdir>/control-scope.json)
+#     [--require-control-flip] # gate 7b (OPT-IN): prove control wiring at runtime
+#                              # via probe-controls.rb (looker-to-sigma opts in)
+#     [--skip-control-flip R]  # waive gate 7b — name the reason in your report
+#     [--flip-check-leaks]     # gate 7b: also assert flips don't leak
+#                              # (probe --check-out-of-closure; doubles exports)
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -172,6 +185,15 @@
 #      pass=false. Script absent → gate is invisible; inputs absent → stated
 #      SKIP. Escape hatch: --skip-visual-similarity "<reason>" (counted against
 #      the waiver budget).
+#  21  Runtime control flip test failed (gate 7b; OPT-IN via --require-control-flip)
+#      — a control passed the static wiring lint (gate 7) but does NOT actually
+#      filter its targets at runtime (wired-but-inert / builder-level listen->
+#      column mis-mapping), proven by scripts/probe-controls.rb; OR the probe
+#      could not run at all on an opted-in gate (fail-closed). Fix the listen
+#      mapping in build_workbook.py + re-PUT, or re-run once the export API is
+#      reachable. Un-probeable control types (date-range / slider) are an
+#      advisory WARN + control-flip-unverified.json marker, not this failure.
+#      Escape hatch: --skip-control-flip "<reason>" (counts against the budget).
 #
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
@@ -206,6 +228,9 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
   p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--require-control-flip', 'gate 7b (OPT-IN, off by default): after control lint, PROVE each auto-probeable control actually filters its targets at runtime via scripts/probe-controls.rb (live REST export flip test). Closes the self-referential-sidecar hole in gate 7. Adopters (looker-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_control_flip] = true }
+  p.on('--skip-control-flip [REASON]', 'waive gate 7b (runtime control flip test) — the reason MUST be named in your migration report.') { |v| opts[:skip_control_flip] = v || true }
+  p.on('--flip-check-leaks', 'gate 7b: also run probe --check-out-of-closure (asserts a flip does NOT leak to out-of-closure elements; doubles exports). Off by default.') { opts[:flip_check_leaks] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
@@ -294,6 +319,7 @@ WAIVER_HIDES = {
   '--allow-missing-tiles'      => 'gate 5: source tiles absent from the build were accepted',
   '--skip-layout-lint'         => 'gate 6: layout quality never linted',
   '--skip-control-lint'        => 'gate 7: control wiring never linted',
+  '--skip-control-flip'        => 'gate 7b: control wiring never proven at runtime',
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
@@ -321,6 +347,7 @@ waiver_flags << '--skip-layout-check'        if opts[:skip_layout]
 waiver_flags << '--allow-missing-tiles'      if opts[:allow_missing_tiles].to_i.positive?
 waiver_flags << '--skip-layout-lint'         if opts[:skip_lint]
 waiver_flags << '--skip-control-lint'        if opts[:skip_control_lint]
+waiver_flags << '--skip-control-flip'        if opts[:skip_control_flip] && opts[:require_control_flip]
 waiver_flags << '--skip-visual-gate'         if opts[:skip_visual]
 waiver_flags << '--skip-visual-comparison'   if opts[:skip_visual_cmp]
 waiver_flags << '--skip-layout-fill'         if opts[:skip_layout_fill]
@@ -953,6 +980,110 @@ else
              "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
       else
         warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7b — runtime control flip test (exit 21; OPT-IN via --require-control-flip)
+# Gate 7 proves control wiring against the LIVE spec + control-scope.json — but
+# that sidecar is derived by build_workbook.py from the SAME `listen` data it
+# used to wire the spec, so a BUILDER-level mis-mapping yields a spec and a
+# sidecar that AGREE and gate 7 passes. The only independent proof is runtime:
+# flip a control via the REST export API and confirm its targets' output
+# actually changes. This gate shells out to scripts/probe-controls.rb (which
+# already does exactly that) and turns its verdict into a hard gate. Opt-in so
+# converters adopt it deliberately (looker-to-sigma passes --require-control-flip);
+# offline runs (no creds / no workbook) SKIP, never false-fail. See lib/flip_gate.rb.
+# ---------------------------------------------------------------------------
+if !opts[:require_control_flip]
+  puts '[SKIP] gate 7b: runtime control flip test not opted in (pass --require-control-flip to enable)'
+elsif opts[:skip_control_flip]
+  record_waiver.call('--skip-control-flip', 'gate 7b (runtime control flip test)', opts[:skip_control_flip])
+else
+  flip_wb = opts[:wb]
+  if flip_wb.nil?
+    _p = File.join(opts[:tab], 'wb-ids.json')
+    flip_wb = (JSON.parse(File.read(_p))['workbookId'] rescue nil) if File.exist?(_p)
+  end
+  flip_base = ENV['SIGMA_BASE_URL']
+  flip_tok  = ENV['SIGMA_API_TOKEN']
+  probe = File.join(__dir__, 'probe-controls.rb')
+  if flip_wb.nil? || flip_wb.to_s.empty?
+    puts '[SKIP] gate 7b: no workbook ID resolvable for the flip test'
+  elsif flip_base.nil? || flip_base.empty? || flip_tok.nil? || flip_tok.empty?
+    warn '[SKIP] gate 7b: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot exercise controls'
+  elsif !File.exist?(probe)
+    warn '[SKIP] gate 7b: scripts/probe-controls.rb not vendored alongside this script — re-vendor (SHA-1 discipline)'
+  else
+    # Only meaningful when the workbook actually has controls. Reuse gate 7's
+    # spec fetch + ControlLint to count them; 0 controls -> nothing to prove.
+    begin
+      require_relative 'lib/control_lint'
+      require_relative 'lib/flip_gate'
+    rescue LoadError => e
+      warn "[SKIP] gate 7b: #{e.message} — re-vendor scripts/lib (SHA-1 discipline)"
+    end
+    n_controls = nil
+    if defined?(ControlLint) && defined?(FlipGate)
+      uri = URI("#{flip_base}/v2/workbooks/#{flip_wb}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{flip_tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        n_controls = ControlLint.controls_report(spec).length
+      else
+        warn "[SKIP] gate 7b: GET /v2/workbooks/#{flip_wb}/spec returned HTTP #{res.code} — cannot count controls"
+      end
+    end
+    if n_controls == 0
+      puts '[OK] gate 7b: workbook has no controls — nothing to flip-test'
+    elsif !n_controls.nil?
+      out = File.join(opts[:tab], 'probe-controls')
+      cmd = [RbConfig.ruby, probe, '--workbook-id', flip_wb, '--out', out]
+      cmd << '--check-out-of-closure' if opts[:flip_check_leaks]
+      system(*cmd) # inherits stdout — the operator sees the per-control PASS/FAIL/SKIP table
+      probe_rc = $?.exitstatus
+      results = (JSON.parse(File.read(File.join(out, 'probe-results.json'))) rescue nil)
+      decision, info = FlipGate.decide(probe_rc, results)
+      case decision
+      when :ok
+        puts "[OK] gate 7b: #{info[:passes].length} control(s) proven live (in-closure export changes when flipped)" \
+             "#{info[:skips].any? ? "; #{info[:skips].length} un-probeable type(s) skipped" : ''}"
+      when :fail
+        warn "[FAIL] gate 7b: #{info[:fails].length} control(s) wired but INERT on live workbook #{flip_wb}:"
+        info[:fails].each { |cid, note| warn "         - #{cid}: #{note}" }
+        warn '       The control passed the static lint (gate 7) but does not actually filter its'
+        warn '       targets — a builder-level listen->column mis-mapping. Re-check the tile `listen`'
+        warn '       mapping in build_workbook.py, re-PUT the spec, then re-run.'
+        warn "       Reproduce: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
+      when :advisory
+        warn "[WARN] gate 7b: no control could be auto-flipped (#{info[:skips].length} date-range / slider / " \
+             'unlabeled control(s) need an explicit flip value) — runtime wiring is UNVERIFIED.'
+        info[:skips].each { |cid, note| warn "         - #{cid}: #{note}" }
+        marker = File.join(opts[:tab], 'control-flip-unverified.json')
+        File.write(marker, JSON.pretty_generate('workbookId' => flip_wb,
+                                                'unprobed' => info[:skips].map { |c, n| { 'control' => c, 'note' => n } })) rescue nil
+        warn "       Recorded to #{marker}. Prove them with: ruby scripts/probe-controls.rb --workbook-id " \
+             "#{flip_wb} --value <controlId>=<value>  (or waive with --skip-control-flip \"<reason>\")."
+      when :error
+        warn "[FAIL] gate 7b: probe-controls.rb could not verify the wiring (exit #{probe_rc}) on workbook #{flip_wb}."
+        warn '       An opted-in gate that could not run must not pass silently. Re-run once the export'
+        warn "       API is reachable: ruby scripts/probe-controls.rb --workbook-id #{flip_wb}"
+        warn '       Escape hatch: --skip-control-flip "<reason>" (counts against the waiver budget).'
+        exit 21
       end
     end
   end


### PR DESCRIPTION
## Problem

Gate 7 (control-wiring lint) checks the live workbook spec against `control-scope.json` — but that sidecar is **derived by `build_workbook.py` from the same `listen` data it used to wire the spec**. So a builder-level `listen`→column mis-mapping produces a spec and a sidecar that *agree*, and gate 7 passes. Numeric parity never exercises filters either (it queries default control state and skips control elements). The only independent proof — `probe-controls.rb`, which flips a control via the REST export API and asserts its targets' output actually changes — existed but was **optional and never invoked by the gate**. A control that is wired but inert (or mis-wired) could ship GREEN silently.

## Fix — gate 7b (runtime control flip test)

Wires `probe-controls.rb` into `assert-phase6-ran.rb` as a new gate that proves control wiring **independently, at runtime**.

- **Opt-in** via `--require-control-flip`. `looker-to-sigma` adopts it (its orchestrator passes the flag); the other 5 converters that vendor the gate are unaffected until they opt in — mirrors the existing gate 8d (`--require-fidelity-ledger`) precedent.
- **FAIL (exit 21)** when a control is wired but inert. **Advisory WARN + `control-flip-unverified.json` marker** when a control type can't be auto-flipped (date-range / slider — needs an explicit `--value`), so a legitimately date-only dashboard isn't blocked but the gap can't hide. **Offline runs** (no creds / no workbook) **SKIP**, never false-fail.
- `--skip-control-flip "<reason>"` waives it and **counts against the waiver budget** (only when opted in).
- Pure decision logic (probe exit code + `probe-results.json` → verdict) is extracted to **`shared/lib/flip_gate.rb`** so the branch table is unit-testable with no live dependency.

## Governance

`assert-phase6-ran.rb` and the new `flip_gate.rb` are shared/canonical — edited once under `shared/` and fanned out via `tools/sync-shared.rb` (SHA-1 enforced by `tools/check-shared.rb`). `probe-controls.rb` is unchanged.

## Verification

- **Unit**: `scripts/test-flip-gate.rb` — 15 assertions across `:ok` / `:fail` / `:advisory` / `:error`, string- and symbol-keyed rows, fail-closed on unexpected exit. All pass.
- **Live end-to-end** against real workbooks: `:ok` path (multiple controls flipped via real REST exports → `[OK] gate 7b`), and `:fail` path (an inert control → hard **exit 21**).
- **Behavioral**: opt-in isolation (no flag → SKIP, other converters untouched), offline safety (opted-in + no creds → SKIP, no false fail), waiver banner + `waivers.json` census.
- `tools/check-shared.rb` + full pre-commit governance suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)