### PR TITLE
fix(powerbi): emit pivot-table row sort + reproduce PBI blank-first default

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/style-fidelity.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/style-fidelity.md
@@ -57,6 +57,25 @@ donut/pie (per-element `color.scheme` is silently dropped there — the workbook
 `Coalesce([dim], "(Blank)")`, which both matches PBI's label and sorts ahead of
 letters (`(` < `A`) — so every slice gets the color PBI gave it.
 
+### 4b. Pivot row sort (blank-first) — `lib/pbi_pivot_sort.rb`
+A `pivot-table` row sort **is** spec-expressible: `rowsBy[0].sort = { by, direction }`
+(verified accepted + round-tripped + rendered). The builder used to drop it with
+"pivot-table sort is not spec-expressible in Sigma — set it in the UI" and silently
+lost every matrix/tableEx sort — that punt was wrong.
+
+Two rules the emit follows:
+- **Read the VISUAL's sort, never the query's row order.** `extract-pbir.py`'s
+  `_sort_signal` reads `visual.query.sortDefinition`. When that's `null`, PBI still
+  applies its table/matrix default — **first column ascending** — so the extractor
+  emits that (`{ direction: "asc", default: true }`). ⚠️ Do NOT infer the sort from
+  the parity/`executeQueries` row order: that's the DAX `ORDER BY` (typically the
+  first measure, descending), *not* the visual's display sort.
+- **Blank member first.** PBI sorts a blank/null dimension member first; Sigma sorts
+  nulls last and has no nulls-first option. So when sorting **by the row dim itself
+  ascending**, the dim ref is wrapped `Coalesce([dim], "(Blank)")` (same trick as §4)
+  → the blank row lands on top like PBI. A *measure* sort orders the blank by its
+  value, so it is not coalesced. Tests: `test-pbi-pivot-sort.rb`.
+
 ## 5. Number abbreviation ("K"/"M") — now auto-emitted (`lib/pbi_style.rb`)
 PBI cards and charts default to **display units "Auto"**, which abbreviates large
 values (`$126K`, `$1.2M`). PBI *serializes `labelDisplayUnits` only when non-default*,

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -50,6 +50,7 @@ require 'json'
 require 'optparse'
 require_relative 'lib/layout'
 require_relative 'lib/pbi_theme'
+require_relative 'lib/pbi_pivot_sort'
 require_relative 'lib/pbi_style'
 require_relative 'lib/pbi_conditional_formats'
 require_relative 'lib/coverage_catalog'
@@ -581,16 +582,25 @@ end
 #                         grouped table; the sort must nest INSIDE the grouping
 #                         (qlik-to-sigma refs/sigma-build-gotchas.md, verified 2026-06-10)
 #   table (ungrouped)   : sort = [{ columnId, direction }]
+#   pivot-table         : rowsBy[0].sort = { by: <colId>, direction } — the outer
+#                         row grouping is sorted by the resolved column. VERIFIED
+#                         accepted + round-tripped + rendered 2026-07-15; the old
+#                         "pivot-table sort is not spec-expressible, set it in the
+#                         UI" punt was wrong and dropped every matrix/tableEx sort.
+# NOTE: dispatch on el['kind'] (not the caller's `kind`) — a grouped `table` with a
+# Grand Total row is re-expressed as a pivot-table upstream (el['kind'] flips to
+# 'pivot-table' while the caller still passes kind='table'), so its sort must route
+# to the pivot branch, not the grouped-table branch.
 # direction must be the full word "ascending"/"descending" — the API rejects
 # "asc"/"desc" (validate-spec.rb guards this too).
-def apply_sort(el, kind, rec, qr_cids, name)
+def apply_sort(el, kind, rec, qr_cids, name, cols = nil)
   srt = rec['sort']
   return unless srt.is_a?(Hash) && srt['queryRef']
   dir = srt['direction'].to_s.start_with?('desc') ? 'descending' : 'ascending'
   norm = ->(s) { s.to_s.downcase.gsub(/[_\s]+/, ' ').strip }
   pair = qr_cids.find { |qr, _| norm.call(qr) == norm.call(srt['queryRef']) }
   cid = qr_cids[srt['queryRef']] || (pair && pair[1])
-  case kind
+  case (el['kind'] || kind)
   when 'bar-chart', 'line-chart', 'area-chart', 'combo-chart'
     return warn_sort_miss(name, srt) unless cid
     # A visual-level sort BY THE DIM ITSELF must not clobber the model's
@@ -609,10 +619,17 @@ def apply_sort(el, kind, rec, qr_cids, name)
       el['sort'] = [{ 'columnId' => cid, 'direction' => dir }]
     end
   when 'pivot-table'
-    warn "[build-workbook] WARN visual '#{name}': pivot-table sort is not spec-expressible in Sigma — set it in the UI."
-    record_unresolved(visual: name, severity: 'degraded', recoverable: false,
-                      detail: 'pivot-table sort is not spec-expressible in Sigma',
-                      action: 'Set the sort on the pivot in the Sigma UI after migration.')
+    return warn_sort_miss(name, srt) unless cid
+    # rowsBy[0].sort {by,direction}; coalesce-blank-first when sorting the dim
+    # ascending (see lib/pbi_pivot_sort.rb — the old "not spec-expressible" punt
+    # was wrong and dropped every matrix/tableEx sort).
+    applied = PbiPivotSort.apply!(rows_by: el['rowsBy'], cols: cols, cid: cid, dir: dir)
+    unless applied
+      warn "[build-workbook] WARN visual '#{name}': pivot-table has no rowsBy to sort — skipped."
+      record_unresolved(visual: name, severity: 'degraded', recoverable: true,
+                        detail: 'pivot-table sort could not be applied (no rowsBy)',
+                        action: 'Set the sort on the pivot in the Sigma UI after migration.')
+    end
   end
 end
 
@@ -1398,7 +1415,7 @@ def build_element(rec, fields, masters, extra_data = [])
 
   # bead f972: carry the PBI visual's sort onto the built element (runs AFTER the
   # case so a grouped table's sort can nest inside its grouping entry).
-  apply_sort(el, kind, rec, qr_cids, name)
+  apply_sort(el, kind, rec, qr_cids, name, cols)
 
   # Conditional formatting (color scales / data bars) on table + pivot-table.
   # Runs AFTER the case so it sees the final kind (a totals-bearing table is

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -193,12 +193,26 @@ def _sort_signal(visual):
     Entity.Property fallback) so the builder can map it to a Sigma column id."""
     sd = (visual.get("query") or {}).get("sortDefinition") or {}
     entries = sd.get("sort") or []
+    qs = (visual.get("query") or {}).get("queryState") or {}
     if not entries:
+        # No EXPLICIT sort persisted. Do NOT leave a table/matrix unsorted — Power BI
+        # still applies a default: a table/matrix sorts by its FIRST column ascending.
+        # Reproduce that so the migrated pivot matches the report; otherwise Sigma
+        # applies its own (different) default and the row order silently diverges.
+        # (Charts are excluded — their categorical/axis order is handled elsewhere.)
+        # Caveat recorded downstream: the parity/executeQueries ROW ORDER is the DAX
+        # ORDER BY, NOT this visual sort — never infer the sort from parity output.
+        if str(visual.get("visualType", "")) in ("tableEx", "pivotTable", "matrix"):
+            for role in ("Rows", "Category", "Values"):  # first non-empty = leftmost column
+                for p in (qs.get(role) or {}).get("projections", []):
+                    if isinstance(p, dict):
+                        qr = p.get("queryRef") or p.get("nativeQueryRef")
+                        if qr:
+                            return {"queryRef": qr, "direction": "asc", "default": True}
         return None
     first = entries[0]
     direction = "desc" if str(first.get("direction", "")).lower().startswith("desc") else "asc"
     fld = first.get("field")
-    qs = (visual.get("query") or {}).get("queryState") or {}
     for _role, blk in qs.items():
         for p in blk.get("projections", []):
             if isinstance(p, dict) and p.get("field") == fld:

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_pivot_sort.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_pivot_sort.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# lib/pbi_pivot_sort.rb — apply a Power BI matrix/tableEx sort to a Sigma
+# pivot-table's row grouping.
+#
+# Two things this pins that the builder got wrong before:
+#   1. A pivot-table row sort IS spec-expressible — `rowsBy[0].sort = {by, direction}`
+#      is accepted, round-trips, and renders (verified 2026-07-15). The old builder
+#      punted with "pivot-table sort is not spec-expressible, set it in the UI" and
+#      dropped EVERY matrix/tableEx sort.
+#   2. Power BI sorts a blank/null dimension member FIRST; Sigma sorts nulls LAST
+#      and has no nulls-first option. So when we sort the ROW DIMENSION ITSELF
+#      ascending, coalesce its nulls to "(Blank)" ("(" sorts before letters) — the
+#      blank row then lands on top exactly like PBI, matching the donut/pie null
+#      treatment (refs/style-fidelity.md). A MEASURE sort orders the blank by its
+#      value, so we only coalesce when sorting by the dim ascending.
+#
+# NB: the sort's row order is the VISUAL's sort (PBIR query.sortDefinition, or the
+# extractor's first-column-ascending default for null sortDefinition) — NEVER the
+# parity/executeQueries row order, which is the DAX ORDER BY, not the display sort.
+module PbiPivotSort
+  BLANK_LABEL = '(Blank)'
+
+  # Mutates `rows_by` (array of {"id"=>..}) and `cols` (array of {"id","formula"..})
+  # in place. Returns true when a sort was applied, false when it couldn't be.
+  #   rows_by : the pivot's rowsBy array (outer grouping is index 0)
+  #   cols    : the element's built columns (for the coalesce rewrite)
+  #   cid     : the resolved Sigma column id to sort by
+  #   dir     : "ascending" | "descending"
+  def self.apply!(rows_by:, cols:, cid:, dir:)
+    return false unless rows_by.is_a?(Array) && !rows_by.empty? && cid
+
+    rows_by[0] = (rows_by[0] || {}).merge('sort' => { 'by' => cid, 'direction' => dir })
+
+    # blank-first reproduction: only when sorting BY THE ROW DIM ITSELF, ascending
+    if cols.is_a?(Array) && dir == 'ascending' && cid == rows_by[0]['id']
+      dcol = cols.find { |c| c.is_a?(Hash) && c['id'] == cid }
+      f = dcol && dcol['formula']
+      if f.is_a?(String) && !f.strip.downcase.start_with?('coalesce(')
+        dcol['formula'] = %(Coalesce(#{f}, "#{BLANK_LABEL}"))
+      end
+    end
+    true
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-pivot-sort.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-pivot-sort.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-pbi-pivot-sort.rb — regression test for lib/pbi_pivot_sort.rb.
+# Offline: no API, no creds. Run: ruby scripts/test-pbi-pivot-sort.rb
+#
+# Pins the "Region table not sorted like the PBI report" fix (2026-07-15):
+#   - a pivot-table row sort IS spec-expressible (rowsBy[0].sort) — the builder used
+#     to DROP it with "not spec-expressible in Sigma, set it in the UI";
+#   - Power BI sorts a blank/null dim member FIRST while Sigma sorts nulls LAST, so
+#     an ascending sort BY THE DIM coalesces nulls -> "(Blank)" for blank-first parity.
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'pbi_pivot_sort'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+DIM = 'el-c0'  # row dimension column id
+MEA = 'el-c1'  # a measure column id
+def cols_fixture
+  [{ 'id' => DIM, 'formula' => '[V/Region]', 'name' => 'Region' },
+   { 'id' => MEA, 'formula' => 'Sum([V/Net Revenue])', 'name' => 'Net Revenue $' }]
+end
+
+# 1. Default first-column-ascending (by the dim): sort applied + blank-first coalesce.
+rb = [{ 'id' => DIM }]; cols = cols_fixture
+res = PbiPivotSort.apply!(rows_by: rb, cols: cols, cid: DIM, dir: 'ascending')
+ok('returns true when applied',            res == true)
+ok('rowsBy[0].sort is set by+direction',   rb[0]['sort'] == { 'by' => DIM, 'direction' => 'ascending' })
+ok('dim col coalesced -> (Blank) first',   cols[0]['formula'] == 'Coalesce([V/Region], "(Blank)")')
+ok('measure col NOT coalesced',            cols[1]['formula'] == 'Sum([V/Net Revenue])')
+
+# 2. Sort by a MEASURE ascending: sort applied, but the dim must NOT be coalesced
+#    (a measure sort orders the blank by its value, not first).
+rb = [{ 'id' => DIM }]; cols = cols_fixture
+PbiPivotSort.apply!(rows_by: rb, cols: cols, cid: MEA, dir: 'ascending')
+ok('measure sort sets rowsBy sort',        rb[0]['sort'] == { 'by' => MEA, 'direction' => 'ascending' })
+ok('measure sort does NOT coalesce dim',   cols[0]['formula'] == '[V/Region]')
+
+# 3. DESCENDING sort by the dim: no coalesce (blank-first is an ascending concern).
+rb = [{ 'id' => DIM }]; cols = cols_fixture
+PbiPivotSort.apply!(rows_by: rb, cols: cols, cid: DIM, dir: 'descending')
+ok('descending dim sort does NOT coalesce', cols[0]['formula'] == '[V/Region]')
+
+# 4. Idempotent: an already-coalesced dim is not double-wrapped.
+rb = [{ 'id' => DIM }]
+cols = [{ 'id' => DIM, 'formula' => 'Coalesce([V/Region], "(Blank)")' }]
+PbiPivotSort.apply!(rows_by: rb, cols: cols, cid: DIM, dir: 'ascending')
+ok('no double-coalesce',                   cols[0]['formula'] == 'Coalesce([V/Region], "(Blank)")')
+
+# 5. Guards: empty rowsBy / nil cid -> false, no mutation, no crash.
+ok('empty rowsBy -> false',                PbiPivotSort.apply!(rows_by: [], cols: cols_fixture, cid: DIM, dir: 'ascending') == false)
+ok('nil cid -> false',                     PbiPivotSort.apply!(rows_by: [{ 'id' => DIM }], cols: cols_fixture, cid: nil, dir: 'ascending') == false)
+
+puts($fail.zero? ? "\nall pbi-pivot-sort tests passed" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## What
Migrated Power BI matrix/tableEx tables lost their sort in Sigma. Two causes, both fixed:

1. **`apply_sort` dropped pivot-table sorts** as *"pivot-table sort is not spec-expressible in Sigma — set it in the UI."* That's wrong — a `pivot-table` accepts `rowsBy[0].sort = { by, direction }` (verified: accepted, round-trips, renders). Every matrix/tableEx sort was silently dropped.
2. **`_sort_signal` returned `None`** when the PBIR `sortDefinition` was null — but Power BI still applies a default (first column ascending), so the pivot fell back to Sigma's *different* default and the row order diverged from the report.

## Changes
- `build-workbook-from-pbir.rb`: emit `rowsBy[0].sort` for pivots via new `lib/pbi_pivot_sort.rb`; dispatch on `el['kind']` so a grouped-table→pivot (Grand-Total re-expression) routes to the pivot branch.
- `extract-pbir.py`: reproduce PBI's implicit **first-column-ascending** default for `tableEx`/`matrix`/`pivotTable` when `sortDefinition` is null (charts unaffected).
- **Blank-first parity:** PBI sorts a blank/null member *first*; Sigma sorts nulls *last* and has no nulls-first option. When sorting the row dim ascending, coalesce its nulls → `"(Blank)"` (same trick §4 uses for donuts) so the blank row lands on top like PBI. A *measure* sort is left uncoalesced.
- `test-pbi-pivot-sort.rb` (10 assertions); `refs/style-fidelity.md` §4b.

## Lesson encoded
Read the **visual's** sort (`query.sortDefinition`), never the parity/`executeQueries` row order — that's the DAX `ORDER BY` (usually first-measure-desc), not the display sort. Inferring from parity output produced a table sorted the wrong way.

## Verification
- New + existing tests green: `test-pbi-pivot-sort`, `test-pbi-element-match`, `test-drop-unresolved-columns`, `test-control-lint`, `test-coverage-gate`, `test-pbi-timeintel-route`.
- End-to-end on a real matrix dashboard: re-extract + rebuild → pivot sorted, blank coalesced, `0 dropped/degraded`; posted + rendered live — blank row sorts first as `(Blank)`, matching the PBI report exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
