### PR TITLE
skills: Windows python Store-stub shim (shared doctor) + tableau paved-path cheatsheet

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -32,6 +32,18 @@ user-invocable: true
 > ```
 > ruby scripts/migrate-tableau.rb --workbook "<name>" --connection <id>
 > ```
+> - **Pass the Tableau `/#/views/…` share URL straight to `--workbook` (quote it).**
+>   The orchestrator resolves the workbook LUID from the URL's `contentUrl` slug in
+>   process (`find_workbook_by_content_url`). A workbook's display name almost always
+>   differs from its slug ("High Risk Bets" vs `HighRiskBets`), so **never** hand-roll
+>   `name:eq:` REST filters or page the workbook list to find the LUID yourself — that
+>   field-cost a full 500-workbook scan on a cold run. Just give it the URL.
+> - **Flag cheatsheet — use the EXACT flags (do not guess or grep `opts.on`).** When a
+>   STOP routes you to a script directly, these are the ones people trip on:
+>   `migrate-tableau.rb --out DIR` (the workdir flag is **`--out`**, not `--workdir`);
+>   `validate-spec.rb <spec.json> --type dm|workbook` (spec is a **positional** arg, no `--spec`);
+>   `put-layout.rb --workbook ID` (**not** `--workbook-id`) and it reads `SIGMA_API_TOKEN`
+>   from the env — `export SIGMA_API_TOKEN=$(ruby -rjson -e 'print JSON.parse(File.read(ENV["WORK"]+"/auth.json"))["SIGMA_API_TOKEN"]')` first.
 > - **Do NOT hand-drive the per-phase scripts, and do NOT hand-author DM/workbook
 >   JSON, UNLESS an orchestrator STOP message explicitly routes you there** (e.g.
 >   "CONVERTER STOP", the exit-4 workbook handoff). The per-phase table further

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -78,6 +78,29 @@ else
   fi
 fi
 
+# --- Windows Store-stub shim ------------------------------------------------
+# On windows-bash the REAL interpreter is usually `py -3`, but bare `python` /
+# `python3` resolve to the Microsoft Store App-Execution-Alias stub — which
+# silently no-ops and floods every tool call (and any PreToolUse hook that shells
+# `python`) with "Python was not found; run … Microsoft Store" (field-observed:
+# ~15 spurious errors in the first two minutes). The skill's own scripts resolve
+# Python internally, so this only bites bare `python` callers. When `py -3` is
+# real but `python` is the stub, drop a shim in ~/bin (git-bash auto-prepends
+# ~/bin to PATH at login) so `python`/`python3` resolve to `py -3`.
+if [ "$OS" = "windows-bash" ] && py_real py -3 && ! py_real python; then
+  if mkdir -p "$HOME/bin" 2>/dev/null; then
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python"  2>/dev/null && chmod +x "$HOME/bin/python"  2>/dev/null
+    printf '#!/usr/bin/env bash\nexec py -3 "$@"\n' > "$HOME/bin/python3" 2>/dev/null && chmod +x "$HOME/bin/python3" 2>/dev/null
+    if [ -x "$HOME/bin/python" ]; then
+      case ":$PATH:" in
+        *":$HOME/bin:"*) ok "python Store-stub shim installed (~/bin/python → py -3; ~/bin already on PATH)" ;;
+        *) warn "python Store-stub shim installed (~/bin/python → py -3)" \
+                "Add ~/bin to PATH for this shell so bare 'python' stops hitting the Store stub: export PATH=\"\$HOME/bin:\$PATH\"  (git-bash auto-adds ~/bin on next login)" ;;
+      esac
+    fi
+  fi
+fi
+
 # --- visual-similarity deps (gate 14's measured floor) ----------------------
 # visual-similarity.py needs Pillow + numpy; without them the gate exits
 # "SKIPPED: dep missing" instead of measuring (A/B-report field-caught: the


### PR DESCRIPTION
Efficiency fixes from the the field customer field run (bead beads-sigma-tt3z.12): a 1-tile Tableau→Sigma migration took **21 min**, mostly to avoidable Windows + agent-discipline snags. This is separate from the custom-SQL correctness fix (#386).

## 1. Windows python Store-stub shim — `shared/scripts/doctor.sh` (canonical, synced to all plugin doctors)
On windows-bash the real interpreter is `py -3`, but bare `python`/`python3` hit the Microsoft Store App-Execution-Alias stub, which no-ops and floods **every** tool call — and any PreToolUse hook that shells `python` — with *"Python was not found; run … Microsoft Store"* (~15 spurious errors in the first two minutes of the field run). When `py -3` is real but `python` is the stub, doctor now auto-installs a `~/bin/python[3]` → `py -3` shim (git-bash auto-prepends `~/bin` to PATH at login). Benefits every converter's doctor → lives in the shared canonical (`check-shared.rb`: 373 copies match, 0 drift).

## 2. tableau-to-sigma SKILL.md — paved-path guardrails (STEP 1)
- **Pass the `/#/views/…` URL straight to `--workbook`** — the orchestrator resolves the LUID from the URL's `contentUrl` slug in-process (`find_workbook_by_content_url`, already in the lib). Display name ≠ slug ("High Risk Bets" vs `HighRiskBets`), so the field run hand-rolled `name:eq:` and paged **500 workbooks**. Never do that — just give it the URL.
- **Exact-flag cheatsheet** for the scripts people trip on when a STOP routes them directly: `migrate-tableau.rb --out` (not `--workdir`), `validate-spec.rb <spec>` (positional), `put-layout.rb --workbook` (not `--workbook-id`) + `SIGMA_API_TOKEN` export.

## Not in this PR
- **contentUrl resolution (#3)** was already implemented — no code change needed, just the guardrail above.
- **Connection auto-rank from the .twb (#4)** is still TODO — intake runs *before* the `.twb` is downloaded, so pre-ranking the 26-connection ASK needs an ordering change. Scoped as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
