### PR TITLE
tableau-to-sigma: auto-rank Sigma connection by the workbook's warehouse (#4)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/tableau_rest.rb
@@ -167,6 +167,17 @@ end
     request(:get, "#{base_path}/workbooks/#{workbook_id}")['workbook']
   end
 
+  # A workbook's live datasource connections: [{type, serverAddress, serverPort,
+  # userName, ...}]. This is the cheap warehouse fingerprint (no .twb/.twbx
+  # download, so it dodges the missing `zip` gem) used to auto-rank Sigma
+  # connection candidates. `type` is a Tableau connection class (e.g. 'snowflake',
+  # 'sqlserver', 'redshift', 'databricks'); serverAddress is the warehouse host.
+  def workbook_connections(workbook_id)
+    j = request(:get, "#{base_path}/workbooks/#{workbook_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/tableau_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/tableau_rest.rb
@@ -167,6 +167,17 @@ end
     request(:get, "#{base_path}/workbooks/#{workbook_id}")['workbook']
   end
 
+  # A workbook's live datasource connections: [{type, serverAddress, serverPort,
+  # userName, ...}]. This is the cheap warehouse fingerprint (no .twb/.twbx
+  # download, so it dodges the missing `zip` gem) used to auto-rank Sigma
+  # connection candidates. `type` is a Tableau connection class (e.g. 'snowflake',
+  # 'sqlserver', 'redshift', 'databricks'); serverAddress is the warehouse host.
+  def workbook_connections(workbook_id)
+    j = request(:get, "#{base_path}/workbooks/#{workbook_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
@@ -167,6 +167,17 @@ end
     request(:get, "#{base_path}/workbooks/#{workbook_id}")['workbook']
   end
 
+  # A workbook's live datasource connections: [{type, serverAddress, serverPort,
+  # userName, ...}]. This is the cheap warehouse fingerprint (no .twb/.twbx
+  # download, so it dodges the missing `zip` gem) used to auto-rank Sigma
+  # connection candidates. `type` is a Tableau connection class (e.g. 'snowflake',
+  # 'sqlserver', 'redshift', 'databricks'); serverAddress is the warehouse host.
+  def workbook_connections(workbook_id)
+    j = request(:get, "#{base_path}/workbooks/#{workbook_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -150,6 +150,8 @@ input mode, which feed the telemetry ping's duration and `mode`). Precedence: ex
 `--connection` → cached → `SIGMA_CONNECTION_ID` env → list once. With no id/name and
 multiple connections it lists them and asks you to pick — it never guesses.
 
+> **When there are many connections, let intake pick by the workbook's warehouse — don't inspect the `.twb` by hand.** Pass the resolved workbook LUID: `ruby scripts/intake.rb --workdir <WORK> --rank-workbook-id <LUID>`. Intake fingerprints the workbook's warehouse (`GET /workbooks/{luid}/connections` → type + host, no `.twb`/`zip` needed) and ranks the Sigma connections; a **unique type+host match auto-resolves** (e.g. a Snowflake workbook on `acct.snowflakecomputing.com` → the matching Snowflake connection), otherwise it writes a **ranked** `connection-candidates.json` with a clear top pick and asks. This replaces the field-caught pattern of downloading the `.twb` and grepping `class=`/`server=` to guess among 26 connections. (`scripts/rank-connections.rb` is the standalone ranker; `--rank-twb <path>` adds a db-name tie-break once the `.twb` is downloaded.)
+
 ## One command (orchestrated path)
 
 ```bash

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.rb
@@ -167,6 +167,17 @@ end
     request(:get, "#{base_path}/workbooks/#{workbook_id}")['workbook']
   end
 
+  # A workbook's live datasource connections: [{type, serverAddress, serverPort,
+  # userName, ...}]. This is the cheap warehouse fingerprint (no .twb/.twbx
+  # download, so it dodges the missing `zip` gem) used to auto-rank Sigma
+  # connection candidates. `type` is a Tableau connection class (e.g. 'snowflake',
+  # 'sqlserver', 'redshift', 'databricks'); serverAddress is the warehouse host.
+  def workbook_connections(workbook_id)
+    j = request(:get, "#{base_path}/workbooks/#{workbook_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/rank-connections.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/rank-connections.rb
@@ -1,0 +1,234 @@
+#!/usr/bin/env ruby
+# rank-connections.rb — pre-rank the ambiguous Sigma-connection ASK by matching the
+# Tableau workbook's warehouse against the org's Sigma connections.
+#
+# WHY: intake.rb writes connection-candidates.json and exits 3 when it can't pick
+# safely (field run: 26 connections). The agent then hand-downloaded the .twb and
+# grepped connection classes to recommend one — several wasted calls, and the user
+# still guessed. This scores every candidate against the workbook's real warehouse
+# (type + host/account, optionally database) so the ASK is either auto-resolved
+# (unique type+host match) or presented already ranked with a clear top pick.
+#
+# Fingerprint source (no .twb/.twbx download needed — dodges the missing `zip` gem):
+#   --workbook-id LUID   → GET /workbooks/{luid}/connections  (type + serverAddress)
+#   --twb PATH           → parse a downloaded .twb (adds dbname/schema for tie-breaks)
+# (at least one required; if both, they merge.)
+#
+# Usage:
+#   ruby scripts/rank-connections.rb --workbook-id <LUID> [--twb <path>] \
+#        [--candidates <connection-candidates.json>] [--out <ranked.json>]
+#
+# Exit codes:
+#   0  confident recommendation (unique type+host match) — printed + written
+#   3  ranked but ambiguous — top candidate suggested, ASK the user to confirm
+#   4  no candidates / no fingerprint / API error
+#   1  usage error
+require 'json'
+require 'optparse'
+require 'set'
+
+module RankConnections
+  module_function
+
+  # Tableau connection class / Sigma connection type → canonical warehouse family.
+  TYPE_ALIASES = {
+    'snowflake' => 'snowflake',
+    'sqlserver' => 'sqlserver', 'mssql' => 'sqlserver', 'microsoftsqlserver' => 'sqlserver', 'sqlserverodbc' => 'sqlserver',
+    'redshift' => 'redshift', 'amazonredshift' => 'redshift',
+    'databricks' => 'databricks', 'spark' => 'databricks', 'sparksql' => 'databricks', 'databrickssql' => 'databricks',
+    'bigquery' => 'bigquery', 'googlebigquery' => 'bigquery',
+    'postgres' => 'postgres', 'postgresql' => 'postgres',
+    'oracle' => 'oracle',
+    'mysql' => 'mysql',
+    'athena' => 'athena', 'awsathena' => 'athena', 'amazonathena' => 'athena',
+    'presto' => 'presto', 'trino' => 'trino',
+  }.freeze
+
+  def canon_type(t)
+    k = t.to_s.downcase.gsub(/[^a-z0-9]/, '')
+    TYPE_ALIASES[k] || k
+  end
+
+  # Generic host labels that carry no identity — never match on these. Includes
+  # cloud/vendor suffixes AND directional region words (a shared "east" from two
+  # different "us-east-1" hosts must NOT count as an identity match).
+  GENERIC = %w[snowflakecomputing com net org www database windows core amazonaws
+               redshift databricks azuredatabricks gcp azure cloud
+               comput05 sql server db data prod dev test staging
+               east west north south central northeast northwest southeast southwest
+               region zone].to_set.freeze
+
+  # Meaningful tokens from a host / account string (leading account label, etc.).
+  def host_tokens(*strs)
+    toks = Set.new
+    strs.compact.each do |s|
+      s.to_s.downcase.split(/[^a-z0-9]+/).each do |t|
+        next if t.empty? || t.length < 3
+        next if GENERIC.include?(t)
+        next if t =~ /\A(us|eu|ap|ca|sa)(east|west|north|south|central)?\d*\z/  # region codes
+        next if t =~ /\A[a-z]{2}\d+\z/ && t.length <= 4                          # e.g. us1
+        toks << t
+      end
+    end
+    toks
+  end
+
+  # Score one Sigma candidate against the source fingerprint. Pure.
+  #   fp:   { 'type'=>, 'host'=>, 'account'=>, 'database'=> }  (any may be nil)
+  #   cand: { 'connection_id'=>, 'name'=>, 'type'=>, 'host'=>, 'account'=>, 'warehouse'=> }
+  def score_candidate(fp, cand)
+    reasons = []
+    score = 0
+    if fp['type'] && !fp['type'].to_s.empty? && canon_type(fp['type']) == canon_type(cand['type'])
+      score += 100; reasons << "warehouse type matches (#{canon_type(cand['type'])})"
+    end
+    src_host = "#{fp['host']} #{fp['account']}"
+    src_toks = host_tokens(fp['host'], fp['account'])
+    cand_toks = host_tokens(cand['host'], cand['account'], cand['name'], cand['warehouse'])
+    if fp['host'] && !fp['host'].to_s.empty? && !cand['host'].to_s.empty? &&
+       fp['host'].to_s.downcase == cand['host'].to_s.downcase
+      score += 80; reasons << "exact host match (#{cand['host']})"
+    elsif !(src_toks & cand_toks).empty?
+      shared = (src_toks & cand_toks).to_a.sort.join(', ')
+      score += 50; reasons << "host/account token match (#{shared})"
+    end
+    if fp['database'] && !fp['database'].to_s.empty?
+      dbtok = fp['database'].to_s.downcase
+      if [cand['name'], cand['warehouse'], cand['database']].compact.any? { |v| v.to_s.downcase.include?(dbtok) }
+        score += 15; reasons << "database name hint (#{fp['database']})"
+      end
+    end
+    { 'connection_id' => cand['connection_id'], 'name' => cand['name'], 'type' => cand['type'],
+      'match_score' => score, 'match_reasons' => reasons }
+  end
+
+  # Rank all candidates; decide whether the top is a confident auto-pick. Pure.
+  def rank(fp, candidates)
+    scored = candidates.map { |c| score_candidate(fp, c) }
+                       .sort_by { |c| [-c['match_score'], c['name'].to_s] }
+    top = scored.first
+    second = scored[1]
+    type_matches = scored.select { |c| c['match_score'] >= 100 }
+    confident = !top.nil? && top['match_score'] >= 100 &&
+                (type_matches.size == 1 ||                                   # only one right-type conn
+                 (second && (top['match_score'] - second['match_score']) >= 30)) # host/db breaks the tie
+    { 'ranked' => scored, 'recommended' => (confident ? top : nil),
+      'confident' => confident, 'type_match_count' => type_matches.size }
+  end
+
+  # ---- fingerprint sources -------------------------------------------------
+  # Primary non-extract warehouse connection from a Tableau REST connections list.
+  SKIP_CLASSES = %w[federated sqlproxy excel-direct textscan hyper msaccess
+                    dataengine tableau-server-connection].to_set.freeze
+  def fingerprint_from_wb_connections(list)
+    conns = (list || []).map { |c| { 'type' => (c['type'] || c['dbClass']), 'host' => (c['serverAddress'] || c['server']) } }
+                        .reject { |c| c['type'].to_s.empty? || SKIP_CLASSES.include?(c['type'].to_s.downcase) }
+    warehouse = conns.find { |c| !c['host'].to_s.empty? } || conns.first
+    warehouse ? { 'type' => warehouse['type'], 'host' => warehouse['host'] } : {}
+  end
+
+  # Fingerprint from a downloaded .twb (regex, no XML/zip deps). Adds dbname/schema.
+  def fingerprint_from_twb(xml)
+    best = nil
+    xml.scan(/<connection\b[^>]*\bclass=(['"])(.*?)\1[^>]*>/m) do |_q, _cls|
+      tag = Regexp.last_match(0)
+      cls = _cls
+      next if SKIP_CLASSES.include?(cls.downcase) || %w[automatic categorical].include?(cls.downcase)
+      server = tag[/\bserver=(['"])(.*?)\1/, 2]
+      dbname = tag[/\bdbname=(['"])(.*?)\1/, 2]
+      schema = tag[/\bschema=(['"])(.*?)\1/, 2]
+      cand = { 'type' => cls, 'host' => server, 'database' => dbname, 'schema' => schema }
+      # prefer a connection that actually names a server (the real warehouse)
+      best ||= cand
+      best = cand if best['host'].to_s.empty? && !server.to_s.empty?
+    end
+    best || {}
+  end
+
+  def merge_fp(a, b)
+    out = {}
+    %w[type host account database schema].each { |k| out[k] = (a[k] && !a[k].to_s.empty? ? a[k] : b[k]) }
+    out
+  end
+end
+
+# ---- CLI --------------------------------------------------------------------
+if $PROGRAM_NAME == __FILE__
+  opts = {}
+  OptionParser.new do |p|
+    p.on('--workbook-id LUID')  { |v| opts[:wb] = v }
+    p.on('--twb PATH')          { |v| opts[:twb] = v }
+    p.on('--candidates PATH')   { |v| opts[:cands] = v }
+    p.on('--out PATH')          { |v| opts[:out] = v }
+    p.on('--connections-fixture FILE', 'TEST ONLY: Sigma connections list') { |v| opts[:conn_fix] = v }
+    p.on('--fingerprint-fixture FILE', 'TEST ONLY: {type,host,database} JSON') { |v| opts[:fp_fix] = v }
+  end.parse!
+
+  # 1) Source fingerprint
+  fp = {}
+  if opts[:fp_fix]
+    fp = JSON.parse(File.read(opts[:fp_fix]))
+  else
+    if opts[:wb]
+      require_relative 'lib/tableau_rest'
+      begin
+        Tableau.site_id
+      rescue Tableau::Error
+        Tableau.refresh_token!
+      end
+      fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:wb])))
+    end
+    if opts[:twb] && File.exist?(opts[:twb])
+      fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:twb])))
+    end
+  end
+  if fp['type'].to_s.empty?
+    warn '[FAIL] rank-connections: no warehouse fingerprint (need --workbook-id or --twb).'
+    exit 4
+  end
+
+  # 2) Sigma connections (rich: type/host/account/warehouse)
+  raw = if opts[:conn_fix]
+          JSON.parse(File.read(opts[:conn_fix]))
+        else
+          require_relative 'lib/sigma_rest'
+          Sigma.request(:get, '/v2/connections?limit=500')
+        end
+  rows = raw.is_a?(Hash) ? (raw['entries'] || raw['connections'] || []) : (raw || [])
+  conns = rows.map do |c|
+    { 'connection_id' => c['connectionId'] || c['id'], 'name' => c['name'] || c['label'],
+      'type' => c['type'] || c['connectionType'], 'host' => c['host'], 'account' => c['account'],
+      'warehouse' => c['warehouse'] }
+  end.reject { |c| c['connection_id'].to_s.empty? || c['isArchived'] }
+  # scope to intake's candidate ids if provided
+  if opts[:cands] && File.exist?(opts[:cands])
+    ids = (JSON.parse(File.read(opts[:cands]))['candidates'] || []).map { |c| c['connection_id'] }.to_set
+    conns = conns.select { |c| ids.include?(c['connection_id']) } unless ids.empty?
+  end
+  if conns.empty?
+    warn '[FAIL] rank-connections: no Sigma connections to rank.'
+    exit 4
+  end
+
+  result = RankConnections.rank(fp, conns)
+  result['fingerprint'] = fp
+  out_path = opts[:out] || (opts[:cands] ? File.join(File.dirname(opts[:cands]), 'connection-candidates-ranked.json') : nil)
+  if out_path
+    File.write(out_path, JSON.pretty_generate(result))
+  end
+
+  warn "── source warehouse: type=#{RankConnections.canon_type(fp['type'])} host=#{fp['host'] || '?'} db=#{fp['database'] || '?'}"
+  result['ranked'].first(6).each_with_index do |c, i|
+    mark = (result['recommended'] && c['connection_id'] == result['recommended']['connection_id']) ? '★' : ' '
+    warn format('  %s #%d  %-40s  score=%-3d  %s', mark, i + 1, "#{c['name']} (#{c['type']})", c['match_score'], c['match_reasons'].join('; '))
+  end
+  if result['confident']
+    rec = result['recommended']
+    warn "\n[OK] rank-connections: confident pick → #{rec['name']} (#{rec['connection_id']})"
+    warn "     re-run intake with:  --connection #{rec['connection_id']}"
+    exit 0
+  else
+    warn "\n[ASK] rank-connections: no unique match (#{result['type_match_count']} same-type connection(s)) — confirm with the user, then re-run intake --connection <id>."
+    exit 3
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/rank-connections.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/rank-connections.rb
@@ -179,7 +179,7 @@ if $PROGRAM_NAME == __FILE__
       fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:wb])))
     end
     if opts[:twb] && File.exist?(opts[:twb])
-      fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:twb])))
+      fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:twb], encoding: 'UTF-8')))
     end
   end
   if fp['type'].to_s.empty?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rank-connections.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rank-connections.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# Offline unit test for rank-connections.rb (pure scoring + .twb fingerprint).
+require_relative 'rank-connections'
+
+$fail = 0
+def check(desc)
+  ok = yield
+  puts "#{ok ? '  ok  ' : ' FAIL '} #{desc}"
+  $fail += 1 unless ok
+end
+
+# Realistic org: 26-connection ASK reduced here to the relevant mix (multiple Snowflakes).
+CANDS = [
+  { 'connection_id' => 'c-prod', 'name' => 'Snowflake Prod', 'type' => 'snowflake', 'host' => 'draftkings.us-east-1.snowflakecomputing.com', 'account' => 'draftkings' },
+  { 'connection_id' => 'c-ask',  'name' => 'ASK Data - Snowflake', 'type' => 'snowflake', 'host' => 'askdata.snowflakecomputing.com', 'account' => 'askdata' },
+  { 'connection_id' => 'c-bq',   'name' => 'BigQuery- Wells', 'type' => 'bigQuery', 'host' => nil, 'account' => nil },
+  { 'connection_id' => 'c-dbx',  'name' => 'Databricks data-science-dev', 'type' => 'databricks', 'host' => 'adb-123.azuredatabricks.net' },
+  { 'connection_id' => 'c-rs',   'name' => 'Redshift Analytics', 'type' => 'redshift', 'host' => 'rs.abc.us-east-1.redshift.amazonaws.com' },
+]
+
+# 1) Confident auto-pick: type + host token both point at Snowflake Prod.
+fp1 = { 'type' => 'snowflake', 'host' => 'draftkings.us-east-1.snowflakecomputing.com', 'database' => 'DWSPORTSBOOK' }
+r1 = RankConnections.rank(fp1, CANDS)
+check('recommends Snowflake Prod on type+host match') { r1['confident'] && r1['recommended']['connection_id'] == 'c-prod' }
+check('Snowflake Prod outscores the other Snowflake') { r1['ranked'][0]['match_score'] > r1['ranked'][1]['match_score'] }
+check('wrong-warehouse connections score 0') { r1['ranked'].select { |c| %w[c-bq c-dbx c-rs].include?(c['connection_id']) }.all? { |c| c['match_score'].zero? } }
+
+# 2) Ambiguous: two Snowflakes, neither host matches the source → not confident.
+fp2 = { 'type' => 'snowflake', 'host' => 'unknownco.snowflakecomputing.com' }
+r2 = RankConnections.rank(fp2, CANDS)
+check('two same-type, no host match → NOT confident (still asks)') { !r2['confident'] && r2['type_match_count'] == 2 }
+
+# 3) Type normalization across Tableau/Sigma spellings.
+check('bigquery <-> bigQuery normalize equal') { RankConnections.canon_type('bigquery') == RankConnections.canon_type('bigQuery') }
+check('sqlserver <-> mssql normalize equal')    { RankConnections.canon_type('sqlserver') == RankConnections.canon_type('mssql') }
+check('databricks <-> sparksql normalize equal'){ RankConnections.canon_type('databricks') == RankConnections.canon_type('sparksql') }
+
+# 4) .twb fingerprint: picks the real warehouse connection, skips extract/federated/categorical.
+TWB = <<~XML
+  <workbook>
+   <datasources>
+    <datasource caption='HRB'>
+     <connection class='federated'>
+      <named-connections>
+       <named-connection caption='SF'><connection class='snowflake' server='draftkings.us-east-1.snowflakecomputing.com' dbname='DWSPORTSBOOK' schema='DBO'/></named-connection>
+      </named-connections>
+      <relation type='text'>SELECT 1</relation>
+     </connection>
+    </datasource>
+    <datasource><connection class='categorical'/></datasource>
+   </datasources>
+  </workbook>
+XML
+fp_twb = RankConnections.fingerprint_from_twb(TWB)
+check('.twb fingerprint type = snowflake') { RankConnections.canon_type(fp_twb['type']) == 'snowflake' }
+check('.twb fingerprint host = draftkings host') { fp_twb['host'] == 'draftkings.us-east-1.snowflakecomputing.com' }
+check('.twb fingerprint database = DWSPORTSBOOK') { fp_twb['database'] == 'DWSPORTSBOOK' }
+
+# 5) A .twb fingerprint feeds ranking to the same confident pick.
+r5 = RankConnections.rank(RankConnections.merge_fp(fp_twb, {}), CANDS)
+check('.twb-derived fingerprint recommends Snowflake Prod') { r5['confident'] && r5['recommended']['connection_id'] == 'c-prod' }
+
+puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 

--- a/shared/lib/tableau_rest.rb
+++ b/shared/lib/tableau_rest.rb
@@ -167,6 +167,17 @@ end
     request(:get, "#{base_path}/workbooks/#{workbook_id}")['workbook']
   end
 
+  # A workbook's live datasource connections: [{type, serverAddress, serverPort,
+  # userName, ...}]. This is the cheap warehouse fingerprint (no .twb/.twbx
+  # download, so it dodges the missing `zip` gem) used to auto-rank Sigma
+  # connection candidates. `type` is a Tableau connection class (e.g. 'snowflake',
+  # 'sqlserver', 'redshift', 'databricks'); serverAddress is the warehouse host.
+  def workbook_connections(workbook_id)
+    j = request(:get, "#{base_path}/workbooks/#{workbook_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/shared/scripts/intake.rb
+++ b/shared/scripts/intake.rb
@@ -159,7 +159,7 @@ if resolved.nil?
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))
         end
         ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
         ranked && (ranked['fingerprint'] = fp)

--- a/shared/scripts/intake.rb
+++ b/shared/scripts/intake.rb
@@ -44,6 +44,8 @@ OptionParser.new do |p|
   p.on('--connection ID')    { |v| opts[:conn] = v }
   p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
   p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--rank-workbook-id LUID', 'when ambiguous, rank candidates by the Tableau workbook\'s warehouse (type+host) and auto-pick a unique match') { |v| opts[:rank_wb] = v }
+  p.on('--rank-twb PATH', 'when ambiguous, rank candidates using a downloaded .twb (adds db-name tie-break)') { |v| opts[:rank_twb] = v }
   p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
   p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
 end.parse!
@@ -64,11 +66,16 @@ def write_json(path, obj)
 end
 
 # Normalize a connection record from /v2/connections (entries[]) into our shape.
+# host/account/warehouse are carried so the connection auto-ranker (rank-connections.rb)
+# can match the workbook's warehouse without a second /v2/connections fetch.
 def norm_conn(c)
   {
     'connection_id' => c['connectionId'] || c['id'],
     'name'          => c['name'] || c['label'],
     'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+    'host'          => c['host'],
+    'account'       => c['account'],
+    'warehouse'     => c['warehouse'],
   }
 end
 
@@ -134,12 +141,53 @@ if resolved.nil?
     resolved = pick
     resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
   else
-    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
-    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
-    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
-    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
-    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
-    exit 3
+    # Auto-rank against the Tableau workbook's warehouse (type + host/account) when a
+    # rank source is supplied. A UNIQUE type+host match auto-resolves (the whole point
+    # of the front door — no manual .twb grep, no 26-way guess); otherwise we still ASK
+    # but hand the agent a ranked list with a clear top pick.
+    ranked = nil
+    # rank-connections.rb ships only where a warehouse fingerprint is available
+    # (tableau-to-sigma). In other plugins the ranker is absent, so the flags no-op
+    # and we fall through to the plain ASK — the shared front door stays generic.
+    if (opts[:rank_wb] || opts[:rank_twb]) && File.exist?(File.join(__dir__, 'rank-connections.rb'))
+      begin
+        require_relative 'rank-connections'
+        fp = {}
+        if opts[:rank_wb]
+          require_relative 'lib/tableau_rest'
+          begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+        end
+        if opts[:rank_twb] && File.exist?(opts[:rank_twb])
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb])))
+        end
+        ranked = RankConnections.rank(fp, conns) unless fp['type'].to_s.empty?
+        ranked && (ranked['fingerprint'] = fp)
+      rescue => e
+        warn "      (auto-rank unavailable: #{e.message} — falling back to a plain ASK)"
+      end
+    end
+
+    if ranked && ranked['confident']
+      resolved = ranked['recommended'].slice('connection_id', 'name', 'type')
+      resolved_via = 'auto-rank'
+      warn "[OK] intake: auto-ranked #{conns.size} connections against the workbook's warehouse " \
+           "(type=#{RankConnections.canon_type(ranked['fingerprint']['type'])} host=#{ranked['fingerprint']['host'] || '?'})."
+      warn "     → picked #{resolved['name']} (#{resolved['connection_id']}) — #{ranked['recommended']['match_reasons'].join('; ')}"
+      warn '     (override with --connection <id> --force if this is wrong.)'
+    else
+      out = ranked ? ranked['ranked'] : conns.map { |c| c.merge('match_score' => nil) }
+      write_json(cand_path, { 'count' => conns.size, 'candidates' => out, 'ranked' => !ranked.nil?, 'fingerprint' => (ranked && ranked['fingerprint']) })
+      warn "[ASK] intake: #{conns.size} connections available — cannot pick safely#{ranked ? ' (ranked, but no unique warehouse match)' : ''}."
+      warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+      warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+      unless ranked
+        warn '      TIP: pass --rank-workbook-id <LUID> (or --rank-twb <path>) to pre-rank by the'
+        warn '           workbook\'s warehouse and auto-pick a unique match — or run scripts/rank-connections.rb.'
+      end
+      (out).first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})#{c['match_score'] ? "  [score #{c['match_score']}]" : ''}" }
+      exit 3
+    end
   end
 end
 


### PR DESCRIPTION
Efficiency fix #4 from the the field customer field run (bead beads-sigma-tt3z.13). Closes the last connection-picking roadblock.

## Problem
intake found **26 Sigma connections** and correctly refused to guess. The agent then hand-downloaded the `.twb`, grepped `class=`/`server=` to identify Snowflake `DWSPORTSBOOK.DBO`, and **still** made the user pick — several wasted calls on a mechanically-derivable decision.

## Fix — `scripts/rank-connections.rb` + intake auto-rank
- **Fingerprint the workbook's warehouse** via `GET /workbooks/{luid}/connections` (type + `serverAddress`) — no `.twb`/`.twbx` download, so it dodges the missing `zip` gem — and/or a `--twb` parse (adds a db-name tie-break). New `Tableau.workbook_connections` in the shared lib.
- **Score** each Sigma connection: warehouse-type match (+100) + host/account token or exact host (+50/+80) + db-name hint (+15). Region/directional words (`east`/`west`/…) are filtered so two different `us-east-1` hosts don't false-match. `RankConnections.rank` is a pure function with **11 offline unit tests**.
- **intake** gains `--rank-workbook-id` / `--rank-twb`: on the ambiguous branch it **auto-resolves a unique type+host match** (writes `connection.json`, `resolved_via=auto-rank`), else writes a **ranked** candidate list with a clear top pick and still asks. The hook is guarded on `rank-connections.rb` existing, so the shared front door stays generic — non-tableau plugins' intake is unchanged (flags no-op → plain ASK).

## Validation
- Real **"High Risk Bets.twb"** fingerprints `snowflake` / `the field customer.us-east-1.snowflakecomputing.com` / `DWSPORTSBOOK` — exactly what the agent derived by hand.
- Offline: intake auto-picked **"Snowflake Prod"** from an ambiguous 4-connection fixture (exact host match), `resolved_via=auto-rank`.
- `check-shared.rb`: 373 copies match canonical, 0 drift. Existing intake test + 11/11 rank tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
