### PR TITLE
tableau: Windows/portability hardening — put-layout auth, stale-PAT preflight, F5 lint (single-source + widened)

### DIFF
--- a/.githooks/run-governance-checks.sh
+++ b/.githooks/run-governance-checks.sh
@@ -21,6 +21,7 @@ fail=0
 ruby tools/check-shared.rb || fail=1
 ruby tools/lint-skills.rb   || fail=1
 [ -f tools/lint-esm-imports.rb ] && { ruby tools/lint-esm-imports.rb || fail=1; }
+[ -f tools/lint-twb-encoding.rb ] && { ruby tools/lint-twb-encoding.rb || fail=1; }
 [ -f tools/check-agent-variants.rb ] && { ruby tools/check-agent-variants.rb || fail=1; }
 if [ "$fail" -ne 0 ]; then
   echo "" >&2

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -208,6 +208,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-sql-quoting.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sql-ident-check.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-quarantine.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
@@ -231,17 +232,7 @@ jobs:
         # runner (US-ASCII) it raises Encoding::CompatibilityError on any non-ASCII
         # .twb/XML — which has silently crashed migrations 3+ times. Any read of a
         # .twb / xml / layout file MUST pass `encoding: 'UTF-8'`.
-        run: |
-          set -uo pipefail
-          hits=$(grep -rnE "File\.read\(([^)]*\b(twb|INP|disc_log)\b[^)]*)\)" \
-                   plugins/tableau-to-sigma/skills/*/scripts/*.rb 2>/dev/null \
-                   | grep -v "encoding:" | grep -viE "JSON\.parse|\.json|\.rb'|File\.write" || true)
-          if [ -n "$hits" ]; then
-            echo "::error::File.read on a .twb without encoding: 'UTF-8' (F5 crash class):"
-            echo "$hits"
-            exit 1
-          fi
-          echo "OK: no unencoded .twb/XML File.read sites."
+        run: ruby tools/lint-twb-encoding.rb   # single source of truth (plugins/ + shared/); also run by .githooks/run-governance-checks.sh
       - name: Run offline test_*.py suites
         # EXPLICIT allow-list — creds-free, network-free Python tests only.
         # PyYAML is needed by the looker offline dashboard parser

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -429,6 +429,32 @@ if _tab_needed && !_tab_creds_ok && _tab_skip && !_tab_skip.to_s.empty?
   Offramp.log(WORK, kind: 'tableau-gate-waived', reason: _tab_skip.to_s)
 end
 
+# ── Stale-PAT preflight (single, non-retrying live sign-in) ──────────────────
+# The presence gate above proves creds EXIST; it does not prove the PAT WORKS. A
+# revoked/expired/mistyped PAT otherwise fails deep in discovery after work is
+# done — and Tableau LOCKS a PAT after 4 consecutive FAILED sign-ins. Validate it
+# ONCE here (a SUCCESSFUL sign-in does NOT count toward lockout, so a healthy PAT
+# costs ~1s and warms the token discovery reuses). No retry: on failure we abort
+# clean at Step 0 with the regenerate message rather than hammering toward lockout.
+# Only on the fresh-PAT discovery path, and skippable with SIGMA_SKIP_CRED_SMOKE
+# (the same switch the doctor honors) for offline tests / air-gapped setups.
+if _tab_needed && _tab_creds_ok && !_tab_via_mcp && ENV['SIGMA_SKIP_CRED_SMOKE'].to_s.empty?
+  begin
+    Tableau.refresh_token!   # one live PAT sign-in; raises Tableau::Error on 401 / bad config
+    puts '  [preflight] Tableau PAT sign-in OK — token minted.'
+  rescue Tableau::Error => e
+    Offramp.log(WORK, kind: 'tableau-pat-preflight-failed', reason: e.message.lines.first.to_s.strip) rescue nil
+    abort <<~MSG
+      FATAL: Tableau PAT sign-in failed at preflight — #{e.message.lines.first.to_s.strip}
+      The personal access token is invalid / expired / revoked, or the site is wrong.
+      Regenerate the PAT (Tableau → My Account Settings → Personal Access Tokens),
+      re-run scripts/setup-tableau.rb, or fix TABLEAU_SITE_CONTENT_URL / TABLEAU_SERVER_URL.
+      Validated ONCE on purpose: a bad PAT locks after 4 failed sign-ins, so we do NOT
+      retry. (Waive the preflight: SIGMA_SKIP_CRED_SMOKE="<reason>".)
+    MSG
+  end
+end
+
 # ── Design-consistency advisory readout (doctor.json) ────────────────────────
 # The hard gate above proves the environment passed; these two are the silent
 # DESIGN-variance killers the gate does not block on — surface them at every

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/put-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/put-layout.rb
@@ -48,18 +48,41 @@ end.parse!
 abort('missing --workbook') unless opts[:wb]
 abort('missing --layout') unless opts[:layout] || opts[:apply_pivot_totals]
 
-BASE = ENV.fetch('SIGMA_BASE_URL')
-TOK  = ENV.fetch('SIGMA_API_TOKEN')
+# Read the Sigma token the shell-neutral way every sibling script uses (post-and-
+# readback.rb etc.): lib/sigma_rest loads <WORK>/auth.json (get_token.py's handoff)
+# at require time — keyed on SIGMA_WORKDIR then cwd — sets SIGMA_BASE_URL from it,
+# and self-mints/refreshes via client_credentials. This replaces the old
+# ENV.fetch('SIGMA_API_TOKEN') that KeyError-crashed at load when the token lived
+# only in auth.json (field-caught: put-layout forced a manual token-export + a
+# Git-Bash /c/ path failure). Honor this script's --workdir / --layout dir as
+# <WORK> so a standalone run finds auth.json even when launched elsewhere; explicit
+# env always wins. MUST set SIGMA_WORKDIR before the require (bootstrap runs then).
+ENV['SIGMA_WORKDIR'] ||= opts[:workdir] ||
+                         (opts[:layout] && File.dirname(File.expand_path(opts[:layout])))
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+BASE = ENV.fetch('SIGMA_BASE_URL') # sigma_rest fills this from auth.json when unset
 
 def http(method, path, body = nil)
-  uri = URI("#{BASE}#{path}")
-  req = case method
-        when :get then Net::HTTP::Get.new(uri)
-        when :put then r = Net::HTTP::Put.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
-        end
-  req['Authorization'] = "Bearer #{TOK}"
-  req['Accept']        = 'application/json'
-  Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = case method
+          when :get then Net::HTTP::Get.new(uri)
+          when :put then r = Net::HTTP::Put.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
+          end
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept']        = 'application/json'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      warn '  [auth] Sigma token expired mid-run — refreshing and retrying...'
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
 end
 
 spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
@@ -89,10 +89,20 @@ Dir.mktmpdir do |home|
     check(!out.include?('no Tableau credentials resolvable'), 'reused discovery (stamp present) skips the Tableau gate', fails)
     File.delete(File.join(work, 'discovery-stamp.json'))
 
-    # (7) Tableau PAT present in env => Tableau gate passes.
+    # (7) Tableau PAT present in env => Tableau gate passes. SIGMA_SKIP_CRED_SMOKE
+    #     bypasses the new live sign-in preflight so this stays a pure presence-gate test.
+    code, out = run_no_creds(MT, home, work,
+                             sigma.merge('TABLEAU_PAT_NAME' => 'pat', 'TABLEAU_PAT_SECRET' => 'sec',
+                                         'SIGMA_SKIP_CRED_SMOKE' => 'offline-test'))
+    check(!out.include?('no Tableau credentials resolvable'), 'env Tableau PAT satisfies the gate', fails)
+
+    # (8) PAT present but NO server/site and NO skip => stale-PAT preflight fires and
+    #     aborts. refresh_token! raises 'TABLEAU_SITE_CONTENT_URL not set' before any
+    #     socket, so this is fully offline (no network, no lockout risk).
     code, out = run_no_creds(MT, home, work,
                              sigma.merge('TABLEAU_PAT_NAME' => 'pat', 'TABLEAU_PAT_SECRET' => 'sec'))
-    check(!out.include?('no Tableau credentials resolvable'), 'env Tableau PAT satisfies the gate', fails)
+    check(out.include?('sign-in failed at preflight'),
+          'misconfigured/stale PAT aborts at the single-attempt preflight (no retry)', fails)
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
@@ -23,7 +23,12 @@ def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}
 # Run with a hard timeout+kill: cases that PASS the cred gate proceed toward
 # discovery (network) and must not hang the test — we only need the early output
 # to confirm the cred abort did/didn't fire.
-def run_no_creds(mt, home, work, extra_env = {}, timeout: 20)
+# NB: extra_env is a plain trailing positional hash (NOT a keyword param). A `timeout:`
+# keyword here would make Ruby 3 route callers' inline `'KEY' => val` hashes to keywords
+# → "unknown keyword" (green on Ruby 2.6's old coercion, red on CI's Ruby 3). Keep it
+# positional so `run_no_creds(mt, home, work, 'K' => 'v')` works on both.
+def run_no_creds(mt, home, work, extra_env = {})
+  timeout = 20
   env = {
     'HOME' => home, 'SIGMA_SKIP_DOCTOR_GATE' => 'test',
     'SIGMA_API_TOKEN' => nil, 'SIGMA_CLIENT_ID' => nil,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-put-layout-auth.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-put-layout-auth.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Offline test (bead tt3z.14): put-layout.rb must read the Sigma token from
+# <WORK>/auth.json via lib/sigma_rest — NOT ENV.fetch('SIGMA_API_TOKEN') — so it
+# no longer KeyError-crashes at load when the token lives only in auth.json (the
+# field-caught friction that forced a manual token-export + a /c/ path failure).
+# Loopback WEBrick over http:// (put-layout's http helper now derives TLS from the
+# URL scheme), no creds, no network.
+require 'webrick'
+require 'json'
+require 'tmpdir'
+require 'open3'
+
+$fail = 0
+def ok(desc); r = yield; puts "#{r ? '  ok  ' : ' FAIL '} #{desc}"; $fail += 1 unless r; end
+
+SCRIPT = File.expand_path('put-layout.rb', __dir__)
+
+Dir.mktmpdir do |work|
+  captured = { get_auth: nil, saw_put: false }
+  srv = WEBrick::HTTPServer.new(Port: 0, BindAddress: '127.0.0.1',
+                                Logger: WEBrick::Log.new(File::NULL), AccessLog: [])
+  port = srv.config[:Port]
+  srv.mount_proc('/') do |req, res|
+    if req.request_method == 'GET'
+      captured[:get_auth] ||= req['authorization']
+      res.body = { 'pages' => [{ 'id' => 'p1', 'name' => 'P', 'elements' => [] }] }.to_json
+    else # PUT
+      captured[:saw_put] = true
+      res.body = { 'workbookId' => 'wb-test' }.to_json
+    end
+    res['Content-Type'] = 'application/json'
+    res.status = 200
+  end
+  th = Thread.new { srv.start }
+
+  File.write(File.join(work, 'auth.json'),
+             { 'SIGMA_API_TOKEN' => 'filetok', 'SIGMA_BASE_URL' => "http://127.0.0.1:#{port}" }.to_json)
+  layout = File.join(work, 'layout.xml')
+  File.write(layout, "<Layout><Zone/></Layout>", encoding: 'UTF-8')
+
+  # Scrub the env AND redirect HOME so sigma_rest's ~/.sigma-migration/env neutral
+  # bootstrap (real creds on a dev box) can't leak in — the token+base must come
+  # ONLY from <WORK>/auth.json.
+  scrub = { 'SIGMA_API_TOKEN' => nil, 'SIGMA_BASE_URL' => nil,
+            'SIGMA_CLIENT_ID' => nil, 'SIGMA_CLIENT_SECRET' => nil, 'HOME' => work }
+
+  # (1) token in auth.json only — must load it, PUT, exit 0
+  out1, st1 = Open3.capture2e(scrub.merge('SIGMA_WORKDIR' => work),
+                              'ruby', SCRIPT, '--workbook', 'wb-test', '--layout', layout)
+  ok('exit 0 with token only in auth.json (no KeyError at load)') { st1.exitstatus == 0 }
+  ok('GET carried "Bearer filetok" — token came from auth.json, not ENV') { captured[:get_auth] == 'Bearer filetok' }
+  ok('reached the PUT (full flow)') { captured[:saw_put] }
+  puts out1 unless st1.exitstatus == 0
+
+  # (2) no token anywhere (no auth.json, no env, no client creds) — must fail LOUD, not silently pass
+  Dir.mktmpdir do |empty|
+    layout2 = File.join(empty, 'layout.xml'); File.write(layout2, "<Layout/>", encoding: 'UTF-8')
+    _o2, st2 = Open3.capture2e(scrub.merge('SIGMA_WORKDIR' => empty, 'HOME' => empty),
+                               'ruby', SCRIPT, '--workbook', 'wb-test', '--layout', layout2)
+    ok('no token anywhere → non-zero exit (fail-loud, never silent-pass)') { st2.exitstatus != 0 }
+  end
+
+  srv.shutdown
+  th.join
+end
+
+puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/tools/lint-twb-encoding.rb
+++ b/tools/lint-twb-encoding.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# lint-twb-encoding.rb — F5 crash-class gate (beads tt3z.24 + tt3z.17).
+#
+# `File.read(path)` uses the locale's default external encoding; on a US-ASCII CI
+# runner (and on Windows) it raises Encoding::CompatibilityError the moment the
+# file holds a non-ASCII byte — which has silently crashed migrations 3+ times on
+# real .twb/XML/layout content ("F5 crash class"). Any read of a .twb / xml /
+# layout file MUST pass `encoding: 'UTF-8'`.
+#
+# This is the single source of truth for that gate: CI (corpus-check.yml) and the
+# local pre-push hook (.githooks/run-governance-checks.sh) both call it, so the
+# regex can't drift between them. Scans BOTH `plugins/` and `shared/` — the old
+# inline CI grep only scanned plugins/tableau-to-sigma, so a #388-class unencoded
+# read in shared/ or another plugin was invisible until it hit a non-ASCII file.
+#
+# Exit 0 = clean; exit 1 = at least one unencoded .twb/XML read (prints each site).
+# Faithful port of the former inline grep pipeline:
+#   grep -rnE "File\.read\(([^)]*\b(twb|INP|disc_log)\b[^)]*)\)"  (case-sensitive)
+#     | grep -v "encoding:"                                       (case-sensitive)
+#     | grep -viE "JSON\.parse|\.json|\.rb'|File\.write"          (case-insensitive)
+
+ROOT = File.expand_path('..', __dir__)
+Dir.chdir(ROOT)
+
+# File.read(...) whose argument mentions a .twb-ish path token. Matches `twb` as a
+# whole word AND as an identifier suffix (`rank_twb`, `wb_twb`) — the CI grep's
+# `\btwb\b` silently skipped the `_twb` suffix form, which is exactly how half of
+# the #388 unencoded read (opts[:rank_twb]) slipped past the gate.
+TOKEN     = /File\.read\(([^)]*(?:\btwb\b|_twb\b|\bINP\b|\bdisc_log\b)[^)]*)\)/
+# Already-safe or not-a-.twb reads to skip (case-insensitive, mirrors grep -vi).
+EXCLUDE   = /JSON\.parse|\.json|\.rb'|File\.write/i
+
+hits = []
+%w[plugins shared].each do |dir|
+  next unless Dir.exist?(dir)
+  Dir.glob(File.join(dir, '**', '*.rb')).sort.each do |f|
+    File.foreach(f, encoding: 'UTF-8').with_index(1) do |line, n|
+      next unless line =~ TOKEN
+      next if line.include?('encoding:')   # already sets an encoding — safe
+      next if line =~ EXCLUDE
+      hits << "#{f}:#{n}: #{line.strip}"
+    end
+  end
+end
+
+if hits.empty?
+  puts 'OK: no unencoded .twb/XML File.read sites (plugins/ + shared/).'
+  exit 0
+end
+
+warn "::error::File.read on a .twb without encoding: 'UTF-8' (F5 crash class):"
+hits.each { |h| warn "  #{h}" }
+warn ''
+warn "Fix: add `encoding: 'UTF-8'` — e.g. File.read(path, encoding: 'UTF-8')."
+exit 1


### PR DESCRIPTION
Three cohesive Windows/portability fixes from the the field customer field run (beads tt3z.14 / tt3z.18 / tt3z.17+.24). All **non-shared** files; governance hook + F5 lint green.

### tt3z.14 — put-layout.rb reads the token from `auth.json` (not ENV)
`put-layout.rb` did `ENV.fetch('SIGMA_API_TOKEN')` and **KeyError-crashed at load** when the token lived only in `<WORK>/auth.json` — the friction that forced a manual token-export dance + a Git-Bash `/c/` path failure at layout time (L1323–1352). Now it requires `lib/sigma_rest` (auth.json bootstrap + `client_credentials` self-mint + 401-refresh), exactly like `post-and-readback.rb`. `http()` also derives TLS from the URL scheme. Test: `test-put-layout-auth.rb` (WEBrick loopback — token-from-auth.json + fail-loud when no token anywhere).

### tt3z.18 — stale-PAT preflight
One **non-retrying** live PAT sign-in right after the credential-presence gate. A revoked/expired PAT otherwise fails deep in discovery, and Tableau **locks a PAT after 4 failed sign-ins** — so a bad PAT now aborts clean at Step 0 with the regenerate message (a *successful* sign-in doesn't count toward lockout and warms the token discovery reuses). Skippable via `SIGMA_SKIP_CRED_SMOKE`. Tests: `test-cred-gate.rb` case 7 (skip) + new case 8 (preflight fires, fully offline). Added to the CI unit-test allowlist.
> Live-E2E (good-PAT proceeds / bad-PAT aborts) verified during the next live migration run.

### tt3z.17 + tt3z.24 — F5 encoding lint: single source of truth + widened
Extracted the "`File.read` on a `.twb` without `encoding: 'UTF-8'`" lint into **`tools/lint-twb-encoding.rb`**, now called by BOTH CI and the local pre-push hook (no regex drift). **Widened** from tableau-only to `plugins/` + `shared/`, and **broadened** to catch the `_twb` suffix form (`rank_twb`) the old grep silently skipped — the exact site that slipped through in #388. Parity-verified against the old grep; 0 hits on the clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
