### PR TITLE
tableau: orchestrator robustness — null-DM-element false-handoff fix (.19) + opt-in --fast (.23)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -209,6 +209,8 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sql-ident-check.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-quarantine.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fast-flag.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -222,6 +222,11 @@ OptionParser.new do |o|
   o.on('--skip-dashboard-read REASON', 'waive the Phase 1d source dashboard-read gate — REQUIRED reason; name it in your report') { |v| opts[:skip_dashboard_read] = v }
   o.on('--skip-doctor-gate REASON', 'waive the Step-0 environment gate (doctor.json) — REQUIRED reason; name it in your report') { |v| opts[:skip_doctor_gate] = v }
   o.on('--skip-ref-check REASON', 'waive the pre-POST workbook ref-resolution gate — REQUIRED reason; name it in your report') { |v| opts[:skip_ref_check] = v }
+  o.on('--fast REASON', 'TRUSTED table/pivot-only fast path (opt-in, OFF by default): at --finalize, waive the ' \
+                        'Phase-6f visual render gate (8) + recorded visual comparison (8b) with REASON — for a ' \
+                        'workbook whose elements are detail tables / pivots with no charts, so no PNG render or ' \
+                        'side-by-side is needed. Recorded as a quality waiver (counts toward the >2 budget cap). ' \
+                        'Do NOT use for chart-bearing dashboards.') { |v| opts[:fast] = v }
   o.on('--skip-extract-landing REASON', 'proceed although every datasource is an embedded file extract and no ' \
                                         'landing manifest was found (exit 17 otherwise) — you own the DM table paths') { |v| opts[:skip_extract_landing] = v }
   o.on('--no-auto-land', 'keep the manual extract-landing gate (exit 17) instead of auto-running land-extracts.py ' \
@@ -820,7 +825,11 @@ if opts[:finalize]
   # render that exists. The agent records the verdict with record-visual-check.rb
   # after the Phase 6f side-by-side read (see SKILL.md); without it the gate
   # exits 13. tableau-to-sigma is the reference adopter of this opt-in gate.
-  gate += ['--require-visual-comparison']
+  # --fast (opt-in, trusted table/pivot-only workbooks): waive the two VISUAL gates
+  # (8 render + 8b recorded comparison) with the operator's recorded reason, and do
+  # NOT require the comparison. OFF by default — this trades visual QA and violates
+  # the "never declare done on HTTP 200" contract, so it is never implicit.
+  gate += ['--require-visual-comparison'] unless opts[:fast]
   # Phase 5g — require the RCF fidelity ledger (gate 8d) unless the loop was
   # explicitly disabled at pass 1 (--rcf-passes 0). Legacy state (pre-5g) has no
   # rcf_passes key → default to requiring it, since the ledger is the new bar.
@@ -832,6 +841,9 @@ if opts[:finalize]
   # Gate 11 (post-publish interactivity guide) waiver pass-through — the gate
   # itself decides whether the source's actions require POSTPUBLISH_GUIDE.md.
   gate += ['--skip-postpublish-guide', opts[:skip_postpublish_guide]] if opts[:skip_postpublish_guide]
+  # --fast: stamp the two visual-gate waivers with the operator's reason (recorded
+  # in parity-final.json's waivers[] and counted toward the >2-waiver budget cap).
+  gate += ['--skip-visual-gate', opts[:fast], '--skip-visual-comparison', opts[:fast]] if opts[:fast]
   _, gst = sigma_run!(gate, allow_fail: true)
   mark('assert-phase6-ran')
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fast-flag.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fast-flag.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+# Wiring/drift test (bead tt3z.23): the opt-in --fast flag must, at --finalize,
+# waive the two VISUAL gates and NOT require the recorded comparison. This is a
+# deterministic source-structure guard (network-free, creds-free) — it proves the
+# flag is defined and wired into the assert-phase6-ran gate array exactly as
+# intended, so a future refactor can't silently drop the opt-in or, worse, make it
+# implicit. Behavioral end-to-end is covered by a live pivot-only migration run.
+require 'set'
+MT = File.read(File.join(__dir__, 'migrate-tableau.rb'), encoding: 'UTF-8')
+$fail = 0
+def ok(d); r = yield; puts "#{r ? '  ok  ' : ' FAIL '} #{d}"; $fail += 1 unless r; end
+
+ok('--fast REASON option is defined and sets opts[:fast]') do
+  MT =~ /o\.on\('--fast REASON'.*\)\s*\{\s*\|v\|\s*opts\[:fast\]\s*=\s*v\s*\}/m
+end
+ok('--fast REASON is mandatory (REASON arg → recorded reason, not a bare flag)') do
+  MT.include?("o.on('--fast REASON'")
+end
+ok('--require-visual-comparison (gate 8b) is SUPPRESSED under --fast') do
+  MT =~ /gate \+= \['--require-visual-comparison'\]\s+unless opts\[:fast\]/
+end
+ok('--fast appends BOTH visual waivers with the operator reason') do
+  MT =~ /gate \+= \['--skip-visual-gate', opts\[:fast\], '--skip-visual-comparison', opts\[:fast\]\] if opts\[:fast\]/
+end
+ok('the waiver append lands BEFORE the gate actually runs (sigma_run!)') do
+  wi = MT.index("--skip-visual-gate', opts[:fast]")
+  ri = MT.index('_, gst = sigma_run!(gate')
+  wi && ri && wi < ri
+end
+ok('OFF by default: no code path sets opts[:fast] without the flag') do
+  # opts[:fast] is only ever ASSIGNED in the --fast option block (never defaulted truthy)
+  MT.scan(/opts\[:fast\]\s*=/).length == 1
+end
+# Downstream contract: assert-phase6-ran.rb actually accepts the two waivers --fast passes.
+GATE = File.read(File.join(__dir__, 'assert-phase6-ran.rb'), encoding: 'UTF-8')
+ok('assert-phase6-ran.rb accepts --skip-visual-gate (gate 8 escape)') { GATE.include?('--skip-visual-gate') }
+ok('assert-phase6-ran.rb accepts --skip-visual-comparison (gate 8b escape)') { GATE.include?('--skip-visual-comparison') }
+
+puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
@@ -138,8 +138,32 @@ check(out.include?('schemaVersion'), 'names the missing schemaVersion', fails)
 check(out =~ /pages\[0\] has no "id"/, 'names the missing page id', fails)
 check(out.include?('needs source.kind "data-model"'), 'catches table-kind-with-dataModelId misbinding', fails)
 
+puts
+puts 'Part G — --dm-context with null element names must NOT false-abort (reused-DM handoff bug)'
+def validate_dm_ctx(wb, ctx)
+  wf = Tempfile.new(['g-wb-', '.json']);  wf.write(JSON.generate(wb));   wf.close
+  cf = Tempfile.new(['g-ctx-', '.json']); cf.write(JSON.generate(ctx)); cf.close
+  out, err, st = Open3.capture3('ruby', VALIDATE, '--type', 'workbook', '--dm-context', cf.path, wf.path)
+  wf.unlink; cf.unlink
+  [out + err, st.exitstatus]
+end
+# A DM-sourced master whose refs use the SQL element's own [Custom SQL/COL] prefix.
+wb = { 'schemaVersion' => 1, 'name' => 'g', 'folderId' => 'f',
+       'pages' => [{ 'id' => 'p1', 'name' => 'P', 'elements' => [
+         { 'id' => 'master', 'kind' => 'table', 'name' => 'Master',
+           'source' => { 'kind' => 'data-model', 'dataModelId' => 'dm-x', 'elementId' => 'J9ADKnuzjR' },
+           'columns' => [{ 'id' => 'c1', 'name' => 'N', 'formula' => '[Custom SQL/N]' }] }] }] }
+# (G1) elements present but every name == null → WARN + continue (exit 0), the field fix.
+out, code = validate_dm_ctx(wb, { 'dataModelId' => 'dm-x',
+  'pages' => [{ 'id' => 'dp', 'elements' => [{ 'id' => 'J9ADKnuzjR', 'kind' => 'table', 'name' => nil }] }] })
+check(code == 0, "null-name DM element does NOT false-abort (got #{code}: #{out.lines.grep(/ERROR|0 element names/).join.strip})", fails)
+check(out.include?('all names were null'), 'emits the null-name WARN (does not silently pass)', fails)
+# (G2) genuinely EMPTY context (zero elements) → still the loud abort.
+out2, code2 = validate_dm_ctx(wb, { 'dataModelId' => 'dm-x', 'pages' => [{ 'id' => 'dp', 'elements' => [] }] })
+check(code2 != 0 && out2.include?('loaded 0 element names'), 'empty dm-context (0 elements) still aborts loudly', fails)
+
 if fails.empty?
-  puts 'OK — validate-spec ID-uniqueness + function-tier + envelope guards all pass'
+  puts 'OK — validate-spec ID-uniqueness + function-tier + envelope + null-name guards all pass'
   exit 0
 else
   warn "FAIL — #{fails.size} check(s) failed:"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-spec.rb
@@ -46,9 +46,32 @@ if opts[:type] == 'workbook' && opts[:dm_context]
     external_names.concat(ctx['elements'].map { |e| e['name'] }.compact)
   end
   if external_names.empty?
-    abort "validate-spec.rb: --dm-context loaded 0 element names from #{opts[:dm_context]}. " \
-          "Expected either {pages:[{elements:[...]}]} (post-and-readback output) or {elements:[...]} (flat). " \
-          "Re-run post-and-readback.rb --type datamodel and pass its --out file."
+    # How many elements did the context carry, regardless of name?
+    el_count = if ctx['pages'].is_a?(Array)
+                 ctx['pages'].sum { |p| p.fetch('elements', []).size }
+               elsif ctx['elements'].is_a?(Array)
+                 ctx['elements'].size
+               else
+                 0
+               end
+    if el_count.positive?
+      # Elements ARE present but every name came back null — a known DM-readback
+      # quirk (field-caught: a reused DM's element name:null produced "0 element
+      # names" here → the fast path FALSE-aborted to a manual handoff, even though
+      # running the gated scripts by hand POSTed the workbook fine). These names
+      # are only used as known prefixes for CROSS-element ref validation; a
+      # data-model-sourced master's [Custom SQL/COL] refs resolve via own_prefixes
+      # (below), and the authoritative column-level check is assert-wb-refs-
+      # resolve.rb's job (see this file's header). So WARN and continue instead of
+      # false-aborting the whole workbook build.
+      warn "WARN: validate-spec.rb --dm-context carried #{el_count} element(s) but all names were null " \
+           "(DM readback quirk) — skipping external-name prefix validation; assert-wb-refs-resolve.rb still " \
+           "checks column-level refs."
+    else
+      abort "validate-spec.rb: --dm-context loaded 0 element names from #{opts[:dm_context]}. " \
+            "Expected either {pages:[{elements:[...]}]} (post-and-readback output) or {elements:[...]} (flat). " \
+            "Re-run post-and-readback.rb --type datamodel and pass its --out file."
+    end
   end
 end
 


### PR DESCRIPTION
Two orchestrator wins from the the field customer field run (beads tt3z.19 / tt3z.23). Both non-shared; CI-gated + governance clean.

### tt3z.19 — kill the null-DM-element false handoff (~3m20s, the biggest single sink)
When a **reused** DM's readback returned elements with `name: null`, `validate-spec.rb --dm-context` loaded "0 element names" and **aborted → the fast path bailed to a manual handoff** — even though running the gated scripts by hand POSTed the workbook fine (transcript L1179–1265). Now: **elements present but all names null → WARN + continue** (external names are only cross-element-ref *prefixes*; a DM-sourced master's `[Custom SQL/COL]` resolves via `own_prefixes`, and `assert-wb-refs-resolve.rb` still does the authoritative column-level check). A genuinely **empty** context (zero elements) still aborts loudly. Test: `test-validate-spec-guards.rb` Part G.

### tt3z.23 — opt-in `--fast`
`migrate-tableau.rb --fast REASON` (OFF by default): for a **trusted table/pivot-only** workbook, waive the Phase-6f visual render gate (8) + recorded comparison (8b) with a recorded reason and don't require the comparison — skipping the ~90–120s cold render when there are no charts to eyeball. Recorded as a quality waiver (counts toward the >2 budget cap). Never implicit; not for chart-bearing dashboards. Test: `test-fast-flag.rb`.

Both tests added to the CI allowlist. **Live cold migration to verify `.19` in-flight (the reused-DM fast-path) + live-check `.18`'s PAT preflight is running next.**

### Deferred to a focused follow-up (informed by the live baseline)
`.20` render lane, `.21` in-process Phase-1d gate, `.22` result-cache priming — the intricate threading changes whose real validation is the live run; kept separate to stay reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
