### PR TITLE
tableau: Windows path-portability (.15 cygpath winpath) + zip-gem-free .twbx (.16)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -210,6 +210,8 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-quarantine.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zip-extract.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-py-resolve-winpath.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fast-flag.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/py_resolve.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/py_resolve.rb
@@ -34,6 +34,31 @@ module PyResolve
     argv.join(' ')
   end
 
+  # Convert a Git-Bash / MSYS / Cygwin POSIX path ("/c/Users/x/f.twbx", "/mnt/c/…")
+  # into a native Windows path ("C:\\Users\\x\\f.twbx") so a NATIVE Windows Python
+  # (py -3 / python.org) can open() it — the field-caught "Windows Python can't open
+  # /c/… paths" failure. Wrap EVERY filesystem-path ARG a Ruby script shells to
+  # Python. Hard no-op on macOS/Linux, on already-native paths (C:\, C:/, UNC), and
+  # on anything not starting with "/" (so flags like --out, ids, and numbers pass
+  # through untouched). Prefers `cygpath -w` (honors the real mount table) and falls
+  # back to a pure-Ruby transform when cygpath is absent (cmd/PowerShell).
+  def winpath(p)
+    s = p.to_s
+    return p unless windows?
+    return p if s.empty?
+    return p if s =~ %r{\A[A-Za-z]:[\\/]} || s.start_with?('\\\\') # already C:\ / C:/ / UNC
+    return p unless s.start_with?('/')                             # only absolute POSIX paths
+    begin
+      require 'open3'
+      out, st = Open3.capture2('cygpath', '-w', s)
+      return out.strip if st.success? && !out.strip.empty?
+    rescue StandardError
+      # cygpath not on PATH — fall through to the pure-Ruby transform.
+    end
+    m = s.match(%r{\A/(?:mnt/)?([A-Za-z])/(.*)\z})                 # /c/… or /mnt/c/…
+    m ? "#{m[1].upcase}:\\#{m[2].tr('/', '\\')}" : p
+  end
+
   def windows?
     # RbConfig is the reliable host check; ENV['OS'] is a cheap secondary signal.
     (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/i) || ENV['OS'].to_s =~ /windows/i

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/py_resolve.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/py_resolve.rb
@@ -34,6 +34,31 @@ module PyResolve
     argv.join(' ')
   end
 
+  # Convert a Git-Bash / MSYS / Cygwin POSIX path ("/c/Users/x/f.twbx", "/mnt/c/…")
+  # into a native Windows path ("C:\\Users\\x\\f.twbx") so a NATIVE Windows Python
+  # (py -3 / python.org) can open() it — the field-caught "Windows Python can't open
+  # /c/… paths" failure. Wrap EVERY filesystem-path ARG a Ruby script shells to
+  # Python. Hard no-op on macOS/Linux, on already-native paths (C:\, C:/, UNC), and
+  # on anything not starting with "/" (so flags like --out, ids, and numbers pass
+  # through untouched). Prefers `cygpath -w` (honors the real mount table) and falls
+  # back to a pure-Ruby transform when cygpath is absent (cmd/PowerShell).
+  def winpath(p)
+    s = p.to_s
+    return p unless windows?
+    return p if s.empty?
+    return p if s =~ %r{\A[A-Za-z]:[\\/]} || s.start_with?('\\\\') # already C:\ / C:/ / UNC
+    return p unless s.start_with?('/')                             # only absolute POSIX paths
+    begin
+      require 'open3'
+      out, st = Open3.capture2('cygpath', '-w', s)
+      return out.strip if st.success? && !out.strip.empty?
+    rescue StandardError
+      # cygpath not on PATH — fall through to the pure-Ruby transform.
+    end
+    m = s.match(%r{\A/(?:mnt/)?([A-Za-z])/(.*)\z})                 # /c/… or /mnt/c/…
+    m ? "#{m[1].upcase}:\\#{m[2].tr('/', '\\')}" : p
+  end
+
   def windows?
     # RbConfig is the reliable host check; ENV['OS'] is a cheap secondary signal.
     (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/i) || ENV['OS'].to_s =~ /windows/i

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/py_resolve.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/py_resolve.rb
@@ -34,6 +34,31 @@ module PyResolve
     argv.join(' ')
   end
 
+  # Convert a Git-Bash / MSYS / Cygwin POSIX path ("/c/Users/x/f.twbx", "/mnt/c/…")
+  # into a native Windows path ("C:\\Users\\x\\f.twbx") so a NATIVE Windows Python
+  # (py -3 / python.org) can open() it — the field-caught "Windows Python can't open
+  # /c/… paths" failure. Wrap EVERY filesystem-path ARG a Ruby script shells to
+  # Python. Hard no-op on macOS/Linux, on already-native paths (C:\, C:/, UNC), and
+  # on anything not starting with "/" (so flags like --out, ids, and numbers pass
+  # through untouched). Prefers `cygpath -w` (honors the real mount table) and falls
+  # back to a pure-Ruby transform when cygpath is absent (cmd/PowerShell).
+  def winpath(p)
+    s = p.to_s
+    return p unless windows?
+    return p if s.empty?
+    return p if s =~ %r{\A[A-Za-z]:[\\/]} || s.start_with?('\\\\') # already C:\ / C:/ / UNC
+    return p unless s.start_with?('/')                             # only absolute POSIX paths
+    begin
+      require 'open3'
+      out, st = Open3.capture2('cygpath', '-w', s)
+      return out.strip if st.success? && !out.strip.empty?
+    rescue StandardError
+      # cygpath not on PATH — fall through to the pure-Ruby transform.
+    end
+    m = s.match(%r{\A/(?:mnt/)?([A-Za-z])/(.*)\z})                 # /c/… or /mnt/c/…
+    m ? "#{m[1].upcase}:\\#{m[2].tr('/', '\\')}" : p
+  end
+
   def windows?
     # RbConfig is the reliable host check; ENV['OS'] is a cheap secondary signal.
     (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/i) || ENV['OS'].to_s =~ /windows/i

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -5901,8 +5901,9 @@ unless opts[:pages_mode] == :worksheet
     return nil unless twbx && zip_path
     dest = File.join(assets_dir, File.basename(zip_path))
     unless File.exist?(dest)
-      data, st = Open3.capture2('unzip', '-p', twbx, zip_path)
-      return nil unless st.success? && !data.empty?
+      require_relative 'lib/zip_extract' # stdlib Zlib reader — no shelled unzip binary (Windows-safe)
+      data = ZipExtract.read(twbx, zip_path)
+      return nil unless data && !data.empty?
       require 'fileutils'
       FileUtils.mkdir_p(assets_dir)
       File.binwrite(dest, data)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
@@ -262,8 +262,8 @@ when 'render'
   out_png = File.join(opts[:dir], "rcf-pass-#{n}.png")
   renderer = File.join(HERE, 'sigma-export-png.py')
   require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
-  cmd_r = [*PyResolve.argv, renderer, '--workbook', ledger['workbook_id'],
-           '--page', ledger['page_id'], '--out', out_png,
+  cmd_r = [*PyResolve.argv, PyResolve.winpath(renderer), '--workbook', ledger['workbook_id'],
+           '--page', ledger['page_id'], '--out', PyResolve.winpath(out_png),
            '--w', opts[:width].to_s, '--h', opts[:height].to_s]
   ok = system(*cmd_r)
   unless ok && File.exist?(out_png) && File.size(out_png) > 5_000

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/py_resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/py_resolve.rb
@@ -34,6 +34,31 @@ module PyResolve
     argv.join(' ')
   end
 
+  # Convert a Git-Bash / MSYS / Cygwin POSIX path ("/c/Users/x/f.twbx", "/mnt/c/…")
+  # into a native Windows path ("C:\\Users\\x\\f.twbx") so a NATIVE Windows Python
+  # (py -3 / python.org) can open() it — the field-caught "Windows Python can't open
+  # /c/… paths" failure. Wrap EVERY filesystem-path ARG a Ruby script shells to
+  # Python. Hard no-op on macOS/Linux, on already-native paths (C:\, C:/, UNC), and
+  # on anything not starting with "/" (so flags like --out, ids, and numbers pass
+  # through untouched). Prefers `cygpath -w` (honors the real mount table) and falls
+  # back to a pure-Ruby transform when cygpath is absent (cmd/PowerShell).
+  def winpath(p)
+    s = p.to_s
+    return p unless windows?
+    return p if s.empty?
+    return p if s =~ %r{\A[A-Za-z]:[\\/]} || s.start_with?('\\\\') # already C:\ / C:/ / UNC
+    return p unless s.start_with?('/')                             # only absolute POSIX paths
+    begin
+      require 'open3'
+      out, st = Open3.capture2('cygpath', '-w', s)
+      return out.strip if st.success? && !out.strip.empty?
+    rescue StandardError
+      # cygpath not on PATH — fall through to the pure-Ruby transform.
+    end
+    m = s.match(%r{\A/(?:mnt/)?([A-Za-z])/(.*)\z})                 # /c/… or /mnt/c/…
+    m ? "#{m[1].upcase}:\\#{m[2].tr('/', '\\')}" : p
+  end
+
   def windows?
     # RbConfig is the reliable host check; ENV['OS'] is a cheap secondary signal.
     (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/i) || ENV['OS'].to_s =~ /windows/i

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/zip_extract.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/zip_extract.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+#
+# zip_extract.rb — dependency-free ZIP reader for .twbx (and other zip) members.
+#
+# Why: reading a .twbx (a ZIP of the inner .twb + embedded .hyper extract) via the
+# `rubyzip` gem crashes on stock RubyInstaller with "cannot load such file -- zip"
+# (field-caught), and shelling to `unzip`/python adds interpreter + PATH footguns.
+# Ruby ships `zlib` in every MRI build, so this parses the ZIP central directory and
+# inflates members with Zlib alone — no gems, no external binaries, no Python.
+#
+# It reads ONE named member at a time (entries → read), so discovery can inflate the
+# small inner .twb and derive the .hyper presence from the NAME list WITHOUT ever
+# inflating the multi-GB .hyper into a Ruby String. ZIP64-aware (extract-backed
+# .twbx with a >4GB .hyper or >65535 members is written as ZIP64).
+require 'zlib'
+
+module ZipExtract
+  module_function
+
+  EOCD_SIG    = "PK\x05\x06".b
+  EOCD64_SIG  = "PK\x06\x06".b
+  LOC64_SIG   = "PK\x06\x07".b
+  CEN_SIG     = "PK\x01\x02".b
+  U32_MAX     = 0xFFFFFFFF
+  U16_MAX     = 0xFFFF
+
+  # All member names (central-directory walk; no inflation). ZIP64-aware.
+  def entries(path)
+    central(File.binread(path)).map { |e| e[:name] }
+  end
+
+  # Inflate/copy exactly ONE member by name; nil if absent.
+  def read(path, name)
+    buf = File.binread(path)
+    e = central(buf).find { |x| x[:name] == name }
+    e && member_bytes(buf, e)
+  end
+
+  # Extract every member under dest (skips directory entries). Convenience for
+  # callers that genuinely need the whole tree; prefer read() for a single member.
+  def extract_all(path, dest)
+    require 'fileutils'
+    buf = File.binread(path)
+    central(buf).each do |e|
+      next if e[:name].end_with?('/')
+      out = File.join(dest, e[:name])
+      FileUtils.mkdir_p(File.dirname(out))
+      File.binwrite(out, member_bytes(buf, e))
+    end
+  end
+
+  # ── internals ─────────────────────────────────────────────────────────────
+
+  # Locate the End Of Central Directory record (scan back over any trailing comment).
+  def eocd_index(buf)
+    i = buf.rindex(EOCD_SIG) or raise "not a zip (no EOCD): truncated or wrong file"
+    i
+  end
+
+  # Return [cd_offset, total_entries], resolving ZIP64 when the classic fields are
+  # saturated (0xFFFFFFFF / 0xFFFF).
+  def cd_locate(buf)
+    e = eocd_index(buf)
+    total     = buf[e + 10, 2].unpack1('v')
+    cd_offset = buf[e + 16, 4].unpack1('V')
+    return [cd_offset, total] unless cd_offset == U32_MAX || total == U16_MAX
+    # ZIP64: the locator (PK\x06\x07) sits 20 bytes before the classic EOCD.
+    loc = buf.rindex(LOC64_SIG, e) or raise 'zip64 EOCD locator missing'
+    z64 = buf[loc + 8, 8].unpack1('Q<')            # offset of the ZIP64 EOCD record
+    raise 'zip64 EOCD record missing' unless buf[z64, 4] == EOCD64_SIG
+    [buf[z64 + 48, 8].unpack1('Q<'), buf[z64 + 32, 8].unpack1('Q<')]  # cd_offset, total
+  end
+
+  # Walk the central directory → [{name, method, csize, lho}, ...].
+  def central(buf)
+    cd_offset, total = cd_locate(buf)
+    out = []
+    p = cd_offset
+    total.times do
+      raise 'corrupt central directory' unless buf[p, 4] == CEN_SIG
+      method   = buf[p + 10, 2].unpack1('v')
+      csize    = buf[p + 20, 4].unpack1('V')
+      nlen     = buf[p + 28, 2].unpack1('v')
+      elen     = buf[p + 30, 2].unpack1('v')
+      clen     = buf[p + 32, 2].unpack1('v')
+      lho      = buf[p + 42, 4].unpack1('V')
+      name     = buf[p + 46, nlen]
+      extra    = buf[p + 46 + nlen, elen]
+      if csize == U32_MAX || lho == U32_MAX
+        usize32 = buf[p + 24, 4].unpack1('V')
+        csize, lho = zip64_extra(extra, usize32, csize, lho)
+      end
+      out << { name: name, method: method, csize: csize, lho: lho }
+      p += 46 + nlen + elen + clen
+    end
+    out
+  end
+
+  # Parse the 0x0001 ZIP64 extra field. Values appear IN ORDER only for the fields
+  # whose classic slot was saturated: uncompressed, compressed, local-header-offset,
+  # disk. Returns the resolved [csize, lho].
+  def zip64_extra(extra, usize32, csize, lho)
+    i = 0
+    while i + 4 <= extra.bytesize
+      id  = extra[i, 2].unpack1('v')
+      len = extra[i + 2, 2].unpack1('v')
+      if id == 0x0001
+        body = extra[i + 4, len]
+        j = 0
+        j += 8 if usize32 == U32_MAX                       # skip uncompressed size
+        if csize == U32_MAX then csize = body[j, 8].unpack1('Q<'); j += 8 end
+        if lho   == U32_MAX then lho   = body[j, 8].unpack1('Q<'); j += 8 end
+        break
+      end
+      i += 4 + len
+    end
+    [csize, lho]
+  end
+
+  # Bytes of one member: re-derive the data start from the LOCAL header (its
+  # name/extra lengths can differ from the central copy), then inflate (method 8)
+  # or copy (method 0).
+  def member_bytes(buf, e)
+    lho = e[:lho]
+    raise "bad local header @#{lho}" unless buf[lho, 4] == "PK\x03\x04".b
+    lnlen = buf[lho + 26, 2].unpack1('v')
+    lelen = buf[lho + 28, 2].unpack1('v')
+    data  = buf[lho + 30 + lnlen + lelen, e[:csize]]
+    case e[:method]
+    when 0 then data                                    # stored
+    when 8 then Zlib::Inflate.new(-Zlib::MAX_WBITS).inflate(data)  # raw deflate
+    else raise "unsupported zip compression method #{e[:method]}"
+    end
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -791,7 +791,7 @@ module MechanicalSpecs
     raw_text  = File.join(workdir, 'conv-hosted-out.json')
     meta_out  = File.join(workdir, 'conv-meta.json')
     File.write(args_file, JSON.pretty_generate(args))
-    o, e, st = Open3.capture3(*PyResolve.argv, client, 'convert_tableau_to_sigma', args_file, raw_text)
+    o, e, st = Open3.capture3(*PyResolve.argv, PyResolve.winpath(client), 'convert_tableau_to_sigma', PyResolve.winpath(args_file), PyResolve.winpath(raw_text))
     raise "hosted converter failed (sigma-data-model-mcp.onrender.com): #{e}#{o}" unless st.success?
     out = JSON.parse(File.read(raw_text))
     bare = out['model'] || out['sigmaDataModel'] || out

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1664,11 +1664,11 @@ if mechanical
         prefix = wb_luid ? "#{slug}_#{wb_luid.to_s.delete('-')[0, 6].upcase}" : slug
         line "embedded-extract sources (#{conn_classes.join(', ')}) — AUTO-LANDING the frozen extract " \
              "(prefix #{prefix}; --no-auto-land to keep the manual gate)"
-        _o, lst = run!([*PyResolve.argv, File.join(HERE, 'land-extracts.py'),
-                        '--twbx', twbx_payload,
+        _o, lst = run!([*PyResolve.argv, PyResolve.winpath(File.join(HERE, 'land-extracts.py')),
+                        '--twbx', PyResolve.winpath(twbx_payload),
                         '--db', (opts[:db] || 'CSA'), '--schema', (opts[:schema] || 'TJ'),
                         '--prefix', prefix, '--sigma-connection-id', opts[:conn],
-                        '--manifest-out', File.join(WORK, 'landing-manifest.json')],
+                        '--manifest-out', PyResolve.winpath(File.join(WORK, 'landing-manifest.json'))],
                        allow_fail: true)
         mani_p = File.join(WORK, 'landing-manifest.json')
         # Parse the manifest INDEPENDENTLY of the exit status — a nonzero exit
@@ -3367,8 +3367,8 @@ Array.new([3, content_pages.size].min.clamp(1, 3)) do
       end
       out = File.join(vqa, "#{pg['id']}.png")
       o, st = Open3.capture2e({ 'SIGMA_API_TOKEN' => vqa_tok },
-                              *PyResolve.argv, File.join(HERE, 'sigma-export-png.py'),
-                              '--workbook', wb_id, '--page', pg['id'], '--out', out, '--w', '1800', '--h', '1000')
+                              *PyResolve.argv, PyResolve.winpath(File.join(HERE, 'sigma-export-png.py')),
+                              '--workbook', wb_id, '--page', pg['id'], '--out', PyResolve.winpath(out), '--w', '1800', '--h', '1000')
       vqa_mx.synchronize do
         o.each_line { |l| puts "   #{l.rstrip}" } unless o.strip.empty?
         st.success? ? (rendered += 1) : line("WARN: visual-QA render failed for page #{pg['id']}")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/render-baseline.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/render-baseline.rb
@@ -222,7 +222,7 @@ rescue StandardError
 end
 
 def run_py(code, *args)
-  out, st = Open3.capture2(*PyResolve.argv, '-c', code, *args.map(&:to_s))
+  out, st = Open3.capture2(*PyResolve.argv, '-c', code, *args.map { |a| PyResolve.winpath(a.to_s) })
   return nil unless st.success?
   JSON.parse(out)
 rescue StandardError

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/resolve-published-ds.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/resolve-published-ds.rb
@@ -38,13 +38,12 @@ abort 'usage: --twb PATH --out PATH' unless opts[:twb] && opts[:out]
 # a bare .tds when there's no extract).
 def tds_text_from(bytes)
   if bytes[0, 2] == 'PK' # zip
+    require_relative 'lib/zip_extract' # stdlib Zlib reader — no rubygems 'zip', no shelled unzip binary (Windows-safe)
     Tempfile.create(['pds', '.tdsx']) do |f|
       f.binmode; f.write(bytes); f.flush
-      names, _ = Open3.capture2('unzip', '-Z1', f.path)
-      tds = names.lines.map(&:chomp).find { |n| n.end_with?('.tds') }
+      tds = ZipExtract.entries(f.path).find { |n| n.end_with?('.tds') }
       return nil unless tds
-      out, st = Open3.capture2('unzip', '-p', f.path, tds)
-      return st.success? ? out : nil
+      ZipExtract.read(f.path, tds)&.force_encoding('UTF-8')
     end
   else
     bytes

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scout-validate-and-persist.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scout-validate-and-persist.rb
@@ -144,7 +144,7 @@ else
     'error_columns' => res['error_columns']
   }.compact
   esc_cmd = [
-    *PyResolve.argv, escalate,
+    *PyResolve.argv, PyResolve.winpath(escalate),
     '--skill',              'tableau-to-sigma',
     '--category',           'converter',
     '--feature',            opts[:feature],

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/synth-twb-e2e.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/synth-twb-e2e.rb
@@ -270,7 +270,7 @@ puts "master: #{mcols.size} column(s)"
 
 # Enrich the master-map with caption/space/underscore-flexible keys so chart refs
 # that use friendly captions resolve to warehouse-named master columns (n4pi.7).
-run!([*PyResolve.argv, File.join(HERE, 'enrich-master-map.py'), WORK, opts[:twb]])
+run!([*PyResolve.argv, PyResolve.winpath(File.join(HERE, 'enrich-master-map.py')), PyResolve.winpath(WORK), PyResolve.winpath(opts[:twb])])
 
 # ---------------------------------------------------------------------------
 # 4. build-charts. --auto-controls materializes Tableau parameters/shared-view
@@ -356,8 +356,8 @@ if opts[:render]
   page_id = (wbspec['pages'] || []).map { |pg| pg['id'] }.compact.first
   if wb_id && page_id
     puts "\n== 8. render PNG =="
-    run!([*PyResolve.argv, File.join(HERE, 'sigma-export-png.py'), '--workbook', wb_id,
-          '--page', page_id, '--out', File.join(WORK, 'rendered.png')], allow_fail: true)
+    run!([*PyResolve.argv, PyResolve.winpath(File.join(HERE, 'sigma-export-png.py')), '--workbook', wb_id,
+          '--page', page_id, '--out', PyResolve.winpath(File.join(WORK, 'rendered.png'))], allow_fail: true)
   else
     puts '  render skipped (no workbook id / page id)'
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
@@ -61,19 +61,13 @@ require 'thread'
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'tableau_rest'
-require 'py_resolve'
-
-# Cross-platform replacement for shelling `unzip` (not present on stock
-# Windows): Ruby has no stdlib zip reader, so this delegates to Python's
-# stdlib `zipfile` via a Store-stub-safe interpreter (see lib/py_resolve.rb).
-# Returns true/false like the old `system('unzip', ...)` call did.
-def unzip_extract(zip_path, dest_dir)
-  require 'open3'
-  code = 'import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])'
-  _out, err, status = Open3.capture3(*PyResolve.argv, '-c', code, zip_path, dest_dir)
-  warn "  unzip failed for #{zip_path}: #{err.strip[0, 300]}" if !status.success? && !err.to_s.strip.empty?
-  status.success?
-end
+# .twbx is a ZIP (inner .twb + embedded .hyper extract). Read it with the stdlib-
+# only Zlib reader — NOT the rubygems 'zip' (crashes "cannot load such file -- zip"
+# on stock RubyInstaller, field-caught) and NOT a shelled unzip/python (PATH/Store-
+# stub footguns). lib/zip_extract selectively inflates ONE member, so we read the
+# small .twb and derive .hyper presence from the name list without ever inflating
+# the multi-GB extract.
+require 'zip_extract'
 
 opts = { fetch_view_images: 'dashboard-only', pool: 5 }
 OptionParser.new do |o|
@@ -212,31 +206,28 @@ unless opts[:skip_content]
         twbx_path = File.join(opts[:out], 'workbook-content.twbx')
         atomic_write(twbx_path, payload)
         log "wrote workbook-content.twbx  (#{payload.bytesize} bytes)"
-        require 'tmpdir'
-        Dir.mktmpdir do |tmp|
-          unless unzip_extract(twbx_path, tmp)
-            log '.twbx auto-unzip failed; leaving .twbx in place'
-          else
-            hypers = Dir.glob(File.join(tmp, '**', '*.hyper')).any?
-            inner = Dir.glob(File.join(tmp, '**', '*.twb')).first
-            if inner
-              twb_path = File.join(opts[:out], 'workbook-content.twb')
-              # Force UTF-8: a bare File.read uses the locale default (US-ASCII on
-              # many systems) and raises "invalid byte sequence in US-ASCII" on the
-              # first non-ASCII byte (em-dash, @handles, curly quotes). The direct-
-              # download branch below already force_encodes; the .twbx path must too.
-              xml = File.read(inner, encoding: 'UTF-8')
-              if FcpNormalize.needed?(xml)
-                n = xml.scan(/_\.fcp\./).length
-                xml = FcpNormalize.normalize(xml)
-                log "FCP-normalized workbook XML (#{n} forward-compatibility token(s) → canonical names)"
-              end
-              atomic_write(twb_path, xml)
-              log "extracted workbook-content.twb  (#{File.size(twb_path)} bytes) from .twbx"
-            else
-              log '.twbx contained no inner .twb — odd'
+        begin
+          names  = ZipExtract.entries(twbx_path)
+          hypers = names.any? { |n| n.downcase.end_with?('.hyper') } # from names — no inflation
+          inner  = names.find { |n| n.downcase.end_with?('.twb') }
+          if inner
+            twb_path = File.join(opts[:out], 'workbook-content.twb')
+            # Force UTF-8: the raw bytes may hold non-ASCII (em-dash, @handles,
+            # curly quotes); force_encode so FcpNormalize + downstream regex don't
+            # raise "invalid byte sequence in US-ASCII".
+            xml = ZipExtract.read(twbx_path, inner).to_s.force_encoding('UTF-8')
+            if FcpNormalize.needed?(xml)
+              n = xml.scan(/_\.fcp\./).length
+              xml = FcpNormalize.normalize(xml)
+              log "FCP-normalized workbook XML (#{n} forward-compatibility token(s) → canonical names)"
             end
+            atomic_write(twb_path, xml)
+            log "extracted workbook-content.twb  (#{File.size(twb_path)} bytes) from .twbx"
+          else
+            log '.twbx contained no inner .twb — odd'
           end
+        rescue StandardError => e
+          log ".twbx read failed (#{e.message.to_s[0, 200]}); leaving .twbx in place"
         end
       else
         twb_path = File.join(opts[:out], 'workbook-content.twb')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-py-resolve-winpath.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-py-resolve-winpath.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# Offline test (bead tt3z.15): PyResolve.winpath converts Git-Bash /c/… POSIX paths
+# to native Windows paths so a native Windows Python can open() them, and is a strict
+# no-op everywhere else. Runs on macOS/Linux CI by FORCING windows? true; since those
+# hosts have no `cygpath`, the Open3 spawn raises and the pure-Ruby fallback is what's
+# exercised (the branch Windows-cmd/PowerShell users without cygpath also hit).
+require_relative 'lib/py_resolve'
+
+$fail = 0
+def ok(d); r = yield; puts "#{r ? '  ok  ' : ' FAIL '} #{d}"; $fail += 1 unless r; end
+
+# Force Windows semantics on the (non-Windows) test host.
+def PyResolve.windows?; true; end
+
+ok('/c/Users/x/f.twbx -> C:\\Users\\x\\f.twbx')      { PyResolve.winpath('/c/Users/x/f.twbx') == 'C:\\Users\\x\\f.twbx' }
+ok('/mnt/c/tmp/a.json -> C:\\tmp\\a.json (WSL form)') { PyResolve.winpath('/mnt/c/tmp/a.json') == 'C:\\tmp\\a.json' }
+ok('drive letter uppercased')                        { PyResolve.winpath('/d/data/x') == 'D:\\data\\x' }
+ok('already-native C:\\ untouched')                  { PyResolve.winpath('C:\\Users\\x') == 'C:\\Users\\x' }
+ok('already-native C:/ untouched')                   { PyResolve.winpath('C:/Users/x') == 'C:/Users/x' }
+ok('UNC path untouched')                             { PyResolve.winpath('\\\\srv\\share') == '\\\\srv\\share' }
+ok('flag (no leading /) untouched')                  { PyResolve.winpath('--out') == '--out' }
+ok('relative path untouched')                        { PyResolve.winpath('views/a.csv') == 'views/a.csv' }
+ok('bare id untouched')                              { PyResolve.winpath('wb-1234') == 'wb-1234' }
+ok('empty untouched')                                { PyResolve.winpath('') == '' }
+ok('non-string coerced safely')                      { PyResolve.winpath(nil) == nil }
+
+# Strict no-op OFF Windows (the mac/linux/CI runtime path).
+def PyResolve.windows?; false; end
+ok('no-op on non-Windows: /c/… passes through unchanged') { PyResolve.winpath('/c/Users/x/f.twbx') == '/c/Users/x/f.twbx' }
+
+puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zip-extract.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zip-extract.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Hermetic offline test (bead tt3z.16): ZipExtract reads .twbx members with stdlib
+# Zlib only — no `zip`/`unzip`/python. Builds a classic ZIP in-Ruby (STORE + DEFLATE
+# + a directory entry + a UTF-8 name) and round-trips it, then unit-tests the ZIP64
+# central-field resolution (the branch that guards extract-backed .twbx > 4 GB).
+require 'zlib'
+require_relative 'lib/zip_extract'
+
+$fail = 0
+def ok(d); r = yield; puts "#{r ? '  ok  ' : ' FAIL '} #{d}"; $fail += 1 unless r; end
+
+# Assemble a minimal, spec-correct classic ZIP from [[name, bytes, method], ...]
+# (method 0 = store, 8 = raw deflate). Inverse of ZipExtract's reader.
+def build_zip(members)
+  locals = +''.b
+  central = +''.b
+  offsets = []
+  members.each do |name, data, method|
+    data = data.b
+    stored = method == 8 ? Zlib::Deflate.deflate(data, Zlib::DEFAULT_COMPRESSION).then { |z| z } : data
+    stored = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS).deflate(data, Zlib::FINISH) if method == 8
+    crc = Zlib.crc32(data)
+    offsets << locals.bytesize
+    n = name.b
+    locals << ["PK\x03\x04".b, 20, 0, method, 0, 0, crc, stored.bytesize, data.bytesize, n.bytesize, 0].pack('a4vvvvvVVVvv') << n << stored
+  end
+  cd_offset = locals.bytesize
+  members.each_with_index do |(name, data, method), i|
+    data = data.b
+    stored_size = method == 8 ? Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS).deflate(data, Zlib::FINISH).bytesize : data.bytesize
+    crc = Zlib.crc32(data)
+    n = name.b
+    central << ["PK\x01\x02".b, 20, 20, 0, method, 0, 0, crc, stored_size, data.bytesize, n.bytesize, 0, 0, 0, 0, 0, offsets[i]].pack('a4vvvvvvVVVvvvvvVV') << n
+  end
+  eocd = ["PK\x05\x06".b, 0, 0, members.size, members.size, central.bytesize, cd_offset, 0].pack('a4vvvvVVv')
+  locals + central + eocd
+end
+
+require 'tmpdir'
+Dir.mktmpdir do |d|
+  twb = %(<workbook>— em-dash é unicode — dateadd(...) &lt;= x</workbook>) # non-ASCII → UTF-8 exercise
+  hyper = ("\x89HYPER\x00".b + ("\xDE\xAD\xBE\xEF".b * 2000))
+  zip = build_zip([['wb.twb', twb, 8], ['Data/x.hyper', hyper, 0], ['Data/', ''.b, 0]])
+  path = File.join(d, 'a.twbx'); File.binwrite(path, zip)
+
+  names = ZipExtract.entries(path)
+  ok('entries lists every member incl. the dir entry') { names.sort == ['Data/', 'Data/x.hyper', 'wb.twb'] }
+  got = ZipExtract.read(path, 'wb.twb')
+  ok('DEFLATE member round-trips bytes exactly') { got.b == twb.b }
+  ok('inflated .twb is valid UTF-8') { got.force_encoding('UTF-8').valid_encoding? }
+  ok('STORE .hyper round-trips bytes exactly') { ZipExtract.read(path, 'Data/x.hyper').b == hyper }
+  ok('.hyper presence derivable from names (no inflation)') { names.any? { |n| n.downcase.end_with?('.hyper') } }
+  ok('missing member → nil') { ZipExtract.read(path, 'nope').nil? }
+end
+
+# ZIP64 central-field resolution: classic csize/lho are 0xFFFFFFFF sentinels; real
+# 64-bit values live in the 0x0001 extra (order: uncompressed?, compressed?, lho?).
+# uncompressed is NOT saturated here (usize32 != FFFFFFFF) so it is absent from the extra.
+body = [0x123456789, 0x2ABCDEF01].pack('Q<Q<')            # csize, lho
+extra = [0x0001, body.bytesize].pack('vv') + body
+csize, lho = ZipExtract.zip64_extra(extra, 100, 0xFFFFFFFF, 0xFFFFFFFF)
+ok('zip64_extra resolves 64-bit csize') { csize == 0x123456789 }
+ok('zip64_extra resolves 64-bit local-header offset') { lho == 0x2ABCDEF01 }
+# When only lho is saturated, the extra carries only the lho value (compressed absent).
+body2 = [0x3FFFFFFFF].pack('Q<')
+extra2 = [0x0001, body2.bytesize].pack('vv') + body2
+csize2, lho2 = ZipExtract.zip64_extra(extra2, 100, 4242, 0xFFFFFFFF)
+ok('zip64_extra leaves a non-saturated csize untouched') { csize2 == 4242 }
+ok('zip64_extra resolves lho when it is the only saturated field') { lho2 == 0x3FFFFFFFF }
+
+puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-dashboard-visual.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-dashboard-visual.rb
@@ -76,8 +76,8 @@ dash_layout.each do |d|
   # 2) Sigma page render
   pid = page_id_by_name[name] || page_id_by_name.reject { |k, _| k == 'Data' }.values.first
   if pid
-    render_out, render_st = Open3.capture2e(*PyResolve.argv, png_script, '--workbook', opts[:wb], '--page', pid,
-                                            '--out', sig_png, '--w', opts[:w].to_s, '--h', opts[:h].to_s)
+    render_out, render_st = Open3.capture2e(*PyResolve.argv, PyResolve.winpath(png_script), '--workbook', opts[:wb], '--page', pid,
+                                            '--out', PyResolve.winpath(sig_png), '--w', opts[:w].to_s, '--h', opts[:h].to_s)
     ok = render_st.success?
     rec['sigma_png'] = sig_png if ok && File.size?(sig_png)
     # NAME the ceiling instead of failing opaquely: a full-page render that

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-interaction.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-interaction.rb
@@ -485,9 +485,9 @@ sel['by_dashboard'].each do |dash, cands|
           nil # evidence only — silent
         end
         if rec['page_id']
-          ok = system(*PyResolve.argv, png_script, '--workbook', WB, '--page', rec['page_id'],
+          ok = system(*PyResolve.argv, PyResolve.winpath(png_script), '--workbook', WB, '--page', rec['page_id'],
                       '--param', "#{cid}=#{value}",
-                      '--out', File.join(EVD, "#{slug}.sigma.png"),
+                      '--out', PyResolve.winpath(File.join(EVD, "#{slug}.sigma.png")),
                       out: File::NULL, err: File::NULL)
           renders['sigma'] = "interaction/#{slug}.sigma.png" if ok && File.size?(File.join(EVD, "#{slug}.sigma.png"))
         end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-visual-tiles.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-visual-tiles.rb
@@ -71,7 +71,7 @@ crop_from_dashboard = lambda do |ws, out_png|
   src = File.join(opts[:dash_dir], "#{dash}.png")
   src = Dir[File.join(opts[:dash_dir], '*.png')].first unless File.exist?(src)
   return false unless src && File.exist?(src)
-  system(*PyResolve.argv, '-c', CROP_PY, src, out_png, *rect.map(&:to_s),
+  system(*PyResolve.argv, '-c', CROP_PY, PyResolve.winpath(src), PyResolve.winpath(out_png), *rect.map(&:to_s),
          out: File::NULL, err: File::NULL) && File.size?(out_png)
 end
 
@@ -176,8 +176,8 @@ Array.new([3, tiles.size].min.clamp(1, 3)) do
   # 2) Sigma element render
   render_out = nil
   if t['element_id']
-    render_out, render_st = Open3.capture2e(*PyResolve.argv, png_script, '--workbook', opts[:wb], '--element', t['element_id'],
-                                            '--out', sigma_png, '--w', opts[:w].to_s, '--h', opts[:h].to_s)
+    render_out, render_st = Open3.capture2e(*PyResolve.argv, PyResolve.winpath(png_script), '--workbook', opts[:wb], '--element', t['element_id'],
+                                            '--out', PyResolve.winpath(sigma_png), '--w', opts[:w].to_s, '--h', opts[:h].to_s)
     rec['sigma_png'] = sigma_png if render_st.success? && File.size?(sigma_png)
   end
 

--- a/shared/lib/py_resolve.rb
+++ b/shared/lib/py_resolve.rb
@@ -34,6 +34,31 @@ module PyResolve
     argv.join(' ')
   end
 
+  # Convert a Git-Bash / MSYS / Cygwin POSIX path ("/c/Users/x/f.twbx", "/mnt/c/…")
+  # into a native Windows path ("C:\\Users\\x\\f.twbx") so a NATIVE Windows Python
+  # (py -3 / python.org) can open() it — the field-caught "Windows Python can't open
+  # /c/… paths" failure. Wrap EVERY filesystem-path ARG a Ruby script shells to
+  # Python. Hard no-op on macOS/Linux, on already-native paths (C:\, C:/, UNC), and
+  # on anything not starting with "/" (so flags like --out, ids, and numbers pass
+  # through untouched). Prefers `cygpath -w` (honors the real mount table) and falls
+  # back to a pure-Ruby transform when cygpath is absent (cmd/PowerShell).
+  def winpath(p)
+    s = p.to_s
+    return p unless windows?
+    return p if s.empty?
+    return p if s =~ %r{\A[A-Za-z]:[\\/]} || s.start_with?('\\\\') # already C:\ / C:/ / UNC
+    return p unless s.start_with?('/')                             # only absolute POSIX paths
+    begin
+      require 'open3'
+      out, st = Open3.capture2('cygpath', '-w', s)
+      return out.strip if st.success? && !out.strip.empty?
+    rescue StandardError
+      # cygpath not on PATH — fall through to the pure-Ruby transform.
+    end
+    m = s.match(%r{\A/(?:mnt/)?([A-Za-z])/(.*)\z})                 # /c/… or /mnt/c/…
+    m ? "#{m[1].upcase}:\\#{m[2].tr('/', '\\')}" : p
+  end
+
   def windows?
     # RbConfig is the reliable host check; ENV['OS'] is a cheap secondary signal.
     (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/i) || ENV['OS'].to_s =~ /windows/i

--- a/shared/lib/zip_extract.rb
+++ b/shared/lib/zip_extract.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+#
+# zip_extract.rb — dependency-free ZIP reader for .twbx (and other zip) members.
+#
+# Why: reading a .twbx (a ZIP of the inner .twb + embedded .hyper extract) via the
+# `rubyzip` gem crashes on stock RubyInstaller with "cannot load such file -- zip"
+# (field-caught), and shelling to `unzip`/python adds interpreter + PATH footguns.
+# Ruby ships `zlib` in every MRI build, so this parses the ZIP central directory and
+# inflates members with Zlib alone — no gems, no external binaries, no Python.
+#
+# It reads ONE named member at a time (entries → read), so discovery can inflate the
+# small inner .twb and derive the .hyper presence from the NAME list WITHOUT ever
+# inflating the multi-GB .hyper into a Ruby String. ZIP64-aware (extract-backed
+# .twbx with a >4GB .hyper or >65535 members is written as ZIP64).
+require 'zlib'
+
+module ZipExtract
+  module_function
+
+  EOCD_SIG    = "PK\x05\x06".b
+  EOCD64_SIG  = "PK\x06\x06".b
+  LOC64_SIG   = "PK\x06\x07".b
+  CEN_SIG     = "PK\x01\x02".b
+  U32_MAX     = 0xFFFFFFFF
+  U16_MAX     = 0xFFFF
+
+  # All member names (central-directory walk; no inflation). ZIP64-aware.
+  def entries(path)
+    central(File.binread(path)).map { |e| e[:name] }
+  end
+
+  # Inflate/copy exactly ONE member by name; nil if absent.
+  def read(path, name)
+    buf = File.binread(path)
+    e = central(buf).find { |x| x[:name] == name }
+    e && member_bytes(buf, e)
+  end
+
+  # Extract every member under dest (skips directory entries). Convenience for
+  # callers that genuinely need the whole tree; prefer read() for a single member.
+  def extract_all(path, dest)
+    require 'fileutils'
+    buf = File.binread(path)
+    central(buf).each do |e|
+      next if e[:name].end_with?('/')
+      out = File.join(dest, e[:name])
+      FileUtils.mkdir_p(File.dirname(out))
+      File.binwrite(out, member_bytes(buf, e))
+    end
+  end
+
+  # ── internals ─────────────────────────────────────────────────────────────
+
+  # Locate the End Of Central Directory record (scan back over any trailing comment).
+  def eocd_index(buf)
+    i = buf.rindex(EOCD_SIG) or raise "not a zip (no EOCD): truncated or wrong file"
+    i
+  end
+
+  # Return [cd_offset, total_entries], resolving ZIP64 when the classic fields are
+  # saturated (0xFFFFFFFF / 0xFFFF).
+  def cd_locate(buf)
+    e = eocd_index(buf)
+    total     = buf[e + 10, 2].unpack1('v')
+    cd_offset = buf[e + 16, 4].unpack1('V')
+    return [cd_offset, total] unless cd_offset == U32_MAX || total == U16_MAX
+    # ZIP64: the locator (PK\x06\x07) sits 20 bytes before the classic EOCD.
+    loc = buf.rindex(LOC64_SIG, e) or raise 'zip64 EOCD locator missing'
+    z64 = buf[loc + 8, 8].unpack1('Q<')            # offset of the ZIP64 EOCD record
+    raise 'zip64 EOCD record missing' unless buf[z64, 4] == EOCD64_SIG
+    [buf[z64 + 48, 8].unpack1('Q<'), buf[z64 + 32, 8].unpack1('Q<')]  # cd_offset, total
+  end
+
+  # Walk the central directory → [{name, method, csize, lho}, ...].
+  def central(buf)
+    cd_offset, total = cd_locate(buf)
+    out = []
+    p = cd_offset
+    total.times do
+      raise 'corrupt central directory' unless buf[p, 4] == CEN_SIG
+      method   = buf[p + 10, 2].unpack1('v')
+      csize    = buf[p + 20, 4].unpack1('V')
+      nlen     = buf[p + 28, 2].unpack1('v')
+      elen     = buf[p + 30, 2].unpack1('v')
+      clen     = buf[p + 32, 2].unpack1('v')
+      lho      = buf[p + 42, 4].unpack1('V')
+      name     = buf[p + 46, nlen]
+      extra    = buf[p + 46 + nlen, elen]
+      if csize == U32_MAX || lho == U32_MAX
+        usize32 = buf[p + 24, 4].unpack1('V')
+        csize, lho = zip64_extra(extra, usize32, csize, lho)
+      end
+      out << { name: name, method: method, csize: csize, lho: lho }
+      p += 46 + nlen + elen + clen
+    end
+    out
+  end
+
+  # Parse the 0x0001 ZIP64 extra field. Values appear IN ORDER only for the fields
+  # whose classic slot was saturated: uncompressed, compressed, local-header-offset,
+  # disk. Returns the resolved [csize, lho].
+  def zip64_extra(extra, usize32, csize, lho)
+    i = 0
+    while i + 4 <= extra.bytesize
+      id  = extra[i, 2].unpack1('v')
+      len = extra[i + 2, 2].unpack1('v')
+      if id == 0x0001
+        body = extra[i + 4, len]
+        j = 0
+        j += 8 if usize32 == U32_MAX                       # skip uncompressed size
+        if csize == U32_MAX then csize = body[j, 8].unpack1('Q<'); j += 8 end
+        if lho   == U32_MAX then lho   = body[j, 8].unpack1('Q<'); j += 8 end
+        break
+      end
+      i += 4 + len
+    end
+    [csize, lho]
+  end
+
+  # Bytes of one member: re-derive the data start from the LOCAL header (its
+  # name/extra lengths can differ from the central copy), then inflate (method 8)
+  # or copy (method 0).
+  def member_bytes(buf, e)
+    lho = e[:lho]
+    raise "bad local header @#{lho}" unless buf[lho, 4] == "PK\x03\x04".b
+    lnlen = buf[lho + 26, 2].unpack1('v')
+    lelen = buf[lho + 28, 2].unpack1('v')
+    data  = buf[lho + 30 + lnlen + lelen, e[:csize]]
+    case e[:method]
+    when 0 then data                                    # stored
+    when 8 then Zlib::Inflate.new(-Zlib::MAX_WBITS).inflate(data)  # raw deflate
+    else raise "unsupported zip compression method #{e[:method]}"
+    end
+  end
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -130,6 +130,12 @@
    ]
   },
   {
+   "canonical": "shared/lib/zip_extract.rb",
+   "targets": [
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/zip_extract.rb"
+   ]
+  },
+  {
    "canonical": "shared/lib/sigma_telemetry.py",
    "targets": [
     "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py",


### PR DESCRIPTION
Two Windows reliability fixes from the the field customer field run (beads tt3z.15 / tt3z.16).

### tt3z.16 — zip-gem-free `.twbx` (the customer's actual blocker)
`shared/lib/zip_extract.rb`: a **stdlib-only (Zlib) ZIP reader** — no rubygems `zip` (crashes *"cannot load such file -- zip"* on stock RubyInstaller — the exact error the customer hit) and no shelled `unzip`/python. **ZIP64-aware**; reads **one member at a time**, so discovery inflates the small inner `.twb` and derives `.hyper` presence from the name list **without inflating the multi-GB extract**. Rewired `tableau-discover.rb` (`.twbx`), `resolve-published-ds.rb` (`.tdsx`), and `build-charts` (image assets) off `unzip`/python.
- **Hermetic test** (`test-zip-extract.rb`): Ruby-built classic-zip round-trip (STORE + DEFLATE + UTF-8) + ZIP64 field-resolution units.
- **Live E2E**: a real python-created `.twbx` round-tripped through `ZipExtract` — inner `.twb` inflated, UTF-8 valid, `.hyper` detected + stored bytes byte-exact.

### tt3z.15 — Windows path normalization
`PyResolve.winpath()` converts Git-Bash `/c/…` (and WSL `/mnt/c/…`) paths to native Windows paths so a native Windows Python can `open()` them (field-caught). Prefers `cygpath -w`, pure-Ruby fallback; **hard no-op on macOS/Linux, already-native paths, and non-path args**. Wrapped the filesystem-path args at the 10 Python-invocation sites. Test: `test-py-resolve-winpath.rb` (12 cases; forces `windows?` on the CI host to exercise the pure-Ruby fallback).
- *Deferred:* `assert-phase6-ran.rb`'s bare `python3` gate-14 call (shared, secondary, degrades gracefully) — noted on the bead.

Governance: 374 shared copies match, 0 drift. Both tests in the CI allowlist. winpath integration is Windows-only (no-op on Mac); the PR-C cold migration confirms no Mac-pipeline regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
