### PR TITLE
fix(powerbi): stop labeling the one-shot RESOLUTION check as value "parity"

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -1455,12 +1455,19 @@ end
 divergent = fresh_classes.count { |c| c[0] == 'DIVERGENT' }
 
 parity_ok = err_cols.empty? && divergent.zero?
+# NOTE: this is a RESOLUTION check, not value parity. It proves every column
+# resolves (no type "error") and the warehouse matches the PBI snapshot
+# (freshness) — it does NOT diff the built aggregates against the source's
+# DAX/SQL results. Value parity is the assert-phase6-ran.rb / phase6-parity-pbi.rb
+# gate (writes parity-final.json). Labeling this "PARITY: PASS" over-claimed and
+# masked that the value bar was never run in the one-shot path (bead: p5y2 seam).
 if err_cols.empty?
-  puts "   PARITY: #{parity_ok ? 'PASS' : 'FAIL'} — #{total_cols} workbook column(s) resolve (0 error-typed); " \
+  puts "   RESOLUTION: #{parity_ok ? 'PASS' : 'FAIL'} — #{total_cols} workbook column(s) resolve (0 error-typed); " \
        "#{chart_els.size} chart element(s) built across #{chart_pages.size} page(s)"
-  puts "   PARITY: FAIL — #{divergent} DIVERGENT freshness delta(s) above" unless divergent.zero?
+  puts '   NOTE: value parity NOT diffed vs source in this path — run assert-phase6-ran.rb / phase6-parity-pbi.rb to value-verify.'
+  puts "   RESOLUTION: FAIL — #{divergent} DIVERGENT freshness delta(s) above" unless divergent.zero?
 else
-  puts "   PARITY: FAIL — #{err_cols.size}/#{total_cols} column(s) resolved to type 'error':"
+  puts "   RESOLUTION: FAIL — #{err_cols.size}/#{total_cols} column(s) resolved to type 'error':"
   err_cols.first(8).each { |c| puts "     [#{c['elementId']}] #{c['label']}: #{c['formula']}" }
 end
 
@@ -1517,8 +1524,8 @@ puts
 puts '================ RESULT ================'
 puts "dataModelId : #{dm_id}"
 puts "workbookId  : #{wb_id}"
-puts "PARITY      : #{parity_ok ? 'PASS' : 'FAIL'} (#{total_cols} cols resolve, #{err_cols.size} error" \
-     "#{fresh_classes.any? ? format(', freshness: %d match / %d stale-explained / %d divergent', fresh_classes.count { |c| c[0] == 'MATCH' }, fresh_classes.count { |c| c[0] == 'STALE-EXPLAINED' }, divergent) : ''})"
+puts "RESOLUTION  : #{parity_ok ? 'PASS' : 'FAIL'} (#{total_cols} cols resolve, #{err_cols.size} error" \
+     "#{fresh_classes.any? ? format(', freshness: %d match / %d stale-explained / %d divergent', fresh_classes.count { |c| c[0] == 'MATCH' }, fresh_classes.count { |c| c[0] == 'STALE-EXPLAINED' }, divergent) : ''}); value parity NOT run — see assert-phase6-ran.rb"
 if fresh_ok
   puts "freshness   : PBI last refresh #{fresh_ok['endTime']} (#{stale_days} days ago)" \
        "#{freshness['credsSuspect'] ? ' — REFRESH FAILING (creds)' : ''}"
@@ -1540,8 +1547,11 @@ end
 begin
   succ = File.join(WORK, 'phase6-success.json')
   if built_ok
+    # 'resolution-pass' (not 'parity-pass'): this marker records that the build
+    # resolved + freshness-matched, NOT that values were diffed against source.
+    # verify-complete.rb reports value parity separately (parity-final.json).
     File.write(succ, JSON.pretty_generate('workbookId' => wb_id, 'chartCount' => chart_els.size,
-                                          'gates' => 'parity-pass',
+                                          'gates' => 'resolution-pass',
                                           'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   elsif File.exist?(succ)
     File.delete(succ) # a prior success marker is stale if this run isn't green

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-complete.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-complete.rb
@@ -3,18 +3,27 @@
 #
 # verify-complete.rb — the single offline "is this migration actually done?" check.
 #
-# A Power BI→Sigma conversion is done ONLY when migrate-powerbi.rb finished with a
-# real, parity-passing workbook — which it records by stamping
-# <workdir>/phase6-success.json (workbookId + chartCount + parity-pass) at exit 0.
-# An EMPTY / placeholder workbook (pages but no elements — the classic failure
-# where a blocked agent hand-builds a shell) never gets that marker, because the
-# orchestrator refuses to green a 0-element build. So "done" is a fact on disk,
-# not "the pages look right". Run this before claiming success or handing off.
+# A Power BI→Sigma conversion produced a real, non-empty workbook ONLY when
+# migrate-powerbi.rb finished and stamped <workdir>/phase6-success.json
+# (workbookId + chartCount + gates) at exit 0. An EMPTY / placeholder workbook
+# (pages but no elements — the classic failure where a blocked agent hand-builds
+# a shell) never gets that marker, because the orchestrator refuses to green a
+# 0-element build. So "built" is a fact on disk, not "the pages look right".
+#
+# IMPORTANT — what the marker does and does NOT prove: the one-shot orchestrator's
+# gate is a RESOLUTION check (every column resolves + warehouse freshness matches),
+# recorded as gates:'resolution-pass'. It does NOT diff the built aggregates against
+# the source's DAX/SQL results. VALUE PARITY is a separate gate — assert-phase6-ran.rb
+# / phase6-parity-pbi.rb, which writes parity-final.json — and this script reports its
+# status separately so a green here is never mistaken for "numbers verified vs source".
+# (Aligning powerbi/qlik to the assert-phase6-ran-stamped marker the other plugins use
+# is tracked under the runtime-contract completion seam, bead p5y2.)
 #
 # Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
 #
 # Exit codes:
-#   0  DONE   — phase6-success.json present with chartCount > 0 (parity passed)
+#   0  DONE   — phase6-success.json present with chartCount > 0 (built + resolution-verified;
+#              value-parity status reported separately from parity-final.json)
 #   2  NOT DONE — no success marker (conversion didn't complete / was hand-built)
 #   3  NOT DONE — marker present but 0 chart elements (empty workbook)
 #   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
@@ -32,7 +41,7 @@ abort 'FATAL: --workdir required' unless opts[:wd]
 succ = File.join(opts[:wd], 'phase6-success.json')
 unless File.exist?(succ)
   warn '⛔ NOT DONE — no phase6-success.json in the workdir.'
-  warn '   The conversion did not complete a parity-passing build. If pages exist but are empty,'
+  warn '   The conversion did not complete a resolution-verified build. If pages exist but are empty,'
   warn '   they were NOT produced by a real migrate-powerbi.rb run — re-run the orchestrator'
   warn "   (never hand-author a workbook). Workdir checked: #{opts[:wd]}"
   exit 2
@@ -53,9 +62,27 @@ if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
   exit 4
 end
 
-puts '✅ DONE — migrate-powerbi.rb built a parity-passing workbook for this run.'
-puts "   workbook : #{sj['workbookId']}"
-puts "   charts   : #{sj['chartCount']}"
-puts "   gates    : #{sj['gates']}"
-puts "   stamped  : #{sj['generatedAt']}"
+# Report VALUE PARITY separately from the build/resolution marker. The value gate
+# (assert-phase6-ran.rb / phase6-parity-pbi.rb) writes parity-final.json; surface its
+# status honestly rather than implying the one-shot build already value-verified.
+pf = File.join(opts[:wd], 'parity-final.json')
+vparity = begin
+  st = File.exist?(pf) ? JSON.parse(File.read(pf))['status'].to_s.upcase : nil
+  st && (st == 'PASS' ? 'CONFIRMED (parity-final.json)' : "#{st} (parity-final.json)")
+rescue StandardError
+  nil
+end
+
+puts '✅ DONE — migrate-powerbi.rb built a resolution-verified workbook for this run.'
+puts "   workbook     : #{sj['workbookId']}"
+puts "   charts       : #{sj['chartCount']}"
+puts "   gates        : #{sj['gates']} (columns resolve + freshness match)"
+if vparity
+  puts "   value parity : #{vparity}"
+else
+  puts '   value parity : NOT RUN in this path — the build resolved but its aggregates were'
+  puts '                  NOT diffed vs the source. Run assert-phase6-ran.rb / phase6-parity-pbi.rb'
+  puts '                  before reporting numeric parity with Power BI.'
+end
+puts "   stamped      : #{sj['generatedAt']}"
 exit 0


### PR DESCRIPTION
## Problem

The powerbi one-shot orchestrator (`migrate-powerbi.rb`) declares completion on a check it mislabels as **parity**.

Its "Phase 6" is a **RESOLUTION** check — every workbook column resolves (no type `error`) + warehouse freshness matches the PBI snapshot — but it:
- prints `PARITY: PASS`,
- self-stamps `phase6-success.json` with `gates: 'parity-pass'` (`migrate-powerbi.rb:~1544`),
- and `verify-complete.rb` reports `✅ DONE — built a parity-passing workbook`.

**No aggregate is ever diffed against the source's DAX/SQL.** The real value-parity gate — `assert-phase6-ran.rb` (requires `parity-final.json` `status=PASS`) / `phase6-parity-pbi.rb` — is **never invoked** by the one-shot path (grep-confirmed).

### Why it matters
The tool tells the agent/user "parity-passing DONE" when only resolution was verified. In a live run this pushed the agent to either trust an over-claimed green **or** hand-roll value parity outside the plugin. `looker` / `quicksight` / `thoughtspot` already do this correctly (their `verify-complete.rb` say the marker is *"recorded by the assert-phase6-ran hard gate"*); **powerbi + qlik are the laggards** on the old self-stamped-resolution marker.

## This PR — honesty only (no behavior/CI change)

- **`migrate-powerbi.rb`**: label the check `RESOLUTION` (not `PARITY`), add a `NOTE` that value parity was not diffed vs source, and stamp `gates: 'resolution-pass'`.
- **`verify-complete.rb`**: still `DONE` / exit 0 for a built + resolved workbook, but report **VALUE PARITY separately** by reading `parity-final.json` — `CONFIRMED` when the value gate ran and passed, `NOT RUN` otherwise. Header + exit-code docs updated.

`test-verify-complete.rb` stays green (9/9); `ruby -c` clean.

### Output after
```
✅ DONE — migrate-powerbi.rb built a resolution-verified workbook for this run.
   gates        : resolution-pass (columns resolve + freshness match)
   value parity : NOT RUN in this path — the build resolved but its aggregates were
                  NOT diffed vs the source. Run assert-phase6-ran.rb / phase6-parity-pbi.rb
                  before reporting numeric parity with Power BI.
```

## Follow-up (not in this PR)

Wire value parity **into** the one-shot path so powerbi/qlik match the `assert-phase6-ran`-stamped pattern the other three plugins use (oracle → batch actuals collector → `--finalize` → `assert-phase6-ran` stamps the marker). Tracked in **beads-sigma-p5y2.1** under the runtime-contract completion-seam epic; coordinate with `q0y9` (orchestrator finalize) + `vspc` (verify-warehouse / over-claim WARN). `qlik` needs the same relabel — happy to extend this PR to it.

Related: `beads-sigma-p5y2` (epic), `q0y9`, `vspc`, `qk9u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)