### PR TITLE
tableau: auto-rank resolves PDS / virtual-connection workbooks' real warehouse (#388 follow-up)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -212,6 +212,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zip-extract.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-py-resolve-winpath.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rank-connections.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fast-flag.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/tableau_rest.rb
@@ -178,6 +178,41 @@ end
     list.is_a?(Array) ? list : [list]
   end
 
+  # A published/embedded datasource's connections. For a CLASSIC published DS this
+  # names the warehouse directly; for a virtual-connection-backed DS it echoes
+  # publishedConnection (resolve via virtual_connection_connections instead).
+  def datasource_connections(datasource_id)
+    j = request(:get, "#{base_path}/datasources/#{datasource_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
+  # All Tableau Virtual Connections on the site (paged). A workbook backed by a VC
+  # exposes no VC LUID in its own /connections, so callers match by name.
+  def virtual_connections(page_size: 100)
+    out = []
+    page = 1
+    loop do
+      j = request(:get, "#{base_path}/virtualConnections?pageSize=#{page_size}&pageNumber=#{page}")
+      list = j.dig('virtualConnections', 'virtualConnection') || []
+      list = [list] unless list.is_a?(Array)
+      out.concat(list)
+      total = j.dig('pagination', 'totalAvailable').to_i
+      break if list.empty? || page * page_size >= total
+      page += 1
+    end
+    out
+  end
+
+  # A Virtual Connection's underlying warehouse connections: [{dbClass, server, port,
+  # username, ...}]. This is where the real warehouse (snowflake host, etc.) lives
+  # for a VC-backed workbook.
+  def virtual_connection_connections(vc_id)
+    j = request(:get, "#{base_path}/virtualConnections/#{vc_id}/connections")
+    list = j.dig('virtualConnectionConnections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/tableau_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/tableau_rest.rb
@@ -178,6 +178,41 @@ end
     list.is_a?(Array) ? list : [list]
   end
 
+  # A published/embedded datasource's connections. For a CLASSIC published DS this
+  # names the warehouse directly; for a virtual-connection-backed DS it echoes
+  # publishedConnection (resolve via virtual_connection_connections instead).
+  def datasource_connections(datasource_id)
+    j = request(:get, "#{base_path}/datasources/#{datasource_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
+  # All Tableau Virtual Connections on the site (paged). A workbook backed by a VC
+  # exposes no VC LUID in its own /connections, so callers match by name.
+  def virtual_connections(page_size: 100)
+    out = []
+    page = 1
+    loop do
+      j = request(:get, "#{base_path}/virtualConnections?pageSize=#{page_size}&pageNumber=#{page}")
+      list = j.dig('virtualConnections', 'virtualConnection') || []
+      list = [list] unless list.is_a?(Array)
+      out.concat(list)
+      total = j.dig('pagination', 'totalAvailable').to_i
+      break if list.empty? || page * page_size >= total
+      page += 1
+    end
+    out
+  end
+
+  # A Virtual Connection's underlying warehouse connections: [{dbClass, server, port,
+  # username, ...}]. This is where the real warehouse (snowflake host, etc.) lives
+  # for a VC-backed workbook.
+  def virtual_connection_connections(vc_id)
+    j = request(:get, "#{base_path}/virtualConnections/#{vc_id}/connections")
+    list = j.dig('virtualConnectionConnections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
@@ -178,6 +178,41 @@ end
     list.is_a?(Array) ? list : [list]
   end
 
+  # A published/embedded datasource's connections. For a CLASSIC published DS this
+  # names the warehouse directly; for a virtual-connection-backed DS it echoes
+  # publishedConnection (resolve via virtual_connection_connections instead).
+  def datasource_connections(datasource_id)
+    j = request(:get, "#{base_path}/datasources/#{datasource_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
+  # All Tableau Virtual Connections on the site (paged). A workbook backed by a VC
+  # exposes no VC LUID in its own /connections, so callers match by name.
+  def virtual_connections(page_size: 100)
+    out = []
+    page = 1
+    loop do
+      j = request(:get, "#{base_path}/virtualConnections?pageSize=#{page_size}&pageNumber=#{page}")
+      list = j.dig('virtualConnections', 'virtualConnection') || []
+      list = [list] unless list.is_a?(Array)
+      out.concat(list)
+      total = j.dig('pagination', 'totalAvailable').to_i
+      break if list.empty? || page * page_size >= total
+      page += 1
+    end
+    out
+  end
+
+  # A Virtual Connection's underlying warehouse connections: [{dbClass, server, port,
+  # username, ...}]. This is where the real warehouse (snowflake host, etc.) lives
+  # for a VC-backed workbook.
+  def virtual_connection_connections(vc_id)
+    j = request(:get, "#{base_path}/virtualConnections/#{vc_id}/connections")
+    list = j.dig('virtualConnectionConnections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.rb
@@ -178,6 +178,41 @@ end
     list.is_a?(Array) ? list : [list]
   end
 
+  # A published/embedded datasource's connections. For a CLASSIC published DS this
+  # names the warehouse directly; for a virtual-connection-backed DS it echoes
+  # publishedConnection (resolve via virtual_connection_connections instead).
+  def datasource_connections(datasource_id)
+    j = request(:get, "#{base_path}/datasources/#{datasource_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
+  # All Tableau Virtual Connections on the site (paged). A workbook backed by a VC
+  # exposes no VC LUID in its own /connections, so callers match by name.
+  def virtual_connections(page_size: 100)
+    out = []
+    page = 1
+    loop do
+      j = request(:get, "#{base_path}/virtualConnections?pageSize=#{page_size}&pageNumber=#{page}")
+      list = j.dig('virtualConnections', 'virtualConnection') || []
+      list = [list] unless list.is_a?(Array)
+      out.concat(list)
+      total = j.dig('pagination', 'totalAvailable').to_i
+      break if list.empty? || page * page_size >= total
+      page += 1
+    end
+    out
+  end
+
+  # A Virtual Connection's underlying warehouse connections: [{dbClass, server, port,
+  # username, ...}]. This is where the real warehouse (snowflake host, etc.) lives
+  # for a VC-backed workbook.
+  def virtual_connection_connections(vc_id)
+    j = request(:get, "#{base_path}/virtualConnections/#{vc_id}/connections")
+    list = j.dig('virtualConnectionConnections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/rank-connections.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/rank-connections.rb
@@ -118,13 +118,71 @@ module RankConnections
 
   # ---- fingerprint sources -------------------------------------------------
   # Primary non-extract warehouse connection from a Tableau REST connections list.
-  SKIP_CLASSES = %w[federated sqlproxy excel-direct textscan hyper msaccess
-                    dataengine tableau-server-connection].to_set.freeze
+  SKIP_CLASSES = %w[federated sqlproxy publishedconnection excel-direct textscan hyper
+                    msaccess dataengine tableau-server-connection].to_set.freeze
+  # Indirection layers that POINT AT a warehouse rather than being one. A workbook
+  # backed by these has no warehouse signal in its own /connections (serverAddress
+  # is empty) — the real warehouse must be resolved from the published datasource
+  # or virtual connection (fingerprint_via_published_source). Field-caught on
+  # "Orders Executive Overview" (all Sigma connections scored 0).
+  INDIRECT_CLASSES = %w[publishedconnection sqlproxy].to_set.freeze
+
   def fingerprint_from_wb_connections(list)
     conns = (list || []).map { |c| { 'type' => (c['type'] || c['dbClass']), 'host' => (c['serverAddress'] || c['server']) } }
                         .reject { |c| c['type'].to_s.empty? || SKIP_CLASSES.include?(c['type'].to_s.downcase) }
     warehouse = conns.find { |c| !c['host'].to_s.empty? } || conns.first
     warehouse ? { 'type' => warehouse['type'], 'host' => warehouse['host'] } : {}
+  end
+
+  # Normalize a warehouse host: the VC/Metadata APIs store Snowflake as a console
+  # URL ("https://acct.snowflakecomputing.com/console/login#/") — strip scheme,
+  # path/fragment, and :port to the canonical host ("acct.snowflakecomputing.com").
+  def clean_host(s)
+    h = s.to_s.strip
+    return h if h.empty?
+    h.sub(%r{\Ahttps?://}i, '').sub(%r{[/#?].*\z}, '').sub(/:\d+\z/, '')
+  end
+
+  # Choose the Virtual Connection backing a workbook. The workbook's /connections
+  # carries no VC LUID — only the (munged) published-DS name — so match VC by name.
+  # NEVER guess between candidates: nil ⇒ caller falls back to the ranked ASK.
+  def pick_virtual_connection(vcs, ds_name)
+    vcs = (vcs || []).select { |v| v && v['id'] }
+    return vcs.first if vcs.size == 1
+    dn = ds_name.to_s.downcase
+    hits = vcs.select { |v| !v['name'].to_s.empty? && dn.include?(v['name'].to_s.downcase) }
+    hits.size == 1 ? hits.first : nil
+  end
+
+  # Resolve the real warehouse behind an INDIRECT (publishedConnection/sqlproxy)
+  # workbook connection, via read-only REST: first the pointed-at datasource's own
+  # connections (a CLASSIC published DS names the warehouse there); else resolve the
+  # Virtual Connection by name and read ITS connection. Never raises, never guesses
+  # — {} on any miss so the caller degrades to the ranked ASK.
+  def fingerprint_via_published_source(raw_conns, rest)
+    ptr = (raw_conns || []).find { |c| INDIRECT_CLASSES.include?(c['type'].to_s.downcase) }
+    return {} unless ptr
+    ds = ptr['datasource'] || {}
+    if ds['id'] && !ds['id'].to_s.empty?
+      fp = (fingerprint_from_wb_connections(rest.datasource_connections(ds['id'])) rescue {})
+      return fp unless fp['type'].to_s.empty?   # classic PDS resolved
+    end
+    vc = pick_virtual_connection((rest.virtual_connections rescue []), ds['name'])
+    return {} unless vc
+    fp = (fingerprint_from_wb_connections(rest.virtual_connection_connections(vc['id'])) rescue {})
+    fp['host'] = clean_host(fp['host']) unless fp['host'].to_s.empty?
+    fp
+  end
+
+  # Orchestrator: the workbook's warehouse fingerprint, resolving through a
+  # published-DS / virtual-connection indirection when the direct connection has no
+  # warehouse signal. `rest` is duck-typed (the Tableau module in prod; a stub in tests).
+  def fingerprint_from_workbook(rest, wb_id)
+    raw = (rest.workbook_connections(wb_id) rescue [])
+    fp = fingerprint_from_wb_connections(raw)
+    return fp unless fp['type'].to_s.empty?
+    via = fingerprint_via_published_source(raw, rest)
+    via.empty? ? fp : via
   end
 
   # Fingerprint from a downloaded .twb (regex, no XML/zip deps). Adds dbname/schema.
@@ -176,7 +234,7 @@ if $PROGRAM_NAME == __FILE__
       rescue Tableau::Error
         Tableau.refresh_token!
       end
-      fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:wb])))
+      fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:wb]))
     end
     if opts[:twb] && File.exist?(opts[:twb])
       fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:twb], encoding: 'UTF-8')))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rank-connections.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rank-connections.rb
@@ -60,5 +60,61 @@ check('.twb fingerprint database = DWSPORTSBOOK') { fp_twb['database'] == 'DWSPO
 r5 = RankConnections.rank(RankConnections.merge_fp(fp_twb, {}), CANDS)
 check('.twb-derived fingerprint recommends Snowflake Prod') { r5['confident'] && r5['recommended']['connection_id'] == 'c-prod' }
 
+# 6) PDS / Virtual-Connection resolution (bead tt3z #388 follow-up). A duck-typed
+#    REST stub mirrors the live shapes so fingerprint_from_workbook is tested offline.
+class FakeRest
+  def initialize(h) ; @h = h ; end
+  def workbook_connections(_id) ; @h[:wb] || [] ; end
+  def datasource_connections(id) ; (@h[:ds] || {})[id] || [] ; end
+  def virtual_connections ; @h[:vcs] || [] ; end
+  def virtual_connection_connections(id) ; (@h[:vcc] || {})[id] || [] ; end
+end
+DS_NAME = 'ORDER_FACT (CSA.ORDER_FACT)+ (New Virtual Connection)'
+
+# (6a) garbage-fp regression: a publishedConnection stub yields EMPTY (not {type:'publishedConnection'}).
+check('publishedConnection stub → empty direct fingerprint (was the score-0 bug)') do
+  RankConnections.fingerprint_from_wb_connections([{ 'type' => 'publishedConnection', 'serverAddress' => '' }]) == {}
+end
+
+# (6b) VC-backed workbook resolves through the virtual connection to the real warehouse.
+vc_rest = FakeRest.new(
+  wb:  [{ 'type' => 'publishedConnection', 'serverAddress' => '', 'datasource' => { 'id' => 'ds1', 'name' => DS_NAME } }],
+  ds:  { 'ds1' => [{ 'type' => 'publishedConnection', 'serverAddress' => '' }] },        # dead-ends (VC-backed)
+  vcs: [{ 'id' => 'vc1', 'name' => 'New Virtual Connection' }],
+  vcc: { 'vc1' => [{ 'dbClass' => 'snowflake', 'server' => 'https://ymb68310.snowflakecomputing.com/console/login#/' }] })
+vc_fp = RankConnections.fingerprint_from_workbook(vc_rest, 'wb1')
+check('VC-backed → type snowflake') { RankConnections.canon_type(vc_fp['type']) == 'snowflake' }
+check('VC-backed → host cleaned (no scheme/path/port)') { vc_fp['host'] == 'ymb68310.snowflakecomputing.com' }
+
+# (6c) classic published DS resolves at the datasource hop; VC endpoints never consulted.
+pds_rest = FakeRest.new(
+  wb: [{ 'type' => 'publishedConnection', 'serverAddress' => '', 'datasource' => { 'id' => 'ds1', 'name' => 'X' } }],
+  ds: { 'ds1' => [{ 'type' => 'snowflake', 'serverAddress' => 'acme.snowflakecomputing.com' }] })
+pds_fp = RankConnections.fingerprint_from_workbook(pds_rest, 'wb1')
+check('classic PDS → resolves at datasource hop (host=acme)') { pds_fp['host'] == 'acme.snowflakecomputing.com' && RankConnections.canon_type(pds_fp['type']) == 'snowflake' }
+
+# (6d) ambiguity guard: 2 VCs, neither uniquely named in ds_name → EMPTY (never guess).
+amb_rest = FakeRest.new(
+  wb:  [{ 'type' => 'publishedConnection', 'serverAddress' => '', 'datasource' => { 'id' => 'ds1', 'name' => 'unmatched' } }],
+  ds:  { 'ds1' => [{ 'type' => 'publishedConnection', 'serverAddress' => '' }] },
+  vcs: [{ 'id' => 'a', 'name' => 'VC A' }, { 'id' => 'b', 'name' => 'VC B' }])
+check('ambiguous VC (no unique name match) → empty (falls back to ASK, never guesses)') do
+  RankConnections.fingerprint_from_workbook(amb_rest, 'wb1') == {}
+end
+
+# (6e) direct-warehouse workbook ("Test Custom Sql" analog): direct fp, resolution NOT invoked.
+direct_rest = FakeRest.new(wb: [{ 'type' => 'snowflake', 'serverAddress' => 'draftkings.us-east-1.snowflakecomputing.com' }])
+direct_fp = RankConnections.fingerprint_from_workbook(direct_rest, 'wb1')
+check('direct-warehouse workbook fingerprints straight from serverAddress') do
+  RankConnections.canon_type(direct_fp['type']) == 'snowflake' && direct_fp['host'] == 'draftkings.us-east-1.snowflakecomputing.com'
+end
+
+# (6f) VC fingerprint then RANKS the CSA.TJ (ymb68310) candidates to the top.
+CANDS2 = CANDS + [{ 'connection_id' => 'c-ymb', 'name' => 'ymb68310', 'type' => 'snowflake', 'host' => 'ymb68310.snowflakecomputing.com', 'account' => 'ymb68310' }]
+r6 = RankConnections.rank(RankConnections.merge_fp(vc_fp, {}), CANDS2)
+check('VC fingerprint ranks the ymb68310 (CSA.TJ) connection #1 (score>100, was 0)') do
+  r6['ranked'].first['connection_id'] == 'c-ymb' && r6['ranked'].first['match_score'] > 100
+end
+
 puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
 exit($fail.zero? ? 0 : 1)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))

--- a/shared/lib/tableau_rest.rb
+++ b/shared/lib/tableau_rest.rb
@@ -178,6 +178,41 @@ end
     list.is_a?(Array) ? list : [list]
   end
 
+  # A published/embedded datasource's connections. For a CLASSIC published DS this
+  # names the warehouse directly; for a virtual-connection-backed DS it echoes
+  # publishedConnection (resolve via virtual_connection_connections instead).
+  def datasource_connections(datasource_id)
+    j = request(:get, "#{base_path}/datasources/#{datasource_id}/connections")
+    list = j.dig('connections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
+  # All Tableau Virtual Connections on the site (paged). A workbook backed by a VC
+  # exposes no VC LUID in its own /connections, so callers match by name.
+  def virtual_connections(page_size: 100)
+    out = []
+    page = 1
+    loop do
+      j = request(:get, "#{base_path}/virtualConnections?pageSize=#{page_size}&pageNumber=#{page}")
+      list = j.dig('virtualConnections', 'virtualConnection') || []
+      list = [list] unless list.is_a?(Array)
+      out.concat(list)
+      total = j.dig('pagination', 'totalAvailable').to_i
+      break if list.empty? || page * page_size >= total
+      page += 1
+    end
+    out
+  end
+
+  # A Virtual Connection's underlying warehouse connections: [{dbClass, server, port,
+  # username, ...}]. This is where the real warehouse (snowflake host, etc.) lives
+  # for a VC-backed workbook.
+  def virtual_connection_connections(vc_id)
+    j = request(:get, "#{base_path}/virtualConnections/#{vc_id}/connections")
+    list = j.dig('virtualConnectionConnections', 'connection') || []
+    list.is_a?(Array) ? list : [list]
+  end
+
   # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
   # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
   def download_workbook_content(workbook_id, include_extract: false)

--- a/shared/scripts/intake.rb
+++ b/shared/scripts/intake.rb
@@ -156,7 +156,7 @@ if resolved.nil?
         if opts[:rank_wb]
           require_relative 'lib/tableau_rest'
           begin; Tableau.site_id; rescue Tableau::Error; Tableau.refresh_token!; end
-          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_wb_connections(Tableau.workbook_connections(opts[:rank_wb])))
+          fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_workbook(Tableau, opts[:rank_wb]))
         end
         if opts[:rank_twb] && File.exist?(opts[:rank_twb])
           fp = RankConnections.merge_fp(fp, RankConnections.fingerprint_from_twb(File.read(opts[:rank_twb], encoding: 'UTF-8')))


### PR DESCRIPTION
Fixes the `#388` gap caught during the Opus-4.8 cold-migration timing of **Orders Executive Overview**: a workbook backed by a Tableau published/virtual connection returns `GET /workbooks/{id}/connections = {type:'publishedConnection', serverAddress:''}`, so the ranker produced a garbage fingerprint and **every Sigma connection scored 0** → blind manual ASK.

## Fix — pure read-only REST resolution
No `.twb` download, no Metadata GraphQL (its lineage is empty for VC-backed workbooks — verified). When the direct connection has no warehouse signal, resolve through the indirection:
1. `datasource.id` → `datasource_connections` (a **classic** published DS names the warehouse here), else
2. list `virtualConnections`, pick by name (unique-or-nothing), read `virtualConnections/{id}/connections` = `{dbClass:'snowflake', server:'https://acct…/console/login#/'}`, and `clean_host` it → `acct.snowflakecomputing.com`.

**Never guesses** between multiple VCs (returns `{}` → ranked ASK).

- `shared/lib/tableau_rest.rb` (canonical + synced): 3 additive read-only GET wrappers (`datasource_connections`, `virtual_connections`, `virtual_connection_connections`) — safe/no-op for non-tableau plugins.
- `rank-connections.rb`: skip `publishedConnection` as a warehouse type (kills the garbage fp) + `fingerprint_from_workbook`/`fingerprint_via_published_source`/`pick_virtual_connection`/`clean_host`.
- Hooked at the rank-connections CLI + intake `--rank-workbook-id`.

## Verified
- **Live on the reproducer** (Orders Executive Overview): all-0 → `snowflake / ymb68310.snowflakecomputing.com`, the two CSA.TJ connections **score 180 (#1/#2)**. Exits ranked-ASK only because *two* Sigma connections share that exact host (a genuine tie — safe not to blind-pick), now a clean 2-way choice vs. a blind 26-way one.
- Direct-warehouse workbook ("Test Custom Sql") regression clean.
- Offline: `test-rank-connections.rb` +7 cases (FakeRest: VC / classic-PDS / ambiguity-guard / direct / garbage-fp), added to CI allowlist. Governance: 374 shared copies match, 0 drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)