### PR TITLE
looker: migrate Looks (single saved queries) → grouped tables, pivot-tables, KPIs

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
@@ -14,6 +14,7 @@ python3 scripts/migrate-looker.py --lookml-dir fixtures/skilltest-orders \
     --dashboard fixtures/skilltest-orders/skilltest_orders.dashboard.lookml \
     [--name PREFIX] [--workdir /tmp/look-run]
 # live: --dashboard-id <id> instead of --dashboard (needs ~/.looker/looker.ini)
+# live Look (single saved query → one-tile workbook): --look-id <id>
 ```
 > **Windows:** launch with the `py` launcher — `py -3 scripts/migrate-looker.py …` —
 > not a bare `python3`. A bare `python`/`python3` on Windows often resolves to the
@@ -57,9 +58,12 @@ export SIGMA_CONNECTION_ID=<full-connection-uuid>   # NOT a short prefix
 ```bash
 python3 scripts/looker_api.py raw GET /lookml_models   # list models/explores
 python3 scripts/looker_api.py raw GET /dashboards      # list dashboards (UDD + LookML)
+python3 scripts/looker_api.py raw GET /looks           # list Looks (single saved queries)
 
 # pull one dashboard into the normalized contract (works for UDD AND LookML)
 python3 scripts/fetch_looker_dashboard.py <dashboard_id> /tmp/look/<dash>.contract.json
+# pull one Look into the SAME contract (one tile + fieldMeta)
+python3 scripts/fetch_looker_look.py <look_id> /tmp/look/<look>.contract.json
 # offline (dev/test only — cannot see UDDs):
 python3 scripts/parse_lookml_dashboard.py <file.dashboard.lookml> --out /tmp/look/<dash>.contract.json
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -58,6 +58,20 @@ Looker has two independent layers; convert them separately.
 |---|---|---|---|
 | **Semantic model** | LookML views+model (Looker API/MCP, or files offline) | local vendored `converter/lookml.mjs` (run in-process via `node`; the `convert_lookml_to_sigma` MCP tool is a manual fallback only) | data model |
 | **Dashboards** | `GET /dashboards/{id}` JSON — covers **user-defined (UDD) AND LookML dashboards** | `fetch_looker_dashboard.py` → contract → `build_workbook.py` | workbook |
+| **Looks** | `GET /looks/{id}` (LookWithQuery) — a single saved query | `fetch_looker_look.py` → the **same contract** (one tile) → `build_workbook.py` | workbook |
+
+**Looks are a thin add on the dashboard pipeline.** A Look's `.query` is the same Looker
+`Query` shape a dashboard tile embeds, so `fetch_looker_look.py` synthesizes a one-tile
+contract (via the shared `normalize_element`) with `filters:[]` and a full-width layout —
+everything downstream (`build_workbook.py`, parity, gates) is reused unchanged. A Look with
+**dimensions + measures becomes a Sigma grouped `table`** (dims → `groupings.groupBy`,
+measures → `groupings.calculations`); measure-only → a KPI row; pivoted → a `pivot-table`
+(rowsBy/columnsBy/values); a chart Look → the matching chart. The Look path additionally
+emits `fieldMeta` (authoritative dim/measure category from the explore metadata + custom
+`dynamic_fields`) so ad-hoc/custom measures classify correctly even with no local LookML.
+Run it with `--look-id <id>` (see the ONE COMMAND block). A **table-only** Look verifies via
+a grand-total parity target; a dimension-only detail Look has no measure to check (named
+`--skip-parity-gate` waiver + the offline golden test + visual QA).
 
 **Critical — UDD is the primary path.** Most real Looker dashboards are **user-defined
 (UDD)** — built in the UI, NOT in any LookML file. They are reachable ONLY via the Looker
@@ -102,6 +116,9 @@ python3 scripts/migrate-looker.py --lookml-dir fixtures/skilltest-orders \
 # live (UDD or LookML dashboard, ~/.looker/looker.ini configured):
 python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
     --dashboard-id <id> [--explore <name>] [--name PREFIX] [--workdir DIR]
+# live (a single Look → a one-tile workbook: grouped table / KPI / pivot / chart):
+python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
+    --look-id <id> [--explore <name>] [--name PREFIX] [--workdir DIR]
 ```
 
 - **Decision points are flags with safe defaults, never silent:** `detect_rls.py`
@@ -161,7 +178,8 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
 | `scripts/probe-controls.rb` | **Optional Phase-4 flip test** — runtime proof that controls actually filter: per control, exports one in-closure element CSV with and without `parameters:{controlId: <non-default value>}` (must differ) and, with `--check-out-of-closure`, an out-of-closure element (must NOT differ). Not the mandatory inner loop. Shared, vendored byte-identical. `refs/control-parity.md` has the design + the MCP-vs-export answer. |
 | `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` → `SIGMA_API_TOKEN` (~1h TTL). `eval "$(scripts/get-token.sh)"` |
 | `scripts/looker_api.py` | Minimal Looker REST API 4.0 client (no SDK). Reads `~/.looker/looker.ini`, logs in via `client_credentials`, exposes `L.call(method, path, body)`. **Caches the bearer per process** (thread-safe; one login instead of one per call — ~150ms/call saved, measured 2.4x on a 10-call run) and retries once with a fresh login on 401. CLI: `python3 looker_api.py whoami` / `get <path>` / `raw GET /lookml_models`. |
-| `scripts/fetch_looker_dashboard.py` | **Phase 1 (live):** `GET /dashboards/{id}` → the normalized contract (`refs/dashboard-contract.md`). Works for UDD AND LookML dashboards. Self-contained (reads `~/.looker/looker.ini`). `tileType` is read from `query.vis_config.type` (NOT `element.type`, which is always `"vis"`); `listen` from `result_maker.filterables`; layout from the **active** layout's components. |
+| `scripts/fetch_looker_dashboard.py` | **Phase 1 (live):** `GET /dashboards/{id}` → the normalized contract (`refs/dashboard-contract.md`). Works for UDD AND LookML dashboards. Self-contained (reads `~/.looker/looker.ini`). `tileType` is read from `query.vis_config.type` (NOT `element.type`, which is always `"vis"`); `listen` from `result_maker.filterables`; layout from the **active** layout's components. Exposes the shared `normalize_element()` (one tile → one contract element) and `build_field_meta()` (authoritative dim/measure category from the explore metadata + `dynamic_fields`). |
+| `scripts/fetch_looker_look.py` | **Phase 1 (live — Looks):** `GET /looks/{id}` → the **same contract** as the dashboard fetch but with ONE tile, `filters:[]`, a full-width layout, and a `fieldMeta` map. Imports+reuses `fetch_looker_dashboard`'s helpers (single source of truth), so a Look tile normalizes identically to a dashboard tile. `python3 fetch_looker_look.py <look_id> [out.json]`. |
 | `scripts/parse_lookml_dashboard.py` | **Phase 1 (offline):** parse a `.dashboard.lookml` (YAML) → the SAME contract. Dev/test only; cannot see UDD dashboards. Requires PyYAML. |
 | `scripts/detect_rls.py` | **Phase 1 (RLS scan):** dependency-free regex scan of a LookML dir/file (and/or model JSON) for row-level-security constructs (`access_filter`, `sql_always_where`, `access_grant`, `user_attribute`). Prints a structured summary + recommended Sigma mapping per finding (or `--json`). **Prints nothing / exits 0 when there's no RLS** (zero-overhead). `python3 detect_rls.py <lookml_dir> [--json]` |
 | `scripts/apply_sigma_rls.py` | **Phase 1.5 (apply RLS):** scripted, API-driven RLS port. Reuse-first `GET /v2/user-attributes` (prints a match before creating); `--create` → `POST /v2/user-attributes`; `--assign` (+`--member-id`,`--value`) → `POST /v2/user-attributes/{id}/users`; `--field`/`--element-id` → print the verified RLS calc-col + element-filter snippet, `--apply --dm-id` → PATCH it into the DM element spec. **Read-only / plan-only by default — mutates only on an explicit `--create`/`--assign`/`--apply` flag.** Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN` like `post_dm.py`. |
@@ -172,18 +190,22 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
 | `scripts/post_dm.py` | **Phase 2:** POST a DM spec to `/v2/dataModels/spec` (auto-finds a writable folder, swaps in the full connection UUID). Env: `SIGMA_API_TOKEN`, `SIGMA_BASE_URL`, `SIGMA_CONNECTION_ID`; args `<spec.json>`. |
 | `scripts/build_workbook.py` | **Phase 3:** dashboard contract + the explore's view `.lkml` files → a Sigma `/v2/workbooks/spec` body (hidden Data page + master table, one element per tile, controls from filters, newspaper→24-col layout XML). Generates locally; does **not** POST. Handles ratio measures, joined-col `Field (alias)` naming, table calcs, pivot-flatten + warn. Layout: a top control bar (row 0), a full-width strip of **tall** KPI tiles (height ≥ 6 so titles render), then the remaining tiles shifted down. |
 | `scripts/looker-render-dashboard.py` | **Phase 4 (visual QA — SOURCE side):** render a LIVE Looker dashboard to PNG via the Looker render API (`POST /render_tasks/dashboards/{id}/png` → poll `GET /render_tasks/{task_id}` until `success` → `GET .../results`). Pairs with `sigma-export-png.py` for source-vs-migrated side-by-side. Reuses `looker_api.py` `~/.looker/looker.ini` auth. `python3 looker-render-dashboard.py <dashboard_id> [out.png] [--w 1200 --h 1600]`. |
+| `scripts/looker-render-look.py` | **Phase 4 (visual QA — SOURCE side, Looks):** render a LIVE Look to PNG via `GET /looks/{id}/run/png` (SYNCHRONOUS — no render-task poll). The Look analog of `looker-render-dashboard.py`; pairs with `sigma-export-png.py`. `python3 looker-render-look.py <look_id> [out.png] [--w 1200 --h 900]`. |
 | `scripts/sigma-export-png.py` | **Phase 4 (visual QA — MIGRATED side):** render a posted workbook page or element to PNG via `POST /v2/workbooks/{id}/export` → poll `GET /v2/query/{queryId}/download`. For side-by-side layout/render checks against the source Looker dashboard render (catches hidden KPI titles, orphaned filters, overlaps, bare-number vs `$`/`%` formats that a numeric parity check can't). **Read each migrated PNG and check it against `refs/layout-visual-qa.md` (mandatory gate — see Phase 4a).** Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN`. `python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png` (or `--element <id>`). |
 | `scripts/build_looker_dashboard.py` | **TEST-FIXTURE BUILDER (not a migration step).** Builds the "Orders Overview" UDD on `csa_thelook` via the Looker API (4 KPIs + line/column/bar/pie + grid, 3 filters wired via `result_maker.filterables.listen`). |
 | `scripts/build_looker_dashboard2.py` | **TEST-FIXTURE BUILDER (not a migration step).** Builds the "Orders Deep Dive" UDD — area, pivot, table-calcs, scatter, donut, text tile — the harder dashboard surface for the converter. |
+| `scripts/build_looker_look.py` | **TEST-FIXTURE BUILDER (not a migration step).** Creates a matrix of test Looks on `csa_thelook`/`order_fact` (grouped table, measure-only, dims-only, bar, pivot, and a `dynamic_fields` custom measure) to exercise the Look → grouped-table / pivot / KPI / chart converter. `POST /queries` then `POST /looks`. `python3 build_looker_look.py [looker_folder_id]`. |
+| `scripts/record-visual-check.rb` | **Phase 4a (visual gate):** record the agent's source-vs-target visual verdict into `parity-final.json` so `assert-phase6-ran.rb` gate 8b can confirm the comparison happened (not a prose "I looked"). Shared/vendored byte-identical with the other migration plugins. `ruby record-visual-check.rb --workdir <dir> --agent-vision true --verdict pass --screenshot <png> --checklist "…" --notes "…"`. |
 | `scripts/gap-scout.md` | **Gap scout (converter gaps):** runbook for the main agent — when/how to spawn a scout subagent for a LookML construct the converter can't translate, the LookML→Sigma candidate table, and the opt-in issue-filing flow. Read before spawning. |
 | `scripts/scout-validate.py` | **Gap scout:** validate a candidate Sigma formula against a real DM element (throwaway test workbook → check column type ≠ `error` → delete), persist a win to `~/.looker-to-sigma/learned-rules.yaml`, or return an opt-in `escalation` block on failure. Also a quick "does this formula resolve?" check for Phase-4 validation. Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN`. |
 | `scripts/learned-rules.py` | **Gap scout:** loader for the customer-local `learned-rules.yaml` (`load()`/`apply()`); applied to LookML measure expressions before the converter/WARN fallback. Home = `~/.looker-to-sigma` (override `LOOKER_TO_SIGMA_HOME`). |
 | `scripts/escalate-gap.py` | **Gap scout (shared, identical across all migration skills):** opt-in GitHub-issue filer — category→repo routing, dedupe (open issues + beads), converter-repo mirroring, bead cross-link. **Dry-run by default; files only with `--yes`.** Requires `gh`. |
 
 > **Test-fixture builders vs migration scripts.** `build_looker_dashboard.py` /
-> `build_looker_dashboard2.py` **author** Looker dashboards (migration *targets*); they are
-> for standing up known demo content to convert and parity-check. Never run them against a
-> customer's Looker. Everything else converts *from* Looker *to* Sigma.
+> `build_looker_dashboard2.py` / `build_looker_look.py` **author** Looker dashboards/Looks
+> (migration *targets*); they are for standing up known demo content to convert and
+> parity-check. Never run them against a customer's Looker. Everything else converts *from*
+> Looker *to* Sigma.
 
 ---
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/csa_thelook.model.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/csa_thelook.model.lkml
@@ -1,0 +1,155 @@
+connection: "csa_tj"
+
+include: "/views/*.view.lkml"
+
+label: "CSA thelook"
+
+# ---- Explore 1: order line fact (star schema, snowflake joins) ----
+explore: order_fact {
+  label: "Orders"
+  description: "Order line fact joined to customer, product, store, order date and promotion dimensions."
+
+  # Row-level security: restrict rows to the region(s) in the user's allowed_region user attribute.
+  access_filter: {
+    field: customer_dim.region
+    user_attribute: allowed_region
+  }
+
+  join: customer_dim {
+    type: left_outer
+    sql_on: ${order_fact.customer_key} = ${customer_dim.customer_key} ;;
+    relationship: many_to_one
+  }
+  join: product_dim {
+    type: left_outer
+    sql_on: ${order_fact.product_key} = ${product_dim.product_key} ;;
+    relationship: many_to_one
+  }
+  join: store_dim {
+    type: left_outer
+    sql_on: ${order_fact.order_store_key} = ${store_dim.store_key} ;;
+    relationship: many_to_one
+  }
+  join: order_date {
+    from: date_dim
+    type: left_outer
+    sql_on: ${order_fact.order_date_key} = ${order_date.date_key} ;;
+    relationship: many_to_one
+  }
+  join: promo_dim {
+    type: left_outer
+    sql_on: ${order_fact.promo_key} = ${promo_dim.promo_key} ;;
+    relationship: many_to_one
+  }
+}
+
+# ---- Explore 2: customer 360 (dim + derived-table summary) ----
+explore: customer_dim {
+  label: "Customer 360"
+  description: "Customer dimension enriched with a derived-table lifetime order summary."
+
+  join: customer_order_summary {
+    type: left_outer
+    sql_on: ${customer_dim.customer_key} = ${customer_order_summary.customer_key} ;;
+    relationship: one_to_one
+  }
+}
+
+# ---- Explore 3: secured orders (exercises explore-level access/filter features) ----
+explore: orders_secure {
+  from: order_fact
+  label: "Orders (Secured)"
+  description: "Exercises sql_always_where, always_filter, full_outer + field-limited joins."
+
+  # row-level + default filters
+  sql_always_where: ${orders_secure.order_status} != 'Cancelled' ;;
+  always_filter: {
+    filters: [orders_secure.order_channel: "Online,App"]
+  }
+
+  join: customer_dim {
+    type: full_outer
+    relationship: many_to_one
+    sql_on: ${orders_secure.customer_key} = ${customer_dim.customer_key} ;;
+    fields: [customer_dim.region, customer_dim.loyalty_tier, customer_dim.customer_segment]
+  }
+  join: product_dim {
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${orders_secure.product_key} = ${product_dim.product_key} ;;
+    fields: [product_dim.category, product_dim.brand]
+  }
+}
+
+# ============================================================
+# Benchmark additions (2026-06-22) — escalating-complexity tiers
+# ============================================================
+
+# Datagroup driving the customer_order_summary PDT persistence (T3).
+datagroup: daily_refresh {
+  sql_trigger: SELECT CURRENT_DATE ;;
+  max_cache_age: "24 hours"
+}
+
+# Model access grant — gates order_fact.secured_net_profit (T4).
+# Default-allows so existing dashboards are unaffected; converter still notes it.
+access_grant: can_view_profit {
+  user_attribute: can_view_profit
+  allowed_values: ["yes"]
+}
+
+# ---- T1: trivial single-view explore (no joins, no RLS) ----
+explore: product_catalog {
+  from: product_dim
+  label: "Product Catalog"
+  description: "Single-view product dimension — no joins, no RLS (T1)."
+}
+
+# ---- T2: star-join orders explore (multi-join, NO RLS) ----
+explore: orders_basic {
+  from: order_fact
+  label: "Orders (Basic)"
+  description: "Order line fact joined to customer/product/order date. Star schema, no RLS (T2)."
+
+  join: customer_dim {
+    type: left_outer
+    sql_on: ${orders_basic.customer_key} = ${customer_dim.customer_key} ;;
+    relationship: many_to_one
+  }
+  join: product_dim {
+    type: left_outer
+    sql_on: ${orders_basic.product_key} = ${product_dim.product_key} ;;
+    relationship: many_to_one
+  }
+  join: order_date {
+    from: date_dim
+    type: left_outer
+    sql_on: ${orders_basic.order_date_key} = ${order_date.date_key} ;;
+    relationship: many_to_one
+  }
+}
+
+# ---- T4: secured orders explore (access_filter RLS + sql_always_where + access_grant) ----
+explore: orders_secured {
+  from: order_fact
+  label: "Orders (Region-Secured)"
+  description: "Region RLS via access_filter + sql_always_where + access-grant-gated profit (T4)."
+
+  access_filter: {
+    field: customer_dim.region
+    user_attribute: allowed_region
+  }
+  sql_always_where: ${orders_secured.order_status} != 'Cancelled' ;;
+
+  join: customer_dim {
+    type: left_outer
+    sql_on: ${orders_secured.customer_key} = ${customer_dim.customer_key} ;;
+    relationship: many_to_one
+  }
+  join: order_date {
+    from: date_dim
+    type: left_outer
+    sql_on: ${orders_secured.order_date_key} = ${order_date.date_key} ;;
+    relationship: many_to_one
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_bar.contract.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_bar.contract.json
@@ -1,0 +1,60 @@
+{
+  "id": "5",
+  "title": "Skilltest Look \u2014 Bar",
+  "layoutMode": "newspaper",
+  "source": "api-look",
+  "lookmlLinkId": "/looks/5",
+  "filters": [],
+  "elements": [
+    {
+      "name": "Skilltest Look \u2014 Bar",
+      "tileType": "looker_column",
+      "merge": null,
+      "model": "csa_thelook",
+      "explore": "order_fact",
+      "fields": [
+        "customer_dim.region",
+        "order_fact.total_net_revenue"
+      ],
+      "pivots": [],
+      "filters": {},
+      "sorts": [
+        "order_fact.total_net_revenue desc"
+      ],
+      "limit": 5000,
+      "listen": {},
+      "dynamicFields": [],
+      "noteText": null,
+      "subtitleText": null,
+      "bodyText": null,
+      "referenceLines": [],
+      "color": {
+        "seriesColors": {},
+        "palette": [],
+        "colorApplication": null
+      },
+      "cellVisualizations": {},
+      "layout": {
+        "row": 0,
+        "col": 0,
+        "width": 24,
+        "height": 8
+      },
+      "total": false,
+      "rowTotal": false,
+      "columnLimit": 50
+    }
+  ],
+  "fieldMeta": {
+    "customer_dim.region": {
+      "category": "dimension"
+    },
+    "order_fact.total_net_revenue": {
+      "category": "measure",
+      "aggType": "sum",
+      "sql": "${TABLE}.NET_REVENUE ",
+      "baseColumn": "order_fact.NET_REVENUE",
+      "valueFormat": "usd"
+    }
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_custom_measure.contract.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_custom_measure.contract.json
@@ -1,0 +1,66 @@
+{
+  "id": "7",
+  "title": "Skilltest Look \u2014 Custom Measure",
+  "layoutMode": "newspaper",
+  "source": "api-look",
+  "lookmlLinkId": "/looks/7",
+  "filters": [],
+  "elements": [
+    {
+      "name": "Skilltest Look \u2014 Custom Measure",
+      "tileType": "looker_grid",
+      "merge": null,
+      "model": "csa_thelook",
+      "explore": "order_fact",
+      "fields": [
+        "customer_dim.region",
+        "custom_total_profit"
+      ],
+      "pivots": [],
+      "filters": {},
+      "sorts": [
+        "custom_total_profit desc"
+      ],
+      "limit": 5000,
+      "listen": {},
+      "dynamicFields": [
+        {
+          "measure": "custom_total_profit",
+          "based_on": "order_fact.net_profit",
+          "type": "sum",
+          "label": "Custom Total Profit",
+          "_kind_hint": "measure"
+        }
+      ],
+      "noteText": null,
+      "subtitleText": null,
+      "bodyText": null,
+      "referenceLines": [],
+      "color": {
+        "seriesColors": {},
+        "palette": [],
+        "colorApplication": null
+      },
+      "cellVisualizations": {},
+      "layout": {
+        "row": 0,
+        "col": 0,
+        "width": 24,
+        "height": 8
+      },
+      "total": false,
+      "rowTotal": false,
+      "columnLimit": 50
+    }
+  ],
+  "fieldMeta": {
+    "customer_dim.region": {
+      "category": "dimension"
+    },
+    "custom_total_profit": {
+      "category": "measure",
+      "aggType": "sum",
+      "baseColumn": "order_fact.net_profit"
+    }
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_dims_only.contract.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_dims_only.contract.json
@@ -1,0 +1,54 @@
+{
+  "id": "4",
+  "title": "Skilltest Look \u2014 Dims Only",
+  "layoutMode": "newspaper",
+  "source": "api-look",
+  "lookmlLinkId": "/looks/4",
+  "filters": [],
+  "elements": [
+    {
+      "name": "Skilltest Look \u2014 Dims Only",
+      "tileType": "looker_grid",
+      "merge": null,
+      "model": "csa_thelook",
+      "explore": "order_fact",
+      "fields": [
+        "customer_dim.region",
+        "order_fact.order_channel"
+      ],
+      "pivots": [],
+      "filters": {},
+      "sorts": [],
+      "limit": 5000,
+      "listen": {},
+      "dynamicFields": [],
+      "noteText": null,
+      "subtitleText": null,
+      "bodyText": null,
+      "referenceLines": [],
+      "color": {
+        "seriesColors": {},
+        "palette": [],
+        "colorApplication": null
+      },
+      "cellVisualizations": {},
+      "layout": {
+        "row": 0,
+        "col": 0,
+        "width": 24,
+        "height": 8
+      },
+      "total": false,
+      "rowTotal": false,
+      "columnLimit": 50
+    }
+  ],
+  "fieldMeta": {
+    "customer_dim.region": {
+      "category": "dimension"
+    },
+    "order_fact.order_channel": {
+      "category": "dimension"
+    }
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_grouped_table.contract.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_grouped_table.contract.json
@@ -1,0 +1,77 @@
+{
+  "id": "2",
+  "title": "Skilltest Look \u2014 Grouped Table",
+  "layoutMode": "newspaper",
+  "source": "api-look",
+  "lookmlLinkId": "/looks/2",
+  "filters": [],
+  "elements": [
+    {
+      "name": "Skilltest Look \u2014 Grouped Table",
+      "tileType": "looker_grid",
+      "merge": null,
+      "model": "csa_thelook",
+      "explore": "order_fact",
+      "fields": [
+        "customer_dim.region",
+        "product_dim.category",
+        "order_fact.total_net_revenue",
+        "order_fact.distinct_order_count",
+        "order_fact.average_order_value"
+      ],
+      "pivots": [],
+      "filters": {},
+      "sorts": [],
+      "limit": 5000,
+      "listen": {},
+      "dynamicFields": [],
+      "noteText": null,
+      "subtitleText": null,
+      "bodyText": null,
+      "referenceLines": [],
+      "color": {
+        "seriesColors": {},
+        "palette": [],
+        "colorApplication": null
+      },
+      "cellVisualizations": {},
+      "layout": {
+        "row": 0,
+        "col": 0,
+        "width": 24,
+        "height": 8
+      },
+      "total": false,
+      "rowTotal": false,
+      "columnLimit": 50
+    }
+  ],
+  "fieldMeta": {
+    "customer_dim.region": {
+      "category": "dimension"
+    },
+    "product_dim.category": {
+      "category": "dimension"
+    },
+    "order_fact.total_net_revenue": {
+      "category": "measure",
+      "aggType": "sum",
+      "sql": "${TABLE}.NET_REVENUE ",
+      "baseColumn": "order_fact.NET_REVENUE",
+      "valueFormat": "usd"
+    },
+    "order_fact.distinct_order_count": {
+      "category": "measure",
+      "aggType": "count_distinct",
+      "sql": "${order_id} ",
+      "baseColumn": "order_fact.order_id"
+    },
+    "order_fact.average_order_value": {
+      "category": "measure",
+      "aggType": "number",
+      "sql": "1.0 * ${total_net_revenue} / NULLIF(${distinct_order_count}, 0) ",
+      "baseColumn": "order_fact.total_net_revenue",
+      "valueFormat": "usd"
+    }
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_measure_only.contract.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_measure_only.contract.json
@@ -1,0 +1,68 @@
+{
+  "id": "3",
+  "title": "Skilltest Look \u2014 Measure Only",
+  "layoutMode": "newspaper",
+  "source": "api-look",
+  "lookmlLinkId": "/looks/3",
+  "filters": [],
+  "elements": [
+    {
+      "name": "Skilltest Look \u2014 Measure Only",
+      "tileType": "looker_grid",
+      "merge": null,
+      "model": "csa_thelook",
+      "explore": "order_fact",
+      "fields": [
+        "order_fact.total_net_revenue",
+        "order_fact.distinct_order_count",
+        "order_fact.total_quantity"
+      ],
+      "pivots": [],
+      "filters": {},
+      "sorts": [],
+      "limit": 5000,
+      "listen": {},
+      "dynamicFields": [],
+      "noteText": null,
+      "subtitleText": null,
+      "bodyText": null,
+      "referenceLines": [],
+      "color": {
+        "seriesColors": {},
+        "palette": [],
+        "colorApplication": null
+      },
+      "cellVisualizations": {},
+      "layout": {
+        "row": 0,
+        "col": 0,
+        "width": 24,
+        "height": 8
+      },
+      "total": false,
+      "rowTotal": false,
+      "columnLimit": 50
+    }
+  ],
+  "fieldMeta": {
+    "order_fact.total_net_revenue": {
+      "category": "measure",
+      "aggType": "sum",
+      "sql": "${TABLE}.NET_REVENUE ",
+      "baseColumn": "order_fact.NET_REVENUE",
+      "valueFormat": "usd"
+    },
+    "order_fact.distinct_order_count": {
+      "category": "measure",
+      "aggType": "count_distinct",
+      "sql": "${order_id} ",
+      "baseColumn": "order_fact.order_id"
+    },
+    "order_fact.total_quantity": {
+      "category": "measure",
+      "aggType": "sum",
+      "sql": "${TABLE}.QUANTITY_ORDERED ",
+      "baseColumn": "order_fact.QUANTITY_ORDERED"
+    }
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_pivot_table.contract.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/look_pivot_table.contract.json
@@ -1,0 +1,65 @@
+{
+  "id": "6",
+  "title": "Skilltest Look \u2014 Pivot Table",
+  "layoutMode": "newspaper",
+  "source": "api-look",
+  "lookmlLinkId": "/looks/6",
+  "filters": [],
+  "elements": [
+    {
+      "name": "Skilltest Look \u2014 Pivot Table",
+      "tileType": "looker_grid",
+      "merge": null,
+      "model": "csa_thelook",
+      "explore": "order_fact",
+      "fields": [
+        "customer_dim.region",
+        "order_fact.total_net_revenue"
+      ],
+      "pivots": [
+        "order_fact.order_channel"
+      ],
+      "filters": {},
+      "sorts": [
+        "order_fact.total_net_revenue desc"
+      ],
+      "limit": 5000,
+      "listen": {},
+      "dynamicFields": [],
+      "noteText": null,
+      "subtitleText": null,
+      "bodyText": null,
+      "referenceLines": [],
+      "color": {
+        "seriesColors": {},
+        "palette": [],
+        "colorApplication": null
+      },
+      "cellVisualizations": {},
+      "layout": {
+        "row": 0,
+        "col": 0,
+        "width": 24,
+        "height": 8
+      },
+      "total": false,
+      "rowTotal": false,
+      "columnLimit": 50
+    }
+  ],
+  "fieldMeta": {
+    "customer_dim.region": {
+      "category": "dimension"
+    },
+    "order_fact.total_net_revenue": {
+      "category": "measure",
+      "aggType": "sum",
+      "sql": "${TABLE}.NET_REVENUE ",
+      "baseColumn": "order_fact.NET_REVENUE",
+      "valueFormat": "usd"
+    },
+    "order_fact.order_channel": {
+      "category": "dimension"
+    }
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/customer_dim.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/customer_dim.view.lkml
@@ -1,0 +1,65 @@
+view: customer_dim {
+  sql_table_name: CSA.TJ.CUSTOMER_DIM ;;
+
+  dimension: customer_key {
+    primary_key: yes
+    hidden: yes
+    sql: ${TABLE}.CUSTOMER_KEY ;;
+  }
+  dimension: customer_id {
+    label: "Customer ID"
+    sql: ${TABLE}.CUSTOMER_ID ;;
+  }
+  dimension: first_name {
+    sql: ${TABLE}.FIRST_NAME ;;
+  }
+  dimension: last_name {
+    sql: ${TABLE}.LAST_NAME ;;
+  }
+  dimension: full_name {
+    label: "Customer Name"
+    sql: ${TABLE}.FIRST_NAME || ' ' || ${TABLE}.LAST_NAME ;;
+  }
+  dimension: email {
+    sql: ${TABLE}.EMAIL ;;
+  }
+  dimension: city {
+    sql: ${TABLE}.CITY ;;
+  }
+  dimension: state {
+    sql: ${TABLE}.STATE ;;
+  }
+  dimension: region {
+    label: "Region"
+    sql: ${TABLE}.REGION ;;
+  }
+  dimension: customer_segment {
+    label: "Customer Segment"
+    sql: ${TABLE}.CUSTOMER_SEGMENT ;;
+  }
+  dimension: loyalty_tier {
+    label: "Loyalty Tier"
+    sql: ${TABLE}.LOYALTY_TIER ;;
+  }
+  dimension: acquisition_channel {
+    label: "Acquisition Channel"
+    sql: ${TABLE}.ACQUISITION_CHANNEL ;;
+  }
+  dimension: lifetime_revenue {
+    type: number
+    value_format_name: usd
+    sql: ${TABLE}.LIFETIME_REVENUE ;;
+  }
+
+  measure: customer_count {
+    label: "Customers"
+    type: count_distinct
+    sql: ${customer_key} ;;
+  }
+  measure: total_lifetime_revenue {
+    label: "Lifetime Revenue"
+    type: sum
+    sql: ${TABLE}.LIFETIME_REVENUE ;;
+    value_format_name: usd
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/date_dim.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/date_dim.view.lkml
@@ -1,0 +1,51 @@
+view: date_dim {
+  sql_table_name: CSA.TJ.DATE_DIM ;;
+
+  dimension: date_key {
+    primary_key: yes
+    hidden: yes
+    sql: ${TABLE}.DATE_KEY ;;
+  }
+
+  dimension_group: order {
+    label: "Order"
+    type: time
+    timeframes: [date, week, month, month_name, quarter, year]
+    datatype: date
+    sql: ${TABLE}.FULL_DATE ;;
+  }
+
+  dimension: day_of_week {
+    label: "Day of Week"
+    sql: ${TABLE}.DAY_OF_WEEK ;;
+  }
+  dimension: month_name {
+    label: "Month Name"
+    sql: ${TABLE}.MONTH_NAME ;;
+  }
+  dimension: month_number {
+    type: number
+    sql: ${TABLE}.MONTH_NUMBER ;;
+  }
+  dimension: quarter_number {
+    type: number
+    label: "Quarter"
+    sql: ${TABLE}.QUARTER ;;
+  }
+  dimension: year {
+    type: number
+    sql: ${TABLE}.YEAR ;;
+  }
+  dimension: is_weekend {
+    type: yesno
+    sql: ${TABLE}.IS_WEEKEND = 1 ;;
+  }
+  dimension: is_holiday {
+    type: yesno
+    sql: ${TABLE}.IS_HOLIDAY = 1 ;;
+  }
+  dimension: fiscal_period {
+    label: "Fiscal Period"
+    sql: ${TABLE}.FISCAL_PERIOD ;;
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/order_fact.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/order_fact.view.lkml
@@ -1,0 +1,277 @@
+view: order_fact {
+  sql_table_name: CSA.TJ.ORDER_FACT ;;
+
+  # ---------- keys ----------
+  dimension: order_line_id {
+    primary_key: yes
+    hidden: yes
+    sql: ${order_id} || '-' || ${order_line} ;;
+  }
+  dimension: order_id {
+    label: "Order ID"
+    sql: ${TABLE}.ORDER_ID ;;
+    # link: feature — drill to an external order page
+    link: {
+      label: "View order in OMS"
+      url: "https://oms.example.com/orders/{{ value }}"
+    }
+  }
+  dimension: order_line {
+    type: number
+    sql: ${TABLE}.ORDER_LINE ;;
+  }
+  dimension: customer_key {
+    hidden: yes
+    sql: ${TABLE}.CUSTOMER_KEY ;;
+  }
+  dimension: product_key {
+    hidden: yes
+    sql: ${TABLE}.PRODUCT_KEY ;;
+  }
+  dimension: order_store_key {
+    hidden: yes
+    sql: ${TABLE}.ORDER_STORE_KEY ;;
+  }
+  dimension: promo_key {
+    hidden: yes
+    sql: ${TABLE}.PROMO_KEY ;;
+  }
+  dimension: order_date_key {
+    hidden: yes
+    sql: ${TABLE}.ORDER_DATE_KEY ;;
+  }
+
+  # ---------- attribute dimensions ----------
+  dimension: order_channel {
+    label: "Order Channel"
+    sql: ${TABLE}.ORDER_CHANNEL ;;
+  }
+  dimension: ship_method {
+    label: "Ship Method"
+    sql: ${TABLE}.SHIP_METHOD ;;
+  }
+  dimension: order_status {
+    label: "Order Status"
+    sql: ${TABLE}.ORDER_STATUS ;;
+    # html: feature — colored status pill
+    html: <span style="color: {% if value == 'Cancelled' %}#c0392b{% else %}#27ae60{% endif %}">{{ value }}</span> ;;
+  }
+  dimension: is_first_order {
+    type: yesno
+    sql: ${TABLE}.IS_FIRST_ORDER = 1 ;;
+  }
+  dimension: is_returned {
+    type: yesno
+    sql: ${TABLE}.IS_RETURNED = 1 ;;
+  }
+  dimension: is_cancelled {
+    type: yesno
+    sql: ${TABLE}.IS_CANCELLED = 1 ;;
+  }
+
+  # ---------- tier / bucket dimensions ----------
+  dimension: order_value_tier {
+    label: "Order Value Tier"
+    type: tier
+    tiers: [0, 25, 50, 100, 250, 500]
+    style: integer
+    sql: ${TABLE}.NET_REVENUE ;;
+  }
+  dimension: days_to_ship_tier {
+    label: "Days to Ship Bucket"
+    type: tier
+    tiers: [0, 2, 5, 8]
+    style: integer
+    sql: ${TABLE}.DAYS_TO_SHIP ;;
+  }
+
+  # ---------- CASE / derived dimensions ----------
+  dimension: profitability_band {
+    label: "Profitability Band"
+    sql:
+      CASE
+        WHEN ${TABLE}.NET_PROFIT < 0 THEN 'Loss'
+        WHEN ${TABLE}.NET_PROFIT < 20 THEN 'Low'
+        WHEN ${TABLE}.NET_PROFIT < 100 THEN 'Medium'
+        ELSE 'High'
+      END ;;
+  }
+
+  # ---------- numeric dimensions ----------
+  dimension: net_revenue {
+    type: number
+    value_format_name: usd
+    sql: ${TABLE}.NET_REVENUE ;;
+  }
+  dimension: net_profit {
+    type: number
+    value_format_name: usd
+    sql: ${TABLE}.NET_PROFIT ;;
+  }
+  dimension: quantity_ordered {
+    type: number
+    sql: ${TABLE}.QUANTITY_ORDERED ;;
+  }
+  dimension: quantity_returned {
+    type: number
+    sql: ${TABLE}.QUANTITY_RETURNED ;;
+  }
+  dimension: unit_price {
+    type: number
+    value_format_name: usd
+    sql: ${TABLE}.UNIT_PRICE ;;
+  }
+  dimension: days_to_ship {
+    type: number
+    sql: ${TABLE}.DAYS_TO_SHIP ;;
+  }
+
+  # ---------- measures: simple aggregates ----------
+  measure: order_count {
+    label: "Order Lines"
+    type: count
+  }
+  measure: distinct_order_count {
+    label: "Orders"
+    type: count_distinct
+    sql: ${order_id} ;;
+  }
+  measure: distinct_customers {
+    label: "Active Customers"
+    type: count_distinct
+    sql: ${customer_key} ;;
+  }
+  measure: total_net_revenue {
+    label: "Net Revenue"
+    type: sum
+    sql: ${TABLE}.NET_REVENUE ;;
+    value_format_name: usd
+    drill_fields: [order_id, order_channel, order_status, net_revenue]
+  }
+  measure: total_gross_revenue {
+    label: "Gross Revenue"
+    type: sum
+    sql: ${TABLE}.GROSS_REVENUE ;;
+    value_format_name: usd
+  }
+  measure: total_net_profit {
+    label: "Net Profit"
+    type: sum
+    sql: ${TABLE}.NET_PROFIT ;;
+    value_format_name: usd
+  }
+  measure: total_gross_profit {
+    label: "Gross Profit"
+    type: sum
+    sql: ${TABLE}.GROSS_PROFIT ;;
+    value_format_name: usd
+  }
+  measure: total_quantity {
+    label: "Units Ordered"
+    type: sum
+    sql: ${TABLE}.QUANTITY_ORDERED ;;
+  }
+
+  # ---------- measures: statistical ----------
+  measure: avg_unit_price {
+    label: "Avg Unit Price"
+    type: average
+    sql: ${TABLE}.UNIT_PRICE ;;
+    value_format_name: usd
+  }
+  measure: median_net_revenue {
+    label: "Median Line Revenue"
+    type: median
+    sql: ${TABLE}.NET_REVENUE ;;
+    value_format_name: usd
+  }
+  measure: p90_net_revenue {
+    label: "P90 Line Revenue"
+    type: percentile
+    percentile: 90
+    sql: ${TABLE}.NET_REVENUE ;;
+    value_format_name: usd
+  }
+
+  # ---------- measures: filtered ----------
+  measure: cancelled_order_count {
+    label: "Cancelled Lines"
+    type: count
+    filters: [is_cancelled: "yes"]
+  }
+  measure: first_order_revenue {
+    label: "First-Order Net Revenue"
+    type: sum
+    sql: ${TABLE}.NET_REVENUE ;;
+    filters: [is_first_order: "yes"]
+    value_format_name: usd
+  }
+  measure: returned_units {
+    label: "Returned Units"
+    type: sum
+    sql: ${TABLE}.QUANTITY_RETURNED ;;
+    filters: [is_returned: "yes"]
+  }
+
+  # ---------- measures: ratios (reference other measures) ----------
+  measure: average_order_value {
+    label: "Avg Order Value"
+    type: number
+    sql: 1.0 * ${total_net_revenue} / NULLIF(${distinct_order_count}, 0) ;;
+    value_format_name: usd
+  }
+  measure: gross_margin_pct {
+    label: "Gross Margin %"
+    type: number
+    sql: ${total_gross_profit} / NULLIF(${total_gross_revenue}, 0) ;;
+    value_format_name: percent_1
+  }
+  measure: return_rate {
+    label: "Return Rate"
+    type: number
+    sql: 1.0 * ${returned_units} / NULLIF(${total_quantity}, 0) ;;
+    value_format_name: percent_1
+  }
+
+  # ---------- measure gated by a model access_grant (T4 security tier) ----------
+  measure: secured_net_profit {
+    label: "Net Profit (Secured)"
+    type: sum
+    sql: ${TABLE}.NET_PROFIT ;;
+    value_format_name: usd
+    required_access_grants: [can_view_profit]
+  }
+
+  # ---------- measures: custom value_format ----------
+  measure: revenue_thousands {
+    label: "Net Revenue ($K)"
+    type: sum
+    sql: ${TABLE}.NET_REVENUE / 1000.0 ;;
+    value_format: "$#,##0.0\"K\""
+  }
+
+  # ---------- parameter + Liquid-templated measure ----------
+  parameter: revenue_metric_picker {
+    label: "Revenue Metric"
+    type: unquoted
+    allowed_value: {
+      label: "Net Revenue"
+      value: "NET_REVENUE"
+    }
+    allowed_value: {
+      label: "Gross Revenue"
+      value: "GROSS_REVENUE"
+    }
+    default_value: "NET_REVENUE"
+  }
+  measure: selected_revenue {
+    label_from_parameter: revenue_metric_picker
+    type: sum
+    sql: ${TABLE}.{% parameter revenue_metric_picker %} ;;
+    value_format_name: usd
+  }
+
+  set: order_detail {
+    fields: [order_id, order_channel, order_status, net_revenue, total_net_revenue]
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/product_dim.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/product_dim.view.lkml
@@ -1,0 +1,43 @@
+view: product_dim {
+  sql_table_name: CSA.TJ.PRODUCT_DIM ;;
+
+  dimension: product_key {
+    primary_key: yes
+    hidden: yes
+    sql: ${TABLE}.PRODUCT_KEY ;;
+  }
+  dimension: product_id {
+    label: "Product ID"
+    sql: ${TABLE}.PRODUCT_ID ;;
+  }
+  dimension: product_name {
+    label: "Product Name"
+    sql: ${TABLE}.PRODUCT_NAME ;;
+  }
+  dimension: category {
+    label: "Category"
+    sql: ${TABLE}.CATEGORY ;;
+  }
+  dimension: subcategory {
+    label: "Subcategory"
+    sql: ${TABLE}.SUBCATEGORY ;;
+  }
+  dimension: brand {
+    label: "Brand"
+    sql: ${TABLE}.BRAND ;;
+  }
+  dimension: is_private_label {
+    type: yesno
+    sql: ${TABLE}.IS_PRIVATE_LABEL = 1 ;;
+  }
+  dimension: is_seasonal {
+    type: yesno
+    sql: ${TABLE}.IS_SEASONAL = 1 ;;
+  }
+
+  measure: product_count {
+    label: "Products"
+    type: count_distinct
+    sql: ${product_key} ;;
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/promo_dim.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/promo_dim.view.lkml
@@ -1,0 +1,74 @@
+view: promo_dim {
+  sql_table_name: CSA.TJ.PROMO_DIM ;;
+  view_label: "Promotion"
+
+  dimension: promo_key {
+    primary_key: yes
+    hidden: yes
+    sql: ${TABLE}.PROMO_KEY ;;
+  }
+  dimension: promo_id {
+    label: "Promo ID"
+    group_label: "Promo Attributes"
+    sql: ${TABLE}.PROMO_ID ;;
+  }
+  dimension: promo_name {
+    label: "Promo Name"
+    group_label: "Promo Attributes"
+    sql: ${TABLE}.PROMO_NAME ;;
+  }
+  dimension: promo_type {
+    label: "Promo Type"
+    group_label: "Promo Attributes"
+    sql: ${TABLE}.PROMO_TYPE ;;
+  }
+  dimension: channel {
+    label: "Promo Channel"
+    sql: ${TABLE}.CHANNEL ;;
+  }
+  dimension: discount_pct {
+    type: number
+    value_format_name: percent_1
+    sql: ${TABLE}.DISCOUNT_PCT / 100.0 ;;
+  }
+  dimension: target_segment {
+    label: "Target Segment"
+    sql: ${TABLE}.TARGET_SEGMENT ;;
+  }
+
+  # legacy `case:` parameter (when/then/else) — distinct from a sql CASE expression
+  dimension: discount_band {
+    label: "Discount Band"
+    case: {
+      when: {
+        sql: ${TABLE}.DISCOUNT_PCT >= 30 ;;
+        label: "Deep (30%+)"
+      }
+      when: {
+        sql: ${TABLE}.DISCOUNT_PCT >= 15 ;;
+        label: "Medium (15-29%)"
+      }
+      else: "Light (<15%)"
+    }
+  }
+
+  # duration dimension_group (days/weeks between two dates)
+  dimension_group: campaign_length {
+    type: duration
+    intervals: [day, week]
+    sql_start: ${TABLE}.START_DATE ;;
+    sql_end: ${TABLE}.END_DATE ;;
+  }
+
+  measure: promo_count {
+    label: "Promotions"
+    type: count_distinct
+    sql: ${promo_key} ;;
+  }
+  measure: avg_discount_pct {
+    label: "Avg Discount %"
+    type: average
+    sql: ${TABLE}.DISCOUNT_PCT / 100.0 ;;
+    value_format_name: percent_1
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/store_dim.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-looks/views/store_dim.view.lkml
@@ -1,0 +1,41 @@
+view: store_dim {
+  sql_table_name: CSA.TJ.STORE_DIM ;;
+
+  dimension: store_key {
+    primary_key: yes
+    hidden: yes
+    sql: ${TABLE}.STORE_KEY ;;
+  }
+  dimension: store_id {
+    label: "Store ID"
+    sql: ${TABLE}.STORE_ID ;;
+  }
+  dimension: store_name {
+    label: "Store Name"
+    sql: ${TABLE}.STORE_NAME ;;
+  }
+  dimension: store_type {
+    label: "Store Type"
+    sql: ${TABLE}.STORE_TYPE ;;
+  }
+  dimension: city {
+    sql: ${TABLE}.CITY ;;
+  }
+  dimension: state {
+    sql: ${TABLE}.STATE ;;
+  }
+  dimension: region {
+    label: "Store Region"
+    sql: ${TABLE}.REGION ;;
+  }
+  dimension: district {
+    label: "District"
+    sql: ${TABLE}.DISTRICT ;;
+  }
+
+  measure: store_count {
+    label: "Stores"
+    type: count_distinct
+    sql: ${store_key} ;;
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/dashboard-contract.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/dashboard-contract.md
@@ -1,8 +1,11 @@
 # Looker Dashboard → normalized JSON contract
 
-The dashboard converter consumes ONE normalized shape, produced by either source:
+The dashboard converter consumes ONE normalized shape, produced by any source:
 - **Live (canonical):** Looker REST `GET /dashboards/{id}` + `GET /dashboards/{id}/dashboard_layouts`
   (+ `dashboard_filters`). Covers user-defined (UDD) **and** LookML dashboards identically.
+- **Live (Looks):** `GET /looks/{id}` → a **one-tile** instance of this contract
+  (`elements:[<tile>]`, `filters:[]`, synthesized full-width `layout`, plus `fieldMeta`), via
+  `fetch_looker_look.py` reusing the same `normalize_element`.
 - **Offline (dev only):** parse a `.dashboard.lookml` file and normalize into this shape.
 
 Keep the converter source-agnostic: it only sees this contract.
@@ -37,11 +40,32 @@ Keep the converter source-agnostic: it only sees this contract.
       "dynamicFields": [],             // table calcs / custom measures (client-side) → workbook formulas
       "noteText": "…", "subtitleText": "…",
       "cellVisualizations": {},        // grid in-cell data bars: {field: {scheme:[hex]|null}} from vis_config.series_cell_visualizations → conditionalFormats dataBars (often absent from the API even when the render shows bars — see SKILL.md Phase 3b)
+      "total": false,                  // (Look-only) query `total` → column grand totals (UI follow-up)
+      "rowTotal": false,               // (Look-only) query `row_total` → pivot row totals (UI follow-up)
+      "columnLimit": 50,               // (Look-only) query `column_limit` (pivot column cap)
       "layout": { "row": 0, "col": 0, "width": 8, "height": 6 }  // newspaper units
     }
-  ]
+  ],
+  "fieldMeta": {                       // (Look-only, ADDITIVE) authoritative field categories
+    "order_fact.total_net_revenue": { "category": "measure", "aggType": "sum",
+                                      "baseColumn": "order_fact.NET_REVENUE", "valueFormat": "usd" },
+    "customer_dim.region": { "category": "dimension" }
+  }
 }
 ```
+
+## `fieldMeta` (Look path only — additive, backward-compatible)
+
+Dashboards do **not** emit `fieldMeta`; when the key is absent `build_workbook.py` classifies
+dim-vs-measure from the view `.lkml` (`is_measure()`) exactly as before. `fetch_looker_look.py`
+adds it from Looker's authoritative source — `GET /lookml_models/{model}/explores/{explore}`
+field categories + `dynamic_fields` `_kind_hint` — so a Look's **ad-hoc/custom measures** (or a
+run with **no local LookML**) classify correctly instead of being dropped or forced into a
+`groupBy`. Per-field: `{category: "measure"|"dimension", aggType?, baseColumn? (fully-qualified
+"view.col"), valueFormat?, sql?}`. The builder consults `category` first, then folds any
+measure absent from the local views into its index (aggType + base column → the right Sigma
+aggregate). `total`/`rowTotal`/`columnLimit` are likewise Look-only and default falsy on
+dashboards.
 
 ## Field provenance (API vs LookML)
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_looker_look.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_looker_look.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""TEST-FIXTURE BUILDER (not a migration step). Creates a small matrix of Looker
+"Looks" (saved single queries) on csa_thelook/order_fact via the Looker API, to
+exercise the Look → Sigma grouped-table / pivot-table / KPI / chart converter.
+
+Each Look = POST /queries (model/view/fields/pivots/vis_config[/dynamic_fields])
+then POST /looks {title, query_id, folder_id}. Mirrors build_looker_dashboard.py.
+NEVER run against a customer's Looker.
+
+Usage:
+  python3 build_looker_look.py [looker_folder_id]
+  (folder defaults to the API user's personal folder)
+"""
+import json
+import sys
+
+import looker_api as L
+
+MODEL, EXPLORE = "csa_thelook", "order_fact"
+
+# (title, vis_type, fields, pivots, sorts, limit, dynamic_fields)
+LOOKS = [
+    # (1) GROUPED TABLE — 2 dims + 3 measures → groupings{groupBy:[2], calculations:[3]}
+    ("Skilltest Look — Grouped Table", "looker_grid",
+     ["customer_dim.region", "product_dim.category",
+      "order_fact.total_net_revenue", "order_fact.distinct_order_count",
+      "order_fact.average_order_value"], [], None, None, None),
+    # (2) MEASURE-ONLY — no dims → a row of KPI tiles
+    ("Skilltest Look — Measure Only", "looker_grid",
+     ["order_fact.total_net_revenue", "order_fact.distinct_order_count",
+      "order_fact.total_quantity"], [], None, None, None),
+    # (3) DIMS-ONLY — detail table (no groupings; nothing to aggregate)
+    ("Skilltest Look — Dims Only", "looker_grid",
+     ["customer_dim.region", "order_fact.order_channel"], [], None, None, None),
+    # (4) BAR — dim + measure, looker_column → vertical bar-chart
+    ("Skilltest Look — Bar", "looker_column",
+     ["customer_dim.region", "order_fact.total_net_revenue"], [],
+     ["order_fact.total_net_revenue desc"], None, None),
+    # (5) PIVOT TABLE — region rows × order_channel columns, revenue cells
+    ("Skilltest Look — Pivot Table", "looker_grid",
+     ["customer_dim.region", "order_fact.total_net_revenue"],
+     ["order_fact.order_channel"], ["order_fact.total_net_revenue desc"], None, None),
+    # (6) CUSTOM MEASURE (dynamic_fields, absent from the view .lkml) — must classify
+    #     as a MEASURE via fieldMeta → calculations, NOT a groupBy dimension.
+    ("Skilltest Look — Custom Measure", "looker_grid",
+     ["customer_dim.region", "custom_total_profit"], [],
+     ["custom_total_profit desc"], None,
+     [{"measure": "custom_total_profit", "based_on": "order_fact.net_profit",
+       "type": "sum", "label": "Custom Total Profit", "_kind_hint": "measure"}]),
+]
+
+
+def _personal_folder():
+    code, me = L.call("GET", "/user")
+    fid = (me or {}).get("personal_folder_id") or (me or {}).get("home_folder_id")
+    return str(fid) if fid else None
+
+
+def main(folder_id=None):
+    folder_id = str(folder_id) if folder_id else _personal_folder()
+    if not folder_id:
+        print("FATAL: no folder_id given and could not resolve the personal folder"); sys.exit(1)
+    print(f"creating Looks in Looker folder {folder_id} on {MODEL}/{EXPLORE}")
+    made = []
+    for title, vis, fields, pivots, sorts, limit, dyn in LOOKS:
+        qbody = {"model": MODEL, "view": EXPLORE, "fields": fields, "vis_config": {"type": vis}}
+        if pivots:
+            qbody["pivots"] = pivots
+        if sorts:
+            qbody["sorts"] = sorts
+        if limit:
+            qbody["limit"] = str(limit)
+        if dyn:
+            qbody["dynamic_fields"] = json.dumps(dyn)   # Looker stores this as a JSON string
+        code, q = L.call("POST", "/queries", qbody)
+        if code >= 300:
+            print(f"  query FAILED '{title}': {code} {q}"); continue
+        code, look = L.call("POST", "/looks",
+                            {"title": title, "query_id": q["id"], "folder_id": folder_id})
+        if code >= 300:
+            print(f"  look  FAILED '{title}': {code} {look}"); continue
+        made.append((look.get("id"), title))
+        print(f"  look '{title}': id={look.get('id')}")
+    print("\nDONE. Look ids: " + ", ".join(str(i) for i, _ in made))
+    return made
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else None)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -349,6 +349,12 @@ def main():
     a = ap.parse_args()
 
     dash = json.load(open(a.contract))
+    # Item 1 — authoritative dim/measure classification. A Look (fetch_looker_look.py)
+    # carries `fieldMeta` = {field: {category, aggType?, baseColumn?, valueFormat?, sql?}}
+    # pulled from Looker's explore metadata + dynamic_fields hints. Dashboards emit no
+    # `fieldMeta`, so this dict is empty for them and every predicate below falls back
+    # to the view-.lkml classification (behavior unchanged; golden diff empty).
+    field_cat = dash.get("fieldMeta") or {}
     # Model files live alongside or one level above the views dir — read their
     # join `from:` aliases so alias-qualified dashboard fields resolve.
     model_files = (glob.glob(os.path.join(a.views, "*.model.lkml"))
@@ -357,6 +363,28 @@ def main():
     warnings = []
     measures, dims, view_pk, formats, yesno_dims, dim_groups, dim_labels = build_field_index(
         sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))), aliases, warnings)
+
+    # Fold Looker's authoritative categories into the local indexes so a Look's
+    # ad-hoc/custom measures (dynamic_fields) — or a run with NO --views — classify
+    # correctly instead of being dropped or forced into groupBy. A measure absent
+    # from the local views gets a synthesized index entry (aggType + base column)
+    # so col_display()/formula_for() produce the right Sigma aggregate.
+    for _fname, _meta in field_cat.items():
+        _cat = _meta.get("category")
+        if _cat == "measure" and _fname not in measures:
+            _base = _meta.get("baseColumn")          # fully-qualified "view.col" (or None)
+            _agg = _meta.get("aggType") or "sum"
+            _sqlx = _meta.get("sql") or (("${TABLE}.%s" % leaf(_base)) if _base else "")
+            # store the base DISPLAY leaf (like a view measure); col_display() derives
+            # the denorm suffix from field_cat[...].baseColumn's view (below).
+            measures[_fname] = (_agg, disp(leaf(_base)) if _base else None, _sqlx, [])
+            _vf = _meta.get("valueFormat")
+            if _vf and _fname not in formats:
+                _fmt = sigma_format_for(_vf, None)
+                if _fmt:
+                    formats[_fname] = _fmt
+        elif _cat == "dimension":
+            dims.add(_fname)
 
     # ── per-explore masters ────────────────────────────────────────────────────
     # A Looker dashboard's tiles can hit SEVERAL explores; one master per explore,
@@ -429,7 +457,13 @@ def main():
         if ff: col["format"] = ff
         return col
 
-    def is_measure(f): return f in measures
+    def is_measure(f):
+        # fieldMeta is AUTHORITATIVE (Looker's own dim/measure category); fall back to
+        # the view-.lkml index only when the field isn't in fieldMeta (dashboard path).
+        c = (field_cat.get(f) or {}).get("category")
+        if c is not None:
+            return c == "measure"
+        return f in measures
     def is_ratio(f):
         """Measure whose sql references other measures or is a type:number arithmetic
         expression (e.g. AOV = revenue/orders) — has no single base column."""
@@ -477,6 +511,12 @@ def main():
             if is_ratio(f): return None           # composite — components needed separately
             base = measures[f][1]                 # base column (None for plain count)
             if not base: return None
+            # fieldMeta (custom/dynamic) measure: its field name is bare (no "view."
+            # prefix), so derive the denorm suffix from the base column's OWN view.
+            _bc = (field_cat.get(f) or {}).get("baseColumn")
+            if _bc:
+                _bview = _bc.split(".")[0] if "." in _bc else view
+                return base + ("" if _bview == explore else f" ({_bview})")
             # A count/count_distinct on a JOINED view keyed on that view's PK
             # references the join key — which the denorm element OMITS (a
             # cross-element passthrough of a join key compiles to type "error").
@@ -667,6 +707,8 @@ def main():
     def field_resolvable(f):
         if not f or "." not in f:
             return True                      # synthetic/unqualified — leave alone
+        if f in field_cat:
+            return True                      # Looker says it exists — trust it (no-checkout path)
         if is_measure(f) or f in dims:
             return True
         if dimgroup_display(f) is not None:
@@ -890,6 +932,15 @@ def main():
         ex = el["explore"]
         ms = [f for f in el["fields"] if is_measure(f)]
         ds = [f for f in el["fields"] if not is_measure(f)]
+
+        # ── pivoted table → real Sigma pivot-table (cross-tab) ────────────────
+        # A Looker grid/table WITH pivots is a cross-tab: row dims on the row shelf,
+        # the pivot field(s) on the column shelf, measures as the aggregated cells.
+        # Requires ≥1 non-pivot row dim AND ≥1 measure; otherwise fall through to the
+        # flat `table` branch (which flattens + warns). Sigma pivot-table REQUIRES
+        # both rowsBy and columnsBy (verified: sigma-workbooks tables.md).
+        if kind == "table" and el.get("pivots") and ds and ms:
+            kind = "pivot-table"
 
         # ── measure-only grid → a row of KPI tiles ────────────────────────────
         # A Looker table/grid with NO dimensions renders one row of totals. A
@@ -1151,6 +1202,27 @@ def main():
                 warnings.append(f"tile '{el['name']}': pivot {el['pivots']} flattened to columns — "
                                 f"rebuild as a Sigma pivot-table for true cross-tab")
 
+        elif kind == "pivot-table":
+            # Cross-tab: row dims → rowsBy, pivot field(s) → columnsBy, measures →
+            # values (the aggregated cells). Same source/columns as `table`; the
+            # shelves replace `groupings`. Shape verified: sigma-workbooks tables.md.
+            cols, row_ids, col_ids, val_ids = [], [], [], []
+            pivset = set(el.get("pivots") or [])
+            for f in el["fields"] + (el.get("pivots") or []):
+                tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": disp(leaf(f))}
+                if is_measure(f):
+                    apply_fmt(tcol, f); _warn_count(f, el); val_ids.append(tcol["id"])
+                elif f in pivset:
+                    col_ids.append(tcol["id"])
+                else:
+                    row_ids.append(tcol["id"])
+                cols.append(tcol)
+                field2cid[f] = tcol["id"]
+            base["columns"] = cols
+            base["values"] = val_ids
+            base["rowsBy"] = [{"id": i} for i in row_ids]
+            base["columnsBy"] = [{"id": i} for i in col_ids]
+
         # merged-results auto-join (Looker merge_result_id) — adds the secondary
         # explore's measure(s) as Max(Lookup(...)) columns now that base is built.
         attach_merge(el, base, kind, ex)
@@ -1196,11 +1268,66 @@ def main():
                     base["groupings"][0].setdefault("sort", []).append({"columnId": cid, "direction": direction})
                 else:
                     base.setdefault("sort", []).append({"columnId": cid, "direction": direction})
+            elif kind == "pivot-table":
+                # a dimension sort attaches to its row/column shelf item; a measure
+                # sort attaches `by: <value colId>` to the first row shelf item.
+                placed = False
+                for shelf in ("rowsBy", "columnsBy"):
+                    for it in base.get(shelf, []):
+                        if it.get("id") == cid:
+                            it["sort"] = {"direction": direction}; placed = True
+                if not placed and is_measure(sf) and base.get("rowsBy"):
+                    base["rowsBy"][0]["sort"] = {"direction": direction, "by": cid}
+
+        # ── row limit (Looker `limit`) → element top-N filter ─────────────────
+        # A Looker grid's row limit is a "first N after sort"; Sigma's closest
+        # spec-authorable analog is a top-N element filter ranked by a measure
+        # (rowCount is a literal — sigma-workbooks tables.md). Applies to grouped
+        # tables / pivots (an aggregated row set). Needs a measure column to rank by.
+        # Only a DELIBERATE small cap (< 500) is a top-N; Looker's default 500/5000
+        # row cap is a safety limit, not an analytical top-N — don't add a filter for it.
+        lim = el.get("limit")
+        if kind in ("table", "pivot-table") and isinstance(lim, int) and 0 < lim < 500:
+            rank_cid = None
+            # prefer the measure named in the first sort; else the first measure column
+            for s in (el.get("sorts") or []):
+                sf0 = str(s).split()[0]
+                if is_measure(sf0) and field2cid.get(sf0):
+                    rank_cid = field2cid[sf0]; break
+            if not rank_cid:
+                rank_cid = next((field2cid[f] for f in el["fields"] if is_measure(f) and field2cid.get(f)), None)
+            if rank_cid and base.get("groupings" if kind == "table" else "values"):
+                base.setdefault("filters", []).append({
+                    "id": sid("f"), "columnId": rank_cid, "kind": "top-n",
+                    "rankingFunction": "rank", "mode": "top-n", "rowCount": lim,
+                    "includeNulls": "when-no-value-is-selected"})
+                warnings.append(f"tile '{el['name']}': Looker row limit {lim} → Sigma top-{lim} "
+                                "filter ranked by the primary measure (approximates 'first N after sort').")
+            elif kind in ("table", "pivot-table"):
+                warnings.append(f"tile '{el['name']}': Looker row limit {lim} not applied — no measure "
+                                "column to rank a top-N by; add a Top-N in the Sigma UI if needed.")
+
+        # ── totals (Looker `total` / `row_total`) — UI follow-up ──────────────
+        # Column/row grand totals have no reliably-portable spec key on table/
+        # pivot-table (pivot `totals` also 500s CSV export), so surface them as a
+        # loud follow-up instead of emitting an unverified key. Never silent.
+        if el.get("total") or el.get("rowTotal"):
+            which = " + ".join([w for w, on in (("column totals", el.get("total")),
+                                                ("row totals", el.get("rowTotal"))) if on])
+            warnings.append(f"tile '{el['name']}': Looker {which} not ported — enable totals on the "
+                            "Sigma element in the UI (spec totals aren't reliably round-trippable).")
+
         # Looker table calcs (dynamic_fields) → Sigma formula columns
         for dyn in (el.get("dynamicFields") or []):
             if not isinstance(dyn, dict):
                 continue
             expr = dyn.get("expression") or ""
+            if not expr:
+                # A custom measure/dimension (based_on/measure/dimension, no
+                # `expression`) is a regular field — it is classified via fieldMeta
+                # and emitted through the normal field path. Skip here so it doesn't
+                # also append an empty-formula duplicate column.
+                continue
             label = dyn.get("label") or dyn.get("table_calculation") or "Calc"
             def _subfield(m):
                 f = m.group(1)
@@ -1213,7 +1340,15 @@ def main():
                 warnings.append(f"tile '{el['name']}': table calc '{label}' uses an unsupported "
                                 f"window fn — review: {expr}")
                 continue
-            base.setdefault("columns", []).append({"id": sid("tc"), "formula": sig.strip(), "name": label})
+            tcid = sid("tc")
+            base.setdefault("columns", []).append({"id": tcid, "formula": sig.strip(), "name": label})
+            # A table calc on a grouped/pivot table must join the aggregation, or it
+            # renders detached from the roll-up. Wire it into the grouping's
+            # calculations (grouped table) / the pivot's values.
+            if kind == "table" and base.get("groupings"):
+                base["groupings"][0].setdefault("calculations", []).append(tcid)
+            elif kind == "pivot-table":
+                base.setdefault("values", []).append(tcid)
         elements.append(base)
         el.setdefault("_emitted", []).append(base)   # control-targeting (listen:)
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
@@ -10,6 +10,7 @@ Usage:
 """
 import json
 import os
+import re
 import sys
 import urllib.parse
 import urllib.request
@@ -175,6 +176,132 @@ def _listen(el):
     return out
 
 
+def normalize_element(el, layout=None):
+    """One dashboard_element (or a synthesized Look tile) -> one contract tile dict,
+    or None to skip. `layout` overrides the per-element layout dict (default {}).
+
+    This is the single source of truth for tile normalization: a Look's synthesized
+    element flows through here and normalizes byte-identically to a dashboard tile.
+    """
+    lay = layout if layout is not None else {}
+    q = _query_of(el)
+    # Text/markdown tiles (headers, notes) have no query/fields — capture them
+    # as text elements so the builder can emit a Sigma text element.
+    if el.get("type") == "text" or (not q and (el.get("title_text") or el.get("body_text"))):
+        return {
+            "name": el.get("title") or el.get("title_text") or f"element_{el.get('id')}",
+            "tileType": "text",
+            "titleText": el.get("title_text"),
+            "bodyText": el.get("body_text"),
+            "subtitleText": el.get("subtitle_text"),
+            "layout": lay,
+        }
+    if not q and el.get("type") in (None, "text") and not el.get("title"):
+        return None
+    # Merged-results tile: a `merge_result_id` joins multiple explore queries.
+    # `q` (result_maker.query) is the PRIMARY source only, so render from it but
+    # attach the full merge so the builder can join (or flag) the others.
+    merge = _merge_of(el)
+    if merge and merge.get("sourceQueries"):
+        prim = next((s for s in merge["sourceQueries"] if s.get("isPrimary")), merge["sourceQueries"][0])
+        if not q:                                   # fall back to the primary source query
+            q = {"model": prim.get("model"), "view": prim.get("explore"),
+                 "fields": prim.get("fields") or [], "pivots": prim.get("pivots") or []}
+    vc = _vis_config(el, q)
+    return {
+        "name": el.get("title") or el.get("title_text") or f"element_{el.get('id')}",
+        "tileType": _vis_type(el, q),
+        "merge": merge,
+        "model": q.get("model"), "explore": q.get("view"),
+        "fields": q.get("fields") or [],
+        "pivots": q.get("pivots") or [],
+        "filters": q.get("filters") or {},
+        "sorts": q.get("sorts") or [],
+        "limit": int(q["limit"]) if str(q.get("limit") or "").isdigit() else q.get("limit"),
+        "listen": _listen(el),
+        "dynamicFields": _dyn(q.get("dynamic_fields")),
+        "noteText": el.get("note_text"), "subtitleText": el.get("subtitle_text"),
+        "bodyText": el.get("body_text"),
+        # chart reference lines + color encoding (vis_config) → Sigma refMarks/color
+        "referenceLines": _reflines(vc),
+        "color": _color(vc),
+        "cellVisualizations": _cell_viz(vc),
+        "layout": lay,
+    }
+
+
+def _explore_field_meta(model, explore):
+    """GET /lookml_models/{model}/explores/{explore} -> {field_name: {category,
+    aggType?, valueFormat?}}. Cached per (model, explore). Empty on any error."""
+    cache = getattr(_explore_field_meta, "_c", None)
+    if cache is None:
+        cache = {}; _explore_field_meta._c = cache
+    key = (model, explore)
+    if key in cache:
+        return cache[key]
+    meta = {}
+    if model and explore:
+        try:
+            ex = get("/lookml_models/%s/explores/%s" % (
+                urllib.parse.quote(str(model), safe=""), urllib.parse.quote(str(explore), safe="")))
+            flds = ex.get("fields") or {}
+            for cat, items in (("dimension", flds.get("dimensions") or []),
+                               ("measure", flds.get("measures") or [])):
+                for fdef in items:
+                    nm = fdef.get("name")
+                    if not nm:
+                        continue
+                    m = {"category": cat}
+                    if cat == "measure":
+                        m["aggType"] = fdef.get("type")
+                        # base column, kept fully-qualified ("view.col") so the
+                        # workbook builder can compute the denorm suffix correctly.
+                        sql = fdef.get("sql")
+                        if sql:
+                            m["sql"] = sql
+                            r = re.search(r"\$\{(?:TABLE\}\.)?([\w.]+)\}?", sql)
+                            if r:
+                                col = r.group(1)
+                                vw = nm.split(".")[0]
+                                m["baseColumn"] = col if "." in col else "%s.%s" % (vw, col)
+                    vf = fdef.get("value_format_name") or fdef.get("value_format")
+                    if vf:
+                        m["valueFormat"] = vf
+                    meta[nm] = m
+        except Exception:
+            pass
+    cache[key] = meta
+    return meta
+
+
+def build_field_meta(elements):
+    """Authoritative dim/measure category per referenced field, from the explore
+    metadata API + dynamic_fields hints. Returns {field: {category, aggType?,
+    baseColumn?, valueFormat?}}. Empty when the API is unreachable (the caller then
+    omits `fieldMeta` and build_workbook falls back to view-.lkml classification)."""
+    out = {}
+    for el in elements:
+        em = _explore_field_meta(el.get("model"), el.get("explore"))
+        for f in (el.get("fields") or []) + (el.get("pivots") or []):
+            if f in em:
+                out[f] = em[f]
+        # dynamic_fields (table calcs / custom measures) — authoritative _kind_hint
+        for dfld in (el.get("dynamicFields") or []):
+            if not isinstance(dfld, dict):
+                continue
+            nm = (dfld.get("table_calculation") or dfld.get("measure")
+                  or dfld.get("dimension") or dfld.get("name"))
+            if not nm:
+                continue
+            kind = dfld.get("_kind_hint")
+            if dfld.get("measure") or kind == "measure":
+                out[nm] = {"category": "measure", "aggType": dfld.get("type") or "sum",
+                           "baseColumn": dfld.get("based_on")}
+            else:
+                out[nm] = {"category": "dimension"}
+    return out
+
+
 def normalize(d):
     # active layout -> element_id -> {row,col,width,height}
     layout_mode, comp_by_el = "newspaper", {}
@@ -198,51 +325,9 @@ def normalize(d):
 
     elements = []
     for el in d.get("dashboard_elements", []):
-        q = _query_of(el)
-        # Text/markdown tiles (headers, notes) have no query/fields — capture them
-        # as text elements so the builder can emit a Sigma text element.
-        if el.get("type") == "text" or (not q and (el.get("title_text") or el.get("body_text"))):
-            elements.append({
-                "name": el.get("title") or el.get("title_text") or f"element_{el.get('id')}",
-                "tileType": "text",
-                "titleText": el.get("title_text"),
-                "bodyText": el.get("body_text"),
-                "subtitleText": el.get("subtitle_text"),
-                "layout": comp_by_el.get(el.get("id"), {}),
-            })
-            continue
-        if not q and el.get("type") in (None, "text") and not el.get("title"):
-            continue
-        # Merged-results tile: a `merge_result_id` joins multiple explore queries.
-        # `q` (result_maker.query) is the PRIMARY source only, so render from it but
-        # attach the full merge so the builder can join (or flag) the others.
-        merge = _merge_of(el)
-        if merge and merge.get("sourceQueries"):
-            prim = next((s for s in merge["sourceQueries"] if s.get("isPrimary")), merge["sourceQueries"][0])
-            if not q:                                   # fall back to the primary source query
-                q = {"model": prim.get("model"), "view": prim.get("explore"),
-                     "fields": prim.get("fields") or [], "pivots": prim.get("pivots") or []}
-        vc = _vis_config(el, q)
-        elements.append({
-            "name": el.get("title") or el.get("title_text") or f"element_{el.get('id')}",
-            "tileType": _vis_type(el, q),
-            "merge": merge,
-            "model": q.get("model"), "explore": q.get("view"),
-            "fields": q.get("fields") or [],
-            "pivots": q.get("pivots") or [],
-            "filters": q.get("filters") or {},
-            "sorts": q.get("sorts") or [],
-            "limit": int(q["limit"]) if str(q.get("limit") or "").isdigit() else q.get("limit"),
-            "listen": _listen(el),
-            "dynamicFields": _dyn(q.get("dynamic_fields")),
-            "noteText": el.get("note_text"), "subtitleText": el.get("subtitle_text"),
-            "bodyText": el.get("body_text"),
-            # chart reference lines + color encoding (vis_config) → Sigma refMarks/color
-            "referenceLines": _reflines(vc),
-            "color": _color(vc),
-            "cellVisualizations": _cell_viz(vc),
-            "layout": comp_by_el.get(el.get("id"), {}),
-        })
+        tile = normalize_element(el, comp_by_el.get(el.get("id"), {}))
+        if tile is not None:
+            elements.append(tile)
 
     return {
         "id": str(d.get("id")),

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_look.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_look.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Live discovery: Looker `GET /looks/{id}` (a saved single-query "Look") -> the
+SAME normalized contract as fetch_looker_dashboard.py, but with a SINGLE tile, no
+dashboard filters, and no dashboard layout.
+
+A Look's `.query` is structurally identical to a dashboard_element's query, so the
+tile normalizes byte-identically via fetch_looker_dashboard.normalize_element() —
+the single source of truth for tile normalization.
+
+Adds two Look-only, additive contract features (absent on dashboards, so
+build_workbook falls back to its current behavior when they're missing):
+  - `fieldMeta`: authoritative dim/measure category per referenced field, pulled
+    from the explore metadata API + dynamic_fields hints (build_field_meta). This
+    is what lets a Look with ad-hoc/custom measures (or no local LookML checkout)
+    classify correctly instead of dropping/misgrouping fields.
+  - per-tile `total` / `rowTotal` / `columnLimit` from the Look query.
+
+Auth from ~/.looker/looker.ini (client_credentials, API 4.0).
+
+Usage:
+  python3 fetch_looker_look.py <look_id> [out.json]
+"""
+import json
+import sys
+import urllib.parse
+
+import fetch_looker_dashboard as fd
+
+
+def normalize_look(look):
+    q = look.get("query") or {}
+    # Synthesize a dashboard_element around the Look's query so normalize_element
+    # handles it exactly like a dashboard tile. Full-width layout: a lone tile owns
+    # the whole page (and avoids build_workbook's auto-flow warning).
+    el = {"query": q, "title": look.get("title"), "type": "vis"}
+    tile = fd.normalize_element(el, layout={"row": 0, "col": 0, "width": 24, "height": 8})
+    elements = [tile] if tile else []
+    for t in elements:
+        # Look-only fidelity keys — build_workbook reads el.get(...) with a falsy
+        # default, so dashboards (which never set these) are unaffected.
+        t["total"] = bool(q.get("total"))
+        t["rowTotal"] = bool(q.get("row_total"))
+        cl = q.get("column_limit")
+        t["columnLimit"] = int(cl) if str(cl or "").isdigit() else cl
+
+    contract = {
+        "id": str(look.get("id")),
+        "title": look.get("title") or ("Look %s" % look.get("id")),
+        "layoutMode": "newspaper",
+        "source": "api-look",
+        "lookmlLinkId": look.get("short_url"),
+        "filters": [],
+        "elements": elements,
+    }
+    # Authoritative classification (explore field metadata + dynamic_fields hints).
+    # Empty when the API is unreachable -> key omitted -> build_workbook uses the
+    # view-.lkml is_measure() path (legacy behavior).
+    fm = fd.build_field_meta(elements)
+    if fm:
+        contract["fieldMeta"] = fm
+    return contract
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__); sys.exit(1)
+    lid = sys.argv[1]
+    # A single-item GET returns the LookWithQuery (embedded .query). The `fields`
+    # selector expands the nested query explicitly in case the default is sparse.
+    path = "/looks/%s?fields=%s" % (
+        urllib.parse.quote(str(lid), safe=""),
+        urllib.parse.quote("id,title,short_url,query"))
+    look = fd.get(path)
+    if not (look.get("query")):
+        # fall back to the plain resource if the fields selector stripped it
+        look = fd.get("/looks/%s" % urllib.parse.quote(str(lid), safe=""))
+    contract = normalize_look(look)
+    out = sys.argv[2] if len(sys.argv) > 2 else None
+    txt = json.dumps(contract, indent=2)
+    if out:
+        with open(out, "w") as f:
+            f.write(txt)
+        print("wrote %s: %d element(s), fieldMeta=%d field(s), title=%r" % (
+            out, len(contract["elements"]), len(contract.get("fieldMeta") or {}),
+            contract["title"]))
+    else:
+        print(txt)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker-render-look.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker-render-look.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""looker-render-look.py — render a LIVE Looker Look to PNG for Phase 4 SOURCE-vs-
+MIGRATED side-by-side visual QA (the Look analog of looker-render-dashboard.py).
+
+A Look renders SYNCHRONOUSLY — no render-task poll:
+  GET /looks/{id}/run/png?width=&height=   -> raw PNG bytes
+
+Pairs with sigma-export-png.py: render the Looker SOURCE Look here and the migrated
+Sigma workbook there, then read them together to catch chart-kind / grouping /
+formatting drift a numeric parity check can't see.
+
+Reuses looker_api.py's ~/.looker/looker.ini auth (fresh login per call). The render
+endpoint returns binary, so this fetches the bytes directly (no json decode).
+
+Usage:
+  python3 looker-render-look.py <look_id> [out.png] [--w 1200 --h 900]
+"""
+import argparse
+import os
+import sys
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import looker_api  # noqa: E402
+
+
+def _get_bytes(url, tok, verify, accept="image/png"):
+    req = urllib.request.Request(url, headers={"Authorization": "Bearer " + tok,
+                                               "Accept": accept}, method="GET")
+    try:
+        with urllib.request.urlopen(req, context=looker_api._ctx(verify), timeout=180) as r:
+            return r.status, r.read(), r.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(), e.headers.get("Content-Type", "")
+
+
+def render(look_id, out_path, width, height, fmt="png"):
+    base, tok, verify = looker_api.login()
+    url = f"{base}/looks/{look_id}/run/{fmt}?width={width}&height={height}"
+    code, content, ct = _get_bytes(url, tok, verify)
+    if code != 200 or not content:
+        sys.exit(f"look render GET {code} ({ct}): {content[:400].decode('utf-8', 'replace')}")
+    with open(out_path, "wb") as f:
+        f.write(content)
+    print(f"[looker] {len(content)} bytes -> {out_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("look_id")
+    ap.add_argument("out", nargs="?", default=None,
+                    help="output PNG path (default: /tmp/looker-look-<id>.png)")
+    ap.add_argument("--w", type=int, default=1200, help="render width px")
+    ap.add_argument("--h", type=int, default=900, help="render height px")
+    a = ap.parse_args()
+    render(a.look_id, a.out or f"/tmp/looker-look-{a.look_id}.png", a.w, a.h)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -474,6 +474,8 @@ def main():
                     "permission on the project; see looker_project.py).")
     ap.add_argument("--dashboard", help="offline: a .dashboard.lookml file")
     ap.add_argument("--dashboard-id", help="live: Looker dashboard id (needs ~/.looker/looker.ini)")
+    ap.add_argument("--look-id", help="live: Looker Look id (a single saved query → a "
+                    "one-tile workbook; needs ~/.looker/looker.ini)")
     ap.add_argument("--explore", help="explore to convert (default: the contract's most-used)")
     ap.add_argument("--name", help="name PREFIX applied to the DM and the workbook")
     ap.add_argument("--workdir")
@@ -507,11 +509,11 @@ def main():
         print(_path or "none")
         print(_desc)
         return 0
-    if not a.dashboard and not a.dashboard_id:
-        ap.error("--dashboard (offline .dashboard.lookml) or --dashboard-id (live) required")
+    if not a.dashboard and not a.dashboard_id and not a.look_id:
+        ap.error("--dashboard (offline .dashboard.lookml) / --dashboard-id / --look-id (live) required")
     if not a.lookml_dir and not a.project:
         ap.error("--lookml-dir (local checkout) or --project (pull via Looker API) required")
-    offline = not a.dashboard_id
+    offline = not a.dashboard_id and not a.look_id
     wd = os.path.abspath(os.path.expanduser(a.workdir or "./looker-migration"))
     os.makedirs(wd, exist_ok=True)
 
@@ -542,7 +544,11 @@ def main():
     # ── Phase 1 — Parse (the normalized dashboard contract) ──────────────────
     hdr(1, TOTAL, "Parse")
     contract_path = os.path.join(wd, "contract.json")
-    if offline:
+    if a.look_id:
+        # A Look is a single saved query → the same normalized contract with one tile.
+        run([sys.executable, os.path.join(HERE, "fetch_looker_look.py"),
+             a.look_id, contract_path])
+    elif offline:
         run([sys.executable, os.path.join(HERE, "parse_lookml_dashboard.py"),
              a.dashboard, "--out", contract_path])
     else:
@@ -1033,6 +1039,53 @@ console.error('stats:', JSON.stringify(res.stats));
         headers, rows = parse_csv(export_csv(wb, c["sigma_element_id"]))
         cidx = {h: i for i, h in enumerate(headers)}
         want = c["sigma_columns"]
+        if c.get("kind") == "table-total":
+            # A table-only Look → grand-total check: SUM the additive column over
+            # every displayed (grouped/pivot) row = the overall total (grain-
+            # invariant). EXPECTED = the same grand total of the tile's first
+            # measure from Looker (live) / the warehouse re-aggregation (offline).
+            def _num(x):
+                v = numify(x)
+                return v if isinstance(v, (int, float)) else None
+            if c.get("source_kind") == "pivot-table":
+                # A pivot CSV is a cross-tab: line 0 is a meta row, `headers` is the
+                # value/pivot-dim names, the first data row is the real column header
+                # (rowDim, pivotVals…, "Total"), and Sigma appends a grand-Total row
+                # (first cell "Total") whose last cell is the grand total. Prefer that;
+                # else sum the body cells excluding the Total row + Total column.
+                colhdr = rows[0] if rows else []
+                tot_cols = {i for i, h in enumerate(colhdr) if str(h).strip().lower() == "total"}
+                trow = next((r for r in rows if r and str(r[0]).strip().lower() == "total"), None)
+                gt = None
+                if trow:
+                    tail = [_num(trow[i]) for i in sorted(tot_cols) if i < len(trow)]
+                    tail = [n for n in tail if n is not None] or [n for n in map(_num, trow) if n is not None]
+                    gt = tail[-1] if tail else None
+                if gt is None:
+                    gt = sum(n for r in rows[1:] if not (r and str(r[0]).strip().lower() == "total")
+                             for i, cc in enumerate(r) if i not in tot_cols
+                             for n in [_num(cc)] if n is not None)
+                act = [[None, gt if gt is not None else 0]]
+            else:
+                # grouped table: a single named value column, no auto-total row → sum it
+                vi = cidx.get(want[0], 0)
+                act = [[None, sum(n for r in rows if vi < len(r)
+                                  for n in [_num(r[vi])] if n is not None)]]
+            el = by_name.get(cname)
+            if el is None:
+                msgs.append(f"   WARN: no source tile named {cname!r} in the contract — will DIVERGE")
+                return cname, act, None, msgs
+            exp = None
+            try:
+                rowsexp = None
+                if not offline:
+                    rowsexp = expected_live(el, measures)
+                if rowsexp is None:
+                    rowsexp = expected_offline(el, ev, mr)
+                exp = [[None, sum(numify(v) for _d, v in rowsexp if v is not None)]]
+            except Exception as ex:
+                msgs.append(f"   WARN: table-total expected fetch failed for {cname!r} ({ex})")
+            return cname, act, exp, msgs
         if len(want) == 1:                      # KPI
             vi = cidx.get(want[0], 0)
             act = [[None, numify(rows[0][vi])]] if rows else []

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/phase6-parity-looker.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/phase6-parity-looker.rb
@@ -92,6 +92,27 @@ def chart_columns(el)
   end
 end
 
+# A single Look often maps to a `table` / `pivot-table` with NO *-chart element,
+# so the chart-only planner above would leave charts empty and abort. Give such an
+# element a grain-invariant GRAND-TOTAL parity target: the SUM of its first ADDITIVE
+# aggregate column (grouped-table calculation / pivot value). SUM of per-group sums
+# == the overall total, so it holds regardless of the row grain — but ONLY for
+# additive measures (summing per-group AVERAGEs is meaningless), so a non-additive-
+# only table returns nil and is handled by a named parity waiver instead.
+ADDITIVE_AGG = /\A\s*(Sum|Count|CountDistinct|SumIf|CountIf|GrandTotal|CumulativeSum)\s*\(/i
+def table_total_column(el)
+  cols = el['columns'] || []
+  by = cols.each_with_object({}) { |c, h| h[c['id']] = c }
+  cand = if el['kind'] == 'pivot-table'
+           Array(el['values'])
+         else
+           g = Array(el['groupings']).first
+           g ? Array(g['calculations']) : []
+         end
+  add = cand.find { |id| by[id] && by[id]['formula'].to_s =~ ADDITIVE_AGG }
+  add && by[add] ? [add, by[add]['name']] : nil
+end
+
 if !opts[:finalize]
   abort('--workbook-id required for pass 1') unless opts[:wb]
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
@@ -107,14 +128,22 @@ if !opts[:finalize]
   charts = []
   Array(spec['pages']).each do |page|
     Array(page['elements']).each do |el|
-      next unless el['kind'].to_s.end_with?('-chart')
-      pairs = chart_columns(el)
-      next unless pairs
-      charts << { 'chart' => el['name'], 'sigma_element_id' => el['id'],
-                  'kind' => el['kind'],
-                  'sigma_columns' => pairs.compact.map { |id_name| id_name[1] },
-                  'sigma_column_ids' => pairs.compact.map { |id_name| id_name[0] },
-                  'workbook_id' => opts[:wb] }
+      if el['kind'].to_s.end_with?('-chart')
+        pairs = chart_columns(el)
+        next unless pairs
+        charts << { 'chart' => el['name'], 'sigma_element_id' => el['id'],
+                    'kind' => el['kind'],
+                    'sigma_columns' => pairs.compact.map { |id_name| id_name[1] },
+                    'sigma_column_ids' => pairs.compact.map { |id_name| id_name[0] },
+                    'workbook_id' => opts[:wb] }
+      elsif %w[table pivot-table].include?(el['kind'].to_s)
+        tt = table_total_column(el)
+        next unless tt
+        charts << { 'chart' => el['name'], 'sigma_element_id' => el['id'],
+                    'kind' => 'table-total', 'source_kind' => el['kind'],
+                    'sigma_columns' => [tt[1]], 'sigma_column_ids' => [tt[0]],
+                    'workbook_id' => opts[:wb] }
+      end
     end
   end
   abort('no plannable chart elements found in the workbook spec') if charts.empty?
@@ -142,7 +171,10 @@ if !opts[:finalize]
     # queries); the display names ride along in a trailing SQL comment for readability.
     ids = c['sigma_column_ids']
     names = c['sigma_columns']
-    sql = if ids.length >= 2
+    sql = if c['kind'] == 'table-total'
+            # grand total of an additive column over the grouped/pivot element
+            %(SELECT SUM("#{ids[0]}") AS val FROM "workbook"."#{c['sigma_element_id']}" -- grand total of: #{names[0]})
+          elsif ids.length >= 2
             %(SELECT "#{ids[0]}" AS dim, "#{ids[1]}" AS val FROM "workbook"."#{c['sigma_element_id']}" ORDER BY dim NULLS FIRST -- dim: #{names[0]}, val: #{names[1]})
           else
             %(SELECT "#{ids[0]}" AS val FROM "workbook"."#{c['sigma_element_id']}" -- val: #{names[0]})

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/record-visual-check.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/record-visual-check.rb
@@ -1,0 +1,155 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# record-visual-check.rb — record the outcome of the MANDATORY Phase 6f
+# full-dashboard source-vs-target visual comparison into parity-final.json, so
+# assert-phase6-ran.rb gate 8b (--require-visual-comparison) can confirm the
+# comparison actually happened instead of trusting a prose "I looked at it".
+#
+# Run this AFTER you have rendered the Sigma page (sigma-export-png.py) AND read
+# it side-by-side against the source dashboard PNG (Tableau MCP get-view-image):
+#
+#   ruby scripts/record-visual-check.rb --workdir /tmp/<name> --agent-vision true \
+#     --verdict pass            --notes "matches source; KPI row + 3 trend tiles aligned"
+#   ruby scripts/record-visual-check.rb --workdir /tmp/<name> --agent-vision true \
+#     --verdict divergent       --notes "Region bar truncated vs source — fixing"  [--screenshot <png>]
+#   ruby scripts/record-visual-check.rb --workdir /tmp/<name> --agent-vision false \
+#     --verdict not-executable  --notes "driving agent has no image input"
+#
+# It does NOT judge for you — it records the verdict YOU reached. `pass` stamps
+# visual_checked:true; `divergent` records the gap (visual_checked stays false so
+# the gate still blocks until you fix + re-record `pass`).
+#
+# VISION PRECONDITION (SKILL_IMPROVEMENT_PLAN_V3 §D5): a pixel-fidelity verdict
+# requires an agent that actually READ the render. --agent-vision true|false is
+# required (env AGENT_VISION accepted as a fallback source):
+#   --agent-vision false + --verdict pass  → REFUSED (exit 2, nothing written).
+#     Record --verdict not-executable instead, or re-run the visual loop from a
+#     vision-capable session (Claude Code with image input).
+#   --verdict not-executable (--notes mandatory) → stamps visual_checked:false,
+#     visual_verdict:"not-executable", agent_vision:false — gate 8b then fails
+#     with the named degradation instead of accepting a blind attestation.
+#   Every verdict stamps `agent_vision` into parity-final.json.
+# Back-compat: omitting --agent-vision entirely warns LOUDLY and assumes true
+# (existing callers keep working) — that default is deprecated; pass the flag.
+require 'json'
+require 'optparse'
+
+VERDICTS = %w[pass divergent not-executable].freeze
+# v5.3 STYLE CHECKLIST (round-5 owner-eye consensus dimensions). A gestalt
+# "pass" repeatedly shipped exposed chrome, broken palettes, and decomposed
+# layouts that an exacting owner rejected — the verdict must now attest each
+# dimension separately, judged against the SOURCE image, not the intent.
+CHECKLIST_KEYS = %w[element_titles_hidden palette_match composition_match
+                    chart_shapes_match labels_legible numbers_formatted].freeze
+CHECKLIST_VALS = %w[pass fail na].freeze
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')   { |v| opts[:dir] = v }
+  p.on('--verdict V', VERDICTS, 'pass = render matches the source; divergent = a gap remains (gate stays blocked); not-executable = the visual loop could not run (vision-less agent) — --notes required, gate 8b fails with a named degradation') { |v| opts[:verdict] = v }
+  p.on('--notes S')       { |v| opts[:notes] = v }
+  p.on('--screenshot P')  { |v| opts[:shot] = v }
+  p.on('--agent-vision B', %w[true false], 'REQUIRED: can the driving agent actually read images? (env AGENT_VISION accepted as fallback)') { |v| opts[:vision] = (v == 'true') }
+  p.on('--checklist S', "REQUIRED with --verdict pass: 'k=pass|fail|na,...' covering #{CHECKLIST_KEYS.join(', ')} — " \
+                        'each judged against the SOURCE image (element_titles_hidden = no exposed/truncated element-title ' \
+                        'chrome the source hides; palette_match = series/background/accent colors match the source swatches; ' \
+                        'composition_match = same canvas grid/proportions, section headers adjacent to their charts, no dead ' \
+                        'zones; chart_shapes_match = every tile same chart family + encoding; labels_legible = no truncated/' \
+                        'clipped labels or leaked control stubs; numbers_formatted = value formats as printed in the source)') do |v|
+    pairs = v.split(',').map(&:strip).reject(&:empty?)
+    bad = pairs.reject { |kv| kv.include?('=') }
+    abort "FATAL: --checklist entries need key=value (bad: #{bad.join(', ')})" if bad.any?
+    opts[:checklist] = pairs.map { |kv| kv.split('=', 2).map(&:strip) }.to_h
+  end
+end.parse!
+
+# checklist keys/values are validated for EVERY verdict that carries one — a
+# divergent record feeds the fix loop and must not stamp junk (v5.3.1).
+if opts[:checklist]
+  missing_v = opts[:checklist].reject { |_k, v| CHECKLIST_VALS.include?(v) }
+  abort "FATAL: --checklist value(s) must be pass|fail|na: #{missing_v.keys.join(', ')}" if missing_v.any?
+  unknown_k = opts[:checklist].keys - CHECKLIST_KEYS
+  abort "FATAL: --checklist unknown key(s): #{unknown_k.join(', ')} (want: #{CHECKLIST_KEYS.join(', ')})" if unknown_k.any?
+end
+
+abort 'FATAL: --workdir required' unless opts[:dir]
+abort "FATAL: --verdict #{VERDICTS.join('|')} required" unless opts[:verdict]
+
+# --agent-vision: flag > env AGENT_VISION > (deprecated) assume-true.
+if opts[:vision].nil? && !ENV['AGENT_VISION'].to_s.strip.empty?
+  ev = ENV['AGENT_VISION'].to_s.strip.downcase
+  abort "FATAL: AGENT_VISION must be true|false (got #{ENV['AGENT_VISION'].inspect})" unless %w[true false].include?(ev)
+  opts[:vision] = (ev == 'true')
+end
+if opts[:vision].nil?
+  warn '=' * 74
+  warn 'WARN: --agent-vision not given (and AGENT_VISION unset) — ASSUMING true so'
+  warn '      existing callers keep working. This default is DEPRECATED: a visual'
+  warn '      verdict from an agent that cannot read images is a blind attestation.'
+  warn '      Pass --agent-vision true|false explicitly (SKILL_IMPROVEMENT_PLAN_V3 §D5).'
+  warn '=' * 74
+  opts[:vision] = true
+end
+
+if opts[:verdict] == 'pass' && !opts[:vision]
+  warn 'REFUSED: a pass verdict requires an agent that actually read the render. ' \
+       'Record --verdict not-executable instead, or re-run the visual loop from a ' \
+       'vision-capable session (Claude Code with image input).'
+  exit 2
+end
+if opts[:verdict] == 'not-executable' && opts[:notes].to_s.strip.empty?
+  abort 'FATAL: --verdict not-executable requires --notes (say WHY the visual loop could not run).'
+end
+# v5.3: a PASS must attest every style dimension; any 'fail' means the render
+# does NOT match the source — record divergent and fix instead.
+if opts[:verdict] == 'pass'
+  cl = opts[:checklist]
+  if cl.nil?
+    warn 'REFUSED: --verdict pass now requires --checklist (round-5: gestalt passes shipped exposed'
+    warn "         chrome/broken palettes an exacting owner rejected). Provide all of:"
+    warn "         --checklist \"#{CHECKLIST_KEYS.map { |k| "#{k}=pass" }.join(',')}\""
+    warn '         judging each against the SOURCE image; use fail/na honestly (fail ⇒ record divergent).'
+    exit 2
+  end
+  missing = CHECKLIST_KEYS - cl.keys
+  bad_vals = cl.reject { |_k, v| CHECKLIST_VALS.include?(v) }
+  abort "FATAL: --checklist missing key(s): #{missing.join(', ')}" if missing.any?
+  abort "FATAL: --checklist value(s) must be pass|fail|na: #{bad_vals.keys.join(', ')}" if bad_vals.any?
+  fails = cl.select { |k, v| CHECKLIST_KEYS.include?(k) && v == 'fail' }.keys
+  if fails.any?
+    warn "REFUSED: checklist marks #{fails.join(', ')} = fail — that is a DIVERGENT render, not a pass."
+    warn '         Record --verdict divergent with the same checklist, fix, re-render, re-judge.'
+    exit 2
+  end
+end
+
+path = File.join(opts[:dir], 'parity-final.json')
+abort "FATAL: #{path} not found — run phase6-parity.rb --finalize first (the visual check records onto the parity result)." unless File.exist?(path)
+
+s = JSON.parse(File.read(path))
+s['visual_verdict']  = opts[:verdict]
+s['visual_notes']    = opts[:notes] if opts[:notes]
+s['visual_checked']  = (opts[:verdict] == 'pass')
+s['screenshot_path'] = opts[:shot] if opts[:shot]
+s['style_checklist'] = opts[:checklist] if opts[:checklist]
+# not-executable means the driving agent could not read the render — stamp
+# agent_vision:false regardless of the flag so gate 8b sees the degradation.
+s['agent_vision']    = opts[:verdict] == 'not-executable' ? false : opts[:vision]
+File.write(path, JSON.pretty_generate(s))
+
+case opts[:verdict]
+when 'pass'
+  puts "[OK] recorded visual comparison: PASS#{opts[:notes] ? " — #{opts[:notes]}" : ''}"
+  puts "     parity-final.json now satisfies assert-phase6-ran.rb gate 8b."
+when 'divergent'
+  puts "[RECORDED] visual comparison: DIVERGENT#{opts[:notes] ? " — #{opts[:notes]}" : ''}"
+  warn "     visual_checked stays FALSE — gate 8b (--require-visual-comparison) will still BLOCK."
+  warn '     Fix the divergence, re-render, re-read, then re-run with --verdict pass.'
+else # not-executable
+  puts "[RECORDED] visual comparison: NOT-EXECUTABLE — #{opts[:notes]}"
+  warn '     visual_checked stays FALSE, agent_vision=false — gate 8b will fail with'
+  warn '     "visual gate not executable" until the RCF/visual loop is re-run from a'
+  warn '     vision-capable session (Claude Code with image input) and a pass verdict'
+  warn '     is recorded, or the gate is explicitly waived (--skip-visual-comparison "<reason>").'
+end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_look_migration.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_look_migration.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Look → Sigma migration regression (single saved query → one-tile workbook).
+
+Builds each fixtures/skilltest-looks/look_*.contract.json (exactly what
+fetch_looker_look.py emits, incl. `fieldMeta`) through the REAL build_workbook.py
+against the vendored csa_thelook demo views, and asserts the CONVERTER decisions
+that a Look migration hinges on — with no live warehouse:
+
+  grouped_table  → ONE `table` with groupings{groupBy:[2], calculations:[3]}   (dims+measures grouped)
+  measure_only   → a row of `kpi-chart` elements                               (no dims to group)
+  dims_only      → a `table` with NO groupings                                 (detail, nothing to aggregate)
+  bar            → a vertical `bar-chart` (no `orientation`)                    (looker_column)
+  pivot_table    → a `pivot-table` with rowsBy + columnsBy + values            (cross-tab)
+  custom_measure → the ad-hoc `fieldMeta` measure lands in `calculations`,      (Item 1: authoritative
+                   NOT groupBy, with a Sum(...) formula                          classification)
+
+Every built spec must also pass preflight_lint (T1: a grouped table has groupings).
+
+Run: python3 tests/test_look_migration.py   (exit 0 = pass)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCRIPTS = os.path.join(SKILL, "scripts")
+FIX = os.path.join(SKILL, "fixtures", "skilltest-looks")
+VIEWS = os.path.join(FIX, "views")
+LINT = os.path.join(SCRIPTS, "lib", "preflight_lint.rb")
+
+
+def build(name):
+    contract = os.path.join(FIX, f"look_{name}.contract.json")
+    with tempfile.TemporaryDirectory() as d:
+        out = os.path.join(d, "wb.json")
+        r = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS, "build_workbook.py"), contract,
+             "--views", VIEWS, "--dm-element-name", "Order Fact View", "--out", out],
+            capture_output=True, text=True)
+        assert r.returncode == 0, f"build_workbook failed for {name}:\n{r.stderr}"
+        spec = json.load(open(out))
+        # preflight must be clean (T1: grouped table has groupings)
+        json.dump(spec, open(out, "w"))
+        lr = subprocess.run(["ruby", LINT, out], capture_output=True, text=True)
+        assert lr.returncode == 0, f"preflight FAILED for {name}:\n{lr.stdout}{lr.stderr}"
+        return spec, (r.stdout + r.stderr)
+
+
+def tiles(spec):
+    """Real content elements (skip the hidden Data master + layout containers)."""
+    out = []
+    for pg in spec.get("pages", []):
+        for e in pg.get("elements", []):
+            if e.get("kind") in ("container", "text") or e.get("name") == "Data":
+                continue
+            out.append(e)
+    return out
+
+
+def _one(spec, kind):
+    els = [e for e in tiles(spec) if e.get("kind") == kind]
+    assert len(els) == 1, f"expected exactly one {kind}, got {[e.get('kind') for e in tiles(spec)]}"
+    return els[0]
+
+
+def test_grouped_table():
+    spec, _ = build("grouped_table")
+    t = _one(spec, "table")
+    g = (t.get("groupings") or [])
+    assert g, "grouped table has no groupings — would render raw detail rows"
+    assert len(g[0]["groupBy"]) == 2, f"expected 2 groupBy dims, got {len(g[0]['groupBy'])}"
+    assert len(g[0]["calculations"]) >= 3, f"expected >=3 calc measures, got {len(g[0]['calculations'])}"
+    print("[ok] grouped_table: table with groupings groupBy=2 calc>=3")
+
+
+def test_measure_only():
+    spec, _ = build("measure_only")
+    kpis = [e for e in tiles(spec) if e.get("kind") == "kpi-chart"]
+    assert len(kpis) >= 3, f"expected >=3 KPI tiles, got {len(kpis)}"
+    assert not [e for e in tiles(spec) if e.get("kind") == "table"], "measure-only must not emit a table"
+    print(f"[ok] measure_only: {len(kpis)} kpi-chart tiles (no table)")
+
+
+def test_dims_only():
+    spec, _ = build("dims_only")
+    t = _one(spec, "table")
+    assert not t.get("groupings"), "dims-only detail table must have NO groupings"
+    print("[ok] dims_only: detail table (no groupings)")
+
+
+def test_bar():
+    spec, _ = build("bar")
+    b = _one(spec, "bar-chart")
+    assert "orientation" not in b, "looker_column → vertical bar (no orientation key)"
+    assert b.get("xAxis") and b.get("yAxis"), "bar chart missing x/y axis"
+    print("[ok] bar: vertical bar-chart with x/y axes")
+
+
+def test_pivot_table():
+    spec, _ = build("pivot_table")
+    p = _one(spec, "pivot-table")
+    assert p.get("rowsBy"), "pivot-table missing rowsBy (row shelf)"
+    assert p.get("columnsBy"), "pivot-table missing columnsBy (column shelf)"
+    assert p.get("values"), "pivot-table missing values (measure cells)"
+    print(f"[ok] pivot_table: rowsBy={len(p['rowsBy'])} columnsBy={len(p['columnsBy'])} values={len(p['values'])}")
+
+
+def test_custom_measure_classification():
+    """Item 1: a dynamic_fields custom measure (absent from the view .lkml) must be
+    classified as a MEASURE via fieldMeta → a `calculations` column with a Sum(...)
+    formula — NOT dropped and NOT forced into groupBy."""
+    spec, out = build("custom_measure")
+    t = _one(spec, "table")
+    g = (t.get("groupings") or [])
+    assert g, "custom-measure grouped table has no groupings"
+    cols = {c["id"]: c for c in t.get("columns", [])}
+    cm = next((c for c in t["columns"] if c["name"] == "Custom Total Profit"), None)
+    assert cm, f"custom measure column missing — got {[c['name'] for c in t['columns']]}"
+    assert cm["id"] in g[0]["calculations"], "custom measure must be a calculation, not a groupBy dim"
+    assert cm["id"] not in g[0]["groupBy"], "custom measure wrongly placed in groupBy"
+    assert cm["formula"].startswith("Sum("), f"custom measure should aggregate — got {cm['formula']!r}"
+    print(f"[ok] custom_measure: classified as calculation, formula {cm['formula']!r}")
+
+
+if __name__ == "__main__":
+    test_grouped_table()
+    test_measure_only()
+    test_dims_only()
+    test_bar()
+    test_pivot_table()
+    test_custom_measure_classification()
+    print("ALL PASS")


### PR DESCRIPTION
## What

Adds a **Look → Sigma** migration path to `looker-to-sigma`, alongside the existing dashboard pipeline. A Look is a single saved query; a Look with **dimensions + measures becomes a Sigma grouped `table`** (dims → `groupings.groupBy`, measures → `groupings.calculations`), a pivoted Look → a real `pivot-table`, a measure-only Look → a KPI row, and a chart Look → the matching chart.

A Look's `.query` is the same Looker `Query` shape a dashboard tile embeds, so this **reuses the dashboard converter end-to-end** via a shared `normalize_element` — the diff is a thin fetch/dispatch layer plus classification/pivot fidelity.

## Changes

- **`fetch_looker_look.py`** (new): `GET /looks/{id}` → the *same* one-tile contract (`filters:[]`, full-width layout) + a `fieldMeta` map (authoritative dim/measure category from the explore metadata + `dynamic_fields` hints).
- **`build_workbook.py`**: `fieldMeta` classification so ad-hoc/custom measures land in `calculations` not `groupBy` **even with no local LookML checkout** (was: silently dropped / mis-grouped); a real **`pivot-table`** branch (`rowsBy`/`columnsBy`/`values`); row-limit → top-N, pivot sort, and a loud totals follow-up. **Dashboard path is byte-identical** (golden unchanged).
- **`migrate-looker.py`**: `--look-id` (arg/guard/offline/dispatch) + table-total EXPECTED.
- **`phase6-parity-looker.rb`**: grain-invariant **table-total** parity for table-only Looks (grouped-table column sum; pivot cross-tab grand total) so they pass the gate **without touching the shared `assert-phase6-ran.rb`**.
- **`build_looker_look.py`** (new): 6-case test-fixture builder; **`looker-render-look.py`** (new): source render; **`tests/test_look_migration.py`** + `fixtures/skilltest-looks/` (structural test on the vendored csa_thelook demo views).
- **Vendor `record-visual-check.rb`** (byte-identical): gate 8b referenced it but it was missing from this plugin, blocking the visual gate for *all* looker migrations.

## Validation (live, hakkoda1)

- 6 test Looks fetch + build correctly: grouped table (groupBy=2/calc=3), KPI row, detail table, vertical bar, `pivot-table`, and a `dynamic_fields` custom measure → `Sum([…/Net Profit])` in calculations.
- Pivot-table spec **POSTs + renders** (shape verified against sigma-workbooks `tables.md`).
- A no-RLS Look runs the **full pipeline to GREEN** — table-total parity PASS, all gates, `verify-complete` stamped.
- `order_fact` Looks diverge only by the **West-region RLS factor** (2.814×, same as dashboard 11) — port via `apply_sigma_rls`, not a conversion bug.
- All three test suites pass; dashboard golden byte-identical; `check-shared`/gate/ESM/encoding hooks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)