### PR TITLE
cognos-to-sigma: /api/v1 API-key extraction path + apply-layout fixes + Sigma-target gotchas

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-assessment/refs/ca-rest.md
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/refs/ca-rest.md
@@ -1,9 +1,11 @@
 # CA REST endpoints used by cognos-assessment
 
-All read-only. Base path is **`/bi/v1`** (NOT `/api/v1`). Auth = a logged-in
-session **cookie** + the **`X-XSRF-Token`** header (grab both from DevTools →
-Network → any `bi/v1/...` request → "Copy as cURL"). Sessions are short-lived —
-re-grab when a request 401/403s.
+All read-only. Base path is **instance-dependent**: prefer the durable **`/api/v1`**
+API-key surface (headless — `PUT /api/v1/session` with `CAMAPILoginKey`, then `X-XSRF-Token`
++ cookie jar; folder = `GET /api/v1/content/{id}/items`, module = `GET /api/v1/modules/{id}/metadata`),
+and fall back to the **`/bi/v1`** surface below (session **cookie** + **`X-XSRF-Token`** header,
+grabbed from DevTools → Network → any `bi/v1/...` request → "Copy as cURL") only if `/api/v1`
+content calls 441/403 (Akamai-walled tenant). Sessions are short-lived — re-grab when a request 401/403/441s.
 
 | Need | Endpoint | Notes |
 |---|---|---|

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/QUICKSTART.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/QUICKSTART.md
@@ -42,11 +42,12 @@ connection reaches the same warehouse the Cognos content reports on.
 Duration: 2
 
 - **A coding agent that runs skills** — Claude Code (CLI or desktop), Cursor, Cortex Code, etc.
-- **Cognos Analytics 11.1+ REST access** (on-prem or CA on Cloud). Base path is `<host>/bi/v1`
-  (**not** `/api/v1`). Auth = a logged-in session: a **session cookie** + the **`X-XSRF-Token`**
-  header. On IBMid-SSO trials you can't log in headlessly — grab a live browser session
-  (DevTools → Network → any `…/bi/v1/…` request → **Copy as cURL**) and feed it to
-  `scripts/get-cognos-session.sh`.
+- **Cognos Analytics 11.1+ REST access** (on-prem or CA on Cloud). Two surfaces; try the durable
+  one first: **(1) `/api/v1` + a CA API key (preferred, headless)** — `scripts/cognos-apikey-session.sh`
+  (`PUT /api/v1/session` with `CAMAPILoginKey`; verified doing full content read+write on a paid
+  instance); **(2) `/bi/v1` session replay (fallback)** — a **session cookie** + **`X-XSRF-Token`**
+  from a live browser session (DevTools → Network → any `…/bi/v1/…` request → **Copy as cURL**) fed to
+  `scripts/get-cognos-session.sh`, for Akamai-walled IBMid-SSO trials where `/api/v1` content 441/403s.
 - **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`).
 - A **Sigma connection to the same warehouse** the Cognos content reports on (for true parity).
 - The **Cognos → Sigma converter** — ships **inside the skill** as a prebuilt local bundle

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -125,15 +125,20 @@ checkpoint, never silently ported or dropped).
 
 ## Prerequisites
 
-- **Cognos Analytics 11.1+** REST access (on-prem or CA on Cloud). Base path is
-  `<host>/bi/v1` (NOT `/api/v1`). Auth = a logged-in session: a **session cookie** +
-  the **`X-XSRF-Token`** header. On IBMid-SSO trials you can't log in headlessly —
-  grab a live session from the browser (DevTools → Network → any `coreBundle.js`-initiated
-  `bi/v1/...` XHR → **Copy as cURL**) and capture it with `scripts/get-cognos-session.sh`
-  (paste the **whole** Cookie header — incl. the Akamai `_abck`/`bm_sz`/`bm_sv`/`ak_bmsc`
-  cookies, or the WAF returns 441). CAoC sessions are short-lived: an `HTTP 441` means
-  re-login + re-copy. The **durable** path for a real engagement is a CA API key/service
-  credential where the tenant allows it — prefer it over session replay.
+- **Cognos Analytics 11.1+** REST access (on-prem or CA on Cloud). Two surfaces exist;
+  which reaches content is **instance-dependent** — try the durable one first:
+  1. **`/api/v1` + CA API key (preferred, headless).** `eval "$(scripts/cognos-apikey-session.sh)"`
+     with `COG_INSTANCE` + `COG_APIKEY` — it does `PUT /api/v1/session` with `CAMAPILoginKey`,
+     grabs the XSRF cookie, and gives you `cog_get`. **Verified 2026 on a paid CAoC instance:
+     `/api/v1` does full content read + write while `/bi/v1` returned 441.** No browser round-trip.
+  2. **`/bi/v1` session replay (fallback).** Auth = a **session cookie** + the **`X-XSRF-Token`**
+     header from a live browser session (DevTools → Network → any `bi/v1/...` XHR → **Copy as cURL**),
+     captured with `scripts/get-cognos-session.sh` (paste the **whole** Cookie header incl. the Akamai
+     `_abck`/`bm_sz`/`bm_sv`/`ak_bmsc` cookies). Needed on Akamai-walled IBMid-SSO trials where
+     `/api/v1` content calls 441/403. CAoC sessions are short-lived — `HTTP 441` means re-login + re-copy.
+
+  Probe `/api/v1` with the API key first; fall back to `/bi/v1` only if content calls 441/403.
+  (Note the paths differ — see `refs/design-notes.md → API access`.)
 - **Sigma** API token (via the `sigma-api` skill) to POST the data model + workbook.
 - **Node** for the converter (`converter/`: `npm install` once).
 
@@ -171,11 +176,11 @@ And keep pushing for the **durable path**: a CA **API key / service credential**
 (where the tenant allows it) removes the session-death problem entirely — batch
 windows are the workaround for session-replay auth, not a substitute for asking.
 
-- Samples folder, modules, and reports are discovered by walking `GET /objects/{id}/items`.
-- **Data Module spec**: `GET /bi/v1/metadata/modules/{id}` (NOT `/modules/{id}`, which is empty).
-- **Report spec**: `GET /bi/v1/objects/{id}?fields=specification` → the `specification` string is the report XML.
-- **Dashboard spec**: `GET /bi/v1/objects/{id}?fields=specification` → the `specification` string is **exploration JSON** (not XML). This is a different artifact the converter does NOT handle — hand-author per **`refs/dashboard-migration.md`**. ⚠️ A Cognos dashboard's **tabs (`spec.layout.items[]`) must become separate Sigma pages** — never flatten all widgets onto one page.
-- **Akamai/CAF wall**: plain `curl` of `/bi/v1` can return **441/403** (TLS fingerprinting) even with a good cookie/API key. Use the headed-Chrome Puppeteer bridge in `refs/dashboard-migration.md` for dashboard pulls + the dataset-query data path.
+- Folders, modules, and reports are discovered by walking folder items — `/api/v1/content/{id}/items` (API-key) or `/bi/v1/objects/{id}/items` (session-replay).
+- **Data Module spec**: `/api/v1/modules/{id}/metadata` (API-key) or `/bi/v1/metadata/modules/{id}` (session-replay; NOT the plain `/bi/v1/modules/{id}`, which is empty).
+- **Report spec**: `GET .../content|objects/{id}?fields=specification` → the `specification` string is the report XML.
+- **Dashboard spec**: `GET .../content|objects/{id}?fields=specification` → the `specification` string is **exploration JSON** (not XML). The converter does NOT handle it — hand-author per **`refs/dashboard-migration.md`**. ⚠️ A Cognos dashboard's **tabs (`spec.layout.items[]`) must become separate Sigma pages** — never flatten all widgets onto one page. (Note: on `/api/v1` a dashboard is content `type:"exploration"`; its `specification` is a **stringified** JSON on read AND write.)
+- **Akamai/CAF wall is `/bi/v1`-specific and tenant-dependent**: plain `curl` of `/bi/v1` can return **441/403** (TLS fingerprinting) on some tenants — but the **`/api/v1` API-key surface often bypasses it** (verified: a paid instance where `/bi/v1`=441 but `/api/v1` read+write worked). Try `/api/v1` first; if a tenant walls *both*, use the headed-Chrome Puppeteer bridge in `refs/dashboard-migration.md` for dashboard pulls + the dataset-query data path.
 - Prefer **warehouse-backed** modules (built on a Data server connection) over file-backed
   ones — they carry complete schemas. File-backed modules (uploaded `.xlsx`) are a
   *land-in-warehouse-first* case (see Verify/parity).

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/design-notes.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/design-notes.md
@@ -29,14 +29,42 @@ Schema reference: [Cognos SDK v10.2.1 Report Specification Schema Reference v10.
 
 ## API access
 
-CA 11.1+ exposes REST at **`/bi/v1/...`** (NOT `/api/v1` — that base path only serves
-`PUT /api/v1/session` for login; content sub-resources 403 on it). Same surface
-on-prem and Cognos Analytics on Cloud (SaaS).
+CA 11.1+ exposes **two** REST surfaces; which one works for content is
+**instance-dependent** (WAF config), so try the durable one first and fall back:
 
-- Auth: session cookie + `X-XSRF-Token` (CAM credentials / API key via `PUT /api/v1/session`).
-- Discovery: `GET /bi/v1/objects/{id}/items?fields=defaultName,type,id`.
-- Report spec download: `GET /bi/v1/objects/{id}?fields=specification` — returns the report-spec XML as a string property.
-- Data module: `GET /bi/v1/metadata/modules/{id}` — returns the data module JSON (the plain `/modules/{id}` returns EMPTY).
+1. **`/api/v1/...`** — the durable, API-key surface. Authenticate headlessly with a
+   CA API login key: `PUT /api/v1/session` body `{"parameters":[{"name":"CAMAPILoginKey","value":"<key>"}]}`,
+   then send the `XSRF-TOKEN` cookie value as the `X-XSRF-Token` header + the cookie jar.
+   **Verified 2026 on a paid CAoC instance: `/api/v1` does full content read AND write**
+   (list datasources, create a Snowflake data server, register+import a schema, `POST /modules`,
+   `POST /content/{folder}/items` for an exploration) with plain curl — while `/bi/v1` returned
+   HTTP 441 from the Akamai WAF on that same tenant. Use `scripts/cognos-apikey-session.sh`.
+2. **`/bi/v1/...`** — the SPA "glass" surface. Session cookie + `X-XSRF-Token`, typically from a
+   replayed browser session (`scripts/get-cognos-session.sh`). On IBMid-SSO trials this is the
+   only surface that reaches content (Akamai TLS-fingerprints plain curl on some tenants).
+
+> The old assumption "`/api/v1` is login-only; content 403s there" held on an Akamai-walled
+> **trial**; it is NOT universal. Probe `/api/v1` with the API key first — it's the cleaner,
+> headless, durable path — and fall back to `/bi/v1` session-replay only if content calls 441/403.
+
+Endpoint mapping (the two surfaces name paths differently):
+
+| Need | `/api/v1` (API key) | `/bi/v1` (session replay) |
+|---|---|---|
+| List a folder | `GET /api/v1/content/{id}/items` | `GET /bi/v1/objects/{id}/items?fields=defaultName,type,id` |
+| Report-spec XML | `GET /api/v1/content/{id}?fields=specification` | `GET /bi/v1/objects/{id}?fields=specification` |
+| Data module JSON | `GET /api/v1/modules/{id}/metadata` | `GET /bi/v1/metadata/modules/{id}` (plain `/modules/{id}` = EMPTY) |
+| OpenAPI (this build) | `GET /api/api-docs/swagger.json` | — |
+
+## Sigma-target build gotchas (verified 2026-07 on a live Cognos→Sigma run)
+
+Building the migrated DM + workbook via the Sigma REST API surfaced three non-obvious rules — all cost a failed POST/round-trip if missed:
+
+1. **DM source formulas use the ACTUAL warehouse column names, not the Cognos labels.** The converter emits `[V_GRADES/Numeric Grade]` (prettified from the Cognos label); Snowflake exposes `NUMERIC_GRADE`, so that formula posts 200 but the column resolves to `type:"error"`. Reference the real column and set a pretty `name`: `{ "name": "Numeric Grade", "formula": "[V_GRADES/NUMERIC_GRADE]" }`. Always `validate_dm_columns` after POST (the `/columns` readback can be empty = vacuously "clean").
+2. **Workbook formulas on a DM element must be ELEMENT-QUALIFIED.** Bare `Avg([Numeric Grade])` in a workbook viz sourced from a data-model element fails with `Unknown name`. Qualify with the element name: `Avg([Grades/Numeric Grade])`. (`source.elementId` accepts the element id OR name.)
+3. **New warehouse tables/views need a connection sync before a DM can bind them.** A DM POST referencing a just-created view fails `Source not found` even with grants — Sigma's introspection is cached. Trigger it: `POST /v2/connections/{id}/sync` body `{"path":["<DB>","<SCHEMA>"]}` (path is `[db, schema]` or `[db, schema, table]`), then retry.
+
+Also: `POST /v2/{dataModels,workbooks}/spec` returns a **plain-text** body (`success: true` / `workbookId: …`), not JSON — parse accordingly.
 
 Working REST wrappers (use as reference, don't depend on them):
 - Python: [ykud/cognosanalyticspy](https://github.com/ykud/cognosanalyticspy) — real auth + content-tree traversal

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/format-shapes.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/format-shapes.md
@@ -11,7 +11,11 @@ What the converter actually parses. Verified 2026 against IBM sample content on 
 | **Report-spec XML** | `GET /bi/v1/objects/{id}?fields=specification` | `data[0].specification` is the report XML string (schema 17.x) |
 | Data server connections | Manage → Data server connections | relational sources (e.g. GOSALES); warehouse-backed modules build on these |
 
-Auth: session cookie + `X-XSRF-Token`. Base path is **`/bi/v1`** (not `/api/v1`).
+Auth: session cookie + `X-XSRF-Token`. Base path is **instance-dependent** — prefer the
+durable **`/api/v1`** API-key surface (`scripts/cognos-apikey-session.sh`; module spec at
+`/api/v1/modules/{id}/metadata`, folder at `/api/v1/content/{id}/items`), and fall back to the
+**`/bi/v1`** session-replay surface above only if `/api/v1` content calls 441/403 (Akamai-walled
+tenant). See `refs/design-notes.md → API access` for the full endpoint mapping.
 
 ## Data Module JSON (`metadata/modules/{id}`)
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
@@ -27,7 +27,7 @@
 import { api, parseArgs } from './lib/sigma-rest.mjs';
 import { pythonArgv } from './lib/py_resolve.mjs';
 import { spawnSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -106,7 +106,9 @@ function pageLayout(page, fallbackTitle) {
       // KPI panel: the whole run in ONE band container, rows of up to 3 TALL tiles
       let j = i; while (j < content.length && content[j].kind === 'kpi-chart') j++;
       const run = content.slice(i, j);
-      const perRow = Math.min(run.length, 3);
+      // exec headers commonly have 4 KPIs — keep them on ONE row (span 6 each)
+      // instead of 3+1 (a lonely wrapped tile reads as a layout bug); else cap at 3.
+      const perRow = run.length === 4 ? 4 : Math.min(run.length, 3);
       const span = Math.floor(24 / perRow);
       const lines = run.map((k, n) => {
         const col0 = 1 + (n % perRow) * span;

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/cognos-apikey-session.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/cognos-apikey-session.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# cognos-apikey-session.sh — establish a Cognos Analytics REST session with a
+# CA API key (login key) against the DURABLE /api/v1 surface — fully headless,
+# no browser cookie paste. Emits a `cog_get` function (same contract as
+# get-cognos-session.sh) so it drops into Phase 0b discovery.
+#
+#   WHEN TO USE THIS vs get-cognos-session.sh (session replay):
+#   • Try THIS FIRST for any tenant where you have a CA API key. On instances
+#     whose /api/v1 surface is NOT behind an Akamai/bot-protection WAF, the API
+#     key authenticates AND content reads/writes work headlessly over /api/v1.
+#     Verified 2026 on a PAID CAoC instance: /api/v1 read+write worked with
+#     plain curl (list datasources, create a Snowflake data server, register +
+#     import a schema, POST /modules, POST an exploration) WHILE /bi/v1 returned
+#     HTTP 441 from the WAF — the inverse of the trial-tenant assumption.
+#   • If /api/v1 content calls return 441/403 (Akamai-walled tenant — common on
+#     IBMid-SSO trials), FALL BACK to get-cognos-session.sh (browser session
+#     replay) + the headed-Chrome/Puppeteer bridge in refs/dashboard-migration.md.
+#   Document which path the engagement is using.
+#
+#   ENDPOINT NOTE — /api/v1 paths differ from the /bi/v1 "glass" paths:
+#     folder items   /api/v1/content/{id}/items                 (vs /bi/v1/objects/{id}/items)
+#     data module    /api/v1/modules/{id}/metadata              (vs /bi/v1/metadata/modules/{id})
+#     report / dash  /api/v1/content/{id}?fields=specification  (report XML / exploration JSON)
+#     datasources    /api/v1/datasources ... /connections ... /signons/{id}/schemas
+#     OpenAPI (this instance) /api/api-docs/swagger.json
+#
+# USAGE:
+#   export COG_INSTANCE=https://<your-instance>.ca.analytics.ibm.com   # no trailing /api/v1
+#   export COG_APIKEY=<CA API key>                         # or COG_APIKEY_FILE=~/.cognos/apikey.txt
+#   eval "$(scripts/cognos-apikey-session.sh)"
+#   cog_get "/content/.public_folders/items?fields=defaultName,type,id"   # smoke test
+#
+# Env it expects:
+#   COG_INSTANCE     https://<instance>            (base host, no /api/v1)
+#   COG_APIKEY       the CA API login key value    (or COG_APIKEY_FILE=<path>)
+#   COG_COOKIE_JAR   cookie jar path (default ~/.cognos/apikey_cookies.txt)
+
+: "${COG_INSTANCE:?set COG_INSTANCE=https://<instance> (no trailing /api/v1)}"
+KEY="${COG_APIKEY:-}"
+if [ -z "$KEY" ] && [ -n "${COG_APIKEY_FILE:-}" ] && [ -s "${COG_APIKEY_FILE}" ]; then
+  KEY="$(tr -d '\r\n' < "$COG_APIKEY_FILE")"
+fi
+if [ -z "$KEY" ]; then
+  echo "echo 'Set COG_APIKEY=<CA API key> or COG_APIKEY_FILE=<path>' >&2; false"; exit 0
+fi
+JAR="${COG_COOKIE_JAR:-$HOME/.cognos/apikey_cookies.txt}"
+mkdir -p "$(dirname "$JAR")"; : > "$JAR"
+BASE="${COG_INSTANCE%/}/api/v1"
+
+# 1) create the session with the API login key (PUT /api/v1/session).
+_body=$(printf '{"parameters":[{"name":"CAMAPILoginKey","value":"%s"}]}' "$KEY")
+_code=$(curl -s -o /dev/null -w '%{http_code}' -X PUT "$BASE/session" \
+  -H 'Content-Type: application/json' -c "$JAR" -d "$_body")
+if [ "$_code" != "201" ] && [ "$_code" != "200" ]; then
+  echo "echo 'CA API-key auth failed: PUT /api/v1/session -> HTTP $_code (401=bad key, 403=existing session/blocked, 000=host unreachable)' >&2; false"; exit 0
+fi
+# 2) obtain the XSRF-TOKEN cookie (GET /api/v1/session), required on every later call.
+curl -s -o /dev/null -b "$JAR" -c "$JAR" "$BASE/session" >/dev/null 2>&1 || true
+_xsrf=$(awk '$0 !~ /^#/ && $6=="XSRF-TOKEN"{print $7}' "$JAR" | tail -1)
+
+# Emit the session env + a `cog_get` (eval this script's stdout).
+cat <<EOF
+export COG_BASE='$BASE'
+export COG_COOKIE_JAR='$JAR'
+export COG_XSRF='$_xsrf'
+# cog_get "<path under /api/v1>" -> prints body; nonzero on HTTP>=400.
+#   441/403 here = /api/v1 is WAF-walled on this tenant; fall back to get-cognos-session.sh.
+cog_get() {
+  local p="\$1" code
+  code=\$(curl -s -o /tmp/cog_last.json -w '%{http_code}' "\$COG_BASE\$p" \\
+    -H 'Accept: application/json' -H "X-XSRF-Token: \$COG_XSRF" \\
+    -H 'X-Requested-With: XMLHttpRequest' -b "\$COG_COOKIE_JAR" -c "\$COG_COOKIE_JAR")
+  if [ "\$code" -ge 400 ]; then
+    echo "Cognos GET \$p -> HTTP \$code (441/403 => /api/v1 WAF-walled here; use get-cognos-session.sh)" >&2
+    cat /tmp/cog_last.json >&2; echo >&2; return 1
+  fi
+  cat /tmp/cog_last.json
+}
+EOF


### PR DESCRIPTION
## What
Adds the durable **`/api/v1` + CA API-key** extraction path to `cognos-to-sigma`, corrects the docs that assumed it never works, fixes two real `apply-layout.mjs` bugs, and documents three Sigma-target build gotchas — all surfaced by a **live end-to-end Cognos→Sigma migration**.

## Why
On a **paid** CAoC instance, `/api/v1` + `CAMAPILoginKey` did full content read **and write** with plain `curl` (list datasources, create a Snowflake data server, register + import a schema, `POST /modules`, `POST` an exploration) while `/bi/v1` returned Akamai **441**. The skill previously asserted in six places that `/api/v1` is login-only and Akamai blocks content — true for the IBMid-SSO **trial** it was hardened against, but **instance-dependent**. This makes the headless, durable path the preferred first option and keeps `/bi/v1` cookie-replay as the Akamai fallback.

## Changes
- **New** `scripts/cognos-apikey-session.sh` — headless `PUT /api/v1/session` (`CAMAPILoginKey`) → XSRF + cookie jar → `cog_get` (same contract as `get-cognos-session.sh`); feeds Phase 0b. Includes the `/api/v1` endpoint map.
- **Docs** — soften the six "NOT /api/v1" absolutes → instance-dependent (try `/api/v1` API key first, fall back to `/bi/v1` on 441/403): `SKILL.md`, `QUICKSTART.md`, `refs/design-notes.md`, `refs/format-shapes.md`, `cognos-assessment/refs/ca-rest.md`.
- **`apply-layout.mjs`** — (1) `import { …, mkdirSync }` — the visual-QA step always crashed (`ReferenceError: mkdirSync is not defined`); (2) lay a **4-KPI exec header on one row** instead of 3+1 (a lonely wrapped tile reads as a layout bug).
- **`refs/design-notes.md`** — three Sigma-target build gotchas: DM source formulas use **warehouse column names** (not Cognos labels); workbook formulas must be **element-qualified** (`[Grades/Numeric Grade]`); new warehouse views need `POST /v2/connections/{id}/sync` before a DM binds them; `spec` POST returns **plain-text**, not JSON.

## Validation
- `ruby tools/check-shared.rb` → OK (no shared drift) · `ruby tools/lint-skills.rb` → OK · pre-commit gates (ESM imports, agent variants) → OK
- **Live run:** Cognos module + dashboard → Sigma data model (19 cols, **0 errors**) + workbook (8 elements, **0 errors**) + banded layout (lint-clean, verified by rendering the page PNG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
