### PR TITLE
powerbi: wire warehouseType from connection type + re-vendor Databricks-casing converter (beads-sigma-lanq.6/.7)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -139,6 +139,17 @@ resume with `--converter-out`. The hosted MCP is a fallback, not the default pat
 
 `convertPowerBIToSigma(model_json, connection_id, database, schema)`.
 
+> **Databricks / lower-case warehouses (beads-sigma-lanq.7):** physical identifiers default to
+> UPPER (Snowflake/BigQuery fold that way). Databricks/Spark store identifiers **lower-case** and
+> bind only against a lower-cased warehouse path, so an UPPER path fails at POST with
+> `Source not found`. `migrate-powerbi.rb` reads the resolved connection's `type` from
+> `connection.json` and passes `warehouseType` to the converter automatically; the flag
+> **`--warehouse-type databricks`** forces it (use this if the connection was passed with
+> `--connection <id>`, since that path doesn't populate the type). The element name and
+> `[Table/Col]` formula refs stay UPPER (Sigma-internal) — only `source.path` + column physical
+> names fold to the warehouse case. A single `--schema` also no longer collapses a multi-schema
+> model (beads-sigma-lanq.6): it's applied as a repoint only on a single-schema model.
+
 > ⚠️ **`--converter-out` takes the converter's output — never a hand-authored spec.**
 > The flag exists so you can run the converter (the fallback `convert_powerbi_to_sigma`
 > MCP tool when the local bundle is unavailable), save its

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/PROVENANCE.json
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "867c669",
-  "source_commit_date": "2026-06-22",
+  "source_commit": "bd8a107",
+  "source_commit_date": "2026-07-16",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "powerbi.mjs",
   "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/powerbi.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/powerbi.mjs
@@ -1,6 +1,15 @@
-// ../../../Users/tjwells/sigma-data-model-mcp/build/sigma-ids.js
+// ../wt-pbi-converter/build/sigma-ids.js
 var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 var _usedIds = /* @__PURE__ */ new Set();
+var _idCounter = 0;
+function encodeBase62(n, len) {
+  let x = n, s = "";
+  while (x > 0) {
+    s = SIGMA_CHARS[x % 62] + s;
+    x = Math.floor(x / 62);
+  }
+  return s.padStart(len, SIGMA_CHARS[0]);
+}
 var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "a",
   "an",
@@ -26,28 +35,32 @@ var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
 ]);
 function resetIds() {
   _usedIds.clear();
+  _idCounter = 0;
 }
 function sigmaShortId(len = 10) {
   let id;
   do {
-    id = Array.from({ length: len }, () => SIGMA_CHARS[Math.floor(Math.random() * SIGMA_CHARS.length)]).join("");
+    id = encodeBase62(++_idCounter, len);
   } while (_usedIds.has(id));
   _usedIds.add(id);
   return id;
 }
-function sigmaInodeId(identifier) {
-  return `inode-${sigmaShortId(22)}/${identifier.toUpperCase()}`;
+function sigmaInodeId(identifier, casing = "upper") {
+  const phys = casing === "lower" ? identifier.toLowerCase() : identifier.toUpperCase();
+  return `inode-${sigmaShortId(22)}/${phys}`;
 }
-function sigmaPhysicalName(s) {
+function sigmaPhysicalName(s, casing = "upper") {
   const r = (s || "").trim();
-  if (/^[A-Z0-9_]+$/.test(r))
+  const verbatim = casing === "lower" ? /^[a-z0-9_]+$/ : /^[A-Z0-9_]+$/;
+  if (verbatim.test(r))
     return r;
   const normalized = r.replace(/[^A-Za-z0-9_\s]/g, " ").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
-  return normalized.toUpperCase().split(/[_\s]+/).filter(Boolean).join("_");
+  const joined = normalized.split(/[_\s]+/).filter(Boolean).join("_");
+  return casing === "lower" ? joined.toLowerCase() : joined.toUpperCase();
 }
 function sigmaDisplayName(s) {
   const normalized = (s || "").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
-  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
+  const words = normalized.toLowerCase().split(/[_\s/-]+/).filter(Boolean);
   return words.map((w, i) => i === 0 || !SIGMA_LOWERCASE_WORDS.has(w) ? w.charAt(0).toUpperCase() + w.slice(1) : w).join(" ");
 }
 function formatFromMask(mask) {
@@ -251,7 +264,7 @@ function buildDerivedElements(elements) {
   return derived;
 }
 
-// ../../../Users/tjwells/sigma-data-model-mcp/build/powerbi.js
+// ../wt-pbi-converter/build/powerbi.js
 var PBI_COMMUNITY_LINKS = {
   lod: "community.sigmacomputing.com/t/tableau-level-of-detail-or-lod-calculations-in-sigma/6427",
   groupings: "community.sigmacomputing.com/t/how-to-use-groupings-aggregate-calculations/2003",
@@ -1778,9 +1791,10 @@ function emitTimeIntelElements(model, elements, warnings) {
         continue;
       const agg = AGG[am[1].toUpperCase()];
       const col = am[2];
+      const normCol = (s) => (s || "").toUpperCase().replace(/[\s_]/g, "");
       let parent = null, valDisp = "", dateDisp = "";
       for (const v of views) {
-        const vc = (v.columns || []).find((c) => lastSeg(c.formula).toUpperCase() === col.toUpperCase());
+        const vc = (v.columns || []).find((c) => normCol(lastSeg(c.formula)) === normCol(col));
         const dc = (v.columns || []).find((c) => /full date/i.test(viewColDisplay(c.formula))) || (v.columns || []).find((c) => /date/i.test(lastSeg(c.formula)) && !/key/i.test(lastSeg(c.formula)));
         if (vc && dc) {
           parent = v;
@@ -1793,6 +1807,14 @@ function emitTimeIntelElements(model, elements, warnings) {
         continue;
       const pn = parent.name;
       const b = (m.name || "TI").replace(/[^a-zA-Z0-9]/g, "").slice(0, 14);
+      const refTables = [...dax.matchAll(/([A-Za-z_]\w*)\s*\[/g)].map((x) => x[1]);
+      const dimTable = refTables.length ? refTables[refTables.length - 1] : null;
+      if (dimTable && dimTable !== t.name) {
+        const rel = (model.relationships || []).find((r) => r.fromTable === t.name && r.toTable === dimTable);
+        if (rel && rel.isActive === false) {
+          warnings.push(`\u26A0 "${m.name}": the ${t.name}\u2192${dimTable} relationship is INACTIVE and no measure activates it (USERELATIONSHIP), so the original Power BI measure does not filter by ${dimTable} \u2014 it returns an unfiltered total per ${dimTable} period. The synthesized element groups by ${t.name}'s own date instead, yielding a true per-period prior-year. Confirm this matches intent (the source measure may be silently mis-modeled).`);
+        }
+      }
       if (shape === "prior") {
         const prior = `${valDisp} (Prior Year)`;
         const cols = [
@@ -1842,8 +1864,11 @@ function convertPowerBIToSigma(modelJson, options = {}) {
   if (!model.tables || !Array.isArray(model.tables)) {
     throw new Error('Invalid model \u2014 no "tables" array found');
   }
-  const dbOverride = (database || "").toUpperCase();
-  const schOverride = (schema || "").toUpperCase();
+  const whLower = /\b(databricks|spark|hive|delta)\b/i.test(options.warehouseType || "");
+  const physCasing = whLower ? "lower" : "upper";
+  const physCase = (s) => whLower ? String(s).toLowerCase() : String(s).toUpperCase();
+  const dbOverride = physCase(database || "");
+  const schOverride = physCase(schema || "");
   const warnings = [];
   const security = [];
   const elements = [];
@@ -1918,6 +1943,22 @@ function convertPowerBIToSigma(modelJson, options = {}) {
       }
     }
   }
+  const _schemasSeen = /* @__PURE__ */ new Set();
+  const _catalogsSeen = /* @__PURE__ */ new Set();
+  for (const t of model.tables) {
+    if (measureOnlyTables.has(t.name) || calcGroupTables.has(t.name))
+      continue;
+    if (t.name.startsWith("LocalDateTable_") || t.name.startsWith("DateTableTemplate_"))
+      continue;
+    const _expr = (t.partitions || [])[0]?.source?.expression;
+    const _mp = _expr ? pbiExtractPathFromM(Array.isArray(_expr) ? _expr.join("\n") : String(_expr)) : null;
+    if (_mp && _mp.length >= 3) {
+      _catalogsSeen.add(_mp[0]);
+      _schemasSeen.add(_mp[1]);
+    }
+  }
+  const modelMultiSchema = _schemasSeen.size > 1;
+  const modelMultiCatalog = _catalogsSeen.size > 1;
   for (const t of model.tables) {
     if (measureOnlyTables.has(t.name))
       continue;
@@ -2004,16 +2045,19 @@ SELECT 1 AS _placeholder`;
       }
     }
     if (path) {
-      if (dbOverride && path.length >= 3)
-        path[0] = dbOverride;
-      if (schOverride && path.length >= 3)
-        path[1] = schOverride;
-      else if (schOverride && path.length === 2)
+      if (path.length >= 3) {
+        if (dbOverride && !modelMultiCatalog)
+          path[0] = dbOverride;
+        if (schOverride && !modelMultiSchema)
+          path[1] = schOverride;
+      } else if (schOverride && path.length === 2) {
         path[0] = schOverride;
+      }
     } else {
-      path = [dbOverride || "DATABASE", schOverride || "SCHEMA", tableName.toUpperCase()];
+      path = [dbOverride || physCase("DATABASE"), schOverride || physCase("SCHEMA"), physCase(tableName)];
       warnings.push(`\u26A0 Table "${tableName}": could not extract source path from M expression \u2014 using default.`);
     }
+    const physPath = whLower && path ? path.map((s) => String(s).toLowerCase()) : path;
     const columns = [];
     const order = [];
     const pbiToSigmaName = {};
@@ -2028,7 +2072,7 @@ SELECT 1 AS _placeholder`;
       }
       const sourceCol = c.sourceColumn || c.name;
       const displayName = sigmaDisplayName(sourceCol);
-      const colId = sigmaInodeId(sigmaPhysicalName(sourceCol));
+      const colId = sigmaInodeId(sigmaPhysicalName(sourceCol, physCasing), physCasing);
       tableColMap[tableName][c.name] = colId;
       pbiToSigmaName[c.name] = displayName;
       allPbiToSigmaNames[c.name] = displayName;
@@ -2044,7 +2088,7 @@ SELECT 1 AS _placeholder`;
       id: elementId,
       kind: "table",
       name: path && path.length ? path[path.length - 1] : tableName.toUpperCase(),
-      source: { connectionId: connectionId || "<CONNECTION_ID>", kind: "warehouse-table", path },
+      source: { connectionId: connectionId || "<CONNECTION_ID>", kind: "warehouse-table", path: physPath },
       columns,
       order
     };
@@ -2164,7 +2208,7 @@ SELECT 1 AS _placeholder`;
       id: elementId,
       kind: "table",
       name: baseElementName,
-      source: { connectionId: connectionId || "<CONNECTION_ID>", kind: "warehouse-table", path },
+      source: { connectionId: connectionId || "<CONNECTION_ID>", kind: "warehouse-table", path: physPath },
       columns,
       order
     };

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -102,6 +102,11 @@ OptionParser.new do |o|
   o.on('--connection ID')   { |v| opts[:conn]   = v }
   o.on('--database DB')     { |v| opts[:db]     = v }
   o.on('--schema S')        { |v| opts[:schema] = v }
+  # Target warehouse dialect for physical-identifier casing (beads-sigma-lanq.7).
+  # Databricks/Spark store identifiers lower-case and bind only against a lower-cased
+  # warehouse path; Snowflake/BigQuery (the default) fold to UPPER. Default is read
+  # from the resolved connection's `type` in connection.json; this flag overrides it.
+  o.on('--warehouse-type T') { |v| opts[:wh_type] = v }
   o.on('--ref-dm ID')       { |v| opts[:ref_dm] = v }
   o.on('--folder ID')       { |v| opts[:folder] = v }
   o.on('--name NAME')       { |v| opts[:name]   = v }
@@ -187,7 +192,11 @@ abort "FATAL: missing --pbir (the Power BI report layout / PBIR bundle).\n#{CONN
 abort "FATAL: --pbir not found: #{opts[:pbir]}\n#{CONNECT_HINT}" unless File.exist?(opts[:pbir])
 # intake.rb (front-door) caches the resolved connection in <out>/connection.json; honor it
 # when --connection is omitted so the agent need not re-pass the id it just resolved.
-opts[:conn] ||= (JSON.parse(File.read(File.join(opts[:out], 'connection.json')))['connection_id'] rescue nil) if opts[:out]
+if opts[:out] && File.exist?(File.join(opts[:out], 'connection.json'))
+  _cj = (JSON.parse(File.read(File.join(opts[:out], 'connection.json'))) rescue {})
+  opts[:conn]    ||= _cj['connection_id']
+  opts[:wh_type] ||= _cj['type']   # warehouse dialect → physical-identifier casing (beads-sigma-lanq.7)
+end
 # bead hjke(a): abort early on a truncated/partial connection id — it survives
 # all the way to the DM POST and fails there opaquely ("Source not found").
 if opts[:conn] && opts[:conn] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
@@ -396,13 +405,14 @@ elsif CONV_MODULE.nil?
   puts '   vendored converter (converter/powerbi.mjs) missing and no local sigma-data-model-mcp build (--mcp-dir / PBI_MCP_DIR).'
   puts
   puts '   >>> GATE: run the convert_powerbi_to_sigma MCP tool on the TMSL model'
-  puts "       (#{opts[:tmsl]}) with connectionId=#{opts[:conn]} database=#{opts[:db]} schema=#{opts[:schema]},"
+  puts "       (#{opts[:tmsl]}) with connectionId=#{opts[:conn]} database=#{opts[:db]} schema=#{opts[:schema]} warehouseType=#{opts[:wh_type].to_s.empty? ? '(default UPPER)' : opts[:wh_type]},"
   puts '       save the tool result JSON to a file, then re-run this command with'
   puts '       --converter-out <that file>. No Sigma objects were created.'
   exit 10
 end
 unless opts[:cvt_out]
 puts "   converter: #{CONV_MODULE == VENDORED_PBI ? 'vendored bundle (converter/powerbi.mjs)' : CONV_MODULE} (no data leaves this machine)"
+puts "   warehouse dialect: #{opts[:wh_type].to_s.empty? ? 'default (UPPER — Snowflake/BigQuery)' : "#{opts[:wh_type]} → lower-case physical ids"} (beads-sigma-lanq.7)"
 shim = File.join(WORK, '_convert.mjs')
 # Node ESM on Windows rejects a bare drive-letter specifier
 # (`import ... from "C:/path/powerbi.mjs"` → ERR_UNSUPPORTED_ESM_URL_SCHEME,
@@ -423,6 +433,7 @@ File.write(shim, <<~JS)
     connectionId: #{(opts[:conn] || '').to_json},
     database: #{opts[:db].to_json},
     schema: #{opts[:schema].to_json},
+    warehouseType: #{(opts[:wh_type] || '').to_json},
   });
   // Write the UNWRAPPED model to dm-raw.json. convert-model.rb MODE B unwraps
   // only {sigmaDataModel} or a bare spec, NOT this converter's {model,...}


### PR DESCRIPTION
Fast-follow to **sigma-data-model-mcp#105** (merged) — the skill now *uses* the merged Databricks-casing / multi-schema converter.

## Changes
- **`migrate-powerbi.rb`** — new `--warehouse-type` flag; default read from the resolved connection's `type` in `connection.json`; passed as `warehouseType` to the converter shim so physical `source.path` + column ids fold to the warehouse case. Surfaced in the convert log.
- **`converter/powerbi.mjs`** — re-vendored from the merged converter (`tools/vendor-converters.sh`, esbuild) — now carries `warehouseType` / `physCase` / `modelMultiSchema`.
- **`SKILL.md` Phase 3** — documents `--warehouse-type databricks` + the multi-schema behavior.

## Full-pipeline E2E on live Databricks
Ran `migrate-powerbi.rb` end-to-end against a real Databricks connection (synthetic claims fixture, `--warehouse-type databricks`):
- **exit 0, 27.8s** — convert → **DM POST: 6 columns clean (0 error types)** → **workbook POST: 9 clean** → layout → **Phase-6 RESOLUTION PASS** (9 cols resolve, 0 error).
- Live query of the built DM returned **real Databricks rows** with lower-case physical ids (`inode-.../hvid` → `984/P/IL`, …).
- Test DM + workbook deleted.

This is the piece that was blocked on #105 merging (couldn't vendor unmerged code). With the old bundle the same run would have produced UPPER paths → `Source not found`; now it's clean end-to-end.

Neutral fixture; no customer identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)