### PR TITLE
powerbi: cause-grouped coverage + DM-POST grant action (beads-sigma-flva)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -226,10 +226,13 @@ $used_control_ids = Hash.new(0)
 #              false -> a genuine Sigma spec limitation (informational only)
 $unresolved = []
 def record_unresolved(visual:, severity:, detail:, pbi_type: nil, sigma_kind: nil,
-                      recoverable: false, action: nil)
+                      recoverable: false, action: nil, entity: nil)
+  # `entity` = the PBI table/entity the dropped ref pointed at (e.g. "Dim Region"),
+  # so migrate-powerbi.rb can attribute the drop to an ungranted schema for the
+  # cause-grouped coverage readout (CoverageGate.classify_causes).
   $unresolved << { 'visual' => visual.to_s, 'pbi_type' => pbi_type, 'sigma_kind' => sigma_kind,
                    'severity' => severity, 'detail' => detail.to_s,
-                   'recoverable' => recoverable, 'action' => action }
+                   'recoverable' => recoverable, 'action' => action, 'entity' => entity }
 end
 
 # TMSL column type for ENTITY.LEAF — date-typed slicers must become date-range
@@ -728,8 +731,11 @@ def drop_unresolved_columns!(el, rec, kind)
   end
   el['values'] = Array(el['values']).reject(&has_bad) if el['values'].is_a?(Array)
   leaves = bad.map { |c| c['name'] }.compact.join(', ')
+  # Entity = the part before the first dot in the unresolved `[Entity.Leaf]` ref
+  # (e.g. "Dim Region"), used to attribute the drop to an ungranted schema.
+  entities = bad.map { |c| c['formula'].to_s[/\A\[([^\]\/.]+)\./, 1] }.compact.uniq.join(', ')
   record_unresolved(visual: (rec['title'] || rec['visual_id']), pbi_type: rec['visual_type'],
-                    sigma_kind: kind, severity: 'dropped', recoverable: true,
+                    sigma_kind: kind, severity: 'dropped', recoverable: true, entity: entities,
                     detail: "field(s) #{leaves} could not be resolved to a master column — dropped " \
                             '(would have shipped as a type=error column)',
                     action: "Map the PBI queryRef(s) for #{leaves} to a master column in master-map.json and re-run.")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_gate.rb
@@ -89,4 +89,85 @@ module CoverageGate
         'default' => 'accept the gap (ship without this component)' }
     end
   end
+
+  # ── Cause classification (customer feedback 2026-07-17: dim names / measures /
+  # filters silently dropped → empty tiles with no "why/what-to-do"). Group drops
+  # by WHY and attach ONE concrete action per cause: an empty tile becomes
+  # "grant schema X" or "non-translatable DAX (accepted)" instead of a silent gap.
+  # The orchestrator alone knows the DM readback + converter warnings, so it
+  # gathers the inputs; this stays pure + unit-tested (test-coverage-gate.rb).
+  CAUSE_ORDER = { 'ungranted_schema' => 0, 'cross_table_measure' => 1,
+                  'nontranslatable_dax' => 2, 'empty_tile' => 3, 'unmapped' => 4 }.freeze
+
+  def norm_ident(s)
+    s.to_s.downcase.gsub(/[^a-z0-9]/, '')
+  end
+
+  # Stamp each unresolved entry with a `cause` and (for non-translatable DAX)
+  # flip recoverable:false so the visual-compare gate isn't blocked by a genuine
+  # Sigma/DAX limitation — it is SURFACED, not gated. Mutates + returns coverage.
+  #   ungranted        : { "<catalog>.<schema>" => [table, …] } (warehouse elements
+  #                      absent from the DM readback = schema the connection can't read)
+  #   dax_dropped      : measure names the converter dropped as non-translatable (⛔)
+  #   dax_crosstable   : measure names dropped as cross-table (⚠)
+  def classify_causes(coverage, ungranted: {}, connection: nil, dax_dropped: [], dax_crosstable: [])
+    return coverage unless coverage.is_a?(Hash)
+    ung   = ungranted.values.flatten.map { |t| norm_ident(t) }.reject(&:empty?)
+    drop  = dax_dropped.map { |m| norm_ident(m) }.reject(&:empty?)
+    cross = dax_crosstable.map { |m| norm_ident(m) }.reject(&:empty?)
+    (coverage['unresolved'] || []).each do |u|
+      en  = norm_ident(u['entity'])
+      hay = norm_ident("#{u['detail']} #{u['visual']} #{u['entity']}")
+      u['cause'] =
+        if !en.empty? && ung.any? { |t| t == en || en.include?(t) || t.include?(en) }
+          u['recoverable'] = true
+          'ungranted_schema'
+        elsif !drop.empty? && drop.any? { |m| hay.include?(m) }
+          u['recoverable'] = false
+          'nontranslatable_dax'
+        elsif !cross.empty? && cross.any? { |m| hay.include?(m) }
+          u['recoverable'] = true
+          'cross_table_measure'
+        elsif u['detail'].to_s =~ /no (resolvable|field|bind)/i
+          'empty_tile'
+        else
+          'unmapped'
+        end
+    end
+    coverage['causes_summary'] = { 'ungranted_schemas' => ungranted, 'connection' => connection } unless ungranted.empty?
+    coverage
+  end
+
+  # Grouped, actionable report lines: a schema-level GRANT headline first (the
+  # highest-leverage action — one grant recovers every column/measure on those
+  # tables), then one action line per remaining cause. Falls back to the flat
+  # report_lines when nothing has been classified.
+  def report_lines_by_cause(coverage)
+    return report_lines(coverage) unless coverage.is_a?(Hash)
+    classified = (coverage['unresolved'] || []).any? { |u| u['cause'] } || coverage['causes_summary']
+    return report_lines(coverage) unless classified
+    out = []
+    conn = coverage.dig('causes_summary', 'connection')
+    (coverage.dig('causes_summary', 'ungranted_schemas') || {}).each do |sch, tbls|
+      shown = Array(tbls).uniq
+      out << "  • [UNGRANTED SCHEMA] #{sch} — #{shown.size} table(s) the connection can't read: " \
+             "#{shown.first(6).join(', ')}#{shown.size > 6 ? ', …' : ''}" \
+             "\n      ↳ grant #{sch} to connection #{conn || '<the DM connection>'} and re-run — recovers every column/measure on these tables (e.g. the dimension NAME columns + measures)."
+    end
+    items = (coverage['unresolved'] || []).reject { |u| u['cause'] == 'ungranted_schema' }
+    items.group_by { |u| u['cause'] || 'unmapped' }
+         .sort_by { |c, _| CAUSE_ORDER[c] || 9 }.each do |cause, grp|
+      names = grp.map { |u| u['visual'] }.compact.uniq
+      action =
+        case cause
+        when 'nontranslatable_dax' then 'non-translatable DAX (no Sigma equivalent) — accepted; recreate as a workbook calc if the visual needs it.'
+        when 'cross_table_measure' then 'cross-table measure — recreate at the visual grain in a workbook element.'
+        when 'empty_tile'          then 'no resolvable bindings — supply the missing source (grant the schema / map the queryRef) and re-run.'
+        else                            'map the PBI queryRef to a master column in master-map.json and re-run.'
+        end
+      out << "  • [#{cause.tr('_', ' ').upcase}] #{grp.size} item(s): " \
+             "#{names.first(6).join(', ')}#{names.size > 6 ? ', …' : ''}\n      ↳ #{action}"
+    end
+    out
+  end
 end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -280,6 +280,38 @@ def run_wb!(cmd, env: {})
   out
 end
 
+# A DM POST fails HARD ("Cannot resolve columns … dependency not found" /
+# "Source not found: warehouse table '…'") when a source table lives in a schema
+# the connection CANNOT READ — the single most common enterprise blocker (customer
+# feedback 2026-07-17; the "1,763 → 0 errors" iteration). Map the offending
+# element/table in the POST output back to its source-path schema and return a
+# concrete GRANT action so the user isn't left decoding an opaque 400. Returns nil
+# when the failure isn't an unreadable-table error.
+def explain_unreadable_tables(out, dm_spec_path, conn)
+  spec = (JSON.parse(File.read(dm_spec_path)) rescue nil)
+  return nil unless spec
+  els = (spec['elements'] || []) + (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  by_id = {}; by_tail = {}
+  els.each do |e|
+    p = e.dig('source', 'path')
+    next unless p.is_a?(Array) && !p.empty?
+    sch = p.length >= 3 ? "#{p[0]}.#{p[-2]}" : (p[-2] || p[0]).to_s
+    by_id[e['id']] = [sch, p[-1]]
+    by_tail[e['name'].to_s.downcase] = [sch, p[-1]] if e['name']
+    by_tail[p[-1].to_s.downcase] = [sch, p[-1]]
+  end
+  hits = Hash.new { |h, k| h[k] = [] }
+  out.scan(/table '([^']+)'/i) { |m| (s = by_id[m[0]]) && (hits[s[0]] << s[1]) }
+  out.scan(/formula reference '([^'\/]+)\//i) { |m| (s = by_tail[m[0].to_s.downcase]) && (hits[s[0]] << s[1]) }
+  out.scan(/warehouse table '([^']+)'/i) do |m|
+    parts = m[0].split('.'); next if parts.size < 2
+    sch = parts.size >= 3 ? "#{parts[0]}.#{parts[-2]}" : parts[-2]
+    hits[sch] << parts[-1]
+  end
+  return nil if hits.empty?
+  hits.map { |sch, tbls| "   │    • #{sch}  (table(s): #{tbls.uniq.first(6).join(', ')}) — grant to connection #{conn || '<the DM connection>'}" }.join("\n")
+end
+
 # Pull likely-offending field/column names out of a failed workbook build/POST log
 # so the fallback message can name them. Looks for the common rejection shapes:
 #   "Dependency not found: <X>", "Unknown column \"[<X>]\"", "source: {} ... <X>",
@@ -749,8 +781,23 @@ end
 run!(fixup, env: ENV.to_h)
 run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec])
 dm_readback = File.join(WORK, 'dm-readback.json')
-run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
-      '--spec', dm_spec, '--out', dm_readback, '--workdir', WORK], env: ENV.to_h)
+# DM POST — captured (not run!) so an unreadable-table failure surfaces a concrete
+# GRANT action instead of an opaque 400 (customer feedback 2026-07-17).
+_dm_post = ['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
+            '--spec', dm_spec, '--out', dm_readback, '--workdir', WORK]
+_dm_out, _dm_st = Open3.capture2e(ENV.to_h, *_dm_post)
+_dm_out.each_line { |l| puts "   #{l.rstrip}" } unless _dm_out.strip.empty?
+unless _dm_st.success?
+  hint = explain_unreadable_tables(_dm_out, dm_spec, opts[:conn])
+  if hint
+    warn ''
+    warn '   ┌─ UNREADABLE WAREHOUSE TABLE(S): the data-model POST failed because the'
+    warn '   │  connection cannot read one or more source tables — almost always a missing GRANT:'
+    warn hint
+    warn '   └─ grant the schema(s) above to the connection (or drop those tables/visuals), then re-run.'
+  end
+  abort "FATAL: data model POST failed (#{_dm_st.exitstatus})."
+end
 dm_rb = JSON.parse(File.read(dm_readback))
 dm_id = dm_rb['dataModelId']
 puts "   dataModelId = #{dm_id}"
@@ -1259,10 +1306,31 @@ puts "   workbookId = #{wb_id}"
 # ---------------------------------------------------------------------------
 coverage = CoverageGate.load(File.join(WORK, 'coverage.json'))
 if coverage
+  # Cause-grouping (customer feedback 2026-07-17: dim names/measures dropped → empty
+  # tiles with no "why"). Attribute each silent drop to a CAUSE with an action.
+  # UNGRANTED SCHEMA = a warehouse-table element the converter emitted that VANISHED
+  # from the DM readback (POST dropped/error-typed it → the connection can't read
+  # that schema); DAX drops come from the converter's ⛔/⚠ measure warnings.
+  rb_names = dm_elements.map { |e| e['name'] }.compact
+  rb_ids   = dm_elements.map { |e| e['id'] }.compact
+  ungranted = Hash.new { |h, k| h[k] = [] }
+  conv_elements.each do |cel|
+    p = cel.dig('source', 'path')
+    next unless p.is_a?(Array) && !p.empty?                         # warehouse-table element only
+    next if rb_names.include?(cel['name']) || rb_ids.include?(cel['id'])  # survived the readback
+    sch = p.length >= 3 ? "#{p[0]}.#{p[-2]}" : (p[-2] || p[0] || '(unknown)')
+    ungranted[sch] << p[-1] unless ungranted[sch].include?(p[-1])
+  end
+  mname = ->(w) { w.to_s[/["“']([^"”']+)["”']/, 1] }
+  dax_dropped    = conv_warnings.select { |w| w.to_s.include?('⛔') }.map(&mname).compact
+  dax_crosstable = conv_warnings.select { |w| w.to_s =~ /cross-table|different relationship path/i }.map(&mname).compact
+  coverage = CoverageGate.classify_causes(coverage, ungranted: ungranted, connection: opts[:conn],
+                                          dax_dropped: dax_dropped, dax_crosstable: dax_crosstable)
+  File.write(File.join(WORK, 'coverage.json'), JSON.pretty_generate(coverage)) # single channel for assert-visual-compare.rb
   puts
   puts '==================== MIGRATION COVERAGE ===================='
   puts "   #{CoverageGate.headline(coverage)}"
-  rlines = CoverageGate.report_lines(coverage)
+  rlines = CoverageGate.report_lines_by_cause(coverage)
   unless rlines.empty?
     puts
     puts rlines.join("\n")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-coverage-gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-coverage-gate.rb
@@ -77,5 +77,41 @@ ok('load(nil) -> nil', CoverageGate.load(nil).nil?)
 ok('load(missing) -> nil', CoverageGate.load('/no/such/coverage.json').nil?)
 ok('questions(nil) -> []', CoverageGate.questions(nil) == [])
 
+# ── classify_causes + report_lines_by_cause (cause grouping, 2026-07-17) ──
+# neutral fixture names (no customer identifiers).
+cov = {
+  'summary' => { 'sourceVisuals' => 4 },
+  'unresolved' => [
+    { 'visual' => 'Region sales', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Dim Territory',
+      'detail' => 'field(s) TerritoryName could not be resolved to a master column — dropped' },
+    { 'visual' => 'Margin KPI', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Fact Sales',
+      'detail' => 'field(s) Weird Ratio could not be resolved to a master column — dropped' },
+    { 'visual' => 'Rank tile', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Fact Sales',
+      'detail' => 'field(s) Sales Rank could not be resolved to a master column — dropped' }
+  ]
+}
+CoverageGate.classify_causes(cov,
+                             ungranted: { 'maincat.gold_dims' => ['Dim Territory', 'Dim Vendor'] },
+                             connection: 'conn-123',
+                             dax_dropped: ['Weird Ratio'],
+                             dax_crosstable: ['Sales Rank'])
+by = cov['unresolved'].each_with_object({}) { |u, h| h[u['visual']] = u }
+ok('classify: ungranted-schema drop matched by entity', by['Region sales']['cause'] == 'ungranted_schema')
+ok('classify: non-translatable DAX flipped to recoverable:false',
+   by['Margin KPI']['cause'] == 'nontranslatable_dax' && by['Margin KPI']['recoverable'] == false)
+ok('classify: cross-table measure stays recoverable',
+   by['Rank tile']['cause'] == 'cross_table_measure' && by['Rank tile']['recoverable'] == true)
+ok('classify: causes_summary carries schema + connection',
+   cov.dig('causes_summary', 'ungranted_schemas').key?('maincat.gold_dims') &&
+   cov.dig('causes_summary', 'connection') == 'conn-123')
+
+cl = CoverageGate.report_lines_by_cause(cov)
+ok('grouped: leads with a GRANT action naming schema + connection',
+   cl.any? { |l| l.include?('UNGRANTED SCHEMA') && l.include?('gold_dims') && l.include?('grant') && l.include?('conn-123') })
+ok('grouped: surfaces non-translatable DAX as its own cause',
+   cl.any? { |l| l.include?('NONTRANSLATABLE DAX') })
+ok('grouped: falls back to flat report when unclassified',
+   CoverageGate.report_lines_by_cause(COVERAGE).size == 2)
+
 puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
 exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb
@@ -100,6 +100,10 @@ Dir.mktmpdir do |d|
   all_drops  = cover.count { |u| u['severity'] == 'dropped' }
   ok('>=4 visuals record the explicit miu7 column drop', miu7_drops >= 4)
   ok('all 5 ghost-bearing visuals surface a dropped entry', all_drops >= 5)
+  # the drop record carries the source ENTITY (part before the dot in [Entity.Leaf])
+  # so CoverageGate.classify_causes can attribute it to an ungranted schema.
+  ok('miu7 drop records the source entity for cause attribution',
+     cover.any? { |u| u['detail'].to_s =~ /could not be resolved/ && !u['entity'].to_s.strip.empty? })
 end
 
 puts $fail.zero? ? "\nall drop-unresolved-columns tests passed" : "\n#{$fail} FAILED"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/coverage_gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/coverage_gate.rb
@@ -89,4 +89,85 @@ module CoverageGate
         'default' => 'accept the gap (ship without this component)' }
     end
   end
+
+  # ── Cause classification (customer feedback 2026-07-17: dim names / measures /
+  # filters silently dropped → empty tiles with no "why/what-to-do"). Group drops
+  # by WHY and attach ONE concrete action per cause: an empty tile becomes
+  # "grant schema X" or "non-translatable DAX (accepted)" instead of a silent gap.
+  # The orchestrator alone knows the DM readback + converter warnings, so it
+  # gathers the inputs; this stays pure + unit-tested (test-coverage-gate.rb).
+  CAUSE_ORDER = { 'ungranted_schema' => 0, 'cross_table_measure' => 1,
+                  'nontranslatable_dax' => 2, 'empty_tile' => 3, 'unmapped' => 4 }.freeze
+
+  def norm_ident(s)
+    s.to_s.downcase.gsub(/[^a-z0-9]/, '')
+  end
+
+  # Stamp each unresolved entry with a `cause` and (for non-translatable DAX)
+  # flip recoverable:false so the visual-compare gate isn't blocked by a genuine
+  # Sigma/DAX limitation — it is SURFACED, not gated. Mutates + returns coverage.
+  #   ungranted        : { "<catalog>.<schema>" => [table, …] } (warehouse elements
+  #                      absent from the DM readback = schema the connection can't read)
+  #   dax_dropped      : measure names the converter dropped as non-translatable (⛔)
+  #   dax_crosstable   : measure names dropped as cross-table (⚠)
+  def classify_causes(coverage, ungranted: {}, connection: nil, dax_dropped: [], dax_crosstable: [])
+    return coverage unless coverage.is_a?(Hash)
+    ung   = ungranted.values.flatten.map { |t| norm_ident(t) }.reject(&:empty?)
+    drop  = dax_dropped.map { |m| norm_ident(m) }.reject(&:empty?)
+    cross = dax_crosstable.map { |m| norm_ident(m) }.reject(&:empty?)
+    (coverage['unresolved'] || []).each do |u|
+      en  = norm_ident(u['entity'])
+      hay = norm_ident("#{u['detail']} #{u['visual']} #{u['entity']}")
+      u['cause'] =
+        if !en.empty? && ung.any? { |t| t == en || en.include?(t) || t.include?(en) }
+          u['recoverable'] = true
+          'ungranted_schema'
+        elsif !drop.empty? && drop.any? { |m| hay.include?(m) }
+          u['recoverable'] = false
+          'nontranslatable_dax'
+        elsif !cross.empty? && cross.any? { |m| hay.include?(m) }
+          u['recoverable'] = true
+          'cross_table_measure'
+        elsif u['detail'].to_s =~ /no (resolvable|field|bind)/i
+          'empty_tile'
+        else
+          'unmapped'
+        end
+    end
+    coverage['causes_summary'] = { 'ungranted_schemas' => ungranted, 'connection' => connection } unless ungranted.empty?
+    coverage
+  end
+
+  # Grouped, actionable report lines: a schema-level GRANT headline first (the
+  # highest-leverage action — one grant recovers every column/measure on those
+  # tables), then one action line per remaining cause. Falls back to the flat
+  # report_lines when nothing has been classified.
+  def report_lines_by_cause(coverage)
+    return report_lines(coverage) unless coverage.is_a?(Hash)
+    classified = (coverage['unresolved'] || []).any? { |u| u['cause'] } || coverage['causes_summary']
+    return report_lines(coverage) unless classified
+    out = []
+    conn = coverage.dig('causes_summary', 'connection')
+    (coverage.dig('causes_summary', 'ungranted_schemas') || {}).each do |sch, tbls|
+      shown = Array(tbls).uniq
+      out << "  • [UNGRANTED SCHEMA] #{sch} — #{shown.size} table(s) the connection can't read: " \
+             "#{shown.first(6).join(', ')}#{shown.size > 6 ? ', …' : ''}" \
+             "\n      ↳ grant #{sch} to connection #{conn || '<the DM connection>'} and re-run — recovers every column/measure on these tables (e.g. the dimension NAME columns + measures)."
+    end
+    items = (coverage['unresolved'] || []).reject { |u| u['cause'] == 'ungranted_schema' }
+    items.group_by { |u| u['cause'] || 'unmapped' }
+         .sort_by { |c, _| CAUSE_ORDER[c] || 9 }.each do |cause, grp|
+      names = grp.map { |u| u['visual'] }.compact.uniq
+      action =
+        case cause
+        when 'nontranslatable_dax' then 'non-translatable DAX (no Sigma equivalent) — accepted; recreate as a workbook calc if the visual needs it.'
+        when 'cross_table_measure' then 'cross-table measure — recreate at the visual grain in a workbook element.'
+        when 'empty_tile'          then 'no resolvable bindings — supply the missing source (grant the schema / map the queryRef) and re-run.'
+        else                            'map the PBI queryRef to a master column in master-map.json and re-run.'
+        end
+      out << "  • [#{cause.tr('_', ' ').upcase}] #{grp.size} item(s): " \
+             "#{names.first(6).join(', ')}#{names.size > 6 ? ', …' : ''}\n      ↳ #{action}"
+    end
+    out
+  end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-coverage-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-coverage-gate.rb
@@ -77,5 +77,41 @@ ok('load(nil) -> nil', CoverageGate.load(nil).nil?)
 ok('load(missing) -> nil', CoverageGate.load('/no/such/coverage.json').nil?)
 ok('questions(nil) -> []', CoverageGate.questions(nil) == [])
 
+# ── classify_causes + report_lines_by_cause (cause grouping, 2026-07-17) ──
+# neutral fixture names (no customer identifiers).
+cov = {
+  'summary' => { 'sourceVisuals' => 4 },
+  'unresolved' => [
+    { 'visual' => 'Region sales', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Dim Territory',
+      'detail' => 'field(s) TerritoryName could not be resolved to a master column — dropped' },
+    { 'visual' => 'Margin KPI', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Fact Sales',
+      'detail' => 'field(s) Weird Ratio could not be resolved to a master column — dropped' },
+    { 'visual' => 'Rank tile', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Fact Sales',
+      'detail' => 'field(s) Sales Rank could not be resolved to a master column — dropped' }
+  ]
+}
+CoverageGate.classify_causes(cov,
+                             ungranted: { 'maincat.gold_dims' => ['Dim Territory', 'Dim Vendor'] },
+                             connection: 'conn-123',
+                             dax_dropped: ['Weird Ratio'],
+                             dax_crosstable: ['Sales Rank'])
+by = cov['unresolved'].each_with_object({}) { |u, h| h[u['visual']] = u }
+ok('classify: ungranted-schema drop matched by entity', by['Region sales']['cause'] == 'ungranted_schema')
+ok('classify: non-translatable DAX flipped to recoverable:false',
+   by['Margin KPI']['cause'] == 'nontranslatable_dax' && by['Margin KPI']['recoverable'] == false)
+ok('classify: cross-table measure stays recoverable',
+   by['Rank tile']['cause'] == 'cross_table_measure' && by['Rank tile']['recoverable'] == true)
+ok('classify: causes_summary carries schema + connection',
+   cov.dig('causes_summary', 'ungranted_schemas').key?('maincat.gold_dims') &&
+   cov.dig('causes_summary', 'connection') == 'conn-123')
+
+cl = CoverageGate.report_lines_by_cause(cov)
+ok('grouped: leads with a GRANT action naming schema + connection',
+   cl.any? { |l| l.include?('UNGRANTED SCHEMA') && l.include?('gold_dims') && l.include?('grant') && l.include?('conn-123') })
+ok('grouped: surfaces non-translatable DAX as its own cause',
+   cl.any? { |l| l.include?('NONTRANSLATABLE DAX') })
+ok('grouped: falls back to flat report when unclassified',
+   CoverageGate.report_lines_by_cause(COVERAGE).size == 2)
+
 puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
 exit($fail.zero? ? 0 : 1)

--- a/shared/lib/coverage_gate.rb
+++ b/shared/lib/coverage_gate.rb
@@ -89,4 +89,85 @@ module CoverageGate
         'default' => 'accept the gap (ship without this component)' }
     end
   end
+
+  # ── Cause classification (customer feedback 2026-07-17: dim names / measures /
+  # filters silently dropped → empty tiles with no "why/what-to-do"). Group drops
+  # by WHY and attach ONE concrete action per cause: an empty tile becomes
+  # "grant schema X" or "non-translatable DAX (accepted)" instead of a silent gap.
+  # The orchestrator alone knows the DM readback + converter warnings, so it
+  # gathers the inputs; this stays pure + unit-tested (test-coverage-gate.rb).
+  CAUSE_ORDER = { 'ungranted_schema' => 0, 'cross_table_measure' => 1,
+                  'nontranslatable_dax' => 2, 'empty_tile' => 3, 'unmapped' => 4 }.freeze
+
+  def norm_ident(s)
+    s.to_s.downcase.gsub(/[^a-z0-9]/, '')
+  end
+
+  # Stamp each unresolved entry with a `cause` and (for non-translatable DAX)
+  # flip recoverable:false so the visual-compare gate isn't blocked by a genuine
+  # Sigma/DAX limitation — it is SURFACED, not gated. Mutates + returns coverage.
+  #   ungranted        : { "<catalog>.<schema>" => [table, …] } (warehouse elements
+  #                      absent from the DM readback = schema the connection can't read)
+  #   dax_dropped      : measure names the converter dropped as non-translatable (⛔)
+  #   dax_crosstable   : measure names dropped as cross-table (⚠)
+  def classify_causes(coverage, ungranted: {}, connection: nil, dax_dropped: [], dax_crosstable: [])
+    return coverage unless coverage.is_a?(Hash)
+    ung   = ungranted.values.flatten.map { |t| norm_ident(t) }.reject(&:empty?)
+    drop  = dax_dropped.map { |m| norm_ident(m) }.reject(&:empty?)
+    cross = dax_crosstable.map { |m| norm_ident(m) }.reject(&:empty?)
+    (coverage['unresolved'] || []).each do |u|
+      en  = norm_ident(u['entity'])
+      hay = norm_ident("#{u['detail']} #{u['visual']} #{u['entity']}")
+      u['cause'] =
+        if !en.empty? && ung.any? { |t| t == en || en.include?(t) || t.include?(en) }
+          u['recoverable'] = true
+          'ungranted_schema'
+        elsif !drop.empty? && drop.any? { |m| hay.include?(m) }
+          u['recoverable'] = false
+          'nontranslatable_dax'
+        elsif !cross.empty? && cross.any? { |m| hay.include?(m) }
+          u['recoverable'] = true
+          'cross_table_measure'
+        elsif u['detail'].to_s =~ /no (resolvable|field|bind)/i
+          'empty_tile'
+        else
+          'unmapped'
+        end
+    end
+    coverage['causes_summary'] = { 'ungranted_schemas' => ungranted, 'connection' => connection } unless ungranted.empty?
+    coverage
+  end
+
+  # Grouped, actionable report lines: a schema-level GRANT headline first (the
+  # highest-leverage action — one grant recovers every column/measure on those
+  # tables), then one action line per remaining cause. Falls back to the flat
+  # report_lines when nothing has been classified.
+  def report_lines_by_cause(coverage)
+    return report_lines(coverage) unless coverage.is_a?(Hash)
+    classified = (coverage['unresolved'] || []).any? { |u| u['cause'] } || coverage['causes_summary']
+    return report_lines(coverage) unless classified
+    out = []
+    conn = coverage.dig('causes_summary', 'connection')
+    (coverage.dig('causes_summary', 'ungranted_schemas') || {}).each do |sch, tbls|
+      shown = Array(tbls).uniq
+      out << "  • [UNGRANTED SCHEMA] #{sch} — #{shown.size} table(s) the connection can't read: " \
+             "#{shown.first(6).join(', ')}#{shown.size > 6 ? ', …' : ''}" \
+             "\n      ↳ grant #{sch} to connection #{conn || '<the DM connection>'} and re-run — recovers every column/measure on these tables (e.g. the dimension NAME columns + measures)."
+    end
+    items = (coverage['unresolved'] || []).reject { |u| u['cause'] == 'ungranted_schema' }
+    items.group_by { |u| u['cause'] || 'unmapped' }
+         .sort_by { |c, _| CAUSE_ORDER[c] || 9 }.each do |cause, grp|
+      names = grp.map { |u| u['visual'] }.compact.uniq
+      action =
+        case cause
+        when 'nontranslatable_dax' then 'non-translatable DAX (no Sigma equivalent) — accepted; recreate as a workbook calc if the visual needs it.'
+        when 'cross_table_measure' then 'cross-table measure — recreate at the visual grain in a workbook element.'
+        when 'empty_tile'          then 'no resolvable bindings — supply the missing source (grant the schema / map the queryRef) and re-run.'
+        else                            'map the PBI queryRef to a master column in master-map.json and re-run.'
+        end
+      out << "  • [#{cause.tr('_', ' ').upcase}] #{grp.size} item(s): " \
+             "#{names.first(6).join(', ')}#{names.size > 6 ? ', …' : ''}\n      ↳ #{action}"
+    end
+    out
+  end
 end

--- a/shared/scripts/test-coverage-gate.rb
+++ b/shared/scripts/test-coverage-gate.rb
@@ -77,5 +77,41 @@ ok('load(nil) -> nil', CoverageGate.load(nil).nil?)
 ok('load(missing) -> nil', CoverageGate.load('/no/such/coverage.json').nil?)
 ok('questions(nil) -> []', CoverageGate.questions(nil) == [])
 
+# ── classify_causes + report_lines_by_cause (cause grouping, 2026-07-17) ──
+# neutral fixture names (no customer identifiers).
+cov = {
+  'summary' => { 'sourceVisuals' => 4 },
+  'unresolved' => [
+    { 'visual' => 'Region sales', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Dim Territory',
+      'detail' => 'field(s) TerritoryName could not be resolved to a master column — dropped' },
+    { 'visual' => 'Margin KPI', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Fact Sales',
+      'detail' => 'field(s) Weird Ratio could not be resolved to a master column — dropped' },
+    { 'visual' => 'Rank tile', 'severity' => 'dropped', 'recoverable' => true, 'entity' => 'Fact Sales',
+      'detail' => 'field(s) Sales Rank could not be resolved to a master column — dropped' }
+  ]
+}
+CoverageGate.classify_causes(cov,
+                             ungranted: { 'maincat.gold_dims' => ['Dim Territory', 'Dim Vendor'] },
+                             connection: 'conn-123',
+                             dax_dropped: ['Weird Ratio'],
+                             dax_crosstable: ['Sales Rank'])
+by = cov['unresolved'].each_with_object({}) { |u, h| h[u['visual']] = u }
+ok('classify: ungranted-schema drop matched by entity', by['Region sales']['cause'] == 'ungranted_schema')
+ok('classify: non-translatable DAX flipped to recoverable:false',
+   by['Margin KPI']['cause'] == 'nontranslatable_dax' && by['Margin KPI']['recoverable'] == false)
+ok('classify: cross-table measure stays recoverable',
+   by['Rank tile']['cause'] == 'cross_table_measure' && by['Rank tile']['recoverable'] == true)
+ok('classify: causes_summary carries schema + connection',
+   cov.dig('causes_summary', 'ungranted_schemas').key?('maincat.gold_dims') &&
+   cov.dig('causes_summary', 'connection') == 'conn-123')
+
+cl = CoverageGate.report_lines_by_cause(cov)
+ok('grouped: leads with a GRANT action naming schema + connection',
+   cl.any? { |l| l.include?('UNGRANTED SCHEMA') && l.include?('gold_dims') && l.include?('grant') && l.include?('conn-123') })
+ok('grouped: surfaces non-translatable DAX as its own cause',
+   cl.any? { |l| l.include?('NONTRANSLATABLE DAX') })
+ok('grouped: falls back to flat report when unclassified',
+   CoverageGate.report_lines_by_cause(COVERAGE).size == 2)
+
 puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
 exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
**Track 1 of the Power BI fidelity epic** (customer feedback: a Databricks BIM+PBIR migration silently dropped dim names/measures → empty charts with no "why"). Turn silent drops into actionable guidance.

## Changes
- **`shared/lib/coverage_gate.rb`** — `classify_causes` + `report_lines_by_cause`: group each drop by CAUSE (`ungranted_schema` / `nontranslatable_dax` / `cross_table_measure` / `empty_tile`) with one concrete action; non-translatable DAX flips to `recoverable:false` (surfaced, not gated). Pure + unit-tested; synced to the 2 targets.
- **`build-workbook-from-pbir.rb`** — record the dropped source **entity** so a drop can be attributed to an ungranted schema.
- **`migrate-powerbi.rb`** — compute ungranted schemas (converter elements absent from the DM readback) + DAX-drop warnings, classify, re-write `coverage.json` (single channel for `assert-visual-compare.rb`), print the grouped readout. **And** surface a concrete GRANT action at the **DM-POST failure** — an ungranted table is a hard 400 (`Cannot resolve columns / Source not found`), so that's where the guidance belongs.

## Why the DM-POST hook (a finding from live testing)
An ungranted table doesn't drop gracefully — it **fails the DM POST entirely** (400), halting before the coverage readout. Verified live on the TJ Databricks Demo connection: `samples.nyctaxi` now prints `grant samples.nyctaxi to connection <id> and re-run` instead of an opaque 400. The coverage-readout grouping handles the drops that *do* reach Phase 5c (granted-dim resolution, DAX).

## Validation
- Unit: `test-coverage-gate.rb` (classify + grouped report + fallback), `test-drop-unresolved-columns.rb` (entity recorded). Green.
- Live E2E (TJ Databricks Demo): ungranted case → grant action; clean single-schema case → unchanged, RESOLUTION PASS. Test objects deleted.
- `check-shared` / `lint-skills` / esm / agent-variants all green.

Neutral fixtures; no customer identifiers. Tracks 2 (measure alias / grain / granted-dim resolution) + 3 (report filters) + a converter bead (cross-table measure) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)