### PR TITLE
powerbi: recover measures + granted-dim names — friendly-vs-physical name reconciliation (beads-sigma-2xap)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/convert-model.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/convert-model.rb
@@ -127,6 +127,38 @@ named = 0
 end
 dm['name'] = opts[:name] if opts[:name]
 
+# Fixup 3b (beads-sigma-<1b>): reconcile a base warehouse-table column's formula
+# PREFIX to its OWN element name. The converter prefixes base columns with the PBI
+# FRIENDLY table name ("[Sales/Amount]") while Fixup 3 names the element
+# after the PHYSICAL path-tail ("VW_SALES"); when the friendly name != the
+# physical view name (vw_* views / renames — common in enterprise models) the prefix
+# is UNKNOWN and the POST fails ("prefix '…' unknown" / "dependency not found"). This
+# is the customer's manual "proper-case element naming" workaround, automated. Only
+# rewrite a base element's OWN 2-segment ref whose prefix matches NO element name — a
+# valid cross-element ref (prefix IS a known element) is left untouched.
+known_norm = []
+(dm['pages'] || []).each { |pg| (pg['elements'] || []).each { |el| known_norm << el['name'].to_s.downcase.gsub(/[^a-z0-9]/, '') } }
+reprefixed = 0
+(dm['pages'] || []).each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless (el['source'] || {})['kind'] == 'warehouse-table'
+    name = el['name'].to_s
+    next if name.empty?
+    (el['columns'] || []).each do |c|
+      f = c['formula']
+      next unless f.is_a?(String)
+      m = f.match(%r{\A\[([^\]/]+)/([^\]/]+)\]\z}) # exactly [Prefix/Leaf], a single slash
+      next unless m
+      pfx = m[1]
+      next if pfx == name # already references its own element
+      next if known_norm.include?(pfx.downcase.gsub(/[^a-z0-9]/, '')) # valid ref to a known element
+      c['formula'] = "[#{name}/#{m[2]}]"
+      reprefixed += 1
+    end
+  end
+end
+warn "   [convert-model] re-prefixed #{reprefixed} base column formula(s) to their element name (friendly!=physical table name)" if reprefixed.positive?
+
 # Fixup 4 (bead xe7r): --table-map repoints warehouse-table sources at the
 # tables the customer actually landed the import-mode data in (a JSON map,
 # e.g. {"Store": "RETAIL_STORE"}). Two coupled rewrites, both required:

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -383,6 +383,27 @@ tmsl = JSON.parse(File.read(opts[:tmsl]))
 model = tmsl['model'] || tmsl
 tables = (model['tables'] || []).reject { |t| t['name'].to_s.start_with?('LocalDateTable_', 'DateTableTemplate_') }
 all_measures = tables.flat_map { |t| (t['measures'] || []).map { |m| [t['name'], m['name'], Array(m['expression']).join] } }
+# measure name -> its ORIGINAL TMSL table = the entity a PBIR visual binds it under.
+# PBI measure names are model-unique (the same assumption ti_orig_table relies on).
+# Used by the master-map loop to alias a re-homed measure back to its source entity
+# so "_Measures.TotalSales" resolves (beads-sigma-<2a>).
+measure_orig_table = {}
+all_measures.each { |tbl, mname, _| measure_orig_table[mname] = tbl }
+
+# PBI friendly table name <-> physical warehouse table (the M-query path-tail). PBIR
+# visuals reference columns under the FRIENDLY entity ("Sales") but the converter
+# names the DM element after the PHYSICAL table ("vw_sales"), so an entity-qualified
+# queryRef misses the master-map and the column silently drops — the customer's missing
+# dim NAME columns (beads-sigma-<1b>). Capture the map so the master-map can alias every
+# key under the friendly entity too.
+_normt = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]/, '') }
+physical_to_pbi = {} # normalized physical path-tail -> PBI friendly table name
+tables.each do |t|
+  _e = ((t['partitions'] || [])[0] || {}).dig('source', 'expression')
+  _e = _e.join("\n") if _e.is_a?(Array)
+  _tail = _e.to_s[/\[\s*Name\s*=\s*"([^"]+)"\s*,\s*Kind\s*=\s*"(?:Table|View)"\s*\]/i, 1]
+  physical_to_pbi[_normt.call(_tail)] = t['name'] if _tail && t['name'] && !t['name'].to_s.empty?
+end
 modes = tables.flat_map { |t| (t['partitions'] || []).map { |p| p['mode'] } }.compact.uniq
 mode_summ = modes.empty? ? 'unknown' : modes.join('/')
 
@@ -945,8 +966,18 @@ conv_elements.each_with_index do |cel, cel_idx|
     # arg compiles the column to type "error" (verified: dropping it fixes).
     # Strip a trailing integer start arg until the converter is fixed.
     rewritten = rewritten.gsub(/\bFind\((\[[^\]]+\]|"[^"]*")\s*,\s*(\[[^\]]+\]|"[^"]*")\s*,\s*\d+\s*\)/, 'Find(\1, \2)')
-    field_map["#{cname}.#{m['name']}"] = { 'master' => mkey, 'ref' => rewritten, 'agg' => nil,
-                                           'format' => (m.dig('format', 'formatString')) }
+    ref = { 'master' => mkey, 'ref' => rewritten, 'agg' => nil,
+            'format' => (m.dig('format', 'formatString')) }
+    field_map["#{cname}.#{m['name']}"] = ref
+    # 2a (beads-sigma-<2a>): a measure re-homed from a measure-only table onto the
+    # fact element (powerbi.ts moveMeasures) is keyed here under the FACT element,
+    # but the PBIR visual still binds it under its ORIGINAL measures-table entity
+    # ("_Measures.TotalSales"). Alias it so the binding resolves — mirrors
+    # ti_orig_table (below) / the calc-table Bug-E alias. Guarded (`||=` + orig !=
+    # cname) so a converter-DROPPED measure is never fabricated, and a fact-native
+    # measure is a no-op.
+    orig = measure_orig_table[m['name']]
+    field_map["#{orig}.#{m['name']}"] ||= ref if orig && orig != cname
   end
 end
 
@@ -1226,6 +1257,26 @@ all_visuals.flat_map { |v| (v['bindings'] || {}).values.flatten }.uniq.each do |
     next unless base && base['ref'].to_s =~ /\A\[[^\]]+\]\z/
     field_map[r] = base.merge('ref' => "DateTrunc(\"#{m[2].downcase}\", #{base['ref']})", 'agg' => nil)
   end
+end
+
+# PBI-friendly-entity aliases (beads-sigma-<1b>): a key "VW_SALES.Amount" is
+# ALSO reachable as "Sales.Amount" — the form PBIR visuals actually use. This
+# is why granted dim NAME columns dropped: the DM element is named after the physical
+# view ("vw_sales") but the visual binds under the friendly entity, and field_spec's
+# normalize-fallback can't bridge a `vw_` prefix. Never overwrites an existing key; only
+# adds when the physical element maps to a DIFFERENT friendly name.
+unless physical_to_pbi.empty?
+  aliases = {}
+  field_map.each do |k, v|
+    ent, dot, leaf = k.rpartition('.')
+    next if dot.empty? || ent.empty? || leaf.empty?
+    pbi = physical_to_pbi[_normt.call(ent)]
+    next unless pbi && _normt.call(pbi) != _normt.call(ent)
+    ak = "#{pbi}.#{leaf}"
+    aliases[ak] = v unless field_map.key?(ak) || aliases.key?(ak)
+  end
+  field_map.merge!(aliases)
+  puts "   master-map: +#{aliases.size} PBI-friendly-entity alias(es) (physical view name -> friendly table name)" unless aliases.empty?
 end
 
 master_map = { 'masters' => masters, 'fields' => field_map }


### PR DESCRIPTION
**Track 2 of the Power BI fidelity epic.** The customer's granted dimension NAME columns dropped (and measures went missing) — root cause: the PBI **friendly** table name differs from the **physical** warehouse view (a friendly `Sales` over `vw_sales`; every `vw_`/renamed table in the model).

## Fixes
- **`migrate-powerbi.rb` — 2a measure entity-alias:** build `measure_orig_table` from `all_measures`; alias a re-homed measure under its ORIGINAL measures-table entity so `"_Measures.X"` resolves. Guarded so a converter-dropped measure is never fabricated (mirrors `ti_orig_table` / Bug-E).
- **`convert-model.rb` — Fixup 3b (the DM-level blocker):** a base warehouse-table column's formula prefix must reference its OWN element. The converter prefixes with the *friendly* name but the element is named after the *physical* path-tail → when they differ the POST fails `prefix '…' unknown`. Rewrite a base element's own 2-segment ref whose prefix matches **no** element name to the element name (valid cross-element refs untouched). **This automates the customer's manual "proper-case element naming" workaround** from the recap.
- **`migrate-powerbi.rb` — 1b master-map alias:** alias every master-map key under the PBI friendly entity so PBIR visual queryRefs (which use friendly names) resolve against the physically-named element.

## Validation (live, TJ Databricks Demo)
A friendly≠physical fixture (`Claims Dim` over physical `claims_sample_synthetic`) that **previously FAILED the DM POST** (`prefix 'CLAIMS DIM' unknown`) now: re-prefixes 2 formulas → **DM POST clean** → master-map adds the friendly alias → **RESOLUTION PASS, 0 dropped**; the friendly-name column resolves end-to-end. Test objects deleted.
Unit: coverage-gate / drop-unresolved / intake / dax green; `check-shared` + `lint-skills` green.

Month-grain (3b) deferred to a low-priority follow-up bead. Neutral fixtures; no customer identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)