### PR TITLE
powerbi: Phase 5e source render — hand the agent PNGs, soft-fail off-capacity, add --tenant

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -236,14 +236,16 @@ with exact query parity and still looked broken (collapsed KPIs, stacked bars
 that should be clustered, alphabetical months) — caught only by putting full
 pages next to the Power BI renders. Do this BEFORE Phase 6, every run:
 
-1. Export the SOURCE pages: `"$PY" scripts/export-pbi-pages.py --report <reportId> --out-dir $WORK/visual-qa`
-   (PNG is commonly tenant-disabled — the script falls through to PDF; per-page when pypdf is installed).
+1. Export the SOURCE pages: `"$PY" scripts/export-pbi-pages.py --report <reportId> [--workspace <groupId>] [--tenant <guid|url>] --out-dir $WORK/visual-qa`
+   (PNG is commonly tenant-disabled — the script falls through to PDF and **rasterizes it to per-page `powerbi-page{N}.png`** so the downstream `Read` needs no poppler. Guest/B2B report in another tenant? pass `--tenant <guid|report-url>`.)
    > **`ExportToFile` is the ONLY documented way to render a PBI page programmatically** — and it's
-   > what this script uses (it does its own **Power BI-audience** device sign-in, scope
-   > `analysis.windows.net/powerbi/api/.default`, separate from the Fabric extraction token — don't
-   > reuse the Fabric token or it 404s; see `pbi-export-pages-token-audience`). Preconditions: the
-   > report is in a workspace on **Fabric capacity** (trial/premium), the user completes that export
-   > sign-in, and PNG isn't tenant-disabled (else PDF — the agent Reads PDFs the same way). **There is
+   > what this script uses (**Power BI-audience** scope `analysis.windows.net/powerbi/api/.default`,
+   > via the shared `pbi_fabric` per-tenant cache — don't reuse the Fabric-audience token or it 404s;
+   > see `pbi-export-pages-token-audience`). Because the cache is shared, once you've completed the
+   > Fabric extraction sign-in for the same tenant this second audience is usually **silent** (no
+   > extra device-code prompt). If the workspace isn't on **Fabric/PPU/premium capacity** (or export
+   > is tenant-disabled / fails), the script **soft-fails (exit 3)** with a reason + the Phase-6
+   > waiver to use — it does NOT crash the run; the compare falls back to a structural check. **There is
    > no other agent-driven render path:** the Power BI **Modeling MCP is model/DAX-only** (no visuals),
    > there is **no PBI `get-view-image` MCP tool** (Tableau has one; Power BI does not), and Power BI
    > **Embedded** screenshotting needs an Entra app + embed token this corporate tenant blocks. So:
@@ -272,8 +274,8 @@ pages next to the Power BI renders. Do this BEFORE Phase 6, every run:
      (every KPI, the top-3 of each ranked list/table, one representative bucket
      per chart; schema: `refs/source-anchors.md`). Land the source page PNG at a
      path the gate discovers so the bar arms: set it as `source_png` in
-     `png-read.json`, **or** copy it to `$WORK/dashboards/source.png` (if the
-     source export is a PDF, convert one page first: `sips -s format png in.pdf --out out.png` / `pdftoppm -png`).
+     `png-read.json`, **or** copy it to `$WORK/dashboards/source.png` (the export
+     already lands per-page `visual-qa/powerbi-page{N}.png` — copy the matching page).
      Then verify against the live workbook:
      `ruby scripts/verify-anchors.rb --workdir $WORK --workbook-id <wbId>` → `anchors-verdict.json` (must pass).
    - **Visual-similarity floor.** `"$PY" scripts/visual-similarity.py --source <sourcePagePng> --render $WORK/visual-qa/sigma-<page>.png --json-out $WORK/visual-similarity.json` — a deterministic ink/layout floor beneath the human compare.
@@ -439,7 +441,7 @@ The conversion is script-driven (mirrors `tableau-to-sigma/scripts/`). `scripts/
 | `fabric-extract-batch.py` | 1 batch | Fleet extraction: every requested report → 2 artifact tasks (model TMSL + report def) on ONE 4-wide pool; report→model binding via PBI REST `datasetId` (name-match fallback); `manifest.json` + `timings.json`. 3 reports = 7.5s measured. |
 | `extract-pbir.py` | 1 extract | Fetch a report's PBIR (or parse one already on disk) → normalized `signals.json` (per-visual `sigma_kind` + role bindings + x/y/w/h). Live fetch uses the `pbi_fabric` fast LRO path. The PBI analog of `parse-twb-layout.rb`. |
 | `pbi-freshness.py` | 1.5 preflight | SOURCE-FRESHNESS: refresh history (incl. FAILED/creds-expired refreshes) + cheap executeQueries row-count/max-date snapshot (**4-wide parallel per-table probes**) → `freshness.json`. Launched **non-blocking** by run.sh/migrate-powerbi.rb (consumed at parity). Leads the parity output; deltas classify MATCH / STALE-EXPLAINED / DIVERGENT (bead fmte). |
-| `export-pbi-pages.py` | 5e compare | SOURCE page renders via ExportToFile (PNG → PDF fallback; per-page split with pypdf) for the mandatory visual compare. |
+| `export-pbi-pages.py` | 5e compare | SOURCE page renders via ExportToFile (PNG → PDF fallback, **PDF rasterized to per-page PNG** via pypdfium2 so `Read` needs no poppler) for the mandatory visual compare; `--tenant` for guest/B2B; soft-fails (exit 3) with a waiver hint when export is unavailable instead of crashing. |
 | `sigma-export-png.py` | 5e/5f compare | Renders a built Sigma page to PNG (`--workbook <id> --page <pageId> --out … --w 1600`) for the source-vs-target compare AND the Phase 5f Visual QA read (checked against `refs/layout-visual-qa.md`). |
 | `assert-visual-compare.rb` | 5e gate | HARD GATE: blocks Phase 6 unless visual-compare.json has a PASS/ACCEPTED verdict (with explained deltas) for every content page. |
 | `convert-model.rb` | 2–3 convert/post | MODE A prints the exact `convert_powerbi_to_sigma` MCP call for a `model.bim`; MODE B takes the converter output and applies the 3 fixups (schemaVersion + folderId/ownerId via a ref-DM harvest + base-element names) → postable DM spec. |

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/export-pbi-pages.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/export-pbi-pages.py
@@ -1,94 +1,186 @@
 #!/usr/bin/env python3
 """export-pbi-pages.py — download the SOURCE Power BI report's rendered pages
-for the Phase 5e visual compare.
+for the Phase 5e visual compare, as PNGs the agent can Read with no system deps.
 
-Uses the ExportToFile API. PNG export is commonly DISABLED at tenant level
-("Export report to image is disabled") — PDF almost never is, and a per-page
-PDF is fine for the compare (the agent Reads PDFs/PNGs the same way). When
-pypdf is importable the PDF is split into one file per page; otherwise the
-single multi-page PDF is kept (Read it with the `pages` parameter).
+ExportToFile is the only agent-driven PBI render path:
+  * PNG export first (multi-page comes back as a zip of per-page PNGs); PNG is
+    often tenant-disabled ("Export report to image is disabled").
+  * PDF fallback (almost never disabled). The PDF is then rasterized to one PNG
+    per page IN THIS SCRIPT (pypdfium2 -> pdftoppm -> per-page PDF), because the
+    downstream `Read` renders PNG natively but shells out to `pdftoppm` (poppler)
+    for PDFs — which the agent's machine usually does NOT have. Handing over PNGs
+    keeps the mandatory visual compare dependency-free.
 
-Requires the report's workspace to be on capacity (Fabric trial/premium).
+Capacity: ExportToFile needs the report's workspace on Premium/PPU/Fabric
+capacity with image/PDF export enabled. When it isn't (or export is
+tenant-disabled / the job fails), this SOFT-FAILS (exit 3) with a reason and the
+exact Phase-6 waiver to use — instead of crashing — so the visual-compare gate
+falls back to the structural compare.
+
+Guest/B2B: pass --tenant <guid|report-url> (or set PBI_TENANT) when the report
+lives in a DIFFERENT tenant than your home tenant.
 
 Usage:
-  python3 export-pbi-pages.py --report <reportId> --out-dir ./visual-qa
+  python3 export-pbi-pages.py --report <reportId> [--workspace <groupId>] \
+      [--tenant <guid|url>] [--out-dir ./visual-qa]
 """
-import truststore; truststore.inject_into_ssl()
-import argparse, os, sys, time
-import msal, requests
+import argparse
+import os
+import sys
+import time
 
-_T = os.environ.get("PBI_TENANT", "organizations")  # #347: guest/B2B tenant via PBI_TENANT
-CACHE = os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _T == "organizations" else f"/tmp/pbiauth/cache-{_T}.bin")
-CLIENT = "ea0616ba-638b-4df5-95b9-636659ae5121"
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import pbi_fabric as fab  # noqa: E402  (injects truststore; auth + tenant helpers)
+import requests           # noqa: E402  (truststore already injected by pbi_fabric)
+
+EXIT_NO_TOKEN = 2
+EXIT_EXPORT_UNAVAILABLE = 3
 
 
-def token():
-    cache = msal.SerializableTokenCache()
-    if os.path.exists(CACHE):
-        cache.deserialize(open(CACHE).read())
-    app = msal.PublicClientApplication(
-        CLIENT, authority=f"https://login.microsoftonline.com/{_T}", token_cache=cache)
-    for a in app.get_accounts():
-        r = app.acquire_token_silent(["https://analysis.windows.net/powerbi/api/.default"], account=a)
-        if r and "access_token" in r:
-            return r["access_token"]
-    flow = app.initiate_device_flow(scopes=["https://analysis.windows.net/powerbi/api/.default"])
-    print(">>> " + flow["verification_uri"] + " code " + flow["user_code"], file=sys.stderr)
-    return app.acquire_token_by_device_flow(flow)["access_token"]
+def soft_fail(out_dir, reason):
+    """Export can't run here — leave a machine/human readable reason and exit 3
+    (non-crash) so Phase 5e degrades to a structural compare instead of aborting."""
+    os.makedirs(out_dir, exist_ok=True)
+    msg = (
+        f"EXPORT UNAVAILABLE: {reason}\n\n"
+        "ExportToFile is the only agent-driven PBI render path and needs the "
+        "report's workspace on Premium/PPU/Fabric capacity with image/PDF export "
+        "enabled. A structural (signals-based) compare is the expected fallback "
+        "here. At the Phase-6 gate, waive the source-render bars with a reason:\n"
+        "  --skip-anchors-gate  and/or  --skip-visual-similarity \"<reason>\"\n"
+    )
+    with open(os.path.join(out_dir, "EXPORT_UNAVAILABLE.txt"), "w") as fh:
+        fh.write(msg)
+    print(msg, file=sys.stderr)
+    sys.exit(EXIT_EXPORT_UNAVAILABLE)
+
+
+def rasterize_pdf(pdf_path, out_dir):
+    """PDF -> one PNG per page. Prefer pypdfium2 (portable, pinned in
+    requirements.txt, no system libraries); fall back to pdftoppm (poppler) if
+    present; last resort keep per-page PDFs + a loud note. Returns the basenames
+    the agent should Read, or None if only PDFs could be produced."""
+    # 1) pypdfium2 + Pillow — cross-platform wheels, no system dependency
+    try:
+        import pypdfium2 as pdfium
+        pdf = pdfium.PdfDocument(pdf_path)
+        pngs = []
+        for i in range(len(pdf)):
+            bmp = pdf[i].render(scale=2)  # ~144 dpi
+            out = os.path.join(out_dir, f"powerbi-page{i + 1}.png")
+            bmp.to_pil().save(out)
+            pngs.append(os.path.basename(out))
+        pdf.close()
+        if pngs:
+            print(f"[export] rasterized {len(pngs)} page PNG(s) via pypdfium2 -> {out_dir}",
+                  file=sys.stderr)
+            return pngs
+    except Exception as e:  # ImportError, or a render/Pillow failure
+        print(f"[export] pypdfium2 rasterize unavailable ({e}); trying pdftoppm", file=sys.stderr)
+
+    # 2) pdftoppm (poppler) if it happens to be installed
+    import shutil
+    import subprocess
+    if shutil.which("pdftoppm"):
+        prefix = os.path.join(out_dir, "powerbi-page")
+        subprocess.run(["pdftoppm", "-png", "-r", "144", pdf_path, prefix], check=True)
+        pngs = sorted(f for f in os.listdir(out_dir)
+                      if f.startswith("powerbi-page") and f.endswith(".png"))
+        print(f"[export] rasterized {len(pngs)} page PNG(s) via pdftoppm -> {out_dir}",
+              file=sys.stderr)
+        return pngs
+
+    # 3) last resort — split into per-page PDFs (agent needs poppler to Read them)
+    n = "?"
+    try:
+        from pypdf import PdfReader, PdfWriter
+        rd = PdfReader(pdf_path)
+        for i, pg in enumerate(rd.pages, 1):
+            w = PdfWriter()
+            w.add_page(pg)
+            with open(os.path.join(out_dir, f"powerbi-page{i}.pdf"), "wb") as fh:
+                w.write(fh)
+        n = len(rd.pages)
+    except Exception:
+        pass
+    print(f"[export] WARNING: no PNG rasterizer available — kept {n} PDF(s). `Read` needs "
+          "poppler (brew install poppler) to view PDFs; install pypdfium2 (already in "
+          "scripts/requirements.txt) for PNGs with no system deps.", file=sys.stderr)
+    return None
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--report", required=True)
     ap.add_argument("--workspace", default=None, help="group id; omit for My workspace")
+    ap.add_argument("--tenant", default=None,
+                    help="target tenant when the report is in a DIFFERENT tenant (guest/B2B): "
+                         "a raw tenant GUID, or a pasted report URL (ctid=... is extracted)")
     ap.add_argument("--out-dir", default="./visual-qa")
     a = ap.parse_args()
-    tok = token()
+
+    # Set PBI_TENANT before get_token resolves the (call-time) authority/cache.
+    if a.tenant:
+        os.environ["PBI_TENANT"] = fab.normalize_tenant(a.tenant)
+
+    tok = fab.get_token(scopes=fab.POWERBI_SCOPE)
+    if not tok:
+        print("NO_TOKEN — device code blocked or no client worked.", file=sys.stderr)
+        sys.exit(EXIT_NO_TOKEN)
     H = {"Authorization": f"Bearer {tok}"}
     base = ("https://api.powerbi.com/v1.0/myorg" if not a.workspace
             else f"https://api.powerbi.com/v1.0/myorg/groups/{a.workspace}")
     os.makedirs(a.out_dir, exist_ok=True)
 
-    fmt_order = ["PNG", "PDF"]  # PNG preferred; tenant-disabled falls through to PDF
-    for fmt in fmt_order:
-        r = requests.post(f"{base}/reports/{a.report}/ExportTo",
-                          headers={**H, "Content-Type": "application/json"}, json={"format": fmt})
-        if r.status_code == 403 and "disabled" in r.text:
+    # Capacity precheck (only determinable with an explicit workspace). ExportToFile
+    # requires dedicated capacity — catch the common no-capacity case before the LRO.
+    if a.workspace:
+        try:
+            ws = requests.get(base, headers=H, timeout=30).json()
+            if ws.get("isOnDedicatedCapacity") is False:
+                soft_fail(a.out_dir,
+                          f"workspace '{ws.get('name', a.workspace)}' is not on dedicated capacity")
+        except requests.RequestException:
+            pass  # transient GET — let the export attempt surface the real error
+
+    for fmt in ("PNG", "PDF"):  # PNG preferred; tenant-disabled falls through to PDF
+        try:
+            r = requests.post(f"{base}/reports/{a.report}/ExportTo",
+                              headers={**H, "Content-Type": "application/json"},
+                              json={"format": fmt}, timeout=60)
+        except requests.RequestException as e:
+            soft_fail(a.out_dir, f"ExportTo request failed: {e}")
+        if r.status_code == 403 and "disabled" in r.text.lower():
             print(f"[export] {fmt} disabled at tenant level — trying next format", file=sys.stderr)
             continue
-        r.raise_for_status()
+        if r.status_code >= 400:  # capacity / permission / other — degrade, don't crash
+            soft_fail(a.out_dir, f"ExportTo {fmt} -> HTTP {r.status_code}: {r.text[:300]}")
         eid = r.json()["id"]
         st = {}
         for _ in range(80):
-            st = requests.get(f"{base}/reports/{a.report}/exports/{eid}", headers=H).json()
+            st = requests.get(f"{base}/reports/{a.report}/exports/{eid}", headers=H, timeout=30).json()
             if st.get("status") in ("Succeeded", "Failed"):
                 break
             time.sleep(5)
         if st.get("status") != "Succeeded":
-            sys.exit(f"export failed: {st}")
-        data = requests.get(f"{base}/reports/{a.report}/exports/{eid}/file", headers=H).content
-        if data[:2] == b"PK":  # PNG multi-page comes back zipped
-            import io, zipfile
+            soft_fail(a.out_dir, f"export job did not succeed: {st}")
+        data = requests.get(f"{base}/reports/{a.report}/exports/{eid}/file", headers=H, timeout=120).content
+        if data[:2] == b"PK":  # multi-page PNG comes back zipped
+            import io
+            import zipfile
             zipfile.ZipFile(io.BytesIO(data)).extractall(a.out_dir)
             print(f"[export] unzipped page PNGs -> {a.out_dir}", file=sys.stderr)
         elif fmt == "PDF":
             pdf = os.path.join(a.out_dir, "powerbi-report.pdf")
-            open(pdf, "wb").write(data)
-            try:
-                from pypdf import PdfReader, PdfWriter
-                rd = PdfReader(pdf)
-                for i, pg in enumerate(rd.pages, 1):
-                    w = PdfWriter(); w.add_page(pg)
-                    with open(os.path.join(a.out_dir, f"powerbi-page{i}.pdf"), "wb") as f:
-                        w.write(f)
-                print(f"[export] {len(rd.pages)} page PDFs -> {a.out_dir}", file=sys.stderr)
-            except ImportError:
-                print(f"[export] wrote {pdf} (pypdf not installed — Read it with pages=N)", file=sys.stderr)
-        else:
-            open(os.path.join(a.out_dir, "powerbi-report.png"), "wb").write(data)
-        print(os.listdir(a.out_dir))
+            with open(pdf, "wb") as fh:
+                fh.write(data)
+            rasterize_pdf(pdf, a.out_dir)
+        else:  # single-page PNG
+            with open(os.path.join(a.out_dir, "powerbi-report.png"), "wb") as fh:
+                fh.write(data)
+        print(sorted(os.listdir(a.out_dir)))
         return
-    sys.exit("all export formats disabled for this tenant")
+    soft_fail(a.out_dir, "all export formats (PNG, PDF) disabled for this tenant")
 
 
 if __name__ == "__main__":

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_fabric.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_fabric.py
@@ -109,7 +109,12 @@ def _persist_msal(cache, path):
 
 
 def get_token(scopes=None, interactive=True, tenant=None):
-    """Silent token from the per-tenant cache; device-code fallback when allowed."""
+    """Silent token from the per-tenant cache; device-code fallback when allowed.
+    A pre-acquired bearer in $PBI_ACCESS_TOKEN wins (CI / callers who already
+    authed out-of-band) — audience must match `scopes`."""
+    pre = os.environ.get("PBI_ACCESS_TOKEN")
+    if pre:
+        return pre
     scopes = scopes or FABRIC_SCOPE
     authority = _authority(tenant)
     path = cache_path(tenant)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/requirements.txt
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/requirements.txt
@@ -1,3 +1,8 @@
 msal>=1.28,<1.32
 requests
 truststore>=0.9,<0.11
+# Phase 5e source render: rasterize the ExportToFile PDF -> per-page PNGs in
+# export-pbi-pages.py so the agent's `Read` needs no poppler/pdftoppm. pypdfium2
+# ships portable abi3 wheels (BSD/Apache); Pillow writes the PNGs.
+pypdfium2>=4.30,<5
+Pillow>=10.4,<12


### PR DESCRIPTION
## Why
While device-auth'ing into a different Fabric tenant to screenshot a report, the export path surfaced friction that the **mandatory Phase 5e visual-compare gate** depends on. The token-audience 404 from `pbi-export-pages-token-audience` is already fixed on `main`; these are the *next* gaps, all reproduced live.

## What changed — `export-pbi-pages.py`
1. **Hand the agent PNGs, not PDFs.** PNG export is commonly tenant-disabled, so the script falls back to PDF — but the agent's `Read` rasterizes PDFs via `pdftoppm` (poppler), which usually isn't installed, so the source render was silently unviewable. The script now rasterizes the PDF to per-page `powerbi-page{N}.png` in-process (pypdfium2 → pdftoppm → per-page PDF + loud note).
2. **Soft-fail instead of crash.** Added a capacity precheck (`isOnDedicatedCapacity`) and wrapped every ExportTo failure (no-capacity, tenant-disabled, job `Failed`) into a clean `EXPORT_UNAVAILABLE.txt` + **exit 3** with the exact Phase-6 waiver to use — rather than `raise_for_status()`/`sys.exit` aborting the mandatory gate with a stack trace.
3. **`--tenant <guid|report-url>` parity** with `fabric-extract.py` for guest/B2B, by reusing `pbi_fabric.get_token`. Bonus: the shared per-tenant MSAL cache makes the PBI-audience token usually **silent** after the Fabric-extraction sign-in (no second device-code prompt).

Supporting changes:
- `pbi_fabric.get_token` honors a pre-supplied `$PBI_ACCESS_TOKEN` (CI / already-authed callers).
- `requirements.txt`: `pypdfium2>=4.30,<5` (portable abi3 wheels, no system libs) + `Pillow`.
- `SKILL.md`: documents the PNG hand-off, the soft-fail/waiver behavior, and `--tenant`.

## Validation (live, guest-tenant Fabric report)
- **Success:** `--tenant` parsed from a pasted report URL (`ctid`) → PNG disabled at tenant → fell through to PDF → **6 page PNGs**, exit 0.
- **Soft-fail:** bogus report id → HTTP 404 → `EXPORT_UNAVAILABLE.txt` + exit 3 (no traceback).
- `py_compile`, `--help`, `check-shared.rb`, `lint-skills.rb`, and all pre-commit gates green.

## Coordination
Branched off `main`. Touches `SKILL.md` near the Phase 5e render-path prose that the in-flight `feat/pbi-source-screenshot-prompt` branch also edits — a small merge overlap may need resolving depending on merge order; the script + requirements changes are independent.

beads-sigma-m7mk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
