### PR TITLE
tableau: forbid "lighter for the demo" downgrades + harden exit-4 handoff

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -58,6 +58,25 @@ user-invocable: true
 >   A clean **PASS 1 (exit 12) is NOT done** — it means "run `--finalize`". Never
 >   report success, hand off, or write a completion summary until
 >   `verify-complete.rb` prints ✅ DONE. Nothing else counts as green.
+> - **This is a PRODUCTION migration, not a demo — regardless of who is watching
+>   or why (hackathon, POC, "just a demo", a `…-demo/` folder in a path).** The bar
+>   is EXACT parity against the same warehouse (see the parity note below), always.
+>   When you hit a wall, you have exactly two moves: **follow the STOP/handoff the
+>   orchestrator printed**, or **surface the blocker plainly and stop.** You may
+>   NEVER take a third path — do **not** propose or build a "lighter", "simplified",
+>   "good-enough-for-the-demo", "quick version", or reduced-scope workbook to get
+>   past a blocker, and do not drop tiles/filters/calcs to make a run look finished.
+>   Cutting fidelity to escape a struggle is a **worse failure than stopping**: it
+>   ships something that looks done but silently isn't. If a lighter scope is
+>   genuinely wanted, the **user** decides that explicitly — you never volunteer it.
+> - **An orchestrator STOP is an instruction to YOU (the agent), not a handoff to a
+>   human — keep going.** A non-zero exit that routes you (e.g. the **exit-4 workbook
+>   handoff**, "CONVERTER STOP") is the sanctioned authorization to do the next step
+>   yourself: author the spec it names and **re-enter the gated spine** (for exit 4:
+>   `--reuse-dm <id> --wb-spec <path>`). "The data model is posted" is **not** a
+>   finish line — a DM without its workbook is an incomplete migration. Do not report
+>   done, ask the user to build the workbook, or wait for a human at these STOPs;
+>   the only finish line is `verify-complete.rb` exit 0 (above).
 > - **Credentials:** if you are **not** on Claude Code, the orchestrator will stop
 >   at step 0 telling you to run `ruby scripts/setup.rb` once — that is expected;
 >   do it (in a real terminal) rather than working around the auth error.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -3232,6 +3232,13 @@ rescue WorkbookBuildError => e
   names = failed.empty? ? 'one or more fields' : failed.join(', ')
   n = failed.empty? ? 'some' : failed.size.to_s
   puts
+  puts '── EXIT 4 — WORKBOOK HANDOFF (this is NOT the finish line, and NOT a handoff to a human).'
+  puts '   This STOP is an instruction to YOU, the agent: the data model is posted; now build the'
+  puts '   workbook and re-enter the gated spine. A data model without its workbook is an INCOMPLETE'
+  puts '   migration — do NOT report success, do NOT ask the user to build the workbook, and do NOT'
+  puts '   substitute a "lighter"/"demo"/reduced-scope workbook. Keep going until verify-complete.rb'
+  puts '   exits 0. Pick ONE of the two paths below and continue in this same run:'
+  puts
   puts "── Mechanical path: data model built OK (dataModelId=#{dm_id}). The WORKBOOK " \
        "layer hit #{n} field(s) the mechanical path can't translate (#{names}). " \
        'Two ways forward:'
@@ -3251,6 +3258,8 @@ rescue WorkbookBuildError => e
   puts '          straight to the workbook layer — see --help.)'
   puts '   The data model is posted and ready to attach either way. A conversion is NOT done'
   puts '   until scripts/assert-phase6-ran.rb exits 0 — that hard gate applies on both paths.'
+  puts '   Reminder: continue now. Shipping only the data model, or a scaled-down "demo" workbook,'
+  puts '   does NOT satisfy this migration — the next action is yours.'
   # Authorize the hand-authoring re-entry: this STOP is the ONLY sanctioned way to
   # reach --wb-spec/--dm-spec. The token lets the re-run's manual-spec gate pass
   # (a COLD hand-author with no prior orchestrator run is refused).


### PR DESCRIPTION
## Why

Two agent-behavior gaps caught on a live hackathon `tableau-to-sigma` run — both the same shape: **when the agent hits a wall it does the wrong thing instead of following the designed path.**

1. **It offered to do "something lighter for the demo."** Grep confirms the skill never contained any corner-cutting language. But an ambient demo/hackathon frame (the user's own words, the `~/.claude/sigma-skills-demo/` creds path in the hackathon prompt, and sibling *demo* migration skills in the skill list) let a stuck agent rationalize scope reduction. The skill forbade *faking done* but never forbade *proposing a smaller version*.

2. **It gave up at the exit-4 workbook handoff.** The DM posted, the orchestrator printed the exit-4 handoff, and the agent stopped and reported done — a human had to tell it to build the workbook. Exit 4 already instructs the agent to author `wb-spec.json` and re-enter with `--reuse-dm`, but a non-zero exit labeled "handoff" reads as terminal.

## What

- **SKILL.md** — two new rules next to the "'Done' is a file on disk" rule:
  - Production migration always; EXACT parity always. When blocked you may only follow the STOP or surface it — **never** volunteer a "lighter"/"demo"/reduced-scope workbook. A lighter scope is the *user's* explicit call.
  - An orchestrator STOP (exit-4 handoff, CONVERTER STOP) is an instruction to **you, the agent** — keep going; a DM without its workbook is incomplete; the only finish line is `verify-complete.rb` exit 0.
- **migrate-tableau.rb** — the exit-4 message now leads with a banner: this is **not** the finish line and **not** a human handoff; build the workbook and re-enter; don't substitute a demo workbook.

Message/doc-only — **no logic change**.

## Test
Touched-area tests green: `test-fast-flag`, `test-validate-spec-guards`, `test-fastpath-flags`, `test-offramp`, `test-route-persistence`, `test-post-guardrails`. Pre-commit lints clean: `lint-skills`, `check-shared`, `lint-twb-encoding`, `lint-esm-imports`, agent-variant sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)