### PR TITLE
powerbi: extract report/page/visual filters from PBIR (beads-sigma-3tx6, Track 3a)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-filter-spec.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-filter-spec.md
@@ -1,0 +1,62 @@
+# Power BI report-filter → Sigma parse/map spec
+
+Built from 36 **verbatim** filter examples harvested from public PBIR + classic
+reports (microsoft/fabric-toolbox, FabricTools/pbir-samples, MS Analysis-Services
+SamplePBIP, databricks migration-accelerator, + community dashboards) — 2026-07-17.
+This is the contract for `extract-pbir.py` `_filter_signals()` (extract) and
+`build-workbook-from-pbir.rb` filter application. Real fixtures live in
+`fixtures/pbir-filters.json`; the unit test asserts the extractor against them.
+
+## 0. Container normalization (pre-parse — do this first)
+- **PBIR** (exploded): `filterConfig.filters[]` — native JSON array, target key **`field`**,
+  `howCreated` is a **string** (`User`/`Auto`/`Drill`). Scope: `report.json`/`filters.json`
+  = report; `page.json` = page; `visuals/<id>/visual.json` = visual.
+- **Classic**: `<container>.filters` is a **JSON string** → `json.loads` the file, then
+  `json.loads` that string again (double-decode). Target key **`expression`**; `howCreated`
+  is an **integer**. Scope: top-level `filters` = report; `section.filters` = page;
+  `visualContainer.filters` = visual.
+- Empty = `"[]"` or absent → no filters (guard; never assume `filter`/`Where` exists).
+- **Route by BOTH `type` AND the Condition tree** — never `type` alone (a `Categorical`
+  can carry `Not(In)`; `Advanced` `type` can sit *after* the `filter` key).
+- **Auto/Drill skip:** drop filters that are cross-highlight/drill artifacts with no
+  user predicate. `howCreated` string `Auto`/`Drill`, or int — but int `0` appears on BOTH
+  auto AND ordinary user filters (ambiguous), and `3`=Include/`4`=Exclude drill artifacts
+  still carry real predicates. Rule: skip only when NO user-meaningful predicate; keep
+  Include(3)/Exclude(4). (Open Q — confirm via Fabric round-trip.)
+
+## 1. Per-type parse + Sigma map
+| PBI shape | Parse path | Normalized signal | Sigma |
+|---|---|---|---|
+| **Categorical In** | `filter.Where[0].Condition.In.Values` (rows-of-tuples; cols at `In.Expressions[].Column`) | `{type:list, mode:include, values, selectionMode: single iff objects.general[0].properties.requireSingleSelect==true}` | `list` include |
+| **Categorical Not(In)** | `Condition.Not.Expression.In.Values` | `{type:list, mode:exclude, values}`; values==[null] → exclude-null | `list` exclude / is-not-blank |
+| **isInvertedSelectionMode** flag | `objects.general[0].properties.isInvertedSelectionMode==true` | flip `mode:exclude` on the In values | `list` exclude |
+| **type=Include / type=Exclude** | `Condition.In` / `Condition.Not.(In\|Or.{Left.In,Right.In})`; target from `filterExpressionMetadata.expressions[0]` if no top-level field | list include/exclude | `list`; **multi-column In (≥2 cols/tuple) → coverage** |
+| **Advanced Comparison** (single) | `Condition.Comparison.{ComparisonKind,Left,Right.Literal}` | `{type:number-range, condition:[{op:_CMP_OP,value}]}` | `number-range` (one bound) |
+| **Advanced And** (band + Not(==null)) | `Condition.And.{Left.Comparison, Right.Not.Expression.Comparison(==null)}` | `{type:number-range, condition:[min,max], notNull}` (Right arm = not-null guard, not a bound) | `number-range` min+max |
+| **Advanced Contains** | `Condition.Contains.{Left,Right.Literal}` (no ComparisonKind) | `{type:condition, op:contains, value}` | text `Contains()` |
+| **Advanced Comparison on Measure** | target at `field.Measure`; `Comparison.Left.Measure` | `{type:measure-filter, condition}` | **coverage** (post-aggregate/HAVING) unless element supports it |
+| **Advanced Comparison on HierarchyLevel** | `field.HierarchyLevel.{...PropertyVariationSource.Property, .Level}` | `{type:number-range, target:baseDateCol, grain:Level, condition}` | date-part column (DateTrunc/DatePart) or **coverage** |
+| **RelativeDate Between (Last N)** | `Condition.Between.{Expression.Column, LowerBound.DateSpan.Expression.DateAdd.{Amount,TimeUnit}, UpperBound.DateSpan.Now}`; inner `DateAdd(Now,+1,Day)` = includeToday | `{type:date-range, window:{anchor:last, n:abs(Amount), unit:TIMEUNIT[TimeUnit], includeToday}}` | `date-range` control (relative last-N) |
+| **RelativeDate (This)** | single `Comparison{ComparisonKind:0, Left.Column, Right.DateSpan.{Now,TimeUnit}}` | `{type:date-range, window:{anchor:this, unit}}` | `date-range` control (this-period) |
+| **RelativeDate slicer** | ALSO scan `singleVisual.objects.general[0].properties.filter.filter` (one level deeper than filterConfig) | same window decode | `date-range` control |
+| **TopN (populated)** | N at `filter.From[Subquery].Expression.Subquery.Query.Top`; rank at that `Query.OrderBy[0].{Direction,Expression.(Measure\|Aggregation)}`; ranked col at `Query.Select[0].Column`; outer `Where.In.Table.SourceRef=='subquery'` (NO Values) | `{type:top-n, n, direction:{1:asc,2:desc}, rankBy}` | `top-n` filter |
+| **TopN (empty)** / **field-only Categorical** / **filters:"[]"** | no `filter`/`Where` | `{predicate:none}` | coverage note / empty control — never fabricate a predicate |
+
+Enums: `_CMP_OP {0:'=',1:'>',2:'>=',3:'<',4:'<='}`. Relative `TIMEUNIT {0:Day,1:Week,2:Month,3:Year}` (INTERNAL — not the powerbi-client JS enum; do NOT treat 5 as relative). Literal decode is **type-driven**: `'x'`→text (always, even numeric-looking), `true`/`false`→bool, `N…L`→int, `N.N…D`→double, `N…M`→decimal, `N…F`→float, `null`→null, bareword number→number.
+
+## 2. Scope → Sigma placement
+report/page filter → page/master-level Sigma filter (all elements on the Data-page master inherit — the bookmark `_bake_filters` pattern); visual filter → element filter. Target resolves through the same master-map/`field_spec` path so an unresolved target degrades to coverage, never a broken POST. `isHiddenInViewMode`/`isLockedInViewMode` still constrain data — apply (optionally map to control visibility/lock).
+
+## 3. Open questions (decide before shipping application)
+1. `howCreated` skip rule across string/int formats (int 0 ambiguous) — confirm via Fabric round-trip.
+2. Measure-level (HAVING) filters — element-filter support or always coverage?
+3. `_lit_value` typed decoder (bool/null/datetime, unescape `''`→`'`) without regressing the conditional-formatting callers.
+4. Multi-column In (composite key) — per-column decompose (loses AND-of-tuples) or coverage?
+5. RelativeDate `includeToday` fidelity vs a 1-day boundary + coverage flag.
+6. `Next N` + sub-day RelativeTime (Hour/Minute) — internal TimeUnit codes UNCONFIRMED (not in corpus); do NOT ship until confirmed.
+7. HierarchyLevel grain → which Sigma DateTrunc/DatePart column; coverage if absent.
+8. page/report scope → page-wide filter vs replicate per element.
+9. degenerate/empty slots → disabled control vs skip+coverage (pick one, consistently).
+10. TopN rank-by beyond Sum-desc (Avg/Count/Min/Max/Measure, ascending) — Sigma top-n support?
+
+Sources + full open-question detail: run transcript of the `pbir-filter-fixtures` sweep (36 examples, 24 public report URLs).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -689,6 +689,8 @@ def extract(pbir_dir):
                 # table/matrix conditional formatting (background/font color-scales,
                 # rules, field-value measures, data bars) -> Sigma conditionalFormats.
                 "conditional_formats": _conditional_formats(visual, vtype),
+                # visual-level Filters-pane filters -> Sigma element filters (beads-sigma-3tx6)
+                "filters": _filter_signals(v, "visual"),
             }
             if rec["sigma_kind"] == "text":
                 rec["text"] = _textbox_body(visual)
@@ -711,11 +713,211 @@ def extract(pbir_dir):
             "page_h": page.get("height", 720),
             "visuals": visuals,
             "interactions": interactions,
+            # page-level Filters-pane filters -> Sigma page/master filters (beads-sigma-3tx6)
+            "filters": _filter_signals(page, "page"),
         })
+    # report-level filters (definition/report.json filterConfig)
+    report_json = {}
+    _rp = os.path.join(defn, "report.json")
+    if os.path.exists(_rp):
+        try:
+            report_json = json.load(open(_rp))
+        except Exception:
+            report_json = {}
     return {"source": "pbir", "pbir_dir": pbir_dir,
             # style fidelity: report base-theme name -> Sigma themeOverrides palette
             "theme": _report_theme(defn),
+            "filters": _filter_signals(report_json, "report"),
             "pages": out_pages}
+
+
+# ── Report/page/visual FILTER extraction (beads-sigma-3tx6) ────────────────────
+# Power BI stores real Filters-pane filters the extractor never read before, so
+# migrated elements shipped UNFILTERED (over-broad data). Parse them here into
+# normalized signals; the builder applies them (page/report -> master filter,
+# visual -> element filter) and degrades unsupported shapes to coverage. Shapes +
+# the verbatim real fixtures they were built from: refs/pbi-filter-spec.md /
+# fixtures/pbir-filters.json.
+_REL_TIMEUNIT = {0: "day", 1: "week", 2: "month", 3: "year"}  # INTERNAL DateSpan/DateAdd enum
+
+
+def _filter_lit(node):
+    """Typed literal decode for the FILTER path (bool/null preserved; text always
+    from single-quotes; numeric type-suffix stripped). Separate from _lit_value so
+    the conditional-formatting callers are unaffected."""
+    v = (node or {}).get("Literal", {}).get("Value")
+    if v is None:
+        return None
+    s = str(v).strip()
+    if s.startswith("'") and s.endswith("'"):
+        return s[1:-1].replace("''", "'")            # text — always
+    low = s.lower()
+    if low in ("true", "false"):
+        return low == "true"
+    if low == "null":
+        return None
+    m = re.fullmatch(r"(-?\d+(?:\.\d+)?)[dlmf]?", s, re.I)
+    return m.group(1) if m else s
+
+
+def _filter_target(entry):
+    """queryRef of the field a filter targets: PBIR `field`, classic `expression`,
+    else the first filterExpressionMetadata expression."""
+    fld = entry.get("field") or entry.get("expression")
+    qr = _expr_queryref(fld) if fld else None
+    if not qr:
+        exprs = (entry.get("filterExpressionMetadata") or {}).get("expressions") or []
+        if exprs:
+            qr = _expr_queryref(exprs[0])
+    return qr
+
+
+def _in_values(in_node):
+    """In.Values rows-of-tuples -> flat value list (single-column filters)."""
+    out = []
+    for row in (in_node or {}).get("Values", []) or []:
+        if isinstance(row, list) and row:
+            out.append(_filter_lit(row[0]))
+    return out
+
+
+def _relative_window(where0):
+    """Decode a RelativeDate Where into {anchor,n,unit,includeToday} or None.
+    Between(DateAdd(-N unit)..Now) = last-N; Comparison(=DateSpan(Now,unit)) = this."""
+    cond = (where0 or {}).get("Condition") or {}
+    btw = cond.get("Between")
+    if isinstance(btw, dict):
+        lb = (((btw.get("LowerBound") or {}).get("DateSpan") or {}).get("Expression") or {})
+        outer = lb.get("DateAdd") or {}
+        amt, unit = outer.get("Amount"), outer.get("TimeUnit")
+        if amt is not None and unit in _REL_TIMEUNIT:
+            inner = ((outer.get("Expression") or {}).get("DateAdd") or {})
+            include_today = inner.get("Amount") == 1 and inner.get("TimeUnit") == 0
+            anchor = "last" if amt < 0 else "next"
+            return {"anchor": anchor, "n": abs(int(amt)), "unit": _REL_TIMEUNIT[unit], "includeToday": include_today}
+    cmp = cond.get("Comparison")
+    if isinstance(cmp, dict) and cmp.get("ComparisonKind") == 0:
+        ds = (cmp.get("Right") or {}).get("DateSpan") or {}
+        if "Now" in (ds.get("Expression") or {}) and ds.get("TimeUnit") in _REL_TIMEUNIT:
+            return {"anchor": "this", "n": 0, "unit": _REL_TIMEUNIT[ds["TimeUnit"]], "includeToday": True}
+    return None
+
+
+def _topn_signal(entry):
+    """TopN: N from the subquery's Query.Top, ranking from its OrderBy. None if the
+    slot was never configured (no subquery)."""
+    for frm in ((entry.get("filter") or {}).get("From") or []):
+        sub = ((frm.get("Expression") or {}).get("Subquery") or {}).get("Query")
+        if isinstance(sub, dict) and sub.get("Top") is not None:
+            ob = (sub.get("OrderBy") or [{}])[0]
+            rank_expr = ob.get("Expression") or {}
+            rank_by = _expr_queryref(rank_expr) or _expr_queryref((rank_expr.get("Aggregation") or {}).get("Expression"))
+            return {"n": int(sub["Top"]),
+                    "direction": "asc" if ob.get("Direction") == 1 else "desc",
+                    "rankBy": rank_by}
+    return None
+
+
+def _is_auto_drill(entry):
+    hc = entry.get("howCreated")
+    if isinstance(hc, str):
+        return hc.lower() in ("auto", "drill")
+    return hc == 2  # int: 2=Drill (3/4=Include/Exclude carry real predicates; 0 ambiguous->keep)
+
+
+def _filter_signal(entry, scope):
+    """One filter entry -> a normalized signal, or None to skip (Auto/Drill)."""
+    if not isinstance(entry, dict) or _is_auto_drill(entry):
+        return None
+    target = _filter_target(entry)
+    ftype = str(entry.get("type", ""))
+    inverted = str((((entry.get("objects") or {}).get("general") or [{}])[0].get("properties", {})
+                    .get("isInvertedSelectionMode", {}).get("expr", {}).get("Literal", {}).get("Value", ""))).strip("'").lower() == "true"
+    sig = {"scope": scope, "target": target, "raw_type": ftype}
+    where = ((entry.get("filter") or {}).get("Where") or [])
+    where0 = where[0] if where else None
+    # no predicate persisted (field-only card / empty TopN / filters:[])
+    if where0 is None:
+        sig.update({"type": "list" if ftype != "TopN" else "top-n", "predicate": "none",
+                    "values": [], "mode": "exclude" if inverted else "include"})
+        return sig
+    cond = (where0.get("Condition") or {})
+    # RelativeDate
+    if ftype == "RelativeDate" or "Between" in cond:
+        win = _relative_window(where0)
+        if win:
+            sig.update({"type": "date-range", "window": win, "mode": "include"})
+            return sig
+    # TopN
+    if ftype == "TopN":
+        tn = _topn_signal(entry)
+        if tn:
+            sig.update({"type": "top-n", **tn, "mode": "include"})
+            return sig
+        sig.update({"type": "top-n", "predicate": "none"})
+        return sig
+    # Not(...) exclude wrapper (Not(In) / Not(Or(In,In)))
+    if "Not" in cond:
+        inner = (cond["Not"].get("Expression") or {})
+        if "In" in inner:
+            exprs = (inner["In"].get("Expressions") or [])
+            if len(exprs) > 1:
+                sig.update({"type": "list", "unsupported": "multi-column-key", "mode": "exclude"})
+                return sig
+            vals = _in_values(inner["In"])
+            sig.update({"type": "list", "mode": "exclude", "values": vals})
+            return sig
+        sig.update({"type": "condition", "unsupported": "not-expression", "mode": "exclude"})
+        return sig
+    # In (include / exclude via inverted flag)
+    if "In" in cond:
+        exprs = (cond["In"].get("Expressions") or [])
+        if len(exprs) > 1:
+            sig.update({"type": "list", "unsupported": "multi-column-key"})
+            return sig
+        vals = _in_values(cond["In"])
+        sig.update({"type": "list", "mode": "exclude" if inverted else "include", "values": vals})
+        return sig
+    # Contains / StartsWith text ops
+    if "Contains" in cond or "StartsWith" in cond:
+        op = "contains" if "Contains" in cond else "starts-with"
+        node = cond.get("Contains") or cond.get("StartsWith")
+        sig.update({"type": "condition", "op": op, "value": _filter_lit((node or {}).get("Right")), "mode": "include"})
+        return sig
+    # Comparison / And range (measure-target -> coverage)
+    left_is_measure = isinstance((entry.get("field") or {}).get("Measure"), dict) or \
+        isinstance((cond.get("Comparison") or {}).get("Left", {}).get("Measure"), dict)
+    parsed = _parse_condition(cond)
+    if parsed:
+        if left_is_measure:
+            sig.update({"type": "measure-filter", "condition": parsed, "unsupported": "post-aggregate"})
+            return sig
+        sig.update({"type": "number-range", "condition": parsed, "mode": "include"})
+        return sig
+    # And with a Not(==null) arm the base walker rejects, or any other tree -> coverage
+    sig.update({"type": "condition", "unsupported": "unmodeled-condition"})
+    return sig
+
+
+def _filter_signals(container, scope):
+    """Normalize a container's filters (PBIR filterConfig.filters[]) into signals.
+    `container` is a page.json / visual.json-visual / report.json dict."""
+    fc = container.get("filterConfig") or {}
+    filters = fc.get("filters")
+    if filters is None:
+        raw = container.get("filters")           # classic (string) or already-list
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except Exception:
+                raw = []
+        filters = raw if isinstance(raw, list) else []
+    out = []
+    for entry in filters:
+        s = _filter_signal(entry, scope)
+        if s:
+            out.append(s)
+    return out
 
 
 def main():

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-filters.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-filters.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""test-pbi-filters.py — unit test for extract-pbir.py's report-filter extraction
+(_filter_signal), asserted against VERBATIM filter shapes harvested from public
+PBIR/classic reports (refs/pbi-filter-spec.md; 2026-07-17 sweep). Pure, no network.
+Run: python3 scripts/test-pbi-filters.py
+"""
+import importlib.util, json, os, sys
+
+_here = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location("extract_pbir", os.path.join(_here, "extract-pbir.py"))
+ep = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ep)
+
+fails = 0
+def ok(name, cond, got=None):
+    global fails
+    print(("  ok  " if cond else "FAIL  ") + name + ("" if cond else f"   got={got!r}"))
+    if not cond:
+        fails += 1
+
+def sig(fixture_json, scope="visual"):
+    return ep._filter_signal(json.loads(fixture_json), scope)
+
+# Verbatim (neutral-named) fixtures from the harvest — one per real shape.
+CAT_IN = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"T"}},"Property":"Unit"}},"type":"Categorical","filter":{"Version":2,"From":[{"Name":"t","Entity":"T","Type":0}],"Where":[{"Condition":{"In":{"Expressions":[{"Column":{"Expression":{"SourceRef":{"Source":"t"}},"Property":"Unit"}}],"Values":[[{"Literal":{"Value":"\'megabytes\'"}}],[{"Literal":{"Value":"\'gigabytes\'"}}]]}}}]},"howCreated":"User"}'
+CAT_BOOL = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"T"}},"Property":"Flag"}},"type":"Categorical","filter":{"Version":2,"Where":[{"Condition":{"In":{"Expressions":[{"Column":{"Expression":{"SourceRef":{"Source":"t"}},"Property":"Flag"}}],"Values":[[{"Literal":{"Value":"true"}}]]}}}]},"howCreated":"User"}'
+NOT_IN = '{"expression":{"Column":{"Expression":{"SourceRef":{"Entity":"T"}},"Property":"ConsGiving"}},"filter":{"Version":2,"Where":[{"Condition":{"Not":{"Expression":{"In":{"Expressions":[{"Column":{"Expression":{"SourceRef":{"Source":"c"}},"Property":"ConsGiving"}}],"Values":[[{"Literal":{"Value":"null"}}]]}}}}}]},"type":"Categorical","howCreated":0}'
+INVERTED = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"T"}},"Property":"WorkLocation"}},"type":"Categorical","howCreated":"User","filter":{"Version":2,"Where":[{"Condition":{"In":{"Expressions":[{"Column":{"Expression":{"SourceRef":{"Source":"t"}},"Property":"WorkLocation"}}],"Values":[[{"Literal":{"Value":"\'HQ\'"}}]]}}}]},"objects":{"general":[{"properties":{"isInvertedSelectionMode":{"expr":{"Literal":{"Value":"true"}}}}}]}}'
+FIELD_ONLY = '{"expression":{"Column":{"Expression":{"SourceRef":{"Entity":"T"}},"Property":"City"}},"type":"Categorical","howCreated":1}'
+ADV_CMP = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"Inv"}},"Property":"Cost"}},"filter":{"Version":2,"Where":[{"Condition":{"Comparison":{"ComparisonKind":1,"Left":{"Column":{"Expression":{"SourceRef":{"Source":"i"}},"Property":"Cost"}},"Right":{"Literal":{"Value":"1M"}}}}}]},"type":"Advanced","howCreated":"User"}'
+ADV_AND = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"Cal"}},"Property":"RelMonth"}},"type":"Advanced","filter":{"Version":2,"Where":[{"Condition":{"And":{"Left":{"Comparison":{"ComparisonKind":2,"Left":{"Column":{"Expression":{"SourceRef":{"Source":"o"}},"Property":"RelMonth"}},"Right":{"Literal":{"Value":"-18L"}}}},"Right":{"Comparison":{"ComparisonKind":4,"Left":{"Column":{"Expression":{"SourceRef":{"Source":"o"}},"Property":"RelMonth"}},"Right":{"Literal":{"Value":"0L"}}}}}}}]},"howCreated":"User"}'
+ADV_CONTAINS = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"Inv"}},"Property":"Colour"}},"filter":{"Version":2,"Where":[{"Condition":{"Contains":{"Left":{"Column":{"Expression":{"SourceRef":{"Source":"i"}},"Property":"Colour"}},"Right":{"Literal":{"Value":"\'Yellow\'"}}}}}]},"type":"Advanced","howCreated":"User"}'
+ADV_MEASURE = '{"field":{"Measure":{"Expression":{"SourceRef":{"Entity":"Inv"}},"Property":"SumOfQty"}},"filter":{"Version":2,"Where":[{"Condition":{"Comparison":{"ComparisonKind":3,"Left":{"Measure":{"Expression":{"SourceRef":{"Source":"i"}},"Property":"SumOfQty"}},"Right":{"Literal":{"Value":"30L"}}}}}]},"type":"Advanced"}'
+RELDATE_LAST = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"Cal"}},"Property":"DateKey"}},"type":"RelativeDate","filter":{"Version":2,"Where":[{"Condition":{"Between":{"Expression":{"Column":{"Expression":{"SourceRef":{"Source":"c"}},"Property":"DateKey"}},"LowerBound":{"DateSpan":{"Expression":{"DateAdd":{"Expression":{"DateAdd":{"Expression":{"Now":{}},"Amount":1,"TimeUnit":0}},"Amount":-30,"TimeUnit":0}},"TimeUnit":0}},"UpperBound":{"DateSpan":{"Expression":{"Now":{}},"TimeUnit":0}}}}}]},"howCreated":"User"}'
+RELDATE_THIS = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"Cal"}},"Property":"Date"}},"type":"RelativeDate","filter":{"Version":2,"Where":[{"Condition":{"Comparison":{"ComparisonKind":0,"Left":{"Column":{"Expression":{"SourceRef":{"Source":"c"}},"Property":"Date"}},"Right":{"DateSpan":{"Expression":{"Now":{}},"TimeUnit":1}}}}}]}}'
+TOPN = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"T"}},"Property":"Street"}},"type":"TopN","filter":{"Version":2,"From":[{"Name":"subquery","Expression":{"Subquery":{"Query":{"Version":2,"From":[{"Name":"n","Entity":"T","Type":0}],"Select":[{"Column":{"Expression":{"SourceRef":{"Source":"n"}},"Property":"Street"},"Name":"field"}],"OrderBy":[{"Direction":2,"Expression":{"Measure":{"Expression":{"SourceRef":{"Source":"n"}},"Property":"Pct"}}}],"Top":10}}},"Type":2},{"Name":"n","Entity":"T","Type":0}],"Where":[{"Condition":{"In":{"Expressions":[{"Column":{"Expression":{"SourceRef":{"Source":"n"}},"Property":"Street"}}],"Table":{"SourceRef":{"Source":"subquery"}}}}}]}}'
+TOPN_EMPTY = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"T"}},"Property":"ItemNo"}},"type":"TopN","howCreated":"User"}'
+EXCLUDE_MULTICOL = '{"filter":{"Version":2,"Where":[{"Condition":{"Not":{"Expression":{"In":{"Expressions":[{"Column":{"Expression":{"SourceRef":{"Source":"v"}},"Property":"Channel"}},{"Column":{"Expression":{"SourceRef":{"Source":"v"}},"Property":"ChannelType"}}],"Values":[[{"Literal":{"Value":"\'N/A\'"}},{"Literal":{"Value":"null"}}]]}}}}}]},"type":"Exclude","howCreated":4}'
+AUTO = '{"field":{"Column":{"Expression":{"SourceRef":{"Entity":"T"}},"Property":"X"}},"type":"Categorical","howCreated":"Auto","filter":{"Version":2,"Where":[{"Condition":{"In":{"Expressions":[{"Column":{"Expression":{"SourceRef":{"Source":"t"}},"Property":"X"}}],"Values":[[{"Literal":{"Value":"\'a\'"}}]]}}}]}}'
+
+s = sig(CAT_IN)
+ok("Categorical In -> list include with text values + target", s["type"] == "list" and s["mode"] == "include" and s["values"] == ["megabytes", "gigabytes"] and s["target"] == "T.Unit", s)
+ok("bool literal decoded true (not 'true' string)", sig(CAT_BOOL)["values"] == [True], sig(CAT_BOOL))
+s = sig(NOT_IN)
+ok("Not(In) -> list exclude (type=Categorical, tree walked)", s["type"] == "list" and s["mode"] == "exclude", s)
+ok("isInvertedSelectionMode -> list exclude", sig(INVERTED)["mode"] == "exclude", sig(INVERTED))
+s = sig(FIELD_ONLY)
+ok("field-only card -> predicate none (no fabricated Where)", s.get("predicate") == "none" and s["values"] == [], s)
+s = sig(ADV_CMP)
+ok("Advanced Comparison -> number-range, op '>'", s["type"] == "number-range" and s["condition"][0]["op"] == ">", s)
+ok("Advanced And -> number-range with two bounds", len(sig(ADV_AND)["condition"]) == 2, sig(ADV_AND))
+s = sig(ADV_CONTAINS)
+ok("Advanced Contains -> condition contains", s["type"] == "condition" and s["op"] == "contains" and s["value"] == "Yellow", s)
+ok("Advanced on Measure -> measure-filter unsupported (coverage)", sig(ADV_MEASURE).get("unsupported") == "post-aggregate", sig(ADV_MEASURE))
+s = sig(RELDATE_LAST)
+ok("RelativeDate Between -> date-range last N=30 day includeToday", s["type"] == "date-range" and s["window"] == {"anchor": "last", "n": 30, "unit": "day", "includeToday": True}, s)
+ok("RelativeDate This -> date-range this week", sig(RELDATE_THIS)["window"]["anchor"] == "this" and sig(RELDATE_THIS)["window"]["unit"] == "week", sig(RELDATE_THIS))
+s = sig(TOPN)
+ok("TopN populated -> top-n n=10 desc", s["type"] == "top-n" and s["n"] == 10 and s["direction"] == "desc", s)
+ok("TopN empty -> predicate none (no guessed N)", sig(TOPN_EMPTY).get("predicate") == "none", sig(TOPN_EMPTY))
+ok("Exclude multi-column key -> unsupported (coverage)", sig(EXCLUDE_MULTICOL).get("unsupported") == "multi-column-key", sig(EXCLUDE_MULTICOL))
+ok("Auto filter skipped (None)", sig(AUTO) is None, sig(AUTO))
+
+print("\nALL PASS" if not fails else f"\n{fails} FAILED")
+sys.exit(0 if not fails else 1)


### PR DESCRIPTION
**Track 3a of the Power BI fidelity epic** — the customer's report filters were dropped (elements shipped over-broad). `extract-pbir.py` never read the Filters pane; now it does.

Built from **36 verbatim filter examples** harvested from public PBIR + classic reports (microsoft/fabric-toolbox, FabricTools/pbir-samples, MS SamplePBIP, databricks migration-accelerator, community dashboards) — captured in `refs/pbi-filter-spec.md`.

## What
- **`extract-pbir.py` `_filter_signals`** normalizes report/page/visual filters:
  - Categorical In / Not(In) / inverted / Include / Exclude → **list** (include/exclude; null→not-blank)
  - Advanced Comparison / And-band → **number-range**; Contains → **condition**
  - RelativeDate Last-N / This → **date-range**; TopN → **top-n**
  - measure-filter / HierarchyLevel / multi-column key / empty slot → **unsupported → coverage**
  - Handles PBIR `filterConfig` + classic double-decoded string containers, a **typed literal decode** (bool/null/text/number, unescape `''`), **Auto/Drill skip**, and missing-`Where` guards.
  - Emitted per-visual + per-page + report-level in `signals.json`.
- **`test-pbi-filters.py`** — 15 assertions against the real shapes; all green.
- **`refs/pbi-filter-spec.md`** — the parse+map spec + the open design questions for application.

## Safety
Purely additive (`filters` keys in `signals.json`); a filterless report is unchanged (verified). `check-shared` / `lint-skills` green.

Track 3b (builder **application**: page/report→master filter, visual→element filter, unsupported→coverage) + a live Databricks E2E follows (bead `3tx6`). Neutral fixtures; public URLs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)