### PR TITLE
powerbi: apply report/page/visual filters to Sigma elements (Track 3b, beads-sigma-3tx6)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-filter-spec.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-filter-spec.md
@@ -47,7 +47,31 @@ Enums: `_CMP_OP {0:'=',1:'>',2:'>=',3:'<',4:'<='}`. Relative `TIMEUNIT {0:Day,1:
 ## 2. Scope → Sigma placement
 report/page filter → page/master-level Sigma filter (all elements on the Data-page master inherit — the bookmark `_bake_filters` pattern); visual filter → element filter. Target resolves through the same master-map/`field_spec` path so an unresolved target degrades to coverage, never a broken POST. `isHiddenInViewMode`/`isLockedInViewMode` still constrain data — apply (optionally map to control visibility/lock).
 
-## 3. Open questions (decide before shipping application)
+## 2b. Track 3b APPLICATION — shipped shapes + decisions (build-workbook-from-pbir.rb)
+**VERIFIED element-filter shapes** (live PUT+GET round-trip 2026-07-17 on TJ Databricks Demo; memory `reference_sigma_element_filter_shapes`). These are the ELEMENT `filters[]` shapes, distinct from a *control*'s shape:
+| signal type | Sigma element filter |
+|---|---|
+| `list` | `{id, columnId, kind:"list", mode:"include"\|"exclude", values:[…]}` |
+| `number-range` | `{id, columnId, kind:"number-range", min?, max?}` — **`min`/`max`, NOT the control's `low`/`high`** (element `low`/`high` and positional `value:[lo,hi]` are silently dropped). Needs a NUMERIC target column. Bounds are inclusive; a PBI `>`/`<` is applied inclusively. |
+| `top-n` | `{id, columnId, kind:"top-n", rankingFunction:"rank", mode:"top-n", rowCount:N}` — **visual scope only** (a top-n on a shared master caps every element sourcing it — memory `sigma-source-element-filter-propagates`). |
+
+**Placement:** visual filter → the built element's own `filters[]` (only when the target column is PROJECTED on the element — element filters reference the element's own columns; resolved via the `_qr_cids` map). `pivot-table` element filters are silently dropped by Sigma → coverage. page/report filter → the source MASTER element(s) carrying the column (propagation = page-filter semantics); a page filter is applied only to masters used SOLELY by that page (a shared master can't be isolated → coverage); a report filter → every master carrying the column.
+
+**Coverage (never a broken/inert filter):** date-range (no static element date filter — routed to coverage with a date-range-control action; **control emission is the documented fast-follow**), measure/HAVING, multi-column key, text/`contains`/`starts-with` conditions, unmodeled trees, page/report-scope top-n, unresolved + non-projected targets, pivot element filters. `predicate:none` (empty slots) = a faithful no-op → noted, never fabricated.
+
+## 3. Open questions — DECIDED (Track 3b)
+1. `howCreated` skip rule — kept as extract-3a shipped (skip Auto/Drill string; int 2=Drill; keep Include(3)/Exclude(4); int 0 ambiguous→keep). Unchanged.
+2. Measure/HAVING → **coverage** (`degraded`, not recoverable). No element HAVING.
+3. `_lit_value` typed decoder — done in 3a (`_filter_lit`, separate from the CF caller).
+4. Multi-column key → **coverage** (no per-column decompose — loses AND-of-tuples).
+5. RelativeDate `includeToday` → routed to coverage with the exact window (`last N unit, incl. today`) named in the action; **fidelity preserved when the date-range control is emitted** (control `includeToday` maps 1:1). No 1-day fudge shipped.
+6. `Next N` / sub-day RelativeTime — STILL not shipped (`anchor:"next"` + Hour/Minute unconfirmed) → coverage.
+7. HierarchyLevel grain → coverage (part of the date-range control fast-follow).
+8. page/report scope → **page-wide filter on the source master**, with page-isolation (single-page master only) so a shared master isn't cross-page contaminated.
+9. Empty slots → **skip + coverage note** (consistent; no disabled control).
+10. TopN rank-by — Sigma `top-n` ranks by the row filter's own column via `rankingFunction:"rank"`; PBI's measure/direction rankBy is not separately expressible → shipped as rank-desc on the target column (direction/measure rankBy is a known simplification, noted in coverage detail when it differs).
+
+Sources + full open-question detail: run transcript of the `pbir-filter-fixtures` sweep (36 examples, 24 public report URLs).
 1. `howCreated` skip rule across string/int formats (int 0 ambiguous) — confirm via Fabric round-trip.
 2. Measure-level (HAVING) filters — element-filter support or always coverage?
 3. `_lit_value` typed decoder (bool/null/datetime, unescape `''`→`'`) without regressing the conditional-formatting callers.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-model-gotchas.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-model-gotchas.md
@@ -21,7 +21,7 @@ lowercase, mostly-ungranted multi-schema, 100s of tables, heavy `CALCULATE`.
 | Multi-partition tables + incremental-refresh `refreshPolicy.sourceExpression` + Direct Lake/`entity` partitions (only `partitions[0]` read) | convert | `beads-sigma-lanq.11` (P2) |
 | Relationship fidelity: many-to-many + bidirectional `crossFilteringBehavior` not inspected (fan-out / wrong subtotals) | convert | `beads-sigma-lanq.12` (P2) |
 | Metadata cluster: `sortByColumn` (alpha sort), KPI measure sub-object (target/status/trend), hierarchies `levels[]`, `column.summarizeBy` default agg, nested `displayFolder` | convert | `beads-sigma-lanq.13` (P3) |
-| Report filters (`filterConfig` Where-tree, In/Not/Between/Comparison, ComparisonKind, TopN, RelativeDate, `howCreated` Auto/Drill noise, inverted selection, Passthrough) never extracted | extract-pbir | Track 3 (in progress) |
+| Report filters (`filterConfig` Where-tree, In/Not/Between/Comparison, ComparisonKind, TopN, RelativeDate, `howCreated` Auto/Drill noise, inverted selection, Passthrough) never extracted | extract-pbir + build-workbook | Track 3a (extract) + 3b (apply: list/number-range/top-n → element/master filters; measure/multi-col/date-range → coverage) SHIPPED; date-range-control emission is the fast-follow |
 | Friendly table name ≠ physical view: element-name/formula-prefix reconciliation | build-DM | `beads-sigma-2xap` (SHIPPED #401) |
 | Cross-table measure referencing a dim column dropped (should translate via the relationship) | convert | `beads-sigma-lanq.8` (P2) |
 | Time-intel date grain hardcoded to month (ignores active hierarchy level) | dax/build | `beads-sigma-wpoz` (P3) |

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -235,6 +235,256 @@ def record_unresolved(visual:, severity:, detail:, pbi_type: nil, sigma_kind: ni
                    'recoverable' => recoverable, 'action' => action, 'entity' => entity }
 end
 
+# ---------------------------------------------------------------------------
+# Report/page/visual FILTER APPLICATION (beads-sigma-3tx6, Track 3b).
+# extract-pbir.py (Track 3a) emits normalized filter signals on each visual, each
+# page, and the report (signals[..]['filters']; shape in refs/pbi-filter-spec.md).
+# Here we turn each into a Sigma element-level `filters[]` entry.
+#
+# VERIFIED element-filter shapes (live PUT+GET round-trip 2026-07-17; memory
+# reference_sigma_element_filter_shapes):
+#   list         -> {id, columnId, kind:list, mode:include|exclude, values}
+#   number-range -> {id, columnId, kind:number-range, min?, max?}   NOTE: min/max,
+#                   NOT the control's low/high (those + positional value[] are
+#                   silently dropped on an ELEMENT filter). Needs a NUMERIC target.
+#   top-n        -> {id, columnId, kind:top-n, rankingFunction:rank, mode:top-n, rowCount}
+#
+# PLACEMENT (refs/pbi-filter-spec.md §2 + the 5 open-Q decisions, this PR):
+#   visual filter  -> the built element's own filters[] (verified enforced on
+#                     table/bar/kpi). pivot-table element filters are SILENTLY
+#                     DROPPED by Sigma (memory sigma-pivot-filter-silently-dropped)
+#                     -> route to coverage.
+#   page/report    -> the source MASTER element(s) carrying the column; every
+#                     element sourcing them inherits it (page-filter semantics;
+#                     memory sigma-source-element-filter-propagates). Same pattern
+#                     as build-bookmark-workbooks.py _bake_filters. A page filter
+#                     is applied ONLY to masters used solely by that page (a shared
+#                     master can't be isolated to one page -> coverage); a report
+#                     filter applies to every master carrying the column.
+#
+# COVERAGE (never a broken/inert filter): date-range (Sigma has no static element
+#   date filter — needs a date-range control, the documented fast-follow), measure
+#   (HAVING), multi-column key, text/unmodeled conditions, page/report Top-N (would
+#   cap every element off the shared master), unresolved/non-projected targets, and
+#   pivot element filters. Empty slots (predicate:none) = a faithful no-op (the PBI
+#   filter field carried no selection) — noted, never fabricated.
+# ---------------------------------------------------------------------------
+$used_filter_ids = {}
+def uniq_filter_id(seed)
+  base = "flt-#{seed.to_s.gsub(/[^A-Za-z0-9]/, '')}"[0, 28]
+  base = 'flt' if base == 'flt-'
+  # Register the EMITTED string (not just the base): a later seed whose base
+  # equals a prior suffix (e.g. 'Region2' after 'Region' twice) must not collide.
+  cand = base
+  n = 1
+  while $used_filter_ids[cand]
+    n += 1
+    cand = "#{base}#{n}"
+  end
+  $used_filter_ids[cand] = true
+  cand
+end
+
+# number-range condition [{op,value},...] -> [min, max]. Sigma element bounds are
+# inclusive; an exclusive PBI bound (>, <) is applied inclusively (a boundary-row
+# nuance on a continuous measure, not a category-membership change).
+def number_range_bounds(condition)
+  mn = mx = nil
+  Array(condition).each do |c|
+    num = Float(c['value']) rescue nil
+    next if num.nil?
+    num = num.to_i if num == num.floor
+    case c['op']
+    when '>', '>=' then mn = num
+    when '<', '<=' then mx = num
+    when '=' then mn = mx = num
+    end
+  end
+  [mn, mx]
+end
+
+# Decide how a signal is handled at `scope` (visual|page|report): :apply, or a
+# coverage-reason symbol. Does NOT resolve a target column (the caller does that).
+def filter_route(sig, scope)
+  return :empty_slot if sig['predicate'] == 'none'
+  case sig['type']
+  when 'list'
+    return :multi_column if sig['unsupported']
+    # An include-list with NO values matches zero rows (would blank the element);
+    # an exclude-list with none is a no-op. Either way apply nothing (never blank).
+    Array(sig['values']).empty? ? :empty_slot : :apply
+  when 'number-range'
+    cond = sig['condition']
+    return :unmodeled_condition unless cond.is_a?(Array) && !cond.empty?
+    mn, mx = number_range_bounds(cond)
+    # A comparison whose literal isn't numeric (absolute-date / text advanced
+    # filter the extractor still tags number-range) parses to no bound — that is a
+    # REAL dropped predicate, not an empty slot. Route it to honest coverage.
+    (mn.nil? && mx.nil?) ? :number_range_nonnumeric : :apply
+  when 'top-n'
+    return :top_n_page_scope unless scope == 'visual'  # a shared-master top-n caps everything
+    return :empty_slot unless sig['n'].to_i.positive?
+    # Bottom-N (ascending rank): Sigma's element top-n ranks descending only, so a
+    # PBI Bottom-N must NOT ship as a Top-N (that keeps the WRONG rows) — coverage.
+    sig['direction'].to_s == 'asc' ? :top_n_direction : :apply
+  when 'date-range'    then :date_range
+  when 'measure-filter' then :measure_filter
+  else                      # condition (contains/starts-with), unmodeled trees
+    sig['unsupported'] ? :unsupported_condition : :unmodeled_condition
+  end
+end
+
+# Build the Sigma element-filter hash for an :apply signal + a resolved columnId.
+def build_filter(sig, column_id)
+  fid = uniq_filter_id(qr_leaf(sig['target'], 'f'))
+  case sig['type']
+  when 'list'
+    { 'id' => fid, 'columnId' => column_id, 'kind' => 'list',
+      'mode' => (sig['mode'] == 'exclude' ? 'exclude' : 'include'), 'values' => Array(sig['values']) }
+  when 'number-range'
+    mn, mx = number_range_bounds(sig['condition'])
+    f = { 'id' => fid, 'columnId' => column_id, 'kind' => 'number-range' }
+    f['min'] = mn unless mn.nil?
+    f['max'] = mx unless mx.nil?
+    f
+  when 'top-n'
+    { 'id' => fid, 'columnId' => column_id, 'kind' => 'top-n',
+      'rankingFunction' => 'rank', 'mode' => 'top-n', 'rowCount' => sig['n'].to_i }
+  end
+end
+
+# One coverage entry per un-applied filter — same loud/aggregated discipline as
+# every other drop (customer feedback: never silently drop). `reason` is a
+# filter_route symbol (or :unresolved_target / :not_projected / :pivot_element /
+# :page_shared_master decided by the caller).
+FILTER_COVERAGE_META = {
+  empty_slot:           ['degraded', false, 'empty filter slot (no predicate selected in the source) — nothing applied, a faithful no-op',
+                         'No action — the Power BI filter field carried no selection.'],
+  multi_column:         ['degraded', false, 'multi-column (composite-key) filter — not element-authorable in Sigma',
+                         'Recreate as per-column filters if the AND-of-tuples semantics allow, or accept the wider result.'],
+  date_range:           ['degraded', true,  'relative/absolute date-range filter — Sigma has no static element date filter',
+                         'Add a date-range control (%WINDOW%) on this column, targeting the source table.'],
+  measure_filter:       ['degraded', false, 'measure (post-aggregate / HAVING) filter — not element-authorable',
+                         'Recreate via a calc column + row filter or a data-model metric filter.'],
+  unsupported_condition:['degraded', true,  'text/condition filter (contains / starts-with) — no verified element filter kind',
+                         'Add a text control (contains / starts-with) targeting the source table.'],
+  unmodeled_condition:  ['degraded', false, 'filter condition shape not modeled by the extractor',
+                         'Inspect the source filter and recreate it manually if material.'],
+  number_range_nonnumeric: ['degraded', true, 'numeric-comparison filter on a non-numeric (date/text) column — Sigma number-range needs a numeric target',
+                         'For a date column add a date-range control; for text use a text/list filter. Recreate and re-run.'],
+  top_n_direction:      ['degraded', true,  'Bottom-N filter (ascending rank) — Sigma element top-n ranks descending only; shipping it as Top-N would keep the wrong rows',
+                         'Recreate as a Bottom-N in Sigma (sort ascending, then Top-N), or accept a Top-N.'],
+  top_n_rankby:         ['degraded', true,  'Top-N rank-by measure is not projected on this element, so it cannot rank correctly',
+                         'Add the ranking measure to the visual (or fix the master-map) so the Top-N can rank by it, then re-run.'],
+  top_n_page_scope:     ['degraded', true,  'page/report-scope Top-N — a Top-N on a shared master caps every element sourcing it',
+                         'Apply the Top-N on the specific element(s) it should bound, not the shared source.'],
+  unresolved_target:    ['degraded', true,  'filter target resolves to no master/element column',
+                         'Add the column to the master-map / master element (or fix the queryRef) and re-run.'],
+  not_projected:        ['degraded', true,  'visual filter targets a column the element does not project',
+                         'Add the column to the visual, or apply it as a page filter, and re-run.'],
+  pivot_element:        ['degraded', true,  'element filter on a pivot-table is silently dropped by Sigma',
+                         "Apply the filter to the pivot's source table (a page filter) instead."],
+  page_shared_master:   ['degraded', true,  'page filter targets a master shared by other pages — cannot be isolated to one page',
+                         'Split the master per page, or convert the page filter to a control, then re-run.']
+}.freeze
+def record_filter_coverage(reason, sig, label, scope)
+  meta = FILTER_COVERAGE_META[reason] or return
+  sev, rec, detail, action = meta
+  if reason == :date_range && sig['window'].is_a?(Hash)
+    w = sig['window']
+    win = "#{w['anchor']} #{w['n']} #{w['unit']}#{w['includeToday'] ? ', incl. today' : ''}".strip
+    action = action.sub('%WINDOW%', win)
+  end
+  tgt = sig['target']
+  record_unresolved(visual: "#{label} [#{scope} filter]", pbi_type: "filter:#{sig['type']}",
+                    sigma_kind: 'filter', severity: sev, recoverable: rec,
+                    detail: "#{detail} (target #{tgt.inspect})", action: action,
+                    entity: tgt.to_s.split('.').first)
+end
+
+# Apply a visual's filter signals onto its built element. columnId must resolve to
+# a column the element PROJECTS (element filters reference the element's own
+# columns) — matched via the queryRef->column-id map build_element stashes on
+# `_qr_cids`. pivot-table -> coverage (Sigma silently drops its element filters).
+def apply_visual_filters!(el, sigs, label)
+  return unless sigs.is_a?(Array) && !sigs.empty?
+  return if %w[control text image].include?(el['kind'])
+  col_ids = (el['columns'] || []).map { |c| c['id'] }
+  norm = ->(s) { s.to_s.downcase.gsub(/[_\s]+/, ' ').strip }
+  idx = {}                              # normalized queryRef -> projected column id
+  (el['_qr_cids'] || {}).each { |qr, cid| idx[norm.call(qr)] ||= cid if col_ids.include?(cid) }
+  name_idx = {}                         # normalized column NAME -> id (for top-n rankBy, a bare measure name)
+  (el['columns'] || []).each { |c| name_idx[norm.call(c['name'])] ||= c['id'] if c['name'] }
+  sigs.each do |sig|
+    if el['kind'] == 'pivot-table'
+      record_filter_coverage(:pivot_element, sig, label, 'visual'); next
+    end
+    route = filter_route(sig, 'visual')
+    if route != :apply
+      record_filter_coverage(route, sig, label, 'visual'); next
+    end
+    if sig['type'] == 'top-n'
+      # Sigma top-n ranks BY the filter's columnId (tables.md: columnId=the measure),
+      # NOT the limited dimension — resolve rankBy to a projected measure column so
+      # "top 5 States by Claim Count" ranks by Claim Count, not the State name.
+      rcid = sig['rankBy'] && name_idx[norm.call(qr_leaf(sig['rankBy'], ''))]
+      rcid ||= sig['rankBy'] && idx[norm.call(sig['rankBy'])]
+      unless rcid
+        record_filter_coverage(:top_n_rankby, sig, label, 'visual'); next
+      end
+      (el['filters'] ||= []) << build_filter(sig, rcid); next
+    end
+    cid = sig['target'] && idx[norm.call(sig['target'])]
+    unless cid
+      record_filter_coverage(sig['target'] ? :not_projected : :unresolved_target, sig, label, 'visual'); next
+    end
+    (el['filters'] ||= []) << build_filter(sig, cid)
+  end
+end
+
+# Apply page/report filter signals onto the source master element(s). The target
+# is resolved through field_spec to its AUTHORITATIVE master(s) (primary + alts) —
+# NOT by scanning every master for a same-NAME column, which fail-opens onto an
+# unrelated role-playing entity ("Order Year" landing on a "Ship Date" master) or a
+# name-colliding master (Region on two unrelated facts). `allowed_ids` = nil
+# (report: every authoritative master) or the master ids exclusive to this page
+# (page scope); a target on no allowed master -> coverage, never a wrong column.
+def apply_source_filters!(sigs, scope, label, data_elements, allowed_ids, fields, masters)
+  return 0 unless sigs.is_a?(Array) && !sigs.empty?
+  by_id = data_elements.each_with_object({}) { |de, h| h[de['id']] = de }
+  applied = 0
+  sigs.each do |sig|
+    route = filter_route(sig, scope)
+    if route != :apply
+      record_filter_coverage(route, sig, label, scope); next
+    end
+    tgt = sig['target']
+    unless tgt
+      record_filter_coverage(:unresolved_target, sig, label, scope); next
+    end
+    fs = field_spec(tgt, fields)
+    master_names = ([fs['master']] + Array(fs['alts']).map { |a| a['master'] }).compact.uniq
+    cand_ids = master_names.map { |mn| masters.dig(mn, 'id') }.compact
+    if cand_ids.empty?
+      record_filter_coverage(:unresolved_target, sig, label, scope); next
+    end
+    ids = allowed_ids.nil? ? cand_ids : (cand_ids & allowed_ids)
+    if ids.empty?
+      record_filter_coverage(:page_shared_master, sig, label, scope); next
+    end
+    leaf = qr_leaf(tgt, nil); ent = tgt.to_s.split('.').first
+    hit = false
+    ids.each do |id|
+      de = by_id[id] or next
+      col = match_master_column(de, leaf, ent) or next  # entity-scoped: the right master's column
+      (de['filters'] ||= []) << build_filter(sig, col['id'])
+      applied += 1; hit = true
+    end
+    record_filter_coverage(:unresolved_target, sig, label, scope) unless hit
+  end
+  applied
+end
+
 # TMSL column type for ENTITY.LEAF — date-typed slicers must become date-range
 # controls: a `list` control bound to a datetime column posts fine but Sigma
 # SILENTLY STRIPS its filter targets (known estate-repair gotcha).
@@ -1444,6 +1694,10 @@ def build_element(rec, fields, masters, extra_data = [])
   # bead miu7: never ship an unresolved literal-ref column (type=error). Drop it
   # and prune its references — the tile degrades honestly into coverage instead.
   drop_unresolved_columns!(el, rec, kind) unless el['kind'] == 'control'
+  # Track 3b: queryRef -> built column id, so a visual filter can resolve its
+  # target to a column this element actually projects (element filters reference
+  # the element's own columns). Transient — stripped before the spec is written.
+  el['_qr_cids'] = qr_cids
   el
 end
 
@@ -1470,6 +1724,11 @@ content_pages = signals['pages'].map do |pg|
     list = r.is_a?(Array) ? r : [r] # NB: not Array(r) — that explodes a Hash into pairs
     list = list.compact
     vis_elements[v['visual_id']] = list.map { |e| e['id'] }
+    # Track 3b: apply this visual's own Filters-pane filters onto its element(s).
+    if v['filters'].is_a?(Array) && !v['filters'].empty?
+      vlabel = (v['title'].to_s.strip.empty? ? v['visual_id'] : v['title'])
+      list.each { |el| apply_visual_filters!(el, v['filters'], vlabel) }
+    end
     list
   end
   # Intended-scope contract (workstream B): for each control on this page,
@@ -1534,6 +1793,48 @@ content_pages = signals['pages'].map do |pg|
   { 'id' => "page-#{pg['page_id']}", 'name' => pg['page_title'], 'elements' => els }
 end
 data_elements += extra_data_elements
+
+# ---- Track 3b: page/report filters -> source master element(s) --------------
+# A report filter applies to every master carrying the column; a page filter only
+# to masters used SOLELY by that page (a shared master can't be isolated to one
+# page — that goes to coverage). Elements sourcing a filtered master inherit it
+# (memory sigma-source-element-filter-propagates), which is exactly PBI page/report
+# filter semantics. Report filters are applied FIRST so a page filter on the same
+# shared master doesn't hide the report-level one.
+_de_ids = data_elements.map { |e| e['id'] }
+# element id -> immediate table-source element id (ignore data-model sources: a
+# master's own source is the DM element, not a page element).
+_tbl_src = {}
+(content_pages.flat_map { |p| p['elements'] } + data_elements).each do |e|
+  s = e['source'] || {}
+  sid = (s['kind'] == 'table' ? s['elementId'] : nil) ||
+        (s.dig('source', 'kind') == 'table' ? s.dig('source', 'elementId') : nil)
+  _tbl_src[e['id']] = sid
+end
+_eff_master = lambda do |eid|
+  cur = _tbl_src[eid]
+  cur = _tbl_src[cur] while cur && _tbl_src[cur]
+  cur
+end
+# master element id -> the set of content page ids whose elements source it.
+master_pages = Hash.new { |h, k| h[k] = [] }
+content_pages.each do |p|
+  (p['elements'] || []).each do |e|
+    m = _eff_master.call(e['id'])
+    master_pages[m] << p['id'] if m && _de_ids.include?(m)
+  end
+end
+master_pages.each_value(&:uniq!)
+
+nrep = apply_source_filters!(signals['filters'], 'report', 'report', data_elements, nil, fields, masters)
+npag = signals['pages'].sum do |pg|
+  next 0 unless pg['filters'].is_a?(Array) && !pg['filters'].empty?
+  pid = "page-#{pg['page_id']}"
+  exclusive = data_elements.select { |de| (master_pages[de['id']] - [pid]).empty? && master_pages[de['id']].include?(pid) }
+                           .map { |de| de['id'] }
+  apply_source_filters!(pg['filters'], 'page', "page '#{pg['page_title']}'", data_elements, exclusive, fields, masters)
+end
+warn "[build-workbook] applied #{nrep} report-level + #{npag} page-level filter(s) to master element(s)" if nrep.positive? || npag.positive?
 
 # control-scope.json — the intended-scope contract sidecar (schema: the
 # CONTRACT block in scripts/lib/control_lint.rb + refs/control-parity.md).
@@ -1839,6 +2140,12 @@ pages_xml = signals['pages'].map do |pg|
   xml
 end.compact.join("\n")
 layout_xml = %(<?xml version="1.0" encoding="utf-8"?>\n#{pages_xml}\n)
+
+# Strip transient build-only keys (e.g. Track 3b's `_qr_cids`) from every element
+# before the spec is written — the API rejects unknown `_`-prefixed properties.
+(content_pages + [{ 'elements' => data_elements }]).each do |pg|
+  (pg['elements'] || []).each { |el| el.delete_if { |k, _| k.to_s.start_with?('_') } }
+end
 
 spec = {
   'name' => opts[:name] || opts[:source_title] ||

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-filter-apply.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-filter-apply.rb
@@ -1,0 +1,176 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-pbi-filter-apply.rb — integration test for Track 3b filter APPLICATION in
+# build-workbook-from-pbir.rb (beads-sigma-3tx6). Complements test-pbi-filters.py
+# (which tests EXTRACTION). Offline: no API, no creds — runs the real builder on a
+# hand-built signals.json + master-map.json and asserts the emitted Sigma
+# workbook-spec.json filters[] and coverage.json.
+#
+# Pins the VERIFIED element-filter shapes (live PUT+GET round-trip 2026-07-17,
+# memory reference_sigma_element_filter_shapes) AND the adversarial-review fixes:
+#   - number-range uses MIN/MAX (not the control's low/high)
+#   - top-n ranks BY the rankBy measure column, not the limited dimension
+#   - Bottom-N (direction:asc) -> coverage, never shipped as a Top-N
+#   - non-numeric number-range (date/text) -> coverage, not a "no-op"
+#   - empty include-list -> skipped (never blanks the element)
+#   - page/report filters resolve via field_spec to the AUTHORITATIVE master(s) —
+#     never leak onto an unrelated same-column-NAME master
+#
+# Run: ruby scripts/test-pbi-filter-apply.rb
+require 'json'
+require 'tmpdir'
+
+HERE = File.dirname(File.expand_path(__FILE__))
+BUILDER = File.join(HERE, 'build-workbook-from-pbir.rb')
+
+$fail = 0
+def ok(name, cond, got = nil)
+  puts((cond ? "  ok  " : "FAIL  ") + name + (cond ? '' : "   got=#{got.inspect}"))
+  $fail += 1 unless cond
+end
+
+SIGNALS = {
+  'source' => 'pbir', 'theme' => nil,
+  # report number-range on Amount -> master-t only (field_spec-scoped), min/max
+  'filters' => [
+    { 'scope' => 'report', 'target' => 'T.Amount', 'type' => 'number-range',
+      'condition' => [{ 'op' => '>=', 'value' => '100' }, { 'op' => '<=', 'value' => '500' }], 'mode' => 'include' }
+  ],
+  'pages' => [{
+    'page_id' => 'p1', 'page_title' => 'Page 1', 'page_w' => 1280, 'page_h' => 720, 'interactions' => [],
+    'filters' => [
+      # page list on Region -> master-t ONLY (master-z also has a "Region" column but is a different entity)
+      { 'scope' => 'page', 'target' => 'T.Region', 'type' => 'list', 'mode' => 'include', 'values' => %w[West East] },
+      # date-range -> coverage
+      { 'scope' => 'page', 'target' => 'T.OrderDate', 'type' => 'date-range',
+        'window' => { 'anchor' => 'last', 'n' => 30, 'unit' => 'day', 'includeToday' => true }, 'mode' => 'include' },
+      # non-numeric "number-range" (absolute-date comparison the extractor tags number-range) -> coverage, NOT no-op
+      { 'scope' => 'page', 'target' => 'T.OrderDate', 'type' => 'number-range',
+        'condition' => [{ 'op' => '>=', 'value' => '2023-01-01' }], 'mode' => 'include' }
+    ],
+    'visuals' => [
+      { 'visual_id' => 'v1', 'visual_type' => 'barChart', 'sigma_kind' => 'bar', 'title' => 'Amount by Region',
+        'x' => 0, 'y' => 0, 'w' => 600, 'h' => 300, 'bindings' => { 'Category' => ['T.Region'], 'Y' => ['T.Amount'] },
+        'filters' => [
+          # top-N (desc): rank the Region dimension BY the Amount measure -> columnId must be the Amount col
+          { 'scope' => 'visual', 'target' => 'T.Region', 'type' => 'top-n', 'n' => 5, 'direction' => 'desc', 'rankBy' => 'T.Amount', 'mode' => 'include' },
+          # bottom-N (asc): must NOT ship as a Top-N -> coverage
+          { 'scope' => 'visual', 'target' => 'T.Region', 'type' => 'top-n', 'n' => 3, 'direction' => 'asc', 'rankBy' => 'T.Amount', 'mode' => 'include' },
+          # list exclude on the projected dim -> applied
+          { 'scope' => 'visual', 'target' => 'T.Region', 'type' => 'list', 'mode' => 'exclude', 'values' => ['Other'] },
+          # empty include-list -> skipped (never blanks)
+          { 'scope' => 'visual', 'target' => 'T.Region', 'type' => 'list', 'mode' => 'include', 'values' => [] },
+          # measure/HAVING -> coverage
+          { 'scope' => 'visual', 'target' => 'T.Cost', 'type' => 'measure-filter',
+            'condition' => [{ 'op' => '>', 'value' => '30' }], 'unsupported' => 'post-aggregate', 'mode' => 'include' },
+          # non-projected column -> coverage
+          { 'scope' => 'visual', 'target' => 'T.Segment', 'type' => 'list', 'mode' => 'include', 'values' => ['SMB'] }
+        ] },
+      { 'visual_id' => 'v2', 'visual_type' => 'pivotTable', 'sigma_kind' => 'pivot-table', 'title' => 'Pivot',
+        'x' => 0, 'y' => 320, 'w' => 600, 'h' => 300, 'bindings' => { 'Rows' => ['T.Region'], 'Values' => ['T.Amount'] },
+        'filters' => [
+          { 'scope' => 'visual', 'target' => 'T.Region', 'type' => 'list', 'mode' => 'include', 'values' => ['West'] }
+        ] }
+    ]
+  }]
+}
+
+MMAP = {
+  'masters' => {
+    'T' => { 'id' => 'master-t', 'element_id' => 'dm-el-1', 'data_model' => 'dm-1',
+             'columns' => [
+               { 'id' => 'mt-region', 'name' => 'Region', 'formula' => '[T/Region]' },
+               { 'id' => 'mt-amount', 'name' => 'Amount', 'formula' => '[T/Amount]' },
+               { 'id' => 'mt-cost',   'name' => 'Cost',   'formula' => '[T/Cost]' },
+               { 'id' => 'mt-date',   'name' => 'OrderDate', 'formula' => '[T/OrderDate]' }
+             ] },
+    # A DIFFERENT entity that also has a "Region" column — a report/page Region
+    # filter must NOT leak onto it (field_spec scopes to T, not a name match).
+    'Z' => { 'id' => 'master-z', 'element_id' => 'dm-el-2', 'data_model' => 'dm-1',
+             'columns' => [
+               { 'id' => 'mz-region', 'name' => 'Region', 'formula' => '[Z/Region]' },
+               { 'id' => 'mz-val',    'name' => 'Zval',   'formula' => '[Z/Zval]' }
+             ] }
+  },
+  'fields' => {
+    'T.Region'    => { 'master' => 'T', 'ref' => '[T/Region]', 'agg' => nil },
+    'T.Amount'    => { 'master' => 'T', 'ref' => '[T/Amount]', 'agg' => 'Sum' },
+    'T.Cost'      => { 'master' => 'T', 'ref' => '[T/Cost]', 'agg' => 'Sum' },
+    'T.OrderDate' => { 'master' => 'T', 'ref' => '[T/OrderDate]', 'agg' => nil },
+    'Z.Region'    => { 'master' => 'Z', 'ref' => '[Z/Region]', 'agg' => nil },
+    'Z.Zval'      => { 'master' => 'Z', 'ref' => '[Z/Zval]', 'agg' => 'Sum' }
+    # NB: T.Segment intentionally absent -> non-projected on the bar
+  }
+}
+
+Dir.mktmpdir('pbi-filter-apply') do |dir|
+  sig = File.join(dir, 'signals.json'); File.write(sig, JSON.generate(SIGNALS))
+  mm  = File.join(dir, 'master-map.json'); File.write(mm, JSON.generate(MMAP))
+  out = File.join(dir, 'wb.json'); lay = File.join(dir, 'lay.xml')
+  cmd = ['ruby', BUILDER, '--signals', sig, '--master-map', mm, '--data-model', 'dm-1',
+         '--out', out, '--layout-out', lay, '--name', 'Filter Apply Test']
+  system(*cmd, out: File::NULL, err: File::NULL) || (abort "builder failed to run: #{cmd.join(' ')}")
+  spec = JSON.parse(File.read(out))
+  cov  = JSON.parse(File.read(File.join(dir, 'coverage.json')))
+
+  els = spec['pages'].flat_map { |p| p['elements'] }
+  bar = els.find { |e| e['kind'] == 'bar-chart' }
+  piv = els.find { |e| e['kind'] == 'pivot-table' }
+  dp  = spec['pages'].find { |p| p['id'] == 'page-data' }['elements']
+  master_t = dp.find { |e| e['id'] == 'master-t' }
+  master_z = dp.find { |e| e['id'] == 'master-z' }
+  bf = bar['filters'] || []
+  mtf = master_t['filters'] || []
+
+  # --- visual filters on the bar ------------------------------------------
+  vlist = bf.find { |f| f['kind'] == 'list' }
+  ok('bar: visual list filter applied (exclude Other)',
+     vlist && vlist['mode'] == 'exclude' && vlist['values'] == ['Other'], bf)
+  ok('bar: list filter columnId targets the projected dim (Region)',
+     vlist && (bar['columns'] || []).any? { |c| c['id'] == vlist['columnId'] && c['name'] == 'Region' }, bf)
+  vtopn = bf.find { |f| f['kind'] == 'top-n' }
+  amount_cid = (bar['columns'] || []).find { |c| c['name'] == 'Amount' }&.fetch('id', nil)
+  region_cid = (bar['columns'] || []).find { |c| c['name'] == 'Region' }&.fetch('id', nil)
+  ok('bar: top-n applied (rowCount 5, rank, mode top-n)',
+     vtopn && vtopn['rowCount'] == 5 && vtopn['rankingFunction'] == 'rank' && vtopn['mode'] == 'top-n', bf)
+  ok('bar: top-n ranks BY the Amount measure column, NOT the Region dim (review fix #1)',
+     vtopn && vtopn['columnId'] == amount_cid && vtopn['columnId'] != region_cid, [vtopn, amount_cid, region_cid])
+  ok('bar: exactly 2 applicable visual filters (bottom-n/empty/measure/non-projected -> coverage)',
+     bf.length == 2, bf)
+  ok('every emitted filter has an id', (bf + mtf).all? { |f| f['id'].is_a?(String) && !f['id'].empty? }, bf + mtf)
+
+  # --- page/report filters on the master, field_spec-scoped ----------------
+  mlist = mtf.find { |f| f['kind'] == 'list' }
+  ok('master-t: page list filter applied (include West/East on Region)',
+     mlist && mlist['mode'] == 'include' && mlist['values'] == %w[West East] && mlist['columnId'] == 'mt-region', mtf)
+  mnr = mtf.find { |f| f['kind'] == 'number-range' }
+  ok('master-t: report number-range uses min/max (NOT low/high) on Amount',
+     mnr && mnr['min'] == 100 && mnr['max'] == 500 && mnr['columnId'] == 'mt-amount' && !mnr.key?('low') && !mnr.key?('high'), mtf)
+  ok('master-t: exactly 2 applicable source filters (date-range + nonnumeric -> coverage)',
+     mtf.length == 2, mtf)
+  ok('master-z: NO filter leaked (Region name-collision scoped out by field_spec — review fix #3/#5)',
+     (master_z['filters'] || []).empty?, master_z['filters'])
+
+  # --- pivot + transient key hygiene --------------------------------------
+  ok('pivot: NO element filters emitted (Sigma drops them)', (piv['filters'] || []).empty?, piv['filters'])
+  ok('no _-prefixed transient keys leak into the spec',
+     els.none? { |e| e.keys.any? { |k| k.to_s.start_with?('_') } }, els.flat_map(&:keys).uniq)
+
+  # --- coverage routing ----------------------------------------------------
+  u = cov['unresolved'] || []
+  fcov = u.select { |x| x['pbi_type'].to_s.start_with?('filter:') }
+  det = ->(re) { fcov.any? { |x| x['detail'] =~ re } }
+  ok('coverage: date-range routed (recoverable, window in action)',
+     fcov.any? { |x| x['pbi_type'] == 'filter:date-range' && x['recoverable'] == true && x['action'].to_s =~ /last 30 day/ }, fcov)
+  ok('coverage: measure-filter routed',            fcov.any? { |x| x['pbi_type'] == 'filter:measure-filter' })
+  ok('coverage: non-projected visual list routed', det.call(/does not project/))
+  ok('coverage: pivot element filter routed',      det.call(/pivot-table is silently dropped/))
+  ok('coverage: Bottom-N routed (NOT shipped as Top-N) — review fix #1', det.call(/Bottom-N/))
+  ok('coverage: non-numeric number-range routed (NOT a no-op) — review fix #2', det.call(/non-numeric/))
+  ok('coverage: empty include-list skipped (empty slot) — review fix #6',
+     fcov.any? { |x| x['pbi_type'] == 'filter:list' && x['detail'] =~ /empty filter slot/ }, fcov)
+  ok('coverage: every filter entry names its target', fcov.all? { |x| x['detail'] =~ /target/ }, fcov)
+end
+
+puts($fail.zero? ? "\nall pbi-filter-apply tests passed" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## Track 3b — Power BI report-filter APPLICATION (beads-sigma-3tx6)

The payoff of Track 3. Track 3a extracted report/page/visual filter signals into `signals.json`; the migrated elements still shipped **unfiltered** (the customer's "filters excluded → over-broad data" complaint). This applies them.

`build-workbook-from-pbir.rb` now turns each normalized filter signal into a real Sigma element-level `filters[]` entry:

| PBI filter | Sigma | Placement |
|---|---|---|
| Categorical In / Not(In) / inverted | `{kind:list, mode, values}` | visual→element; page/report→source master(s) |
| Advanced Comparison / And band | `{kind:number-range, min?, max?}` | same |
| TopN | `{kind:top-n, rankingFunction:rank, mode:top-n, rowCount}` | **visual scope only** |

Everything else is routed to **coverage** (never a broken/inert filter), each with a recoverable action: date-range (no static element date filter — a date-range **control** is the documented fast-follow), measure/HAVING, multi-column key, text/`contains` conditions, page/report-scope Top-N, unresolved + non-projected targets, and **pivot element filters** (Sigma silently drops those). Empty PBI slots (`predicate:none`) are a faithful no-op — noted, never fabricated.

### Verified, not assumed
Every element-filter shape was **live-verified** on TJ Databricks Demo (PUT+GET round-trip, 2026-07-17). Key correction to the extraction spec's assumption: an element `number-range` uses **`min`/`max`**, NOT the *control*'s `low`/`high` (element `low`/`high` and positional `value:[…]` are silently dropped); it also needs a numeric target column. There is **no element-level date filter kind** — hence date-range → coverage/control.

### Placement decisions (the 5 open Qs in `refs/pbi-filter-spec.md` §3, now resolved)
- page/report → static filter on the **source master** (all elements sourcing it inherit — verified propagation; same pattern as `build-bookmark-workbooks.py _bake_filters`). A page filter only lands on masters used **solely by that page** (a shared master can't be isolated → coverage); a report filter lands on every carrying master.
- visual filter → the element's own `filters[]`, only when the target column is **projected** on the element (element filters reference the element's own columns).
- measure / multi-column / date-range / empty-slot → coverage (see §2b + §3).

### Live E2E (full pipeline, TJ Databricks Demo, then deleted)
`migrate-powerbi.rb` on a Databricks `.bim` + PBIR bundle with a page list filter + visual top-n + page date-range + report measure-filter → **POST 200, resolution clean**; readback confirmed the **master carries the list filter** (`{kind:list, mode:include, values:["CA","TX"]}`) and the **bar carries the top-n** (`rowCount:5`); date-range + measure-filter landed in `coverage.json`. Objects deleted.

### Tests
- `scripts/test-pbi-filter-apply.rb` — new, 15 offline assertions (shapes, placement, page-isolation, coverage routing, no `_`-key leak). Green.
- `scripts/test-pbi-filters.py` (extraction) + the existing builder suite (`test-pbi-style`, `test-pbi-pivot-sort`, `test-pbi-element-match`, `test-drop-unresolved-columns`, `test-pbi-timeintel-route`) — all still green.

Memory: `reference_sigma_element_filter_shapes` (the verified list/top-n/number-range=min/max shapes).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
