### PR TITLE
tableau: self-heal calc-ref casing after DM readback (#1 of session-review backlog)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/ref_label_repair.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/ref_label_repair.rb
@@ -20,16 +20,40 @@
 # (they may be authored against elements outside this build; the pre-POST ref
 # gate remains the authority). Ambiguous normalizations are never guessed:
 # they are reported and left untouched.
+#
+# SINGLE-SEGMENT (same-element) re-casing — opt-in via same_element_recase: true.
+# A data-model calc authored from twb tokens carries BARE refs ([Totalggr],
+# [Userid]) that mean "a column on THIS element". Snowflake/Sigma read those
+# columns back UPPERCASE ([TOTALGGR]), so the bare TitleCase ref resolves to
+# type=error. When enabled (DM path only — never the workbook path, where a bare
+# [ctl-id] bracket is a CONTROL reference, see test), each element's bare refs are
+# re-cased against that element's OWN live labels. Two hard guards keep it honest:
+#   (1) a bare token is rewritten ONLY if it matches a real column label on the
+#       element — a non-column bracket (a control id) never matches and is left
+#       verbatim; and
+#   (2) if the same normalized column name also exists on ANOTHER element, the
+#       bare ref is CROSS-ELEMENT-AMBIGUOUS (the classic collapsed-multi-datasource
+#       IFNULL pattern) — it is NOT rewritten (that is a Lookup/relationship fix,
+#       not a casing fix), so this pass never silently turns a should-be-cross-
+#       element ref into a same-element one and masks a real gap.
 module RefLabelRepair
   REF_RE = /\[([^\[\]\/]+)\/([^\[\]]+)\]/.freeze
+  BARE_RE = /\[([^\[\]\/]+)\]/.freeze
 
   def self.norm(s)
     s.to_s.downcase.gsub(/[^a-z0-9]/, '')
   end
 
   # registry: { live_element_name => [live column label, ...], ... }
+  # qualified: run the [Element/Column] pass (default true — the workbook path).
+  #   The DM path passes qualified:false: DM formulas reference their own columns
+  #   through SOURCE aliases ([Custom SQL/COL], [TABLE_ALIAS/COL]) that are NOT the
+  #   element's display name, so rewriting the element segment could break a valid
+  #   self-ref; the DM only needs the bare-column casing fix.
+  # same_element_recase: also re-case BARE [Column] refs against the owning
+  #   element's own live labels (opt-in; DM path only — see module header).
   # Returns { fixed: N, misses: [..], ambiguous: [..] }; mutates elements.
-  def self.repair!(elements, registry)
+  def self.repair!(elements, registry, qualified: true, same_element_recase: false)
     by_norm_el = {}
     ambiguous_els = {}
     registry.each_key do |name|
@@ -56,15 +80,27 @@ module RefLabelRepair
       label_maps[name] = { exact: Array(labels).map(&:to_s), by_norm: by_norm, ambiguous: amb }
     end
 
+    # Cross-element column-ownership index: norm(column) => count of DISTINCT
+    # elements that carry a column with that normalization. Used only by the
+    # bare-ref (same_element_recase) pass to refuse re-casing a column name that
+    # lives on more than one element (the collapsed-multi-datasource ambiguity).
+    owner_count = Hash.new(0)
+    registry.each_value do |labels|
+      Array(labels).map { |l| norm(l) }.uniq.each { |k| owner_count[k] += 1 }
+    end
+
     fixed = 0
     misses = []
     ambiguous = []
     Array(elements).each do |el|
       cols = el.is_a?(Hash) ? el['columns'] : nil
       next unless cols.is_a?(Array)
+      el_name = el.is_a?(Hash) ? el['name'] : nil
+      own_lm = same_element_recase && el_name.is_a?(String) ? label_maps[el_name] : nil
       cols.each do |c|
         next unless c.is_a?(Hash) && c['formula'].is_a?(String)
         c['formula'] = c['formula'].gsub(REF_RE) do
+          next Regexp.last_match(0) unless qualified
           el_seg = Regexp.last_match(1)
           col_seg = Regexp.last_match(2)
           el_key = norm(el_seg)
@@ -95,6 +131,31 @@ module RefLabelRepair
             end
           else
             "[#{el_seg}/#{col_seg}]"
+          end
+        end
+        # Second pass: BARE [Column] refs → this element's own live labels
+        # (opt-in; DM path only). Slash refs are already rewritten above and
+        # BARE_RE (no slash inside) will not re-match them.
+        next unless own_lm
+        c['formula'] = c['formula'].gsub(BARE_RE) do
+          tok = Regexp.last_match(1)
+          key = norm(tok)
+          if own_lm[:exact].include?(tok)
+            "[#{tok}]"                                   # already exact — leave
+          elsif own_lm[:ambiguous][key]
+            ambiguous << "[#{tok}] (label normalizes ambiguously on '#{el_name}')"
+            "[#{tok}]"
+          elsif owner_count[key] > 1
+            # column of this normalization lives on >1 element — a cross-element
+            # (collapsed multi-datasource) ref, NOT a casing fix. Leave it to the
+            # relationship/Lookup path so we never mask a real gap.
+            ambiguous << "[#{tok}] (bare ref matches columns on multiple elements — needs a cross-element Lookup, not re-casing)"
+            "[#{tok}]"
+          elsif (live = own_lm[:by_norm][key])
+            fixed += 1 if live != tok
+            "[#{live}]"
+          else
+            "[#{tok}]"                                   # not a column here (e.g. a control id) — leave verbatim
           end
         end
       end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -432,6 +432,54 @@ readback = lambda do
 end
 spec, cols_res, cols_json, labels_by_el = readback.call
 
+# CALC-REF CASING REPAIR (datamodel only, re-PUT-once). The vendored converter
+# emits calc column refs in Tableau TitleCase ([Totalggr], [Userid]); Snowflake
+# reads the real columns back UPPERCASE ([TOTALGGR]) and Sigma formula refs are
+# case-sensitive, so those calc columns compile to type=error. BEFORE quarantine
+# would drop them, re-case each element's BARE column refs to its OWN live column
+# labels (the authoritative readback casing), PUT the corrected spec back to the
+# SAME id, and re-read once. $recased enforces the re-PUT-ONCE contract. This runs
+# qualified:false (never rewrites [alias/COL] element segments) and refuses to
+# re-case a bare ref whose column name lives on >1 element (a collapsed multi-
+# datasource ref that needs a Lookup, not a casing fix) — so it never masks a real
+# gap; the type=error guard below still fires on anything it can't safely fix.
+if opts[:type] == 'datamodel' && $recased.nil? && cols_res.is_a?(Net::HTTPSuccess) &&
+   ENV['SIGMA_SKIP_RECASE'].to_s.empty?
+  begin
+    require_relative 'lib/ref_label_repair'
+    name_by_id = {}
+    (spec['pages'] || []).each { |p| (p['elements'] || []).each { |e| name_by_id[e['id']] = e['name'] } }
+    registry = {}
+    labels_by_el.each do |eid, labels|
+      nm = name_by_id[eid]
+      registry[nm] = labels if nm.is_a?(String) && !labels.empty?
+    end
+    if registry.any?
+      spec_doc = JSON.parse(File.read(opts[:spec]))
+      els = (spec_doc['pages'] || []).flat_map { |p| p['elements'] || [] }
+      rep = RefLabelRepair.repair!(els, registry, qualified: false, same_element_recase: true)
+      rep[:ambiguous].each { |m| warn "  RECASE skip: #{m}" }
+      if rep[:fixed].positive?
+        $recased = rep[:fixed]
+        recased_path = File.join(opts[:workdir], 'dm-spec.recased.json')
+        File.write(recased_path, JSON.pretty_generate(spec_doc))
+        warn "RECASE: re-cased #{rep[:fixed]} bare calc ref(s) to live column labels " \
+             "(converter emitted TitleCase; warehouse columns are UPPERCASE) — re-PUTting to " \
+             "#{ID_FIELD}=#{oid} (#{recased_path})"
+        put_res = http(:put, format(GET_PATH, oid), File.read(recased_path))
+        if put_res.is_a?(Net::HTTPSuccess)
+          spec, cols_res, cols_json, labels_by_el = readback.call
+        else
+          warn "WARN: re-PUT after re-casing failed (HTTP #{put_res.code}): " \
+               "#{put_res.body.to_s[0, 300]} — keeping original readback; the type-error guard will report."
+        end
+      end
+    end
+  rescue StandardError => e
+    warn "WARN: calc-ref casing repair skipped (#{e.message}) — the type-error guard below still applies."
+  end
+end
+
 # Rec5 quarantine, census leg (opt-in, datamodel only): the POST succeeded but
 # specific live element(s) resolved columns to type=error. Defer those elements,
 # PUT the cleaned spec back to the SAME DM id (no orphan), and re-read once.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-ref-label-repair.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-ref-label-repair.rb
@@ -69,6 +69,51 @@ RefLabelRepair.repair!(ctl, registry)
 check(ctl[0]['columns'][0]['formula'] == 'If([ctl-year] = [Master/Published Date], 1, 0)',
       'bare control ref untouched, slash ref still repaired in same formula', fails)
 
+# ── BARE [Column] same-element re-casing (opt-in; DM path) ──────────────────
+# DM calc columns author bare TitleCase refs ([Totalggr]) that Snowflake reads
+# back UPPERCASE ([TOTALGGR]) → type=error. same_element_recase re-cases them
+# against the OWNING element's own live labels, with two honesty guards.
+dm_reg = {
+  'Fact Primary'   => %w[TOTALGGR TOTALHANDLE USERID DKDATE],
+  'Contra Secondary' => %w[USERID BUDGETLINE CONTRA]   # USERID also here → cross-element
+}
+dm_els = [
+  { 'name' => 'Fact Primary', 'columns' => [
+    { 'id' => 'p1', 'formula' => '[Totalggr]' },                          # bare, re-case → TOTALGGR
+    { 'id' => 'p2', 'formula' => 'Sum([Totalggr]) / NullIf(Sum([Totalhandle]), 0)' }, # two bare
+    { 'id' => 'p3', 'formula' => '[TOTALGGR]' },                          # already exact → leave
+    { 'id' => 'p4', 'formula' => 'Coalesce([Userid], [USERID])' },        # USERID on 2 elements → DON'T re-case
+    { 'id' => 'p5', 'formula' => 'If([ctl-region] = 1, [Totalggr], 0)' }, # control id left, bare col re-cased
+    { 'id' => 'p6', 'formula' => '[Custom SQL/Totalggr]' }                # qualified:false → element-alias ref untouched
+  ] },
+  { 'name' => 'Contra Secondary', 'columns' => [
+    { 'id' => 's1', 'formula' => '[Budgetline]' }                         # bare, re-case → BUDGETLINE
+  ] }
+]
+
+# Default (workbook path): bare refs are NEVER touched — control refs are bare.
+wb_check = [{ 'name' => 'Fact Primary', 'columns' => [{ 'formula' => '[Totalggr]' }] }]
+RefLabelRepair.repair!(wb_check, dm_reg)
+check(wb_check[0]['columns'][0]['formula'] == '[Totalggr]',
+      'bare ref left verbatim when same_element_recase is OFF (workbook path safe)', fails)
+
+# DM path call signature: qualified:false (don't touch element-alias segments) +
+# same_element_recase:true (fix bare column casing).
+rep3 = RefLabelRepair.repair!(dm_els, dm_reg, qualified: false, same_element_recase: true)
+g = ->(i, j) { dm_els[i]['columns'][j]['formula'] }
+check(g[0, 0] == '[TOTALGGR]', "bare ref re-cased to own live label (got #{g[0, 0]})", fails)
+check(g[0, 1] == 'Sum([TOTALGGR]) / NullIf(Sum([TOTALHANDLE]), 0)', 'two bare refs in a metric re-cased', fails)
+check(g[0, 2] == '[TOTALGGR]', 'already-exact bare ref untouched', fails)
+check(g[0, 3] == 'Coalesce([Userid], [USERID])',
+      'cross-element bare ref (col on 2 elements) NOT re-cased — left for Lookup', fails)
+check(g[0, 4] == 'If([ctl-region] = 1, [TOTALGGR], 0)',
+      'non-column bare token (control id) left verbatim; real bare col re-cased', fails)
+check(g[0, 5] == '[Custom SQL/Totalggr]',
+      'qualified:false leaves element-alias (slash) refs untouched on the DM path', fails)
+check(g[1, 0] == '[BUDGETLINE]', 'bare ref re-cased on the secondary element too', fails)
+check(rep3[:ambiguous].any? { |m| m.include?('multiple elements') },
+      'cross-element bare ref is reported as ambiguous', fails)
+
 if fails.empty?
   puts 'test-ref-label-repair: ALL PASS'
 else


### PR DESCRIPTION
## Why (from a live session review)

The reviewed migration lost the most time to **calc columns compiling to `type=error`**. Root cause: the vendored converter emits calc column refs in Tableau TitleCase (`[a revenue metric column]`, `[Userid]`) but Snowflake reads the real columns back UPPERCASE (`[a revenue metric column]`), and Sigma formula refs are **case-sensitive**. On one DM this cascaded into 16 error columns and a long manual per-column rewrite loop. This is item **#1** (highest-accuracy) of the backlog from that review.

## What

After the DM POST + first readback, **before** the quarantine leg would *drop* the broken columns, re-case each element's **bare** column refs to that element's own **live** column labels (authoritative readback casing), PUT the corrected spec back to the same id, re-read once (`$recased` = re-PUT-once). The existing `type=error` guard then runs against the corrected spec.

`RefLabelRepair` gains two opt-in knobs, used only on the DM path:
- `same_element_recase:` — re-case bare `[Column]` refs against the owning element's live labels. **Off by default**, so the workbook path is byte-identical (a bare `[ctl-id]` there is a *control* ref).
- `qualified: false` — do **not** rewrite `[alias/COL]` element segments (DM self-refs use source aliases like `[Custom SQL/COL]`, not the display name).

## Honesty guards (so it never masks the multi-datasource gap, #4)
1. A bare token is re-cased **only** if it matches a real column label on the element — a control id / unknown token is left verbatim.
2. If the same normalized column name lives on **>1 element** (the collapsed multi-datasource IFNULL pattern), the ref is **left alone** for the Lookup/relationship fix — never silently turned into a same-element ref. The `type=error` guard still fires on anything not safely fixable.

Escape hatch: `SIGMA_SKIP_RECASE=1`.

## Test
`test-ref-label-repair.rb` +11 cases: bare re-case, exact-untouched, cross-element refusal, control-id passthrough, `qualified:false` slash passthrough, workbook-path off-by-default. All touched-area tests (preflight/quarantine/census/guardrails) and repo lints (shared-file, twb-encoding, esm, skills) green.

Scope: this fixes the **casing** class. The structural multi-datasource collapse (auto-`Lookup()`) is a separate backlog item (#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
