### PR TITLE
shared/preflight: offline control-shape grammar validator (C6/C7/C8) — #2 of session-review

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
@@ -188,6 +188,40 @@ s = valid_spec
 s['pages'][0]['elements'][4].delete('filters')
 check(rule(lint(s), 'C3').size == 1, 'C3 regression: list control wired to nothing still fails', fails)
 
+# ---- C6: controlType enum + docs-only top-n ---------------------------------
+s = valid_spec
+s['pages'][0]['elements'][4]['controlType'] = 'dropdown'
+c6 = rule(lint(s), 'C6')
+check(c6.size == 1 && c6.first.include?('unknown controlType "dropdown"'), 'C6: unknown controlType flagged', fails)
+s = valid_spec
+s['pages'][0]['elements'][4]['controlType'] = 'top-n'
+s['pages'][0]['elements'][4].delete('selectionMode')   # avoid unrelated C5 noise
+c6b = rule(lint(s), 'C6')
+check(c6b.size == 1 && c6b.first.include?('docs-only'), 'C6: docs-only top-n flagged with the element rank-filter fix', fails)
+
+# ---- C7: required per-type fields -------------------------------------------
+s = valid_spec
+ct = s['pages'][0]['elements'][4]
+ct['controlType'] = 'number'; ct.delete('selectionMode'); ct['value'] = 5
+check(rule(lint(s), 'C7').size == 1, 'C7: number control missing `mode` → 1 violation', fails)
+ct['mode'] = '>='
+check(rule(lint(s), 'C7').empty?, 'C7: number control WITH `mode` → clean', fails)
+s = valid_spec
+rs = s['pages'][0]['elements'][4]
+rs['controlType'] = 'range-slider'; rs.delete('selectionMode'); rs.delete('value')
+check(rule(lint(s), 'C7').any? { |e| e.include?('low`/`high') }, 'C7: range-slider without low/high → violation', fails)
+rs['low'] = 0; rs['high'] = 100
+check(rule(lint(s), 'C7').empty?, 'C7: range-slider with low/high → clean', fails)
+
+# ---- C8: includeNulls placement --------------------------------------------
+s = valid_spec
+s['pages'][0]['elements'][4]['includeNulls'] = true    # on a `list` control (off-schema)
+check(rule(lint(s), 'C8').size == 1, 'C8: includeNulls on a list control → 1 violation', fails)
+s = valid_spec
+n = s['pages'][0]['elements'][4]
+n['controlType'] = 'number'; n['mode'] = '='; n.delete('selectionMode'); n['value'] = 1; n['includeNulls'] = true
+check(rule(lint(s), 'C8').empty?, 'C8: includeNulls on a number control → allowed (no violation)', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — preflight_lint K1/S1/C5/N1 fail rules + P1/I1 warnings + T1/C2/C3 regressions'

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end

--- a/shared/lib/preflight_lint.rb
+++ b/shared/lib/preflight_lint.rb
@@ -30,6 +30,11 @@
 #       supermart mini bars). Use container styling instead.
 #   C5  a control with selectionMode:"single" carrying `values` (array) instead
 #       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
 #       the element, not the name).
@@ -45,6 +50,21 @@ require 'json'
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
 PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
 LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -154,6 +174,28 @@ def lint(spec)
         if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
           scalar = el['values'].first
           errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
         end
       end
     end


### PR DESCRIPTION
## Why (from a live session review)

A workbook's controls failed Sigma's **server-side `spec/verify` one shape rule at a time**, each costing a full orchestrator round-trip (~1m) to discover: an invalid `controlType` (`number-input`), then `number` needing a `mode`, then a `top-n` attempt the live tenant 400s. There was no offline validator for the control grammar — only C2 (flat value fields). The run spent ~160 lines decoding the opaque server union-type error. Item **#2** of the backlog.

## What

Extend `preflight_lint` (shared lib, synced to all converters) to mirror Sigma `spec/verify` **offline**, per the canary-verified table in `refs/composition-recipe.md` (2026-07-11):

- **C6** — unknown `controlType`, or the **docs-only `top-n`** (live tenant 400s it → use a top-N rank-filter on the element, not a control).
- **C7** — missing required field for the type: `mode` on `switch`/`checkbox`/`text`/`number`/`date`/`slider`; `low`/`high` on `range-slider` (a bare range-slider emits a 0..0 track that filters every row out).
- **C8** — `includeNulls` on a `controlType` where it is off-schema.

These abort pre-POST (exit 1) with a precise message + fix, instead of a remote 400.

## Shared-file governance
Edited canonical `shared/lib/preflight_lint.rb` and ran `tools/sync-shared.rb` → all 9 converters. `check-shared.rb` clean.

## Test
`test-preflight-lint.rb` +8 cases (unknown type, top-n, number mode-required + clean-with-mode, range-slider bounds, includeNulls placement). The existing valid-spec `list` control stays clean. All plugins' preflight tests + repo lints green.

Pairs with #407 (calc-ref casing). Together they target the two biggest sinks in the reviewed run — calc accuracy and the control round-trip loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)