### PR TITLE
tableau: exit-4 = patch the auto-built spec, not rewrite (#3+#5 of session-review)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb
@@ -222,6 +222,11 @@ module ControlLint
       end
     end
 
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
     rows.each do |r|
       ann = scope_by_cid.delete(r[:control_id]) || {}
       ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
@@ -288,11 +293,29 @@ module ControlLint
     # failure. Only a control the builder recorded as EMITTED but that's missing
     # from the spec is a real bug the source filter was lost.
     surfaced_gap = %w[needs-wiring needs-materialization].freeze
-    scope_by_cid.each do |cid, c|
-      next if surfaced_gap.include?(c['status'].to_s)
-      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
-                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
-                    'has no control with that controlId — the source filter was not migrated'
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
     end
 
     violations

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
@@ -222,6 +222,11 @@ module ControlLint
       end
     end
 
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
     rows.each do |r|
       ann = scope_by_cid.delete(r[:control_id]) || {}
       ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
@@ -288,11 +293,29 @@ module ControlLint
     # failure. Only a control the builder recorded as EMITTED but that's missing
     # from the spec is a real bug the source filter was lost.
     surfaced_gap = %w[needs-wiring needs-materialization].freeze
-    scope_by_cid.each do |cid, c|
-      next if surfaced_gap.include?(c['status'].to_s)
-      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
-                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
-                    'has no control with that controlId — the source filter was not migrated'
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
     end
 
     violations

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/control_lint.rb
@@ -222,6 +222,11 @@ module ControlLint
       end
     end
 
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
     rows.each do |r|
       ann = scope_by_cid.delete(r[:control_id]) || {}
       ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
@@ -288,11 +293,29 @@ module ControlLint
     # failure. Only a control the builder recorded as EMITTED but that's missing
     # from the spec is a real bug the source filter was lost.
     surfaced_gap = %w[needs-wiring needs-materialization].freeze
-    scope_by_cid.each do |cid, c|
-      next if surfaced_gap.include?(c['status'].to_s)
-      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
-                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
-                    'has no control with that controlId — the source filter was not migrated'
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
     end
 
     violations

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
@@ -66,6 +66,36 @@ sig_silent = { 'sourceFilterSignals' => 1, 'controls' => [] }
 check(no_built.call(ControlLint.lint(SPEC, scope: sig_silent)),
       'signals>0 + zero controls + NO scope entries → DOES flag "no controls built" (Qlik silent-miss preserved)', fails)
 
+# --- wholesale controlId DRIFT (from-scratch rewrite) → ONE hint, not N misses -
+# Spec has controls, but NONE of their ids match the sidecar's (kebab auto-build
+# ids vs hand-authored ids) — the exact 14-violation field episode.
+SPEC_CTLS = { 'pages' => [{ 'name' => 'P1', 'elements' => [
+  { 'id' => 'tbl-1', 'kind' => 'table', 'name' => 'T',
+    'columns' => [{ 'id' => 'c-dim', 'name' => 'Region', 'formula' => '[Region]' }] },
+  { 'id' => 'el-c1', 'kind' => 'control', 'controlId' => 'RankFunction', 'name' => 'Rank',
+    'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] },
+  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedRealPersonID', 'name' => 'User',
+    'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] }
+] }] }.freeze
+drift_msg = ->(vs) { vs.any? { |v| v.include?('control-scope drift') } }
+drift_scope = { 'sourceFilterSignals' => 2, 'controls' => [
+  { 'controlId' => 'ctl-param-rank-function-dashboard-1', 'name' => 'Rank', 'status' => 'emitted' },
+  { 'controlId' => 'ctl-unified-realpersonid-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
+] }
+vd = ControlLint.lint(SPEC_CTLS, scope: drift_scope)
+check(drift_msg.call(vd), "wholesale controlId drift → ONE 'control-scope drift' hint (got #{vd.inspect})", fails)
+check(vd.count { |v| v.include?('missing control') }.zero?, 'drift case does NOT emit per-entry "missing control"', fails)
+
+# one sidecar id MATCHES a spec control + one genuine drop → per-entry, NOT drift.
+partial_scope = { 'sourceFilterSignals' => 2, 'controls' => [
+  { 'controlId' => 'RankFunction', 'name' => 'Rank', 'status' => 'emitted' },       # matches el-c1
+  { 'controlId' => 'ctl-dropped', 'name' => 'Gone', 'sourceName' => "param 'Gone'", 'status' => 'emitted' }
+] }
+vp = ControlLint.lint(SPEC_CTLS, scope: partial_scope)
+check(!drift_msg.call(vp), 'a matched control present → NOT treated as wholesale drift', fails)
+check(vp.any? { |v| v.include?('missing control') && v.include?('ctl-dropped') },
+      'genuine single dropped filter still flagged per-entry (not swallowed by drift)', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
@@ -74,13 +74,13 @@ SPEC_CTLS = { 'pages' => [{ 'name' => 'P1', 'elements' => [
     'columns' => [{ 'id' => 'c-dim', 'name' => 'Region', 'formula' => '[Region]' }] },
   { 'id' => 'el-c1', 'kind' => 'control', 'controlId' => 'RankFunction', 'name' => 'Rank',
     'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] },
-  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedRealPersonID', 'name' => 'User',
+  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedPersonkey', 'name' => 'User',
     'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] }
 ] }] }.freeze
 drift_msg = ->(vs) { vs.any? { |v| v.include?('control-scope drift') } }
 drift_scope = { 'sourceFilterSignals' => 2, 'controls' => [
   { 'controlId' => 'ctl-param-rank-function-dashboard-1', 'name' => 'Rank', 'status' => 'emitted' },
-  { 'controlId' => 'ctl-unified-realpersonid-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
+  { 'controlId' => 'ctl-unified-personkey-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
 ] }
 vd = ControlLint.lint(SPEC_CTLS, scope: drift_scope)
 check(drift_msg.call(vd), "wholesale controlId drift → ONE 'control-scope drift' hint (got #{vd.inspect})", fails)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
@@ -222,6 +222,11 @@ module ControlLint
       end
     end
 
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
     rows.each do |r|
       ann = scope_by_cid.delete(r[:control_id]) || {}
       ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
@@ -288,11 +293,29 @@ module ControlLint
     # failure. Only a control the builder recorded as EMITTED but that's missing
     # from the spec is a real bug the source filter was lost.
     surfaced_gap = %w[needs-wiring needs-materialization].freeze
-    scope_by_cid.each do |cid, c|
-      next if surfaced_gap.include?(c['status'].to_s)
-      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
-                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
-                    'has no control with that controlId — the source filter was not migrated'
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
     end
 
     violations

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/control_lint.rb
@@ -222,6 +222,11 @@ module ControlLint
       end
     end
 
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
     rows.each do |r|
       ann = scope_by_cid.delete(r[:control_id]) || {}
       ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
@@ -288,11 +293,29 @@ module ControlLint
     # failure. Only a control the builder recorded as EMITTED but that's missing
     # from the spec is a real bug the source filter was lost.
     surfaced_gap = %w[needs-wiring needs-materialization].freeze
-    scope_by_cid.each do |cid, c|
-      next if surfaced_gap.include?(c['status'].to_s)
-      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
-                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
-                    'has no control with that controlId — the source filter was not migrated'
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
     end
 
     violations

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -77,6 +77,16 @@ user-invocable: true
 >   finish line — a DM without its workbook is an incomplete migration. Do not report
 >   done, ask the user to build the workbook, or wait for a human at these STOPs;
 >   the only finish line is `verify-complete.rb` exit 0 (above).
+> - **At the exit-4 workbook handoff, PATCH the auto-built spec — do NOT rewrite it
+>   from scratch.** The orchestrator already wrote a full workbook spec to
+>   `<WORK>/wb-spec.json` before it stopped; it names the few field(s)/tile(s) it
+>   couldn't translate. Edit ONLY those, keeping every other element **and every
+>   controlId** exactly as the builder wrote them, then re-enter with `--reuse-dm
+>   <id> --wb-spec <WORK>/wb-spec.json`. A from-scratch rewrite throws away working
+>   tiles and drifts your controlIds away from `control-scope.json` — which then
+>   fails control-lint with a wholesale "control-scope drift" (the #1 way this
+>   handoff spirals into a multi-run loop). For a master-level calc, prefer
+>   `--master-col` over hand-editing the tile.
 > - **Credentials:** if you are **not** on Claude Code, the orchestrator will stop
 >   at step 0 telling you to run `ruby scripts/setup.rb` once — that is expected;
 >   do it (in a real terminal) rather than working around the auth error.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_lint.rb
@@ -222,6 +222,11 @@ module ControlLint
       end
     end
 
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
     rows.each do |r|
       ann = scope_by_cid.delete(r[:control_id]) || {}
       ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
@@ -288,11 +293,29 @@ module ControlLint
     # failure. Only a control the builder recorded as EMITTED but that's missing
     # from the spec is a real bug the source filter was lost.
     surfaced_gap = %w[needs-wiring needs-materialization].freeze
-    scope_by_cid.each do |cid, c|
-      next if surfaced_gap.include?(c['status'].to_s)
-      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
-                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
-                    'has no control with that controlId — the source filter was not migrated'
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
     end
 
     violations

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -3246,16 +3246,21 @@ rescue WorkbookBuildError => e
   puts "      Speed Category'), translate its Tableau formula (see calc-fields.json) to"
   puts '      a Sigma formula over master columns and re-run this exact command with:'
   puts "        --master-col '<Name>=<Sigma formula>'   (repeatable)"
-  puts '   2. Otherwise author the workbook spec yourself and RE-ENTER THE GATED SPINE —'
-  puts '      do NOT hand-POST it (that skips control lint + Phase-6 + the hard gate):'
-  puts "        • Author #{WORK}/wb-spec.json against the posted DM (dataModelId=#{dm_id});"
-  puts '          reference elements via "__DM_ID__" / "__DM_ELEMENT__:<Name>"'
-  puts '          (fact = "__DM_ELEMENT__:__FACT__"). See the sigma-workbooks skill.'
-  puts '        • Re-run this exact command adding (REUSE the posted DM — do not rebuild it):'
-  puts "            --reuse-dm #{dm_id} --wb-spec #{WORK}/wb-spec.json"
-  puts '          (attaches to the existing DM; the workbook re-POST is re-gated. This is the'
-  puts '          FAST PATH: the re-run skips discovery + the decisions checkpoint and goes'
-  puts '          straight to the workbook layer — see --help.)'
+  puts "   2. Otherwise: the workbook layer ALREADY auto-built a FULL spec at #{wb_spec_path}"
+  puts '      — PATCH THAT FILE IN PLACE. Do NOT rewrite it from scratch and do NOT hand-POST'
+  puts '      it (hand-POST skips control lint + Phase-6 + the hard gate):'
+  puts "        • Edit ONLY the #{n} failing field(s)/tile(s) named above in that file. Keep"
+  puts '          every other element, control, and controlId EXACTLY as the builder wrote them.'
+  puts '          A from-scratch rewrite throws away working tiles AND drifts your controlIds away'
+  puts '          from control-scope.json — which then fails control-lint with spurious "missing'
+  puts '          control" violations on re-entry (this is the #1 way this handoff spirals).'
+  puts '        • If a failing field is a MASTER-LEVEL calc, prefer option 1 (--master-col) over'
+  puts '          hand-editing the tile. Reference DM elements by their live ids already in the'
+  puts '          file (or "__DM_ID__" / "__DM_ELEMENT__:<Name>" if you add new ones).'
+  puts '        • Re-run this exact command to RE-GATE the patched spec (REUSE the posted DM):'
+  puts "            --reuse-dm #{dm_id} --wb-spec #{wb_spec_path}"
+  puts '          (attaches to the existing DM; the workbook re-POST is re-gated. FAST PATH: the'
+  puts '          re-run skips discovery + the decisions checkpoint — see --help.)'
   puts '   The data model is posted and ready to attach either way. A conversion is NOT done'
   puts '   until scripts/assert-phase6-ran.rb exits 0 — that hard gate applies on both paths.'
   puts '   Reminder: continue now. Shipping only the data model, or a scaled-down "demo" workbook,'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
@@ -66,6 +66,36 @@ sig_silent = { 'sourceFilterSignals' => 1, 'controls' => [] }
 check(no_built.call(ControlLint.lint(SPEC, scope: sig_silent)),
       'signals>0 + zero controls + NO scope entries → DOES flag "no controls built" (Qlik silent-miss preserved)', fails)
 
+# --- wholesale controlId DRIFT (from-scratch rewrite) → ONE hint, not N misses -
+# Spec has controls, but NONE of their ids match the sidecar's (kebab auto-build
+# ids vs hand-authored ids) — the exact 14-violation field episode.
+SPEC_CTLS = { 'pages' => [{ 'name' => 'P1', 'elements' => [
+  { 'id' => 'tbl-1', 'kind' => 'table', 'name' => 'T',
+    'columns' => [{ 'id' => 'c-dim', 'name' => 'Region', 'formula' => '[Region]' }] },
+  { 'id' => 'el-c1', 'kind' => 'control', 'controlId' => 'RankFunction', 'name' => 'Rank',
+    'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] },
+  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedRealPersonID', 'name' => 'User',
+    'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] }
+] }] }.freeze
+drift_msg = ->(vs) { vs.any? { |v| v.include?('control-scope drift') } }
+drift_scope = { 'sourceFilterSignals' => 2, 'controls' => [
+  { 'controlId' => 'ctl-param-rank-function-dashboard-1', 'name' => 'Rank', 'status' => 'emitted' },
+  { 'controlId' => 'ctl-unified-realpersonid-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
+] }
+vd = ControlLint.lint(SPEC_CTLS, scope: drift_scope)
+check(drift_msg.call(vd), "wholesale controlId drift → ONE 'control-scope drift' hint (got #{vd.inspect})", fails)
+check(vd.count { |v| v.include?('missing control') }.zero?, 'drift case does NOT emit per-entry "missing control"', fails)
+
+# one sidecar id MATCHES a spec control + one genuine drop → per-entry, NOT drift.
+partial_scope = { 'sourceFilterSignals' => 2, 'controls' => [
+  { 'controlId' => 'RankFunction', 'name' => 'Rank', 'status' => 'emitted' },       # matches el-c1
+  { 'controlId' => 'ctl-dropped', 'name' => 'Gone', 'sourceName' => "param 'Gone'", 'status' => 'emitted' }
+] }
+vp = ControlLint.lint(SPEC_CTLS, scope: partial_scope)
+check(!drift_msg.call(vp), 'a matched control present → NOT treated as wholesale drift', fails)
+check(vp.any? { |v| v.include?('missing control') && v.include?('ctl-dropped') },
+      'genuine single dropped filter still flagged per-entry (not swallowed by drift)', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
@@ -74,13 +74,13 @@ SPEC_CTLS = { 'pages' => [{ 'name' => 'P1', 'elements' => [
     'columns' => [{ 'id' => 'c-dim', 'name' => 'Region', 'formula' => '[Region]' }] },
   { 'id' => 'el-c1', 'kind' => 'control', 'controlId' => 'RankFunction', 'name' => 'Rank',
     'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] },
-  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedRealPersonID', 'name' => 'User',
+  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedPersonkey', 'name' => 'User',
     'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] }
 ] }] }.freeze
 drift_msg = ->(vs) { vs.any? { |v| v.include?('control-scope drift') } }
 drift_scope = { 'sourceFilterSignals' => 2, 'controls' => [
   { 'controlId' => 'ctl-param-rank-function-dashboard-1', 'name' => 'Rank', 'status' => 'emitted' },
-  { 'controlId' => 'ctl-unified-realpersonid-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
+  { 'controlId' => 'ctl-unified-personkey-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
 ] }
 vd = ControlLint.lint(SPEC_CTLS, scope: drift_scope)
 check(drift_msg.call(vd), "wholesale controlId drift → ONE 'control-scope drift' hint (got #{vd.inspect})", fails)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/control_lint.rb
@@ -222,6 +222,11 @@ module ControlLint
       end
     end
 
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
     rows.each do |r|
       ann = scope_by_cid.delete(r[:control_id]) || {}
       ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
@@ -288,11 +293,29 @@ module ControlLint
     # failure. Only a control the builder recorded as EMITTED but that's missing
     # from the spec is a real bug the source filter was lost.
     surfaced_gap = %w[needs-wiring needs-materialization].freeze
-    scope_by_cid.each do |cid, c|
-      next if surfaced_gap.include?(c['status'].to_s)
-      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
-                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
-                    'has no control with that controlId — the source filter was not migrated'
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
     end
 
     violations

--- a/shared/lib/control_lint.rb
+++ b/shared/lib/control_lint.rb
@@ -222,6 +222,11 @@ module ControlLint
       end
     end
 
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
     rows.each do |r|
       ann = scope_by_cid.delete(r[:control_id]) || {}
       ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
@@ -288,11 +293,29 @@ module ControlLint
     # failure. Only a control the builder recorded as EMITTED but that's missing
     # from the spec is a real bug the source filter was lost.
     surfaced_gap = %w[needs-wiring needs-materialization].freeze
-    scope_by_cid.each do |cid, c|
-      next if surfaced_gap.include?(c['status'].to_s)
-      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
-                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
-                    'has no control with that controlId — the source filter was not migrated'
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
     end
 
     violations

--- a/shared/scripts/test-control-lint.rb
+++ b/shared/scripts/test-control-lint.rb
@@ -66,6 +66,36 @@ sig_silent = { 'sourceFilterSignals' => 1, 'controls' => [] }
 check(no_built.call(ControlLint.lint(SPEC, scope: sig_silent)),
       'signals>0 + zero controls + NO scope entries → DOES flag "no controls built" (Qlik silent-miss preserved)', fails)
 
+# --- wholesale controlId DRIFT (from-scratch rewrite) → ONE hint, not N misses -
+# Spec has controls, but NONE of their ids match the sidecar's (kebab auto-build
+# ids vs hand-authored ids) — the exact 14-violation field episode.
+SPEC_CTLS = { 'pages' => [{ 'name' => 'P1', 'elements' => [
+  { 'id' => 'tbl-1', 'kind' => 'table', 'name' => 'T',
+    'columns' => [{ 'id' => 'c-dim', 'name' => 'Region', 'formula' => '[Region]' }] },
+  { 'id' => 'el-c1', 'kind' => 'control', 'controlId' => 'RankFunction', 'name' => 'Rank',
+    'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] },
+  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedRealPersonID', 'name' => 'User',
+    'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] }
+] }] }.freeze
+drift_msg = ->(vs) { vs.any? { |v| v.include?('control-scope drift') } }
+drift_scope = { 'sourceFilterSignals' => 2, 'controls' => [
+  { 'controlId' => 'ctl-param-rank-function-dashboard-1', 'name' => 'Rank', 'status' => 'emitted' },
+  { 'controlId' => 'ctl-unified-realpersonid-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
+] }
+vd = ControlLint.lint(SPEC_CTLS, scope: drift_scope)
+check(drift_msg.call(vd), "wholesale controlId drift → ONE 'control-scope drift' hint (got #{vd.inspect})", fails)
+check(vd.count { |v| v.include?('missing control') }.zero?, 'drift case does NOT emit per-entry "missing control"', fails)
+
+# one sidecar id MATCHES a spec control + one genuine drop → per-entry, NOT drift.
+partial_scope = { 'sourceFilterSignals' => 2, 'controls' => [
+  { 'controlId' => 'RankFunction', 'name' => 'Rank', 'status' => 'emitted' },       # matches el-c1
+  { 'controlId' => 'ctl-dropped', 'name' => 'Gone', 'sourceName' => "param 'Gone'", 'status' => 'emitted' }
+] }
+vp = ControlLint.lint(SPEC_CTLS, scope: partial_scope)
+check(!drift_msg.call(vp), 'a matched control present → NOT treated as wholesale drift', fails)
+check(vp.any? { |v| v.include?('missing control') && v.include?('ctl-dropped') },
+      'genuine single dropped filter still flagged per-entry (not swallowed by drift)', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'

--- a/shared/scripts/test-control-lint.rb
+++ b/shared/scripts/test-control-lint.rb
@@ -74,13 +74,13 @@ SPEC_CTLS = { 'pages' => [{ 'name' => 'P1', 'elements' => [
     'columns' => [{ 'id' => 'c-dim', 'name' => 'Region', 'formula' => '[Region]' }] },
   { 'id' => 'el-c1', 'kind' => 'control', 'controlId' => 'RankFunction', 'name' => 'Rank',
     'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] },
-  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedRealPersonID', 'name' => 'User',
+  { 'id' => 'el-c2', 'kind' => 'control', 'controlId' => 'UnifiedPersonkey', 'name' => 'User',
     'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'tbl-1' }, 'columnId' => 'c-dim' }] }
 ] }] }.freeze
 drift_msg = ->(vs) { vs.any? { |v| v.include?('control-scope drift') } }
 drift_scope = { 'sourceFilterSignals' => 2, 'controls' => [
   { 'controlId' => 'ctl-param-rank-function-dashboard-1', 'name' => 'Rank', 'status' => 'emitted' },
-  { 'controlId' => 'ctl-unified-realpersonid-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
+  { 'controlId' => 'ctl-unified-personkey-dashboard-1', 'name' => 'User', 'status' => 'emitted' }
 ] }
 vd = ControlLint.lint(SPEC_CTLS, scope: drift_scope)
 check(drift_msg.call(vd), "wholesale controlId drift → ONE 'control-scope drift' hint (got #{vd.inspect})", fails)


### PR DESCRIPTION
## Why (from a live session review)

The exit-4 workbook handoff spiraled into ~7 re-runs and ~2,800 transcript lines. The agent **discarded the orchestrator's already-built `wb-spec.json` and re-authored it from scratch**, which (a) reintroduced regressions the auto-build never had and (b) drifted its controlIds away from `control-scope.json` → **14 spurious "missing control" violations**. This fixes the *cause* (chosen over relaxing the gate).

## What

**1. Steer to PATCH** — `migrate-tableau.rb` exit-4 message + SKILL.md.
The full auto-built spec is already at `<WORK>/wb-spec.json` when exit 4 fires. Option 2 now says: **patch only the named failing field(s)/tile(s) in that file, keep every other element AND every controlId as the builder wrote them**, then re-enter with `--reuse-dm <id> --wb-spec <that file>`. Explicitly warns that a from-scratch rewrite drifts controlIds and trips control-lint. (Builds on #404.)

**2. Consolidate the drift signal** — `shared/lib/control_lint.rb`.
When **none** of the spec's controls match **any** `control-scope.json` id (the wholesale-drift signature of a rewrite), emit **one** actionable `control-scope drift` hint naming the cause + fix, instead of N false "missing control"s. **Still fails (exit non-zero)** — the gate is never weakened; a genuine single dropped filter (some ids still match) is still reported per-entry.

## Shared-file governance
Edited canonical `shared/lib/control_lint.rb` + `shared/scripts/test-control-lint.rb`, ran `tools/sync-shared.rb` to all consumers. `check-shared` + `check-agent-variants` clean.

## Test
`test-control-lint.rb` +4 cases: wholesale drift → one hint + zero per-entry misses; partial-match (one id still matches) → per-entry preserved (genuine drop not swallowed). All plugins' control-lint tests + repo lints green.

Completes the session-review trio with #407 (calc casing) and #408 (control-shape validator). Together they target the calc-accuracy sink and the exit-4/control loop that dominated the reviewed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)