### PR TITLE
tableau: hard-error CurrentDate()/STR() leaks + auto-rewrite to Today()/Text()

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/formula_normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/formula_normalize.rb
@@ -66,7 +66,25 @@ module FormulaNormalize
     | [A-Za-z_][A-Za-z0-9_]*(?=\s*\()     # candidate function name
   /x
 
+  # Tableau→Sigma NAME-ONLY function renames (deterministic, same signature):
+  # auto-rewrite the leaked spelling to its Sigma equivalent so the mechanical
+  # path never ships it as a type=error column. Only unambiguous 1:1 renames go
+  # here (STR→Text, CurrentDate→Today); anything needing arg reshaping stays a
+  # hard leak in sigma_functions.rb TABLEAU_LEAKS (validate-spec errors it).
+  # downcased Tableau spelling => canonical Sigma spelling.
+  TABLEAU_RENAMES = {
+    'str' => 'Text',
+    'currentdate' => 'Today',
+    'current_date' => 'Today',
+  }.freeze
+
   module_function
+
+  # Canonical Sigma spelling for a Tableau name-only leak (STR→Text,
+  # CurrentDate→Today); nil when +name+ isn't such a rename.
+  def tableau_rename_of(name)
+    TABLEAU_RENAMES[name.to_s.downcase]
+  end
 
   # True when +name+ exactly matches a known Sigma function spelling.
   def known_exact?(name)
@@ -92,6 +110,9 @@ module FormulaNormalize
       elsif (canon = case_variant_of(tok))
         rewrites << { from: tok, to: canon, path: path } if rewrites
         canon
+      elsif (sig = tableau_rename_of(tok))
+        rewrites << { from: tok, to: sig, path: path } if rewrites
+        sig # Tableau name-only leak (STR/CurrentDate) → Sigma equivalent
       else
         tok # exact known spelling, or not a known function — leave alone
       end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_functions.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_functions.rb
@@ -137,7 +137,15 @@ module SigmaFunctions
     /\bIsIn\s*\(/        => 'IsIn() is not a Sigma function — use Sigma In(value, list...) OR an or chain',
     /\bToText\s*\(/      => 'ToText() is not a Sigma function — use Sigma Text(...) instead',
     /\bToString\s*\(/    => 'ToString() is not a Sigma function — use Sigma Text(...) instead',
-    /\bToNumber\s*\(/    => 'ToNumber() is not a Sigma function — use Sigma Number(...) instead'
+    /\bToNumber\s*\(/    => 'ToNumber() is not a Sigma function — use Sigma Number(...) instead',
+    # Field-caught (2 live runs): agent-authored/converter-missed date+text
+    # function names that COMPILE-then-error on readback (type=error) and were
+    # only WARNed before (dismissible) — one run waved off the CurrentDate warning
+    # as a false "whitelist gap", cascading into 52 type=error columns. Promote
+    # to hard leaks with the exact Sigma equivalent (also auto-rewritten by
+    # FormulaNormalize::TABLEAU_RENAMES on the mechanical path).
+    /\bSTR\s*\(/i          => 'STR(x) → Sigma Text(x)',
+    /\bCURRENT_?DATE\s*\(/i => 'CurrentDate()/CURRENT_DATE() → Sigma Today() (or Now() for a timestamp)'
   }.freeze
 
   def self.tableau_leaks(formula)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-formula-normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-formula-normalize.rb
@@ -100,6 +100,19 @@ check(rewrites.map { |r| r[:from] }.sort == %w[DATETRUNC left round sum].sort,
 check(spec['pages'][0]['elements'][0]['columns'][2]['formula'] == 'Sum([Fact/Sales])',
       'already-clean formula byte-identical after normalize', fails)
 
+# Tableau name-only leaks (STR/CurrentDate) auto-rewrite to the Sigma spelling.
+tl = { 'pages' => [{ 'elements' => [{ 'columns' => [
+  { 'id' => 'c1', 'formula' => 'STR([Id]) & CurrentDate()' },
+  { 'id' => 'c2', 'formula' => 'CURRENT_DATE()' },
+  { 'id' => 'c3', 'formula' => 'Substring([Name], 1, 2)' } # contains "str" — must NOT change
+] }] }] }
+_, tlr = FormulaNormalize.normalize_spec!(tl)
+tf = ->(i) { tl['pages'][0]['elements'][0]['columns'][i]['formula'] }
+check(tf.call(0) == 'Text([Id]) & Today()', "STR→Text and CurrentDate→Today rewritten (got #{tf.call(0)})", fails)
+check(tf.call(1) == 'Today()', 'CURRENT_DATE→Today rewritten', fails)
+check(tf.call(2) == 'Substring([Name], 1, 2)', 'Substring (contains "str") left byte-identical', fails)
+check(tlr.any? { |r| r[:from] == 'STR' && r[:to] == 'Text' }, 'STR→Text recorded as a rewrite', fails)
+
 # idempotence: a second pass is a no-op
 _, second = FormulaNormalize.normalize_spec!(Marshal.load(Marshal.dump(spec)))
 check(second.empty?, 'normalize is idempotent (second pass rewrites nothing)', fails)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
@@ -162,8 +162,22 @@ check(out.include?('all names were null'), 'emits the null-name WARN (does not s
 out2, code2 = validate_dm_ctx(wb, { 'dataModelId' => 'dm-x', 'pages' => [{ 'id' => 'dp', 'elements' => [] }] })
 check(code2 != 0 && out2.include?('loaded 0 element names'), 'empty dm-context (0 elements) still aborts loudly', fails)
 
+puts 'Part H — Tableau date/text function leaks are HARD errors (non-dismissible), not WARNs'
+# Field-caught (2 runs): CurrentDate()/STR() fell to the dismissible WARN tier;
+# one run waved off the CurrentDate warning as a false "whitelist gap", shipping
+# 52 type=error columns. They must be tableau_leaks (exit 1) naming the fix.
+out, code = validate({ 'pages' => [{ 'elements' => [el('t1', 'T', formula: 'STR([Val])') ] }] })
+check(code == 1, "STR( → hard error, exit 1 (got #{code})", fails)
+check(out.include?('STR(x) → Sigma Text(x)'), 'STR error names the Sigma Text() fix', fails)
+out, code = validate({ 'pages' => [{ 'elements' => [el('t1', 'T', formula: 'CurrentDate()') ] }] })
+check(code == 1, "CurrentDate( → hard error, exit 1 (got #{code})", fails)
+check(out.include?('Today()'), 'CurrentDate error names the Sigma Today() fix', fails)
+# negative: Substring (contains "str") and a clean Today() must NOT be flagged
+out, _ = validate({ 'pages' => [{ 'elements' => [el('t1', 'T', formula: 'Substring([Val], 1, 2)') ] }] })
+check(!out.include?('→ Sigma Text'), 'Substring (contains "str") is NOT flagged as an STR leak', fails)
+
 if fails.empty?
-  puts 'OK — validate-spec ID-uniqueness + function-tier + envelope + null-name guards all pass'
+  puts 'OK — validate-spec ID-uniqueness + function-tier + tableau-leak + envelope + null-name guards all pass'
   exit 0
 else
   warn "FAIL — #{fails.size} check(s) failed:"


### PR DESCRIPTION
## Why (from TWO live sessions)

Agent-authored / converter-missed Sigma-invalid function names compiled clean then errored on readback (`type=error`). **`CurrentDate()`** (Sigma: `Today()`) and **`STR()`** (Sigma: `Text()`) fell to validate-spec's **dismissible** "unknown function" WARN tier — one run explicitly **waved off** the `CurrentDate` warning as a false "whitelist gap", cascading into **52 `type=error` columns** in a POSTED-but-broken workbook. This is item **[A]** of the session-2 backlog (top new item).

## What (both tableau-only libs — nothing shared)

1. **`sigma_functions.rb` `TABLEAU_LEAKS`** — add `STR( → Text(x)` and `CurrentDate()/CURRENT_DATE() → Today()`. Promotes them from dismissible WARN to **hard errors** (validate-spec exits 1) naming the exact Sigma fix — the same mechanism that already errors `IIF`/`COUNTD`/`IsIn`/`RANK_DENSE`.
2. **`formula_normalize.rb` `TABLEAU_RENAMES`** — auto-rewrite these deterministic name-only 1:1 leaks to the Sigma spelling on the mechanical path, so they never reach POST. Only same-signature renames go here; anything needing arg reshaping stays a hard leak.

## Guards
Word-boundary regex so `Substring` (contains "str") is **not** matched — negative test included.

## Test
`test-validate-spec-guards` +Part H (hard error + fix named + `Substring` negative); `test-formula-normalize` +4 cases (auto-rewrite + `Substring` immunity + rewrite recorded). All touched-area tests + repo lints green.

First of the session-2 backlog batch. Scope: name-only date/text leaks; the broader control-validation and db-schema items follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)