### PR TITLE
tableau: derive real db/schema from the .twb (stop defaulting to CSA.TJ) — #7a

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -87,6 +87,59 @@ module MechanicalSpecs
     formula.to_s =~ /\[[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\]/i
   end
 
+  # #7a — derive the REAL [db, schema] from a .twb's first LIVE-warehouse
+  # datasource table relation, so the DM/converter/land steps stop defaulting to
+  # the CSA.TJ placeholder (which 404s on catalog sync — field-caught on 2 live
+  # runs; the real db.schema was only recoverable by hand-reading the .twb).
+  # Returns [db, schema] or [nil, nil]. NEVER derives for embedded-file extracts
+  # (those legitimately land at CSA.TJ) or published/sqlproxy stubs. Self-
+  # contained REXML parse — does not require the un-guarded scan-workbook-gaps.rb.
+  EMBEDDED_CONN_CLASSES = %w[excel-direct textscan hyper ogrdirect csv msexcel].freeze
+  NONDATA_CONN_CLASSES  = %w[mapbox tableau-map wms wms-server].freeze
+  def derive_db_schema_from_twb(twb_path)
+    return [nil, nil] unless twb_path && File.exist?(twb_path)
+    require 'rexml/document'
+    xml = REXML::Document.new(File.read(twb_path, encoding: 'UTF-8'))
+    xml.elements.each('/workbook/datasources/datasource') do |ds|
+      name = ds.attributes['name'].to_s
+      next if name.empty? || name.start_with?('Parameters')
+      # the real (non-wrapper) connection for this datasource
+      conn = nil
+      ds.elements.each('.//connection') do |c|
+        cls = c.attributes['class'].to_s.downcase
+        next if cls.empty? || cls == 'federated'
+        conn ||= c
+      end
+      next unless conn
+      cls = conn.attributes['class'].to_s.downcase
+      # live warehouse only — skip embedded extracts, basemaps, and published stubs
+      next if EMBEDDED_CONN_CLASSES.include?(cls) || NONDATA_CONN_CLASSES.include?(cls) || cls == 'sqlproxy'
+      # first physical table relation (skip the [sqlproxy] published-source stub)
+      rel = nil
+      ds.elements.each('.//relation') do |r|
+        next unless r.attributes['type'].to_s == 'table' && r.attributes['table']
+        next if r.attributes['table'].to_s == '[sqlproxy]'
+        rel ||= r
+      end
+      next unless rel
+      parts = rel.attributes['table'].to_s.scan(/\[([^\]]+)\]/).flatten
+      parts = [rel.attributes['table'].to_s.gsub(/[\[\]]/, '')] if parts.empty?
+      conn_db  = conn.attributes['dbname']
+      conn_sch = conn.attributes['schema']
+      db, sch = case parts.length
+                when 3 then [parts[0], parts[1]]        # [DB].[SCHEMA].[TABLE]
+                when 2 then [conn_db, parts[0]]         # [SCHEMA].[TABLE] + conn dbname
+                else        [conn_db, conn_sch]         # [TABLE] + conn dbname/schema
+                end
+      db = nil if db.to_s.strip.empty?
+      sch = nil if sch.to_s.strip.empty?
+      return [db, sch] if db && sch
+    end
+    [nil, nil]
+  rescue StandardError
+    [nil, nil]
+  end
+
   # Map each Tableau internal field GUID -> its master display name. The
   # converter encodes the raw warehouse column name (a UUID-shaped Tableau field
   # id) as the suffix of the column's sigma inode id ("inode-<hash>/<RAW_UUID>"),

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1582,6 +1582,24 @@ if mechanical
   # FALLBACK: extract-custom-sql.rb (Metadata GraphQL) for Custom SQL. Then
   # hydrate-custom-sql.rb splices the real relation (table or SQL) so the
   # converter's normal path builds the model. No-ops for non-sqlproxy workbooks.
+  # ── #7a: propagate the REAL db/schema from the .twb ─────────────────────────
+  # A live-warehouse workbook whose db.schema the operator did NOT pin defaults to
+  # the CSA.TJ placeholder, which 404s on catalog sync (field-caught on 2 live
+  # runs — the real db.schema was only recoverable by hand-reading the .twb).
+  # Derive it from the .twb's first live-warehouse datasource so all four
+  # consumers (land/hydrate/converter/db=) inherit the real path. Embedded
+  # extracts (which legitimately land at CSA.TJ) and sqlproxy stubs are excluded
+  # inside derive_db_schema_from_twb; --db/--schema still win.
+  if have_twb && opts[:db].nil? && opts[:schema].nil? && !HydrateCustomSql.twb_has_sqlproxy?(twb)
+    d_db, d_sch = MechanicalSpecs.derive_db_schema_from_twb(twb)
+    if d_db && d_sch
+      opts[:db] = d_db
+      opts[:schema] = d_sch
+      line "db/schema: derived #{d_db}.#{d_sch} from the .twb's live-warehouse datasource " \
+           '(instead of the CSA.TJ placeholder) — pass --db/--schema to override'
+    end
+  end
+
   # ── Embedded-extract (file-based) source routing ────────────────────────────
   # A workbook whose datasources are ALL embedded file federations (excel-direct /
   # textscan / hyper / ogrdirect / csv / msexcel) has no live warehouse for Sigma

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-db-schema-propagation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-db-schema-propagation.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Offline test for #7a — MechanicalSpecs.derive_db_schema_from_twb.
+#
+# Field-caught on 2 live runs: a live-warehouse workbook whose db.schema the
+# operator did not pin defaulted to the CSA.TJ placeholder, which 404'd on every
+# Sigma catalog sync; the real db.schema was only recoverable by hand-reading the
+# .twb. This derives it so all downstream consumers inherit the real path — while
+# NEVER touching embedded-extract (CSA.TJ is the correct landing target there) or
+# sqlproxy (hydrate resolves those) sources.
+#
+# Usage: ruby scripts/test-db-schema-propagation.rb
+require 'tempfile'
+require_relative 'mechanical-specs'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+def derive(xml)
+  t = Tempfile.new(['t7a-', '.twb'])
+  t.write(xml)
+  t.close
+  r = MechanicalSpecs.derive_db_schema_from_twb(t.path)
+  t.unlink
+  r
+end
+
+def twb(conn_attrs, table)
+  <<~XML
+    <?xml version='1.0'?>
+    <workbook>
+      <datasources>
+        <datasource name='DS1'>
+          <connection class='federated'>
+            <named-connections>
+              <named-connection>
+                <connection #{conn_attrs}/>
+              </named-connection>
+            </named-connections>
+            <relation type='table' table='#{table}'/>
+          </connection>
+        </datasource>
+      </datasources>
+    </workbook>
+  XML
+end
+
+# Case A — 2-part table + conn dbname/schema
+db, sch = derive(twb("class='snowflake' dbname='REALDB' schema='REALSCH'", '[REALSCH].[ORDER_FACT]'))
+check([db, sch] == %w[REALDB REALSCH], "A: 2-part table + conn dbname → [REALDB, REALSCH] (got [#{db}, #{sch}])", fails)
+
+# Case B — full 3-part table path wins over conn attrs
+db, sch = derive(twb("class='snowflake' dbname='IGNORED' schema='IGNORED'", '[REALDB].[REALSCH].[ORDER_FACT]'))
+check([db, sch] == %w[REALDB REALSCH], "B: 3-part table → [REALDB, REALSCH] (got [#{db}, #{sch}])", fails)
+
+# Case C — embedded extract → NEVER derive (CSA.TJ landing is correct)
+db, sch = derive(twb("class='hyper'", '[Extract].[ORDER_FACT]'))
+check([db, sch] == [nil, nil], "C: embedded (hyper) → [nil, nil] so CSA.TJ default is preserved (got [#{db}, #{sch}])", fails)
+
+# Case D — published/sqlproxy stub → NEVER derive (hydrate resolves it)
+db, sch = derive(twb("class='sqlproxy'", '[sqlproxy]'))
+check([db, sch] == [nil, nil], "D: sqlproxy stub → [nil, nil] (got [#{db}, #{sch}])", fails)
+
+# Case E — 1-part table falls back to conn dbname/schema
+db, sch = derive(twb("class='snowflake' dbname='REALDB' schema='REALSCH'", '[ORDER_FACT]'))
+check([db, sch] == %w[REALDB REALSCH], "E: 1-part table → conn dbname/schema (got [#{db}, #{sch}])", fails)
+
+# Case F — live warehouse but no resolvable db/schema → [nil, nil] (no fabrication)
+db, sch = derive(twb("class='snowflake'", '[ORDER_FACT]'))
+check([db, sch] == [nil, nil], "F: no db/schema anywhere → [nil, nil], never fabricated (got [#{db}, #{sch}])", fails)
+
+# Case G — missing file → [nil, nil], no crash
+check(MechanicalSpecs.derive_db_schema_from_twb('/nonexistent/x.twb') == [nil, nil], 'G: missing file → [nil, nil]', fails)
+
+puts
+if fails.empty?
+  puts 'OK — db/schema propagation derives live-warehouse paths, skips embedded/sqlproxy, never fabricates'
+  exit 0
+else
+  warn "FAIL — #{fails.size} check(s):"
+  fails.each { |f| warn "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## Why (from TWO live sessions)

A live-warehouse workbook whose db.schema the operator didn't pin defaulted to the **CSA.TJ placeholder**, which **404'd on every Sigma catalog sync**. The real db.schema was only recoverable by the agent hand-reading the `.twb`, forcing a manual `--db/--schema` re-run. Backlog **#7a**.

## What (orchestrator-only, no shared files, no converter edit)

- **`MechanicalSpecs.derive_db_schema_from_twb(twb)`** — self-contained REXML parse returning `[db, schema]` from the first **live-warehouse** datasource's table relation (3-part path wins; else conn `dbname` + 2-part schema; else conn `dbname`/`schema`). **Never** derives for embedded-file extracts (CSA.TJ is the correct landing target there), basemaps, or sqlproxy stubs (hydrate resolves those). **Never fabricates** — returns `[nil,nil]` when unresolved. Self-contained so it doesn't `require` the un-main-guarded `scan-workbook-gaps.rb`.
- **`migrate-tableau.rb`** — before the extract/hydrate/converter consumers, when the user did NOT pass `--db/--schema` and the source isn't sqlproxy, set `opts[:db]/opts[:schema]` from the derivation. All four consumers inherit it; `--db/--schema` still win; embedded still lands at CSA.TJ.

## Test
`test-db-schema-propagation.rb`: 7 cases (2-/3-/1-part paths, embedded skip, sqlproxy skip, no-fabrication, missing file). Regressions green (multi-ds, extract-table-mapping, converter-fixtures); `check-shared` clean.

Corroborated on both reviewed DraftKings-class runs. Pairs with #411 (function leaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)