### PR TITLE
shared/preflight: flag unbounded number-range controls (C7) — [B] subset

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
@@ -212,6 +212,13 @@ rs['controlType'] = 'range-slider'; rs.delete('selectionMode'); rs.delete('value
 check(rule(lint(s), 'C7').any? { |e| e.include?('low`/`high') }, 'C7: range-slider without low/high → violation', fails)
 rs['low'] = 0; rs['high'] = 100
 check(rule(lint(s), 'C7').empty?, 'C7: range-slider with low/high → clean', fails)
+s = valid_spec
+nr = s['pages'][0]['elements'][4]
+nr['controlType'] = 'number-range'; nr.delete('selectionMode'); nr.delete('value')
+check(rule(lint(s), 'C7').any? { |e| e.include?('number-range') },
+      'C7: number-range with neither min nor max → violation', fails)
+nr['min'] = 0; nr['max'] = 100
+check(rule(lint(s), 'C7').empty?, 'C7: number-range with min/max → clean', fails)
 
 # ---- C8: includeNulls placement --------------------------------------------
 s = valid_spec

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/shared/lib/preflight_lint.rb
+++ b/shared/lib/preflight_lint.rb
@@ -33,7 +33,8 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       flat `min`/`max` on number-range (unbounded → 400).
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -191,6 +192,13 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: an unbounded number-range (both min AND max null/absent) 400s the
+          # spec — the builder null-fills mode:between bounds instead of omitting
+          # them (field-caught: an opaque union-type 400 mislabeled "modal"). Set
+          # flat min/max, or drop the control if the range is genuinely open.
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil?
+            errs << "C7 control '#{name}': controlType \"number-range\" has neither `min` nor `max` — an unbounded number-range 400s (null-filled between-bounds). Set flat min/max, or drop the control."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)


### PR DESCRIPTION
## Why (Opus 4.8 run)
The builder emitted `number-range` controls with `min:null/max:null` that passed offline lint but **400'd at POST** with an opaque union-type error mislabeled "expected modal" — a control-shape class that slipped past the C6/C7/C8 validator from #408.

## What
Extend **C7** (`shared/lib/preflight_lint.rb`): a `number-range` control with neither `min` nor `max` is an unbounded range that 400s — flag pre-POST with the fix. Mirrors the range-slider `low`/`high` rule. Synced canonical → 9 plugins.

## Test
`test-preflight-lint` +2 (unbounded → violation; bounded → clean). `check-shared` + all preflight tests green.

## Scope note (honest)
The other two classes need info not in the pre-POST spec, so they are deliberately **not guessed** here: list value-source from a calc/boolean column (needs DM column-type), control filter targeting a hidden/integer-coded master column (needs element-visibility + type; overlaps control_lint), and the "let parity proceed past unwired controls" waiver (a policy call). Flagged for a design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)