### PR TITLE
tableau-to-sigma: field-ops bundle — stale-checkout hard gate, extract re-fetch skip, loop stop-at-2, secrets hygiene

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/redact.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/redact.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/redact.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/redact.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/redact.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/redact.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/redact.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/operating-contract.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/operating-contract.md
@@ -87,6 +87,13 @@
   surfaced by the gates, and it MUST be named in the migration report. Rewriting
   `source-anchors.json` to the live actuals remains tampering on every source type.
 
+## Credential hygiene
+- **NEVER echo credential values (tokens, secrets, PATs) into output, commands, or
+  files — reference env var names only. When displaying config, mask all but the
+  last 4 characters.** `scripts/lib/redact.rb` (`Redact.mask` / `Redact.scrub`) is
+  the one sanctioned masking path — a secret pasted into a log, a command line, or
+  a report file is a leak even when the run itself is healthy.
+
 ## Tooling discipline (don't burn the clock)
 - **Run `--help` before any flag you have not used this session.** Inventing a flag
   (`--force-new-workbook`, `--dm-spec`, `--workdir` on the wrong script) costs a

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/offramp.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/offramp.rb
@@ -17,6 +17,8 @@
 #   workbook-handoff     workbook build raised (exit 4) — untranslatable fields handed off
 #   degraded-fastpath    --yes fast path proceeded with missing discovery artifacts
 #   gate-waived          an assert-phase6-ran gate waived (mirrored from waivers.json)
+#   stale-skill-waived   SIGMA_ALLOW_STALE used — run proceeded on a stale checkout
+#   loop-stop            the same failure signature recurred a 3rd time — hard STOP
 #
 # Never fatal: bookkeeping must not break a run.
 
@@ -43,5 +45,40 @@ module Offramp
     File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
   rescue StandardError
     []
+  end
+
+  # ── Same-failure loop breaker (stop-at-2) ──────────────────────────────────
+  # Append SIGNATURE (caller-supplied; recommended: script name + exit code +
+  # SHA1 of the first error line) to <WORK>/loop-log.jsonl and report how many
+  # times it has now occurred: :first, :second, or :stop (third+ — the caller
+  # must hard-STOP and hand control to the operator instead of grinding the
+  # same failure; verify-complete.rb refuses completion over a 3+-count
+  # signature). Distinct signatures never trip it. Never fatal.
+  def loop_check(work, signature:)
+    return :first unless work && Dir.exist?(work.to_s)
+    rec = { 'signature' => signature.to_s,
+            'at' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+    File.open(File.join(work, 'loop-log.jsonl'), 'a') { |f| f.puts(JSON.generate(rec)) }
+    case loop_trail(work).count { |r| r['signature'] == signature.to_s }
+    when 0, 1 then :first
+    when 2    then :second
+    else           :stop
+    end
+  rescue StandardError
+    :first # bookkeeping must never break a run
+  end
+
+  # loop-log entries (oldest first). Empty on any error.
+  def loop_trail(work)
+    path = File.join(work.to_s, 'loop-log.jsonl')
+    return [] unless File.exist?(path)
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+
+  # { signature => occurrence count } over the loop-log.
+  def loop_counts(work)
+    loop_trail(work).each_with_object(Hash.new(0)) { |r, h| h[r['signature']] += 1 }
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/redact.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -124,6 +124,7 @@ require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub saf
 require 'date'
 require 'time'
 require 'set'
+require 'digest' # loop-breaker failure signatures (Offramp.loop_check)
 require_relative 'lib/scout_gate'
 require_relative 'lib/dashboard_read'
 require_relative 'lib/recipe_multimetric'
@@ -392,6 +393,43 @@ unless system(*_dg_cmd)
                 'bash scripts/doctor.sh'
   abort "FATAL: environment gate failed — run the doctor first (#{_doc_hint}; see remediation above), " \
         'or re-run with --skip-doctor-gate "<reason>".'
+end
+
+# 🚧 Step-0 STALENESS HARD GATE (escalates the doctor's SHA/build-age WARN).
+# The doctor stamps {behind_count, days_since_commit} into doctor.json; a
+# checkout behind upstream (or >14 days old) silently re-hits bugs fixed weeks
+# earlier, so the WARN is now enforced at run start. Waive with
+# SIGMA_ALLOW_STALE="<reason>" (recorded as an off-ramp). Best-effort read:
+# a missing/unreadable doctor.json is the doctor gate's problem, not this one's.
+begin
+  _st_path = [File.join(WORK, 'doctor.json'),
+              File.expand_path('~/.sigma-migration/doctor.json')].find { |p| File.exist?(p) }
+  _st = _st_path ? JSON.parse(File.read(_st_path, encoding: 'bom|utf-8')) : {}
+  _st_bc = _st['behind_count']
+  _st_days = _st['days_since_commit']
+  _stale_why = if _st_bc.is_a?(Integer) && _st_bc.positive?
+                 "#{_st_bc} commit(s) behind upstream"
+               elsif _st_days.is_a?(Integer) && _st_days > 14
+                 "build is #{_st_days} days old (>14)"
+               end
+  if _stale_why
+    _stale_reason = ENV['SIGMA_ALLOW_STALE']
+    if _stale_reason && !_stale_reason.to_s.empty?
+      warn "WARN: STALE skill checkout (#{_stale_why}) — proceeding on SIGMA_ALLOW_STALE=#{_stale_reason}."
+      Offramp.log(WORK, kind: 'stale-skill-waived', reason: _stale_reason.to_s, detail: _stale_why)
+    else
+      abort <<~MSG
+        FATAL: stale skill checkout — #{_stale_why} (doctor report: #{_st_path}).
+        A stale build silently re-runs bugs already fixed upstream. Update it first:
+            git pull            # in the skill/marketplace clone
+        …or reinstall the plugin, re-run the doctor (bash scripts/doctor.sh), then retry.
+        (Deliberately running a stale build? SIGMA_ALLOW_STALE="<reason>" waives this
+        gate — the waiver is recorded and must be named in your report.)
+      MSG
+    end
+  end
+rescue JSON::ParserError
+  # unreadable doctor.json was already handled (or waived) by the doctor gate
 end
 
 # 🚧 Step-0 CREDENTIAL GATE (fail-closed). The doctor treats missing creds as a
@@ -1136,6 +1174,26 @@ if opts[:finalize]
   puts "STATUS      : #{all_green ? 'GREEN' : 'NOT GREEN'}"
   puts '======================================='
   phase_summary
+  # ── Same-failure loop breaker (stop-at-2) ──────────────────────────────────
+  # A NOT-GREEN finalize records its gate signature; re-running --finalize into
+  # the SAME failing exit codes a third time is grinding, not converging —
+  # hard-STOP and hand control to the operator instead of looping toward a
+  # forced green (refs/operating-contract.md: "don't spin, don't fake").
+  unless all_green
+    _fsig = "migrate-tableau:finalize:phase6=#{p6st.exitstatus}:gate=#{gst.exitstatus}"
+    if Offramp.loop_check(WORK, signature: _fsig) == :stop
+      _prior = Offramp.loop_trail(WORK).select { |r| r['signature'] == _fsig }[0..-2]
+      puts
+      puts '==================== LOOP STOP (operator action required) ==================='
+      puts "This EXACT finalize failure (#{_fsig}) has now occurred #{_prior.size + 1} times:"
+      _prior.each { |r| puts "  • #{r['at']}  #{_fsig}" }
+      puts "  • (now)                #{_fsig}"
+      puts 'Re-running the same --finalize will not converge. STOPPING — hand this to the'
+      puts "operator with the gate output above and the loop log (#{File.join(WORK, 'loop-log.jsonl')})."
+      puts '============================================================================='
+      Offramp.log(WORK, kind: 'loop-stop', reason: _fsig)
+    end
+  end
   exit(all_green ? 0 : 3)
 end
 
@@ -1389,6 +1447,11 @@ else
   end
   disc = ['ruby', File.join(HERE, 'tableau-discover.rb'), '--out', WORK]
   disc += opts[:wb_id] ? ['--workbook-id', opts[:wb_id]] : ['--workbook-name', opts[:wb_name]]
+  # Live repoint (--skip-extract-landing): the operator owns the DM table paths,
+  # so the frozen extract bytes are never consumed on this route — skip
+  # discovery's heavy includeExtract=true re-download instead of paying for an
+  # unused multi-GB payload.
+  disc << '--no-extract-refetch' if opts[:skip_extract_landing]
   disc_sh = disc.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')
   scan_sh = ['ruby', File.join(HERE, 'scan-workbook-gaps.rb'), twb]
             .map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')
@@ -3542,6 +3605,30 @@ rescue WorkbookBuildError => e
   end
   names = failed.empty? ? 'one or more fields' : failed.join(', ')
   n = failed.empty? ? 'some' : failed.size.to_s
+  # ── Same-failure loop breaker (stop-at-2) ──────────────────────────────────
+  # Every exit-4 handoff records a failure signature (script + exit code + SHA1
+  # of the first error line). A re-run that dies on the SAME signature a third
+  # time is grinding, not converging — hard-STOP and hand control to the
+  # operator (refs/operating-contract.md: "don't spin, don't fake").
+  _err_line = e.captured_output.to_s.lines.map(&:strip).reject(&:empty?).first ||
+              e.message.lines.first.to_s.strip
+  _sig = "migrate-tableau:exit4:#{Digest::SHA1.hexdigest(_err_line.to_s)[0, 12]}"
+  if Offramp.loop_check(WORK, signature: _sig) == :stop
+    _prior = Offramp.loop_trail(WORK).select { |r| r['signature'] == _sig }[0..-2]
+    puts
+    puts '==================== LOOP STOP (operator action required) ==================='
+    puts "The SAME workbook-build failure has now occurred #{_prior.size + 1} times:"
+    _prior.each { |r| puts "  • #{r['at']}  #{_err_line.to_s[0, 160]}" }
+    puts "  • (now)                #{_err_line.to_s[0, 160]}"
+    puts 'Re-running the same command will not converge. STOPPING — hand this to the'
+    puts 'operator with the error above, the salvage inventory (if written), and the'
+    puts "loop log (#{File.join(WORK, 'loop-log.jsonl')}). Signature: #{_sig}"
+    puts '============================================================================='
+    Offramp.log(WORK, kind: 'loop-stop', reason: _sig, detail: _err_line.to_s[0, 200])
+    mark('phase4-workbook')
+    phase_summary
+    exit 4
+  end
   puts
   puts '── EXIT 4 — WORKBOOK HANDOFF (this is NOT the finish line, and NOT a handoff to a human).'
   puts '   This STOP is an instruction to YOU, the agent: the data model is posted; now build the'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
@@ -80,6 +80,8 @@ OptionParser.new do |o|
   o.on('--skip-images')           { opts[:fetch_view_images] = 'none' }
   o.on('--all-view-images')       { opts[:fetch_view_images] = 'all' }
   o.on('--skip-content')          { opts[:skip_content] = true }
+  o.on('--no-extract-refetch', 'skip the includeExtract=true re-download when extract markers are found — ' \
+                               'for routes that never consume the frozen extract bytes (e.g. a live repoint)') { opts[:no_extract_refetch] = true }
   o.on('--pool N', Integer, 'Fetch-pool size (default 5 — measured sweet spot)') { |v| opts[:pool] = v }
 end.parse!
 
@@ -114,7 +116,9 @@ end
 RETRYABLE = /\b(429|408|400|50[234])\b|Too Many Requests|timed? ?out|Timeout/i
 
 # Run one named fetch task with timing + backoff-retry. Returns task result or nil.
-def run_task(name)
+# max_attempts caps the backoff-retry budget (default 4; the heavy extract
+# re-download uses 2 — its 120s×4 worst case dominated failed discoveries).
+def run_task(name, max_attempts: 4)
   t0 = Time.now.to_f
   attempts = 0
   begin
@@ -127,12 +131,12 @@ def run_task(name)
     result
   rescue Tableau::Error, Timeout::Error, Errno::ETIMEDOUT, Net::ReadTimeout, Net::OpenTimeout => e
     msg = e.message.lines.first&.chomp || e.class.name
-    if attempts < 4 && msg =~ RETRYABLE
+    if attempts < max_attempts && msg =~ RETRYABLE
       delay = (1.5 * (2**(attempts - 1))) + rand * 0.5
       log "#{name}: retryable (#{msg[0, 80]}) — backoff #{delay.round(1)}s (attempt #{attempts})"
       sleep delay
       retry
-    elsif attempts < 3 && msg =~ /\b401\b/
+    elsif attempts < [max_attempts, 3].min && msg =~ /\b401\b/
       # lib already retried 401 once with a refreshed token; one more explicit
       # re-mint covers session invalidation racing across threads.
       log "#{name}: 401 escaped lib retry — re-minting token (attempt #{attempts})"
@@ -255,15 +259,21 @@ unless opts[:skip_content]
       # the payload; non-extract workbooks never pay the big download.
       if twb_xml && !had_hypers &&
          (twb_xml.include?('<extract') || twb_xml =~ /class='(?:hyper|textscan)'/)
-        log 'embedded extract detected but no .hyper payload in the download — re-fetching WITH includeExtract=true'
-        with_extract = run_task('twb-download-extract') { Tableau.download_workbook_content(wb['id'], include_extract: true) }
-        if with_extract && with_extract.bytesize > bytes.bytesize
-          twb_xml2, had2 = persist.call(with_extract)
-          twb_xml = twb_xml2 || twb_xml
-          log had2 ? 'extract payload landed in workbook-content.twbx' :
-                     'WARN: re-fetch still contained no .hyper — land-extracts.py will need a manual includeExtract=true download'
+        if opts[:no_extract_refetch]
+          # One clear line, then move on: this route never consumes the frozen
+          # extract bytes, so the heavy includeExtract=true download is waste.
+          log 'embedded extract detected — extract re-fetch SKIPPED (--no-extract-refetch: this route needs no extract bytes)'
         else
-          log 'WARN: includeExtract=true re-fetch returned nothing larger — proceeding with the thin .twb'
+          log 'embedded extract detected but no .hyper payload in the download — re-fetching WITH includeExtract=true'
+          with_extract = run_task('twb-download-extract', max_attempts: 2) { Tableau.download_workbook_content(wb['id'], include_extract: true) }
+          if with_extract && with_extract.bytesize > bytes.bytesize
+            twb_xml2, had2 = persist.call(with_extract)
+            twb_xml = twb_xml2 || twb_xml
+            log had2 ? 'extract payload landed in workbook-content.twbx' :
+                       'WARN: re-fetch still contained no .hyper — land-extracts.py will need a manual includeExtract=true download'
+          else
+            log 'WARN: includeExtract=true re-fetch returned nothing larger — proceeding with the thin .twb'
+          end
         end
       end
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-discover-extract-skip.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-discover-extract-skip.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for discovery's conditional extract re-fetch (PR-2 field-ops).
+#
+# tableau-discover.rb re-downloads workbook content WITH includeExtract=true
+# when extract markers are present but the thin download carried no .hyper —
+# a 120s-timeout task that used to burn up to 4 attempts even on routes that
+# never consume the extract bytes. Now: --no-extract-refetch skips it with one
+# clear line (migrate-tableau.rb passes it on the --skip-extract-landing live
+# repoint), and the re-fetch task is capped at 2 attempts. Proven with a
+# STUBBED Tableau lib (the script + its real zip/fcp libs are copied to a
+# tmpdir whose lib/ carries a stub tableau_rest.rb, so no network is possible):
+# the stub serves a thin .twb with extract markers and fails the extract
+# re-fetch retryably, logging every fetch. Offline.
+#
+# Usage: ruby scripts/test-discover-extract-skip.rb
+
+require 'json'
+require 'tmpdir'
+require 'fileutils'
+require 'rbconfig'
+
+DIR = __dir__
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+STUB = <<~'RUBY'
+  # Stub Tableau REST: no network, every fetch appended to STUB_FETCH_LOG.
+  # Classic method defs on purpose — the skills target Ruby 2.6.
+  require 'json'
+  module Tableau
+    class Error < StandardError; end
+    def self.rec(line)
+      File.open(ENV.fetch('STUB_FETCH_LOG'), 'a') { |f| f.puts(line) }
+    end
+    def self.get_workbook(id)
+      { 'id' => id, 'views' => { 'view' => [] } }
+    end
+    def self.find_workbook_by_name(_n)
+      { 'id' => 'wb-stub' }
+    end
+    def self.capabilities
+      {}
+    end
+    def self.download_workbook_content(_id, include_extract: false)
+      rec("download include_extract=#{include_extract}")
+      # thin .twb WITH extract markers => triggers the re-fetch decision;
+      # the extract re-fetch itself fails RETRYABLY (502) every time.
+      raise Error, '502 stub: extract payload unavailable' if include_extract
+      "<workbook><datasources><datasource caption=''><extract count='1'/></datasource></datasources></workbook>"
+    end
+    def self.view_image(_id, resolution: nil); nil; end
+    def self.view_data(_id); nil; end
+    def self.read_metadata(_l); nil; end
+    def self.graphql_datasource_fields(_l); nil; end
+    def self.find_datasource_by_name(_n); nil; end
+    def self.refresh_token!; nil; end
+  end
+RUBY
+
+def run_discover(script, out_dir, log_path, *extra)
+  env = { 'STUB_FETCH_LOG' => log_path }
+  cmd = [RbConfig.ruby, script, '--workbook-id', 'wb-stub', '--out', out_dir, '--skip-images', *extra]
+  out = IO.popen(env, cmd, err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+Dir.mktmpdir do |tmp|
+  # Copy the script + the real libs it needs; the stub REPLACES tableau_rest.rb
+  # (tableau-discover.rb resolves its lib/ relative to its own location).
+  FileUtils.mkdir_p(File.join(tmp, 'lib'))
+  script = File.join(tmp, 'tableau-discover.rb')
+  FileUtils.cp(File.join(DIR, 'tableau-discover.rb'), script)
+  %w[zip_extract.rb fcp_normalize.rb].each do |l|
+    FileUtils.cp(File.join(DIR, 'lib', l), File.join(tmp, 'lib', l))
+  end
+  File.write(File.join(tmp, 'lib', 'tableau_rest.rb'), STUB)
+
+  # (1) default + extract route: re-fetch attempted, capped at 2 attempts.
+  log1 = File.join(tmp, 'fetch1.log')
+  File.write(log1, '')
+  code, out = run_discover(script, File.join(tmp, 'out1'), log1)
+  fetches = File.readlines(log1).map(&:strip)
+  check(code == 0, "default run completes (exit #{code})", fails)
+  check(fetches.count('download include_extract=false') == 1, 'thin download fetched once', fails)
+  n_extract = fetches.count('download include_extract=true')
+  check(n_extract == 2, "extract re-fetch attempted and CAPPED at 2 attempts (got #{n_extract})", fails)
+  check(out.include?('re-fetching WITH includeExtract=true'), 'default route announces the re-fetch', fails)
+
+  # (2) --no-extract-refetch: NO extract fetch, one clear skip line.
+  log2 = File.join(tmp, 'fetch2.log')
+  File.write(log2, '')
+  code, out = run_discover(script, File.join(tmp, 'out2'), log2, '--no-extract-refetch')
+  fetches = File.readlines(log2).map(&:strip)
+  check(code == 0, "--no-extract-refetch run completes (exit #{code})", fails)
+  check(fetches.count('download include_extract=true').zero?, 'no extract fetch under --no-extract-refetch', fails)
+  skip_lines = out.lines.grep(/extract re-fetch SKIPPED/)
+  check(skip_lines.size == 1, "exactly one clear skip line logged (got #{skip_lines.size})", fails)
+  check(out.include?('--no-extract-refetch'), 'skip line names the flag', fails)
+
+  # (3) migrate-tableau.rb wires the flag on the live-repoint route.
+  wiring = File.read(File.join(DIR, 'migrate-tableau.rb'))
+  check(wiring.include?("'--no-extract-refetch' if opts[:skip_extract_landing]"),
+        'orchestrator passes --no-extract-refetch on --skip-extract-landing (live repoint)', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-offramp-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-offramp-loop.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the same-failure loop breaker (stop-at-2, PR-2 field-ops).
+#
+# Offramp.loop_check appends a caller-supplied failure signature to
+# <WORK>/loop-log.jsonl and reports :first / :second / :stop (third+): the
+# orchestrator hard-STOPs at :stop instead of grinding the same gate failure,
+# and verify-complete.rb refuses completion (exit 5) over any signature
+# recorded 3+ times. Distinct signatures never trip it. Offline.
+#
+# Usage: ruby scripts/test-offramp-loop.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+require_relative 'lib/offramp'
+VC = File.join(DIR, 'verify-complete.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+Dir.mktmpdir do |wd|
+  sig_a = 'migrate-tableau:exit4:aaaa11112222'
+  sig_b = 'migrate-tableau:finalize:phase6=2:gate=7'
+
+  # occurrence ladder: :first -> :second -> :stop (and stays :stop)
+  check(Offramp.loop_check(wd, signature: sig_a) == :first,  'first occurrence => :first', fails)
+  check(Offramp.loop_check(wd, signature: sig_a) == :second, 'same signature twice => :second', fails)
+  check(Offramp.loop_check(wd, signature: sig_a) == :stop,   'third occurrence => :stop', fails)
+  check(Offramp.loop_check(wd, signature: sig_a) == :stop,   'fourth occurrence stays :stop', fails)
+
+  # a DIFFERENT signature does not trip the breaker
+  check(Offramp.loop_check(wd, signature: sig_b) == :first, 'different signature => :first (no cross-trip)', fails)
+  check(Offramp.loop_check(wd, signature: sig_b) == :second, 'different signature counts independently', fails)
+
+  # the log is structured + readable back
+  trail = Offramp.loop_trail(wd)
+  check(trail.size == 6, "loop-log carries all 6 records (got #{trail.size})", fails)
+  check(trail.all? { |r| r['signature'] && r['at'] =~ /\d{4}-\d\d-\d\dT/ }, 'records carry signature + timestamp', fails)
+  counts = Offramp.loop_counts(wd)
+  check(counts[sig_a] == 4 && counts[sig_b] == 2, 'loop_counts tallies per signature', fails)
+
+  # never fatal on a missing workdir
+  begin
+    check(Offramp.loop_check('/no/such/dir/really', signature: 'x') == :first,
+          'missing workdir => :first, no raise', fails)
+  rescue StandardError => e
+    check(false, "missing workdir raised: #{e.class}", fails)
+  end
+
+  # verify-complete refuses completion over a 3+-count signature — even with a
+  # success marker on disk (a green claim over a grind loop is invalid).
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'gates' => 'all-pass',
+                           'generatedAt' => '2026-07-18T00:00:00Z'))
+  out = IO.popen(['ruby', VC, '--workdir', wd], err: %i[child out], &:read)
+  code = $?.exitstatus
+  check(code == 5, "verify-complete over a breached loop-log => exit 5 (got #{code})", fails)
+  check(out.include?('NOT DONE') && out.include?(sig_a), 'refusal names the looping signature', fails)
+end
+
+# a clean workdir (no loop-log) is unaffected
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'gates' => 'all-pass',
+                           'generatedAt' => '2026-07-18T00:00:00Z'))
+  IO.popen(['ruby', VC, '--workdir', wd], err: %i[child out], &:read)
+  check($?.exitstatus.zero?, 'no loop-log => verify-complete still exits 0', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-redact.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-redact.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the credential-masking lib (PR-2 field-ops, secrets hygiene).
+#
+# Contract (refs/operating-contract.md "Credential hygiene"): never echo
+# credential values — Redact.mask keeps only the last 4 chars, Redact.scrub
+# masks any sensitive-env-var VALUE (…SECRET/…TOKEN/…_PAT_…/…PASSWORD) found in
+# free text, and PATH-like vars are never touched. Fixture values are assembled
+# at runtime so no credential-shaped literal is committed. Offline.
+#
+# Usage: ruby scripts/test-redact.rb
+
+DIR = __dir__
+require_relative 'lib/redact'
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+# ── mask ─────────────────────────────────────────────────────────────────────
+check(Redact.mask('abcdefgh1234') == '****1234', 'mask keeps only the last 4 chars', fails)
+check(Redact.mask('abcd') == '****', 'a <=4-char value masks entirely', fails)
+check(Redact.mask('ab') == '****', 'a tiny value masks entirely', fails)
+check(Redact.mask('') == '(unset)', 'empty value reads (unset)', fails)
+check(Redact.mask(nil) == '(unset)', 'nil value reads (unset)', fails)
+long = 'zz' * 30 + 'tail'
+check(Redact.mask(long) == '****tail' && !Redact.mask(long).include?('zz'),
+      'long values never leak their body', fails)
+
+# ── scrub ────────────────────────────────────────────────────────────────────
+# Fixture secrets built at runtime (never committed as credential-shaped literals).
+secret = %w[qq ww ee rr tt yy].join + '9876'
+token  = 'tok' + '4321abcd' * 3
+patval = 'pat' + 'value' + '5555'
+ENV['TEST_SCRUB_SECRET']  = secret
+ENV['TEST_SCRUB_TOKEN']   = token
+ENV['TEST_PAT_VALUE']     = patval          # _PAT_ segment => sensitive
+ENV['TEST_SCRUB_PATHISH'] = '/usr/local/some-dir' # PATH-like name => NOT sensitive
+ENV['TEST_TINY_TOKEN']    = 'abc'           # <6 chars => skipped (collision-prone)
+
+text = "creds: #{secret} then #{token}, pat #{patval}, dir /usr/local/some-dir, abc end"
+scrubbed = Redact.scrub(text)
+check(!scrubbed.include?(secret), 'scrub masks a *_SECRET value', fails)
+check(!scrubbed.include?(token), 'scrub masks a *_TOKEN value', fails)
+check(!scrubbed.include?(patval), 'scrub masks a *_PAT_* value', fails)
+check(scrubbed.include?("****#{secret[-4..-1]}"), 'masked value keeps its last 4 chars', fails)
+check(scrubbed.include?('/usr/local/some-dir'), 'PATH-like var values are left alone', fails)
+check(scrubbed.include?('abc end'), 'tiny (<6 char) values are not substituted', fails)
+check(Redact.scrub('no secrets here') == 'no secrets here', 'text without secrets is unchanged', fails)
+
+# PATH itself must never be treated as sensitive (the PAT false-positive trap).
+check(Redact::SENSITIVE_ENV !~ 'PATH' && Redact::SENSITIVE_ENV !~ 'CLASSPATH',
+      'PATH/CLASSPATH names are not sensitive', fails)
+check((Redact::SENSITIVE_ENV =~ 'TABLEAU_PAT_SECRET') && (Redact::SENSITIVE_ENV =~ 'TABLEAU_PAT_NAME') &&
+      (Redact::SENSITIVE_ENV =~ 'SIGMA_CLIENT_SECRET') && (Redact::SENSITIVE_ENV =~ 'SIGMA_API_TOKEN'),
+      'the real credential var names ARE sensitive', fails)
+
+# ── setup.rb applies it (the creds echo path) ────────────────────────────────
+setup_src = File.read(File.join(DIR, 'setup.rb'))
+check(setup_src.include?('Redact.mask'), 'setup.rb masks the secret via Redact.mask', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-stale-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-stale-gate.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the Step-0 STALENESS HARD GATE (PR-2 field-ops).
+#
+# The doctor stamps {behind_count, days_since_commit} into doctor.json; the
+# orchestrator now REFUSES to start on a stale checkout (behind upstream, or
+# >14 days old) instead of warning past it — unless SIGMA_ALLOW_STALE names a
+# reason, in which case the waiver is recorded as a 'stale-skill-waived'
+# off-ramp. Drives migrate-tableau.rb to (or past) the gate offline: the run
+# is invoked as --finalize with dummy Sigma creds, so the very next stop after
+# the gate is the deterministic "--actuals required" abort — reaching it
+# proves the gate let the run proceed. Offline.
+#
+# Usage: ruby scripts/test-stale-gate.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+MIG = File.join(DIR, 'migrate-tableau.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+def doctor_json(behind:, days:)
+  { 'os' => 'macos', 'shell' => 'bash',
+    'runtimes' => { 'ruby' => true, 'python' => true, 'node' => true, 'bash' => true },
+    'versions' => { 'ruby' => '3.0.0', 'python' => 'Python 3.11', 'node' => 'v20' },
+    'sandbox_hint' => 'none', 'cred_smoke' => { 'sigma' => 'skipped', 'tableau' => 'skipped' },
+    'hyperapi_present' => false, 'skill_sha' => 'abc1234',
+    'behind_count' => behind, 'days_since_commit' => days,
+    'agent_vision' => true, 'model_hint' => '', 'generated_at' => '2026-07-18T00:00:00Z',
+    'pass' => true, 'failures' => [] }
+end
+
+# Run the orchestrator against WD (which carries a doctor.json fixture) with
+# dummy creds; --finalize makes "--actuals required" the first post-gate stop.
+def run_gate(wd, extra_env = {})
+  env = { 'SIGMA_CLIENT_ID' => 'test-id', 'SIGMA_CLIENT_SECRET' => 'test-cred-value',
+          'SIGMA_ALLOW_STALE' => nil }.merge(extra_env)
+  out = IO.popen(env, ['ruby', MIG, '--workbook-id', 'wb-test', '--out', wd, '--finalize'],
+                 err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+# (1) stale (behind upstream) + no waiver => refuses with the fix named.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'doctor.json'), JSON.generate(doctor_json(behind: 3, days: 2)))
+  code, out = run_gate(wd)
+  check(code != 0, "stale (behind) refuses to proceed (exit #{code})", fails)
+  check(out.include?('FATAL: stale skill checkout'), 'refusal is a clear FATAL naming staleness', fails)
+  check(out.include?('git pull') && out.include?('reinstall'), 'refusal names the fix (git pull / reinstall)', fails)
+  check(!out.include?('--actuals required'), 'run never got past the gate', fails)
+  check(!File.exist?(File.join(wd, 'offramps.jsonl')), 'a refusal records no waiver off-ramp', fails)
+end
+
+# (2) stale (>14 days old, not behind) + no waiver => also refuses.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'doctor.json'), JSON.generate(doctor_json(behind: 0, days: 30)))
+  code, out = run_gate(wd)
+  check(code != 0 && out.include?('FATAL: stale skill checkout'),
+        "stale (>14 days) refuses to proceed (exit #{code})", fails)
+  check(out.include?('30 days old'), 'refusal names the build age', fails)
+end
+
+# (3) stale + SIGMA_ALLOW_STALE => proceeds AND records the off-ramp.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'doctor.json'), JSON.generate(doctor_json(behind: 3, days: 2)))
+  code, out = run_gate(wd, 'SIGMA_ALLOW_STALE' => 'test-waiver')
+  check(out.include?('--actuals required'), 'waived run proceeds past the gate (reaches the next stop)', fails)
+  check(!out.include?('FATAL: stale skill checkout'), 'no stale FATAL when waived', fails)
+  trail = File.readlines(File.join(wd, 'offramps.jsonl')).map { |l| JSON.parse(l) } rescue []
+  rec = trail.find { |r| r['kind'] == 'stale-skill-waived' }
+  check(!rec.nil?, 'waiver recorded as a stale-skill-waived off-ramp', fails)
+  check(rec && rec['reason'] == 'test-waiver', 'off-ramp carries the waiver reason', fails)
+  _ = code
+end
+
+# (4) fresh checkout => proceeds, no off-ramp.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'doctor.json'), JSON.generate(doctor_json(behind: 0, days: 1)))
+  _, out = run_gate(wd)
+  check(out.include?('--actuals required'), 'fresh checkout proceeds past the gate', fails)
+  check(!File.exist?(File.join(wd, 'offramps.jsonl')), 'fresh run records no waiver off-ramp', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-complete.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-complete.rb
@@ -26,6 +26,8 @@
 #   2  NOT DONE — the hard gate never stamped success (finalize not run / failed)
 #   3  NOT DONE — still at PASS 1 (parity-pending.json present); run --finalize
 #   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
+#   5  NOT DONE — loop-log.jsonl records the SAME failure signature 3+ times
+#      (the stop-at-2 loop breaker was breached; an operator must resolve it)
 
 require 'json'
 require 'optparse'
@@ -73,6 +75,19 @@ if File.exist?(pending)
   warn '   which runs assert-phase6-ran.rb (the only path to GREEN).'
   print_offramps(wd)
   exit 3
+end
+
+# Loop-log enforcement (stop-at-2): a signature recorded 3+ times means the run
+# ground the same failure in a loop — completion can never be claimed over it,
+# success marker or not. The operator resolves the repeat, then clears the log.
+looped = Offramp.loop_counts(wd).select { |_, n| n >= 3 }
+unless looped.empty?
+  warn '⛔ NOT DONE — loop-log.jsonl records the SAME failure signature 3+ times (stop-at-2 breached):'
+  looped.each { |sig, n| warn "   • #{sig}  × #{n}" }
+  warn '   The run was grinding one failure, not converging — an operator must resolve it.'
+  warn "   (After resolving, clear #{File.join(wd, 'loop-log.jsonl')} and re-run the gates.)"
+  print_offramps(wd)
+  exit 5
 end
 
 unless File.exist?(success)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/redact.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/shared/lib/redact.rb
+++ b/shared/lib/redact.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+# redact.rb — credential masking for anything that ECHOES configuration.
+#
+# Contract (refs/operating-contract.md, "Credential hygiene"): NEVER echo
+# credential values (tokens, secrets, PATs) into output, commands, or files —
+# reference env var names only. When displaying config, mask all but the last
+# 4 characters. This lib is the one place that masking lives so every echo
+# path (setup.rb summaries, doctor readouts, logs) masks the same way.
+
+module Redact
+  module_function
+
+  # Env-var NAMES whose values are credentials. \b-less on purpose: matches
+  # SIGMA_CLIENT_SECRET, SIGMA_API_TOKEN, TABLEAU_PAT_SECRET, *_PASSWORD — but
+  # NOT PATH/CLASSPATH (PAT must be a full underscore-delimited segment).
+  SENSITIVE_ENV = /SECRET|TOKEN|PASSWORD|(\A|_)PAT(\z|_)/.freeze
+
+  # Mask a single credential value, keeping only the last 4 characters:
+  #   'sk-abcdef123456' -> '****3456'. Short values mask entirely.
+  def mask(value)
+    v = value.to_s
+    return '(unset)' if v.empty?
+    return '****' if v.length <= 4
+    "****#{v[-4..-1]}"
+  end
+
+  # Scrub free text: any value of a sensitive env var (per SENSITIVE_ENV) that
+  # appears verbatim in TEXT is replaced with its mask. Values shorter than 6
+  # chars are skipped (too collision-prone to substitute safely).
+  def scrub(text)
+    out = text.to_s.dup
+    ENV.each do |k, v|
+      next if v.to_s.length < 6
+      next unless k.to_s =~ SENSITIVE_ENV
+      out = out.gsub(v, mask(v))
+    end
+    out
+  end
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -345,6 +345,20 @@
    ]
   },
   {
+   "canonical": "shared/lib/redact.rb",
+   "targets": [
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/redact.rb",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/redact.rb",
+    "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/redact.rb",
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/redact.rb",
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/redact.rb",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/redact.rb",
+    "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/redact.rb",
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/redact.rb",
+    "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/redact.rb"
+   ]
+  },
+  {
    "canonical": "shared/assessment/dup-dashboards.py",
    "targets": [
     "plugins/cognos-to-sigma/skills/cognos-assessment/scripts/dup-dashboards.py",

--- a/shared/scripts/setup.rb
+++ b/shared/scripts/setup.rb
@@ -25,6 +25,11 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
 NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
@@ -184,7 +189,8 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
-redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
 
 puts
 puts "Credentials saved to:"

--- a/tools/hygiene-patterns.txt
+++ b/tools/hygiene-patterns.txt
@@ -65,5 +65,14 @@ Ship Speed Category
 Subject Selector|Master Selector
 UDEMY_COURSE|UDEMY COURSE|Num Subscribers
 FATSCALE2|el-fat-crosstab
+#
+# --- generic live-secret shapes (org-independent) -------------------------------
+# A committed live secret is a leak regardless of whose it is. Fixture/test values
+# must be built to miss these on purpose (short, or assembled at runtime — never a
+# literal that could pass for a real credential).
+# JWT-shaped literal: eyJ… base64url header + a dot-separated payload segment.
+eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}
+# A long (32+ char) base64/hex-ish literal assigned to a *SECRET/*TOKEN/*PAT/*PASSWORD var.
+(SECRET|TOKEN|_PAT|PASSWORD)[A-Z0-9_]*\s*[=:]\s*["']?[A-Za-z0-9+/=_-]{32,}
 # Customer-identifying guards live in tools/hygiene-patterns.local.txt (gitignored) —
 # committing them would itself disclose the customer. Sweep loads both files.


### PR DESCRIPTION
> Base is `integration/v5.5-e2e` (main + #414, suite-verified). Retarget to `main` after #414 squash-merges. PLAN-v3 PR-2.

Four field-caught operational hardenings.

**1. Staleness hard gate.** The doctor build-SHA/age WARN is now enforced at run start: the orchestrator refuses a checkout behind upstream or >14 days old, printing the exact fix. `SIGMA_ALLOW_STALE="<reason>"` waives and records a `stale-skill-waived` off-ramp. (A field session ran a plugin cache predating every fix on main.)

**2. Extract re-fetch skip.** Discovery's `includeExtract=true` re-download (120s, formerly x4) is conditional: `--no-extract-refetch`, auto-passed on the `--skip-extract-landing` live repoint; retries capped at 2. (~1.5h/6 relaunches in one field session.)

**3. Loop stop-at-2.** `Offramp.loop_check(workdir, signature:)` over `loop-log.jsonl`; signatures recorded at the exit-4 handoff and NOT-GREEN finalize; third identical failure prints LOOP STOP with the two prior occurrences and hands control to the operator; `verify-complete.rb` refuses completion (exit 5) over any 3+ signature. (A field session's background agent cycled the same exit-4 twice; the customer was the loop detector.)

**4. Secrets hygiene.** Shared `lib/redact.rb` (mask keeps last 4; PATH-safe scrub), setup secret echo masked, Credential-hygiene contract rule in `refs/operating-contract.md`, JWT/long-base64 live-secret patterns in `tools/hygiene-patterns.txt`. (Live secrets were printed into transcripts in 2 of 3 field sessions.)

**Tests:** 4 new (`test-stale-gate`, `test-discover-extract-skip`, `test-offramp-loop`, `test-redact`) + all touched-area tests green; check-shared / lint-skills / check-agent-variants / hygiene-sweep / corpus --check clean; shared canonicals synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)