### PR TITLE
tableau layout: no element may be absent from the layout bands (stray white-card fix)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -203,6 +203,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zone-census.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-fill-gate.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-dedup.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-put-layout-prune.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-sql-quoting.rb

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1379,9 +1379,11 @@ end
 # every structural + visual gate above and still ship a page that is mostly
 # empty: tiles silently dropped, or a sparse default stack. build-dashboard-
 # layout.rb emits <workdir>/layout-census.json (one record per page: zones /
-# placed / dropped / grid_fill_pct). This gate hard-fails when any page dropped
-# a tile (placed < zones) OR its grid is under-filled (grid_fill_pct <
-# --min-grid-fill, default 0.45).
+# placed / dropped / grid_fill_pct / unplaced_elements). This gate hard-fails
+# when any page dropped a tile (placed < zones), its grid is under-filled
+# (grid_fill_pct < --min-grid-fill, default 0.45), OR the builder reported
+# ORPHAN elements (unplaced_elements non-empty: an element in the built page
+# that no layout band references — Sigma auto-flows it as a stray white card).
 #
 # Absent census: CONDITIONAL fail. If a dashboard layout was built
 # (dashboard-layout.json present, or a tile_census landed in parity-final.json)
@@ -1401,7 +1403,10 @@ elsif File.exist?(census_fill_path)
     exit 14
   end
   min_fill = opts[:min_grid_fill]
-  bad = pages.select { |p| p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill }
+  bad = pages.select do |p|
+    p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill ||
+      Array(p['unplaced_elements']).any?
+  end
   # Reconcile against the LIVE layout (gate 4 fetched its positioned-element
   # count). A HAND-AUTHORED workbook layout uses element ids the zone-derived
   # census can't match, so build-dashboard-layout.rb reports placed=0/N even
@@ -1426,11 +1431,15 @@ elsif File.exist?(census_fill_path)
         reasons << "#{p['zones'].to_i - p['placed'].to_i} dropped tile(s) (placed #{p['placed']}/#{p['zones']})"
       end
       reasons << "grid fill #{(p['grid_fill_pct'].to_f * 100).round}% < #{(min_fill * 100).round}%" if p['grid_fill_pct'].to_f < min_fill
+      orphans = Array(p['unplaced_elements'])
+      reasons << "#{orphans.length} orphan element(s) no layout band references (auto-flowed as stray cards): #{orphans.join(', ')}" if orphans.any?
       warn "         - #{p['page'].inspect}: #{reasons.join('; ')}"
     end
     warn '       A dropped tile means a source zone never made it into the Sigma layout (empty'
     warn '       view CSV, unhandled rename); an under-filled grid means the page ships mostly'
-    warn '       empty. Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
+    warn '       empty; an orphan element means the built page carries an element the layout'
+    warn '       never places (Sigma auto-flows it as a stray white card, bottom-left).'
+    warn '       Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
     warn '       rebuild the layout, re-PUT, and re-render. Tune with --min-grid-fill F.'
     warn '       Escape hatch (intentionally sparse page): --skip-layout-fill "<reason>" (name it in your report).'
     exit 14

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1379,9 +1379,11 @@ end
 # every structural + visual gate above and still ship a page that is mostly
 # empty: tiles silently dropped, or a sparse default stack. build-dashboard-
 # layout.rb emits <workdir>/layout-census.json (one record per page: zones /
-# placed / dropped / grid_fill_pct). This gate hard-fails when any page dropped
-# a tile (placed < zones) OR its grid is under-filled (grid_fill_pct <
-# --min-grid-fill, default 0.45).
+# placed / dropped / grid_fill_pct / unplaced_elements). This gate hard-fails
+# when any page dropped a tile (placed < zones), its grid is under-filled
+# (grid_fill_pct < --min-grid-fill, default 0.45), OR the builder reported
+# ORPHAN elements (unplaced_elements non-empty: an element in the built page
+# that no layout band references — Sigma auto-flows it as a stray white card).
 #
 # Absent census: CONDITIONAL fail. If a dashboard layout was built
 # (dashboard-layout.json present, or a tile_census landed in parity-final.json)
@@ -1401,7 +1403,10 @@ elsif File.exist?(census_fill_path)
     exit 14
   end
   min_fill = opts[:min_grid_fill]
-  bad = pages.select { |p| p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill }
+  bad = pages.select do |p|
+    p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill ||
+      Array(p['unplaced_elements']).any?
+  end
   # Reconcile against the LIVE layout (gate 4 fetched its positioned-element
   # count). A HAND-AUTHORED workbook layout uses element ids the zone-derived
   # census can't match, so build-dashboard-layout.rb reports placed=0/N even
@@ -1426,11 +1431,15 @@ elsif File.exist?(census_fill_path)
         reasons << "#{p['zones'].to_i - p['placed'].to_i} dropped tile(s) (placed #{p['placed']}/#{p['zones']})"
       end
       reasons << "grid fill #{(p['grid_fill_pct'].to_f * 100).round}% < #{(min_fill * 100).round}%" if p['grid_fill_pct'].to_f < min_fill
+      orphans = Array(p['unplaced_elements'])
+      reasons << "#{orphans.length} orphan element(s) no layout band references (auto-flowed as stray cards): #{orphans.join(', ')}" if orphans.any?
       warn "         - #{p['page'].inspect}: #{reasons.join('; ')}"
     end
     warn '       A dropped tile means a source zone never made it into the Sigma layout (empty'
     warn '       view CSV, unhandled rename); an under-filled grid means the page ships mostly'
-    warn '       empty. Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
+    warn '       empty; an orphan element means the built page carries an element the layout'
+    warn '       never places (Sigma auto-flows it as a stray white card, bottom-left).'
+    warn '       Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
     warn '       rebuild the layout, re-PUT, and re-render. Tune with --min-grid-fill F.'
     warn '       Escape hatch (intentionally sparse page): --skip-layout-fill "<reason>" (name it in your report).'
     exit 14

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1379,9 +1379,11 @@ end
 # every structural + visual gate above and still ship a page that is mostly
 # empty: tiles silently dropped, or a sparse default stack. build-dashboard-
 # layout.rb emits <workdir>/layout-census.json (one record per page: zones /
-# placed / dropped / grid_fill_pct). This gate hard-fails when any page dropped
-# a tile (placed < zones) OR its grid is under-filled (grid_fill_pct <
-# --min-grid-fill, default 0.45).
+# placed / dropped / grid_fill_pct / unplaced_elements). This gate hard-fails
+# when any page dropped a tile (placed < zones), its grid is under-filled
+# (grid_fill_pct < --min-grid-fill, default 0.45), OR the builder reported
+# ORPHAN elements (unplaced_elements non-empty: an element in the built page
+# that no layout band references — Sigma auto-flows it as a stray white card).
 #
 # Absent census: CONDITIONAL fail. If a dashboard layout was built
 # (dashboard-layout.json present, or a tile_census landed in parity-final.json)
@@ -1401,7 +1403,10 @@ elsif File.exist?(census_fill_path)
     exit 14
   end
   min_fill = opts[:min_grid_fill]
-  bad = pages.select { |p| p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill }
+  bad = pages.select do |p|
+    p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill ||
+      Array(p['unplaced_elements']).any?
+  end
   # Reconcile against the LIVE layout (gate 4 fetched its positioned-element
   # count). A HAND-AUTHORED workbook layout uses element ids the zone-derived
   # census can't match, so build-dashboard-layout.rb reports placed=0/N even
@@ -1426,11 +1431,15 @@ elsif File.exist?(census_fill_path)
         reasons << "#{p['zones'].to_i - p['placed'].to_i} dropped tile(s) (placed #{p['placed']}/#{p['zones']})"
       end
       reasons << "grid fill #{(p['grid_fill_pct'].to_f * 100).round}% < #{(min_fill * 100).round}%" if p['grid_fill_pct'].to_f < min_fill
+      orphans = Array(p['unplaced_elements'])
+      reasons << "#{orphans.length} orphan element(s) no layout band references (auto-flowed as stray cards): #{orphans.join(', ')}" if orphans.any?
       warn "         - #{p['page'].inspect}: #{reasons.join('; ')}"
     end
     warn '       A dropped tile means a source zone never made it into the Sigma layout (empty'
     warn '       view CSV, unhandled rename); an under-filled grid means the page ships mostly'
-    warn '       empty. Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
+    warn '       empty; an orphan element means the built page carries an element the layout'
+    warn '       never places (Sigma auto-flows it as a stray white card, bottom-left).'
+    warn '       Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
     warn '       rebuild the layout, re-PUT, and re-render. Tune with --min-grid-fill F.'
     warn '       Escape hatch (intentionally sparse page): --skip-layout-fill "<reason>" (name it in your report).'
     exit 14

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1379,9 +1379,11 @@ end
 # every structural + visual gate above and still ship a page that is mostly
 # empty: tiles silently dropped, or a sparse default stack. build-dashboard-
 # layout.rb emits <workdir>/layout-census.json (one record per page: zones /
-# placed / dropped / grid_fill_pct). This gate hard-fails when any page dropped
-# a tile (placed < zones) OR its grid is under-filled (grid_fill_pct <
-# --min-grid-fill, default 0.45).
+# placed / dropped / grid_fill_pct / unplaced_elements). This gate hard-fails
+# when any page dropped a tile (placed < zones), its grid is under-filled
+# (grid_fill_pct < --min-grid-fill, default 0.45), OR the builder reported
+# ORPHAN elements (unplaced_elements non-empty: an element in the built page
+# that no layout band references — Sigma auto-flows it as a stray white card).
 #
 # Absent census: CONDITIONAL fail. If a dashboard layout was built
 # (dashboard-layout.json present, or a tile_census landed in parity-final.json)
@@ -1401,7 +1403,10 @@ elsif File.exist?(census_fill_path)
     exit 14
   end
   min_fill = opts[:min_grid_fill]
-  bad = pages.select { |p| p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill }
+  bad = pages.select do |p|
+    p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill ||
+      Array(p['unplaced_elements']).any?
+  end
   # Reconcile against the LIVE layout (gate 4 fetched its positioned-element
   # count). A HAND-AUTHORED workbook layout uses element ids the zone-derived
   # census can't match, so build-dashboard-layout.rb reports placed=0/N even
@@ -1426,11 +1431,15 @@ elsif File.exist?(census_fill_path)
         reasons << "#{p['zones'].to_i - p['placed'].to_i} dropped tile(s) (placed #{p['placed']}/#{p['zones']})"
       end
       reasons << "grid fill #{(p['grid_fill_pct'].to_f * 100).round}% < #{(min_fill * 100).round}%" if p['grid_fill_pct'].to_f < min_fill
+      orphans = Array(p['unplaced_elements'])
+      reasons << "#{orphans.length} orphan element(s) no layout band references (auto-flowed as stray cards): #{orphans.join(', ')}" if orphans.any?
       warn "         - #{p['page'].inspect}: #{reasons.join('; ')}"
     end
     warn '       A dropped tile means a source zone never made it into the Sigma layout (empty'
     warn '       view CSV, unhandled rename); an under-filled grid means the page ships mostly'
-    warn '       empty. Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
+    warn '       empty; an orphan element means the built page carries an element the layout'
+    warn '       never places (Sigma auto-flows it as a stray white card, bottom-left).'
+    warn '       Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
     warn '       rebuild the layout, re-PUT, and re-render. Tune with --min-grid-fill F.'
     warn '       Escape hatch (intentionally sparse page): --skip-layout-fill "<reason>" (name it in your report).'
     exit 14

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1379,9 +1379,11 @@ end
 # every structural + visual gate above and still ship a page that is mostly
 # empty: tiles silently dropped, or a sparse default stack. build-dashboard-
 # layout.rb emits <workdir>/layout-census.json (one record per page: zones /
-# placed / dropped / grid_fill_pct). This gate hard-fails when any page dropped
-# a tile (placed < zones) OR its grid is under-filled (grid_fill_pct <
-# --min-grid-fill, default 0.45).
+# placed / dropped / grid_fill_pct / unplaced_elements). This gate hard-fails
+# when any page dropped a tile (placed < zones), its grid is under-filled
+# (grid_fill_pct < --min-grid-fill, default 0.45), OR the builder reported
+# ORPHAN elements (unplaced_elements non-empty: an element in the built page
+# that no layout band references — Sigma auto-flows it as a stray white card).
 #
 # Absent census: CONDITIONAL fail. If a dashboard layout was built
 # (dashboard-layout.json present, or a tile_census landed in parity-final.json)
@@ -1401,7 +1403,10 @@ elsif File.exist?(census_fill_path)
     exit 14
   end
   min_fill = opts[:min_grid_fill]
-  bad = pages.select { |p| p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill }
+  bad = pages.select do |p|
+    p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill ||
+      Array(p['unplaced_elements']).any?
+  end
   # Reconcile against the LIVE layout (gate 4 fetched its positioned-element
   # count). A HAND-AUTHORED workbook layout uses element ids the zone-derived
   # census can't match, so build-dashboard-layout.rb reports placed=0/N even
@@ -1426,11 +1431,15 @@ elsif File.exist?(census_fill_path)
         reasons << "#{p['zones'].to_i - p['placed'].to_i} dropped tile(s) (placed #{p['placed']}/#{p['zones']})"
       end
       reasons << "grid fill #{(p['grid_fill_pct'].to_f * 100).round}% < #{(min_fill * 100).round}%" if p['grid_fill_pct'].to_f < min_fill
+      orphans = Array(p['unplaced_elements'])
+      reasons << "#{orphans.length} orphan element(s) no layout band references (auto-flowed as stray cards): #{orphans.join(', ')}" if orphans.any?
       warn "         - #{p['page'].inspect}: #{reasons.join('; ')}"
     end
     warn '       A dropped tile means a source zone never made it into the Sigma layout (empty'
     warn '       view CSV, unhandled rename); an under-filled grid means the page ships mostly'
-    warn '       empty. Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
+    warn '       empty; an orphan element means the built page carries an element the layout'
+    warn '       never places (Sigma auto-flows it as a stray white card, bottom-left).'
+    warn '       Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
     warn '       rebuild the layout, re-PUT, and re-render. Tune with --min-grid-fill F.'
     warn '       Escape hatch (intentionally sparse page): --skip-layout-fill "<reason>" (name it in your report).'
     exit 14

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -126,6 +126,42 @@ end.parse!
 dash_layout = JSON.parse(File.read(opts[:layout]))
 wb_ids      = JSON.parse(File.read(opts[:wb_ids]))
 
+# ---- Chart provenance (orphan-fix, class 2 prevention) ----------------------
+# chart-provenance.json (written by build-charts-from-signals beside
+# dashboard-layout.json) maps element id → the Tableau WORKSHEET that built it.
+# Zone→element matching is name-based (display_title, then caption) while the
+# builder names tiles by display_title — so a tile whose display name drifted
+# from what the zone knows failed the match, fell into the safety-net band
+# ("N element(s) had no Tableau zone"), and left a stale injected container
+# behind on later re-PUTs. Provenance gives the collision-free caption
+# (worksheet) → element join; aliases are ADDED to els_by_name and never
+# overwrite a real display name. Best-effort: no file → no aliases.
+PROV_BY_ID = begin
+  prov_path = File.join(File.dirname(opts[:layout]), 'chart-provenance.json')
+  File.exist?(prov_path) ? JSON.parse(File.read(prov_path)) : {}
+rescue StandardError
+  {}
+end
+
+# Add provenance worksheet-name aliases for this page's elements (see above).
+def augment_els_by_name!(els_by_name, elements)
+  elements.each do |e|
+    rec = PROV_BY_ID[e['id'].to_s]
+    next unless rec.is_a?(Hash)
+    ws = rec['worksheet'].to_s
+    els_by_name[ws] = e unless ws.empty? || els_by_name.key?(ws)
+  end
+  els_by_name
+end
+
+# Resolve a zone's Sigma element: display-title/rename name first
+# (zone_el_name), then the raw caption — the worksheet name, which hits the
+# provenance alias when the tile was renamed. Shared by all three layout paths
+# and their census counts so matching cannot drift between them.
+def find_zone_el(els_by_name, z, renames)
+  els_by_name[zone_el_name(z, renames)] || els_by_name[z['caption'].to_s]
+end
+
 # Page lookups
 data_page  = wb_ids['pages'].find { |p| p['name'] == 'Data' }
 abort('no "Data" page in wb-ids') unless data_page
@@ -492,6 +528,7 @@ end
 def build_page_from_tree(dashboard, page, opts)
   tree        = dashboard['zone_tree'] || []
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
+  augment_els_by_name!(els_by_name, page['elements'])
   ctl_by_name = page['elements'].select { |e| e['kind'] == 'control' && e['name'] }
                     .each_with_object({}) { |e, h| h[e['name'].to_s.downcase] = e }
   els_by_id   = page['elements'].each_with_object({}) { |e, h| h[e['id']] = e if e['id'] }
@@ -685,7 +722,7 @@ def build_page_from_tree(dashboard, page, opts)
   # element made it into ctx[:placed]. Header band excluded from the fill rects.
   content_zones = ZoneCensus.content_zones(dashboard['zones'])
   placed = content_zones.count do |z|
-    e = els_by_name[zone_el_name(z, opts[:renames])]
+    e = find_zone_el(els_by_name, z, opts[:renames])
     e && ctx[:placed].include?(e['id'])
   end
   fill = ZoneCensus.grid_fill_pct(content_rects, opts[:page_cols], page_rows)
@@ -940,6 +977,7 @@ end
 def build_page_synthesized(dashboard, page, opts, structure)
   zones       = dashboard['zones'] || []
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
+  augment_els_by_name!(els_by_name, page['elements'])
   els_by_id   = page['elements'].each_with_object({}) { |e, h| h[e['id']] = e if e['id'] }
   # Header title: dedicated title-* element, else the source's own top banner
   # (shared detector) — NOT a fabricated page-name H1 alongside the source title.
@@ -1029,7 +1067,7 @@ def build_page_synthesized(dashboard, page, opts, structure)
   resolve_zone_el = lambda do |z|
     case z['kind'].to_s
     when 'chart'
-      el = els_by_name[zone_el_name(z, opts[:renames])]
+      el = find_zone_el(els_by_name, z, opts[:renames])
       el && el['id']
     when 'text', 'title'
       el = els_by_id["text-#{z['id']}"]
@@ -1210,7 +1248,7 @@ def build_page_synthesized(dashboard, page, opts, structure)
 
   content_zones = ZoneCensus.content_zones(zones)
   placed_count = content_zones.count do |z|
-    e = els_by_name[zone_el_name(z, opts[:renames])]
+    e = find_zone_el(els_by_name, z, opts[:renames])
     e && placed.include?(e['id'])
   end
   rects = []
@@ -1231,6 +1269,7 @@ end
 def build_page_for_dashboard(dashboard, page, opts)
   chart_zones = dashboard['zones'].select { |z| z['kind'] == 'chart' && z['caption'] }
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
+  augment_els_by_name!(els_by_name, page['elements'])
   # Dedicated title-* element, else the source's own top banner (shared detector,
   # same as the tree + synthesis paths) — no fabricated page-name H1 alongside a
   # source title.
@@ -1256,14 +1295,17 @@ def build_page_for_dashboard(dashboard, page, opts)
     end
   end
 
+  used_el_ids = {} # one zone per element — a duplicate LayoutElement id makes
+  #   Sigma reject the whole layout PUT (same guard as the tree/synth paths)
   chart_layouts = chart_zones.map do |z|
     lookup_name = zone_el_name(z, o[:renames])
-    el = els_by_name[lookup_name]
+    el = find_zone_el(els_by_name, z, o[:renames])
     if el.nil?
       warn "WARN: no Sigma element matched zone caption #{z['caption'].inspect} on page #{page['name'].inspect}" \
            "#{lookup_name == z['caption'] ? " — if the tile was renamed, pass --rename #{z['caption'].inspect}'=<Sigma name>'" : " (renamed to #{lookup_name.inspect})"} — tile DROPPED from layout"
     end
-    next nil unless el
+    next nil unless el && !used_el_ids[el['id']]
+    used_el_ids[el['id']] = true
     c1, c2, r1, r2 = chart_pos(z, o)
     { el_id: el['id'], c1: c1, c2: c2, r1: r1, r2: r2 }
   end.compact
@@ -1281,6 +1323,7 @@ def build_page_for_dashboard(dashboard, page, opts)
 
   children = []
   extra_els = []
+  placed = [] # element ids this path positions — feeds the shared safety net
   ov_prefix = "band-#{page['id']}"
 
   # Header band derived from the source (colored strip only when the source has
@@ -1290,6 +1333,7 @@ def build_page_for_dashboard(dashboard, page, opts)
   extra_els << container_el(hdr_id, hdr_style)
   if title_el
     children << header_band_xml(hdr_id, title_el['id'])
+    placed << title_el['id']
   else
     txt_id = "#{ov_prefix}-hdrtext"
     extra_els << header_text_el(txt_id, page['name'], hdr_dark ? '#FFFFFF' : nil)
@@ -1310,6 +1354,7 @@ def build_page_for_dashboard(dashboard, page, opts)
     ctl_id = "#{ov_prefix}-ctl"
     extra_els << container_el(ctl_id)
     children << gc(ctl_id, 1, o[:page_cols] + 1, 1 + HEADER_ROWS, 1 + HEADER_ROWS + ctl_rows, inner)
+    placed.concat(ctl_els.map { |c| c['id'] })
   end
 
   # Chart bands: cluster the zone-derived positions into row bands and shift
@@ -1327,6 +1372,7 @@ def build_page_for_dashboard(dashboard, page, opts)
     cid = "#{ov_prefix}-#{i + 1}"
     extra_els << container_el(cid)
     children << band_container_xml(cid, band, row_offset: band_offset)
+    placed.concat(band.map { |it| it[0] })
   end
 
   # B4 (gap ubr5.8): the banded fallback places charts by geometry but not text.
@@ -1346,10 +1392,23 @@ def build_page_for_dashboard(dashboard, page, opts)
     tid = "#{ov_prefix}-text"
     extra_els << container_el(tid)
     children << gc(tid, 1, o[:page_cols] + 1, r0, r0 + 4, inner)
+    placed.concat(text_els.map { |e| e['id'] })
     warn "WARN: #{tn} styled-text element(s) placed in a bottom band on banded page #{page['name'].inspect} " \
          "(source position not reproduced — the container-tree layout places them by geometry): " \
          "#{text_els.map { |e| e['id'] }.join(', ')}"
   end
+
+  # Safety net (orphan-element invariant — parity with the tree + synthesized
+  # paths, which already had one): any placeable element the banded path did
+  # not position (an image/button with no band, a stray text) lands in a
+  # bottom band. An element in the built page but absent from the layout is
+  # auto-flowed by Sigma as a stray white card (bottom-left), so NOTHING may
+  # be left unreferenced.
+  content_bottom = 1 + HEADER_ROWS + ctl_rows +
+                   bands.sum { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min } +
+                   (text_els.empty? ? 0 : 4)
+  band_rect = safety_net_band(page, placed, extra_els, children, ov_prefix,
+                              content_bottom, o[:page_rows])
 
   # ---- Layout census (gate 8c, #259) ----------------------------------------
   # zones  = non-furniture source content zones (real plotting tiles).
@@ -1360,11 +1419,12 @@ def build_page_for_dashboard(dashboard, page, opts)
   #          furniture (header band, styled-text band) excluded from the fill
   #          numerator.
   content_zones = ZoneCensus.content_zones(dashboard['zones'])
-  placed = content_zones.count { |z| els_by_name[zone_el_name(z, o[:renames])] }
+  placed_count = content_zones.count { |z| find_zone_el(els_by_name, z, o[:renames]) }
   content_rects = bands.flat_map { |b| b.map { |i| [i[1], i[2], i[3] + band_offset, i[4] + band_offset] } }
   content_rects << [1, o[:page_cols] + 1, 1 + HEADER_ROWS, 1 + HEADER_ROWS + ctl_rows] if ctl_els.length.positive?
+  content_rects << band_rect if band_rect # safety band holds real tiles → counts as filled
   fill = ZoneCensus.grid_fill_pct(content_rects, o[:page_cols], o[:page_rows])
-  census = ZoneCensus.page_record(page['name'], content_zones.size, placed, fill)
+  census = ZoneCensus.page_record(page['name'], content_zones.size, placed_count, fill)
 
   [page_xml(page['id'], *children), extra_els, chart_layouts.length, bands.length, ctl_els.length,
    census, min_exp]
@@ -1444,6 +1504,35 @@ dash_layout.each do |d|
     # canvas-implied row count (present only for fixed-px sources).
     census['rows'] = o[:page_rows]
     census['canvas_rows'] = canvas_rows if canvas_rows
+    # ---- Placement invariant (orphan-element guard) -------------------------
+    # NO element in the built page may be absent from the layout bands: Sigma
+    # auto-flows an unreferenced element as a stray white card (bottom-left;
+    # live-caught on the synthetic dashboard title). Authoritative check —
+    # scan the page XML the chosen path actually emitted rather than trusting
+    # per-path bookkeeping. Gate 8c (assert-phase6-ran.rb) fails on a
+    # non-empty list.
+    refd = pxml.scan(/elementId="([^"]+)"/).flatten
+    unplaced = page['elements'].select do |e|
+      k = e['kind'].to_s
+      (k.end_with?('-chart') || %w[table pivot-table control text image button].include?(k)) &&
+        e['id'] && !refd.include?(e['id'])
+    end.map { |e| e['id'] }
+    census['unplaced_elements'] = unplaced
+    if unplaced.any?
+      warn "WARN: #{unplaced.length} element(s) on page #{page['name'].inspect} are absent from the " \
+           "built layout — Sigma will auto-flow them as stray cards: #{unplaced.join(', ')}"
+    end
+    # Synthetic dashboard-title accounting: when the source .twb declared NO
+    # header text zone, the header band carrying the synthetic "title-*"
+    # element is layout the zones never described — note it and COUNT the
+    # title in zones/placed so the census reflects what the page shows (it
+    # used to be invisible to gate 8c).
+    syn_title = page['elements'].find { |e| e['kind'].to_s == 'text' && e['id'].to_s.start_with?('title') }
+    if syn_title && structure[:header].empty? && refd.include?(syn_title['id'])
+      census['zones'] += 1
+      census['placed'] += 1
+      census['synthetic_header'] = true
+    end
   end
   page_xmls << pxml
   sidecar[page['id']] = extra_els
@@ -1463,7 +1552,14 @@ File.write("#{opts[:out]}.elements.json", JSON.pretty_generate(sidecar))
 
 # ---- layout-census.json (gate 8c producer, #259) --------------------------
 # One record per dashboard page (zones / placed / dropped / grid_fill_pct) —
-# shape kept exactly compatible. Top-level additions (telemetry, E3):
+# shape kept exactly compatible. Per-page additions (orphan invariant):
+#   unplaced_elements  ids in the built page but ABSENT from the layout XML
+#                      (gate 8c fails on non-empty — Sigma auto-flows these
+#                      as stray cards)
+#   synthetic_header   true when the header band carries the synthetic
+#                      "title-*" element with no source header zone (the
+#                      title is then counted in zones/placed)
+# Top-level additions (telemetry, E3):
 #   bands_detected     {header:bool, kpi_rows:N, sidebar:bool} across pages
 #   min_row_expansions N tiles grown to their per-kind minimum row span
 census_out = opts[:census_out] || File.join(File.dirname(opts[:out]), 'layout-census.json')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/put-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/put-layout.rb
@@ -95,6 +95,31 @@ if opts[:layout]
   abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
   spec['pages'].each { |p| p.delete('layout') }
   spec['layout'] = xml
+
+  # PRUNE stale injected layout chrome (orphan-fix, class 2). A rebuilt layout
+  # (e.g. after --rename fixed zone matching) generates a different container
+  # set, but earlier PUTs already injected the previous set into the spec — and
+  # an injected element no longer referenced by the incoming layout XML is
+  # auto-flowed by Sigma as an empty white card (bottom-left; live-caught on a
+  # stale "tc-<page>-extra" safety-net band surviving every re-PUT). Only OUR
+  # injected id namespaces are candidates — containers "tc-/syn-/band-", their
+  # fabricated "-hdrtext" text, "dv-" dividers (see build-dashboard-layout.rb's
+  # sidecar) — user elements are never touched, and anything the new layout
+  # still references is kept.
+  refd = xml.scan(/elementId="([^"]+)"/).flatten
+  pruned = []
+  spec['pages'].each do |p|
+    (p['elements'] || []).reject! do |el|
+      id = el['id'].to_s
+      injected = (el['kind'] == 'container' && id.match?(/\A(tc|syn|band)-/)) ||
+                 (el['kind'] == 'text' && id.match?(/\A(tc|syn|band)-.*-hdrtext\z/)) ||
+                 (el['kind'] == 'divider' && id.start_with?('dv-'))
+      next false unless injected && !refd.include?(id)
+      pruned << id
+      true
+    end
+  end
+  puts "pruned #{pruned.length} stale injected layout element(s) not referenced by the new layout: #{pruned.join(', ')}" if pruned.any?
 end
 
 # Inject container/header-text spec elements (see header comment).

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-fill-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-fill-gate.rb
@@ -97,5 +97,19 @@ Dir.mktmpdir do |d|
   ok('malformed census fails (exit 14)', gate_code(d) == 14)
 end
 
+# 10. orphan elements (unplaced_elements non-empty) fail even at full fill —
+# an element no layout band references is auto-flowed by Sigma as a stray
+# white card (the live-caught synthetic-title defect).
+Dir.mktmpdir do |d|
+  write_census(d, [FULL.merge('unplaced_elements' => ['title-profitability-watch'])])
+  ok('orphan element fails (exit 14)', gate_code(d) == 14)
+end
+
+# 11. an empty unplaced_elements list (the invariant holds) still passes
+Dir.mktmpdir do |d|
+  write_census(d, [FULL.merge('unplaced_elements' => [])])
+  ok('empty unplaced_elements passes', gate_code(d) == 0)
+end
+
 puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
 exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-synthesis.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-synthesis.rb
@@ -177,6 +177,12 @@ Dir.mktmpdir do |d|
   hdr_ids = hdr_gc ? hdr_gc.elements.to_a('LayoutElement').map { |l| l.attributes['elementId'] } : []
   ok('header band holds the title AND the detected source header text',
      hdr_ids.include?('title-ov') && hdr_ids.include?('text-t1'))
+  ok('synthetic title referenced exactly once (no duplicate beside the source header)',
+     xml.scan(/elementId="title-ov"/).length == 1)
+  ok('census does NOT mark synthetic_header when the source has its own header zone',
+     census && !census['pages'].first.key?('synthetic_header'))
+  ok('census unplaced_elements is present and empty (placement invariant)',
+     census && census['pages'].first['unplaced_elements'] == [])
   ok('no collisions anywhere', collisions(xml).empty?)
   ok('census pages stay exact-compatible (zones/placed/dropped/grid_fill_pct)',
      census && census['pages'].first &&
@@ -312,6 +318,90 @@ Dir.mktmpdir do |d|
   ok('census counts the expansions', census && census['min_row_expansions'] >= 2)
   spec = { 'pages' => WB_MIN['pages'], 'layout' => xml }
   ok('output passes layout lint (no sub-minimum tiles shipped)', LayoutLint.lint(spec).empty?)
+end
+
+# ---- 4. synthetic dashboard title + orphan-element invariant -----------------
+# Live-caught defect (v5.5 e2e, every workbook): the synthetic "# <Dashboard>"
+# title element (id "title-<slug>", emitted by build-charts when the .twb has
+# no top title zone) is NOT a .twb zone — any element the layout bands don't
+# reference is auto-flowed by Sigma as a stray white card, bottom-left. The
+# invariant: NO element in the built page may be absent from the layout; the
+# census records violators in `unplaced_elements` (gate 8c fails on non-empty)
+# and counts a synthesized title header (`synthetic_header: true`).
+puts '-- synthetic title header + orphan invariant'
+DL_TITLE = [{
+  'dashboard' => 'Profitability Watch',
+  'zones' => [
+    { 'id' => 'z1', 'kind' => 'chart', 'caption' => 'Margin Trend', 'chart_kind' => 'bar',
+      'measures' => ['m'], 'x_pct' => 0, 'y_pct' => 5, 'w_pct' => 50, 'h_pct' => 45 },
+    { 'id' => 'z2', 'kind' => 'chart', 'caption' => 'Cost Split', 'chart_kind' => 'line',
+      'measures' => ['m'], 'x_pct' => 50, 'y_pct' => 5, 'w_pct' => 50, 'h_pct' => 45 }
+  ],
+  'zone_tree' => []
+}]
+WB_TITLE = { 'pages' => [
+  { 'name' => 'Data', 'id' => 'page-data', 'elements' => [{ 'id' => 'master', 'kind' => 'table', 'name' => 'M' }] },
+  { 'name' => 'Profitability Watch', 'id' => 'page-pw', 'elements' => [
+    { 'id' => 'title-profitability-watch', 'kind' => 'text', 'name' => nil },
+    { 'id' => 'el-1', 'kind' => 'bar-chart', 'name' => 'Margin Trend' },
+    { 'id' => 'el-2', 'kind' => 'line-chart', 'name' => 'Cost Split' }
+  ] }
+] }
+
+Dir.mktmpdir do |d|
+  xml, census, _log, _els = build(DL_TITLE, WB_TITLE, d)
+  ok('builder produced layout XML (synthetic title, no source header zone)', !xml.nil?)
+  next if xml.nil?
+  doc = doc_for(xml)
+  hdr_gc = doc.elements.to_a('//GridContainer').find { |g| g.attributes['elementId'].to_s.end_with?('-hdr') }
+  hdr_ids = hdr_gc ? hdr_gc.elements.to_a('LayoutElement').map { |l| l.attributes['elementId'] } : []
+  ok('a full-width header band exists and references the synthetic title',
+     hdr_gc && hdr_ids == ['title-profitability-watch'] && rect(hdr_gc)[0] == 1 && rect(hdr_gc)[1] == 25)
+  ok('header band sits at the top of the grid', hdr_gc && rect(hdr_gc)[2] == 1)
+  ok('synthetic title referenced exactly once',
+     xml.scan(/elementId="title-profitability-watch"/).length == 1)
+  pg = census && census['pages'].first
+  ok('census counts the synthesized title (zones/placed include it, synthetic_header noted)',
+     pg && pg['synthetic_header'] == true && pg['zones'] == 3 && pg['placed'] == 3 && pg['dropped'] == 0)
+  ok('census unplaced_elements empty — nothing orphaned', pg && pg['unplaced_elements'] == [])
+  ok('no collisions', collisions(xml).empty?)
+end
+
+# 4b. banded path safety net: an element with NO Tableau zone (here an image)
+# must land in a bottom band, never be left for Sigma to auto-flow.
+Dir.mktmpdir do |d|
+  wb = JSON.parse(JSON.generate(WB_TITLE))
+  wb['pages'][1]['elements'] << { 'id' => 'img-logo', 'kind' => 'image', 'name' => nil }
+  xml, census, _log, _els = build(DL_TITLE, wb, d)
+  ok('builder produced layout XML (zone-less image element)', !xml.nil?)
+  next if xml.nil?
+  ok('zone-less image is placed by the banded-path safety net (referenced in a band)',
+     xml.scan(/elementId="img-logo"/).length == 1 && xml.include?('-extra"'))
+  pg = census && census['pages'].first
+  ok('census unplaced_elements empty — the safety net upheld the invariant',
+     pg && pg['unplaced_elements'] == [])
+  ok('no collisions (safety band below content)', collisions(xml).empty?)
+end
+
+# 4c. provenance-aware zone matching: a tile RENAMED to its display title (so
+# neither the zone caption nor display_title matches the element name) resolves
+# through chart-provenance.json (element id → worksheet) instead of falling
+# into the safety-net band — the stale-container-on-re-PUT source defect.
+Dir.mktmpdir do |d|
+  dl = JSON.parse(JSON.generate(DL_TITLE))
+  wb = JSON.parse(JSON.generate(WB_TITLE))
+  wb['pages'][1]['elements'][1]['name'] = 'Gross Margin Trend (renamed)'
+  File.write(File.join(d, 'chart-provenance.json'), JSON.generate(
+    'el-1' => { 'worksheet' => 'Margin Trend', 'dashboard' => 'Profitability Watch' }))
+  xml, census, log, _els = build(dl, wb, d)
+  ok('builder produced layout XML (renamed tile + provenance)', !xml.nil?)
+  next if xml.nil?
+  ok('renamed tile resolves via provenance — placed as a zone tile, not the safety band',
+     xml.scan(/elementId="el-1"/).length == 1 && !xml.include?('-extra"'))
+  ok('no "no Sigma element matched" WARN for the renamed tile', !log.include?('no Sigma element matched'))
+  pg = census && census['pages'].first
+  ok('census counts the renamed tile as placed (no drop)', pg && pg['dropped'] == 0)
+  ok('census unplaced_elements empty', pg && pg['unplaced_elements'] == [])
 end
 
 puts($fail.zero? ? "\nALL PASS — layout synthesis (bands, rail, KPI containers, min rows, determinism)" : "\n#{$fail} FAILED")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-put-layout-prune.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-put-layout-prune.rb
@@ -1,0 +1,107 @@
+#!/usr/bin/env ruby
+# test-put-layout-prune.rb — put-layout.rb must PRUNE stale injected layout
+# chrome on a re-PUT (orphan-fix, class 2). Re-building a layout (e.g. after
+# --rename fixed zone matching) changes the generated container set; earlier
+# PUTs already injected the previous set into the live spec, and an injected
+# element the new layout XML no longer references is auto-flowed by Sigma as an
+# empty white card, bottom-left (live-caught: a stale "tc-<page>-extra"
+# safety-net band surviving every re-PUT). Only put-layout's own injected id
+# namespaces (tc-/syn-/band- containers, their -hdrtext text, dv- dividers) may
+# be pruned — user elements NEVER, referenced chrome NEVER.
+# Loopback WEBrick over http:// (same harness as test-put-layout-auth.rb) —
+# offline, creds-free. Run: ruby scripts/test-put-layout-prune.rb
+require 'webrick'
+require 'json'
+require 'tmpdir'
+require 'open3'
+
+$fail = 0
+def ok(desc); r = yield; puts "#{r ? '  ok  ' : ' FAIL '} #{desc}"; $fail += 1 unless r; end
+
+SCRIPT = File.expand_path('put-layout.rb', __dir__)
+
+# The live spec as a PRIOR put-layout run left it: user elements + the previous
+# build's injected chrome (safety-net band container, fabricated header text,
+# divider) alongside chrome the new layout still uses.
+LIVE_SPEC = {
+  'workbookId' => 'wb-test',
+  'pages' => [
+    { 'id' => 'page-pw', 'name' => 'Profitability Watch', 'elements' => [
+      { 'id' => 'el-a', 'kind' => 'bar-chart', 'name' => 'Margin Trend' },
+      { 'id' => 'title-profitability-watch', 'kind' => 'text', 'name' => nil },
+      { 'id' => 'text-z9', 'kind' => 'text', 'name' => nil },              # user element, unreferenced — keep
+      { 'id' => 'band-page-pw-hdr', 'kind' => 'container' },               # still referenced — keep
+      { 'id' => 'tc-page-pw-extra', 'kind' => 'container' },               # stale safety band — prune
+      { 'id' => 'band-page-pw-hdrtext', 'kind' => 'text' },                # stale fabricated header — prune
+      { 'id' => 'dv-page-pw-z3', 'kind' => 'divider' }                     # stale divider — prune
+    ] }
+  ]
+}.freeze
+
+# The REBUILT layout: header band + title + chart. No -extra band, no
+# fabricated hdrtext, no divider.
+NEW_XML = <<~XML
+  <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="page-pw">
+  <GridContainer elementId="band-page-pw-hdr" type="grid" gridColumn="1 / 25" gridRow="1 / 4" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    <LayoutElement elementId="title-profitability-watch" gridColumn="1 / 25" gridRow="1 / 4"/>
+  </GridContainer>
+  <GridContainer elementId="band-page-pw-1" type="grid" gridColumn="1 / 25" gridRow="4 / 15" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    <LayoutElement elementId="el-a" gridColumn="1 / 25" gridRow="1 / 12"/>
+    <LayoutElement elementId="text-z9" gridColumn="1 / 4" gridRow="1 / 2"/>
+  </GridContainer>
+  </Page>
+XML
+
+Dir.mktmpdir do |work|
+  put_bodies = []
+  srv = WEBrick::HTTPServer.new(Port: 0, BindAddress: '127.0.0.1',
+                                Logger: WEBrick::Log.new(File::NULL), AccessLog: [])
+  port = srv.config[:Port]
+  srv.mount_proc('/') do |req, res|
+    if req.request_method == 'GET'
+      res.body = JSON.generate(LIVE_SPEC)
+    else # PUT
+      put_bodies << req.body
+      res.body = { 'workbookId' => 'wb-test' }.to_json
+    end
+    res['Content-Type'] = 'application/json'
+    res.status = 200
+  end
+  th = Thread.new { srv.start }
+
+  File.write(File.join(work, 'auth.json'),
+             { 'SIGMA_API_TOKEN' => 'filetok', 'SIGMA_BASE_URL' => "http://127.0.0.1:#{port}" }.to_json)
+  layout = File.join(work, 'layout.xml')
+  File.write(layout, NEW_XML, encoding: 'UTF-8')
+  # Sidecar of the REBUILT layout — injection must stay idempotent alongside
+  # the prune (the referenced container is already live: not re-added).
+  File.write("#{layout}.elements.json", JSON.generate(
+    'page-pw' => [{ 'id' => 'band-page-pw-hdr', 'kind' => 'container' },
+                  { 'id' => 'band-page-pw-1', 'kind' => 'container' }]))
+
+  scrub = { 'SIGMA_API_TOKEN' => nil, 'SIGMA_BASE_URL' => nil,
+            'SIGMA_CLIENT_ID' => nil, 'SIGMA_CLIENT_SECRET' => nil, 'HOME' => work }
+  out, st = Open3.capture2e(scrub.merge('SIGMA_WORKDIR' => work),
+                            'ruby', SCRIPT, '--workbook', 'wb-test', '--layout', layout)
+  ok('re-PUT exits 0') { st.exitstatus == 0 }
+  ok('a PUT was sent') { put_bodies.length == 1 }
+  spec = put_bodies.empty? ? {} : (JSON.parse(put_bodies.first) rescue {})
+  els = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  ids = els.map { |e| e['id'] }
+  ok('stale injected safety-net container pruned (tc-page-pw-extra)') { !ids.include?('tc-page-pw-extra') }
+  ok('stale fabricated header text pruned (band-page-pw-hdrtext)') { !ids.include?('band-page-pw-hdrtext') }
+  ok('stale injected divider pruned (dv-page-pw-z3)') { !ids.include?('dv-page-pw-z3') }
+  ok('referenced injected container kept (band-page-pw-hdr, exactly once)') { ids.count('band-page-pw-hdr') == 1 }
+  ok('sidecar container for the new layout injected (band-page-pw-1)') { ids.count('band-page-pw-1') == 1 }
+  ok('user elements never pruned — even unreferenced-looking text ids') do
+    ids.include?('el-a') && ids.include?('title-profitability-watch') && ids.include?('text-z9')
+  end
+  ok('prune is reported on stdout') { out.include?('pruned 3 stale injected layout element(s)') }
+  ok('the new layout XML rode the PUT') { spec['layout'].to_s.include?('title-profitability-watch') }
+
+  srv.shutdown
+  th.join
+end
+
+puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1379,9 +1379,11 @@ end
 # every structural + visual gate above and still ship a page that is mostly
 # empty: tiles silently dropped, or a sparse default stack. build-dashboard-
 # layout.rb emits <workdir>/layout-census.json (one record per page: zones /
-# placed / dropped / grid_fill_pct). This gate hard-fails when any page dropped
-# a tile (placed < zones) OR its grid is under-filled (grid_fill_pct <
-# --min-grid-fill, default 0.45).
+# placed / dropped / grid_fill_pct / unplaced_elements). This gate hard-fails
+# when any page dropped a tile (placed < zones), its grid is under-filled
+# (grid_fill_pct < --min-grid-fill, default 0.45), OR the builder reported
+# ORPHAN elements (unplaced_elements non-empty: an element in the built page
+# that no layout band references — Sigma auto-flows it as a stray white card).
 #
 # Absent census: CONDITIONAL fail. If a dashboard layout was built
 # (dashboard-layout.json present, or a tile_census landed in parity-final.json)
@@ -1401,7 +1403,10 @@ elsif File.exist?(census_fill_path)
     exit 14
   end
   min_fill = opts[:min_grid_fill]
-  bad = pages.select { |p| p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill }
+  bad = pages.select do |p|
+    p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill ||
+      Array(p['unplaced_elements']).any?
+  end
   # Reconcile against the LIVE layout (gate 4 fetched its positioned-element
   # count). A HAND-AUTHORED workbook layout uses element ids the zone-derived
   # census can't match, so build-dashboard-layout.rb reports placed=0/N even
@@ -1426,11 +1431,15 @@ elsif File.exist?(census_fill_path)
         reasons << "#{p['zones'].to_i - p['placed'].to_i} dropped tile(s) (placed #{p['placed']}/#{p['zones']})"
       end
       reasons << "grid fill #{(p['grid_fill_pct'].to_f * 100).round}% < #{(min_fill * 100).round}%" if p['grid_fill_pct'].to_f < min_fill
+      orphans = Array(p['unplaced_elements'])
+      reasons << "#{orphans.length} orphan element(s) no layout band references (auto-flowed as stray cards): #{orphans.join(', ')}" if orphans.any?
       warn "         - #{p['page'].inspect}: #{reasons.join('; ')}"
     end
     warn '       A dropped tile means a source zone never made it into the Sigma layout (empty'
     warn '       view CSV, unhandled rename); an under-filled grid means the page ships mostly'
-    warn '       empty. Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
+    warn '       empty; an orphan element means the built page carries an element the layout'
+    warn '       never places (Sigma auto-flows it as a stray white card, bottom-left).'
+    warn '       Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
     warn '       rebuild the layout, re-PUT, and re-render. Tune with --min-grid-fill F.'
     warn '       Escape hatch (intentionally sparse page): --skip-layout-fill "<reason>" (name it in your report).'
     exit 14

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -1379,9 +1379,11 @@ end
 # every structural + visual gate above and still ship a page that is mostly
 # empty: tiles silently dropped, or a sparse default stack. build-dashboard-
 # layout.rb emits <workdir>/layout-census.json (one record per page: zones /
-# placed / dropped / grid_fill_pct). This gate hard-fails when any page dropped
-# a tile (placed < zones) OR its grid is under-filled (grid_fill_pct <
-# --min-grid-fill, default 0.45).
+# placed / dropped / grid_fill_pct / unplaced_elements). This gate hard-fails
+# when any page dropped a tile (placed < zones), its grid is under-filled
+# (grid_fill_pct < --min-grid-fill, default 0.45), OR the builder reported
+# ORPHAN elements (unplaced_elements non-empty: an element in the built page
+# that no layout band references — Sigma auto-flows it as a stray white card).
 #
 # Absent census: CONDITIONAL fail. If a dashboard layout was built
 # (dashboard-layout.json present, or a tile_census landed in parity-final.json)
@@ -1401,7 +1403,10 @@ elsif File.exist?(census_fill_path)
     exit 14
   end
   min_fill = opts[:min_grid_fill]
-  bad = pages.select { |p| p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill }
+  bad = pages.select do |p|
+    p['placed'].to_i < p['zones'].to_i || p['grid_fill_pct'].to_f < min_fill ||
+      Array(p['unplaced_elements']).any?
+  end
   # Reconcile against the LIVE layout (gate 4 fetched its positioned-element
   # count). A HAND-AUTHORED workbook layout uses element ids the zone-derived
   # census can't match, so build-dashboard-layout.rb reports placed=0/N even
@@ -1426,11 +1431,15 @@ elsif File.exist?(census_fill_path)
         reasons << "#{p['zones'].to_i - p['placed'].to_i} dropped tile(s) (placed #{p['placed']}/#{p['zones']})"
       end
       reasons << "grid fill #{(p['grid_fill_pct'].to_f * 100).round}% < #{(min_fill * 100).round}%" if p['grid_fill_pct'].to_f < min_fill
+      orphans = Array(p['unplaced_elements'])
+      reasons << "#{orphans.length} orphan element(s) no layout band references (auto-flowed as stray cards): #{orphans.join(', ')}" if orphans.any?
       warn "         - #{p['page'].inspect}: #{reasons.join('; ')}"
     end
     warn '       A dropped tile means a source zone never made it into the Sigma layout (empty'
     warn '       view CSV, unhandled rename); an under-filled grid means the page ships mostly'
-    warn '       empty. Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
+    warn '       empty; an orphan element means the built page carries an element the layout'
+    warn '       never places (Sigma auto-flows it as a stray white card, bottom-left).'
+    warn '       Check build-dashboard-layout.rb WARN lines for dropped/unmatched zones,'
     warn '       rebuild the layout, re-PUT, and re-render. Tune with --min-grid-fill F.'
     warn '       Escape hatch (intentionally sparse page): --skip-layout-fill "<reason>" (name it in your report).'
     exit 14


### PR DESCRIPTION
<!-- See CONTRIBUTING.md. Keep one PR = one plugin (or one isolated shared-lib change). -->

## What & why

Fixes the empty-white-card layout defect observed on **every workbook in three live e2e runs**: an element present in the built page that no layout band references, which Sigma auto-flows as a stray white card bottom-left. Two observed classes, one shared invariant.

**Class 1 — orphaned synthetic dashboard title.** `build-charts-from-signals.rb` emits a synthetic title text element (id `title-<dashboard-slug>`, body `# <Dashboard Name>`) when the .twb has no top title zone — e.g. `{"id": "title-profitability-watch", "kind": "text", "body": "# Profitability Watch"}` in `wb-spec.json`. The title is not a .twb zone, so nothing guaranteed the layout referenced it, and the census could not see a miss: `layout-census.json` reported `zones=7 placed=7` with `bands_detected.header=false` while the title floated unplaced. Root-cause choice: fixed on the **layout/census side**, not emission — all three layout paths already seat a `title-*` element in a slim full-width header band (`detect_header_title_el`), and emission is already correctly suppressed when the source has its own top title zone (`dash_has_top_title`); the actual gap was that placement was unverified and the title was invisible to gate 8c. Now the census counts a synthesized title header in `zones`/`placed` and marks it `synthetic_header: true`, and the banded path gains the same unplaced-elements safety-net band the tree/synthesized paths already had (it previously orphaned any image/button/stray-text element outright).

**Class 2 — stale injected containers on re-PUT (second-run evidence).** Zone→element matching is display-name based while zones only know the worksheet caption, so a renamed tile fell into the safety-net band (`"N element(s) had no Tableau zone"` → injected `tc-<page>-extra` container). After the layout was corrected (e.g. `--rename`) and re-PUT, `put-layout.rb` injected the new container set but **never pruned the previous one** — the stale container stayed in the spec unreferenced and rendered as the white card. Now `put-layout.rb` prunes injected chrome (`tc-`/`syn-`/`band-` containers, their fabricated `-hdrtext` text, `dv-` dividers) that the incoming layout XML no longer references — never user elements, never still-referenced chrome. At the source, `build-dashboard-layout.rb` resolves renamed tiles through `chart-provenance.json` (element id → worksheet, the collision-free join build-charts already writes) plus a shared `find_zone_el` caption fallback across all three paths and their census counts, so the safety net mostly stops firing at all. The banded path also de-dupes element ids like the other paths (a duplicate `LayoutElement` id makes Sigma reject the whole PUT).

**The invariant (durable guard for both classes):** no element in the built page may be absent from the layout bands. `layout-census.json` now carries per-page `unplaced_elements`, computed by scanning the page XML each path actually emitted (not per-path bookkeeping), and gate 8c (`assert-phase6-ran.rb`) hard-fails on a non-empty list.

## Scope

- Plugin(s) touched: tableau-to-sigma (`build-dashboard-layout.rb`, `put-layout.rb`, tests) + the shared gate 8c consumer (`shared/scripts/assert-phase6-ran.rb`, synced to its 6 plugin copies via `tools/sync-shared.rb`)
- [x] The shared-lib edit is the gate-side half of this one fix (census producer + consumer must land together); no other plugin behavior changes

## Checklist

- [x] `ruby tools/check-shared.rb` — green (edited `shared/scripts/assert-phase6-ran.rb`, ran `tools/sync-shared.rb`)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (14/14; no converter goldens affected)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in

## Tests

- `test-layout-synthesis.rb` (extended): synthetic title + **no** header zone → full-width header band exists at the top, title referenced exactly once, census counts it (`zones`/`placed` + `synthetic_header: true`), `unplaced_elements` empty; synthetic title + **real** source header zone → no duplicate reference and no `synthetic_header`; banded-path safety net places a zone-less image element; a renamed tile resolves via `chart-provenance.json` with no safety band and no drop.
- `test-layout-fill-gate.rb` (extended): census with non-empty `unplaced_elements` → gate 8c exit 14; empty list passes.
- `test-put-layout-prune.rb` (new, loopback WEBrick re-PUT): stale `tc-*-extra` / `band-*-hdrtext` / `dv-*` chrome pruned from the spec; still-referenced injected containers and user elements kept; sidecar injection stays idempotent. Registered in `corpus-check.yml`.
- Full layout test set (`test-layout-*`, `test-container-*`, `test-styled-text-layout`, `test-header-band-clamp`, `test-display-title-match`, `test-zone-census`, `test-put-layout-auth`, `test-assert-phase6-gates`) + `tools/hygiene-sweep.sh` + `tools/check-shared.rb` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
