### PR TITLE
tableau: DROPPED_BY_API contract — spec-API accepted-then-silently-dropped control fields (#415/#417)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
@@ -245,6 +245,27 @@ filters:
 
 `top-n` is a dedicated control type for "show the top N" interactions. Wire it like any other control via `filters`; the cap is a flat top-level field.
 
+## Dropped-by-API fields (accepted-then-ignored) — the DROPPED_BY_API contract
+
+A family of control fields that `POST/PUT /v2/workbooks/spec` **accepts with 200 and no validation error, then silently drops**: the readback (`GET /v2/workbooks/{id}/spec`) omits them entirely and they never take effect on the live control. This is a **Sigma product gap**, distinct from spec-grammar mistakes (those 400 or return `Invalid kind: control`). Field-confirmed by round-tripping live workbooks (tableau-to-sigma issues #415 and #417, 2026-07-17).
+
+Do not emit these naively. The machine-readable version of this table is `DROPPED_BY_API` in the shared preflight lint (`shared/lib/preflight_lint.rb`, vendored into every converter's `scripts/lib/`); the lint WARNs (`A1`/`A2`) on any spec carrying one, and the tableau-to-sigma post-POST control-field audit (`post-and-readback.rb`) diffs every posted control against its readback so *future* members of this family surface automatically.
+
+| Field | controlType | Observed behavior | Sanctioned workaround |
+|---|---|---|---|
+| `showNullOption` | `list` / `segmented` / `hierarchy` | 200 on POST/PUT; absent on readback; the live control **still shows "Null" as a selectable value** (#417) | Filter nulls at the control's **option-source**: point the value-list `source` at a hidden helper element carrying an `IsNotNull(<col>)` filter (field-validated) |
+| `allowMultipleSelection` | `list` | 200; dropped on readback; no effect (#417) | `selectionMode: "single"\|"multiple"` — persists |
+| `excludeValues` | `list` / `segmented` / `hierarchy` | 200; dropped on readback; no effect (#417) | `mode: "exclude"` + `values` = the excluded members — persists |
+| `showClearButton` | `list` (editor toggle) | 200; dropped on readback; no effect (#417) | None in the spec — set in the UI control editor post-publish (record in the post-publish guide) |
+| `showSearchBox` | `list` (editor toggle) | 200; dropped on readback; no effect (#417) | None in the spec — set in the UI post-publish |
+| `showHistogram` | `list` / sliders (editor toggle) | 200; dropped on readback; no effect (#417) | None in the spec — set in the UI post-publish |
+| `showExpandedList` | `list` (editor toggle) | 200; dropped on readback; no effect (#417) | None in the spec — set in the UI post-publish |
+| `required` | any (editor toggle) | 200; dropped on readback; no effect (#417) | None in the spec — set in the UI post-publish |
+| `startDate` / `endDate` as a **bare date** (`"2026-01-01"`) or zoneless timestamp | `date-range` (`mode: between`/`custom`) | 200; absent on readback; the control renders the "Select date range" placeholder with **no default**, so filtered elements open unfiltered (#415) | Emit a **full ISO-8601 UTC timestamp** (`"2026-01-01T00:00:00Z"`) — the only string form observed to round-trip; confirm via post-POST readback, else set the default in the UI |
+| `value: {…}` object (e.g. `{min,max}` / `{low,high}`) | `date-range` and others | 200 (or `Invalid kind: control`); stripped on round-trip; no default | Control value fields are **flat top-level** (`startDate`/`endDate`, `low`/`high`, scalar `value`) — see the field table at the top of this file |
+
+> A `selectionMode: "single"` control carrying a `values` **array** is the same accepted-then-ignored class (both the filter and the default silently drop) — the preflight lint fails it as `C5`; use scalar `value`.
+
 ---
 
 ## Referencing a Control's Value in a Formula

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -373,6 +373,24 @@ def current_period_bounds(period, now = Time.now)
   relative_period_bounds(period, 0, 0, now)
 end
 
+# #415: the Workbook Spec API ACCEPTS a bare-date `startDate`/`endDate` default
+# on a date-range control (200 on POST/PUT) and SILENTLY DROPS it on readback —
+# the live control shows the "Select date range" placeholder and every filtered
+# element opens unfiltered. Full ISO-8601 UTC timestamps ("2026-01-01T00:00:00Z")
+# are the only string form observed to round-trip (refs/workbook-layout.md).
+# Normalize every emitted default to that persisting form. Tableau attribute
+# forms handled: "#2026-01-01#", "2026-01-01", "2026-01-01 00:00:00". Anything
+# unrecognized is returned AS-IS — the preflight lint (A2 WARN) and the
+# post-POST control-field audit surface it rather than a silent mangle.
+def iso_utc_datestamp(v, end_of_day: false)
+  s = v.to_s.strip.sub(/\A#/, '').sub(/#\z/, '')
+  return v if s.empty?
+  return s if s =~ /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/
+  m = s.match(/\A(\d{4}-\d{2}-\d{2})(?:[T ](\d{2}:\d{2}:\d{2}))?\z/)
+  return v unless m
+  "#{m[1]}T#{m[2] || (end_of_day ? '23:59:59' : '00:00:00')}Z"
+end
+
 # Tableau period-type → Sigma date-range `unit` enum. Sigma has no bare "week"
 # (it splits Sunday/Monday anchored) and no "weekday"/other Tableau grains.
 # Returns nil for grains Sigma's rolling modes can't express (caller falls back).
@@ -6784,6 +6802,38 @@ unless opts[:no_auto_controls]   # default-on: never miss a .twb parameter/filte
         'columnId' => m['id']
       }
       spec['filters'] = targets
+      # #417 workaround: the Tableau filter EXCLUDES Null, but Sigma's
+      # `showNullOption:false` is accepted by POST/PUT then SILENTLY DROPPED on
+      # readback — it never suppresses the null option. The field-validated
+      # alternative: filter nulls at the control's OPTION-SOURCE — a hidden
+      # helper element sourcing the master with an IsNotNull(<col>) filter, and
+      # the control's value list pointed at it. (Data-side exclusion still rides
+      # the control's mode/values; only the OPTION LIST changes here.)
+      if f['excludes_null'] && spec['controlType'] == 'list'
+        opt_id = "opt-src-#{slug}"
+        opt_val_col = "#{opt_id}-v"
+        opt_nn_col  = "#{opt_id}-nn"
+        data_elements << {
+          'id' => opt_id, 'kind' => 'table', 'name' => "#{cap.strip} Options",
+          'source' => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+          'columns' => [
+            { 'id' => opt_val_col, 'name' => cap.strip, 'formula' => "[Master/#{m['name']}]" },
+            { 'id' => opt_nn_col, 'name' => "#{cap.strip} Not Null",
+              'formula' => "IsNotNull([Master/#{m['name']}])" }
+          ],
+          'filters' => [{ 'columnId' => opt_nn_col, 'kind' => 'list', 'mode' => 'include',
+                          'selectionMode' => 'multiple', 'values' => [true] }],
+          'visibleAsSource' => false
+        }
+        spec['source'] = {
+          'kind'     => 'source',
+          'source'   => { 'kind' => 'table', 'elementId' => opt_id },
+          'columnId' => opt_val_col
+        }
+        warnings << "quick filter '#{cap}' EXCLUDES Null — `showNullOption:false` is silently dropped by " \
+                    "the spec API (#417), so the control's option list sources hidden helper " \
+                    "'#{cap.strip} Options' with an IsNotNull filter at the option source (sanctioned workaround)"
+      end
       if f['exclude']
         warnings << "quick filter '#{cap}' is EXCLUDE-mode → list control mode:exclude seeded with " \
                     "#{(f['members'] || []).size} excluded value(s): #{(f['members'] || []).join(', ')[0..80]}"
@@ -6827,10 +6877,18 @@ unless opts[:no_auto_controls]   # default-on: never miss a .twb parameter/filte
       if %w[date datetime].include?(f['datatype'].to_s)
         # Quantitative filter on a DATE column: a range-slider is the wrong
         # widget (renders epoch numbers) — date-range with the parsed bounds.
+        # Bounds go through iso_utc_datestamp: a bare-date default is accepted
+        # then SILENTLY DROPPED by the spec API (#415); only full ISO-8601 UTC
+        # timestamps round-trip.
         spec['controlType'] = 'date-range'
         spec['mode'] = 'between'
-        spec['startDate'] = f['min'] if f['min']
-        spec['endDate']   = f['max'] if f['max']
+        spec['startDate'] = iso_utc_datestamp(f['min']) if f['min']
+        spec['endDate']   = iso_utc_datestamp(f['max'], end_of_day: true) if f['max']
+        if (f['min'] && spec['startDate'] != f['min']) || (f['max'] && spec['endDate'] != f['max'])
+          warnings << "shared filter '#{cap}' date-range default normalized to ISO-8601 UTC " \
+                      "(#{spec['startDate']}..#{spec['endDate']}) — bare dates are accepted then " \
+                      'silently dropped by the spec API (#415); only Z-suffixed timestamps persist'
+        end
       elsif f['min'] && f['max']
         spec['controlType'] = 'range-slider'
         # Bounds are load-bearing: a bare range-slider renders 0..0 and filters
@@ -6932,10 +6990,17 @@ if opts[:controls]
       spec['mode'] = c['mode'] || 'between'
       if c['default']
         d = c['default']
-        spec['startDate'] = d['startDate'] if d['startDate']
-        spec['endDate']   = d['endDate']   if d['endDate']
+        # #415: bare-date defaults are accepted then silently dropped by the
+        # spec API — normalize to the persisting ISO-8601 UTC timestamp form.
+        # Relative {op,unit,value} hashes (custom mode) pass through untouched.
+        spec['startDate'] = d['startDate'].is_a?(String) ? iso_utc_datestamp(d['startDate']) : d['startDate'] if d['startDate']
+        spec['endDate']   = d['endDate'].is_a?(String) ? iso_utc_datestamp(d['endDate'], end_of_day: true) : d['endDate'] if d['endDate']
         spec['unit']      = d['unit']      if d['unit']
         spec['mode']      = d['mode']      if d['mode']
+        if spec['startDate'] != d['startDate'] || spec['endDate'] != d['endDate']
+          warnings << "control '#{spec['name']}' date-range default normalized to ISO-8601 UTC — bare dates " \
+                      'are accepted then silently dropped by the spec API (#415); only Z-suffixed timestamps persist'
+        end
       end
     when 'segmented'
       spec['source'] = c['source'] || {

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_field_census.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_field_census.rb
@@ -1,0 +1,74 @@
+# Post-readback CONTROL-FIELD census (issues #415/#417).
+#
+# WHY: the Workbook Spec API accepts a family of control fields with 200 on
+# POST/PUT and SILENTLY DROPS them on readback — they never take effect on the
+# live control. Known members: the list-control editor toggles
+# (showNullOption / showClearButton / showSearchBox / showHistogram /
+# allowMultipleSelection / excludeValues / showExpandedList / required, #417)
+# and bare-date date-range startDate/endDate defaults (#415). The preflight
+# lint (A1/A2 in lib/preflight_lint.rb, DROPPED_BY_API) warns on the KNOWN
+# list pre-POST; this census catches the WHOLE class empirically — any field
+# present on a posted control but absent from its readback — so FUTURE members
+# of the family surface automatically without a lint update.
+#
+# Pure functions only — no HTTP, no filesystem — so the logic is fully
+# testable offline (scripts/test-control-field-census.rb). post-and-readback.rb
+# wires it to the live readback on the workbook path and WARNs loudly on any
+# dropped field (a WARN, not a hard stop: the workbook is live and correct
+# except for the ignored field; the operator sets it in the UI).
+
+module ControlFieldCensus
+  # Keys never expected to survive: builder-internal annotations (underscore-
+  # prefixed are stripped before POST anyway) and the in-spec controlScope
+  # allowlist, which Sigma documents as stripped (control_lint.rb CONTRACT).
+  IGNORE_KEYS = %w[controlScope].freeze
+
+  module_function
+
+  # Compare the posted spec's control elements against the readback.
+  #
+  #   posted_spec   — the Hash that was POSTed
+  #   readback_spec — the Hash from GET .../spec after POST/PUT
+  #
+  # Controls are matched by element id, then controlId, then name (workbook
+  # PUTs generally preserve ids; the fallbacks keep the census honest when
+  # they don't). Returns an Array of discrepancy Hashes (empty == clean):
+  #   { 'control' => name-or-id, 'controlType' => ..., 'dropped' => [keys] }
+  # A posted control MISSING from the readback entirely is reported with
+  # 'dropped' => ['(entire control absent from readback)'].
+  def census(posted_spec, readback_spec)
+    rb_controls = controls(readback_spec)
+    by_id   = rb_controls.each_with_object({}) { |e, h| h[e['id']] ||= e if e['id'] }
+    by_cid  = rb_controls.each_with_object({}) { |e, h| h[e['controlId']] ||= e if e['controlId'] }
+    by_name = rb_controls.each_with_object({}) { |e, h| h[e['name']] ||= e if e['name'] }
+
+    problems = []
+    controls(posted_spec).each do |pel|
+      label = pel['name'] || pel['controlId'] || pel['id'] || '?'
+      live = by_id[pel['id']] || by_cid[pel['controlId']] || by_name[pel['name']]
+      if live.nil?
+        problems << { 'control' => label, 'controlType' => pel['controlType'],
+                      'dropped' => ['(entire control absent from readback)'] }
+        next
+      end
+      dropped = pel.keys.reject { |k| k.start_with?('_') || IGNORE_KEYS.include?(k) } - live.keys
+      next if dropped.empty?
+      problems << { 'control' => label, 'controlType' => pel['controlType'],
+                    'dropped' => dropped.sort }
+    end
+    problems
+  end
+
+  def report_lines(problems)
+    problems.map do |p|
+      "control \"#{p['control']}\" (#{p['controlType'] || '?'}): posted field(s) absent from readback: " \
+        "#{Array(p['dropped']).join(', ')}"
+    end
+  end
+
+  def controls(spec)
+    return [] unless spec.is_a?(Hash)
+    (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+                         .select { |e| e.is_a?(Hash) && e['kind'].to_s == 'control' }
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -347,6 +347,7 @@ def normalize_filter(f)
     members = []
     conditions = []
     exclude = false
+    null_member = false
     wildcard = nil
     wildcard_unparsed = nil
     topn = nil
@@ -362,6 +363,12 @@ def normalize_filter(f)
       enum_attr = gf.attributes['user:ui-enumeration'] || gf.attributes['ui-enumeration']
       exclude = true if fn == 'except' || enum_attr.to_s == 'exclusive'
       if fn == 'member'
+        # `%null%` is Tableau's Null member sentinel. unquote_member drops it
+        # (a Sigma list value can't carry null), but REMEMBER we saw it: in an
+        # exclude filter it means "Tableau hides the null bucket" — the signal
+        # the builder needs for the #417 option-source IsNotNull workaround
+        # (Sigma's `showNullOption:false` is accepted then silently dropped).
+        null_member = true if gf.attributes['member'].to_s.strip == '%null%'
         m = unquote_member(gf.attributes['member'])
         members << m if m
       end
@@ -405,6 +412,11 @@ def normalize_filter(f)
     out['kind']    = 'list'
     out['members'] = members
     out['exclude'] = true if exclude
+    # An exclude filter whose excluded members include Null: the view hides
+    # the null bucket. Surfaced so the builder can filter nulls at the list
+    # control's option source (#417 workaround) instead of emitting the
+    # silently-dropped `showNullOption:false`.
+    out['excludes_null'] = true if exclude && null_member
     if topn
       topn['direction']  = (order_dir || 'DESC').to_s.upcase
       topn['order_expr'] = order_expr if order_expr

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -732,6 +732,39 @@ rescue StandardError => e
   warn "WARN: filters census skipped (#{e.class}: #{e.message[0, 80]})"
 end
 
+# CONTROL-FIELD census (workbooks; issues #415/#417) — the Workbook Spec API
+# accepts a family of control fields with 200 and SILENTLY DROPS them on
+# readback (list-control editor toggles like showNullOption, bare-date
+# date-range startDate/endDate defaults). The preflight lint (A1/A2,
+# DROPPED_BY_API in lib/preflight_lint.rb) warns on the KNOWN members
+# pre-POST; this audit diffs EVERY posted control's fields against its
+# readback so future members of the family surface automatically. WARN, not
+# a hard stop: the workbook is live and correct except for the ignored field.
+begin
+  posted_spec ||= (JSON.parse(File.read(opts[:spec])) rescue nil)
+  if opts[:type] == 'workbook' && posted_spec && spec.is_a?(Hash)
+    require_relative 'lib/control_field_census'
+    cf_problems = ControlFieldCensus.census(posted_spec, spec)
+    if cf_problems.any?
+      warn "\n========================================"
+      warn "WARN — CONTROL FIELD(S) silently dropped by the spec API: #{cf_problems.size} control(s) " \
+           'posted field(s) that the readback does not carry (accepted with 200, then ignored — they'
+      warn 'never take effect on the live control; Sigma product gap, NOT a spec 400):'
+      ControlFieldCensus.report_lines(cf_problems).each { |l| warn "  #{l}" }
+      warn 'Known family + sanctioned workarounds: DROPPED_BY_API in scripts/lib/preflight_lint.rb and'
+      warn 'sigma-workbooks reference/specification/controls.md ("Dropped-by-API fields"). A dropped'
+      warn 'DEFAULT (e.g. date-range startDate/endDate) means the control ships with NO default — set it'
+      warn 'in the Sigma UI control editor and record the step in POSTPUBLISH_GUIDE.md.'
+      warn '========================================'
+    else
+      n = ControlFieldCensus.controls(posted_spec).size
+      warn "control-field census: #{n} posted control(s), no silently-dropped fields" if n.positive?
+    end
+  end
+rescue StandardError => e
+  warn "WARN: control-field census skipped (#{e.class}: #{e.message[0, 80]})"
+end
+
 # Rec5 quarantine final report: the (re-)POST succeeded and the census is clean,
 # but only because broken element(s) were REMOVED. The DM is PARTIAL — exit with
 # the distinct code so no caller mistakes this for a full green POST.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-field-census.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-field-census.rb
@@ -1,0 +1,119 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the post-readback CONTROL-FIELD census (issues #415/#417).
+#
+# The Workbook Spec API accepts a family of control fields with 200 on POST/PUT
+# and SILENTLY DROPS them on readback (showNullOption + sibling list-editor
+# toggles, #417; bare-date date-range startDate/endDate defaults, #415). The
+# census diffs EVERY posted control's fields against its readback so future
+# members of the family surface automatically — not just the known list.
+#
+# Pure-lib test: no HTTP, no credentials. Stubs a posted spec + a readback
+# with the dropped fields absent, exactly as the live API behaves.
+#
+# Usage:  ruby scripts/test-control-field-census.rb
+require 'json'
+require_relative 'lib/control_field_census'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+def posted
+  JSON.parse(JSON.generate(
+    'pages' => [{
+      'name' => 'Dash',
+      'elements' => [
+        { 'id' => 'el-master', 'kind' => 'table', 'name' => 'Master',
+          'columns' => [{ 'id' => 'c1', 'name' => 'Region', 'formula' => '[Src/Region]' }] },
+        { 'id' => 'el-ctl-region', 'kind' => 'control', 'controlId' => 'ctl-region',
+          'name' => 'Region', 'controlType' => 'list',
+          'mode' => 'include', 'selectionMode' => 'multiple', 'values' => [],
+          'showNullOption' => false,                       # #417: silently dropped
+          '_scope_dashboards' => ['Dash'],                 # builder-internal — never posted as-is
+          'controlScope' => ['Chart A'],                   # documented as stripped — not a drop signal
+          'source' => { 'kind' => 'source',
+                        'source' => { 'kind' => 'table', 'elementId' => 'el-master' },
+                        'columnId' => 'c1' },
+          'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'el-master' },
+                          'columnId' => 'c1' }] },
+        { 'id' => 'el-ctl-date', 'kind' => 'control', 'controlId' => 'ctl-date',
+          'name' => 'Order Date', 'controlType' => 'date-range', 'mode' => 'between',
+          'startDate' => '2026-01-01',                     # #415: silently dropped
+          'endDate' => '2026-03-31',
+          'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'el-master' },
+                          'columnId' => 'c1' }] }
+      ]
+    }]
+  ))
+end
+
+# Readback exactly as the live API returns it: same controls, dropped fields
+# absent, internal keys never present.
+def readback_dropping(*dropped)
+  rb = posted
+  rb['pages'][0]['elements'].each do |el|
+    next unless el['kind'] == 'control'
+    el.delete('_scope_dashboards')
+    el.delete('controlScope')
+    dropped.each { |k| el.delete(k) }
+  end
+  rb
+end
+
+# ---- a stubbed dropped field is flagged, per control ------------------------
+probs = ControlFieldCensus.census(posted, readback_dropping('showNullOption', 'startDate', 'endDate'))
+check(probs.size == 2, "both controls flagged (got #{probs.inspect})", fails)
+list_p = probs.find { |p| p['control'] == 'Region' }
+check(list_p && list_p['dropped'] == ['showNullOption'],
+      "list control: dropped == ['showNullOption'] (got #{list_p.inspect})", fails)
+date_p = probs.find { |p| p['control'] == 'Order Date' }
+check(date_p && date_p['dropped'] == %w[endDate startDate],
+      "date-range control: dropped == [endDate, startDate] (got #{date_p.inspect})", fails)
+lines = ControlFieldCensus.report_lines(probs)
+check(lines.any? { |l| l.include?('showNullOption') && l.include?('Region') },
+      'report lines name the control and the dropped field', fails)
+
+# ---- clean round-trip → no problems; internal keys never count --------------
+check(ControlFieldCensus.census(posted, readback_dropping) == [],
+      'readback carrying every posted field (minus internal keys) → clean', fails)
+
+# ---- a FUTURE family member (not in any known list) is still caught ---------
+fut = posted
+fut['pages'][0]['elements'][1]['someFutureToggle'] = true
+probs = ControlFieldCensus.census(fut, readback_dropping('showNullOption'))
+reg = probs.find { |p| p['control'] == 'Region' }
+check(reg && reg['dropped'].include?('someFutureToggle'),
+      "unknown dropped field is caught too (got #{reg.inspect})", fails)
+
+# ---- match falls back to controlId, then name, when element ids change ------
+rb = readback_dropping('showNullOption')
+rb['pages'][0]['elements'].each { |el| el['id'] = "srv-#{el['id']}" if el['kind'] == 'control' }
+probs = ControlFieldCensus.census(posted, rb)
+check(probs.any? { |p| p['control'] == 'Region' && p['dropped'] == ['showNullOption'] },
+      'census matches by controlId when the server re-minted element ids', fails)
+
+# ---- a control missing from the readback entirely is reported ---------------
+rb = readback_dropping
+rb['pages'][0]['elements'].reject! { |el| el['controlId'] == 'ctl-date' }
+probs = ControlFieldCensus.census(posted, rb)
+check(probs.any? { |p| p['control'] == 'Order Date' && p['dropped'].first.include?('absent') },
+      'control absent from readback entirely → reported', fails)
+
+# ---- non-control elements are ignored ---------------------------------------
+rb = readback_dropping
+rb['pages'][0]['elements'][0].delete('columns') # table shape change is not this census's job
+check(ControlFieldCensus.census(posted, rb) == [],
+      'non-control elements are out of scope', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — control-field census flags silently-dropped control fields (known + future family members)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-date-default-normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-date-default-normalize.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# Regression test for the #415 date-range default normalization.
+#
+# POST/PUT /v2/workbooks/spec ACCEPTS a date-range control with bare-date
+# `startDate`/`endDate` defaults ("2026-01-01") and SILENTLY DROPS them on
+# readback — the live control shows the "Select date range" placeholder and
+# every element it filters opens unfiltered. Full ISO-8601 UTC timestamps
+# ("2026-01-01T00:00:00Z") are the only string form observed to round-trip
+# (refs/workbook-layout.md). The builder therefore normalizes every emitted
+# default through iso_utc_datestamp; unrecognized inputs pass through AS-IS so
+# the A2 preflight WARN + the post-POST control-field audit can surface them
+# (never a silent mangle).
+#
+# Extracts the pure helper straight from build-charts-from-signals.rb (same
+# technique as test-relative-date-filter.rb) — offline, creds-free.
+#
+# Usage:  ruby scripts/test-date-default-normalize.rb
+
+SRC = File.join(__dir__, 'build-charts-from-signals.rb')
+src = File.read(SRC)
+m = src[/def iso_utc_datestamp.*?\nend/m]
+abort "could not extract iso_utc_datestamp from #{SRC} — did it move/rename?" unless m
+eval(m) # rubocop:disable Security/Eval — trusted first-party source, test-only
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# bare date → persisting UTC form (start-of-day / end-of-day)
+check(iso_utc_datestamp('2026-01-01') == '2026-01-01T00:00:00Z',
+      'bare date → T00:00:00Z (the form the API round-trips)', fails)
+check(iso_utc_datestamp('2026-03-31', end_of_day: true) == '2026-03-31T23:59:59Z',
+      'end bound → T23:59:59Z', fails)
+
+# Tableau attribute forms
+check(iso_utc_datestamp('#2026-01-01#') == '2026-01-01T00:00:00Z',
+      'Tableau #date# literal unwrapped + normalized', fails)
+check(iso_utc_datestamp('2026-01-01 14:30:00') == '2026-01-01T14:30:00Z',
+      'zoneless datetime gets the UTC Z suffix (space separator)', fails)
+
+# already-persisting forms pass through unchanged
+check(iso_utc_datestamp('2026-01-01T00:00:00Z') == '2026-01-01T00:00:00Z',
+      'Z-suffixed timestamp unchanged', fails)
+check(iso_utc_datestamp('2026-01-01T00:00:00+05:30') == '2026-01-01T00:00:00+05:30',
+      'offset timestamp unchanged', fails)
+
+# unrecognized input is returned AS-IS (lint + readback audit surface it)
+check(iso_utc_datestamp('last month') == 'last month',
+      'unparseable input passes through untouched (no silent mangle)', fails)
+check(iso_utc_datestamp('') == '', 'empty string untouched', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — date-range defaults normalize to the persisting ISO-8601 UTC form (#415)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-null-option-source-filter.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-null-option-source-filter.rb
@@ -1,0 +1,190 @@
+#!/usr/bin/env ruby
+# Regression test for the #417 null-option workaround (DROPPED_BY_API family).
+#
+# Sigma's `showNullOption:false` on a list control is accepted by
+# POST/PUT /v2/workbooks/spec (200) and SILENTLY DROPPED on readback — the live
+# control keeps showing "Null" as a selectable value. So the builder must NEVER
+# emit it. When the Tableau quick filter explicitly EXCLUDES Null (an
+# except-wrapped groupfilter with a `%null%` member), the field-validated
+# workaround applies instead: filter nulls at the control's OPTION-SOURCE — a
+# hidden helper element sourcing the master with an IsNotNull(<col>) filter,
+# and the control's value list pointed at the helper.
+#
+# Chain under test:
+#   parse-twb-layout  → flags the filter excludes_null:true (the %null% member
+#                       used to be dropped silently by unquote_member)
+#   build-charts      → emits the "<cap> Options" helper (IsNotNull filter) in
+#                       data_elements, re-points the control's `source` at it,
+#                       and NEVER emits showNullOption
+#   a null-free exclude filter stays byte-identical (source = master).
+#
+# Deterministic + offline + creds-free: synthetic .twb through the ACTUAL
+# parser + builder. Neutral fixture names only (Region A/B, TOTALREV).
+#
+# Usage:  ruby scripts/test-null-option-source-filter.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+    <datasources>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Region' name='[REGION]' datatype='string' role='dimension' />
+        <column caption='Team' name='[TEAM]' datatype='string' role='dimension' />
+        <column caption='Total Revenue' name='[TOTALREV]' datatype='real' role='measure' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Rev Sheet'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.x' />
+          </view>
+          <rows>[federated.x].[sum:TOTALREV:qk]</rows>
+          <cols>[federated.x].[none:REGION:nk]</cols>
+          <pane><mark class='Bar' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Dash'>
+        <zones>
+          <zone id='1' name='Rev Sheet' x='0' y='0' w='100000' h='100000' />
+        </zones>
+      </dashboard>
+    </dashboards>
+    <shared-view name='sv1'>
+      <filter class='categorical' column='[federated.x].[none:REGION:nk]'>
+        <groupfilter function='except'>
+          <groupfilter function='level-members' level='[none:REGION:nk]' />
+          <groupfilter function='union'>
+            <groupfilter function='member' level='[none:REGION:nk]' member='%null%' />
+            <groupfilter function='member' level='[none:REGION:nk]' member='&quot;Region B&quot;' />
+          </groupfilter>
+        </groupfilter>
+      </filter>
+      <filter class='categorical' column='[federated.x].[none:TEAM:nk]'>
+        <groupfilter function='except'>
+          <groupfilter function='level-members' level='[none:TEAM:nk]' />
+          <groupfilter function='union'>
+            <groupfilter function='member' level='[none:TEAM:nk]' member='&quot;Team B&quot;' />
+          </groupfilter>
+        </groupfilter>
+      </filter>
+    </shared-view>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Region$'        => { 'id' => 'm-region', 'name' => 'Region' },
+  '(?i)^Team$'          => { 'id' => 'm-team',   'name' => 'Team' },
+  '(?i)^Total Revenue$' => { 'id' => 'm-rev',    'name' => 'Total Revenue' }
+}
+
+meta = nil
+build_out = nil
+data = []
+build_log = ''
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Rev Sheet' }] }))
+  Dir.mkdir(File.join(d, 'views'))
+  File.write(File.join(d, 'views', 'v1.csv'), '') # empty → build from .twb signals
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  meta = JSON.parse(File.read(lay.sub(/\.json$/, '-meta.json')))
+  out = File.join(d, 'specs.json')
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --skip-dashboard-read unit-test --auto-controls --title Dash --out #{out} 2>&1`
+  build_log = build_log.to_s.force_encoding('UTF-8')
+  build_out = JSON.parse(File.read(out)) if File.exist?(out)
+  # Hidden data elements: inline under 'data_elements' (pages modes) or the
+  # -data-elements.json sidecar (default flat mode).
+  side = out.sub(/\.json$/, '-data-elements.json')
+  data = JSON.parse(File.read(side)) if File.exist?(side)
+end
+
+# ---- Parser: %null% member in an except tree flags excludes_null -------------
+sf_region = (meta['shared_filters'] || []).find { |f| f['column_caption'] == 'Region' }
+check(sf_region && sf_region['excludes_null'] == true,
+      "parser flags the %null%-excluding filter excludes_null:true (got #{sf_region.inspect})", fails)
+check(sf_region && sf_region['members'] == ['Region B'],
+      "the %null% sentinel never leaks into members (got #{sf_region && sf_region['members'].inspect})", fails)
+sf_team = (meta['shared_filters'] || []).find { |f| f['column_caption'] == 'Team' }
+check(sf_team && !sf_team.key?('excludes_null'),
+      'a null-free exclude filter carries NO excludes_null key', fails)
+
+els =
+  if build_out.is_a?(Array)
+    build_out
+  elsif build_out.is_a?(Hash)
+    (build_out['pages'] || []).flat_map { |p| p['elements'] || [] }
+  else
+    []
+  end
+data = build_out['data_elements'] if build_out.is_a?(Hash) && build_out['data_elements']
+
+# ---- Builder: option-source helper with the IsNotNull filter -----------------
+helper = data.find { |e| e['name'] == 'Region Options' }
+check(!helper.nil?, "hidden 'Region Options' helper emitted in data_elements (got #{data.map { |e| e['name'] }.inspect})", fails)
+if helper
+  check(helper.dig('source', 'elementId') == 'master', 'helper sources the master', fails)
+  nn = (helper['columns'] || []).find { |c| c['formula'].to_s.start_with?('IsNotNull(') }
+  check(!nn.nil?, "helper carries an IsNotNull column (got #{helper['columns'].inspect})", fails)
+  hf = (helper['filters'] || []).first
+  check(nn && hf && hf['columnId'] == nn['id'] && hf['values'] == [true],
+        "helper filters IsNotNull == true (got #{hf.inspect})", fails)
+  check(helper['visibleAsSource'] == false, 'helper is hidden (visibleAsSource:false)', fails)
+end
+
+# ---- Builder: the control's value list points at the helper ------------------
+ctl = els.find { |e| e['kind'] == 'control' && e['name'] == 'Region' }
+check(!ctl.nil?, 'Region control emitted', fails)
+if ctl && helper
+  check(ctl.dig('source', 'source', 'elementId') == helper['id'],
+        "control option-source re-pointed at the helper (got #{ctl['source'].inspect})", fails)
+  check(ctl['mode'] == 'exclude' && ctl['values'] == ['Region B'],
+        'data-side exclude semantics untouched (mode:exclude, seeded members)', fails)
+end
+
+# ---- The silently-dropped field is NEVER emitted -----------------------------
+check(!JSON.generate(els + data).include?('showNullOption'),
+      'showNullOption never appears anywhere in the built spec', fails)
+
+# ---- Null-free control keeps the plain master option-source ------------------
+team_ctl = els.find { |e| e['kind'] == 'control' && e['name'] == 'Team' }
+check(team_ctl && team_ctl.dig('source', 'source', 'elementId') == 'master',
+      "null-free exclude control keeps the master option-source (got #{team_ctl && team_ctl['source'].inspect})", fails)
+check(data.none? { |e| e['name'] == 'Team Options' },
+      'no helper emitted for the null-free filter', fails)
+
+# ---- Loud announcement -------------------------------------------------------
+check(build_log =~ /showNullOption.*silently dropped|option list sources hidden helper/i,
+      'builder loudly announces the option-source workaround', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — null-excluding Tableau filters get the option-source IsNotNull workaround (#417); showNullOption never emitted'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build log (tail) ---"
+  puts build_log.to_s.lines.last(30).join
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
@@ -10,6 +10,8 @@
 #   N1  whitespace-only element / column names (break parity header matching)
 #   P1  conditionalFormats includeValues:false (silent no-op)         [WARN]
 #   I1  If() over a bare column ref, no comparison operator (v5.4: If-only)  [WARN]
+#   A1  DROPPED_BY_API control fields (accepted-then-silently-ignored, #417) [WARN]
+#   A2  date-range bare-date startDate/endDate default (silently dropped, #415) [WARN]
 #
 # Each rule: a clean spec passes, each violation is caught with the right rule
 # id + message. WARN rules must never appear in lint() (the FAIL set).
@@ -171,6 +173,83 @@ s = valid_spec
 s['pages'][0]['elements'][0]['columns'][2]['formula'] = 'If([Src/Flag] = 1, [Src/Revenue], 0)'
 check(lint_warnings(s).none? { |x| x.start_with?('I1 ') }, 'I1: If() with explicit comparison → no warning', fails)
 
+# ---- A1 (WARN): DROPPED_BY_API fields — accepted then silently ignored (#417) --
+# One warning PER field, naming the field, the silent-drop behavior, and the
+# workaround — and phrased as "silently ignored", never as a will-400.
+DROPPED_BY_API.each_key do |field|
+  s = valid_spec
+  s['pages'][0]['elements'][4][field] = false
+  warns = lint_warnings(s)
+  a1 = warns.select { |x| x.start_with?('A1 ') }
+  check(a1.size == 1, "A1: `#{field}` on a control → exactly 1 WARNING (got #{a1.inspect})", fails)
+  check(a1.first.to_s.include?("`#{field}`") && a1.first.to_s.include?('SILENTLY DROPPED'),
+        "A1 message names `#{field}` + the silent drop", fails)
+  check(a1.first.to_s.include?('NOT a 400') && a1.first.to_s.include?('Workaround:'),
+        "A1 message (#{field}) distinguishes silently-ignored from will-400 and names a workaround", fails)
+  check(rule(lint(s), 'A1').empty?, "A1 (#{field}) is WARN-only — never in the FAIL set", fails)
+end
+# all eight #417 fields are in the contract table
+%w[showNullOption showClearButton showSearchBox showHistogram allowMultipleSelection
+   excludeValues showExpandedList required].each do |f417|
+  check(DROPPED_BY_API.key?(f417), "DROPPED_BY_API covers #{f417} (#417)", fails)
+end
+# multiple dropped fields on one control → one warning each
+s = valid_spec
+s['pages'][0]['elements'][4]['showNullOption'] = false
+s['pages'][0]['elements'][4]['showSearchBox'] = true
+check(lint_warnings(s).count { |x| x.start_with?('A1 ') } == 2,
+      'A1: two dropped fields on one control → two warnings', fails)
+# the showNullOption workaround is the option-source IsNotNull filter
+s = valid_spec
+s['pages'][0]['elements'][4]['showNullOption'] = false
+a1 = lint_warnings(s).find { |x| x.start_with?('A1 ') }
+check(a1.to_s.include?('IsNotNull'), 'A1 showNullOption workaround names the option-source IsNotNull filter', fails)
+
+# ---- A2 (WARN): date-range bare-date default (#415) ---------------------------
+def date_range_ctl(s, start_d, end_d = nil)
+  ctl = s['pages'][0]['elements'][4]
+  ctl['controlType'] = 'date-range'
+  ctl.delete('selectionMode')
+  ctl.delete('value')
+  ctl['mode'] = 'between'
+  ctl['startDate'] = start_d if start_d
+  ctl['endDate'] = end_d if end_d
+  ctl
+end
+s = valid_spec
+date_range_ctl(s, '2026-01-01')
+warns = lint_warnings(s)
+a2 = warns.select { |x| x.start_with?('A2 ') }
+check(a2.size == 1, "A2: bare-date startDate → 1 WARNING (got #{a2.inspect})", fails)
+check(a2.first.to_s.include?('SILENTLY DROPPED') && a2.first.to_s.include?('2026-01-01T00:00:00Z'),
+      'A2 message says the default silently drops and shows the persisting ISO-UTC form', fails)
+check(a2.first.to_s.include?('POSTPUBLISH_GUIDE'),
+      'A2 message names the UI-default honest floor (postpublish guide)', fails)
+check(rule(lint(s), 'A2').empty?, 'A2 is WARN-only — never in the FAIL set', fails)
+# both bounds bare → one warning per field
+s = valid_spec
+date_range_ctl(s, '2026-01-01', '2026-03-31')
+check(lint_warnings(s).count { |x| x.start_with?('A2 ') } == 2,
+      'A2: bare startDate AND endDate → two warnings', fails)
+# the persisting Z-suffixed form is clean
+s = valid_spec
+date_range_ctl(s, '2026-01-01T00:00:00Z', '2026-03-31T23:59:59Z')
+check(lint_warnings(s).none? { |x| x.start_with?('A2 ') },
+      'A2: full ISO-8601 UTC timestamps → no warning (documented round-trip form)', fails)
+# relative {op,unit,value} hashes (custom mode) are not strings — no warning
+s = valid_spec
+ctl = date_range_ctl(s, nil)
+ctl['mode'] = 'custom'
+ctl['startDate'] = { 'op' => 'now-minus', 'unit' => 'day', 'value' => 30 }
+check(lint_warnings(s).none? { |x| x.start_with?('A2 ') },
+      'A2: relative startDate hash (custom mode) → no warning', fails)
+# A2 is date-range-only: a bare-date scalar on a `date` control is a `value`, not startDate
+s = valid_spec
+ctl = s['pages'][0]['elements'][4]
+ctl['controlType'] = 'date'; ctl['mode'] = '='; ctl.delete('selectionMode'); ctl['value'] = '2026-01-01'
+check(lint_warnings(s).none? { |x| x.start_with?('A2 ') },
+      'A2: date control with scalar value → no warning', fails)
+
 # ---- regression: pre-existing rules untouched ---------------------------------
 # T1: aggregate + dimension table without groupings still fails
 s = valid_spec
@@ -224,7 +303,7 @@ check(rule(lint(s), 'C8').empty?, 'C8: includeNulls on a number control → allo
 
 puts
 if fails.empty?
-  puts 'ALL PASS — preflight_lint K1/S1/C5/N1 fail rules + P1/I1 warnings + T1/C2/C3 regressions'
+  puts 'ALL PASS — preflight_lint K1/S1/C5/N1 fail rules + P1/I1/A1/A2 warnings + T1/C2/C3 regressions'
   exit 0
 else
   puts "FAILURES (#{fails.length}):"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end

--- a/shared/lib/preflight_lint.rb
+++ b/shared/lib/preflight_lint.rb
@@ -45,6 +45,14 @@
 #   I1  heuristic: If() whose FIRST argument is a bare column ref with no
 #       comparison operator — integer/bit predicates fail at render with
 #       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
 require 'json'
 
 AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
@@ -65,6 +73,59 @@ MODE_HINT = {
 }.freeze
 # `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
 INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2) and
+# #417 (list-control editor toggles), both round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
 # I1: If( whose first argument is a bare [ref] immediately followed by `,` or
 # `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
 # v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
@@ -224,6 +285,32 @@ def lint_warnings(spec)
       (el['columns'] || []).each do |c|
         c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
           warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
         end
       end
     end


### PR DESCRIPTION
## What & why

Addresses #415 and #417: a family of Workbook Spec API control fields that POST/PUT accept with 200 and **silently drop on readback** — they never take effect on the live control. These are Sigma product gaps (the issues stay open to track them); this PR makes the pipeline stop emitting them naively, warn loudly, and apply the sanctioned workarounds.

### The DROPPED_BY_API contract

Human-readable table added to `sigma-workbooks reference/specification/controls.md` ("Dropped-by-API fields"); machine-readable twin is `DROPPED_BY_API` in `shared/lib/preflight_lint.rb` (one source of truth, cross-linked):

| Field | controlType | Observed behavior | Sanctioned workaround |
|---|---|---|---|
| `showNullOption` | list/segmented/hierarchy | 200, absent on readback, Null still selectable (#417) | IsNotNull filter at the control's **option-source** (hidden helper element) — field-validated |
| `allowMultipleSelection` | list | 200, dropped, no effect (#417) | `selectionMode` (persists) |
| `excludeValues` | list | 200, dropped, no effect (#417) | `mode:"exclude"` + `values` (persists) |
| `showClearButton` / `showSearchBox` / `showHistogram` / `showExpandedList` / `required` | list editor toggles | 200, dropped, no effect (#417) | none in the spec — set in the UI post-publish |
| `startDate`/`endDate` as bare date | date-range | 200, absent on readback, control ships with **no default** (#415) | emit full ISO-8601 UTC (`"2026-01-01T00:00:00Z"`) — the only string form observed to round-trip (`refs/workbook-layout.md`) |
| `value:{...}` object | date-range etc. | stripped on round-trip | flat top-level value fields (existing C2) |

### Changes

- **preflight_lint (shared, synced ×9)** — new WARN classes `A1` (any DROPPED_BY_API field: names the field, the silent-drop behavior, the workaround) and `A2` (date-range bare/zoneless default). Output explicitly distinguishes *will be silently ignored* from the C-class *will 400* errors. WARN, not error.
- **Builder workaround #417** — `parse-twb-layout.rb` now remembers the `%null%` member of an except-tree (previously swallowed), and `build-charts-from-signals.rb` emits the field-validated workaround for null-excluding Tableau filters: hidden `"<cap> Options"` helper sourcing the master with an `IsNotNull(<col>)` `include:[true]` filter, control value-list re-pointed at it. `showNullOption` is never emitted.
- **Builder workaround #415** — every emitted date-range default runs through `iso_utc_datestamp` → the persisting `...T00:00:00Z` form; unparseable input passes through untouched for the lint/audit to surface.
- **Post-POST readback audit** — `lib/control_field_census.rb` + wiring in `post-and-readback.rb`: diffs every posted control's fields against the readback and WARNs on any field the API dropped (catches **future** members of this family automatically); dropped defaults route the operator to the Sigma UI + POSTPUBLISH_GUIDE.

## Scope

- Plugin(s) touched: tableau-to-sigma (+ the shared `preflight_lint.rb` fan-out and the sigma-workbooks reference doc the issues name as the controls source of truth)
- [x] Shared-lib change edited under `shared/` and synced via `tools/sync-shared.rb`

## Checklist

- [x] `ruby tools/check-shared.rb` — green (383 copies match canonical)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (14/14)
- [x] `bash tools/hygiene-sweep.sh` — clean
- [x] Phase numbers unchanged
- [x] Tests: `test-preflight-lint.rb` (A1 per field + A2 forms), `test-null-option-source-filter.rb` (parser+builder end-to-end), `test-date-default-normalize.rb`, `test-control-field-census.rb` (incl. a stubbed unknown dropped field); existing control tests still green
- [x] No unrelated working-tree changes

Closes nothing — #415/#417 track the Sigma product gap itself and stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)