### PR TITLE
tableau: bound the pooled CSV-export collectors — total-deadline --timeout + rowLimit, loud truncation routing (#416)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/collect-parity-actuals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/collect-parity-actuals.rb
@@ -17,11 +17,23 @@
 # same backoff-retry pattern tableau-discover.rb uses. Runs through
 # lib/sigma_rest so the auto-refresh-on-401 applies mid-run.
 #
+# BOUNDED EXPORTS (issue #416). Every export POST carries Sigma's `rowLimit`
+# (default 100k, --row-limit overrides, 0 = uncapped) and --timeout is the
+# TOTAL wall-clock budget for the run — one deadline computed at start,
+# checked by every poll loop, download, and retry backoff
+# (lib/export_pool.rb). Previously --timeout bounded only each chart's poll
+# wait (and each of up to 4 retries got a fresh window), so a multi-million-
+# row unaggregated detail table hung the pool at 100% CPU with no output.
+# A TRUNCATED export is a FAIL-LOUD condition here — parity over partial data
+# is meaningless — so the chart is marked "too-large-for-export" and routed
+# to the agent-mediated/warehouse path (never silently compared). The pool
+# prints one progress line per chart start/finish.
+#
 # Usage (normally invoked by phase6-parity.rb pass 1):
 #   ruby scripts/collect-parity-actuals.rb \
 #     --plan <dir>/parity-plan.json --workbook-id <wb> \
 #     --workbook-spec <dir>/wb-readback.json \
-#     --out <dir>/parity-actuals.json [--pool 5] [--timeout 120]
+#     --out <dir>/parity-actuals.json [--pool 5] [--timeout 600] [--row-limit N]
 #
 # Output: --out gets { "<chart name>": [[v, v, ...], ...], ... } for every
 # chart it could collect (MERGED into an existing file, never clobbering keys
@@ -43,26 +55,32 @@
 # PENDING (never DIVERGE) until resolved.
 #
 # Exit codes: 0 = ran (collected what it could — uncollected charts are the
-# AGENT's list, not a failure); 1 = bad invocation / no plan.
+# AGENT's list, not a failure); 1 = bad invocation / no plan; 3 = --timeout
+# total deadline expired mid-run (partial actuals written, timed-out charts
+# marked {"status":"timeout"} and named on stdout).
 
 require 'json'
 require 'csv'
 require 'optparse'
 require 'thread'
 
-opts = { pool: 5, timeout: 120 }
+opts = { pool: 5, timeout: 600, row_limit: 100_000 }
 OptionParser.new do |p|
   p.on('--plan PATH')          { |v| opts[:plan] = v }
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
   p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
   p.on('--out PATH')           { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline computed at start; every poll, download, and retry checks it. On expiry: per-chart "timeout" markers, partial actuals written, exit 3.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit; default 100000, 0 = uncapped). A chart whose export is TRUNCATED at the cap is marked "too-large-for-export" and routed to the agent-mediated/warehouse path — parity over partial data is meaningless.') { |v| opts[:row_limit] = v }
 end.parse!
 %i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
+require 'export_pool'
+
+ROW_LIMIT = opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
 
 plan = JSON.parse(File.read(opts[:plan]))
 charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
@@ -89,8 +107,11 @@ RENDER_VERIFY_REASON = 'pivot CSV export 500/empty (known Sigma limitation)'
 
 # One chart: export → poll → download → map plan columns by display name.
 # Returns [:ok, rows] / [:skip, reason] / [:fail, reason] /
-# [:manual, reason] (export 500/empty/HTML → render-verify fallback).
-def collect_chart(c, el_by_id, wb, timeout)
+# [:manual, reason] (export 500/empty/HTML → render-verify fallback) /
+# [:toolarge, reason] (export truncated at ROW_LIMIT — parity over partial
+# data is meaningless; agent-mediated/warehouse path) /
+# [:timeout, reason] (the shared total deadline expired).
+def collect_chart(c, el_by_id, wb, deadline)
   return [:skip, 'pivot-table — CSV export is the wide grid; agent-mediated (mcp-v2)'] if c['sigma_kind'] == 'pivot-table'
   el = el_by_id[c['sigma_element_id']]
   return [:fail, 'element not in workbook spec'] unless el
@@ -101,30 +122,22 @@ def collect_chart(c, el_by_id, wb, timeout)
   attempts = 0
   begin
     attempts += 1
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
-    body = nil
-    t0 = Time.now
-    loop do
-      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        if b && !b.to_s.empty?
-          body = b
-          break
-        end # 204-empty = still rendering
-      rescue Sigma::Error => e
-        msg = e.message.lines.first.to_s
-        raise unless msg =~ /\b404\b/ # query not materialized yet — keep polling
-      end
-    end
+    return [:timeout, "total --timeout (#{deadline.budget.round}s) deadline reached before export started"] if deadline.expired?
+    qid = ExportPool.start_csv_export(wb, c['sigma_element_id'], ROW_LIMIT)
+    return [:fail, 'export POST returned no queryId'] unless qid
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    return [:timeout, "export poll hit the total --timeout (#{deadline.budget.round}s) deadline"] if status == :timeout
     # HTML instead of CSV = the export renderer errored behind a 200 — same
     # class as the 500 (seen live on control-driven pivots).
-    return [:manual, RENDER_VERIFY_REASON] if body.to_s.lstrip.start_with?('<')
+    return [:manual, RENDER_VERIFY_REASON] if status == :html
     rows = CSV.parse(body)
+    # Truncated at the row cap: this "chart" is a huge flat detail grid, not a
+    # comparable plotted aggregate. Parity over a partial export would be
+    # meaningless — fail LOUD and route to the agent-mediated/warehouse path.
+    if ExportPool.truncated?(rows, ROW_LIMIT)
+      return [:toolarge, "element CSV export truncated at rowLimit #{ROW_LIMIT} — " \
+                         'parity over partial data is meaningless']
+    end
     # Empty / header-only exports (large pivots return a bodyless grid while the
     # rendered values are correct) → render-verify fallback, not a failure.
     return [:manual, RENDER_VERIFY_REASON] if rows.empty?
@@ -142,8 +155,10 @@ def collect_chart(c, el_by_id, wb, timeout)
     [:ok, rows.map { |r2| idxs.map { |i| parse_cell(r2[i]) } }]
   rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s
-    if attempts < 4 && msg =~ RETRYABLE
-      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+    if attempts < 4 && msg =~ RETRYABLE && !deadline.expired?
+      # Backoff never sleeps past the shared deadline (each retry used to get
+      # a fresh timeout window — one source of the unbounded total runtime).
+      sleep([(1.5 * (2**(attempts - 1))) + rand * 0.5, [deadline.remaining, 0].max].min)
       retry
     end
     # A persistent 5xx (500 immediately; 502/503/504 after retries) is the known
@@ -154,6 +169,12 @@ def collect_chart(c, el_by_id, wb, timeout)
 end
 
 t_start = Time.now
+# ONE deadline for the entire run (issue #416) — created before any export
+# starts and shared by every worker, poll loop, download, and retry.
+deadline = ExportPool::Deadline.new(opts[:timeout])
+warn format('collect-parity-actuals: %d chart(s), pool=%d, row limit %s, total budget %ds',
+            charts.size, [opts[:pool], charts.size].min.clamp(1, 16),
+            ROW_LIMIT ? ROW_LIMIT.to_s : 'UNCAPPED', opts[:timeout])
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -166,17 +187,36 @@ threads = Array.new([opts[:pool], charts.size].min.clamp(1, 16)) do
       rescue ThreadError
         break
       end
-      status, payload = collect_chart(c, el_by_id, opts[:wb], opts[:timeout])
-      mutex.synchronize { results[c['chart']] = [status, payload] }
+      name = c['chart']
+      if deadline.expired?
+        # Deadline blown: record a clean per-chart timeout without starting.
+        ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                      "(total --timeout #{opts[:timeout]}s reached)")
+        mutex.synchronize { results[name] = [:timeout, "total --timeout (#{opts[:timeout]}s) deadline reached before export started"] }
+        next
+      end
+      ExportPool.progress(deadline, "START   #{name.inspect} (#{c['sigma_element_id']})")
+      t_el = Time.now
+      status, payload = collect_chart(c, el_by_id, opts[:wb], deadline)
+      note = case status
+             when :ok      then "#{payload.length} row(s)"
+             when :toolarge then 'TOO LARGE (truncated at row limit)'
+             when :timeout then 'TIMEOUT'
+             else status.to_s.upcase
+             end
+      ExportPool.progress(deadline, format('DONE    %s — %s in %.1fs', name.inspect, note, Time.now - t_el))
+      mutex.synchronize { results[name] = [status, payload] }
     end
   end
 end
 threads.each(&:join)
 
-ok      = results.select { |_, (s, _)| s == :ok }
-skipped = results.select { |_, (s, _)| s == :skip }
-manual  = results.select { |_, (s, _)| s == :manual }
-failed  = results.select { |_, (s, _)| s == :fail }
+ok       = results.select { |_, (s, _)| s == :ok }
+skipped  = results.select { |_, (s, _)| s == :skip }
+manual   = results.select { |_, (s, _)| s == :manual }
+failed   = results.select { |_, (s, _)| s == :fail }
+toolarge = results.select { |_, (s, _)| s == :toolarge }
+timedout = results.select { |_, (s, _)| s == :timeout }
 
 # Merge into --out (preserve any agent-collected keys already present).
 existing = (JSON.parse(File.read(opts[:out])) rescue {}) if File.exist?(opts[:out])
@@ -191,6 +231,21 @@ manual.each do |name, (_, reason)|
   existing[name] = { 'status' => 'render-verify-required', 'reason' => reason }
   marked << name
 end
+# Too-large / timed-out charts: same never-clobber rule. Both markers keep the
+# chart PENDING in verify-parity and routed to the agent-mediated/warehouse
+# path (phase6-parity re-lists any non-Array, non-render-verify actual).
+marked_toolarge = []
+toolarge.each do |name, (_, reason)|
+  next if existing[name].is_a?(Array)
+  existing[name] = { 'status' => 'too-large-for-export', 'reason' => reason }
+  marked_toolarge << name
+end
+marked_timeout = []
+timedout.each do |name, (_, reason)|
+  next if existing[name].is_a?(Array)
+  existing[name] = { 'status' => 'timeout', 'reason' => reason }
+  marked_timeout << name
+end
 File.write(opts[:out], JSON.pretty_generate(existing))
 
 wall = (Time.now - t_start).round(1)
@@ -202,5 +257,17 @@ if marked.any?
        "#{RENDER_VERIFY_REASON}; marked in #{opts[:out]}; verify each via render-read or direct SQL, " \
        'then set "render_verified": true on the chart in parity-plan.json (or replace the marker with rows).'
 end
+if marked_toolarge.any?
+  puts "  TOO LARGE FOR EXPORT (#{marked_toolarge.size}): #{marked_toolarge.join(', ')} — " \
+       "export truncated at rowLimit #{ROW_LIMIT}; parity over partial data is meaningless. " \
+       "Marked \"too-large-for-export\" in #{opts[:out]}; supply these via an agent-mediated (mcp-v2) " \
+       'AGGREGATE query or the warehouse SQL oracle — or add an element filter so the tile exports fewer rows.'
+end
 failed.each  { |name, (_, why)| puts "  NOT COLLECTED   #{name}: #{why} — agent must supply via mcp-v2" }
+if timedout.any?
+  puts "  TIMEOUT (#{timedout.size}): #{timedout.keys.join(', ')} — total --timeout #{opts[:timeout]}s " \
+       "deadline reached; partial actuals written to #{opts[:out]} (timed-out charts marked " \
+       '"timeout"). Re-run with a higher --timeout, or supply these charts via mcp-v2/warehouse SQL.'
+  exit 3
+end
 exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
@@ -191,11 +191,24 @@ if !opts[:finalize]
     '--out', actuals_path)
   puts coll_out unless coll_out.empty?
   warn coll_err unless coll_err.empty?
-  warn 'collect-parity-actuals failed — ALL charts fall back to agent-mediated MCP queries' unless coll_st.success?
+  if coll_st.exitstatus == 3
+    warn 'collect-parity-actuals hit its --timeout total deadline — partial actuals recorded; ' \
+         'uncollected charts fall back to agent-mediated MCP queries'
+  elsif !coll_st.success?
+    warn 'collect-parity-actuals failed — ALL charts fall back to agent-mediated MCP queries'
+  end
   collected = (JSON.parse(File.read(actuals_path)) rescue {}) if File.exist?(actuals_path)
   collected ||= {}
-  remaining = plan['charts'].reject { |c| collected.key?(c['chart']) && (c['sigma_columns'] || []).length >= 1 }
-                            .select { |c| (c['sigma_columns'] || []).length >= 1 }
+  # A chart counts as collected only when it has real rows OR a render-verify
+  # marker (the known pivot platform bug — resolved via render-read, not
+  # re-query). too-large-for-export / timeout markers (issue #416) stay on the
+  # agent-mediated list: the agent must supply those rows via mcp-v2 aggregate
+  # queries or the warehouse oracle.
+  remaining = plan['charts'].reject do |c|
+    v = collected[c['chart']]
+    usable = v.is_a?(Array) || (v.is_a?(Hash) && v['status'] == 'render-verify-required')
+    usable && (c['sigma_columns'] || []).length >= 1
+  end.select { |c| (c['sigma_columns'] || []).length >= 1 }
   warn format('parity collection: %d/%d chart(s) pooled in %.1fs; %d agent-mediated',
               collected.size, plan['charts'].size, Time.now - t_collect, remaining.size)
 
@@ -296,7 +309,7 @@ total = plan['charts'].size
 # pivot-export render-verify fallback) carry a "(render-verify-required)" suffix.
 passed_chart_names  = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+?)(?:\s+\(score [\d.]+%\))?$/).flatten
 failed_chart_names  = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+?)(?:\s+\(score [\d.]+%\))?$/).flatten
-pending_chart_names = out.scan(/^PENDING\s+\[[^\]]+\]\s+(.+?)(?:\s+\(render-verify-required\))?$/).flatten
+pending_chart_names = out.scan(/^PENDING\s+\[[^\]]+\]\s+(.+?)(?:\s+\((?:render-verify-required|too-large-for-export|timeout)\))?$/).flatten
 
 # ---- Tile census (bead gjhe) ------------------------------------------------
 # Compare the Tableau dashboard's chart-zone count against the charts that made

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bounded-exports.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bounded-exports.rb
@@ -1,0 +1,296 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression tests for issue #416 — the pooled element CSV export used by
+# verify-anchors.rb and collect-parity-actuals.rb hung indefinitely (15+ min,
+# 100% CPU, zero output) on multi-million-row unaggregated detail grids, and
+# --timeout did not bound total runtime. New contract, end to end:
+#
+#   lib/export_pool.rb  ONE wall-clock Deadline per run; every poll loop,
+#     download, and retry checks it; every export POST carries Sigma's
+#     rowLimit; the pool prints one progress line per element start/finish.
+#   verify-anchors.rb  --timeout = TOTAL budget → on expiry per-element
+#     'timeout' status, partial verdict written, exit 4, timed-out elements
+#     named. A miss over a TRUNCATED export → 'inconclusive-truncated' (exit
+#     3), never a hard MISS. Normal path: exit 0, unchanged verdict shape.
+#   collect-parity-actuals.rb  truncated chart export → FAIL-LOUD
+#     'too-large-for-export' marker routed to the agent-mediated/warehouse
+#     path (exit 0); total-deadline expiry → 'timeout' markers + exit 3 with
+#     partial actuals; real rows never clobbered by either marker.
+#   verify-parity.rb  both new markers report PENDING, never DIVERGE.
+#
+# The Sigma REST layer is stubbed per-element (el-anchor / el-big / el-slow /
+# el-ok); no network. Usage:  ruby scripts/test-bounded-exports.rb
+
+require 'json'
+require 'csv'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPTS = __dir__
+REAL_SIGMA_REST = File.expand_path('lib/sigma_rest.rb', SCRIPTS)
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Stub sigma_rest: loaded FIRST (ruby -I <stub> -r sigma_rest); it then marks
+# the real lib path as already-required so the scripts' own `require
+# 'sigma_rest'` no-ops. lib/export_pool.rb loads for real — it is the code
+# under test — and calls this stub's Sigma.request.
+#   el-anchor → small CSV carrying the anchor value (ready on first poll)
+#   el-ok     → small chart CSV (Region/Revenue)
+#   el-big    → header + STUB_BIG_ROWS data rows (== the row cap → truncated)
+#   el-slow   → empty body forever ("still rendering") — only a deadline stops it
+# Every export POST's rowLimit is appended to STUB_LOG for assertion.
+STUB = <<~'RUBY'
+  require 'json'
+  module Sigma
+    class Error < StandardError; end
+    def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
+      return File.read(ENV['STUB_SPEC']) if method == :get && path.end_with?('/spec')
+      if method == :post && path.include?('/export')
+        req = JSON.parse(body)
+        File.open(ENV['STUB_LOG'], 'a') do |f|
+          f.puts(JSON.generate('elementId' => req['elementId'], 'rowLimit' => req['rowLimit']))
+        end
+        return { 'queryId' => req['elementId'] }
+      end
+      if method == :get && path.start_with?('/v2/query/')
+        case path.split('/')[3]
+        when 'el-anchor' then return "Account,Revenue\nUnited Widgets,12345\nAcme,678\n"
+        when 'el-ok'     then return "Region,Revenue\nEast,100\nWest,200\n"
+        when 'el-big'
+          n = ENV.fetch('STUB_BIG_ROWS', '5').to_i
+          return "Region,Revenue\n" + (1..n).map { |i| "R#{i},#{i}" }.join("\n") + "\n"
+        when 'el-slow'   then return ''
+        end
+      end
+      raise Error, "stub: unexpected #{method} #{path}"
+    end
+  end
+  real = ENV['REAL_SIGMA_REST']
+  $LOADED_FEATURES << real if real && !$LOADED_FEATURES.include?(real)
+RUBY
+
+def run_stubbed(stub_dir, extra_env, *argv)
+  Open3.capture3(
+    { 'REAL_SIGMA_REST' => REAL_SIGMA_REST, 'SIGMA_BASE_URL' => 'https://stub.invalid',
+      'SIGMA_API_TOKEN' => 'stub' }.merge(extra_env),
+    RbConfig.ruby, '-I', stub_dir, '-r', 'sigma_rest', *argv)
+end
+
+def write_anchor_fixture(dir, elements, anchors)
+  File.write(File.join(dir, 'stub-spec.json'),
+             JSON.pretty_generate('pages' => [{ 'id' => 'pg1', 'elements' => elements }]))
+  File.write(File.join(dir, 'source-anchors.json'),
+             JSON.pretty_generate('source_image' => 'views/dash.png',
+                                  'transcribed_at' => '2026-07-17T00:00:00Z',
+                                  'anchors' => anchors))
+end
+
+# ============================================================================
+# Part 1 — verify-anchors.rb: truncated export → inconclusive-truncated, exit 3
+# ============================================================================
+puts '-- verify-anchors: truncation → inconclusive-truncated (exit 3) --'
+Dir.mktmpdir do |dir|
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), STUB)
+  write_anchor_fixture(dir,
+                       [{ 'id' => 'el-anchor', 'name' => 'Top Accounts', 'kind' => 'table' },
+                        { 'id' => 'el-big', 'name' => 'Big Detail', 'kind' => 'table' }],
+                       [{ 'id' => 'a1', 'panel' => 'TOP', 'label' => 'United Widgets revenue',
+                          'raw' => '12,345', 'sigma_element_hint' => 'Top Accounts' },
+                        { 'id' => 'a2', 'panel' => 'DETAIL', 'label' => 'Detail total',
+                          'raw' => '99,999', 'sigma_element_hint' => 'Big Detail' }])
+  log = File.join(dir, 'stub-log.jsonl')
+  _out, err, st = run_stubbed(stub_dir,
+                              { 'STUB_SPEC' => File.join(dir, 'stub-spec.json'), 'STUB_LOG' => log,
+                                'STUB_BIG_ROWS' => '5' },
+                              File.join(SCRIPTS, 'verify-anchors.rb'),
+                              '--workdir', dir, '--workbook-id', 'wb',
+                              '--row-limit', '5', '--timeout', '60', '--pool', '2')
+  check(st.exitstatus == 3, "truncation-inconclusive run exits 3 (got #{st.exitstatus})", fails)
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  check(vd['missing'] == [], 'no hard MISS over the truncated export', fails)
+  inc = Array(vd['inconclusive'])
+  check(inc.length == 1 && inc[0]['id'] == 'a2' && inc[0]['status'] == 'inconclusive-truncated',
+        'the unfound anchor is inconclusive-truncated (never MISS)', fails)
+  check(inc[0]['truncated_elements'] == ['Big Detail'], 'inconclusive names the truncated element', fails)
+  check(vd['matched'] == 1 && vd['pass'] == false, 'the found anchor still matches; pass stays false', fails)
+  check(vd['export_status']['Big Detail'] == 'ok-truncated' && vd['export_status']['Top Accounts'] == 'ok',
+        'verdict records per-element export status incl. ok-truncated', fails)
+  posted = File.readlines(log).map { |l| JSON.parse(l) }
+  check(posted.length == 2 && posted.all? { |p| p['rowLimit'] == 5 },
+        'every export POST carries the Sigma rowLimit bound', fails)
+  check(err.include?('INCONCLUSIVE') && err =~ /warehouse SQL oracle|--row-limit/,
+        'guidance names the filter/warehouse-oracle/--row-limit options', fails)
+  check(err.include?('START') && err.include?('DONE') && err.include?('TRUNCATED'),
+        'pool progress lines printed (start/finish, truncation flagged)', fails)
+end
+
+# ============================================================================
+# Part 2 — verify-anchors.rb: total deadline expiry mid-poll → exit 4, partial
+# ============================================================================
+puts '-- verify-anchors: --timeout bounds TOTAL runtime (exit 4, partial results) --'
+Dir.mktmpdir do |dir|
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), STUB)
+  write_anchor_fixture(dir,
+                       [{ 'id' => 'el-anchor', 'name' => 'Top Accounts', 'kind' => 'table' },
+                        { 'id' => 'el-slow', 'name' => 'Slow Tile', 'kind' => 'table' }],
+                       [{ 'id' => 'a1', 'panel' => 'TOP', 'label' => 'United Widgets revenue',
+                          'raw' => '12,345', 'sigma_element_hint' => 'Top Accounts' }])
+  t0 = Time.now
+  _out, err, st = run_stubbed(stub_dir,
+                              { 'STUB_SPEC' => File.join(dir, 'stub-spec.json'),
+                                'STUB_LOG' => File.join(dir, 'stub-log.jsonl') },
+                              File.join(SCRIPTS, 'verify-anchors.rb'),
+                              '--workdir', dir, '--workbook-id', 'wb',
+                              '--row-limit', '100', '--timeout', '4', '--pool', '2')
+  wall = Time.now - t0
+  check(st.exitstatus == 4, "deadline expiry exits with the distinct timeout code 4 (got #{st.exitstatus})", fails)
+  check(wall < 30, "total runtime bounded by --timeout (took #{wall.round(1)}s; used to hang 15+ min)", fails)
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  check(vd['export_status']['Slow Tile'] == 'timeout', "per-element status 'timeout' recorded", fails)
+  check(vd['partial'] == true && vd['export_timed_out'] == ['Slow Tile'],
+        'verdict marks the run partial and names the timed-out element', fails)
+  check(vd['matched'] == 1, 'partial results recorded: the fast element\'s anchor still matched', fails)
+  check(err.include?('[TIMEOUT]') && err.include?('"Slow Tile"'),
+        'actionable timeout message names the timed-out element', fails)
+end
+
+# ============================================================================
+# Part 3 — verify-anchors.rb: normal path unchanged (exit 0, progress printed)
+# ============================================================================
+puts '-- verify-anchors: normal bounded path (exit 0) --'
+Dir.mktmpdir do |dir|
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), STUB)
+  write_anchor_fixture(dir,
+                       [{ 'id' => 'el-anchor', 'name' => 'Top Accounts', 'kind' => 'table' }],
+                       [{ 'id' => 'a1', 'panel' => 'TOP', 'label' => 'United Widgets revenue',
+                          'raw' => '12,345', 'sigma_element_hint' => 'Top Accounts' }])
+  out, err, st = run_stubbed(stub_dir,
+                             { 'STUB_SPEC' => File.join(dir, 'stub-spec.json'),
+                               'STUB_LOG' => File.join(dir, 'stub-log.jsonl') },
+                             File.join(SCRIPTS, 'verify-anchors.rb'),
+                             '--workdir', dir, '--workbook-id', 'wb', '--timeout', '60')
+  check(st.exitstatus.zero?, "all-matched live run still exits 0 (got #{st.exitstatus})", fails)
+  check(out.include?('1/1'), 'summary reports 1/1 matched', fails)
+  vd = JSON.parse(File.read(File.join(dir, 'anchors-verdict.json')))
+  check(vd['pass'] == true && vd['inconclusive'] == [] && vd['export_timed_out'] == [],
+        'clean verdict: pass, no inconclusive, no timeouts', fails)
+  check(err.include?('START') && err.include?('DONE'), 'pool is never silent — progress lines printed', fails)
+end
+
+# ============================================================================
+# Part 4 — collect-parity-actuals.rb: truncated tile → too-large-for-export
+# ============================================================================
+puts '-- collect-parity-actuals: truncated tile fails LOUD, routed off the export path --'
+COLLECT_SPEC = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-ok',   'columns' => [{ 'id' => 'c-r', 'name' => 'Region' }, { 'id' => 'c-v', 'name' => 'Revenue' }] },
+  { 'id' => 'el-big',  'columns' => [{ 'id' => 'c-r2', 'name' => 'Region' }, { 'id' => 'c-v2', 'name' => 'Revenue' }] },
+  { 'id' => 'el-slow', 'columns' => [{ 'id' => 'c-s', 'name' => 'Region' }] }
+] }] }.freeze
+Dir.mktmpdir do |dir|
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), STUB)
+  plan_path = File.join(dir, 'parity-plan.json')
+  spec_path = File.join(dir, 'wb-readback.json')
+  out_path  = File.join(dir, 'parity-actuals.json')
+  File.write(plan_path, JSON.pretty_generate('charts' => [
+    { 'chart' => 'OK Chart',       'sigma_kind' => 'bar-chart', 'sigma_element_id' => 'el-ok',  'sigma_columns' => %w[c-r c-v] },
+    { 'chart' => 'Huge Table',     'sigma_kind' => 'table',     'sigma_element_id' => 'el-big', 'sigma_columns' => %w[c-r2 c-v2] },
+    { 'chart' => 'Huge Preseeded', 'sigma_kind' => 'table',     'sigma_element_id' => 'el-big', 'sigma_columns' => %w[c-r2 c-v2] }
+  ]))
+  File.write(spec_path, JSON.pretty_generate(COLLECT_SPEC))
+  File.write(out_path, JSON.pretty_generate('Huge Preseeded' => [['x', 1]])) # agent rows — never clobbered
+  log = File.join(dir, 'stub-log.jsonl')
+  out, _err, st = run_stubbed(stub_dir, { 'STUB_LOG' => log, 'STUB_BIG_ROWS' => '5' },
+                              File.join(SCRIPTS, 'collect-parity-actuals.rb'),
+                              '--plan', plan_path, '--workbook-id', 'wb', '--workbook-spec', spec_path,
+                              '--out', out_path, '--row-limit', '5', '--timeout', '60')
+  check(st.exitstatus.zero?, "too-large tiles do not fail the run (got #{st.exitstatus})", fails)
+  actuals = JSON.parse(File.read(out_path))
+  check(actuals['OK Chart'] == [['East', 100.0], ['West', 200.0]], 'healthy chart still collected as rows', fails)
+  huge = actuals['Huge Table']
+  check(huge.is_a?(Hash) && huge['status'] == 'too-large-for-export' && huge['reason'].to_s =~ /rowLimit 5/,
+        "truncated tile marked 'too-large-for-export' (never compared over partial data)", fails)
+  check(actuals['Huge Preseeded'] == [['x', 1]], 'pre-existing agent rows never clobbered by the marker', fails)
+  check(out.include?('TOO LARGE FOR EXPORT (1)') && out.include?('Huge Table') &&
+        out =~ /agent-mediated|warehouse/,
+        'loud summary line routes the tile to the agent-mediated/warehouse path', fails)
+  posted = File.readlines(log).map { |l| JSON.parse(l) }
+  check(posted.all? { |p| p['rowLimit'] == 5 }, 'every export POST carries the rowLimit bound', fails)
+end
+
+# ============================================================================
+# Part 5 — collect-parity-actuals.rb: total deadline expiry → exit 3, partial
+# ============================================================================
+puts '-- collect-parity-actuals: --timeout bounds TOTAL runtime (exit 3, partial) --'
+Dir.mktmpdir do |dir|
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), STUB)
+  plan_path = File.join(dir, 'parity-plan.json')
+  spec_path = File.join(dir, 'wb-readback.json')
+  out_path  = File.join(dir, 'parity-actuals.json')
+  File.write(plan_path, JSON.pretty_generate('charts' => [
+    { 'chart' => 'OK Chart',   'sigma_kind' => 'bar-chart', 'sigma_element_id' => 'el-ok',   'sigma_columns' => %w[c-r c-v] },
+    { 'chart' => 'Slow Chart', 'sigma_kind' => 'table',     'sigma_element_id' => 'el-slow', 'sigma_columns' => %w[c-s] }
+  ]))
+  File.write(spec_path, JSON.pretty_generate(COLLECT_SPEC))
+  t0 = Time.now
+  out, err, st = run_stubbed(stub_dir, { 'STUB_LOG' => File.join(dir, 'stub-log.jsonl') },
+                             File.join(SCRIPTS, 'collect-parity-actuals.rb'),
+                             '--plan', plan_path, '--workbook-id', 'wb', '--workbook-spec', spec_path,
+                             '--out', out_path, '--timeout', '4', '--pool', '2')
+  wall = Time.now - t0
+  check(st.exitstatus == 3, "deadline expiry exits with the distinct code 3 (got #{st.exitstatus})", fails)
+  check(wall < 30, "total runtime bounded by --timeout (took #{wall.round(1)}s)", fails)
+  actuals = JSON.parse(File.read(out_path))
+  check(actuals['OK Chart'].is_a?(Array), 'partial actuals written: fast chart collected', fails)
+  check(actuals.dig('Slow Chart', 'status') == 'timeout',
+        "timed-out chart carries a clean 'timeout' marker", fails)
+  check(out.include?('TIMEOUT (1)') && out.include?('Slow Chart'),
+        'summary names the timed-out chart with re-run guidance', fails)
+  check(err.include?('START') && err.include?('"Slow Chart"'),
+        'pool progress lines printed for the slow chart', fails)
+end
+
+# ============================================================================
+# Part 6 — verify-parity.rb: new markers report PENDING, never DIVERGE
+# ============================================================================
+puts '-- verify-parity: too-large-for-export / timeout markers → PENDING --'
+Dir.mktmpdir do |dir|
+  plan_path = File.join(dir, 'plan.json')
+  File.write(plan_path, JSON.pretty_generate([
+    { 'chart' => 'Huge Table', 'expected' => [['East', 1]],
+      'actual' => { 'status' => 'too-large-for-export', 'reason' => 'export truncated at rowLimit 5' } },
+    { 'chart' => 'Slow Chart', 'expected' => [['East', 1]],
+      'actual' => { 'status' => 'timeout', 'reason' => 'total --timeout deadline reached' } }
+  ]))
+  out, _err, _st = Open3.capture3(RbConfig.ruby, File.join(SCRIPTS, 'verify-parity.rb'), '--plan', plan_path)
+  check(out.scan(/^PENDING/).length == 2 && !out.include?('DIVERGE'),
+        'both markers report PENDING (never DIVERGE-against-empty)', fails)
+  check(out.include?('(too-large-for-export)') && out.include?('(timeout)'),
+        'PENDING lines name the marker kind', fails)
+  check(out =~ /warehouse SQL oracle|AGGREGATE query/, 'too-large guidance points at the warehouse path', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS — bounded exports (deadline + rowLimit + loud routing)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-parity.rb
@@ -9,14 +9,21 @@
 #      "extract":  true|false   # optional per-chart override
 #   }]
 #
-# Render-verify fallback (known Sigma platform bug — pivot CSV export 500/empty):
-# collect-parity-actuals.rb may mark a chart's actual as
+# Export-marker fallbacks: collect-parity-actuals.rb may mark a chart's actual
+# as a status marker instead of rows —
 #   "actual": { "status": "render-verify-required", "reason": "..." }
-# instead of rows. Such a chart reports PENDING (pending-manual, never DIVERGE)
-# and keeps the run failing until the agent EITHER replaces the marker with real
-# rows (direct SQL / mcp-v2) OR confirms the values via render-read and sets
+#     (known Sigma platform bug — pivot CSV export 500/empty)
+#   "actual": { "status": "too-large-for-export", "reason": "..." }
+#     (bounded export truncated at rowLimit — parity over partial data is
+#      meaningless; issue #416)
+#   "actual": { "status": "timeout", "reason": "..." }
+#     (the collector's total --timeout deadline expired)
+# Such a chart reports PENDING (pending-manual, never DIVERGE) and keeps the
+# run failing until the agent EITHER replaces the marker with real rows
+# (direct SQL / mcp-v2 — for too-large tiles, an AGGREGATE query or the
+# warehouse oracle) OR confirms the values via render-read and sets
 #   "render_verified": true            # + optional "render_verified_notes"
-# on the chart in the plan — which then PASSes with a named render-verified note.
+# on the chart in the plan — which then PASSes with a named verified note.
 #
 # A top-level wrapper is also accepted:
 #   { "extract": true, "charts": [ ... ] }
@@ -333,11 +340,21 @@ results = plan.map do |p|
                    default_extract
                  end
 
-  # Render-verify fallback (see header): a status marker instead of rows means
-  # the CSV export hit the known pivot 500/empty platform bug — the chart is
-  # PENDING manual verification, never DIVERGE-against-empty. Once the plan
-  # chart carries render_verified:true it PASSes with a named note.
-  if p.dig('actual', 'status') == 'render-verify-required'
+  # Export-marker fallback (see header): a status marker instead of rows means
+  # the CSV export could not serve this chart (pivot 500/empty platform bug,
+  # bounded export truncated on a too-large detail grid, or collector total
+  # timeout) — the chart is PENDING manual verification, never DIVERGE-
+  # against-empty. Once the plan chart carries render_verified:true it PASSes
+  # with a named note.
+  marker_guidance = {
+    'render-verify-required' => 'verify via render-read or direct SQL',
+    'too-large-for-export'   => 'element exceeds the bounded CSV export — supply rows via an ' \
+                                'agent-mediated (mcp-v2) AGGREGATE query or the warehouse SQL oracle',
+    'timeout'                => 're-run collect-parity-actuals.rb with a higher --timeout, or ' \
+                                'supply rows via mcp-v2/warehouse SQL'
+  }
+  marker = p.dig('actual', 'status')
+  if marker_guidance.key?(marker)
     reason = p.dig('actual', 'reason') || 'CSV export unavailable'
     result =
       if p['render_verified']
@@ -346,9 +363,9 @@ results = plan.map do |p|
           notes: ["render-verified: #{reason}; values confirmed via render-read/SQL" \
                   "#{p['render_verified_notes'] ? " — #{p['render_verified_notes']}" : ''}"] }
       else
-        { status: 'PENDING', score: nil, only_in_tableau: [], only_in_sigma: [],
+        { status: 'PENDING', score: nil, only_in_tableau: [], only_in_sigma: [], marker: marker,
           n_expected: exp.size, n_actual: nil, n_matched: nil,
-          notes: ["render-verify-required: #{reason} — verify via render-read or direct SQL, " \
+          notes: ["#{marker}: #{reason} — #{marker_guidance[marker]}, " \
                   'then set "render_verified": true on this chart in the plan ' \
                   '(or replace the marker with actual rows) and re-run'] }
       end
@@ -372,7 +389,7 @@ end
 results.each do |r|
   tag = r[:extract] ? '[extract]' : '[strict] '
   if r[:status] == 'PENDING'
-    printf "%-7s  %s  %s  (render-verify-required)\n", r[:status], tag, r[:chart]
+    printf "%-7s  %s  %s  (%s)\n", r[:status], tag, r[:chart], r[:marker] || 'render-verify-required'
   else
     printf "%-7s  %s  %s  (score %.0f%%)\n", r[:status], tag, r[:chart], (r[:score] || 0) * 100
   end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test-verify-anchors.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping

--- a/shared/lib/export_pool.rb
+++ b/shared/lib/export_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# export_pool.rb — BOUNDED element CSV export collection (issue #416).
+#
+# WHY. verify-anchors.rb and collect-parity-actuals.rb share the same element
+# CSV export flow (POST /v2/workbooks/{wb}/export → poll
+# GET /v2/query/{q}/download). Before this lib, --timeout bounded only the
+# per-element POLL WAIT: the download of the CSV body, CSV.parse over it, and
+# the per-cell scans were all unbounded, and the export itself carried no row
+# cap — so a multi-million-row unaggregated detail grid (the shape a faithful
+# 1:1 Tableau-table migration produces) hung the pool for 15+ minutes at 100%
+# CPU with zero output (field-reported, 2026-07-17: 3 flat detail tables up to
+# ~5.1M rows). Two fixes, both here so the scripts cannot drift apart:
+#
+#   1. Deadline — ONE wall-clock budget computed at process start. Every poll
+#      loop and download checks it, so --timeout bounds TOTAL runtime.
+#   2. rowLimit — Sigma's export API accepts a rowLimit (docs: "Export
+#      workbook"; CSV/JSON/XLSX are truncated at 1M rows regardless), so the
+#      export, the download, the CSV.parse, and every downstream scan are all
+#      bounded by the caller's row cap. A bounded export can be TRUNCATED —
+#      truncated?() detects it and callers MUST treat a miss/compare over a
+#      truncated export as inconclusive, never as a hard verdict.
+#
+# The caller must `require 'sigma_rest'` first (this lib calls Sigma.request,
+# which is exactly what the offline test stubs replace).
+
+require 'json'
+require 'timeout'
+
+module ExportPool
+  # Sigma truncates CSV/JSON/XLSX exports at 1M rows no matter what — a
+  # rowLimit above this is meaningless (batch with `offset` if you truly need
+  # more; none of these verification flows do).
+  SIGMA_EXPORT_HARD_CAP = 1_000_000
+
+  # Whole-run wall-clock budget, created ONCE at the start of a run and shared
+  # by every worker: when it expires, everything stops — poll loops, retries,
+  # downloads, and elements not yet started.
+  class Deadline
+    attr_reader :budget
+
+    def initialize(seconds)
+      @t0 = Time.now
+      @budget = seconds.to_f
+    end
+
+    def elapsed
+      Time.now - @t0
+    end
+
+    def remaining
+      @budget - elapsed
+    end
+
+    def expired?
+      remaining <= 0
+    end
+  end
+
+  module_function
+
+  # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
+  # Returns the queryId or nil.
+  def start_csv_export(wb, element_id, row_limit)
+    body = { elementId: element_id, format: { type: 'csv' } }
+    body[:rowLimit] = row_limit if row_limit
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+    r && r['queryId']
+  end
+
+  # Poll for the rendered CSV and download it, bounded by the shared deadline.
+  # Returns [:ok, body] | [:timeout, nil] | [:html, nil] (HTML behind a 200 =
+  # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
+  # keep their own retry/fallback policies).
+  def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    loop do
+      return [:timeout, nil] if deadline.expired?
+      sleep([poll_interval, [deadline.remaining, 0.05].max].min)
+      return [:timeout, nil] if deadline.expired?
+      begin
+        # The download itself is bounded too: rowLimit keeps the body small,
+        # and Timeout hard-caps a stalled or endlessly-streaming read at the
+        # remaining budget (previously an unbounded multi-hundred-MB body read
+        # was the first half of the silent hang).
+        b = Timeout.timeout([deadline.remaining, 1.0].max) do
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        end
+        next if b.to_s.empty? # still rendering
+        return [:html, nil] if b.to_s.lstrip.start_with?('<')
+        return [:ok, b]
+      rescue Timeout::Error
+        return [:timeout, nil]
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+      end
+    end
+  end
+
+  # rows INCLUDE the header row. A bounded export that came back full is
+  # conservatively truncated (the element may hold exactly row_limit rows, but
+  # the caller cannot tell the difference — treat verdicts over it as
+  # inconclusive either way).
+  def truncated?(rows, row_limit)
+    !row_limit.nil? && rows.is_a?(Array) && (rows.length - 1) >= row_limit
+  end
+
+  # One progress line per pool event, stamped with run-elapsed seconds — the
+  # pool is never silent for minutes. Single write() so concurrent workers
+  # don't interleave mid-line; stderr so stdout contracts stay clean.
+  def progress(deadline, msg)
+    $stderr.write(format("  [pool +%6.1fs] %s\n", deadline.elapsed, msg))
+  end
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -564,6 +564,21 @@
    ]
   },
   {
+   "canonical": "shared/lib/export_pool.rb",
+   "targets": [
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/export_pool.rb",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/export_pool.rb"
+   ]
+  },
+  {
    "canonical": "shared/lib/anchor_values.rb",
    "targets": [
     "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/anchor_values.rb",

--- a/shared/scripts/test-verify-anchors.rb
+++ b/shared/scripts/test-verify-anchors.rb
@@ -102,6 +102,55 @@ v5 = AnchorVerify.verify(
 )
 ok(v5['pass'] == true, 'hinted numeric present IN the hinted element still matches')
 
+puts '-- pure core: truncated-export inconclusiveness (issue #416) --'
+# A bounded (row-capped) export that came back FULL may be missing rows: an
+# anchor that fails to match over it canNOT be declared MISSING — the value may
+# live below the cap. It reports 'inconclusive-truncated' instead (never a hard
+# MISS), and inconclusive anchors still fail `pass` (unverified != vouched-for).
+trunc_exports = {
+  'Big Detail'   => [['V'], ['1'], ['2'], ['3']],
+  'Total Stores' => [['Stores'], ['104']]
+}
+vt1 = AnchorVerify.verify(
+  [{ 'id' => 'tr1', 'label' => 'Detail total', 'raw' => '999', 'sigma_element_hint' => 'Big Detail' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt1['missing'].empty? && vt1['inconclusive'].length == 1,
+   'miss over a truncated in-scope export → inconclusive, NOT missing')
+ok(vt1['inconclusive'].first['status'] == 'inconclusive-truncated' &&
+   vt1['inconclusive'].first['truncated_elements'] == ['Big Detail'],
+   'inconclusive entry carries the status + the truncated element(s)')
+ok(vt1['pass'] == false && vt1['matched'] == 0,
+   'inconclusive anchors still fail pass and do not count as matched')
+vt2 = AnchorVerify.verify(
+  [{ 'id' => 'tr2', 'label' => 'Total Stores', 'raw' => '999', 'sigma_element_hint' => 'Total Stores' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt2['missing'].length == 1 && vt2['inconclusive'].empty?,
+   'truncation OUTSIDE a hinted anchor\'s scope does not soften a genuine MISS')
+vt3 = AnchorVerify.verify(
+  [{ 'id' => 'tr3', 'label' => 'Nowhere Number', 'raw' => '999' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt3['missing'].empty? && vt3['inconclusive'].length == 1,
+   'hint-less miss (search-everywhere) with ANY truncated export → inconclusive')
+vt4 = AnchorVerify.verify(
+  [{ 'id' => 'tr4', 'label' => 'Total Stores', 'raw' => '104' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt4['pass'] == true && vt4['matched'] == 1 && vt4['inconclusive'].empty?,
+   'a matched anchor is unaffected by truncation elsewhere')
+vt5 = AnchorVerify.verify(
+  [{ 'id' => 'tr5', 'label' => 'roster', 'raw' => 'Region Z', 'kind' => 'text' }],
+  trunc_exports, truncated: ['Big Detail']
+)
+ok(vt5['missing'].empty? && vt5['inconclusive'].length == 1,
+   'text-anchor miss over a truncated export → inconclusive too')
+# No kwarg = legacy behavior: same misses stay hard MISSes.
+vt6 = AnchorVerify.verify([{ 'id' => 'tr6', 'label' => 'Nowhere Number', 'raw' => '999' }], trunc_exports)
+ok(vt6['missing'].length == 1 && vt6['inconclusive'].empty?,
+   'without a truncated set the legacy hard-MISS behavior is unchanged')
+
 puts '-- CLI offline mode --'
 def write_fixture(dir, exports_rows, anchors)
   spec = { 'pages' => [{ 'id' => 'pg1', 'elements' =>

--- a/shared/scripts/verify-anchors.rb
+++ b/shared/scripts/verify-anchors.rb
@@ -38,16 +38,32 @@
 # anchor MISSING — found-elsewhere still counts as matched (the value exists;
 # only the label→element mapping was fuzzy) and is noted in the verdict.
 #
+# BOUNDED EXPORTS (issue #416). Element exports are row-capped (the export
+# POST sends Sigma's `rowLimit`; default anchors×10k, min 50k, --row-limit
+# overrides, 0 = uncapped) and --timeout is the TOTAL wall-clock budget for
+# the whole run — one deadline computed at start, checked by every poll loop
+# and download (lib/export_pool.rb). Previously a multi-million-row
+# unaggregated detail grid hung the pool indefinitely at 100% CPU (unbounded
+# export → unbounded download → unbounded CSV.parse → per-cell scan). A
+# TRUNCATED export can hide an anchor value below the cap, so an anchor that
+# misses while any in-scope export was truncated reports
+# 'inconclusive-truncated' — NEVER a hard MISS (a false MISS would demand a
+# workbook "fix" for correct data). The pool prints one progress line per
+# element start/finish; it is never silent for minutes.
+#
 # Usage (live):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-id <id> \
-#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 120]
+#     [--anchors PATH] [--out PATH] [--pool 4] [--timeout 600] [--row-limit N]
 # Usage (offline — tests / pre-collected exports):
 #   ruby scripts/verify-anchors.rb --workdir <W> --workbook-spec spec.json \
 #     --exports-dir <dir-with-<elementId>.csv>
 #
 # Exit codes: 0 = every anchor matched; 1 = one or more anchors missing (the
 # per-miss report names each, with its closest candidate); 2 = usage / missing
-# inputs.
+# inputs; 3 = no hard miss but >=1 anchor inconclusive (truncated bounded
+# export — add an element filter, verify via the warehouse SQL oracle, or
+# raise --row-limit); 4 = --timeout total deadline expired (partial results
+# recorded; the report names each element that timed out).
 
 require 'json'
 require 'csv'
@@ -157,13 +173,35 @@ module AnchorVerify
   #   never silently launders drift into an exact pass. Text/roster anchors
   #   never use tolerance (labels don't drift). Hinted-anchor scoping applies
   #   identically to the tolerance retry.
-  def verify(anchors, exports, extract_tol: nil)
+  # truncated (Array/Set of element NAMES, optional) — elements whose bounded
+  #   CSV export came back FULL (>= the row cap), i.e. the export may be
+  #   missing rows. An anchor that fails to match while ANY element in its
+  #   search scope is truncated canNOT be declared MISSING — the value may
+  #   live below the cap — so it is reported 'inconclusive-truncated' in the
+  #   verdict's `inconclusive` list instead of `missing` (issue #416: a
+  #   truncated export must never produce a false hard MISS). Inconclusive
+  #   anchors still fail `pass` — they are unverified, not vouched-for.
+  def verify(anchors, exports, extract_tol: nil, truncated: nil)
     tol = extract_tol.is_a?(Numeric) && extract_tol.positive? ? extract_tol.to_f : nil
+    trunc = Array(truncated)
     el_names = exports.keys
     numbers = exports.transform_values { |rows| rows_numbers(rows) }
     texts = exports.transform_values { |rows| rows_texts(rows) }
     detail = []
     missing = []
+    inconclusive = []
+    # A miss is only a hard MISS when every export the anchor searched was
+    # complete; otherwise it lands in `inconclusive` with the truncated
+    # element(s) named.
+    classify_miss = lambda do |a, raw, scope_names, entry|
+      t_hits = scope_names.select { |n| trunc.include?(n) }
+      if t_hits.any?
+        inconclusive << entry.merge('status' => 'inconclusive-truncated',
+                                    'truncated_elements' => t_hits)
+      else
+        missing << entry
+      end
+    end
     anchors.each do |a|
       raw = a['raw'].to_s
       order = ranked_elements(a, el_names)
@@ -173,8 +211,9 @@ module AnchorVerify
         if found_in
           detail << { 'id' => a['id'], 'raw' => raw, 'matched_in' => found_in }
         else
-          missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                       'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } }
+          classify_miss.call(a, raw, order,
+                             { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                               'best_candidate' => { 'note' => 'text anchor: label not present in any element export' } })
         end
         next
       end
@@ -226,14 +265,16 @@ module AnchorVerify
           end
           break if best
         end
-        missing << { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
-                     'best_candidate' => best }
+        classify_miss.call(a, raw, search_order,
+                           { 'id' => a['id'], 'label' => a['label'], 'raw' => raw,
+                             'best_candidate' => best })
       end
     end
     { 'checked' => anchors.length,
-      'matched' => anchors.length - missing.length,
+      'matched' => anchors.length - missing.length - inconclusive.length,
       'missing' => missing,
-      'pass' => missing.empty?,
+      'inconclusive' => inconclusive,
+      'pass' => missing.empty? && inconclusive.empty?,
       'matched_via_tolerance' => detail.count { |d| d['tolerance_used'] },
       'detail' => detail }
   end
@@ -372,7 +413,7 @@ def tile_emptiness_census(elements, exports, workdir)
   end.compact
 end
 
-opts = { pool: 8, timeout: 120 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
+opts = { pool: 8, timeout: 600 } # pool 8: A/B report measured phase6-pass1 +70.5s dominated by anchor export collection
 OptionParser.new do |p|
   p.on('--workdir DIR')        { |v| opts[:dir] = v }
   p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
@@ -380,7 +421,8 @@ OptionParser.new do |p|
   p.on('--anchors PATH', 'default: <workdir>/source-anchors.json') { |v| opts[:anchors] = v }
   p.on('--out PATH', 'default: <workdir>/anchors-verdict.json')    { |v| opts[:out] = v }
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
-  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline is computed at start; every export poll and download checks it. On expiry: per-element "timeout" status, partial results recorded, exit 4.') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit). Default: anchors×10,000, min 50,000, capped at Sigma\'s 1M export ceiling. 0 = uncapped (NOT recommended — a multi-million-row detail grid is the issue-#416 hang). A miss over a truncated export reports inconclusive-truncated, never a hard MISS.') { |v| opts[:row_limit] = v }
   p.on('--extract-tol F', Float, 'relative tolerance (e.g. 0.02 = ±2%) for EXTRACT-based sources: the source PNG renders a frozen extract snapshot while the warehouse is fresher, so printed-precision misses can be legitimate drift. ONLY honored when the workdir is extract-marked (get-workbook.json hasExtracts / a landing manifest); tolerance-admitted matches are RECORDED per anchor (tolerance_used + drift), never silent. This — not editing source-anchors.json — is the sanctioned answer to extract drift.') { |v| opts[:extract_tol] = v }
   p.on('--workbook-spec PATH', 'offline: read element names from this spec instead of the live workbook') { |v| opts[:spec] = v }
   p.on('--exports-dir DIR', 'offline: read <elementId>.csv files instead of exporting live') { |v| opts[:exports] = v }
@@ -473,6 +515,10 @@ end
 
 # --- element names + rows: offline (spec+exports dir) or live (REST) ---------
 exports = {} # element name => rows (arrays of cells)
+export_status = {}   # live: element name => 'ok' | 'ok-truncated' | 'timeout' | 'failed'
+truncated_names = [] # live: elements whose bounded export came back FULL (may be missing rows)
+deadline = nil       # live: whole-run wall-clock budget (ExportPool::Deadline)
+row_limit = nil
 
 if opts[:exports]
   spec_path = opts[:spec] || File.join(opts[:dir], 'wb-readback.json')
@@ -499,6 +545,21 @@ else
 
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'export_pool'
+
+  # ONE deadline for the entire run (issue #416: --timeout used to bound only
+  # the per-element poll wait, so total runtime was unbounded). Computed here,
+  # before any export starts; every poll loop and download checks it.
+  deadline = ExportPool::Deadline.new(opts[:timeout])
+  # Bounded exports: anchors need only enough rows to find printed values —
+  # anchors×10k (min 50k) covers every field workbook while keeping a 5M-row
+  # detail grid from hanging the pool. --row-limit overrides; 0 = uncapped.
+  row_limit =
+    if opts.key?(:row_limit)
+      opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool::SIGMA_EXPORT_HARD_CAP].min : nil
+    else
+      [[anchors.length * 10_000, 50_000].max, ExportPool::SIGMA_EXPORT_HARD_CAP].min
+    end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
   spec = begin
@@ -545,23 +606,32 @@ else
     end
   end
 
+  # Export one element, bounded by row_limit and the shared deadline.
+  # Returns [:ok | :ok_truncated, rows] | [:timeout, nil] | [:failed, nil].
   export_one = lambda do |el|
-    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
-                      body: JSON.generate({ elementId: el['id'], format: { type: 'csv' } }))
-    qid = r && r['queryId']
-    return nil unless qid
-    t0 = Time.now
-    loop do
-      return nil if Time.now - t0 > opts[:timeout]
-      sleep 1.0
-      begin
-        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
-        next if b.to_s.empty? # still rendering
-        return nil if b.to_s.lstrip.start_with?('<') # HTML behind a 200 = renderer error
-        return CSV.parse(b)
-      rescue Sigma::Error => e
-        raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet
-      end
+    name = el_display_name(el)
+    t_el = Time.now
+    qid = ExportPool.start_csv_export(wb, el['id'], row_limit)
+    unless qid
+      warn "  [WARN] export POST returned no queryId for element #{name.inspect}"
+      return [:failed, nil]
+    end
+    status, body = ExportPool.poll_csv_download(qid, deadline)
+    case status
+    when :timeout
+      ExportPool.progress(deadline, "TIMEOUT #{name.inspect} after #{(Time.now - t_el).round(1)}s — " \
+                                    "--timeout #{opts[:timeout]}s total deadline reached")
+      [:timeout, nil]
+    when :html # HTML behind a 200 = renderer error
+      warn "  [WARN] export for element #{name.inspect} returned HTML behind a 200 (renderer error)"
+      [:failed, nil]
+    else
+      rows = CSV.parse(body)
+      trunc = ExportPool.truncated?(rows, row_limit)
+      ExportPool.progress(deadline, format('DONE    %s — %d row(s) in %.1fs%s', name.inspect,
+                                           [rows.length - 1, 0].max, Time.now - t_el,
+                                           trunc ? " [TRUNCATED at --row-limit #{row_limit}]" : ''))
+      [trunc ? :ok_truncated : :ok, rows]
     end
   rescue Sigma::Error, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s.strip[0, 120]
@@ -569,7 +639,7 @@ else
       ' [PIVOT-TOTALS CEILING: a `totals` key 500s a pivot CSV export — this pivot still carries one; ' \
       'the strip/restore bracket should have removed it. See refs/layout-visual-qa.md]' : ''
     warn "  [WARN] export failed for element #{el_display_name(el).inspect}: #{msg}#{ceiling}"
-    nil
+    [:failed, nil]
   end
 
   require 'thread'
@@ -591,6 +661,9 @@ else
              'totals-bearing pivot exports may 500; those anchors can only be checked via a totals-free export'
       end
     end
+    warn format('  [pool] exporting %d element(s), pool=%d, row limit %s, total budget %ds',
+                queryable.size, [opts[:pool], queryable.size].min.clamp(1, 8),
+                row_limit ? row_limit.to_s : 'UNCAPPED', opts[:timeout])
     queue = Queue.new
     queryable.each { |el| queue << el }
     mutex = Mutex.new
@@ -602,8 +675,32 @@ else
           rescue ThreadError
             break
           end
-          rows = export_one.call(el)
-          mutex.synchronize { exports[el_display_name(el)] = rows } if rows
+          name = el_display_name(el)
+          if deadline.expired?
+            # Deadline already blown: don't even start the export — record a
+            # clean per-element timeout so the report can name it.
+            ExportPool.progress(deadline, "TIMEOUT #{name.inspect} — not started " \
+                                          "(--timeout #{opts[:timeout]}s total deadline reached)")
+            mutex.synchronize { export_status[name] = 'timeout' }
+            next
+          end
+          ExportPool.progress(deadline, "START   #{name.inspect} (#{el['id']})")
+          status, rows = export_one.call(el)
+          mutex.synchronize do
+            case status
+            when :ok
+              exports[name] = rows
+              export_status[name] = 'ok'
+            when :ok_truncated
+              exports[name] = rows
+              truncated_names << name
+              export_status[name] = 'ok-truncated'
+            when :timeout
+              export_status[name] = 'timeout'
+            else
+              export_status[name] = 'failed'
+            end
+          end
         end
       end
     end.each(&:join)
@@ -664,10 +761,21 @@ if opts[:extract_tol]
                        'reason' => marker || 'workdir not extract-marked (hasExtracts/landing manifest absent)' }
 end
 
-verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active)
+verdict = AnchorVerify.verify(anchors, exports, extract_tol: extract_tol_active,
+                                                truncated: truncated_names)
 verdict['source_anchors'] = anchors_path
 verdict['verified_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 verdict['extract_tolerance'] = extract_tol_info if extract_tol_info
+# Bounded-export provenance (live mode): per-element export status, the row cap
+# used, and whether the total --timeout deadline expired mid-run (issue #416).
+timed_out_elements = export_status.select { |_, s| s == 'timeout' }.keys
+unless export_status.empty?
+  verdict['export_status'] = export_status
+  verdict['export_row_limit'] = row_limit
+  verdict['export_timeout_s'] = opts[:timeout]
+  verdict['export_timed_out'] = timed_out_elements
+  verdict['partial'] = timed_out_elements.any?
+end
 
 # W1.1/W1.2: dashboard-tile emptiness + anchor display scoping. `elements` is in
 # scope from whichever branch (offline spec / live REST) populated `exports`.
@@ -732,6 +840,8 @@ if File.exist?(pf)
     s = JSON.parse(File.read(pf))
     s['anchors'] = { 'checked' => verdict['checked'], 'matched' => verdict['matched'],
                      'pass' => verdict['pass'], 'missing' => verdict['missing'].map { |m| m['id'] } }
+    inc_ids = Array(verdict['inconclusive']).map { |m| m['id'] }
+    s['anchors']['inconclusive'] = inc_ids if inc_ids.any?
     s['anchors']['matched_via_tolerance'] = verdict['matched_via_tolerance'] if verdict['matched_via_tolerance'].to_i.positive?
     s['anchors']['extract_tolerance'] = verdict['extract_tolerance'] if verdict['extract_tolerance']
     s['dashboard_tiles_empty'] = verdict['dashboard_tiles_empty']
@@ -753,6 +863,20 @@ if verdict['matched_via_tolerance'].to_i.positive?
   puts "  [extract-tol] #{verdict['matched_via_tolerance']} anchor(s) matched only within the extract drift " \
        "tolerance (±#{format('%.2f', (extract_tol_active || 0) * 100)}%) — recorded in the verdict; " \
        'name this in your migration report. Anchors were NOT edited.'
+end
+
+# Total-deadline expiry (issue #416): the run is PARTIAL — some elements never
+# exported — so no verdict below is final. Name every timed-out element, keep
+# the partial results on disk, and exit with the distinct timeout code.
+if timed_out_elements.any?
+  warn ''
+  warn "[TIMEOUT] --timeout #{opts[:timeout]}s TOTAL deadline reached — #{timed_out_elements.length} element export(s) timed out:"
+  timed_out_elements.each { |n| warn "         TIMEOUT  #{n.inspect}" }
+  warn "       Partial results recorded in #{out_path} (#{verdict['matched']}/#{verdict['checked']} anchors matched over"
+  warn "       the #{exports.length} export(s) that completed; per-element status under \"export_status\")."
+  warn '       Raise --timeout, lower --row-limit (smaller exports render faster), or add element filters to'
+  warn '       shrink the slow tiles, then re-run. No anchor verdict is final on a partial run.'
+  exit 4
 end
 
 # W1.1: non-empty dashboard tiles — the hard data-path check. A displayed tile
@@ -779,14 +903,34 @@ if verdict['pass']
        "all displayed tiles return data (#{verdict['anchors_matched_in_displayed']}/#{verdict['matched']} anchors in displayed tiles)."
   exit 0
 end
-warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
-verdict['missing'].each do |m|
-  bc = m['best_candidate']
-  warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
-       "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+
+# Truncation-inconclusive anchors (issue #416): the anchor missed, but at least
+# one export it searched was TRUNCATED at the row cap — the value may simply
+# live below the cap, so this is NOT a hard MISS and must not demand a workbook
+# "fix" for possibly-correct data.
+inconclusive = Array(verdict['inconclusive'])
+if inconclusive.any?
+  warn "[INCONCLUSIVE] #{inconclusive.length} anchor(s) could not be verified — a bounded export in their search"
+  warn "               scope was TRUNCATED at the #{row_limit || 'requested'}-row cap (the value may live below it):"
+  inconclusive.each do |m|
+    warn "  INCONCLUSIVE  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect} — " \
+         "truncated export(s): #{Array(m['truncated_elements']).map(&:inspect).join(', ')}"
+  end
+  warn '               Options: add an element filter so the tile exports fewer rows; verify the value via the'
+  warn '               warehouse SQL oracle (verify-warehouse.rb / vds-oracle.rb) instead; or raise --row-limit.'
 end
-warn '       A printed source value that appears NOWHERE in the workbook exports is the'
-warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
-warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
-warn '       transcription was wrong, correct source-anchors.json — then re-run.'
-exit 1
+
+if verdict['missing'].any?
+  warn "[FAIL] #{verdict['missing'].length} anchor(s) MISSING from the live workbook exports:"
+  verdict['missing'].each do |m|
+    bc = m['best_candidate']
+    warn "  MISSING  #{m['id']} #{m['label'].inspect} raw=#{m['raw'].inspect}" \
+         "#{bc ? " — closest candidate #{bc['value']} in #{bc['element'].inspect}" : ' — no numeric candidates at all'}"
+  end
+  warn '       A printed source value that appears NOWHERE in the workbook exports is the'
+  warn '       loudest possible signal the data is wrong (wrong aggregate, wrong unit/10x,'
+  warn '       missing filter, collapsed buckets). Fix the workbook — or, if the SOURCE'
+  warn '       transcription was wrong, correct source-anchors.json — then re-run.'
+  exit 1
+end
+exit 3 # inconclusive-only: unverified, not vouched-for — resolve before shipping


### PR DESCRIPTION
Fixes the indefinite hang reported in #416 (left open for reporter verification): `verify-anchors.rb` and the pooled CSV-export collector it shares with `collect-parity-actuals.rb` ran 15+ minutes at 100% CPU with zero output on multi-million-row unaggregated table elements, and `--timeout` did not bound total runtime.

## Root cause

- `--timeout` bounded only each element's **poll wait** (`Time.now - t0` inside the download-poll loop). In collect-parity-actuals each of up to 4 retries got a **fresh** timeout window.
- Nothing bounded the CSV **download** (Net::HTTP body read), the **`CSV.parse`** of a slurped multi-hundred-MB body, or verify-anchors' **per-cell scan** (`rows_numbers` runs encoding-normalize + regex + `Float()` over every cell of every export) — that scan over a ~5.1M-row grid is the pegged-CPU silent phase.
- The export POST sent no row bound, so Sigma rendered the full element (up to its 1M-row export ceiling) for tiles whose anchors live in the first few thousand rows.

## Fix

**New shared canonical `shared/lib/export_pool.rb`** (fanned to all 10 plugins via `tools/sync-shared.rb`):
- `Deadline` — ONE wall-clock budget computed at run start; every poll loop, download (Timeout-capped at remaining budget), and retry backoff checks it, so `--timeout` now bounds **total** runtime.
- every export POST carries Sigma's documented `rowLimit` (Export workbook API), bounding the render, the download, the parse, and every downstream scan.
- `progress()` — one line per element start/finish with run-elapsed time; the pool is never silent.

**`verify-anchors.rb`** (shared canonical): exit 4 on deadline expiry with per-element `timeout` status, partial verdict recorded (`export_status`, `export_timed_out`, `partial`), and an actionable message naming each timed-out element. Bounded export defaults to anchors×10k rows (min 50k, `--row-limit` overrides, 0 = uncapped). An anchor miss whose search scope includes a **truncated** export reports `inconclusive-truncated` (exit 3) — never a false hard MISS — with add-a-filter / warehouse-SQL-oracle / raise-`--row-limit` guidance. Inconclusive anchors still fail `pass` (unverified ≠ vouched-for).

**`collect-parity-actuals.rb`**: same total deadline (exit 3 on expiry, `{"status":"timeout"}` markers, partial actuals kept). A truncated tile is a FAIL-LOUD `too-large-for-export` marker routed to the agent-mediated/warehouse path — parity over partial data is meaningless. Real rows are never clobbered by either marker.

**`verify-parity.rb` / `phase6-parity.rb`**: both new markers report PENDING (never DIVERGE-against-empty); phase6 re-lists them as agent-mediated and treats the collector's timeout exit as partial, not total, fallback.

## Tests

- `shared/scripts/test-verify-anchors.rb`: pure-core truncation cases (in-scope truncation → inconclusive; out-of-scope truncation still hard-MISSes; legacy no-kwarg behavior unchanged).
- new `scripts/test-bounded-exports.rb` (stubbed Sigma REST, no network): deadline expiry mid-poll → timeout status + exit 4 + partial results (runs in ~4s where it previously hung); truncated anchor scan → `inconclusive-truncated`, `rowLimit` asserted on every POST; too-large parity tile → loud marker + routing, preseeded rows preserved; normal paths unchanged; verify-parity PENDING for both markers.
- Full suite of touched-area tests green; `tools/check-shared.rb`, `tools/lint-skills.rb`, `tools/hygiene-sweep.sh`, and `corpus/run-corpus.sh --check` (14/14) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)