### PR TITLE
corpus: freeze the three field-failure twin fixtures (PLAN-v3 PR-1)

### DIFF
--- a/corpus/README.md
+++ b/corpus/README.md
@@ -23,6 +23,9 @@ corpus/
 | Case | Source format | Golden |
 |---|---|---|
 | tableau/orders-overview | .twb workbook + discovery signals | data model (9 elements, LOD child) |
+| tableau/lookup-grain-mismatch | synthetic field-twin .twb (VC self-join on a non-unique compound key + Top-N params) | join-plan pin + probe fixture + gate-16 checks.sh (no golden DM) |
+| tableau/join-elision-fanout | synthetic field-twin .twb (LEFT JOIN on a flag key, no joined column on shelves + 2nd datasource) | join-plan pin + multi-ds/gap-scan/line-kind checks.sh (no golden DM) |
+| tableau/preagg-kpi | synthetic field-twin .twb ({FIXED day: COUNTD} LODs consumed additively + dual-axis combo) | lod-audit pin + gate-17/dual-axis checks.sh (no golden DM) |
 | tableau/structural-workarounds | synthetic .twb (story + blend + nested LOD/ISOYEAR/FINDNTH/bins) | skill-script pins: story-plan / blend-plan / lod-chains (no golden DM) |
 | powerbi/model-fixtures | 8 TMSL .bim (plugin fixtures) | DM for fixture_01 |
 | powerbi/report-classic-employee-dashboard | legacy single report.json | artifact-pin only |
@@ -45,7 +48,14 @@ corpus/
 ```
 
 `--check` needs only python3 stdlib (PyYAML optional) — runnable in plain CI
-with no creds.
+with no creds. A case may additionally ship a `checks.sh` (executable
+expectations — still offline and creds-free): `--check` runs it after the
+structural check passes, and the case FAILs if it exits nonzero. The tableau
+field-twin cases (PLAN-v3 PR-1) use this to run the skill's ledger
+derivations, fixture-mode probes, and final gates against their synthetic
+.twbs — those need ruby on PATH (both CI runners ship it). A shipped
+`checks.sh` must be listed in the MANIFEST expectations artifacts
+(corpus_check enforces this).
 
 ## Goldens are id-normalized
 
@@ -74,7 +84,11 @@ warnings}` — so warning-text regressions are caught too.
    a `## Expectations` ```json block in `MANIFEST.md` (see any existing case):
    `artifacts` (paths relative to the case dir) + `goldens` (per-file counts
    and optional `element_names` / `metric_names` / `relationship_names`).
-5. `./run-corpus.sh --check <tool>` must pass.
+5. Behavioral expectations (script exit codes, ledger contents, gate
+   verdicts) go in an optional `checks.sh` in the case dir — offline and
+   creds-free, listed in the expectations artifacts. See
+   `tableau/lookup-grain-mismatch/checks.sh` for the pattern.
+6. `./run-corpus.sh --check <tool>` must pass.
 
 Large artifacts: the hosted MCP server rejects bodies over ~100 KB (HTTP 413).
 For those (e.g. the Orders .twb), run the converter from a clean

--- a/corpus/lib/corpus_check.py
+++ b/corpus/lib/corpus_check.py
@@ -213,10 +213,18 @@ def check_case(case_dir):
     expect, err = _read_manifest_expectations(case_dir)
     if err:
         return False, ["  FAIL %s" % err]
+    art_paths = [a if isinstance(a, str) else a.get("path")
+                 for a in expect.get("artifacts", [])]
     for art in expect.get("artifacts", []):
         a_ok, msg = _check_artifact(case_dir, art)
         ok = ok and a_ok
         lines.append(("  ok   " if a_ok else "  FAIL ") + msg)
+    # Executable expectations (run by run-corpus.sh, not here — no ruby dep in
+    # this stdlib checker): a case that ships checks.sh must LIST it in the
+    # expectations artifacts, so the manifest stays the single inventory.
+    if os.path.exists(os.path.join(case_dir, "checks.sh")) and "checks.sh" not in art_paths:
+        ok = False
+        lines.append("  FAIL checks.sh exists but is not listed in the expectations artifacts")
     for fname, gexp in (expect.get("goldens") or {}).items():
         g_ok, msgs = _check_golden(case_dir, fname, gexp)
         ok = ok and g_ok

--- a/corpus/run-corpus.sh
+++ b/corpus/run-corpus.sh
@@ -36,7 +36,17 @@ if [ "$MODE" = "--check" ]; then
   for c in $(cases); do
     total=$((total + 1))
     echo "== $c"
-    if python3 lib/corpus_check.py check "$c"; then
+    ok=1
+    python3 lib/corpus_check.py check "$c" || ok=0
+    # Executable expectations: a case may ship a checks.sh (offline,
+    # creds-free — e.g. the tableau field-twin cases run the skill's ledger
+    # derivations, fixture-mode probes, and gates). Needs ruby for the
+    # skill-script cases; both CI runners ship it.
+    if [ "$ok" -eq 1 ] && [ -f "$c/checks.sh" ]; then
+      echo "   -- checks.sh"
+      bash "$c/checks.sh" || ok=0
+    fi
+    if [ "$ok" -eq 1 ]; then
       echo "   PASS"
     else
       echo "   FAIL"

--- a/corpus/tableau/join-elision-fanout/MANIFEST.md
+++ b/corpus/tableau/join-elision-fanout/MANIFEST.md
@@ -1,0 +1,86 @@
+# tableau / join-elision-fanout
+
+**Synthetic twin of a field-failure shape** (PLAN-v3 PR-1, Wave 1). Invented
+names on the neutral `DEMO_DB.ANALYTICS` demo star — no customer identifiers,
+no live tenant. Reproduces the 2026-07-17 field root cause #2: an agent
+deleted a LEFT JOIN as "provably no-op" without warehouse proof — fan-out
+risk — plus the LOOKS-BAD regression where corrected chart kinds never
+propagated (bars shipped where the source shows lines).
+
+## The shape (what makes this workbook a trap)
+
+- A federated **LEFT JOIN** from `SALES_FACT` to `SEGMENT_DIM` on a
+  **non-unique, low-cardinality FLAG key** (`ACTIVE_FLAG = CURRENT_FLAG`,
+  values 0/1) with **no joined dim column on any shelf** — the join "looks
+  removable". It is not provably removable: the right side has multiple rows
+  per flag value, so eliding OR keeping it changes row counts (fan-out either
+  way). Only `GROUP BY key HAVING COUNT(*) > 1` proves anything.
+- A **wide Measure-Names crosstab** (6 measures × week columns — the shape
+  that renders `##` at source and defeats eyeball anchors), **two line
+  charts**, and a heat map.
+- A **second independent published datasource** (`Reference Notes`, sqlproxy
+  stub) feeding its own worksheet — converter defaults collapse to the
+  primary datasource and silently drop it (exit-11 gap class).
+- A Date-Level list parameter driving `DATETRUNC` via CASE, a `LOOKUP(-1)`
+  WoW table calc, and a sidebar control rail.
+
+## Artifacts
+
+| File | What it is |
+|---|---|
+| `workbook-content.twb` | The synthetic workbook XML (5 worksheets + `Activity Monitor` dashboard) |
+| `join-plan.entries.json` | PINNED `lib/join_plan.rb` derivation: ONE left-join entry on `CURRENT_FLAG` |
+| `probe-fixture/entry-0.json` | Canned probe result: 6 rows over 2 distinct flag values (NON-UNIQUE) |
+| `checks.sh` | Executable expectations, run by `run-corpus.sh --check` |
+
+## Expected gate behaviors (encoded in checks.sh)
+
+1. **Gap scan**: `scan-workbook-gaps.rb` detects the independent
+   multi-datasource shape (`multi_datasource` detail in the gaps JSON +
+   `multi-ds-plan.json` routing table: fact → 4 worksheets, published stub →
+   `Reference Notes`, `sqlproxy: true`).
+2. **Join ledger**: `JoinPlan.derive` records the LEFT JOIN
+   (`join_type: "left"`, keys `[CURRENT_FLAG]`, right_table
+   `DEMO_DB.ANALYTICS.SEGMENT_DIM`) — the elision candidate is on record
+   before any semantic edit.
+3. **Probe**: the fixture proves the flag key non-unique → exit 2 FATAL.
+   Contract: "provably no-op" must be proven by measurement (PR-8's
+   equivalence probe extends this); an unproven elision blocks GREEN via
+   gate 16.
+4. **Chart kinds**: `parse-twb-layout.rb` signals keep both trend worksheets
+   `chart_kind: "line"` (crosstab stays `pivot-table`) — the pin PR-10's
+   kind-parity gate builds on.
+
+## Known limitation (recorded, not yet gated)
+
+**Converter relationship handling**: the MCP converter flattens this
+federated left join into a single collapsed element/relationship set; when
+the joined table contributes no shelf column the relationship can drop from
+the emitted data model entirely, leaving the elision invisible downstream.
+No offline converter run exists for this corpus entry (hosted MCP only), so
+that behavior is recorded here as a known limitation rather than pinned as a
+golden; the join ledger above is the mechanical guard that survives it.
+
+## Converter
+
+No golden data model — this case pins the gap-scan / join-ledger / layout
+signal contracts. Regenerate the pin with:
+
+```
+ruby -rjson -I plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib -r join_plan -e '
+  puts JSON.pretty_generate(JoinPlan.derive(nil,
+    File.read("corpus/tableau/join-elision-fanout/workbook-content.twb", encoding: "UTF-8")))'
+```
+
+## Expectations
+
+```json
+{
+  "artifacts": [
+    {"path": "workbook-content.twb", "format": "xml"},
+    {"path": "join-plan.entries.json", "format": "json"},
+    {"path": "probe-fixture/entry-0.json", "format": "json"},
+    {"path": "checks.sh", "format": "text"}
+  ]
+}
+```

--- a/corpus/tableau/join-elision-fanout/checks.sh
+++ b/corpus/tableau/join-elision-fanout/checks.sh
@@ -48,11 +48,11 @@ ruby -rjson -I "$SCRIPTS/lib" -r join_plan -e '
   entries = JoinPlan.derive(nil, xml)
   File.write(ARGV[1], JSON.pretty_generate(entries) + "\n")
 ' "$CASE_DIR/workbook-content.twb" "$TMP/derived.json" || fail=1
-if cmp -s "$TMP/derived.json" "$CASE_DIR/join-plan.entries.json"; then
+if cmp -s <(tr -d "\r" < "$TMP/derived.json") <(tr -d "\r" < "$CASE_DIR/join-plan.entries.json"); then
   note "ok: join ledger pins the LEFT JOIN (SALES_FACT -> SEGMENT_DIM on CURRENT_FLAG, join_type left)"
 else
   note "FAIL: join-plan derivation drifted from join-plan.entries.json:"
-  diff "$CASE_DIR/join-plan.entries.json" "$TMP/derived.json" | head -20
+  diff <(tr -d "\r" < "$CASE_DIR/join-plan.entries.json") <(tr -d "\r" < "$TMP/derived.json") | head -20
   fail=1
 fi
 

--- a/corpus/tableau/join-elision-fanout/checks.sh
+++ b/corpus/tableau/join-elision-fanout/checks.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# join-elision-fanout — executable expectations (offline, creds-free).
+# Run by corpus/run-corpus.sh --check after corpus_check.py passes.
+#
+#   1. scan-workbook-gaps.rb detects the INDEPENDENT multi-datasource shape
+#      (fact datasource + the published Reference Notes stub) and writes the
+#      multi-ds-plan.json routing table — the converter would collapse to the
+#      primary and silently drop the second source.
+#   2. lib/join_plan.rb captures the LEFT JOIN in the ledger (join_type left,
+#      flag key) — the "looks removable" join is ON RECORD before anyone
+#      considers deleting it.
+#   3. probe-join-keys.rb --fixture proves the flag key NON-UNIQUE (6 rows
+#      over 2 keys) → exit 2 FATAL: the LEFT JOIN is NOT a provable no-op;
+#      eliding it (or keeping it) without measurement risks fan-out.
+#   4. parse-twb-layout.rb preserves the two trend worksheets as chart_kind
+#      "line" in the layout signals (the field regression shipped bars).
+set -uo pipefail
+CASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$CASE_DIR/../../.." && pwd)"
+SCRIPTS="$REPO_ROOT/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts"
+
+command -v ruby >/dev/null || { echo "checks: ruby not found (required for the skill-script checks)"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+note() { printf '     %s\n' "$*"; }
+
+# -- 1. gap scan: independent multi-datasource detected ----------------------
+ruby "$SCRIPTS/scan-workbook-gaps.rb" "$CASE_DIR/workbook-content.twb" "$TMP/gaps-report.md" >"$TMP/gaps.out" 2>&1 || fail=1
+ruby -rjson -e '
+  plan = JSON.parse(File.read(File.join(ARGV[0], "multi-ds-plan.json")))
+  abort "multi-ds-plan not independent" unless plan["independent"] == true
+  ds = plan["datasources"]
+  abort "expected 2 datasources, got #{ds.length}" unless ds.length == 2
+  fact  = ds.find { |d| d["caption"] == "Channel Activity Monitor" }
+  notes = ds.find { |d| d["caption"] == "Reference Notes" }
+  abort "fact datasource missing/mis-routed" unless fact && fact["table"] == "DEMO_DB.ANALYTICS.SALES_FACT" && fact["worksheets"].length == 4
+  abort "published stub missing/mis-flagged" unless notes && notes["sqlproxy"] == true && notes["worksheets"] == ["Reference Notes"]
+  gaps = JSON.parse(File.read(File.join(ARGV[0], "gaps-report.json")))
+  abort "gaps JSON lacks multi_datasource detail" unless gaps["multi_datasource"].is_a?(Array) && gaps["multi_datasource"].length == 2
+' "$TMP" && note "ok: gap scan detects 2 INDEPENDENT datasources (fact + published stub) and writes multi-ds-plan.json" \
+  || { note "FAIL: multi-datasource detection wrong"; fail=1; }
+
+# -- 2. join ledger captures the LEFT JOIN -----------------------------------
+ruby -rjson -I "$SCRIPTS/lib" -r join_plan -e '
+  xml = File.read(ARGV[0], encoding: "UTF-8")
+  entries = JoinPlan.derive(nil, xml)
+  File.write(ARGV[1], JSON.pretty_generate(entries) + "\n")
+' "$CASE_DIR/workbook-content.twb" "$TMP/derived.json" || fail=1
+if cmp -s "$TMP/derived.json" "$CASE_DIR/join-plan.entries.json"; then
+  note "ok: join ledger pins the LEFT JOIN (SALES_FACT -> SEGMENT_DIM on CURRENT_FLAG, join_type left)"
+else
+  note "FAIL: join-plan derivation drifted from join-plan.entries.json:"
+  diff "$CASE_DIR/join-plan.entries.json" "$TMP/derived.json" | head -20
+  fail=1
+fi
+
+# -- 3. probe: the flag key is NON-UNIQUE → deletion is NOT provably no-op ---
+ruby -rjson -I "$SCRIPTS/lib" -r join_plan -e '
+  JoinPlan.write(ARGV[1], JSON.parse(File.read(ARGV[0])))
+' "$CASE_DIR/join-plan.entries.json" "$TMP/join-plan.json" || fail=1
+ruby "$SCRIPTS/probe-join-keys.rb" --workdir "$TMP" --fixture "$CASE_DIR/probe-fixture" >"$TMP/probe.out" 2>"$TMP/probe.err"
+rc=$?
+if [ "$rc" -eq 2 ] \
+   && /usr/bin/grep -q 'JOIN-CARDINALITY FATAL' "$TMP/probe.err" \
+   && /usr/bin/grep -q 'SALES_FACT.*SEGMENT_DIM.*CURRENT_FLAG' "$TMP/probe.err" \
+   && /usr/bin/grep -q 'CURRENT_FLAG=1  -> 4 rows' "$TMP/probe.err"; then
+  note "ok: probe fixture proves the flag key non-unique (6 rows over 2 keys) -> exit 2 FATAL; join elision is unproven"
+else
+  note "FAIL: probe expected exit 2 + FATAL naming SEGMENT_DIM/CURRENT_FLAG (got exit $rc)"; sed -n '1,15p' "$TMP/probe.err"; fail=1
+fi
+
+# -- 4. chart kinds preserved as line in the layout signals ------------------
+ruby "$SCRIPTS/parse-twb-layout.rb" "$CASE_DIR/workbook-content.twb" "$TMP/layout.json" >"$TMP/layout.out" 2>&1 || fail=1
+ruby -rjson -e '
+  zones = JSON.parse(File.read(ARGV[0])).flat_map { |d| d["zones"] || [] }
+  kinds = zones.select { |z| z["kind"] == "chart" }.map { |z| [z["caption"], z["chart_kind"]] }.to_h
+  abort "Amount Trend not line: #{kinds.inspect}" unless kinds["Amount Trend"] == "line"
+  abort "Earn Ratio Trend not line: #{kinds.inspect}" unless kinds["Earn Ratio Trend"] == "line"
+  abort "Channel Crosstab not pivot-table: #{kinds.inspect}" unless kinds["Channel Crosstab"] == "pivot-table"
+' "$TMP/layout.json" && note "ok: layout signals keep both trend worksheets chart_kind=line (crosstab stays pivot-table)" \
+  || { note "FAIL: chart kinds not preserved in layout signals"; fail=1; }
+
+exit "$fail"

--- a/corpus/tableau/join-elision-fanout/join-plan.entries.json
+++ b/corpus/tableau/join-elision-fanout/join-plan.entries.json
@@ -1,0 +1,23 @@
+[
+  {
+    "kind": "federated-join",
+    "join_type": "left",
+    "left": "SALES_FACT",
+    "right": "SEGMENT_DIM",
+    "keys": [
+      "CURRENT_FLAG"
+    ],
+    "key_pairs": [
+      {
+        "left": "ACTIVE_FLAG",
+        "right": "CURRENT_FLAG"
+      }
+    ],
+    "grain_assumption": "right unique on keys",
+    "status": "unprobed",
+    "right_table": "DEMO_DB.ANALYTICS.SEGMENT_DIM",
+    "probe_keys": [
+      "CURRENT_FLAG"
+    ]
+  }
+]

--- a/corpus/tableau/join-elision-fanout/probe-fixture/entry-0.json
+++ b/corpus/tableau/join-elision-fanout/probe-fixture/entry-0.json
@@ -1,0 +1,8 @@
+{
+  "total": 6,
+  "distinct": 2,
+  "duplicates": [
+    { "keys": { "CURRENT_FLAG": "1" }, "count": 4 },
+    { "keys": { "CURRENT_FLAG": "0" }, "count": 2 }
+  ]
+}

--- a/corpus/tableau/join-elision-fanout/workbook-content.twb
+++ b/corpus/tableau/join-elision-fanout/workbook-content.twb
@@ -1,0 +1,527 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- Synthetic field-twin (invented names, no customer data): the JOIN ELISION
+     / FAN-OUT shape. A federated LEFT JOIN from the fact to a dim on a
+     NON-UNIQUE, low-cardinality FLAG key (fact.ACTIVE_FLAG =
+     SEGMENT_DIM.CURRENT_FLAG) where NO joined dim column appears on any
+     shelf — the join "looks removable", but the flag key is massively
+     duplicated, so deleting it (or keeping it) changes row counts: fan-out
+     either way, only provable by measuring the right side's key cardinality.
+     Plus: a wide Measure-Names crosstab, two line charts, a heat map, and a
+     SECOND independent published datasource feeding its own worksheet (the
+     converter collapses to the primary and silently drops it). -->
+<workbook locale='en_US' original-version='18.1' source-build='2026.1.5 (20261.26.0512.1609)' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <preferences />
+  <datasources>
+    <datasource hasconnection='false' inline='true' name='Parameters' version='18.1'>
+      <aliases enabled='yes' />
+      <column caption='Date Level' datatype='string' name='[Parameter 1]' param-domain-type='list' role='measure' type='nominal' value='&quot;Week&quot;'>
+        <calculation class='tableau' formula='&quot;Week&quot;' />
+        <members>
+          <member value='&quot;Day&quot;' />
+          <member value='&quot;Week&quot;' />
+          <member value='&quot;Month&quot;' />
+        </members>
+      </column>
+    </datasource>
+    <datasource caption='Channel Activity Monitor' inline='true' name='federated.0jef0activity01' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='snowflake demo' name='snowflake.0jef0activity01'>
+            <connection class='snowflake' dbname='DEMO_DB' schema='ANALYTICS' server='example.snowflakecomputing.com' warehouse='WH_XS' />
+          </named-connection>
+        </named-connections>
+        <relation join='left' type='join'>
+          <clause type='join'>
+            <expression op='='>
+              <expression op='[SALES_FACT].[ACTIVE_FLAG]' />
+              <expression op='[SEGMENT_DIM].[CURRENT_FLAG]' />
+            </expression>
+          </clause>
+          <relation connection='snowflake.0jef0activity01' name='SALES_FACT' table='[ANALYTICS].[SALES_FACT]' type='table'>
+            <columns>
+              <column datatype='date' name='SALE_DATE' />
+              <column datatype='string' name='CHANNEL_CODE' />
+              <column datatype='real' name='NET_AMOUNT' />
+              <column datatype='real' name='GROSS_AMOUNT' />
+              <column datatype='real' name='REBATE_AMOUNT' />
+              <column datatype='real' name='TAX_AMOUNT' />
+              <column datatype='real' name='FREIGHT_AMOUNT' />
+              <column datatype='real' name='NET_EARNINGS' />
+              <column datatype='integer' name='BUYER_KEY' />
+              <column datatype='integer' name='ACTIVE_FLAG' />
+            </columns>
+          </relation>
+          <relation connection='snowflake.0jef0activity01' name='SEGMENT_DIM' table='[ANALYTICS].[SEGMENT_DIM]' type='table'>
+            <columns>
+              <column datatype='integer' name='CURRENT_FLAG' />
+              <column datatype='string' name='SEGMENT_NAME' />
+              <column datatype='string' name='REGION_NAME' />
+            </columns>
+          </relation>
+        </relation>
+      </connection>
+      <aliases enabled='yes' />
+      <column datatype='string' name='[:Measure Names]' role='dimension' type='nominal' />
+      <column caption='Sale Date' datatype='date' name='[SALE_DATE]' role='dimension' type='ordinal' />
+      <column caption='Channel Code' datatype='string' name='[CHANNEL_CODE]' role='dimension' type='nominal' />
+      <column caption='Net Amount' datatype='real' name='[NET_AMOUNT]' role='measure' type='quantitative' />
+      <column caption='Gross Amount' datatype='real' name='[GROSS_AMOUNT]' role='measure' type='quantitative' />
+      <column caption='Rebate Amount' datatype='real' name='[REBATE_AMOUNT]' role='measure' type='quantitative' />
+      <column caption='Tax Amount' datatype='real' name='[TAX_AMOUNT]' role='measure' type='quantitative' />
+      <column caption='Freight Amount' datatype='real' name='[FREIGHT_AMOUNT]' role='measure' type='quantitative' />
+      <column caption='Net Earnings' datatype='real' name='[NET_EARNINGS]' role='measure' type='quantitative' />
+      <column caption='Buyer Key' datatype='integer' name='[BUYER_KEY]' role='measure' type='quantitative' />
+      <column caption='Active Flag' datatype='integer' name='[ACTIVE_FLAG]' role='measure' type='quantitative' />
+      <column caption='Current Flag' datatype='integer' name='[CURRENT_FLAG]' role='measure' type='quantitative' />
+      <column caption='Segment Name' datatype='string' name='[SEGMENT_NAME]' role='dimension' type='nominal' />
+      <column caption='Region Name' datatype='string' name='[REGION_NAME]' role='dimension' type='nominal' />
+      <column caption='Sale Date (Level)' datatype='date' name='[Calculation_JEF_DateLevel]' role='dimension' type='ordinal'>
+        <calculation class='tableau' formula='CASE [Parameters].[Parameter 1] WHEN &quot;Day&quot; THEN DATETRUNC(&apos;day&apos;, [SALE_DATE]) WHEN &quot;Month&quot; THEN DATETRUNC(&apos;month&apos;, [SALE_DATE]) ELSE DATETRUNC(&apos;week&apos;, [SALE_DATE]) END' />
+      </column>
+      <column caption='Earn Ratio' datatype='real' default-format='p0.0%' name='[Calculation_JEF_EarnRatio]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='IIF([NET_AMOUNT] != 0, [NET_EARNINGS] / [NET_AMOUNT], NULL)' />
+      </column>
+      <column caption='WoW Change Pct' datatype='real' default-format='p0.0%' name='[Calculation_JEF_WoWChangePct]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='(ZN(SUM([NET_AMOUNT])) - LOOKUP(ZN(SUM([NET_AMOUNT])), -1)) / ABS(LOOKUP(ZN(SUM([NET_AMOUNT])), -1))' />
+      </column>
+      <column caption='Trend Flag' datatype='string' name='[Calculation_JEF_TrendFlag]' role='dimension' type='nominal'>
+        <calculation class='tableau' formula='IF [Calculation_JEF_WoWChangePct] &lt; -0.5 THEN &quot;Drop&quot; ELSEIF [Calculation_JEF_WoWChangePct] &gt; 0.5 THEN &quot;Spike&quot; ELSE &quot;Stable&quot; END' />
+      </column>
+      <layout dim-ordering='alphabetic' measure-ordering='alphabetic' show-structure='true' />
+    </datasource>
+    <datasource caption='Reference Notes' inline='true' name='sqlproxy.0jef0refnotes01' version='18.1'>
+      <connection channel='https' class='sqlproxy' dbname='Reference-Notes' port='443' server='example.online.tableau.com' username='' workgroup-auth-mode='prompt'>
+        <relation name='sqlproxy' table='[sqlproxy]' type='table' />
+      </connection>
+      <column datatype='string' name='[Topic]' role='dimension' type='nominal' />
+      <column datatype='real' name='[Note Value]' role='measure' type='quantitative' />
+      <layout dim-ordering='alphabetic' measure-ordering='alphabetic' show-structure='true' />
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Channel Crosstab'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Channel Behavior by Week (last 8 weeks)</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Channel Activity Monitor' name='federated.0jef0activity01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0jef0activity01'>
+            <column datatype='string' name='[:Measure Names]' role='dimension' type='nominal' />
+            <column caption='Sale Date' datatype='date' name='[SALE_DATE]' role='dimension' type='ordinal' />
+            <column caption='Channel Code' datatype='string' name='[CHANNEL_CODE]' role='dimension' type='nominal' />
+            <column caption='Net Amount' datatype='real' name='[NET_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='Gross Amount' datatype='real' name='[GROSS_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='Rebate Amount' datatype='real' name='[REBATE_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='Tax Amount' datatype='real' name='[TAX_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='Freight Amount' datatype='real' name='[FREIGHT_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='WoW Change Pct' datatype='real' default-format='p0.0%' name='[Calculation_JEF_WoWChangePct]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='(ZN(SUM([NET_AMOUNT])) - LOOKUP(ZN(SUM([NET_AMOUNT])), -1)) / ABS(LOOKUP(ZN(SUM([NET_AMOUNT])), -1))' />
+            </column>
+            <column-instance column='[CHANNEL_CODE]' derivation='None' name='[none:CHANNEL_CODE:nk]' pivot='key' type='nominal' />
+            <column-instance column='[SALE_DATE]' derivation='Week-Trunc' name='[twk:SALE_DATE:ok]' pivot='key' type='ordinal' />
+            <column-instance column='[SALE_DATE]' derivation='None' name='[none:SALE_DATE:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[NET_AMOUNT]' derivation='Sum' name='[sum:NET_AMOUNT:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[GROSS_AMOUNT]' derivation='Sum' name='[sum:GROSS_AMOUNT:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[REBATE_AMOUNT]' derivation='Sum' name='[sum:REBATE_AMOUNT:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[TAX_AMOUNT]' derivation='Sum' name='[sum:TAX_AMOUNT:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[FREIGHT_AMOUNT]' derivation='Sum' name='[sum:FREIGHT_AMOUNT:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_JEF_WoWChangePct]' derivation='User' name='[usr:Calculation_JEF_WoWChangePct:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.0jef0activity01].[:Measure Names]'>
+            <groupfilter function='union' user:ui-domain='relevant' user:ui-enumeration='inclusive' user:ui-marker='enumerate' xmlns:user='http://www.tableausoftware.com/xml/user'>
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0jef0activity01].[sum:NET_AMOUNT:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0jef0activity01].[sum:GROSS_AMOUNT:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0jef0activity01].[sum:REBATE_AMOUNT:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0jef0activity01].[sum:TAX_AMOUNT:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0jef0activity01].[sum:FREIGHT_AMOUNT:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0jef0activity01].[usr:Calculation_JEF_WoWChangePct:qk]&quot;' />
+            </groupfilter>
+          </filter>
+          <filter class='categorical' column='[federated.0jef0activity01].[twk:SALE_DATE:ok]'>
+            <groupfilter count='8' end='top' function='end' units='records' user:ui-enumeration='top' user:ui-marker='enumerate' xmlns:user='http://www.tableausoftware.com/xml/user'>
+              <groupfilter direction='DESC' expression='MAX([SALE_DATE])' function='order'>
+                <groupfilter function='level-members' level='[twk:SALE_DATE:ok]' />
+              </groupfilter>
+            </groupfilter>
+          </filter>
+          <filter class='quantitative' column='[federated.0jef0activity01].[none:SALE_DATE:qk]' included-values='non-null' />
+          <filter class='categorical' column='[federated.0jef0activity01].[none:CHANNEL_CODE:nk]'>
+            <groupfilter function='level-members' level='[none:CHANNEL_CODE:nk]' user:ui-domain='database' user:ui-enumeration='all' user:ui-marker='enumerate' xmlns:user='http://www.tableausoftware.com/xml/user' />
+          </filter>
+          <slices>
+            <column>[federated.0jef0activity01].[none:CHANNEL_CODE:nk]</column>
+            <column>[federated.0jef0activity01].[twk:SALE_DATE:ok]</column>
+            <column>[federated.0jef0activity01].[:Measure Names]</column>
+            <column>[federated.0jef0activity01].[Multiple Values]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='header'>
+            <format attr='col-width' field='[federated.0jef0activity01].[:Measure Names]' value='34' />
+          </style-rule>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[federated.0jef0activity01].[sum:NET_AMOUNT:qk]' value='n&quot;$&quot;#,##0.00' />
+            <format attr='text-format' field='[federated.0jef0activity01].[sum:GROSS_AMOUNT:qk]' value='n&quot;$&quot;#,##0.00' />
+            <format attr='text-format' field='[federated.0jef0activity01].[sum:REBATE_AMOUNT:qk]' value='n&quot;$&quot;#,##0.00' />
+            <format attr='text-format' field='[federated.0jef0activity01].[sum:TAX_AMOUNT:qk]' value='n&quot;$&quot;#,##0.00' />
+            <format attr='text-format' field='[federated.0jef0activity01].[sum:FREIGHT_AMOUNT:qk]' value='n&quot;$&quot;#,##0.00' />
+            <format attr='text-format' field='[federated.0jef0activity01].[usr:Calculation_JEF_WoWChangePct:qk]' value='p0.0%' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Text' />
+            <encodings>
+              <text column='[federated.0jef0activity01].[Multiple Values]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.0jef0activity01].[none:CHANNEL_CODE:nk]</rows>
+        <cols>([federated.0jef0activity01].[twk:SALE_DATE:ok] / [federated.0jef0activity01].[:Measure Names])</cols>
+      </table>
+      <simple-id uuid='{BD200001-0000-4000-8000-000000000001}' />
+    </worksheet>
+    <worksheet name='Amount Trend'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Net Amount Trend by Channel (Top 5)</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Channel Activity Monitor' name='federated.0jef0activity01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0jef0activity01'>
+            <column caption='Sale Date' datatype='date' name='[SALE_DATE]' role='dimension' type='ordinal' />
+            <column caption='Channel Code' datatype='string' name='[CHANNEL_CODE]' role='dimension' type='nominal' />
+            <column caption='Net Amount' datatype='real' name='[NET_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='Sale Date (Level)' datatype='date' name='[Calculation_JEF_DateLevel]' role='dimension' type='ordinal'>
+              <calculation class='tableau' formula='CASE [Parameters].[Parameter 1] WHEN &quot;Day&quot; THEN DATETRUNC(&apos;day&apos;, [SALE_DATE]) WHEN &quot;Month&quot; THEN DATETRUNC(&apos;month&apos;, [SALE_DATE]) ELSE DATETRUNC(&apos;week&apos;, [SALE_DATE]) END' />
+            </column>
+            <column-instance column='[CHANNEL_CODE]' derivation='None' name='[none:CHANNEL_CODE:nk]' pivot='key' type='nominal' />
+            <column-instance column='[SALE_DATE]' derivation='None' name='[none:SALE_DATE:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_JEF_DateLevel]' derivation='None' name='[none:Calculation_JEF_DateLevel:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[NET_AMOUNT]' derivation='Sum' name='[sum:NET_AMOUNT:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.0jef0activity01].[none:CHANNEL_CODE:nk]'>
+            <groupfilter count='5' end='top' function='end' units='records' user:ui-enumeration='top' user:ui-marker='enumerate' xmlns:user='http://www.tableausoftware.com/xml/user'>
+              <groupfilter direction='DESC' expression='SUM([NET_AMOUNT])' function='order'>
+                <groupfilter function='level-members' level='[none:CHANNEL_CODE:nk]' />
+              </groupfilter>
+            </groupfilter>
+          </filter>
+          <filter class='quantitative' column='[federated.0jef0activity01].[none:SALE_DATE:qk]' included-values='non-null' />
+          <slices>
+            <column>[federated.0jef0activity01].[none:Calculation_JEF_DateLevel:qk]</column>
+            <column>[federated.0jef0activity01].[sum:NET_AMOUNT:qk]</column>
+            <column>[federated.0jef0activity01].[none:CHANNEL_CODE:nk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style />
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Line' />
+            <encodings>
+              <color column='[federated.0jef0activity01].[none:CHANNEL_CODE:nk]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.0jef0activity01].[sum:NET_AMOUNT:qk]</rows>
+        <cols>[federated.0jef0activity01].[none:Calculation_JEF_DateLevel:qk]</cols>
+      </table>
+      <simple-id uuid='{BD200002-0000-4000-8000-000000000002}' />
+    </worksheet>
+    <worksheet name='Earn Ratio Trend'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Avg Earn Ratio Trend</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Channel Activity Monitor' name='federated.0jef0activity01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0jef0activity01'>
+            <column caption='Sale Date' datatype='date' name='[SALE_DATE]' role='dimension' type='ordinal' />
+            <column caption='Net Amount' datatype='real' name='[NET_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='Net Earnings' datatype='real' name='[NET_EARNINGS]' role='measure' type='quantitative' />
+            <column caption='Sale Date (Level)' datatype='date' name='[Calculation_JEF_DateLevel]' role='dimension' type='ordinal'>
+              <calculation class='tableau' formula='CASE [Parameters].[Parameter 1] WHEN &quot;Day&quot; THEN DATETRUNC(&apos;day&apos;, [SALE_DATE]) WHEN &quot;Month&quot; THEN DATETRUNC(&apos;month&apos;, [SALE_DATE]) ELSE DATETRUNC(&apos;week&apos;, [SALE_DATE]) END' />
+            </column>
+            <column caption='Earn Ratio' datatype='real' default-format='p0.0%' name='[Calculation_JEF_EarnRatio]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='IIF([NET_AMOUNT] != 0, [NET_EARNINGS] / [NET_AMOUNT], NULL)' />
+            </column>
+            <column-instance column='[SALE_DATE]' derivation='None' name='[none:SALE_DATE:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_JEF_DateLevel]' derivation='None' name='[none:Calculation_JEF_DateLevel:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_JEF_EarnRatio]' derivation='Avg' name='[avg:Calculation_JEF_EarnRatio:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <filter class='quantitative' column='[federated.0jef0activity01].[none:SALE_DATE:qk]' included-values='non-null' />
+          <slices>
+            <column>[federated.0jef0activity01].[none:Calculation_JEF_DateLevel:qk]</column>
+            <column>[federated.0jef0activity01].[avg:Calculation_JEF_EarnRatio:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[federated.0jef0activity01].[avg:Calculation_JEF_EarnRatio:qk]' value='p0.0%' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Line' />
+          </pane>
+        </panes>
+        <rows>[federated.0jef0activity01].[avg:Calculation_JEF_EarnRatio:qk]</rows>
+        <cols>[federated.0jef0activity01].[none:Calculation_JEF_DateLevel:qk]</cols>
+      </table>
+      <simple-id uuid='{BD200003-0000-4000-8000-000000000003}' />
+    </worksheet>
+    <worksheet name='Change Heat'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>WoW Change Pct Heat (Channel x Week)</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Channel Activity Monitor' name='federated.0jef0activity01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0jef0activity01'>
+            <column caption='Sale Date' datatype='date' name='[SALE_DATE]' role='dimension' type='ordinal' />
+            <column caption='Channel Code' datatype='string' name='[CHANNEL_CODE]' role='dimension' type='nominal' />
+            <column caption='Net Amount' datatype='real' name='[NET_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='WoW Change Pct' datatype='real' default-format='p0.0%' name='[Calculation_JEF_WoWChangePct]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='(ZN(SUM([NET_AMOUNT])) - LOOKUP(ZN(SUM([NET_AMOUNT])), -1)) / ABS(LOOKUP(ZN(SUM([NET_AMOUNT])), -1))' />
+            </column>
+            <column caption='Trend Flag' datatype='string' name='[Calculation_JEF_TrendFlag]' role='dimension' type='nominal'>
+              <calculation class='tableau' formula='IF [Calculation_JEF_WoWChangePct] &lt; -0.5 THEN &quot;Drop&quot; ELSEIF [Calculation_JEF_WoWChangePct] &gt; 0.5 THEN &quot;Spike&quot; ELSE &quot;Stable&quot; END' />
+            </column>
+            <column-instance column='[CHANNEL_CODE]' derivation='None' name='[none:CHANNEL_CODE:nk]' pivot='key' type='nominal' />
+            <column-instance column='[SALE_DATE]' derivation='Week-Trunc' name='[twk:SALE_DATE:ok]' pivot='key' type='ordinal' />
+            <column-instance column='[SALE_DATE]' derivation='None' name='[none:SALE_DATE:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_JEF_WoWChangePct]' derivation='User' name='[usr:Calculation_JEF_WoWChangePct:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_JEF_TrendFlag]' derivation='User' name='[usr:Calculation_JEF_TrendFlag:nk]' pivot='key' type='nominal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.0jef0activity01].[twk:SALE_DATE:ok]'>
+            <groupfilter count='8' end='top' function='end' units='records' user:ui-enumeration='top' user:ui-marker='enumerate' xmlns:user='http://www.tableausoftware.com/xml/user'>
+              <groupfilter direction='DESC' expression='MAX([SALE_DATE])' function='order'>
+                <groupfilter function='level-members' level='[twk:SALE_DATE:ok]' />
+              </groupfilter>
+            </groupfilter>
+          </filter>
+          <filter class='quantitative' column='[federated.0jef0activity01].[none:SALE_DATE:qk]' included-values='non-null' />
+          <slices>
+            <column>[federated.0jef0activity01].[none:CHANNEL_CODE:nk]</column>
+            <column>[federated.0jef0activity01].[twk:SALE_DATE:ok]</column>
+            <column>[federated.0jef0activity01].[usr:Calculation_JEF_WoWChangePct:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[federated.0jef0activity01].[usr:Calculation_JEF_WoWChangePct:qk]' value='p0.0%' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Square' />
+            <encodings>
+              <color column='[federated.0jef0activity01].[usr:Calculation_JEF_WoWChangePct:qk]' />
+              <text column='[federated.0jef0activity01].[usr:Calculation_JEF_WoWChangePct:qk]' />
+              <tooltip column='[federated.0jef0activity01].[usr:Calculation_JEF_TrendFlag:nk]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.0jef0activity01].[none:CHANNEL_CODE:nk]</rows>
+        <cols>[federated.0jef0activity01].[twk:SALE_DATE:ok]</cols>
+      </table>
+      <simple-id uuid='{BD200004-0000-4000-8000-000000000004}' />
+    </worksheet>
+    <worksheet name='Reference Notes'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Reference Notes (Published Source)</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Reference Notes' name='sqlproxy.0jef0refnotes01' />
+          </datasources>
+          <datasource-dependencies datasource='sqlproxy.0jef0refnotes01'>
+            <column datatype='string' name='[Topic]' role='dimension' type='nominal' />
+            <column datatype='real' name='[Note Value]' role='measure' type='quantitative' />
+            <column-instance column='[Topic]' derivation='None' name='[none:Topic:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Note Value]' derivation='Sum' name='[sum:Note Value:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <slices>
+            <column>[sqlproxy.0jef0refnotes01].[none:Topic:nk]</column>
+            <column>[sqlproxy.0jef0refnotes01].[sum:Note Value:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[sqlproxy.0jef0refnotes01].[sum:Note Value:qk]' value='n#,##0' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Text' />
+            <encodings>
+              <text column='[sqlproxy.0jef0refnotes01].[sum:Note Value:qk]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[sqlproxy.0jef0refnotes01].[none:Topic:nk]</rows>
+        <cols />
+      </table>
+      <simple-id uuid='{BD200005-0000-4000-8000-000000000005}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard enable-sort-zone-taborder='true' name='Activity Monitor'>
+      <style />
+      <size maxheight='900' maxwidth='1400' minheight='900' minwidth='1400' sizing-mode='fixed' />
+      <datasources>
+        <datasource caption='Channel Activity Monitor' name='federated.0jef0activity01' />
+        <datasource caption='Reference Notes' name='sqlproxy.0jef0refnotes01' />
+      </datasources>
+      <zones>
+        <zone h='100000' id='200' type-v2='layout-basic' w='100000' x='0' y='0'>
+          <zone h='100000' id='210' param='horz' type-v2='layout-flow' w='100000' x='0' y='0'>
+            <zone h='100000' id='211' param='vert' type-v2='layout-flow' w='70000' x='0' y='0'>
+              <zone h='55000' id='201' name='Channel Crosstab' w='70000' x='0' y='0'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='3' />
+                </zone-style>
+              </zone>
+              <zone h='45000' id='202' name='Change Heat' w='70000' x='0' y='55000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='3' />
+                </zone-style>
+              </zone>
+            </zone>
+            <zone h='100000' id='212' param='vert' type-v2='layout-flow' w='30000' x='70000' y='0'>
+              <zone h='5000' id='203' mode='compact' param='[Parameters].[Parameter 1]' type-v2='paramctrl' w='30000' x='70000' y='0'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                  <format attr='background-color' value='#f5f5f5' />
+                </zone-style>
+              </zone>
+              <zone h='5500' id='204' name='Amount Trend' param='[federated.0jef0activity01].[none:SALE_DATE:qk]' type-v2='filter' w='30000' x='70000' y='5000'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                  <format attr='background-color' value='#f5f5f5' />
+                </zone-style>
+              </zone>
+              <zone h='8000' id='205' mode='checklist' name='Channel Crosstab' param='[federated.0jef0activity01].[none:CHANNEL_CODE:nk]' type-v2='filter' w='30000' x='70000' y='10500'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                  <format attr='background-color' value='#f5f5f5' />
+                </zone-style>
+              </zone>
+              <zone h='27500' id='206' name='Amount Trend' show-title='false' w='30000' x='70000' y='18500'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='3' />
+                </zone-style>
+              </zone>
+              <zone h='27000' id='207' name='Earn Ratio Trend' show-title='false' w='30000' x='70000' y='46000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='3' />
+                </zone-style>
+              </zone>
+              <zone h='27000' id='208' name='Reference Notes' show-title='false' w='30000' x='70000' y='73000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='3' />
+                </zone-style>
+              </zone>
+            </zone>
+          </zone>
+        </zone>
+      </zones>
+      <simple-id uuid='{BD200010-0000-4000-8000-000000000010}' />
+    </dashboard>
+  </dashboards>
+  <windows source-height='30'>
+    <window class='dashboard' maximized='true' name='Activity Monitor'>
+      <viewpoints>
+        <viewpoint name='Channel Crosstab'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='Change Heat'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='Amount Trend'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='Earn Ratio Trend'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='Reference Notes'>
+          <zoom type='entire-view' />
+        </viewpoint>
+      </viewpoints>
+      <active id='-1' />
+      <simple-id uuid='{BD200011-0000-4000-8000-000000000011}' />
+    </window>
+  </windows>
+</workbook>

--- a/corpus/tableau/lookup-grain-mismatch/MANIFEST.md
+++ b/corpus/tableau/lookup-grain-mismatch/MANIFEST.md
@@ -1,0 +1,79 @@
+# tableau / lookup-grain-mismatch
+
+**Synthetic twin of a field-failure shape** (PLAN-v3 PR-1, Wave 1). Invented
+names on the neutral `DEMO_DB.ANALYTICS` demo star — no customer identifiers,
+no live tenant. Reproduces the 2026-07-17 field root cause #1: a join/Lookup
+synthesized on a **non-unique compound key** silently undercounts a core
+metric, and nothing in the pipeline errors.
+
+## The shape (what makes this workbook a trap)
+
+- Published-virtual-connection federated datasource: relation labels carry the
+  physical path only in parens (`SALES_FACT (ANALYTICS.SALES_FACT)`), the
+  named-connection has **no dbname**, and every field id is a Tableau GUID —
+  captions are the only handle on physical columns.
+- The relation tree **self-joins the fact table** (`Sale Lines` vs `Buyer Day
+  Detail`, same physical `SALES_FACT`) on the AND-wrapped compound key
+  (buyer key × sale date). The fact is at sale-LINE grain, so the right side
+  is NOT unique at that key — every `Unified *` / `Combined Margin` measure
+  that reads a `(Buyer Day Detail)` column undercounts or fans out.
+- Two single-key dim joins (`BUYER_DIM`, `ITEM_DIM`) that ARE unique — the
+  probe must separate the safe joins from the poisoned one.
+- Top-N (list) + Direction parameters driving `RANK_UNIQUE(IIF(...))` +
+  an `In Top N` boolean filter; **param-driven dynamic titles**
+  (`<[Parameters].[Parameter 2]> <[Parameters].[Parameter 1]> Buyers ...`);
+  a **top-shelf control row** (2 paramctrl + 2 filter zones in the first
+  horizontal band) — the layout/controls traps from the same field session.
+
+## Artifacts
+
+| File | What it is |
+|---|---|
+| `workbook-content.twb` | The synthetic workbook XML (4 worksheets + `Profit Watch` dashboard) |
+| `join-plan.entries.json` | PINNED `lib/join_plan.rb` derivation (the join ledger, PR-4) |
+| `probe-fixture/entry-*.json` | Canned probe results for `probe-join-keys.rb --fixture` (the offline seam): dims unique, self-join NON-UNIQUE (5000 rows over 1400 keys + sample duplicates) |
+| `checks.sh` | Executable expectations, run by `run-corpus.sh --check` |
+
+## Expected gate behaviors (encoded in checks.sh)
+
+1. **Derivation**: `JoinPlan.derive(nil, twb, db:, schema:)` emits exactly the
+   pinned 3 federated-join entries. Honest current-code warts are pinned on
+   purpose: the dim probe keys fold the disambiguated captions
+   (`Buyer Key (BUYER_DIM)` → `BUYER_KEY_(BUYER_DIM)` — no such physical
+   column), and the self-join `right_table` keeps the unprobeable VC-inode
+   FQN (`eeee….SALES_FACT (ANALYTICS.SALES_FACT)`) because the alias label
+   has no paren path. Later PRs that fix either fold flip this pin.
+2. **Probe**: `probe-join-keys.rb --fixture` → dims `unique`, self-join
+   `non-unique` → **exit 2** with the JOIN-CARDINALITY FATAL block naming
+   the entry, the compound keys, and sample duplicate keys.
+3. **Gate 16** (`assert-phase6-ran.rb`, exit 23): blocks GREEN while the
+   non-unique entry is unresolved; passes after
+   `probe-join-keys.rb --resolve 2 --how preaggregated --reason "..."`
+   records the evidence.
+
+## Converter
+
+No golden data model — this case pins the PR-4 join-ledger contract, not the
+MCP converter output. Regenerate the pin with:
+
+```
+ruby -rjson -I plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib -r join_plan -e '
+  puts JSON.pretty_generate(JoinPlan.derive(nil,
+    File.read("corpus/tableau/lookup-grain-mismatch/workbook-content.twb", encoding: "UTF-8"),
+    db: "DEMO_DB", schema: "ANALYTICS"))'
+```
+
+## Expectations
+
+```json
+{
+  "artifacts": [
+    {"path": "workbook-content.twb", "format": "xml"},
+    {"path": "join-plan.entries.json", "format": "json"},
+    {"path": "probe-fixture/entry-0.json", "format": "json"},
+    {"path": "probe-fixture/entry-1.json", "format": "json"},
+    {"path": "probe-fixture/entry-2.json", "format": "json"},
+    {"path": "checks.sh", "format": "text"}
+  ]
+}
+```

--- a/corpus/tableau/lookup-grain-mismatch/checks.sh
+++ b/corpus/tableau/lookup-grain-mismatch/checks.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# lookup-grain-mismatch — executable expectations (offline, creds-free).
+# Run by corpus/run-corpus.sh --check after corpus_check.py passes.
+#
+#   1. lib/join_plan.rb derivation on the synthetic .twb yields EXACTLY the
+#      pinned federated-join entries (compound self-join keys resolved via
+#      GUID captions; dim probe keys keep the disambiguated-caption folding;
+#      the VC self-join right_table stays the unprobeable inode FQN — the
+#      honest current-code output, warts recorded on purpose).
+#   2. probe-join-keys.rb --fixture (the offline seam) proves the dim joins
+#      unique and the compound self-join NON-UNIQUE → exit 2 + FATAL block.
+#   3. assert-phase6-ran.rb gate 16 (exit 23) BLOCKS on the probed-non-unique
+#      ledger and PASSES once the resolution evidence is recorded.
+set -uo pipefail
+CASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$CASE_DIR/../../.." && pwd)"
+SCRIPTS="$REPO_ROOT/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts"
+
+command -v ruby >/dev/null || { echo "checks: ruby not found (required for the skill-script checks)"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+note() { printf '     %s\n' "$*"; }
+
+# -- 1. join-plan derivation matches the pin ---------------------------------
+ruby -rjson -I "$SCRIPTS/lib" -r join_plan -e '
+  xml = File.read(ARGV[0], encoding: "UTF-8")
+  entries = JoinPlan.derive(nil, xml, db: "DEMO_DB", schema: "ANALYTICS")
+  File.write(ARGV[1], JSON.pretty_generate(entries) + "\n")
+' "$CASE_DIR/workbook-content.twb" "$TMP/derived.json" || fail=1
+if cmp -s "$TMP/derived.json" "$CASE_DIR/join-plan.entries.json"; then
+  note "ok: join-plan derivation matches join-plan.entries.json (3 federated joins; compound self-join keys BUYER_KEY+SALE_DATE)"
+else
+  note "FAIL: join-plan derivation drifted from join-plan.entries.json:"
+  diff "$CASE_DIR/join-plan.entries.json" "$TMP/derived.json" | head -30
+  fail=1
+fi
+
+# -- 2. offline probe: non-unique self-join → exit 2 + FATAL -----------------
+ruby -rjson -I "$SCRIPTS/lib" -r join_plan -e '
+  entries = JSON.parse(File.read(ARGV[0]))
+  JoinPlan.write(ARGV[1], entries)
+' "$CASE_DIR/join-plan.entries.json" "$TMP/join-plan.json" || fail=1
+probe_err="$TMP/probe.err"
+ruby "$SCRIPTS/probe-join-keys.rb" --workdir "$TMP" --fixture "$CASE_DIR/probe-fixture" >"$TMP/probe.out" 2>"$probe_err"
+rc=$?
+if [ "$rc" -eq 2 ] \
+   && /usr/bin/grep -q 'JOIN-CARDINALITY FATAL' "$probe_err" \
+   && /usr/bin/grep -q 'Sale Lines.*Buyer Day Detail.*BUYER_KEY, SALE_DATE' "$probe_err" \
+   && /usr/bin/grep -q 'BUYER_KEY=1017' "$probe_err"; then
+  note "ok: probe fixture drives exit 2 FATAL on the non-unique compound self-join (5000 rows over 1400 keys)"
+else
+  note "FAIL: probe expected exit 2 + FATAL naming the self-join (got exit $rc)"; sed -n '1,20p' "$probe_err"; fail=1
+fi
+ruby -rjson -e '
+  e = JSON.parse(File.read(ARGV[0]))["entries"]
+  ok = e[0]["status"] == "unique" && e[1]["status"] == "unique" && e[2]["status"] == "non-unique" &&
+       e[2]["duplicates"].length == 5 && e[2]["counts"] == { "total" => 5000, "distinct" => 1400 }
+  abort "ledger statuses wrong: #{e.map { |x| x["status"] }.inspect}" unless ok
+' "$TMP/join-plan.json" && note "ok: ledger records unique/unique/non-unique with counts + sample duplicates" \
+  || { note "FAIL: probed ledger state wrong"; fail=1; }
+
+# -- 3. gate 16 blocks the unresolved ledger, passes the resolved one --------
+# Baseline workdir that satisfies every other offline gate (same shape as
+# scripts/test-assert-phase6-gates.rb): passing parity, valid PNG, telemetry.
+cat > "$TMP/parity-final.json" <<'JSON'
+{
+  "workbook_id": "wb-corpus-lgm", "mode": "strict", "status": "PASS",
+  "charts_total": 4, "charts_pass": 4, "charts_fail": 0,
+  "pass_names": ["Amount Trend", "Buyer Detail", "Group Mix", "KPI Unified Amount"],
+  "fail_names": [],
+  "visual_checked": true, "visual_verdict": "pass",
+  "style_checklist": { "element_titles_hidden": "pass", "palette_match": "pass",
+    "composition_match": "pass", "chart_shapes_match": "pass",
+    "labels_legible": "pass", "numbers_formatted": "pass" },
+  "agent_vision": true
+}
+JSON
+{ printf '\x89PNG\r\n\x1a\n'; head -c 6000 /dev/zero; } > "$TMP/sigma-render.png"
+printf '{"status":"sent","tool":"corpus-checks"}\n' > "$TMP/telemetry-sent.json"
+
+env -u SIGMA_BASE_URL -u SIGMA_API_TOKEN ruby "$SCRIPTS/assert-phase6-ran.rb" --workdir "$TMP" >"$TMP/gate1.out" 2>"$TMP/gate1.err"
+rc=$?
+if [ "$rc" -eq 23 ] && /usr/bin/grep -q 'gate 16: join-cardinality ledger unresolved' "$TMP/gate1.err"; then
+  note "ok: gate 16 (exit 23) blocks GREEN on the unresolved non-unique entry"
+else
+  note "FAIL: gate 16 expected exit 23 on the unresolved ledger (got $rc)"; sed -n '1,12p' "$TMP/gate1.err"; fail=1
+fi
+
+ruby "$SCRIPTS/probe-join-keys.rb" --workdir "$TMP" --resolve 2 --how preaggregated \
+  --reason 'grouped helper "Buyer Day Rollup" at buyer x sale-date grain; Lookup repointed (corpus fixture evidence)' \
+  >"$TMP/resolve.out" 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && /usr/bin/grep -q 'resolved: preaggregated' "$TMP/resolve.out"; then
+  note "ok: --resolve preaggregated records the evidence and clears the probe failure"
+else
+  note "FAIL: --resolve expected exit 0 (got $rc)"; sed -n '1,8p' "$TMP/resolve.out"; fail=1
+fi
+
+env -u SIGMA_BASE_URL -u SIGMA_API_TOKEN ruby "$SCRIPTS/assert-phase6-ran.rb" --workdir "$TMP" >"$TMP/gate2.out" 2>"$TMP/gate2.err"
+rc=$?
+if [ "$rc" -eq 0 ] && /usr/bin/grep -q '\[OK\] gate 16: join-cardinality ledger resolved' "$TMP/gate2.out"; then
+  note "ok: gate 16 passes once the resolution evidence is in the ledger (2 unique, 1 resolved)"
+else
+  note "FAIL: gate 16 expected exit 0 on the resolved ledger (got $rc)"; sed -n '1,12p' "$TMP/gate2.err"; fail=1
+fi
+
+exit "$fail"

--- a/corpus/tableau/lookup-grain-mismatch/checks.sh
+++ b/corpus/tableau/lookup-grain-mismatch/checks.sh
@@ -29,11 +29,11 @@ ruby -rjson -I "$SCRIPTS/lib" -r join_plan -e '
   entries = JoinPlan.derive(nil, xml, db: "DEMO_DB", schema: "ANALYTICS")
   File.write(ARGV[1], JSON.pretty_generate(entries) + "\n")
 ' "$CASE_DIR/workbook-content.twb" "$TMP/derived.json" || fail=1
-if cmp -s "$TMP/derived.json" "$CASE_DIR/join-plan.entries.json"; then
+if cmp -s <(tr -d "\r" < "$TMP/derived.json") <(tr -d "\r" < "$CASE_DIR/join-plan.entries.json"); then
   note "ok: join-plan derivation matches join-plan.entries.json (3 federated joins; compound self-join keys BUYER_KEY+SALE_DATE)"
 else
   note "FAIL: join-plan derivation drifted from join-plan.entries.json:"
-  diff "$CASE_DIR/join-plan.entries.json" "$TMP/derived.json" | head -30
+  diff <(tr -d "\r" < "$CASE_DIR/join-plan.entries.json") <(tr -d "\r" < "$TMP/derived.json") | head -30
   fail=1
 fi
 

--- a/corpus/tableau/lookup-grain-mismatch/join-plan.entries.json
+++ b/corpus/tableau/lookup-grain-mismatch/join-plan.entries.json
@@ -1,0 +1,71 @@
+[
+  {
+    "kind": "federated-join",
+    "join_type": "inner",
+    "left": "Sale Lines",
+    "right": "ITEM_DIM (ANALYTICS.ITEM_DIM)",
+    "keys": [
+      "cccc0001-0000-4000-8000-000000000001"
+    ],
+    "key_pairs": [
+      {
+        "left": "aaaa0003-0000-4000-8000-000000000003",
+        "right": "cccc0001-0000-4000-8000-000000000001"
+      }
+    ],
+    "grain_assumption": "right unique on keys",
+    "status": "unprobed",
+    "right_table": "DEMO_DB.ANALYTICS.ITEM_DIM",
+    "probe_keys": [
+      "ITEM_KEY_(ITEM_DIM)"
+    ]
+  },
+  {
+    "kind": "federated-join",
+    "join_type": "inner",
+    "left": "Sale Lines",
+    "right": "BUYER_DIM (ANALYTICS.BUYER_DIM)",
+    "keys": [
+      "bbbb0001-0000-4000-8000-000000000001"
+    ],
+    "key_pairs": [
+      {
+        "left": "aaaa0001-0000-4000-8000-000000000001",
+        "right": "bbbb0001-0000-4000-8000-000000000001"
+      }
+    ],
+    "grain_assumption": "right unique on keys",
+    "status": "unprobed",
+    "right_table": "DEMO_DB.ANALYTICS.BUYER_DIM",
+    "probe_keys": [
+      "BUYER_KEY_(BUYER_DIM)"
+    ]
+  },
+  {
+    "kind": "federated-join",
+    "join_type": "inner",
+    "left": "Sale Lines",
+    "right": "Buyer Day Detail",
+    "keys": [
+      "aaaa0001-0000-4000-8000-000000000001",
+      "aaaa0002-0000-4000-8000-000000000002"
+    ],
+    "key_pairs": [
+      {
+        "left": "aaaa0001-0000-4000-8000-000000000001",
+        "right": "aaaa0001-0000-4000-8000-000000000001"
+      },
+      {
+        "left": "aaaa0002-0000-4000-8000-000000000002",
+        "right": "aaaa0002-0000-4000-8000-000000000002"
+      }
+    ],
+    "grain_assumption": "right unique on keys",
+    "status": "unprobed",
+    "right_table": "eeee0000-0000-4000-8000-00000000ee01.SALES_FACT (ANALYTICS.SALES_FACT)",
+    "probe_keys": [
+      "BUYER_KEY",
+      "SALE_DATE"
+    ]
+  }
+]

--- a/corpus/tableau/lookup-grain-mismatch/probe-fixture/entry-0.json
+++ b/corpus/tableau/lookup-grain-mismatch/probe-fixture/entry-0.json
@@ -1,0 +1,5 @@
+{
+  "total": 240,
+  "distinct": 240,
+  "duplicates": []
+}

--- a/corpus/tableau/lookup-grain-mismatch/probe-fixture/entry-1.json
+++ b/corpus/tableau/lookup-grain-mismatch/probe-fixture/entry-1.json
@@ -1,0 +1,5 @@
+{
+  "total": 180,
+  "distinct": 180,
+  "duplicates": []
+}

--- a/corpus/tableau/lookup-grain-mismatch/probe-fixture/entry-2.json
+++ b/corpus/tableau/lookup-grain-mismatch/probe-fixture/entry-2.json
@@ -1,0 +1,11 @@
+{
+  "total": 5000,
+  "distinct": 1400,
+  "duplicates": [
+    { "keys": { "BUYER_KEY": "1017", "SALE_DATE": "2025-06-03" }, "count": 9 },
+    { "keys": { "BUYER_KEY": "1044", "SALE_DATE": "2025-06-03" }, "count": 7 },
+    { "keys": { "BUYER_KEY": "1017", "SALE_DATE": "2025-06-02" }, "count": 6 },
+    { "keys": { "BUYER_KEY": "1102", "SALE_DATE": "2025-05-27" }, "count": 5 },
+    { "keys": { "BUYER_KEY": "1063", "SALE_DATE": "2025-05-20" }, "count": 5 }
+  ]
+}

--- a/corpus/tableau/lookup-grain-mismatch/workbook-content.twb
+++ b/corpus/tableau/lookup-grain-mismatch/workbook-content.twb
@@ -1,0 +1,575 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- Synthetic field-twin (invented names, no customer data): the LOOKUP GRAIN
+     MISMATCH shape. A published-virtual-connection federated datasource whose
+     relation tree self-joins the fact table ("Sale Lines" vs "Buyer Day
+     Detail" — SAME physical SALES_FACT) on a NON-UNIQUE compound key
+     (buyer x sale-date; the fact is at sale-LINE grain), plus two single-key
+     dim joins. Field ids are Tableau GUIDs; captions are the only handle on
+     the physical columns. Top-N + Direction parameters drive a RANK_UNIQUE
+     table calc, an In-Top-N boolean filter, and param-driven dynamic titles;
+     the dashboard carries a top-shelf control row. -->
+<workbook locale='en_US' original-version='18.1' source-build='2026.1.5 (20261.26.0512.1609)' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <preferences />
+  <datasources>
+    <datasource hasconnection='false' inline='true' name='Parameters' version='18.1'>
+      <aliases enabled='yes' />
+      <column caption='Top N' datatype='integer' name='[Parameter 1]' param-domain-type='list' role='measure' type='quantitative' value='50'>
+        <calculation class='tableau' formula='50' />
+        <members>
+          <member value='10' />
+          <member value='25' />
+          <member value='50' />
+          <member value='100' />
+        </members>
+      </column>
+      <column caption='Direction' datatype='string' name='[Parameter 2]' param-domain-type='list' role='measure' type='nominal' value='&quot;Top&quot;'>
+        <calculation class='tableau' formula='&quot;Top&quot;' />
+        <members>
+          <member value='&quot;Top&quot;' />
+          <member value='&quot;Bottom&quot;' />
+        </members>
+      </column>
+    </datasource>
+    <datasource caption='Buyer Profitability (Demo Virtual Connection)' inline='true' name='federated.0lgm0buyerprofit01' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='Demo Virtual Connection' name='publishedConnection.0demovc0lgm01'>
+            <connection class='publishedConnection' resourceId='dddd0000-0000-4000-8000-00000000dd01' resourceName='Demo Virtual Connection' workgroup-auth-mode='as-is' />
+          </named-connection>
+        </named-connections>
+        <relation join='inner' type='join'>
+          <clause type='join'>
+            <expression op='='>
+              <expression op='[Sale Lines].[aaaa0003-0000-4000-8000-000000000003]' />
+              <expression op='[ITEM_DIM (ANALYTICS.ITEM_DIM)].[cccc0001-0000-4000-8000-000000000001]' />
+            </expression>
+          </clause>
+          <relation join='inner' type='join'>
+            <clause type='join'>
+              <expression op='='>
+                <expression op='[Sale Lines].[aaaa0001-0000-4000-8000-000000000001]' />
+                <expression op='[BUYER_DIM (ANALYTICS.BUYER_DIM)].[bbbb0001-0000-4000-8000-000000000001]' />
+              </expression>
+            </clause>
+            <relation join='inner' type='join'>
+              <clause type='join'>
+                <expression op='AND'>
+                  <expression op='='>
+                    <expression op='[Sale Lines].[aaaa0001-0000-4000-8000-000000000001]' />
+                    <expression op='[Buyer Day Detail].[aaaa0001-0000-4000-8000-000000000001]' />
+                  </expression>
+                  <expression op='='>
+                    <expression op='[Sale Lines].[aaaa0002-0000-4000-8000-000000000002]' />
+                    <expression op='[Buyer Day Detail].[aaaa0002-0000-4000-8000-000000000002]' />
+                  </expression>
+                </expression>
+              </clause>
+              <relation connection='publishedConnection.0demovc0lgm01' name='Sale Lines' table='[eeee0000-0000-4000-8000-00000000ee01].[SALES_FACT (ANALYTICS.SALES_FACT)]' type='table'>
+                <columns>
+                  <column datatype='date' date-parse-format='yyyyMMdd' name='aaaa0002-0000-4000-8000-000000000002' />
+                </columns>
+              </relation>
+              <relation connection='publishedConnection.0demovc0lgm01' name='Buyer Day Detail' table='[eeee0000-0000-4000-8000-00000000ee01].[SALES_FACT (ANALYTICS.SALES_FACT)]' type='table'>
+                <columns>
+                  <column datatype='date' date-parse-format='yyyyMMdd' name='aaaa0002-0000-4000-8000-000000000002' />
+                </columns>
+              </relation>
+            </relation>
+            <relation connection='publishedConnection.0demovc0lgm01' name='BUYER_DIM (ANALYTICS.BUYER_DIM)' table='[eeee0000-0000-4000-8000-00000000ee02].[BUYER_DIM (ANALYTICS.BUYER_DIM)]' type='table' />
+          </relation>
+          <relation connection='publishedConnection.0demovc0lgm01' name='ITEM_DIM (ANALYTICS.ITEM_DIM)' table='[eeee0000-0000-4000-8000-00000000ee03].[ITEM_DIM (ANALYTICS.ITEM_DIM)]' type='table' />
+        </relation>
+        <cols>
+          <map key='[aaaa0001-0000-4000-8000-000000000001 (Buyer Day Detail)]' value='[Buyer Day Detail].[aaaa0001-0000-4000-8000-000000000001]' />
+          <map key='[aaaa0001-0000-4000-8000-000000000001]' value='[Sale Lines].[aaaa0001-0000-4000-8000-000000000001]' />
+          <map key='[aaaa0002-0000-4000-8000-000000000002 (Buyer Day Detail)]' value='[Buyer Day Detail].[aaaa0002-0000-4000-8000-000000000002]' />
+          <map key='[aaaa0002-0000-4000-8000-000000000002]' value='[Sale Lines].[aaaa0002-0000-4000-8000-000000000002]' />
+          <map key='[aaaa0003-0000-4000-8000-000000000003 (Buyer Day Detail)]' value='[Buyer Day Detail].[aaaa0003-0000-4000-8000-000000000003]' />
+          <map key='[aaaa0003-0000-4000-8000-000000000003]' value='[Sale Lines].[aaaa0003-0000-4000-8000-000000000003]' />
+          <map key='[aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)]' value='[Buyer Day Detail].[aaaa0004-0000-4000-8000-000000000004]' />
+          <map key='[aaaa0004-0000-4000-8000-000000000004]' value='[Sale Lines].[aaaa0004-0000-4000-8000-000000000004]' />
+          <map key='[aaaa0005-0000-4000-8000-000000000005 (Buyer Day Detail)]' value='[Buyer Day Detail].[aaaa0005-0000-4000-8000-000000000005]' />
+          <map key='[aaaa0005-0000-4000-8000-000000000005]' value='[Sale Lines].[aaaa0005-0000-4000-8000-000000000005]' />
+          <map key='[aaaa0006-0000-4000-8000-000000000006 (Buyer Day Detail)]' value='[Buyer Day Detail].[aaaa0006-0000-4000-8000-000000000006]' />
+          <map key='[aaaa0006-0000-4000-8000-000000000006]' value='[Sale Lines].[aaaa0006-0000-4000-8000-000000000006]' />
+          <map key='[aaaa0007-0000-4000-8000-000000000007 (Buyer Day Detail)]' value='[Buyer Day Detail].[aaaa0007-0000-4000-8000-000000000007]' />
+          <map key='[aaaa0007-0000-4000-8000-000000000007]' value='[Sale Lines].[aaaa0007-0000-4000-8000-000000000007]' />
+          <map key='[aaaa0008-0000-4000-8000-000000000008 (Buyer Day Detail)]' value='[Buyer Day Detail].[aaaa0008-0000-4000-8000-000000000008]' />
+          <map key='[aaaa0008-0000-4000-8000-000000000008]' value='[Sale Lines].[aaaa0008-0000-4000-8000-000000000008]' />
+          <map key='[bbbb0001-0000-4000-8000-000000000001]' value='[BUYER_DIM (ANALYTICS.BUYER_DIM)].[bbbb0001-0000-4000-8000-000000000001]' />
+          <map key='[bbbb0002-0000-4000-8000-000000000002]' value='[BUYER_DIM (ANALYTICS.BUYER_DIM)].[bbbb0002-0000-4000-8000-000000000002]' />
+          <map key='[bbbb0003-0000-4000-8000-000000000003]' value='[BUYER_DIM (ANALYTICS.BUYER_DIM)].[bbbb0003-0000-4000-8000-000000000003]' />
+          <map key='[bbbb0004-0000-4000-8000-000000000004]' value='[BUYER_DIM (ANALYTICS.BUYER_DIM)].[bbbb0004-0000-4000-8000-000000000004]' />
+          <map key='[bbbb0005-0000-4000-8000-000000000005]' value='[BUYER_DIM (ANALYTICS.BUYER_DIM)].[bbbb0005-0000-4000-8000-000000000005]' />
+          <map key='[cccc0001-0000-4000-8000-000000000001]' value='[ITEM_DIM (ANALYTICS.ITEM_DIM)].[cccc0001-0000-4000-8000-000000000001]' />
+          <map key='[cccc0002-0000-4000-8000-000000000002]' value='[ITEM_DIM (ANALYTICS.ITEM_DIM)].[cccc0002-0000-4000-8000-000000000002]' />
+        </cols>
+      </connection>
+      <aliases enabled='yes' />
+      <column caption='Buyer Key' datatype='integer' name='[aaaa0001-0000-4000-8000-000000000001]' role='measure' type='quantitative' />
+      <column caption='Buyer Key (Buyer Day Detail)' datatype='integer' name='[aaaa0001-0000-4000-8000-000000000001 (Buyer Day Detail)]' role='measure' type='quantitative' />
+      <column caption='Sale Date' datatype='date' datatype-customized='true' name='[aaaa0002-0000-4000-8000-000000000002]' role='dimension' type='ordinal' />
+      <column caption='Sale Date (Buyer Day Detail)' datatype='date' datatype-customized='true' name='[aaaa0002-0000-4000-8000-000000000002 (Buyer Day Detail)]' role='dimension' type='ordinal' />
+      <column caption='Item Key' datatype='integer' name='[aaaa0003-0000-4000-8000-000000000003]' role='measure' type='quantitative' />
+      <column caption='Item Key (Buyer Day Detail)' datatype='integer' name='[aaaa0003-0000-4000-8000-000000000003 (Buyer Day Detail)]' role='measure' type='quantitative' />
+      <column caption='Net Amount' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004]' role='measure' type='quantitative' />
+      <column caption='Net Amount (Buyer Day Detail)' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)]' role='measure' type='quantitative' />
+      <column caption='Units Sold' datatype='integer' name='[aaaa0005-0000-4000-8000-000000000005]' role='measure' type='quantitative' />
+      <column caption='Units Sold (Buyer Day Detail)' datatype='integer' name='[aaaa0005-0000-4000-8000-000000000005 (Buyer Day Detail)]' role='measure' type='quantitative' />
+      <column caption='Net Earnings' datatype='real' name='[aaaa0006-0000-4000-8000-000000000006]' role='measure' type='quantitative' />
+      <column caption='Net Earnings (Buyer Day Detail)' datatype='real' name='[aaaa0006-0000-4000-8000-000000000006 (Buyer Day Detail)]' role='measure' type='quantitative' />
+      <column caption='Rebate Amount' datatype='real' name='[aaaa0007-0000-4000-8000-000000000007]' role='measure' type='quantitative' />
+      <column caption='Rebate Amount (Buyer Day Detail)' datatype='real' name='[aaaa0007-0000-4000-8000-000000000007 (Buyer Day Detail)]' role='measure' type='quantitative' />
+      <column caption='Sale Id' datatype='string' name='[aaaa0008-0000-4000-8000-000000000008]' role='dimension' type='nominal' />
+      <column caption='Sale Id (Buyer Day Detail)' datatype='string' name='[aaaa0008-0000-4000-8000-000000000008 (Buyer Day Detail)]' role='dimension' type='nominal' />
+      <column caption='Buyer Key (BUYER_DIM)' datatype='integer' name='[bbbb0001-0000-4000-8000-000000000001]' role='measure' type='quantitative' />
+      <column caption='First Name' datatype='string' name='[bbbb0002-0000-4000-8000-000000000002]' role='dimension' type='nominal' />
+      <column caption='Last Name' datatype='string' name='[bbbb0003-0000-4000-8000-000000000003]' role='dimension' type='nominal' />
+      <column caption='Region Name' datatype='string' name='[bbbb0004-0000-4000-8000-000000000004]' role='dimension' type='nominal' />
+      <column caption='Buyer Segment' datatype='string' name='[bbbb0005-0000-4000-8000-000000000005]' role='dimension' type='nominal' />
+      <column caption='Item Key (ITEM_DIM)' datatype='integer' name='[cccc0001-0000-4000-8000-000000000001]' role='measure' type='quantitative' />
+      <column caption='Item Group' datatype='string' name='[cccc0002-0000-4000-8000-000000000002]' role='dimension' type='nominal' />
+      <column caption='Unified Amount' datatype='real' name='[Unified Amount]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='ZN([aaaa0004-0000-4000-8000-000000000004]) + ZN([aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)])' />
+      </column>
+      <column caption='Unified Units' datatype='real' name='[Unified Units]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='ZN([aaaa0005-0000-4000-8000-000000000005]) + ZN([aaaa0005-0000-4000-8000-000000000005 (Buyer Day Detail)])' />
+      </column>
+      <column caption='Combined Margin' datatype='real' name='[Combined Margin]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='SUM([aaaa0006-0000-4000-8000-000000000006]) - SUM([aaaa0007-0000-4000-8000-000000000007 (Buyer Day Detail)])' />
+      </column>
+      <column caption='Buyer Name' datatype='string' name='[Buyer Name]' role='dimension' type='nominal'>
+        <calculation class='tableau' formula='[bbbb0003-0000-4000-8000-000000000003] + &quot;, &quot; + [bbbb0002-0000-4000-8000-000000000002]' />
+      </column>
+      <column caption='Buyer Rank' datatype='integer' name='[Buyer Rank]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='RANK_UNIQUE(IIF([Parameters].[Parameter 2] = &quot;Top&quot;, 1, -1) * SUM([Unified Amount]))'>
+          <table-calc ordering-type='Columns' />
+        </calculation>
+      </column>
+      <column caption='In Top N' datatype='boolean' name='[In Top N]' role='dimension' type='nominal'>
+        <calculation class='tableau' formula='[Buyer Rank] &lt;= [Parameters].[Parameter 1]' />
+      </column>
+      <column caption='Margin Rate' datatype='real' name='[Margin Rate]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='[Combined Margin] / SUM([Unified Amount])' />
+      </column>
+      <layout dim-ordering='alphabetic' measure-ordering='alphabetic' show-structure='true' />
+      <datasource-dependencies datasource='Parameters'>
+        <column caption='Top N' datatype='integer' name='[Parameter 1]' param-domain-type='list' role='measure' type='quantitative' value='50'>
+          <calculation class='tableau' formula='50' />
+        </column>
+        <column caption='Direction' datatype='string' name='[Parameter 2]' param-domain-type='list' role='measure' type='nominal' value='&quot;Top&quot;'>
+          <calculation class='tableau' formula='&quot;Top&quot;' />
+        </column>
+      </datasource-dependencies>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Amount Trend'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>&lt;[Parameters].[Parameter 2]&gt; &lt;[Parameters].[Parameter 1]&gt; Buyers by Amount (Chosen Dates)</run>
+            <run> — Unified Amount &amp; Earnings by Week</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Buyer Profitability (Demo Virtual Connection)' name='federated.0lgm0buyerprofit01' />
+            <datasource name='Parameters' />
+          </datasources>
+          <datasource-dependencies datasource='Parameters'>
+            <column caption='Top N' datatype='integer' name='[Parameter 1]' param-domain-type='list' role='measure' type='quantitative' value='50'>
+              <calculation class='tableau' formula='50' />
+            </column>
+            <column caption='Direction' datatype='string' name='[Parameter 2]' param-domain-type='list' role='measure' type='nominal' value='&quot;Top&quot;'>
+              <calculation class='tableau' formula='&quot;Top&quot;' />
+            </column>
+          </datasource-dependencies>
+          <datasource-dependencies datasource='federated.0lgm0buyerprofit01'>
+            <column caption='Sale Date' datatype='date' datatype-customized='true' name='[aaaa0002-0000-4000-8000-000000000002]' role='dimension' type='ordinal' />
+            <column caption='Net Amount' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004]' role='measure' type='quantitative' />
+            <column caption='Net Amount (Buyer Day Detail)' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)]' role='measure' type='quantitative' />
+            <column caption='Net Earnings' datatype='real' name='[aaaa0006-0000-4000-8000-000000000006]' role='measure' type='quantitative' />
+            <column caption='Unified Amount' datatype='real' name='[Unified Amount]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='ZN([aaaa0004-0000-4000-8000-000000000004]) + ZN([aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)])' />
+            </column>
+            <column caption='Buyer Rank' datatype='integer' name='[Buyer Rank]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='RANK_UNIQUE(IIF([Parameters].[Parameter 2] = &quot;Top&quot;, 1, -1) * SUM([Unified Amount]))'>
+                <table-calc ordering-type='Columns' />
+              </calculation>
+            </column>
+            <column caption='In Top N' datatype='boolean' name='[In Top N]' role='dimension' type='nominal'>
+              <calculation class='tableau' formula='[Buyer Rank] &lt;= [Parameters].[Parameter 1]' />
+            </column>
+            <column caption='Measure Names' datatype='string' name='[:Measure Names]' role='dimension' type='nominal' />
+            <column caption='Measure Values' datatype='real' name='[Multiple Values]' role='measure' type='quantitative' />
+            <column-instance column='[aaaa0002-0000-4000-8000-000000000002]' derivation='Week-Trunc' name='[twk:aaaa0002-0000-4000-8000-000000000002:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[aaaa0002-0000-4000-8000-000000000002]' derivation='None' name='[none:aaaa0002-0000-4000-8000-000000000002:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Unified Amount]' derivation='Sum' name='[sum:Unified Amount:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[aaaa0006-0000-4000-8000-000000000006]' derivation='Sum' name='[sum:aaaa0006-0000-4000-8000-000000000006:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Buyer Rank]' derivation='User' name='[usr:Buyer Rank:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[In Top N]' derivation='User' name='[usr:In Top N:nk]' pivot='key' type='nominal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.0lgm0buyerprofit01].[:Measure Names]'>
+            <groupfilter function='union' user:op='manual' xmlns:user='http://www.tableausoftware.com/xml/user'>
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0lgm0buyerprofit01].[sum:aaaa0006-0000-4000-8000-000000000006:qk]&quot;' />
+            </groupfilter>
+          </filter>
+          <filter class='categorical' column='[federated.0lgm0buyerprofit01].[usr:In Top N:nk]'>
+            <groupfilter function='member' level='[usr:In Top N:nk]' member='true' />
+          </filter>
+          <filter class='quantitative' column='[federated.0lgm0buyerprofit01].[none:aaaa0002-0000-4000-8000-000000000002:qk]' included-values='in-range'>
+            <min>#2023-01-01#</min>
+            <max>#2026-12-31#</max>
+          </filter>
+          <slices>
+            <column>[federated.0lgm0buyerprofit01].[:Measure Names]</column>
+            <column>[federated.0lgm0buyerprofit01].[twk:aaaa0002-0000-4000-8000-000000000002:qk]</column>
+            <column>[federated.0lgm0buyerprofit01].[Multiple Values]</column>
+            <column>[federated.0lgm0buyerprofit01].[usr:In Top N:nk]</column>
+            <column>[federated.0lgm0buyerprofit01].[none:aaaa0002-0000-4000-8000-000000000002:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Line' />
+            <encodings>
+              <color column='[federated.0lgm0buyerprofit01].[:Measure Names]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.0lgm0buyerprofit01].[Multiple Values]</rows>
+        <cols>[federated.0lgm0buyerprofit01].[twk:aaaa0002-0000-4000-8000-000000000002:qk]</cols>
+      </table>
+      <simple-id uuid='{AC100001-0000-4000-8000-000000000001}' />
+    </worksheet>
+    <worksheet name='Buyer Detail'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>&lt;[Parameters].[Parameter 2]&gt; &lt;[Parameters].[Parameter 1]&gt; Buyers by Amount (Chosen Dates)</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Buyer Profitability (Demo Virtual Connection)' name='federated.0lgm0buyerprofit01' />
+            <datasource name='Parameters' />
+          </datasources>
+          <datasource-dependencies datasource='Parameters'>
+            <column caption='Top N' datatype='integer' name='[Parameter 1]' param-domain-type='list' role='measure' type='quantitative' value='50'>
+              <calculation class='tableau' formula='50' />
+            </column>
+            <column caption='Direction' datatype='string' name='[Parameter 2]' param-domain-type='list' role='measure' type='nominal' value='&quot;Top&quot;'>
+              <calculation class='tableau' formula='&quot;Top&quot;' />
+            </column>
+          </datasource-dependencies>
+          <datasource-dependencies datasource='federated.0lgm0buyerprofit01'>
+            <column caption='First Name' datatype='string' name='[bbbb0002-0000-4000-8000-000000000002]' role='dimension' type='nominal' />
+            <column caption='Last Name' datatype='string' name='[bbbb0003-0000-4000-8000-000000000003]' role='dimension' type='nominal' />
+            <column caption='Buyer Key' datatype='integer' name='[aaaa0001-0000-4000-8000-000000000001]' role='measure' type='quantitative' />
+            <column caption='Region Name' datatype='string' name='[bbbb0004-0000-4000-8000-000000000004]' role='dimension' type='nominal' />
+            <column caption='Buyer Segment' datatype='string' name='[bbbb0005-0000-4000-8000-000000000005]' role='dimension' type='nominal' />
+            <column caption='Net Amount' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004]' role='measure' type='quantitative' />
+            <column caption='Net Amount (Buyer Day Detail)' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)]' role='measure' type='quantitative' />
+            <column caption='Net Earnings' datatype='real' name='[aaaa0006-0000-4000-8000-000000000006]' role='measure' type='quantitative' />
+            <column caption='Units Sold' datatype='integer' name='[aaaa0005-0000-4000-8000-000000000005]' role='measure' type='quantitative' />
+            <column caption='Units Sold (Buyer Day Detail)' datatype='integer' name='[aaaa0005-0000-4000-8000-000000000005 (Buyer Day Detail)]' role='measure' type='quantitative' />
+            <column caption='Rebate Amount (Buyer Day Detail)' datatype='real' name='[aaaa0007-0000-4000-8000-000000000007 (Buyer Day Detail)]' role='measure' type='quantitative' />
+            <column caption='Buyer Name' datatype='string' name='[Buyer Name]' role='dimension' type='nominal'>
+              <calculation class='tableau' formula='[bbbb0003-0000-4000-8000-000000000003] + &quot;, &quot; + [bbbb0002-0000-4000-8000-000000000002]' />
+            </column>
+            <column caption='Unified Amount' datatype='real' name='[Unified Amount]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='ZN([aaaa0004-0000-4000-8000-000000000004]) + ZN([aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)])' />
+            </column>
+            <column caption='Unified Units' datatype='real' name='[Unified Units]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='ZN([aaaa0005-0000-4000-8000-000000000005]) + ZN([aaaa0005-0000-4000-8000-000000000005 (Buyer Day Detail)])' />
+            </column>
+            <column caption='Combined Margin' datatype='real' name='[Combined Margin]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='SUM([aaaa0006-0000-4000-8000-000000000006]) - SUM([aaaa0007-0000-4000-8000-000000000007 (Buyer Day Detail)])' />
+            </column>
+            <column caption='Buyer Rank' datatype='integer' name='[Buyer Rank]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='RANK_UNIQUE(IIF([Parameters].[Parameter 2] = &quot;Top&quot;, 1, -1) * SUM([Unified Amount]))'>
+                <table-calc ordering-type='Columns' />
+              </calculation>
+            </column>
+            <column caption='In Top N' datatype='boolean' name='[In Top N]' role='dimension' type='nominal'>
+              <calculation class='tableau' formula='[Buyer Rank] &lt;= [Parameters].[Parameter 1]' />
+            </column>
+            <column caption='Measure Names' datatype='string' name='[:Measure Names]' role='dimension' type='nominal' />
+            <column caption='Measure Values' datatype='real' name='[Multiple Values]' role='measure' type='quantitative' />
+            <column-instance column='[Buyer Name]' derivation='None' name='[none:Buyer Name:nk]' pivot='key' type='nominal' />
+            <column-instance column='[aaaa0001-0000-4000-8000-000000000001]' derivation='None' name='[none:aaaa0001-0000-4000-8000-000000000001:ok]' pivot='key' type='ordinal' />
+            <column-instance column='[bbbb0004-0000-4000-8000-000000000004]' derivation='None' name='[none:bbbb0004-0000-4000-8000-000000000004:nk]' pivot='key' type='nominal' />
+            <column-instance column='[bbbb0005-0000-4000-8000-000000000005]' derivation='None' name='[none:bbbb0005-0000-4000-8000-000000000005:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Unified Amount]' derivation='Sum' name='[sum:Unified Amount:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Unified Units]' derivation='Sum' name='[sum:Unified Units:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Combined Margin]' derivation='User' name='[usr:Combined Margin:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Buyer Rank]' derivation='User' name='[usr:Buyer Rank:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[In Top N]' derivation='User' name='[usr:In Top N:nk]' pivot='key' type='nominal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.0lgm0buyerprofit01].[:Measure Names]'>
+            <groupfilter function='union' user:op='manual' xmlns:user='http://www.tableausoftware.com/xml/user'>
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0lgm0buyerprofit01].[sum:Unified Units:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0lgm0buyerprofit01].[usr:Combined Margin:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[federated.0lgm0buyerprofit01].[usr:Buyer Rank:qk]&quot;' />
+            </groupfilter>
+          </filter>
+          <filter class='categorical' column='[federated.0lgm0buyerprofit01].[usr:In Top N:nk]'>
+            <groupfilter function='member' level='[usr:In Top N:nk]' member='true' />
+          </filter>
+          <filter class='categorical' column='[federated.0lgm0buyerprofit01].[none:bbbb0004-0000-4000-8000-000000000004:nk]'>
+            <groupfilter function='level-members' level='[none:bbbb0004-0000-4000-8000-000000000004:nk]' />
+          </filter>
+          <filter class='categorical' column='[federated.0lgm0buyerprofit01].[none:bbbb0005-0000-4000-8000-000000000005:nk]'>
+            <groupfilter function='level-members' level='[none:bbbb0005-0000-4000-8000-000000000005:nk]' />
+          </filter>
+          <slices>
+            <column>[federated.0lgm0buyerprofit01].[none:Buyer Name:nk]</column>
+            <column>[federated.0lgm0buyerprofit01].[none:aaaa0001-0000-4000-8000-000000000001:ok]</column>
+            <column>[federated.0lgm0buyerprofit01].[:Measure Names]</column>
+            <column>[federated.0lgm0buyerprofit01].[Multiple Values]</column>
+            <column>[federated.0lgm0buyerprofit01].[usr:In Top N:nk]</column>
+            <column>[federated.0lgm0buyerprofit01].[none:bbbb0004-0000-4000-8000-000000000004:nk]</column>
+            <column>[federated.0lgm0buyerprofit01].[none:bbbb0005-0000-4000-8000-000000000005:nk]</column>
+          </slices>
+          <computed-sort column='[federated.0lgm0buyerprofit01].[none:Buyer Name:nk]' direction='DESC' using='[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]' />
+          <aggregation value='true' />
+        </view>
+        <style>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[federated.0lgm0buyerprofit01].[Multiple Values]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.0lgm0buyerprofit01].[none:Buyer Name:nk] / [federated.0lgm0buyerprofit01].[none:aaaa0001-0000-4000-8000-000000000001:ok]</rows>
+        <cols>[federated.0lgm0buyerprofit01].[:Measure Names]</cols>
+      </table>
+      <simple-id uuid='{AC100002-0000-4000-8000-000000000002}' />
+    </worksheet>
+    <worksheet name='Group Mix'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Group Mix — Unified Amount by Month</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Buyer Profitability (Demo Virtual Connection)' name='federated.0lgm0buyerprofit01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0lgm0buyerprofit01'>
+            <column caption='Sale Date' datatype='date' datatype-customized='true' name='[aaaa0002-0000-4000-8000-000000000002]' role='dimension' type='ordinal' />
+            <column caption='Item Group' datatype='string' name='[cccc0002-0000-4000-8000-000000000002]' role='dimension' type='nominal' />
+            <column caption='Net Amount' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004]' role='measure' type='quantitative' />
+            <column caption='Net Amount (Buyer Day Detail)' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)]' role='measure' type='quantitative' />
+            <column caption='Unified Amount' datatype='real' name='[Unified Amount]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='ZN([aaaa0004-0000-4000-8000-000000000004]) + ZN([aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)])' />
+            </column>
+            <column-instance column='[aaaa0002-0000-4000-8000-000000000002]' derivation='Month-Trunc' name='[tmn:aaaa0002-0000-4000-8000-000000000002:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[cccc0002-0000-4000-8000-000000000002]' derivation='None' name='[none:cccc0002-0000-4000-8000-000000000002:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Unified Amount]' derivation='Sum' name='[sum:Unified Amount:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <slices>
+            <column>[federated.0lgm0buyerprofit01].[tmn:aaaa0002-0000-4000-8000-000000000002:qk]</column>
+            <column>[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]</column>
+            <column>[federated.0lgm0buyerprofit01].[none:cccc0002-0000-4000-8000-000000000002:nk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Bar' />
+            <encodings>
+              <color column='[federated.0lgm0buyerprofit01].[none:cccc0002-0000-4000-8000-000000000002:nk]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]</rows>
+        <cols>[federated.0lgm0buyerprofit01].[tmn:aaaa0002-0000-4000-8000-000000000002:qk]</cols>
+      </table>
+      <simple-id uuid='{AC100003-0000-4000-8000-000000000003}' />
+    </worksheet>
+    <worksheet name='KPI Unified Amount'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Total Unified Amount</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Buyer Profitability (Demo Virtual Connection)' name='federated.0lgm0buyerprofit01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0lgm0buyerprofit01'>
+            <column caption='Net Amount' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004]' role='measure' type='quantitative' />
+            <column caption='Net Amount (Buyer Day Detail)' datatype='real' name='[aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)]' role='measure' type='quantitative' />
+            <column caption='Unified Amount' datatype='real' name='[Unified Amount]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='ZN([aaaa0004-0000-4000-8000-000000000004]) + ZN([aaaa0004-0000-4000-8000-000000000004 (Buyer Day Detail)])' />
+            </column>
+            <column-instance column='[Unified Amount]' derivation='Sum' name='[sum:Unified Amount:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <slices>
+            <column>[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]' value='n&quot;$&quot;#,##0' />
+          </style-rule>
+          <style-rule element='text'>
+            <format attr='text-format' field='[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]' value='n&quot;$&quot;#,##0' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[federated.0lgm0buyerprofit01].[sum:Unified Amount:qk]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows></rows>
+        <cols></cols>
+      </table>
+      <simple-id uuid='{AC100004-0000-4000-8000-000000000004}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard enable-sort-zone-taborder='true' name='Profit Watch'>
+      <style />
+      <size maxheight='800' maxwidth='1200' minheight='800' minwidth='1200' sizing-mode='fixed' />
+      <datasources>
+        <datasource caption='Parameters' name='Parameters' />
+        <datasource caption='Buyer Profitability (Demo Virtual Connection)' name='federated.0lgm0buyerprofit01' />
+      </datasources>
+      <zones>
+        <zone h='100000' id='200' type-v2='layout-basic' w='100000' x='0' y='0'>
+          <zone h='100000' id='201' param='vert' type-v2='layout-flow' w='100000' x='0' y='0'>
+            <zone h='8000' id='202' param='horz' type-v2='layout-flow' w='100000' x='0' y='0'>
+              <zone h='8000' id='203' param='[Parameters].[Parameter 1]' type-v2='paramctrl' w='25000' x='0' y='0'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                </zone-style>
+              </zone>
+              <zone h='8000' id='204' param='[Parameters].[Parameter 2]' type-v2='paramctrl' w='25000' x='25000' y='0'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                </zone-style>
+              </zone>
+              <zone h='8000' id='205' name='Amount Trend' param='[federated.0lgm0buyerprofit01].[none:aaaa0002-0000-4000-8000-000000000002:qk]' type-v2='filter' w='25000' x='50000' y='0'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                </zone-style>
+              </zone>
+              <zone h='8000' id='206' mode='checkdropdown' name='Buyer Detail' param='[federated.0lgm0buyerprofit01].[none:bbbb0004-0000-4000-8000-000000000004:nk]' type-v2='filter' w='25000' x='75000' y='0'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                </zone-style>
+              </zone>
+            </zone>
+            <zone h='15000' id='210' param='horz' type-v2='layout-flow' w='100000' x='0' y='8000'>
+              <zone h='15000' id='211' name='KPI Unified Amount' w='100000' x='0' y='8000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                </zone-style>
+              </zone>
+            </zone>
+            <zone h='38000' id='220' param='horz' type-v2='layout-flow' w='100000' x='0' y='23000'>
+              <zone h='38000' id='221' name='Amount Trend' w='60000' x='0' y='23000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                </zone-style>
+              </zone>
+              <zone h='38000' id='222' name='Group Mix' w='40000' x='60000' y='23000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                </zone-style>
+              </zone>
+            </zone>
+            <zone h='39000' id='230' param='horz' type-v2='layout-flow' w='100000' x='0' y='61000'>
+              <zone h='39000' id='231' name='Buyer Detail' w='100000' x='0' y='61000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='2' />
+                </zone-style>
+              </zone>
+            </zone>
+          </zone>
+        </zone>
+      </zones>
+      <simple-id uuid='{AC100010-0000-4000-8000-000000000010}' />
+    </dashboard>
+  </dashboards>
+  <windows source-height='30'>
+    <window class='dashboard' maximized='true' name='Profit Watch'>
+      <viewpoints>
+        <viewpoint name='Amount Trend'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='Buyer Detail'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='Group Mix'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='KPI Unified Amount'>
+          <zoom type='entire-view' />
+        </viewpoint>
+      </viewpoints>
+      <active id='-1' />
+      <simple-id uuid='{AC100011-0000-4000-8000-000000000011}' />
+    </window>
+  </windows>
+</workbook>

--- a/corpus/tableau/preagg-kpi/MANIFEST.md
+++ b/corpus/tableau/preagg-kpi/MANIFEST.md
@@ -1,0 +1,94 @@
+# tableau / preagg-kpi
+
+**Synthetic twin of a field-failure shape** (PLAN-v3 PR-1, Wave 1). Invented
+names on the neutral `DEMO_DB.ANALYTICS` demo star — no customer identifiers,
+no live tenant. Reproduces the 2026-07-17 field root cause #3 (aggregation
+semantics compile clean) and the #423 LOD failure classes (fuzzy alias +
+silent drop), plus the dual-axis and integer-coded-dimension LOOKS-BAD traps.
+
+## The shape (what makes this workbook a trap)
+
+- Two `{FIXED [CAL_DATE] : COUNTD(...)}` LOD calcs materialize **day-grain
+  distinct counts** (`Daily Distinct Buyers`, `Daily Active Sales`).
+- Three KPI formulas consume them **ADDITIVELY** —
+  `SUM([NET_AMOUNT]) / SUM([Daily Distinct Buyers])`,
+  `SUM([Daily Active Sales]) / SUM([Daily Distinct Buyers])`,
+  `SUM(IF ... ) / SUM([Daily Distinct Buyers])` — summing a pre-aggregated
+  DISTINCT count over any grain other than day double-counts buyers. This
+  **compiles clean in every existing gate**.
+- A **dual-axis combo** worksheet (`Amount vs Growth`) built the multi-pane
+  way — three `<pane>`s with `y-axis-name`, a `(A + B)` rows shelf, and **no
+  `synchronized='true'`** anywhere.
+- An **integer-coded dimension filter** (`SITE_KEY`, integer, role=dimension)
+  as a dashboard checkdropdown — the misclassification / silently-inert
+  filter class (PR-18).
+- A date `Anchor Week` parameter feeding a `DATEDIFF` calc, KPI
+  customized-labels, and a sidebar control rail.
+
+## Artifacts
+
+| File | What it is |
+|---|---|
+| `workbook-content.twb` | The synthetic workbook XML (5 worksheets + `Wallet Pulse` dashboard) |
+| `dm-spec.fixture.json` | Canned converter-emission fixture (the audit's `--dm-spec` seam): the FIELD shape — `Daily Distinct Buyers` fuzzy-aliased to a raw `ACTIVE_BUYER_FLAG` column, `Daily Active Sales` emitted nowhere |
+| `lod-audit.entries.json` | PINNED `audit-lod-calcs.rb` ledger: `suspect-alias` + `silently-dropped` — honest CURRENT-code classification (run 2026-07-18) |
+| `checks.sh` | Executable expectations, run by `run-corpus.sh --check` |
+
+## Expected gate behaviors (encoded in checks.sh)
+
+1. **LOD audit** (`audit-lod-calcs.rb`, run against the .twb census + the
+   emission fixture): `Daily Distinct Buyers` → **suspect-alias** (emitted
+   formula reads `ACTIVE_BUYER_FLAG`, not in the LOD's own reference set
+   `{CAL_DATE, BUYER_KEY}`); `Daily Active Sales` → **silently-dropped**.
+   Exit 2 with both FATAL blocks. Not guessed: this is what the current
+   `lib/lod_audit.rb` classifies, pinned verbatim. (The lod-synth resolved
+   path is covered by `scripts/test-lod-audit.rb`.)
+2. **Gate 17** (`assert-phase6-ran.rb`, exit 24): blocks GREEN on the
+   unresolved ledger; passes after `--resolve 0 --how manual` +
+   `--resolve 1 --how waived` record evidence.
+3. **Dual-axis known-limitation pin**: `parse-twb-layout.rb` reads
+   `Amount vs Growth` as `chart_kind: "bar"`, `dual_axis: false` — the twin
+   shape carries no `synchronized='true'`, and the current conservative
+   detection only fires on explicit synchronization. The check FAILS LOUDLY
+   if this ever flips, forcing the MANIFEST + pin update — that flip is the
+   acceptance signal for a dual-axis detection fix (PR-10/PR-11 territory).
+
+## Known gaps (documented, NOT yet gated — this entry is the future test bed)
+
+- **Aggregation semantics (→ PLAN-v3 PR-7)**: nothing today flags
+  `SUM()` over the pre-aggregated `Daily Distinct Buyers` / `Daily Active
+  Sales` columns in KPI positions (`COUNTD`→`Sum`, `DISTINCT_*` heuristics).
+  The three KPI formulas above are the concrete inputs PR-7's
+  aggregation-semantics lint must flag; until it lands, this hazard passes
+  every gate silently. When PR-7 lands, wire its lint into `checks.sh` here
+  as a BLOCK expectation.
+- **Integer-coded dimension filter (→ PLAN-v3 PR-18)**: `SITE_KEY` is an
+  integer-typed dimension driving a dashboard filter; no detection/decode
+  routing exists yet. PR-18's shelf-role + cardinality probe (via PR-4's
+  runner) lands here as its fixture.
+
+## Converter
+
+No golden data model — this case pins the LOD-audit ledger + layout-signal
+contracts. Regenerate the pin with:
+
+```
+W=$(mktemp -d)
+cp corpus/tableau/preagg-kpi/workbook-content.twb "$W/"
+cp corpus/tableau/preagg-kpi/dm-spec.fixture.json "$W/dm-spec.json"
+ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-lod-calcs.rb --workdir "$W"
+# then copy the "entries" array of $W/lod-audit.json over lod-audit.entries.json
+```
+
+## Expectations
+
+```json
+{
+  "artifacts": [
+    {"path": "workbook-content.twb", "format": "xml"},
+    {"path": "dm-spec.fixture.json", "format": "json"},
+    {"path": "lod-audit.entries.json", "format": "json"},
+    {"path": "checks.sh", "format": "text"}
+  ]
+}
+```

--- a/corpus/tableau/preagg-kpi/checks.sh
+++ b/corpus/tableau/preagg-kpi/checks.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# preagg-kpi — executable expectations (offline, creds-free).
+# Run by corpus/run-corpus.sh --check after corpus_check.py passes.
+#
+#   1. audit-lod-calcs.rb against the .twb census + the canned field-shaped
+#      dm-spec fixture classifies the two {FIXED day : COUNTD} calcs exactly
+#      as the CURRENT code does: "Daily Distinct Buyers" = suspect-alias
+#      (emitted formula reads an unrelated raw flag column), "Daily Active
+#      Sales" = silently-dropped → exit 2 + FATAL blocks.
+#   2. assert-phase6-ran.rb gate 17 (exit 24) BLOCKS on the unresolved ledger
+#      and PASSES once resolutions are recorded via --resolve.
+#   3. parse-twb-layout.rb reads the unsynchronized dual-axis combo worksheet
+#      as chart_kind "bar" with dual_axis false — the KNOWN LIMITATION this
+#      entry pins (no synchronized='true' in the twin shape); flipping this
+#      pin is the acceptance signal for a dual-axis detection fix.
+#
+# NOT yet gated (documented known-gap, see MANIFEST): the additive
+# SUM(preagg)/SUM(preagg) KPI hazard has no lint today — PLAN-v3 PR-7's
+# aggregation-semantics lint lands here as its test bed.
+set -uo pipefail
+CASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$CASE_DIR/../../.." && pwd)"
+SCRIPTS="$REPO_ROOT/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts"
+
+command -v ruby >/dev/null || { echo "checks: ruby not found (required for the skill-script checks)"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+note() { printf '     %s\n' "$*"; }
+
+# -- 1. LOD audit: suspect-alias + silently-dropped, exit 2 ------------------
+cp "$CASE_DIR/workbook-content.twb" "$TMP/"
+cp "$CASE_DIR/dm-spec.fixture.json" "$TMP/dm-spec.json"
+ruby "$SCRIPTS/audit-lod-calcs.rb" --workdir "$TMP" >"$TMP/audit.out" 2>"$TMP/audit.err"
+rc=$?
+if [ "$rc" -eq 2 ] \
+   && /usr/bin/grep -q 'LOD TRANSLATION FATAL' "$TMP/audit.err" \
+   && /usr/bin/grep -q 'reads ACTIVE_BUYER_FLAG' "$TMP/audit.err" \
+   && /usr/bin/grep -q 'silently-dropped.*Daily Active Sales' "$TMP/audit.err"; then
+  note "ok: LOD audit blocks (exit 2): suspect-alias reads ACTIVE_BUYER_FLAG; Daily Active Sales silently-dropped"
+else
+  note "FAIL: LOD audit expected exit 2 + both FATAL classes (got $rc)"; sed -n '1,15p' "$TMP/audit.err"; fail=1
+fi
+ruby -rjson -e '
+  got = JSON.parse(File.read(File.join(ARGV[0], "lod-audit.json")))["entries"]
+  pin = JSON.parse(File.read(ARGV[1]))
+  abort "ledger entries drifted from lod-audit.entries.json:\n#{JSON.pretty_generate(got)}" unless got == pin
+' "$TMP" "$CASE_DIR/lod-audit.entries.json" \
+  && note "ok: ledger classification matches the pinned lod-audit.entries.json (honest current-code output)" \
+  || { note "FAIL: LOD ledger drifted from the pin"; fail=1; }
+
+# -- 2. gate 17 blocks unresolved, passes resolved ---------------------------
+cat > "$TMP/parity-final.json" <<'JSON'
+{
+  "workbook_id": "wb-corpus-pak", "mode": "strict", "status": "PASS",
+  "charts_total": 5, "charts_pass": 5, "charts_fail": 0,
+  "pass_names": ["KPI Avg Amount", "KPI Sales per Active", "KPI Pct Earnings", "Amount vs Growth", "Weekly Outlook"],
+  "fail_names": [],
+  "visual_checked": true, "visual_verdict": "pass",
+  "style_checklist": { "element_titles_hidden": "pass", "palette_match": "pass",
+    "composition_match": "pass", "chart_shapes_match": "pass",
+    "labels_legible": "pass", "numbers_formatted": "pass" },
+  "agent_vision": true
+}
+JSON
+{ printf '\x89PNG\r\n\x1a\n'; head -c 6000 /dev/zero; } > "$TMP/sigma-render.png"
+printf '{"status":"sent","tool":"corpus-checks"}\n' > "$TMP/telemetry-sent.json"
+
+env -u SIGMA_BASE_URL -u SIGMA_API_TOKEN ruby "$SCRIPTS/assert-phase6-ran.rb" --workdir "$TMP" >"$TMP/gate1.out" 2>"$TMP/gate1.err"
+rc=$?
+if [ "$rc" -eq 24 ] && /usr/bin/grep -q 'gate 17: LOD translation ledger unresolved' "$TMP/gate1.err"; then
+  note "ok: gate 17 (exit 24) blocks GREEN on the unresolved suspect-alias/silently-dropped entries"
+else
+  note "FAIL: gate 17 expected exit 24 (got $rc)"; sed -n '1,12p' "$TMP/gate1.err"; fail=1
+fi
+
+ruby "$SCRIPTS/audit-lod-calcs.rb" --workdir "$TMP" --resolve 0 --how manual \
+  --reason 'grouped helper element "Daily Buyer Rollup" (CAL_DATE grain, CountDistinct BUYER_KEY) authored by hand (corpus fixture evidence)' >>"$TMP/resolve.out" 2>&1
+rc0=$?
+ruby "$SCRIPTS/audit-lod-calcs.rb" --workdir "$TMP" --resolve 1 --how waived \
+  --reason 'corpus operator: Daily Active Sales accepted-missing in the frozen fixture; PR-7/PR-5 flip this' >>"$TMP/resolve.out" 2>&1
+rc1=$?
+if [ "$rc0" -eq 2 ] && [ "$rc1" -eq 0 ]; then
+  note "ok: --resolve records evidence (still exit 2 while one entry blocks; exit 0 once both resolved)"
+else
+  note "FAIL: --resolve sequence expected exits 2 then 0 (got $rc0 then $rc1)"; sed -n '1,10p' "$TMP/resolve.out"; fail=1
+fi
+
+env -u SIGMA_BASE_URL -u SIGMA_API_TOKEN ruby "$SCRIPTS/assert-phase6-ran.rb" --workdir "$TMP" >"$TMP/gate2.out" 2>"$TMP/gate2.err"
+rc=$?
+if [ "$rc" -eq 0 ] && /usr/bin/grep -q '\[OK\] gate 17: LOD translation ledger resolved' "$TMP/gate2.out"; then
+  note "ok: gate 17 passes once both resolutions are in the ledger"
+else
+  note "FAIL: gate 17 expected exit 0 on the resolved ledger (got $rc)"; sed -n '1,12p' "$TMP/gate2.err"; fail=1
+fi
+
+# -- 3. dual-axis known-limitation pin ---------------------------------------
+ruby "$SCRIPTS/parse-twb-layout.rb" "$CASE_DIR/workbook-content.twb" "$TMP/layout.json" >"$TMP/layout.out" 2>&1 || fail=1
+ruby -rjson -e '
+  zones = JSON.parse(File.read(ARGV[0])).flat_map { |d| d["zones"] || [] }
+  combo = zones.find { |z| z["caption"] == "Amount vs Growth" }
+  abort "combo zone missing" unless combo
+  # KNOWN LIMITATION (pinned on purpose): the unsynchronized multi-pane
+  # dual-axis shape reads as a plain bar with dual_axis false. A dual-axis
+  # detection fix MUST flip this assertion.
+  abort "combo now reads #{combo["chart_kind"].inspect}/dual_axis=#{combo["dual_axis"].inspect} — the known-limitation pin flipped; update MANIFEST + this check" \
+    unless combo["chart_kind"] == "bar" && combo["dual_axis"] == false
+  kpis = zones.select { |z| z["is_kpi"] }.map { |z| z["caption"] }.sort
+  abort "KPI zones wrong: #{kpis.inspect}" unless kpis == ["KPI Avg Amount", "KPI Pct Earnings", "KPI Sales per Active"]
+  outlook = zones.find { |z| z["caption"] == "Weekly Outlook" }
+  abort "Weekly Outlook not line" unless outlook && outlook["chart_kind"] == "line"
+' "$TMP/layout.json" \
+  && note "ok: known-limitation pinned — dual-axis combo reads chart_kind=bar / dual_axis=false (3 KPI zones + line detected)" \
+  || { note "FAIL: layout known-limitation pin"; fail=1; }
+
+exit "$fail"

--- a/corpus/tableau/preagg-kpi/dm-spec.fixture.json
+++ b/corpus/tableau/preagg-kpi/dm-spec.fixture.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "Canned converter-emission fixture (the offline seam for audit-lod-calcs.rb --dm-spec): the FIELD-FAILURE shape. 'Daily Distinct Buyers' was fuzzy-aliased to an unrelated raw flag column; 'Daily Active Sales' was emitted nowhere. Synthetic — invented names only.",
+  "pages": [
+    {
+      "id": "page-1",
+      "elements": [
+        {
+          "id": "el-fact",
+          "kind": "table",
+          "name": "Sales Fact Master",
+          "source": { "kind": "warehouse-table", "path": ["DEMO_DB", "ANALYTICS", "SALES_FACT"] },
+          "columns": [
+            { "id": "c-net-amount", "name": "Net Amount", "formula": "[SALES_FACT/NET_AMOUNT]" },
+            { "id": "c-net-earnings", "name": "Net Earnings", "formula": "[SALES_FACT/NET_EARNINGS]" },
+            { "id": "c-site-key", "name": "Site Key", "formula": "[SALES_FACT/SITE_KEY]" },
+            { "id": "c-ddb", "name": "Daily Distinct Buyers", "formula": "[SALES_FACT/ACTIVE_BUYER_FLAG]" },
+            { "id": "c-avg-amt", "name": "Avg Amount per Buyer", "formula": "Sum([Net Amount]) / Sum([Daily Distinct Buyers])" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/corpus/tableau/preagg-kpi/lod-audit.entries.json
+++ b/corpus/tableau/preagg-kpi/lod-audit.entries.json
@@ -1,0 +1,37 @@
+[
+  {
+    "calc": "Daily Distinct Buyers",
+    "internal_name": "[Calculation_DDB]",
+    "lod_kind": "FIXED",
+    "formula": "{FIXED [CAL_DATE] : COUNTD([BUYER_KEY])}",
+    "reference_set": [
+      "CAL_DATE",
+      "BUYER_KEY"
+    ],
+    "class": "suspect-alias",
+    "status": "unresolved",
+    "evidence": {
+      "spec": "dm-spec",
+      "element": "Sales Fact Master",
+      "column": "Daily Distinct Buyers",
+      "formula": "[SALES_FACT/ACTIVE_BUYER_FLAG]"
+    },
+    "suspect_refs": [
+      "ACTIVE_BUYER_FLAG"
+    ],
+    "detail": "emitted formula reads \"ACTIVE_BUYER_FLAG\" \u2014 not in the LOD expression's own reference set (fuzzy name-alias: the numbers are silently wrong)"
+  },
+  {
+    "calc": "Daily Active Sales",
+    "internal_name": "[Calculation_DAS]",
+    "lod_kind": "FIXED",
+    "formula": "{FIXED [CAL_DATE] : COUNTD([SALE_ID])}",
+    "reference_set": [
+      "CAL_DATE",
+      "SALE_ID"
+    ],
+    "class": "silently-dropped",
+    "status": "unresolved",
+    "detail": "no emitted dm-spec/wb-spec translation carries this calc's name and no manual-residues.json entry declares it \u2014 the calc vanished with no signal"
+  }
+]

--- a/corpus/tableau/preagg-kpi/workbook-content.twb
+++ b/corpus/tableau/preagg-kpi/workbook-content.twb
@@ -1,0 +1,567 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- Synthetic field-twin (invented names, no customer data): the PRE-AGGREGATED
+     KPI shape. {FIXED day : COUNTD(...)} LOD calcs materialize day-grain
+     distinct counts, then KPI formulas consume them ADDITIVELY
+     (SUM(preagg)/SUM(preagg)) — compiles clean everywhere, numbers wrong at
+     any grain other than day. Plus a dual-axis combo worksheet built the
+     multi-pane way (NO synchronized='true' — the shape parse-twb-layout
+     reads as a plain bar), an integer-coded dimension filter (SITE_KEY),
+     and a date-anchor parameter. -->
+<workbook locale='en_US' original-version='18.1' source-build='2026.1.5 (20261.26.0512.1609)' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <preferences />
+  <datasources>
+    <datasource hasconnection='false' inline='true' name='Parameters' version='18.1'>
+      <aliases enabled='yes' />
+      <column caption='Anchor Week' datatype='date' name='[P_AnchorWeek]' param-domain-type='any' role='measure' type='quantitative' value='#2025-06-03#'>
+        <calculation class='tableau' formula='#2025-06-03#' />
+      </column>
+    </datasource>
+    <datasource caption='Wallet Pulse (SALES_FACT+CALENDAR_DIM)' inline='true' name='federated.0pak0walletpulse01' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='snowflake demo' name='snowflake.0pak0walletpulse01'>
+            <connection class='snowflake' dbname='DEMO_DB' schema='ANALYTICS' server='example.snowflakecomputing.com' warehouse='WH_XS' />
+          </named-connection>
+        </named-connections>
+        <relation join='inner' type='join'>
+          <clause type='join'>
+            <expression op='='>
+              <expression op='[SALES_FACT].[SALE_DATE_KEY]' />
+              <expression op='[CALENDAR_DIM].[DATE_KEY]' />
+            </expression>
+          </clause>
+          <relation connection='snowflake.0pak0walletpulse01' name='SALES_FACT' table='[ANALYTICS].[SALES_FACT]' type='table'>
+            <columns>
+              <column datatype='string' name='SALE_ID' />
+              <column datatype='integer' name='BUYER_KEY' />
+              <column datatype='integer' name='SITE_KEY' />
+              <column datatype='integer' name='SALE_DATE_KEY' />
+              <column datatype='real' name='NET_AMOUNT' />
+              <column datatype='real' name='NET_EARNINGS' />
+            </columns>
+          </relation>
+          <relation connection='snowflake.0pak0walletpulse01' name='CALENDAR_DIM' table='[ANALYTICS].[CALENDAR_DIM]' type='table'>
+            <columns>
+              <column datatype='integer' name='DATE_KEY' />
+              <column datatype='date' name='CAL_DATE' />
+            </columns>
+          </relation>
+        </relation>
+      </connection>
+      <aliases enabled='yes' />
+      <column caption='Sale Id' datatype='string' name='[SALE_ID]' role='dimension' type='nominal' />
+      <column caption='Buyer Key' datatype='integer' name='[BUYER_KEY]' role='measure' type='quantitative' />
+      <column caption='Site Key' datatype='integer' name='[SITE_KEY]' role='dimension' type='ordinal' />
+      <column caption='Sale Date Key' datatype='integer' name='[SALE_DATE_KEY]' role='measure' type='quantitative' />
+      <column caption='Net Amount' datatype='real' name='[NET_AMOUNT]' role='measure' type='quantitative' />
+      <column caption='Net Earnings' datatype='real' name='[NET_EARNINGS]' role='measure' type='quantitative' />
+      <column caption='Date Key' datatype='integer' name='[DATE_KEY]' role='measure' type='quantitative' />
+      <column caption='Cal Date' datatype='date' name='[CAL_DATE]' role='dimension' type='ordinal' />
+      <column caption='Daily Distinct Buyers' datatype='integer' name='[Calculation_DDB]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='{FIXED [CAL_DATE] : COUNTD([BUYER_KEY])}' />
+      </column>
+      <column caption='Daily Active Sales' datatype='integer' name='[Calculation_DAS]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='{FIXED [CAL_DATE] : COUNTD([SALE_ID])}' />
+      </column>
+      <column caption='Avg Amount per Buyer' datatype='real' name='[Calculation_AvgAmt]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='SUM([NET_AMOUNT]) / SUM([Calculation_DDB])' />
+      </column>
+      <column caption='Sales per Active' datatype='real' name='[Calculation_SPA]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='SUM([Calculation_DAS]) / SUM([Calculation_DDB])' />
+      </column>
+      <column caption='Pct Buyers with Earnings' datatype='real' name='[Calculation_PctEarn]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='SUM(IF [NET_EARNINGS] &gt; 0 THEN 1 ELSE 0 END) / SUM([Calculation_DDB])' />
+      </column>
+      <column caption='Week Anchor' datatype='date' name='[Calculation_WeekAnchor]' role='dimension' type='ordinal'>
+        <calculation class='tableau' formula='DATEADD(&apos;day&apos;, 2, DATETRUNC(&apos;week&apos;, DATEADD(&apos;day&apos;, -2, [CAL_DATE])))' />
+      </column>
+      <column caption='Is Current Week?' datatype='boolean' name='[Calculation_IsCurWeek]' role='dimension' type='nominal'>
+        <calculation class='tableau' formula='DATETRUNC(&apos;week&apos;, [CAL_DATE]) = DATETRUNC(&apos;week&apos;, TODAY())' />
+      </column>
+      <column caption='Pct Growth YY' datatype='real' name='[Calculation_GrowthYY]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='(ZN(SUM([NET_AMOUNT])) - LOOKUP(ZN(SUM([NET_AMOUNT])), -52)) / ABS(LOOKUP(ZN(SUM([NET_AMOUNT])), -52))' />
+      </column>
+      <column caption='Weeks From Anchor' datatype='integer' name='[Calculation_WFA]' role='dimension' type='ordinal'>
+        <calculation class='tableau' formula='DATEDIFF(&apos;week&apos;, [Parameters].[P_AnchorWeek], [Calculation_WeekAnchor])' />
+      </column>
+      <layout dim-ordering='alphabetic' measure-ordering='alphabetic' show-structure='true' />
+      <datasource-dependencies datasource='Parameters'>
+        <column caption='Anchor Week' datatype='date' name='[P_AnchorWeek]' param-domain-type='any' role='measure' type='quantitative' value='#2025-06-03#'>
+          <calculation class='tableau' formula='#2025-06-03#' />
+        </column>
+      </datasource-dependencies>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='KPI Avg Amount'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Avg Amount per Buyer</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Wallet Pulse (SALES_FACT+CALENDAR_DIM)' name='federated.0pak0walletpulse01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0pak0walletpulse01'>
+            <column caption='Avg Amount per Buyer' datatype='real' name='[Calculation_AvgAmt]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='SUM([NET_AMOUNT]) / SUM([Calculation_DDB])' />
+            </column>
+            <column-instance column='[Calculation_AvgAmt]' derivation='User' name='[usr:Calculation_AvgAmt:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <slices>
+            <column>[federated.0pak0walletpulse01].[usr:Calculation_AvgAmt:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[federated.0pak0walletpulse01].[usr:Calculation_AvgAmt:qk]' value='n&quot;$&quot;#,##0.00' />
+          </style-rule>
+          <style-rule element='gridline'>
+            <format attr='line-pattern' value='none' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[federated.0pak0walletpulse01].[usr:Calculation_AvgAmt:qk]' />
+            </encodings>
+            <customized-label>
+              <formatted-text>
+                <run fontname='Tableau Bold' fontsize='26'>&lt;[federated.0pak0walletpulse01].[usr:Calculation_AvgAmt:qk]&gt;</run>
+              </formatted-text>
+            </customized-label>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='true' />
+                <format attr='mark-labels-cull' value='true' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows />
+        <cols />
+      </table>
+      <simple-id uuid='{CE300001-0000-4000-8000-000000000001}' />
+    </worksheet>
+    <worksheet name='KPI Sales per Active'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Sales per Active</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Wallet Pulse (SALES_FACT+CALENDAR_DIM)' name='federated.0pak0walletpulse01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0pak0walletpulse01'>
+            <column caption='Sales per Active' datatype='real' name='[Calculation_SPA]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='SUM([Calculation_DAS]) / SUM([Calculation_DDB])' />
+            </column>
+            <column-instance column='[Calculation_SPA]' derivation='User' name='[usr:Calculation_SPA:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <slices>
+            <column>[federated.0pak0walletpulse01].[usr:Calculation_SPA:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[federated.0pak0walletpulse01].[usr:Calculation_SPA:qk]' value='n#,##0.00' />
+          </style-rule>
+          <style-rule element='gridline'>
+            <format attr='line-pattern' value='none' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[federated.0pak0walletpulse01].[usr:Calculation_SPA:qk]' />
+            </encodings>
+            <customized-label>
+              <formatted-text>
+                <run fontname='Tableau Bold' fontsize='26'>&lt;[federated.0pak0walletpulse01].[usr:Calculation_SPA:qk]&gt;</run>
+              </formatted-text>
+            </customized-label>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='true' />
+                <format attr='mark-labels-cull' value='true' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows />
+        <cols />
+      </table>
+      <simple-id uuid='{CE300002-0000-4000-8000-000000000002}' />
+    </worksheet>
+    <worksheet name='KPI Pct Earnings'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Pct Buyers with Earnings</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Wallet Pulse (SALES_FACT+CALENDAR_DIM)' name='federated.0pak0walletpulse01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0pak0walletpulse01'>
+            <column caption='Pct Buyers with Earnings' datatype='real' name='[Calculation_PctEarn]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='SUM(IF [NET_EARNINGS] &gt; 0 THEN 1 ELSE 0 END) / SUM([Calculation_DDB])' />
+            </column>
+            <column-instance column='[Calculation_PctEarn]' derivation='User' name='[usr:Calculation_PctEarn:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <slices>
+            <column>[federated.0pak0walletpulse01].[usr:Calculation_PctEarn:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[federated.0pak0walletpulse01].[usr:Calculation_PctEarn:qk]' value='p0.0%' />
+          </style-rule>
+          <style-rule element='gridline'>
+            <format attr='line-pattern' value='none' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[federated.0pak0walletpulse01].[usr:Calculation_PctEarn:qk]' />
+            </encodings>
+            <customized-label>
+              <formatted-text>
+                <run fontname='Tableau Bold' fontsize='26'>&lt;[federated.0pak0walletpulse01].[usr:Calculation_PctEarn:qk]&gt;</run>
+              </formatted-text>
+            </customized-label>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='true' />
+                <format attr='mark-labels-cull' value='true' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows />
+        <cols />
+      </table>
+      <simple-id uuid='{CE300003-0000-4000-8000-000000000003}' />
+    </worksheet>
+    <worksheet name='Amount vs Growth'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Weekly Net Amount (bars) vs Pct Growth YY (line)</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Wallet Pulse (SALES_FACT+CALENDAR_DIM)' name='federated.0pak0walletpulse01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.0pak0walletpulse01'>
+            <column caption='Net Amount' datatype='real' name='[NET_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='Site Key' datatype='integer' name='[SITE_KEY]' role='dimension' type='ordinal' />
+            <column caption='Week Anchor' datatype='date' name='[Calculation_WeekAnchor]' role='dimension' type='ordinal'>
+              <calculation class='tableau' formula='DATEADD(&apos;day&apos;, 2, DATETRUNC(&apos;week&apos;, DATEADD(&apos;day&apos;, -2, [CAL_DATE])))' />
+            </column>
+            <column caption='Pct Growth YY' datatype='real' name='[Calculation_GrowthYY]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='(ZN(SUM([NET_AMOUNT])) - LOOKUP(ZN(SUM([NET_AMOUNT])), -52)) / ABS(LOOKUP(ZN(SUM([NET_AMOUNT])), -52))' />
+            </column>
+            <column-instance column='[Calculation_WeekAnchor]' derivation='None' name='[none:Calculation_WeekAnchor:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[NET_AMOUNT]' derivation='Sum' name='[sum:NET_AMOUNT:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_GrowthYY]' derivation='User' name='[usr:Calculation_GrowthYY:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[SITE_KEY]' derivation='None' name='[none:SITE_KEY:ok]' pivot='key' type='ordinal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.0pak0walletpulse01].[none:SITE_KEY:ok]'>
+            <groupfilter function='level-members' level='[none:SITE_KEY:ok]' user:ui-enumeration='all' user:ui-marker='enumerate' />
+          </filter>
+          <slices>
+            <column>[federated.0pak0walletpulse01].[none:SITE_KEY:ok]</column>
+            <column>[federated.0pak0walletpulse01].[none:Calculation_WeekAnchor:qk]</column>
+            <column>[federated.0pak0walletpulse01].[sum:NET_AMOUNT:qk]</column>
+            <column>[federated.0pak0walletpulse01].[usr:Calculation_GrowthYY:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='axis'>
+            <format attr='title' field='[federated.0pak0walletpulse01].[none:Calculation_WeekAnchor:qk]' value='Week Anchor (Tue)' />
+            <encoding attr='space' class='0' field='[federated.0pak0walletpulse01].[usr:Calculation_GrowthYY:qk]' field-type='quantitative' fold='true' scope='rows' type='space' />
+          </style-rule>
+          <style-rule element='cell'>
+            <format attr='text-format' field='[federated.0pak0walletpulse01].[usr:Calculation_GrowthYY:qk]' value='p0.0%' />
+          </style-rule>
+          <style-rule element='gridline'>
+            <format attr='line-pattern' value='none' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane id='1' selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Bar' />
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+            </style>
+          </pane>
+          <pane id='2' selection-relaxation-option='selection-relaxation-allow' y-axis-name='[federated.0pak0walletpulse01].[sum:NET_AMOUNT:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Bar' />
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+            </style>
+          </pane>
+          <pane id='3' selection-relaxation-option='selection-relaxation-allow' y-axis-name='[federated.0pak0walletpulse01].[usr:Calculation_GrowthYY:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Line' />
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows>([federated.0pak0walletpulse01].[sum:NET_AMOUNT:qk] + [federated.0pak0walletpulse01].[usr:Calculation_GrowthYY:qk])</rows>
+        <cols>[federated.0pak0walletpulse01].[none:Calculation_WeekAnchor:qk]</cols>
+      </table>
+      <simple-id uuid='{CE300004-0000-4000-8000-000000000004}' />
+    </worksheet>
+    <worksheet name='Weekly Outlook'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Weekly Outlook by Week Anchor</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Wallet Pulse (SALES_FACT+CALENDAR_DIM)' name='federated.0pak0walletpulse01' />
+            <datasource name='Parameters' />
+          </datasources>
+          <datasource-dependencies datasource='Parameters'>
+            <column caption='Anchor Week' datatype='date' name='[P_AnchorWeek]' param-domain-type='any' role='measure' type='quantitative' value='#2025-06-03#'>
+              <calculation class='tableau' formula='#2025-06-03#' />
+            </column>
+          </datasource-dependencies>
+          <datasource-dependencies datasource='federated.0pak0walletpulse01'>
+            <column caption='Net Amount' datatype='real' name='[NET_AMOUNT]' role='measure' type='quantitative' />
+            <column caption='Week Anchor' datatype='date' name='[Calculation_WeekAnchor]' role='dimension' type='ordinal'>
+              <calculation class='tableau' formula='DATEADD(&apos;day&apos;, 2, DATETRUNC(&apos;week&apos;, DATEADD(&apos;day&apos;, -2, [CAL_DATE])))' />
+            </column>
+            <column caption='Is Current Week?' datatype='boolean' name='[Calculation_IsCurWeek]' role='dimension' type='nominal'>
+              <calculation class='tableau' formula='DATETRUNC(&apos;week&apos;, [CAL_DATE]) = DATETRUNC(&apos;week&apos;, TODAY())' />
+            </column>
+            <column caption='Weeks From Anchor' datatype='integer' name='[Calculation_WFA]' role='dimension' type='ordinal'>
+              <calculation class='tableau' formula='DATEDIFF(&apos;week&apos;, [Parameters].[P_AnchorWeek], [Calculation_WeekAnchor])' />
+            </column>
+            <column-instance column='[Calculation_WeekAnchor]' derivation='None' name='[none:Calculation_WeekAnchor:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[NET_AMOUNT]' derivation='Sum' name='[sum:NET_AMOUNT:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_IsCurWeek]' derivation='None' name='[none:Calculation_IsCurWeek:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Calculation_WFA]' derivation='Min' name='[min:Calculation_WFA:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.0pak0walletpulse01].[none:Calculation_IsCurWeek:nk]'>
+            <groupfilter function='level-members' level='[none:Calculation_IsCurWeek:nk]' user:ui-enumeration='all' user:ui-marker='enumerate' />
+          </filter>
+          <slices>
+            <column>[federated.0pak0walletpulse01].[none:Calculation_IsCurWeek:nk]</column>
+            <column>[federated.0pak0walletpulse01].[none:Calculation_WeekAnchor:qk]</column>
+            <column>[federated.0pak0walletpulse01].[sum:NET_AMOUNT:qk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='gridline'>
+            <format attr='line-pattern' value='none' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane selection-relaxation-option='selection-relaxation-allow'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Line' />
+            <encodings>
+              <color column='[federated.0pak0walletpulse01].[none:Calculation_IsCurWeek:nk]' />
+              <lod column='[federated.0pak0walletpulse01].[min:Calculation_WFA:qk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows>[federated.0pak0walletpulse01].[sum:NET_AMOUNT:qk]</rows>
+        <cols>[federated.0pak0walletpulse01].[none:Calculation_WeekAnchor:qk]</cols>
+      </table>
+      <simple-id uuid='{CE300005-0000-4000-8000-000000000005}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard enable-sort-zone-taborder='true' name='Wallet Pulse'>
+      <style />
+      <size maxheight='850' maxwidth='1300' minheight='850' minwidth='1300' sizing-mode='fixed' />
+      <datasources>
+        <datasource caption='Parameters' name='Parameters' />
+        <datasource caption='Wallet Pulse (SALES_FACT+CALENDAR_DIM)' name='federated.0pak0walletpulse01' />
+      </datasources>
+      <zones>
+        <zone h='100000' id='100' type-v2='layout-basic' w='100000' x='0' y='0'>
+          <zone h='100000' id='99' param='horz' type-v2='layout-flow' w='100000' x='0' y='0'>
+            <zone h='100000' id='50' param='vert' type-v2='layout-flow' w='80000' x='0' y='0'>
+              <zone h='18000' id='40' layout-strategy-id='distribute-evenly' param='horz' type-v2='layout-flow' w='80000' x='0' y='0'>
+                <zone h='18000' id='41' name='KPI Avg Amount' w='26666' x='0' y='0'>
+                  <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                  <zone-style>
+                    <format attr='border-style' value='none' />
+                    <format attr='border-width' value='0' />
+                    <format attr='margin' value='2' />
+                    <format attr='background-color' value='#f6f8fb' />
+                  </zone-style>
+                </zone>
+                <zone h='18000' id='42' name='KPI Sales per Active' w='26667' x='26666' y='0'>
+                  <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                  <zone-style>
+                    <format attr='border-style' value='none' />
+                    <format attr='border-width' value='0' />
+                    <format attr='margin' value='2' />
+                    <format attr='background-color' value='#f6f8fb' />
+                  </zone-style>
+                </zone>
+                <zone h='18000' id='43' name='KPI Pct Earnings' w='26667' x='53333' y='0'>
+                  <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                  <zone-style>
+                    <format attr='border-style' value='none' />
+                    <format attr='border-width' value='0' />
+                    <format attr='margin' value='2' />
+                    <format attr='background-color' value='#f6f8fb' />
+                  </zone-style>
+                </zone>
+              </zone>
+              <zone h='40000' id='44' name='Amount vs Growth' w='80000' x='0' y='18000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='3' />
+                </zone-style>
+              </zone>
+              <zone h='42000' id='45' name='Weekly Outlook' w='80000' x='0' y='58000'>
+                <layout-cache minheight='1' minwidth='1' type-h='scalable' type-w='scalable' />
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='3' />
+                </zone-style>
+              </zone>
+            </zone>
+            <zone h='100000' id='60' param='vert' type-v2='layout-flow' w='20000' x='80000' y='0'>
+              <zone forceUpdate='true' h='6000' id='65' type-v2='text' w='20000' x='80000' y='0'>
+                <formatted-text>
+                  <run fontalignment='1' fontcolor='#1a1a2e' fontname='Tableau Bold' fontsize='14'>Wallet Pulse</run>
+                </formatted-text>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='4' />
+                </zone-style>
+              </zone>
+              <zone h='30000' id='61' mode='checkdropdown' name='Amount vs Growth' param='[federated.0pak0walletpulse01].[none:SITE_KEY:ok]' type-v2='filter' w='20000' x='80000' y='6000'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='4' />
+                </zone-style>
+              </zone>
+              <zone h='14000' id='62' param='[Parameters].[P_AnchorWeek]' type-v2='paramctrl' w='20000' x='80000' y='36000'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='4' />
+                </zone-style>
+              </zone>
+              <zone h='16000' id='63' mode='checklist' name='Weekly Outlook' param='[federated.0pak0walletpulse01].[none:Calculation_IsCurWeek:nk]' type-v2='filter' w='20000' x='80000' y='50000'>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='4' />
+                </zone-style>
+              </zone>
+              <zone forceUpdate='true' h='34000' id='64' type-v2='text' w='20000' x='80000' y='66000'>
+                <formatted-text>
+                  <run fontcolor='#5a6472' fontsize='9'> </run>
+                </formatted-text>
+                <zone-style>
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='margin' value='4' />
+                </zone-style>
+              </zone>
+            </zone>
+          </zone>
+        </zone>
+      </zones>
+      <simple-id uuid='{CE300010-0000-4000-8000-000000000010}' />
+    </dashboard>
+  </dashboards>
+  <windows source-height='30'>
+    <window class='dashboard' maximized='true' name='Wallet Pulse'>
+      <viewpoints>
+        <viewpoint name='KPI Avg Amount'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='KPI Sales per Active'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='KPI Pct Earnings'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='Amount vs Growth'>
+          <zoom type='entire-view' />
+        </viewpoint>
+        <viewpoint name='Weekly Outlook'>
+          <zoom type='entire-view' />
+        </viewpoint>
+      </viewpoints>
+      <active id='-1' />
+      <simple-id uuid='{CE300011-0000-4000-8000-000000000011}' />
+    </window>
+  </windows>
+</workbook>


### PR DESCRIPTION
## PLAN-v3 PR-1 — corpus freeze

Three neutralized synthetic fixtures under `corpus/tableau/` reproducing the 2026-07-17 field-session failure shapes offline (structure copied from the live field-twin workbooks; every identifier renamed to neutral invented names on `DEMO_DB.ANALYTICS` — hygiene sweep green). Everything downstream of PLAN-v3 replays against these; later PRs flip the known-bad pins to PASS.

### `lookup-grain-mismatch` (twin A shape)
- Published-VC federated datasource; relation tree **self-joins the fact** (`Sale Lines` / `Buyer Day Detail`) on the AND-wrapped **non-unique compound key** (buyer x sale-date; fact at line grain) + two unique single-key dim joins; GUID field ids with captions as the only physical handle; Top-N/Direction params driving `RANK_UNIQUE` + an In-Top-N filter; param-driven dynamic titles; top-shelf control row.
- Pins the `lib/join_plan.rb` derivation **verbatim, warts included** (dim probe keys fold disambiguated captions to `BUYER_KEY_(BUYER_DIM)`; the self-join `right_table` keeps the unprobeable VC-inode FQN).
- `probe-join-keys.rb --fixture` proves dims unique, self-join non-unique (5000 rows / 1400 keys) -> **exit 2 FATAL**; gate 16 (exit 23) **blocks unprobed, passes resolved** (`--resolve 2 --how preaggregated`).

### `join-elision-fanout` (twin B shape)
- Federated **LEFT JOIN** on a non-unique low-cardinality flag key (`ACTIVE_FLAG = CURRENT_FLAG`) with **no joined column on any shelf** — the "provably no-op" deletion trap; a wide Measure-Names crosstab; two line charts; a heat map; a **second independent published datasource** feeding its own worksheet.
- `scan-workbook-gaps.rb` detects the independent multi-datasource shape (`multi-ds-plan.json`: fact -> 4 sheets, sqlproxy stub -> 1); the join ledger pins the left join; the probe fixture proves the flag key non-unique (6 rows / 2 keys) -> exit 2 FATAL — elision is unproven either way.
- `parse-twb-layout.rb` signals keep both trend worksheets `chart_kind=line` (the pin PR-10's kind-parity gate builds on); converter relationship-drop recorded as a known-limitation note in the MANIFEST.

### `preagg-kpi` (twin C shape)
- `{FIXED [CAL_DATE] : COUNTD(...)}` LODs consumed **additively** in three KPI ratios (`SUM(preagg)/SUM(preagg)`) — compiles clean in every existing gate. **Documented known-gap -> PLAN-v3 PR-7** (no aggregation-semantics lint exists yet; this entry is its future test bed). Integer-coded dim filter (`SITE_KEY`) recorded for PR-18.
- The LOD audit is run honestly against the .twb census + a canned field-shaped emission fixture: `Daily Distinct Buyers` -> **suspect-alias** (emitted formula reads `ACTIVE_BUYER_FLAG`, outside the LOD's own reference set), `Daily Active Sales` -> **silently-dropped**; exit 2 FATAL pinned verbatim; gate 17 (exit 24) blocks unresolved / passes resolved.
- The dual-axis combo (multi-pane, no `synchronized='true'`) is pinned as the current **known limitation**: `parse-twb-layout` reads `chart_kind=bar`, `dual_axis=false` — the check fails loudly if detection ever improves, forcing the pin flip.

### Runner wiring
- `run-corpus.sh --check` now runs a case's `checks.sh` (offline, creds-free; ruby needed for the skill-script cases) after the structural check.
- `corpus_check.py` requires a shipped `checks.sh` to be listed in the MANIFEST expectations artifacts.

### Verification
- `bash corpus/run-corpus.sh --check` -> **17/17 cases pass** (incl. the three new entries' checks.sh: ledger pins byte-stable, probes exit 2, gates 16/17 block -> resolve -> pass).
- `bash tools/hygiene-sweep.sh` -> clean (48 patterns over 1558 tracked files + staged diff).
- `ruby tools/lint-twb-encoding.rb` -> OK; `ruby tools/check-shared.rb` -> OK (untouched, 393 copies match).
- `test-join-plan.rb`, `test-lod-audit.rb`, `test-probe-join-keys.rb` -> all pass (no skill scripts modified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
