### PR TITLE
tableau: tile-grain ground-truth oracle, part A — derivation + execution + coverage ledger (PR-5)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/ground-truth-oracle.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/ground-truth-oracle.md
@@ -1,0 +1,95 @@
+# Tile-grain ground-truth oracle — part A: derivation + execution (PR-5)
+
+The PLAN-v3 centerpiece: an oracle that answers **"are the numbers right?"** by
+deriving, per parity-plan tile, the SQL that computes the tile's value straight
+from the warehouse — from the **source .twb signals**, never from the built
+workbook. A source that renders `##` becomes irrelevant: warehouse SQL doesn't
+render. Part A covers derivation + execution + the coverage ledger; the
+comparison against Sigma exports and the hard gate are **PR-6** (see forward
+pointer below).
+
+## Independence contract
+
+Ground-truth SQL derives from the .twb ONLY:
+
+- **zones** — `parse-twb-layout.rb` output (`dashboard-layout.json` +
+  `*-meta.json`): shelves, aggregations, worksheet filters, channels;
+- **the raw .twb** — datasource table/join specs (physical `<relation
+  type='join'>` AND the 2020.2+ relationship/object-graph model) and
+  datasource/extract-level filters;
+- **extracted calc formulas** — `calc-fields.json` (falling back to the layout
+  meta's `columns_by_guid` formulas).
+
+`scripts/lib/ground_truth_sql.rb` and its drivers import **nothing** from
+`build-charts-from-signals.rb` and read nothing from the built wb-spec — the
+oracle cannot share the builder's misreadings (test-enforced in
+`test-ground-truth-derive.rb`).
+
+**The documented common-mode residue:** a calc measure's SQL consumes the same
+extracted formula text the DM build translated. Every such dependency is
+recorded per tile in `provenance.calc_dependencies` (name + `formula_hash` +
+source artifact) so a translation bug is *traceable*; anchors
+(`refs/source-anchors.md`) remain the fully independent channel.
+
+## Classifications — the coverage ledger
+
+Every parity-plan chart gets **exactly one** entry in `ground-truth-plan.json`;
+nothing silently drops out (`summary.coverage_complete` asserts it):
+
+| classification | meaning | downstream |
+|---|---|---|
+| `warehouse-sql` | entry carries executable `SELECT <dims>, <AGG(measure)> FROM <.twb-joined tables> WHERE <worksheet + datasource filters> GROUP BY …` | `run-ground-truth.rb` executes it |
+| `vds` | the tile's value is a window/table calc (RUNNING_*, RANK, percent-of-total quick calc, …) — Tableau must compute it | the existing `scripts/vds-oracle.rb` path |
+| `anchor-only` | blends, LOD calcs, relationship models with non-unique related tables, IF/CASE calcs and filter kinds outside the mechanical SQL subset — with the **reason named** | rendered-source anchors carry the value bar |
+| `unverifiable(reason)` | no source zone matched / no measures / no resolvable warehouse table | named in the report; PR-6 will require a waiver |
+
+Derivation is deliberately conservative: it emits SQL only for constructs it
+can rewrite **mechanically** (plain aggregates, user-agg ratio calcs with a
+`NULLIF` divide-by-zero guard, `ZN`→`COALESCE`, `COUNTD`→`COUNT(DISTINCT …)`,
+member/range/wildcard filters, parameter defaults substituted and recorded in
+`provenance.parameters`). Anything it cannot prove, it refuses with a named
+reason — a fanned-out or guessed ground truth would be silently wrong, the
+exact failure class this oracle exists to catch. Relationship-model joins are
+derived only when every related table is unique-keyed (a LEFT JOIN to a unique
+key cannot change the fact grain); otherwise the tile is anchor-only rather
+than replicating Tableau's per-viz join culling.
+
+## Artifacts
+
+- `<WORK>/ground-truth-plan.json` — the ledger: per-tile classification, SQL,
+  per-tile provenance (zone/worksheet, dims, measures, which worksheet +
+  datasource filters fed the WHERE, calc dependencies, parameter values),
+  `generated_at`, and a `consumer` pointer.
+- `<WORK>/ground-truth-actuals.json` — per-entry execution results (`ok` rows,
+  `error`, `row-explosion`, `deadline-skipped`, `skipped-<classification>`),
+  stamped with `plan_generated_at` so PR-6 can bind actuals to the exact plan.
+
+## Running it
+
+```bash
+# 1. Derive the ledger (offline; after parse-twb-layout + auto-parity-plan):
+ruby scripts/derive-ground-truth.rb --workdir <WORK> \
+  [--twb <WORK>/workbook-content.twb] [--db <DB> --schema <SCHEMA>]
+
+# 2. Execute the warehouse-sql entries (same probe-workbook Custom SQL seam
+#    as probe-join-keys.rb — no new credential path):
+ruby scripts/run-ground-truth.rb --workdir <WORK> \
+  --connection-id <id> [--folder-id <id>] [--timeout 600] [--row-limit 5000]
+
+# offline tests: --fixture DIR with entry-<plan-index>.json canned results
+```
+
+Bounded-exports rules (PR #426 lessons): one **total** `--timeout` deadline for
+the run (per-entry progress lines; expiry → loud `[PARTIAL]`, exit 3, never a
+hang) and a `LIMIT`-guarded query per entry — ground truth is aggregated, so
+more than `--row-limit` rows means a missing/exploded GROUP BY and fails loud
+(`row-explosion`, exit 2).
+
+## PR-6 forward pointer
+
+Part B compares `ground-truth-actuals.json` against the tile's Sigma element
+export, stamps `numeric_parity` into `parity-final.json`, and adds the hard
+gate: **every displayed tile numeric-verified by ≥1 oracle or named-waived**.
+Contract: anchors = rendered-source truth, oracle = warehouse truth; divergence
+between them is FATAL-investigate, never auto-resolved. Part A intentionally
+wires **no** gate into `assert-phase6-ran.rb`.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-6-parity.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-6-parity.md
@@ -2,6 +2,8 @@
 
 ## Phase 6 — Verify chart data matches Tableau (MANDATORY — hard-gated)
 
+> **Tile-grain warehouse ground truth (PR-5 part A):** `scripts/derive-ground-truth.rb` + `scripts/run-ground-truth.rb` derive and execute per-tile ground-truth SQL from the .twb signals (independent of the builder) — see `refs/ground-truth-oracle.md`; the comparison + hard gate land in PR-6.
+
 > **A conversion is not complete until `scripts/assert-phase6-ran.rb` exits 0.** This is a *hard gate*, not a guideline. `phase6-parity.rb --finalize` writes `<WORK>/parity-final.json` as a sentinel; `assert-phase6-ran.rb` reads it and exits non-zero if Phase 6 was skipped, ran in extract-mode without permission, or failed parity. Subagent flows (cluster followers via `tableau-assessment`) MUST run the assertion as their final step before writing the result line — without it, an agent can silently skip Phase 6 entirely and self-report `charts_pass: 0, charts_total: 0` to slip past the GREEN check. See `beads-sigma-4pm` for the regression that motivated the gate.
 
 > **PUT returning `success: true` is not verification.** It only proves the spec parsed. Two recent customer-visible bugs reached the customer because Phase 6 was skipped: a window-function calc compiling silently as `error` and a pie chart wired to the wrong dimension. Compile-clean from `verify-workbook.rb` is also not parity verification — that only confirms each formula resolves, not that the numbers match.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/derive-ground-truth.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/derive-ground-truth.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# derive-ground-truth.rb — PR-5 part A driver: derive per-tile GROUND-TRUTH
+# warehouse SQL (or an honest classification) from the .twb signals, writing
+# the COVERAGE LEDGER <workdir>/ground-truth-plan.json.
+#
+# INDEPENDENCE: inputs are the SOURCE-side artifacts only — parity-plan.json
+# (the tile list), dashboard-layout.json + *-meta.json (parse-twb-layout
+# output), the raw .twb (join/table specs), calc-fields.json (extracted calc
+# formulas). NOTHING is read from the built wb-spec and nothing is imported
+# from build-charts-from-signals.rb — see scripts/lib/ground_truth_sql.rb.
+#
+# Every parity-plan chart gets EXACTLY ONE ledger entry classified
+# warehouse-sql | vds | anchor-only | unverifiable(reason). The classification
+# IS the coverage ledger; scripts/run-ground-truth.rb executes the
+# warehouse-sql entries; PR-6 (comparison + gate) consumes both artifacts —
+# this script wires NO gate.
+#
+# Usage:
+#   ruby scripts/derive-ground-truth.rb --workdir <WORK> \
+#     [--plan PATH]         # default <WORK>/parity-plan.json
+#     [--layout PATH]       # default <WORK>/dashboard-layout.json
+#     [--meta PATH]         # default <layout basename>-meta.json
+#     [--twb PATH]          # default <WORK>/workbook-content.twb
+#     [--calc-fields PATH]  # default <WORK>/calc-fields.json (optional input)
+#     [--db DB --schema S]  # complete published-VC table labels (join_plan rule)
+#     [--out PATH]          # default <WORK>/ground-truth-plan.json
+#
+# Exit codes: 0 = ledger written (all classifications are honest outcomes,
+#             including unverifiable); 2 = usage / missing required inputs.
+
+require 'json'
+require 'optparse'
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'ground_truth_sql'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')     { |v| opts[:dir] = v }
+  p.on('--plan PATH')       { |v| opts[:plan] = v }
+  p.on('--layout PATH')     { |v| opts[:layout] = v }
+  p.on('--meta PATH')       { |v| opts[:meta] = v }
+  p.on('--twb PATH')        { |v| opts[:twb] = v }
+  p.on('--calc-fields PATH') { |v| opts[:calc_fields] = v }
+  p.on('--db DB')           { |v| opts[:db] = v }
+  p.on('--schema SCHEMA')   { |v| opts[:schema] = v }
+  p.on('--out PATH')        { |v| opts[:out] = v }
+end.parse!
+unless opts[:dir] || (opts[:plan] && opts[:layout] && opts[:twb])
+  warn 'usage: derive-ground-truth.rb --workdir <WORK> [--plan P] [--layout P] [--twb P] [--calc-fields P] [--db D --schema S] [--out P]'
+  exit 2
+end
+
+dir         = opts[:dir]
+plan_path   = opts[:plan]   || File.join(dir, 'parity-plan.json')
+layout_path = opts[:layout] || File.join(dir, 'dashboard-layout.json')
+meta_path   = opts[:meta]   || layout_path.sub(/\.json\z/, '-meta.json')
+twb_path    = opts[:twb]    || File.join(dir, 'workbook-content.twb')
+cf_path     = opts[:calc_fields] || (dir && File.join(dir, 'calc-fields.json'))
+out_path    = opts[:out]    || File.join(dir || File.dirname(plan_path), 'ground-truth-plan.json')
+
+read_json = lambda do |path, required|
+  unless path && File.exist?(path)
+    if required
+      warn "FATAL: required input missing: #{path}"
+      exit 2
+    end
+    return nil
+  end
+  begin
+    JSON.parse(File.read(path))
+  rescue JSON::ParserError => e
+    warn "FATAL: #{path} is malformed JSON: #{e.message.lines.first.to_s.strip[0, 120]}"
+    exit 2
+  end
+end
+
+plan = read_json.call(plan_path, true)
+charts = plan.is_a?(Hash) ? Array(plan['charts']) : Array(plan)
+layout = read_json.call(layout_path, true)
+meta = read_json.call(meta_path, false) || {}
+calc_fields = read_json.call(cf_path, false)
+unless File.exist?(twb_path)
+  warn "FATAL: required input missing: #{twb_path} (the raw .twb is the join/table source of truth)"
+  exit 2
+end
+twb_xml = File.read(twb_path, encoding: 'UTF-8')
+
+doc = GroundTruthSql.derive(charts, layout, meta, twb_xml, calc_fields,
+                            db: opts[:db], schema: opts[:schema])
+doc['generated_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+doc['inputs'] = { 'plan' => plan_path, 'layout' => layout_path, 'meta' => meta_path,
+                  'twb' => twb_path, 'calc_fields' => calc_fields ? cf_path : nil }
+doc['independence_note'] =
+  'Derived from .twb signals only (zones + datasource joins/filters + extracted calc formulas); ' \
+  'never from the built wb-spec. Calc-formula dependencies are the documented common-mode ' \
+  'residue — recorded per tile in provenance.calc_dependencies.'
+doc['consumer'] = 'scripts/run-ground-truth.rb (execution) → PR-6 comparison gate (numeric_parity)'
+File.write(out_path, JSON.pretty_generate(doc))
+
+doc['entries'].each do |e|
+  tag = case e['classification']
+        when 'warehouse-sql' then 'SQL     '
+        when 'vds'           then 'VDS     '
+        when 'anchor-only'   then 'ANCHOR  '
+        else 'UNVERIF '
+        end
+  detail = e['classification'] == 'warehouse-sql' ? "#{Array(e['columns']).size} column(s)" : e['reason'].to_s[0, 110]
+  puts "  #{tag} #{e['chart'].to_s.inspect} — #{detail}"
+end
+s = doc['summary']
+puts "derive-ground-truth: #{s['tiles']} tile(s) — warehouse-sql #{s['warehouse_sql']}, " \
+     "vds #{s['vds']}, anchor-only #{s['anchor_only']}, unverifiable #{s['unverifiable']} → #{out_path}"
+warn "[WARN] coverage incomplete: #{s['tiles']} ledger entr(y/ies) for #{charts.size} plan chart(s)" unless s['coverage_complete']
+exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/ground_truth_sql.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/ground_truth_sql.rb
@@ -1,0 +1,889 @@
+# frozen_string_literal: true
+#
+# ground_truth_sql.rb — derive per-tile GROUND-TRUTH WAREHOUSE SQL from the
+# .twb signals (PR-5 part A, the PLAN-v3 centerpiece).
+#
+# INDEPENDENCE CONTRACT: everything here derives from the SOURCE workbook's
+# own signals — parse-twb-layout zones (shelves, aggregations, filters),
+# the .twb datasource join/table/filter specs, and the already-extracted calc
+# formulas (calc-fields.json / the layout meta sidecar). NOTHING is imported
+# from build-charts-from-signals.rb or read from the built wb-spec, so the
+# oracle cannot share the builder's misreadings. The one documented common-mode
+# residue is the calc-formula channel: a calc measure's SQL depends on the same
+# extracted formula text the DM build translated — every such dependency is
+# recorded per tile in provenance.calc_dependencies (name + formula_hash) so a
+# translation bug is traceable; anchors remain the fully independent channel.
+#
+# PER-TILE CLASSIFICATION — the coverage ledger. Every parity-plan chart gets
+# EXACTLY ONE entry with EXACTLY ONE classification; nothing silently drops out:
+#   warehouse-sql        entry carries executable SQL:
+#                          SELECT <dims>, <AGG(measure)> FROM <source tables
+#                          joined per the .twb join spec> WHERE <worksheet +
+#                          datasource/extract filters> GROUP BY <dims>
+#   vds                  the tile's value is a window/table calc — Tableau must
+#                          compute it (route to scripts/vds-oracle.rb, the
+#                          existing window-calc oracle path)
+#   anchor-only          blends / LOD / unsupported filter or calc constructs —
+#                          rendered-source anchors are the only value oracle
+#   unverifiable(reason) no source zone / no measures / no resolvable warehouse
+#                          table — nothing numeric to verify against
+#
+# Ruby 2.6-compatible, offline (no network). Parsing via lib/twb_xml.rb;
+# join/table FQN helpers reused from lib/join_plan.rb (the probe-side ledger
+# lib — NOT the builder).
+
+require 'json'
+require 'digest'
+require_relative 'twb_xml'
+require_relative 'join_plan'
+
+module GroundTruthSql
+  VERSION = 1
+  CLASSIFICATIONS = %w[warehouse-sql vds anchor-only unverifiable].freeze
+
+  # Window/table-calc constructs → the vds classification (the existing
+  # vds-oracle path executes the ORIGINAL formula server-side).
+  WINDOW_RE = /\b(?:RUNNING_(?:SUM|AVG|COUNT|MIN|MAX)|WINDOW_[A-Z]+|RANK(?:_DENSE|_UNIQUE|_MODIFIED|_COMPETITION|_PERCENTILE)?|INDEX|FIRST|LAST|SIZE|TOTAL|LOOKUP|PREVIOUS_VALUE)\s*\(/i
+  LOD_RE = /\{\s*(?:FIXED|INCLUDE|EXCLUDE)\b/i
+  # Row-level constructs with no warehouse equivalent (or session-dependent).
+  UNSUPPORTED_FN_RE = /\b(?:RAWSQL\w*|SCRIPT_\w+|USERNAME|USERDOMAIN|ISMEMBEROF|FULLNAME)\s*\(/i
+
+  # Aggregate + row-level function whitelist for the mechanical SQL rewrite.
+  # Anything OUTSIDE this set (IF/CASE/DATE fns/string fns/…) is refused —
+  # the tile classifies anchor-only rather than shipping guessed SQL.
+  AGG_FNS = %w[SUM AVG MIN MAX COUNT COUNTD MEDIAN].freeze
+  ROW_FNS = %w[ZN ABS ROUND].freeze
+  ALLOWED_WORDS = (AGG_FNS + ROW_FNS + %w[DISTINCT]).freeze
+
+  # Shelf derivation prefix → SQL aggregate (parse-twb-layout MEASURE_PREFIXES).
+  AGG_BY_DERIV = {
+    'sum' => 'SUM', 'avg' => 'AVG', 'min' => 'MIN', 'max' => 'MAX',
+    'count' => 'COUNT', 'cnt' => 'COUNT', 'countd' => 'COUNT(DISTINCT',
+    'ctd' => 'COUNT(DISTINCT', 'median' => 'MEDIAN'
+  }.freeze
+  # column-instance derivation attr (KPI marks-card measures) → same mapping.
+  AGG_BY_DERIVATION_ATTR = {
+    'sum' => 'SUM', 'avg' => 'AVG', 'average' => 'AVG', 'min' => 'MIN',
+    'max' => 'MAX', 'count' => 'COUNT', 'countd' => 'COUNT(DISTINCT',
+    'median' => 'MEDIAN'
+  }.freeze
+  # Window-calc quick-calc shelf prefixes (pcto/rtot) → vds.
+  VDS_DERIVS = %w[pcto rtot].freeze
+
+  # Date-TRUNC shelf prefixes → DATE_TRUNC part. Date-PART prefixes → extract
+  # function. Anything else date-shaped (mdy/md/qd/ymd …) is refused (honest).
+  TRUNC_PARTS = { 'tyr' => 'YEAR', 'tqr' => 'QUARTER', 'tmn' => 'MONTH',
+                  'twk' => 'WEEK', 'tdy' => 'DAY', 'thr' => 'HOUR',
+                  'yr' => 'YEAR', 'qr' => 'QUARTER', 'mn' => 'MONTH',
+                  'wk' => 'WEEK', 'dy' => 'DAY' }.freeze
+  # yr/qr/mn/wk/dy on a DISCRETE pill is Tableau's date-PART; on shelves the
+  # trunc form (tyr/tmn/…) is the continuous axis. Both map above: the trunc
+  # translation (DATE_TRUNC) also GROUPs identically for the part case within
+  # one year — close enough is NOT the bar here, so discrete date parts use
+  # the extract function instead:
+  PART_FNS = { 'yr' => 'YEAR', 'qr' => 'QUARTER', 'mn' => 'MONTH',
+               'wk' => 'WEEK', 'dy' => 'DAY' }.freeze
+
+  module_function
+
+  # ---------------------------------------------------------------------------
+  # .twb datasource graph: tables (name → FQN + columns), joins, worksheet →
+  # datasource dependencies. db/schema complete published-VC paren labels the
+  # same way join_plan.rb does.
+  # ---------------------------------------------------------------------------
+  def parse_twb(twb_xml, db: nil, schema: nil)
+    xml = twb_xml.to_s.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+    doc = TwbXml.parse(xml)
+    out = { 'datasources' => {}, 'worksheet_datasources' => {} }
+    doc.elements.each('/workbook/datasources/datasource') do |ds|
+      name = ds.attributes['name'].to_s
+      caption = (ds.attributes['caption'] || name).to_s
+      next if name == 'Parameters' || caption.start_with?('Parameter')
+
+      # 2020.2+ RELATIONSHIP model (object-graph): one <object> per logical
+      # table, <relationship> edges with key expressions. Parsed FIRST — its
+      # <relation type='table'> nodes must not masquerade as a physical join.
+      objects = []
+      ds.elements.each('.//object-graph/objects/object') do |obj|
+        rel = obj.elements[".//relation[@type='table']"]
+        next unless rel
+        tname = rel.attributes['name'].to_s
+        cols = []
+        rel.elements.each('columns/column') { |c| cols << c.attributes['name'].to_s }
+        objects << {
+          'id' => obj.attributes['id'].to_s,
+          'caption' => (obj.attributes['caption'] || tname).to_s,
+          'fqn' => JoinPlan.vc_physical_fqn(tname, db, schema) || JoinPlan.twb_table_fqn(doc, rel),
+          'columns' => cols
+        }
+      end
+      relationships = []
+      ds.elements.each('.//object-graph/relationships/relationship') do |r|
+        eq = r.elements["expression[@op='=']"]
+        sides = eq ? eq.elements.to_a('expression').map { |e| e.attributes['op'].to_s } : []
+        first = r.elements['first-end-point']
+        second = r.elements['second-end-point']
+        next unless first && second && sides.size == 2
+        relationships << { 'first' => first.attributes['object-id'].to_s,
+                           'second' => second.attributes['object-id'].to_s,
+                           'second_unique' => second.attributes['unique-key'].to_s == 'true',
+                           'lexpr' => sides[0], 'rexpr' => sides[1] }
+      end
+
+      tables = []
+      joins = []
+      custom_sql = nil
+      if objects.empty?
+        ds.elements.each(".//relation[@type='table']") do |rel|
+          tname = rel.attributes['name'].to_s
+          next if tables.any? { |t| t['name'] == tname }
+          cols = []
+          rel.elements.each('columns/column') { |c| cols << c.attributes['name'].to_s }
+          tables << {
+            'name' => tname,
+            'fqn'  => JoinPlan.vc_physical_fqn(tname, db, schema) || JoinPlan.twb_table_fqn(doc, rel),
+            'columns' => cols
+          }
+        end
+        ds.elements.each(".//relation[@type='text']") do |rel|
+          custom_sql ||= rel.texts.map(&:value).join.strip if rel.respond_to?(:texts)
+          custom_sql ||= rel.text.to_s.strip
+        end
+        ds.elements.each(".//relation[@type='join']") do |rel|
+          pairs = []
+          rel.elements.each("clause[@type='join']//expression[@op='=']") do |eq|
+            sides = eq.elements.to_a('expression').map { |e| JoinPlan.parse_side(e.attributes['op']) }.compact
+            pairs << { 'ltable' => sides[0][:table], 'lcol' => sides[0][:column],
+                       'rtable' => sides[1][:table], 'rcol' => sides[1][:column] } if sides.size == 2
+          end
+          next if pairs.empty?
+          joins << { 'join_type' => (rel.attributes['join'] || 'inner').to_s, 'pairs' => pairs }
+        end
+      end
+      out['datasources'][name] = { 'name' => name, 'caption' => caption,
+                                   'tables' => tables, 'joins' => joins,
+                                   'objects' => objects, 'relationships' => relationships,
+                                   'custom_sql' => custom_sql }
+    end
+    doc.elements.each('//worksheet') do |ws|
+      wname = ws.attributes['name'].to_s
+      next if wname.empty?
+      deps = []
+      ws.elements.each('.//datasource-dependencies') do |dd|
+        deps << dd.attributes['datasource'].to_s
+      end
+      ws.elements.each('.//view/datasources/datasource') do |d|
+        deps << d.attributes['name'].to_s
+      end
+      deps = deps.reject { |d| d.empty? || d == 'Parameters' }.uniq
+      out['worksheet_datasources'][wname] = deps
+    end
+    out
+  end
+
+  # ---------------------------------------------------------------------------
+  # Calc index: caption/internal-name → {name, formula, formula_hash, source}.
+  # calc-fields.json (the DM-build translation input) wins; the layout meta's
+  # columns_by_guid formulas fill gaps for calcs the scoped extraction dropped.
+  # ---------------------------------------------------------------------------
+  def calc_index(calc_fields, meta)
+    idx = {}
+    reg = lambda do |key, name, formula, source|
+      k = key.to_s.sub(/\A\[/, '').sub(/\]\z/, '')
+      return if k.empty? || formula.to_s.empty?
+      idx[k] ||= { 'name' => name.to_s, 'formula' => formula.to_s,
+                   'formula_hash' => Digest::SHA1.hexdigest(formula.to_s),
+                   'source' => source }
+    end
+    Array(calc_fields.is_a?(Hash) ? calc_fields['calcs'] : nil).each do |c|
+      next unless c.is_a?(Hash)
+      f = c['formula']
+      reg.call(c['name'], c['name'], f, 'calc-fields')
+      reg.call(c['internal_name'], c['name'] || c['internal_name'], f, 'calc-fields')
+    end
+    cbg = meta.is_a?(Hash) ? meta['columns_by_guid'] : nil
+    (cbg || {}).each do |guid, info|
+      next unless info.is_a?(Hash) && info['formula']
+      reg.call(guid, info['caption'] || guid, info['formula'], 'twb-meta')
+      reg.call(info['caption'], info['caption'], info['formula'], 'twb-meta')
+    end
+    idx
+  end
+
+  # Parameter defaults: caption AND internal name → {value, datatype}.
+  def param_index(meta)
+    idx = {}
+    Array(meta.is_a?(Hash) ? meta['parameters'] : nil).each do |p|
+      next unless p.is_a?(Hash)
+      rec = { 'value' => p['default_value'], 'datatype' => p['datatype'].to_s }
+      cap = p['caption'].to_s
+      nm  = p['name'].to_s.sub(/\A\[/, '').sub(/\]\z/, '')
+      idx[cap] = rec unless cap.empty?
+      idx[nm] ||= rec unless nm.empty?
+    end
+    idx
+  end
+
+  # ---------------------------------------------------------------------------
+  # SQL text helpers
+  # ---------------------------------------------------------------------------
+  def sql_string(v)
+    "'#{v.to_s.gsub("'", "''")}'"
+  end
+
+  def sql_literal(v, datatype)
+    case datatype.to_s
+    when 'integer', 'real' then v.to_s.strip
+    else sql_string(v)
+    end
+  end
+
+  def quote_alias(s)
+    %("#{s.to_s.gsub('"', '""')}")
+  end
+
+  # Find the matching close paren for the '(' at src[open]. Returns its index
+  # or nil (unbalanced). Quotes-aware enough for our whitelisted grammar.
+  def match_paren(src, open)
+    depth = 0
+    i = open
+    while i < src.length
+      case src[i]
+      when '(' then depth += 1
+      when ')'
+        depth -= 1
+        return i if depth.zero?
+      when "'"
+        j = src.index("'", i + 1)
+        return nil if j.nil?
+        i = j
+      end
+      i += 1
+    end
+    nil
+  end
+
+  # Rewrite every `FN(inner)` call via the block: `yield(inner) → replacement`.
+  def rewrite_calls(src, fn)
+    out = src.dup
+    loop do
+      m = out.match(/\b#{fn}\s*\(/i)
+      break unless m
+      open = m.end(0) - 1
+      close = match_paren(out, open)
+      return nil if close.nil?
+      inner = out[(open + 1)...close]
+      out = out[0...m.begin(0)] + yield(inner) + out[(close + 1)..-1]
+    end
+    out
+  end
+
+  # Wrap aggregate denominators in NULLIF(x, 0): Tableau division by zero
+  # yields NULL; unwrapped SQL would error the whole ground-truth query.
+  def nullif_denominators(sql)
+    out = sql.dup
+    i = 0
+    while (slash = out.index('/', i))
+      rest = out[(slash + 1)..-1]
+      m = rest.match(/\A\s*(SUM|AVG|MIN|MAX|COUNT|MEDIAN|COALESCE)\s*\(/i)
+      unless m
+        i = slash + 1
+        next
+      end
+      open = slash + 1 + m.end(0) - 1
+      close = match_paren(out, open)
+      return sql if close.nil?
+      call = out[(slash + 1)...(close + 1)]
+      lead = call[/\A\s*/]
+      repl = "#{lead}NULLIF(#{call.strip}, 0)"
+      out = out[0...(slash + 1)] + repl + out[(close + 1)..-1]
+      i = slash + 1 + repl.length
+    end
+    out
+  end
+
+  # ---------------------------------------------------------------------------
+  # Formula → SQL expression translation (mechanical, whitelisted — refuses
+  # anything it cannot rewrite verbatim instead of guessing).
+  # Returns { 'status' => 'ok', 'sql' =>, 'deps' =>, 'params_used' => }
+  #      or { 'status' => 'vds' | 'lod' | 'unsupported', 'reason' => }.
+  # ctx: { 'calcs' =>, 'params' =>, 'resolve_col' => lambda(name)→sql|nil }
+  def translate_formula(formula, ctx, depth = 0)
+    f = formula.to_s.gsub(%r{//[^\n]*}, ' ').strip
+    return { 'status' => 'unsupported', 'reason' => 'empty formula' } if f.empty?
+    return { 'status' => 'vds', 'reason' => 'window/table-calc function' } if f =~ WINDOW_RE
+    return { 'status' => 'lod', 'reason' => 'LOD expression ({FIXED/INCLUDE/EXCLUDE})' } if f =~ LOD_RE
+    if (m = f.match(UNSUPPORTED_FN_RE))
+      return { 'status' => 'unsupported', 'reason' => "#{m[0].sub(/\($/, '').strip}() has no warehouse equivalent" }
+    end
+    return { 'status' => 'unsupported', 'reason' => 'calc references nest too deep (>3 levels)' } if depth > 3
+
+    deps = []
+    params_used = {}
+
+    # [Parameters].[X] → the parameter's CURRENT DEFAULT value (recorded).
+    f = f.gsub(/\[Parameters?(?:\s*\([^)]*\))?\]\s*\.\s*\[([^\]]+)\]/i) do
+      pname = Regexp.last_match(1)
+      p = ctx['params'][pname]
+      return { 'status' => 'unsupported', 'reason' => "parameter #{pname.inspect} has no recorded default value" } if p.nil?
+      params_used[pname] = p['value']
+      sql_literal(p['value'], p['datatype'])
+    end
+
+    # Whitelist check on every bare identifier OUTSIDE brackets/strings.
+    masked = f.gsub(/\[[^\]]*\]/, ' ').gsub(/'[^']*'/, ' ')
+    masked.scan(/[A-Za-z_][A-Za-z0-9_]*/).each do |word|
+      next if ALLOWED_WORDS.include?(word.upcase)
+      return { 'status' => 'unsupported',
+               'reason' => "function/keyword #{word.inspect} is outside the mechanical SQL subset" }
+    end
+
+    # Bracket refs: parameter (bare caption) → literal; calc → recurse
+    # (dependency recorded); else physical column via the resolver.
+    sql = f.gsub(/\[([^\]]+)\]/) do
+      name = Regexp.last_match(1)
+      if (p = ctx['params'][name])
+        params_used[name] = p['value']
+        next sql_literal(p['value'], p['datatype'])
+      end
+      if (calc = ctx['calcs'][name])
+        inner = translate_formula(calc['formula'], ctx, depth + 1)
+        return inner unless inner['status'] == 'ok'
+        deps << calc
+        deps.concat(inner['deps'])
+        params_used.merge!(inner['params_used'])
+        next "(#{inner['sql']})"
+      end
+      col = ctx['resolve_col'].call(name)
+      return { 'status' => 'unsupported', 'reason' => "field #{name.inspect} does not resolve to a warehouse column" } if col.nil?
+      col
+    end
+
+    sql = rewrite_calls(sql, 'COUNTD') { |inner| "COUNT(DISTINCT #{inner.strip})" }
+    return { 'status' => 'unsupported', 'reason' => 'unbalanced parentheses (COUNTD)' } if sql.nil?
+    sql = rewrite_calls(sql, 'ZN') { |inner| "COALESCE(#{inner.strip}, 0)" }
+    return { 'status' => 'unsupported', 'reason' => 'unbalanced parentheses (ZN)' } if sql.nil?
+    sql = nullif_denominators(sql)
+
+    { 'status' => 'ok', 'sql' => sql.strip, 'deps' => deps, 'params_used' => params_used }
+  end
+
+  def contains_aggregate?(sql)
+    !!(sql =~ /\b(?:SUM|AVG|MIN|MAX|COUNT|MEDIAN)\s*\(/i)
+  end
+
+  # ---------------------------------------------------------------------------
+  # FROM clause per the .twb join spec. Tables get positional aliases (T1…Tn);
+  # returns { 'sql' =>, 'aliases' => {table name → alias}, 'joined' => [...] }
+  # or { 'error' => reason [, 'anchor_only' => true] }.
+  # meta supplies columns_by_guid for relationship-model key resolution.
+  # ---------------------------------------------------------------------------
+  def build_from(ds, meta = {})
+    return build_from_relationships(ds, meta) unless Array(ds['objects']).empty?
+    tables = ds['tables'] || []
+    if tables.empty?
+      sql = ds['custom_sql'].to_s
+      return { 'error' => 'no warehouse table (or Custom SQL statement) resolvable from the .twb datasource' } if sql.empty?
+      return { 'sql' => "FROM (#{sql}) T1", 'aliases' => {}, 'joined' => ['(custom sql)'] }
+    end
+    missing = tables.select { |t| t['fqn'].to_s.empty? }
+    unless missing.empty?
+      return { 'error' => "table(s) without a resolvable warehouse FQN: #{missing.map { |t| t['name'] }.join(', ')}" }
+    end
+    aliases = {}
+    tables.each_with_index { |t, i| aliases[t['name']] = "T#{i + 1}" }
+    joins = ds['joins'] || []
+    if joins.empty? && tables.size > 1
+      return { 'error' => "#{tables.size} tables but no parseable join clause in the .twb" }
+    end
+    first = tables.first
+    lines = ["FROM #{first['fqn']} #{aliases[first['name']]}"]
+    joined = [first['name']]
+    joins.each do |j|
+      pairs = j['pairs'].select { |p| aliases[p['ltable']] && aliases[p['rtable']] }
+      return { 'error' => 'join clause references an unknown table' } if pairs.empty?
+      # The table not yet in the FROM chain is the one this join introduces.
+      new_side = pairs.first['rtable']
+      new_side = pairs.first['ltable'] unless joined.include?(pairs.first['ltable'])
+      next if joined.include?(new_side)
+      t = tables.find { |x| x['name'] == new_side }
+      kw = case j['join_type']
+           when 'left' then 'LEFT JOIN'
+           when 'right' then 'RIGHT JOIN'
+           when 'full' then 'FULL OUTER JOIN'
+           else 'JOIN'
+           end
+      on = pairs.map do |p|
+        "#{aliases[p['ltable']]}.#{p['lcol']} = #{aliases[p['rtable']]}.#{p['rcol']}"
+      end.join(' AND ')
+      lines << "  #{kw} #{t['fqn']} #{aliases[new_side]} ON #{on}"
+      joined << new_side
+    end
+    { 'sql' => lines.join("\n"), 'aliases' => aliases, 'joined' => joined }
+  end
+
+  # RELATIONSHIP (object-graph) model: FROM the first end-point of the first
+  # relationship, LEFT JOIN each related object — but ONLY when every second
+  # end-point is unique-keyed. A LEFT JOIN on equality to a UNIQUE key cannot
+  # change the fact grain, so joining all related tables is fan-out-safe
+  # without replicating Tableau's per-viz join culling. Any non-unique related
+  # table → refuse (anchor_only): a fanned-out ground truth would be silently
+  # wrong — the exact failure class this oracle exists to catch.
+  def build_from_relationships(ds, meta)
+    objects = ds['objects']
+    rels = ds['relationships'] || []
+    return { 'error' => 'relationship model with no relationship edges parseable', 'anchor_only' => true } if rels.empty?
+    nonuniq = rels.reject { |r| r['second_unique'] }
+    unless nonuniq.empty?
+      return { 'error' => "relationship (object-graph) model: #{nonuniq.size} related table(s) not " \
+                          'unique-keyed — per-viz join culling not derivable in part A (fan-out risk)',
+               'anchor_only' => true }
+    end
+    missing = objects.select { |o| o['fqn'].to_s.empty? }
+    unless missing.empty?
+      return { 'error' => "object(s) without a resolvable warehouse FQN: #{missing.map { |o| o['caption'] }.join(', ')}" }
+    end
+    by_id = {}
+    aliases = {}
+    objects.each_with_index do |o, i|
+      by_id[o['id']] = o
+      a = "T#{i + 1}"
+      aliases[o['id']] = a
+      aliases[o['caption']] ||= a
+    end
+    cbg = meta.is_a?(Hash) ? (meta['columns_by_guid'] || {}) : {}
+    key_sql = lambda do |expr, al|
+      s = expr.to_s
+      resolved = true
+      sql = s.gsub(/\[([^\]]+)\]/) do
+        ref = Regexp.last_match(1).sub(/\s+\([^\]]*\)\z/, '') # '<guid> (DUP TABLE)' → guid
+        info = cbg[ref]
+        if info && info['caption']
+          "#{al}.#{JoinPlan.physical_name(info['caption'])}"
+        elsif ref =~ /\A[0-9A-Fa-f-]{20,}\z/
+          resolved = false
+          ref
+        else
+          "#{al}.#{JoinPlan.physical_name(ref)}"
+        end
+      end
+      resolved ? sql : nil
+    end
+    root_id = rels.first['first']
+    root = by_id[root_id]
+    return { 'error' => 'relationship root object unresolvable' } if root.nil?
+    lines = ["FROM #{root['fqn']} #{aliases[root_id]}"]
+    joined = [root_id]
+    rels.each do |r|
+      next if joined.include?(r['second'])
+      unless joined.include?(r['first'])
+        return { 'error' => "relationship chain does not start at #{by_id[r['first']] ? by_id[r['first']]['caption'] : r['first']}" }
+      end
+      o = by_id[r['second']]
+      return { 'error' => 'relationship references an unknown object' } if o.nil?
+      l = key_sql.call(r['lexpr'], aliases[r['first']])
+      rr = key_sql.call(r['rexpr'], aliases[r['second']])
+      if l.nil? || rr.nil?
+        return { 'error' => "relationship key column unresolvable (no caption for the field GUID in the .twb)",
+                 'anchor_only' => true }
+      end
+      lines << "  LEFT JOIN #{o['fqn']} #{aliases[r['second']]} ON #{l} = #{rr}"
+      joined << r['second']
+    end
+    { 'sql' => lines.join("\n"), 'aliases' => aliases, 'joined' => joined.map { |id| by_id[id]['caption'] } }
+  end
+
+  # Column resolver for one datasource: physical name (or renamed
+  # 'COL (TABLE)' cross-table form) → alias-qualified SQL identifier.
+  def column_resolver(ds, aliases)
+    named = (ds['tables'] || []).map { |t| { 'key' => t['name'], 'columns' => t['columns'] } } +
+            Array(ds['objects']).map { |o| { 'key' => o['caption'], 'columns' => o['columns'] } }
+    owners = {}
+    named.each do |t|
+      (t['columns'] || []).each { |c| (owners[c] ||= []) << t['key'] }
+    end
+    lambda do |name|
+      n = name.to_s.strip
+      table_hint = nil
+      if (m = n.match(/\A(.+?)\s+\(([^()]+)\)\z/))
+        # Tableau's cross-table rename: 'REGION (REGION_DIM)'.
+        cand_t = named.find { |t| t['key'] == m[2] || t['key'].start_with?("#{m[2]} (") }
+        if cand_t
+          table_hint = cand_t['key']
+          n = m[1]
+        end
+      end
+      col = JoinPlan.physical_name(n)
+      own = owners[col] || owners[n]
+      tbl = table_hint || (own && own.size == 1 ? own.first : nil)
+      tbl ||= own.first if own && own.include?((named.first || {})['key'])
+      if tbl && aliases[tbl]
+        "#{aliases[tbl]}.#{col}"
+      elsif own && own.first && aliases[own.first]
+        "#{aliases[own.first]}.#{col}"
+      else
+        col # no (or ambiguous) column metadata — emit unqualified; the
+        #     warehouse errors loudly on a genuinely ambiguous name
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Filters → WHERE clauses.
+  # Returns { 'sql' =>, 'skip' => reason } (one of), or { 'error' => reason }
+  # when the filter kind cannot be expressed (→ anchor-only).
+  # ---------------------------------------------------------------------------
+  def filter_clause(fi, ctx)
+    return { 'skip' => 'action filter (dashboard interaction; default state applies no filter)' } if fi['kind'] == 'action' || fi['is_action']
+    target = fi['column_caption'].to_s
+    target = fi['column_guid'].to_s if target.empty?
+    return { 'error' => 'filter target column unresolvable' } if target.empty?
+    col =
+      if (calc = ctx['calcs'][target])
+        t = translate_formula(calc['formula'], ctx)
+        return { 'error' => "filter on calc #{target.inspect}: #{t['reason'] || t['status']}" } unless t['status'] == 'ok'
+        return { 'error' => "filter on aggregate calc #{target.inspect} (HAVING semantics not derivable)" } if contains_aggregate?(t['sql'])
+        (ctx['filter_deps'] ||= []).concat([calc] + t['deps'])
+        "(#{t['sql']})"
+      else
+        ctx['resolve_col'].call(target)
+      end
+    return { 'error' => "filter column #{target.inspect} does not resolve to a warehouse column" } if col.nil?
+
+    case fi['kind']
+    when 'list'
+      return { 'error' => "native top-N filter on #{target.inspect} (rank semantics not derivable in v1)" } if fi['topn']
+      unless Array(fi['condition_expressions']).empty?
+        return { 'error' => "condition-expression filter on #{target.inspect} (not derivable in v1)" }
+      end
+      members = Array(fi['members'])
+      if members.empty?
+        return { 'skip' => "categorical filter on #{target.inspect} enumerates no members (Tableau 'All')" } unless fi['exclude']
+        return { 'skip' => "exclude filter on #{target.inspect} excludes nothing" } if !fi['excludes_null']
+        return { 'sql' => "#{col} IS NOT NULL" }
+      end
+      lits = members.map { |v| sql_literal(v, fi['datatype']) }.join(', ')
+      if fi['exclude']
+        sql = "#{col} NOT IN (#{lits})"
+        sql += " AND #{col} IS NOT NULL" if fi['excludes_null']
+        { 'sql' => sql }
+      else
+        { 'sql' => "#{col} IN (#{lits})" }
+      end
+    when 'wildcard'
+      wc = fi['wildcard']
+      return { 'error' => "unparseable wildcard filter on #{target.inspect}" } unless wc.is_a?(Hash)
+      pat = wc['pattern'].to_s.gsub("'", "''")
+      like = { 'contains' => "%#{pat}%", 'starts-with' => "#{pat}%", 'ends-with' => "%#{pat}" }
+      mode = wc['mode'].to_s
+      base = mode.sub(/\Adoes-not-(?:start-with|end-with|contain)\z/) do |x|
+        x.sub('does-not-', '').sub('contain', 'contains')
+      end
+      p = like[base]
+      return { 'error' => "wildcard mode #{mode.inspect} not derivable" } if p.nil?
+      neg = mode.start_with?('does-not-')
+      { 'sql' => "#{col} #{neg ? 'NOT ' : ''}LIKE '#{p}'" }
+    when 'number-range'
+      parts = []
+      parts << "#{col} >= #{fi['min']}" if fi['min']
+      parts << "#{col} <= #{fi['max']}" if fi['max']
+      return { 'skip' => "quantitative filter on #{target.inspect} carries no bounds" } if parts.empty?
+      { 'sql' => parts.join(' AND ') }
+    when 'relative-date'
+      { 'error' => "relative-date filter on #{target.inspect} (anchor 'today' not reproducible in v1)" }
+    else
+      { 'error' => "filter kind #{fi['kind'].inspect} on #{target.inspect} not derivable" }
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shelf → dims / measures.
+  # ---------------------------------------------------------------------------
+  def shelf_fields(zone)
+    rows = (zone['rows_shelf'] || {})['fields'] || []
+    cols = (zone['cols_shelf'] || {})['fields'] || []
+    # color channel: a dim on the color shelf adds a grouping level.
+    chans = []
+    ch = (zone['channels'] || {})['color']
+    if ch.is_a?(Hash)
+      raw = ch['column'] || ch[:column]
+      chans << { 'raw' => raw.to_s, 'role' => 'dim', 'derivation' => nil,
+                 'guid' => shelf_guid(raw.to_s) } unless raw.to_s.empty?
+    end
+    cols + rows + chans
+  end
+
+  # `[federated.X].[none:NAME:nk]` / `[NAME]` → NAME (same shapes
+  # parse-twb-layout's guid_from_param resolves; local copy keeps this module
+  # layout-parser-independent at runtime).
+  def shelf_guid(raw)
+    m = raw.to_s.match(%r{\.\[(?:[a-z\-]+:)?([0-9a-f\-]{36}|Calculation_\d+|[A-Za-z_][\w. ()/&-]*)(?::[a-z]+\d*)?\]\z}i)
+    return m[1] if m
+    m = raw.to_s.match(%r{\A\[(?:[a-z\-]+:)?([0-9a-f\-]{36}|Calculation_\d+|[A-Za-z_][\w. ()/&-]*)(?::[a-z]+\d*)?\]\z}i)
+    m && m[1]
+  end
+
+  def caption_for(guid, meta)
+    info = meta.is_a?(Hash) ? (meta['columns_by_guid'] || {})[guid] : nil
+    (info && info['caption']) || guid
+  end
+
+  # ---------------------------------------------------------------------------
+  # Per-tile derivation. Returns the ledger entry.
+  # ---------------------------------------------------------------------------
+  def derive_tile(chart, zone, twb, meta, calcs, params, dash_name)
+    entry = {
+      'chart' => chart['chart'] || chart['name'],
+      'tableau_view' => chart['tableau_view'] || zone && zone['caption'],
+      'sigma_element_id' => chart['sigma_element_id'],
+      'classification' => nil, 'reason' => nil, 'sql' => nil, 'columns' => nil,
+      'provenance' => { 'dashboard' => dash_name, 'zone_id' => zone && zone['id'],
+                        'worksheet' => zone && zone['caption'], 'datasource' => nil,
+                        'dims' => [], 'measures' => [], 'filters' => [],
+                        'filters_skipped' => [], 'calc_dependencies' => [],
+                        'parameters' => {} }
+    }
+    classify = lambda do |cls, reason = nil|
+      entry['classification'] = cls
+      entry['reason'] = reason
+      entry
+    end
+    return classify.call('unverifiable', 'no source dashboard zone/worksheet matched this tile') if zone.nil?
+
+    ws = zone['caption'].to_s
+    ds_names = (twb['worksheet_datasources'] || {})[ws] || []
+    return classify.call('anchor-only', "data blend: worksheet depends on #{ds_names.size} datasources (#{ds_names.join(', ')})") if ds_names.size > 1
+    ds = twb['datasources'][ds_names.first] || twb['datasources'].values.first
+    return classify.call('unverifiable', 'no datasource resolvable for the worksheet') if ds.nil?
+    entry['provenance']['datasource'] = ds['caption']
+
+    # FROM derives up front (the resolver wants its aliases), but a FROM error
+    # is only classified AFTER the shelf walk — a window-calc tile on an
+    # underivable datasource is still `vds` (Tableau computes it), not
+    # anchor-only/unverifiable.
+    from = build_from(ds, meta)
+    resolve_col = column_resolver(ds, from['aliases'] || {})
+    ctx = { 'calcs' => calcs, 'params' => params, 'resolve_col' => resolve_col }
+    from_fail = lambda do
+      classify.call(from['anchor_only'] ? 'anchor-only' : 'unverifiable', from['error'])
+    end
+
+    # vds short-circuit: quick-calc window pills (pcto/rtot) on the tile.
+    if Array(zone['quick_calc_pcto']).any?
+      return classify.call('vds', 'percent-of-total quick calc on the marks card — Tableau computes it (vds-oracle path)')
+    end
+
+    fields = shelf_fields(zone)
+    dims = []
+    measures = []
+    calc_deps = []
+    params_used = {}
+
+    add_dep = lambda do |dep_list|
+      dep_list.each do |d|
+        calc_deps << { 'name' => d['name'], 'formula_hash' => d['formula_hash'], 'source' => d['source'] } \
+          unless calc_deps.any? { |x| x['formula_hash'] == d['formula_hash'] }
+      end
+    end
+
+    fields.each do |fld|
+      guid = fld['guid'] || shelf_guid(fld['raw'])
+      next if fld['role'] == 'measure-names'
+      next if guid.nil? && fld['role'] != 'measure-names'
+      cap = caption_for(guid, meta)
+      # A dim already grouped (e.g. the color-channel copy of a shelf dim) adds nothing.
+      next if fld['role'] == 'dim' && dims.any? { |d| d['alias'] == cap || d['alias'].to_s.start_with?("#{cap} (") }
+      if fld['role'] == 'dim'
+        deriv = fld['derivation'].to_s
+        if (calc = calcs[guid.to_s] || calcs[cap.to_s])
+          t = translate_formula(calc['formula'], ctx)
+          return classify.call('vds', "dimension calc #{cap.inspect} is a window/table calc") if t['status'] == 'vds'
+          unless t['status'] == 'ok'
+            return classify.call('anchor-only', "dimension #{cap.inspect}: #{t['reason'] || t['status']}")
+          end
+          return classify.call('anchor-only', "dimension calc #{cap.inspect} aggregates (not a row-level grouping)") if contains_aggregate?(t['sql'])
+          add_dep.call([calc] + t['deps'])
+          params_used.merge!(t['params_used'])
+          dims << { 'raw' => fld['raw'], 'sql' => "(#{t['sql']})", 'alias' => cap }
+        elsif deriv.empty? || deriv == 'none'
+          col = resolve_col.call(cap)
+          return classify.call('anchor-only', "dimension #{cap.inspect} does not resolve to a warehouse column") if col.nil?
+          dims << { 'raw' => fld['raw'], 'sql' => col, 'alias' => cap }
+        elsif TRUNC_PARTS[deriv]
+          col = resolve_col.call(cap)
+          return classify.call('anchor-only', "date dimension #{cap.inspect} does not resolve to a warehouse column") if col.nil?
+          if deriv.start_with?('t')
+            dims << { 'raw' => fld['raw'], 'sql' => "DATE_TRUNC('#{TRUNC_PARTS[deriv]}', #{col})",
+                      'alias' => "#{cap} (#{TRUNC_PARTS[deriv].downcase})" }
+          else
+            dims << { 'raw' => fld['raw'], 'sql' => "#{PART_FNS[deriv]}(#{col})",
+                      'alias' => "#{cap} (#{PART_FNS[deriv].downcase} part)" }
+          end
+        else
+          return classify.call('anchor-only', "dimension derivation #{deriv.inspect} on #{cap.inspect} not derivable")
+        end
+      elsif fld['role'] == 'measure'
+        deriv = fld['derivation'].to_s.downcase
+        return classify.call('vds', "shelf quick-calc #{deriv.inspect} on #{cap.inspect} — Tableau computes it (vds-oracle path)") if VDS_DERIVS.include?(deriv)
+        if %w[usr user].include?(deriv)
+          calc = calcs[guid.to_s] || calcs[cap.to_s]
+          return classify.call('anchor-only', "user-aggregated measure #{cap.inspect} has no recorded formula") if calc.nil?
+          t = translate_formula(calc['formula'], ctx)
+          return classify.call('vds', "measure #{cap.inspect} is a window/table calc — Tableau computes it (vds-oracle path)") if t['status'] == 'vds'
+          return classify.call('anchor-only', "measure #{cap.inspect}: #{t['reason'] || t['status']}") unless t['status'] == 'ok'
+          sql = t['sql']
+          sql = "SUM(#{sql})" unless contains_aggregate?(sql) # row-level calc summed by Tableau's default
+          add_dep.call([calc] + t['deps'])
+          params_used.merge!(t['params_used'])
+          measures << { 'raw' => fld['raw'], 'agg' => 'usr', 'sql' => sql, 'alias' => cap }
+        elsif AGG_BY_DERIV[deriv]
+          if (calc = calcs[guid.to_s] || calcs[cap.to_s])
+            t = translate_formula(calc['formula'], ctx)
+            return classify.call('vds', "measure calc #{cap.inspect} is a window/table calc") if t['status'] == 'vds'
+            return classify.call('anchor-only', "measure #{cap.inspect}: #{t['reason'] || t['status']}") unless t['status'] == 'ok'
+            return classify.call('anchor-only', "aggregate-of-aggregate on #{cap.inspect} not derivable") if contains_aggregate?(t['sql'])
+            add_dep.call([calc] + t['deps'])
+            params_used.merge!(t['params_used'])
+            inner = "(#{t['sql']})"
+          else
+            inner = resolve_col.call(cap)
+            return classify.call('anchor-only', "measure #{cap.inspect} does not resolve to a warehouse column") if inner.nil?
+          end
+          agg = AGG_BY_DERIV[deriv]
+          sql = agg.end_with?('(DISTINCT') ? "#{agg} #{inner})" : "#{agg}(#{inner})"
+          measures << { 'raw' => fld['raw'], 'agg' => deriv, 'sql' => sql, 'alias' => "#{cap} (#{deriv})" }
+        else
+          return classify.call('anchor-only', "aggregation #{deriv.inspect} on #{cap.inspect} not derivable (ATTR/stdev/var family)")
+        end
+      end
+    end
+
+    # KPI / marks-card measures (empty shelves): the worksheet's
+    # column-instance measures list.
+    if measures.empty?
+      Array(zone['measures']).each do |mz|
+        guid = shelf_guid(mz['column'])
+        next if guid.nil?
+        cap = caption_for(guid, meta)
+        d = mz['derivation'].to_s.downcase
+        if %w[user usr].include?(d)
+          calc = calcs[guid.to_s] || calcs[cap.to_s]
+          return classify.call('anchor-only', "user-aggregated measure #{cap.inspect} has no recorded formula") if calc.nil?
+          t = translate_formula(calc['formula'], ctx)
+          return classify.call('vds', "measure #{cap.inspect} is a window/table calc — Tableau computes it (vds-oracle path)") if t['status'] == 'vds'
+          return classify.call('anchor-only', "measure #{cap.inspect}: #{t['reason'] || t['status']}") unless t['status'] == 'ok'
+          sql = t['sql']
+          sql = "SUM(#{sql})" unless contains_aggregate?(sql)
+          add_dep.call([calc] + t['deps'])
+          params_used.merge!(t['params_used'])
+          measures << { 'raw' => mz['column'], 'agg' => 'usr', 'sql' => sql, 'alias' => cap }
+        elsif AGG_BY_DERIVATION_ATTR[d]
+          inner = resolve_col.call(cap)
+          return classify.call('anchor-only', "measure #{cap.inspect} does not resolve to a warehouse column") if inner.nil?
+          agg = AGG_BY_DERIVATION_ATTR[d]
+          sql = agg.end_with?('(DISTINCT') ? "#{agg} #{inner})" : "#{agg}(#{inner})"
+          measures << { 'raw' => mz['column'], 'agg' => d, 'sql' => sql, 'alias' => "#{cap} (#{d})" }
+        else
+          return classify.call('anchor-only', "measure derivation #{mz['derivation'].inspect} on #{cap.inspect} not derivable")
+        end
+      end
+    end
+
+    return from_fail.call if from['error']
+    return classify.call('unverifiable', 'no measures derivable from the worksheet shelves/marks card') if measures.empty?
+
+    # Filters: worksheet-level, then datasource/extract-level (post-#414 parse).
+    where = []
+    ctx['filter_deps'] = []
+    Array(zone['filters']).each do |fi|
+      r = filter_clause(fi, ctx)
+      return classify.call('anchor-only', r['error']) if r['error']
+      if r['skip']
+        entry['provenance']['filters_skipped'] << { 'column' => fi['column_caption'] || fi['column_guid'],
+                                                    'source' => 'worksheet', 'reason' => r['skip'] }
+      else
+        where << r['sql']
+        entry['provenance']['filters'] << { 'column' => fi['column_caption'] || fi['column_guid'],
+                                            'source' => 'worksheet', 'kind' => fi['kind'], 'sql' => r['sql'] }
+      end
+    end
+    ds_label = ds['caption'].to_s
+    ds_name = ds['name'].to_s
+    Array(meta.is_a?(Hash) ? meta['datasource_filters'] : nil).each do |fi|
+      next unless [fi['datasource'].to_s, fi['datasource_name'].to_s].include?(ds_label) ||
+                  [fi['datasource'].to_s, fi['datasource_name'].to_s].include?(ds_name)
+      r = filter_clause(fi, ctx)
+      return classify.call('anchor-only', "datasource filter: #{r['error']}") if r['error']
+      if r['skip']
+        entry['provenance']['filters_skipped'] << { 'column' => fi['column_caption'] || fi['column_guid'],
+                                                    'source' => fi['filter_scope'] || 'datasource', 'reason' => r['skip'] }
+      else
+        where << r['sql']
+        entry['provenance']['filters'] << { 'column' => fi['column_caption'] || fi['column_guid'],
+                                            'source' => fi['filter_scope'] || 'datasource',
+                                            'kind' => fi['kind'], 'sql' => r['sql'] }
+      end
+    end
+    add_dep.call(ctx['filter_deps'])
+
+    # Assemble.
+    select_parts = dims.map { |d| "#{d['sql']} AS #{quote_alias(d['alias'])}" } +
+                   measures.map { |m| "#{m['sql']} AS #{quote_alias(m['alias'])}" }
+    sql_lines = ["SELECT #{select_parts.join(",\n       ")}", from['sql']]
+    sql_lines << "WHERE #{where.join("\n  AND ")}" unless where.empty?
+    unless dims.empty?
+      pos = (1..dims.size).to_a.join(', ')
+      sql_lines << "GROUP BY #{pos}"
+      sql_lines << "ORDER BY #{pos}"
+    end
+    entry['sql'] = sql_lines.join("\n")
+    entry['columns'] = dims.map { |d| { 'alias' => d['alias'], 'role' => 'dim' } } +
+                       measures.map { |m| { 'alias' => m['alias'], 'role' => 'measure' } }
+    entry['provenance']['dims'] = dims
+    entry['provenance']['measures'] = measures
+    entry['provenance']['calc_dependencies'] = calc_deps
+    entry['provenance']['parameters'] = params_used
+    classify.call('warehouse-sql')
+  end
+
+  # ---------------------------------------------------------------------------
+  # Whole-plan derivation. charts = parity-plan charts array; dashboards =
+  # dashboard-layout.json array; meta = *-meta.json Hash; twb_xml = raw .twb
+  # text; calc_fields = calc-fields.json Hash (or nil).
+  # ---------------------------------------------------------------------------
+  def derive(charts, dashboards, meta, twb_xml, calc_fields, db: nil, schema: nil)
+    twb = parse_twb(twb_xml, db: db, schema: schema)
+    calcs = calc_index(calc_fields, meta)
+    params = param_index(meta)
+
+    zones_by_caption = {}
+    Array(dashboards).each do |d|
+      Array(d['zones']).each do |z|
+        next unless z['kind'] == 'chart' && z['caption']
+        zones_by_caption[z['caption'].to_s] ||= [d['dashboard'], z]
+        zones_by_caption[z['caption'].to_s.downcase] ||= [d['dashboard'], z]
+      end
+    end
+
+    entries = Array(charts).map do |c|
+      view = (c['tableau_view'] || c['chart'] || c['name']).to_s
+      dash, zone = zones_by_caption[view] || zones_by_caption[view.downcase]
+      derive_tile(c, zone, twb, meta, calcs, params, dash)
+    end
+
+    counts = Hash.new(0)
+    entries.each { |e| counts[e['classification']] += 1 }
+    {
+      'version' => VERSION,
+      'entries' => entries,
+      'summary' => {
+        'tiles' => entries.size,
+        'warehouse_sql' => counts['warehouse-sql'],
+        'vds' => counts['vds'],
+        'anchor_only' => counts['anchor-only'],
+        'unverifiable' => counts['unverifiable'],
+        'coverage_complete' => entries.size == Array(charts).size
+      }
+    }
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/run-ground-truth.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/run-ground-truth.rb
@@ -1,0 +1,223 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# run-ground-truth.rb — PR-5 part A execution: run the `warehouse-sql` entries
+# of ground-truth-plan.json against the warehouse, writing
+# <workdir>/ground-truth-actuals.json for the PR-6 comparison gate.
+#
+# ACCESS PATH: the SAME established warehouse-SQL seam probe-join-keys.rb /
+# probe-custom-sql-columns.rb use — a one-shot probe workbook with a Custom SQL
+# element on the Sigma connection, CSV-exported then deleted (lib/sigma_rest,
+# auto-refresh on 401). No new warehouse credential path. Offline tests use
+# --fixture DIR with canned per-entry results, the same convention as
+# probe-join-keys (DIR/entry-<plan-index>.json).
+#
+# BOUNDED-EXPORTS lessons (PR #426): a TOTAL --timeout deadline covers the
+# whole run (per-entry progress lines; entries past the deadline are recorded
+# `deadline-skipped` and the run exits loud-partial, never hangs), and every
+# query is wrapped in a LIMIT guard — ground truth is aggregated so results
+# should be small; more than --row-limit rows means a missing/exploded GROUP BY
+# and fails LOUD as `row-explosion` instead of dragging a huge export.
+#
+# Usage:
+#   ruby scripts/run-ground-truth.rb --workdir <WORK> \
+#     (--connection-id <id> [--folder-id <id>] | --fixture DIR) \
+#     [--plan PATH] [--out PATH] [--timeout S] [--row-limit N]
+#
+#   --fixture DIR   offline: DIR/entry-<index>.json per PLAN entry index:
+#                     {"columns": [...], "rows": [[...], ...]}  or
+#                     {"error": "<message>"}
+#
+# Exit codes: 0 = every warehouse-sql entry returned rows;
+#             1 = bad invocation;
+#             2 = error / row-explosion entr(y/ies) recorded;
+#             3 = total --timeout deadline expired → loud PARTIAL actuals.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'securerandom'
+
+opts = { timeout: 600, row_limit: 5000 }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--plan PATH')        { |v| opts[:plan] = v }
+  p.on('--out PATH')         { |v| opts[:out] = v }
+  p.on('--connection-id ID') { |v| opts[:conn] = v }
+  p.on('--folder-id ID')     { |v| opts[:folder] = v }
+  p.on('--fixture DIR', 'offline: canned results, DIR/entry-<plan-index>.json') { |v| opts[:fixture] = v }
+  p.on('--timeout S', Integer, 'TOTAL deadline for the whole run (default 600)') { |v| opts[:timeout] = v }
+  p.on('--row-limit N', Integer, 'per-entry row guard (default 5000) — exceeding it = row-explosion FAIL') { |v| opts[:row_limit] = v }
+end.parse!
+
+plan_path = opts[:plan] || (opts[:dir] && File.join(opts[:dir], 'ground-truth-plan.json'))
+unless plan_path && (opts[:fixture] || opts[:conn])
+  warn 'usage: run-ground-truth.rb --workdir <WORK> (--connection-id <id> | --fixture DIR) [--plan P] [--out P] [--timeout S] [--row-limit N]'
+  exit 1
+end
+unless File.exist?(plan_path)
+  warn "FATAL: #{plan_path} not found — run scripts/derive-ground-truth.rb first"
+  exit 1
+end
+out_path = opts[:out] || File.join(File.dirname(plan_path), 'ground-truth-actuals.json')
+
+plan = JSON.parse(File.read(plan_path))
+entries = Array(plan['entries'])
+
+if opts[:conn]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+# Run one SQL statement through a one-shot probe workbook (the established
+# warehouse-SQL seam — see probe-join-keys.rb / probe-custom-sql-columns.rb)
+# and return parsed CSV rows. `deadline` bounds the export poll so a stuck
+# query cannot outlive the run's total budget.
+def sigma_sql_rows(conn_id, folder_id, sql, columns, deadline)
+  spec = {
+    'name' => "_probe_groundtruth_#{SecureRandom.hex(4)}",
+    'schemaVersion' => 1,
+    'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => [{
+      'id' => 'probe', 'kind' => 'table', 'name' => 'Probe',
+      'source' => { 'kind' => 'sql', 'connectionId' => conn_id, 'statement' => sql },
+      'columns' => columns.each_with_index.map { |c, i| { 'id' => "c#{i}", 'name' => c, 'formula' => "[Custom SQL/#{c}]" } }
+    }] }]
+  }
+  spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+  begin
+    r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+  rescue Sigma::Error => e
+    raise "probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
+  end
+  wb_id = r.is_a?(Hash) ? r['workbookId'] : nil
+  raise "probe workbook POST failed: #{r.inspect[0, 160]}" unless wb_id
+  begin
+    exp = Sigma.request(:post, "/v2/workbooks/#{wb_id}/export",
+                        body: JSON.generate('elementId' => 'probe', 'format' => { 'type' => 'csv' }))
+    qid = exp && exp['queryId']
+    raise "export POST returned no queryId: #{exp.inspect[0, 160]}" unless qid
+    csv = nil
+    loop do
+      raise 'export poll hit the total --timeout deadline' if Time.now > deadline
+      sleep 1
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        (csv = b) && break if b && !b.to_s.empty?
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+    CSV.parse(csv)
+  ensure
+    Sigma.request(:delete, "/v2/files/#{wb_id}") rescue nil
+  end
+end
+
+def fixture_result(dir, idx)
+  f = File.join(dir, "entry-#{idx}.json")
+  return { 'error' => "no fixture #{File.basename(f)} in #{dir}" } unless File.exist?(f)
+  JSON.parse(File.read(f))
+rescue JSON::ParserError => e
+  { 'error' => "fixture unparseable: #{e.message[0, 80]}" }
+end
+
+t0 = Time.now
+deadline = t0 + opts[:timeout]
+row_limit = opts[:row_limit]
+results = []
+counts = Hash.new(0)
+exec_idx = entries.each_index.select { |i| entries[i]['classification'] == 'warehouse-sql' }
+n_exec = exec_idx.size
+done = 0
+
+entries.each_with_index do |e, i|
+  base = { 'index' => i, 'chart' => e['chart'], 'sigma_element_id' => e['sigma_element_id'],
+           'classification' => e['classification'] }
+  unless e['classification'] == 'warehouse-sql'
+    results << base.merge('status' => "skipped-#{e['classification']}")
+    counts['skipped'] += 1
+    next
+  end
+  if Time.now > deadline
+    results << base.merge('status' => 'deadline-skipped',
+                          'error' => "total --timeout #{opts[:timeout]}s expired before this entry ran")
+    counts['deadline_skipped'] += 1
+    next
+  end
+  done += 1
+  te = Time.now
+  aliases = Array(e['columns']).map { |c| c['alias'].to_s }
+  # LIMIT guard: aggregated ground truth is SMALL. row_limit+1 rows back means
+  # the GROUP BY exploded (or is missing) — fail loud, never drag the export.
+  guarded_sql = "SELECT * FROM (\n#{e['sql']}\n) GT_GUARD LIMIT #{row_limit + 1}"
+  res =
+    if opts[:fixture]
+      fixture_result(opts[:fixture], i)
+    else
+      begin
+        rows = sigma_sql_rows(opts[:conn], opts[:folder], guarded_sql, aliases, deadline)
+        header = rows.shift || aliases
+        { 'columns' => header.map(&:to_s), 'rows' => rows }
+      rescue StandardError => err
+        { 'error' => err.message.to_s.gsub(/\s+/, ' ').strip[0, 300] }
+      end
+    end
+  elapsed = (Time.now - te).round(1)
+  if res['error']
+    results << base.merge('status' => 'error', 'error' => res['error'], 'elapsed_s' => elapsed)
+    counts['error'] += 1
+    puts "  [#{done}/#{n_exec}] ERROR      #{e['chart'].to_s.inspect} — #{res['error'][0, 120]} (#{elapsed}s)"
+  elsif Array(res['rows']).length > row_limit
+    results << base.merge('status' => 'row-explosion', 'n_rows' => res['rows'].length,
+                          'error' => "returned > --row-limit #{row_limit} rows — ground truth must be " \
+                                     'aggregated; a missing/exploded GROUP BY, not a big export',
+                          'elapsed_s' => elapsed)
+    counts['row_explosion'] += 1
+    warn "  [#{done}/#{n_exec}] ROW-EXPLOSION #{e['chart'].to_s.inspect} — >#{row_limit} row(s): missing GROUP BY? (#{elapsed}s)"
+  else
+    results << base.merge('status' => 'ok', 'columns' => res['columns'] || aliases,
+                          'rows' => res['rows'], 'n_rows' => Array(res['rows']).length,
+                          'elapsed_s' => elapsed)
+    counts['ok'] += 1
+    puts "  [#{done}/#{n_exec}] ok         #{e['chart'].to_s.inspect} — #{Array(res['rows']).length} row(s) (#{elapsed}s)"
+  end
+end
+
+partial = counts['deadline_skipped'].positive?
+doc = {
+  'version' => 1,
+  'ran_at' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+  'mode' => opts[:fixture] ? 'fixture' : 'live',
+  'plan' => plan_path,
+  # Freshness stamp for the PR-6 comparison: actuals bind to the exact plan run.
+  'plan_generated_at' => plan['generated_at'],
+  'timeout_s' => opts[:timeout],
+  'row_limit' => row_limit,
+  'results' => results,
+  'summary' => {
+    'entries' => entries.size,
+    'warehouse_sql' => n_exec,
+    'ok' => counts['ok'],
+    'error' => counts['error'],
+    'row_explosion' => counts['row_explosion'],
+    'deadline_skipped' => counts['deadline_skipped'],
+    'skipped_other_classification' => counts['skipped'],
+    'complete' => !partial && counts['error'].zero? && counts['row_explosion'].zero?
+  },
+  'consumer' => 'PR-6 comparison gate (numeric_parity) — not wired in part A'
+}
+File.write(out_path, JSON.pretty_generate(doc))
+
+s = doc['summary']
+puts "run-ground-truth: #{s['ok']}/#{n_exec} warehouse-sql entr(y/ies) ok — error #{s['error']}, " \
+     "row-explosion #{s['row_explosion']}, deadline-skipped #{s['deadline_skipped']} → #{out_path}"
+if partial
+  warn "[PARTIAL] total --timeout #{opts[:timeout]}s expired: #{s['deadline_skipped']} entr(y/ies) never ran — " \
+       'the actuals file is INCOMPLETE (summary.complete=false); re-run with a larger --timeout.'
+  exit 3
+end
+if counts['error'].positive? || counts['row_explosion'].positive?
+  warn "[FAIL] #{counts['error']} error / #{counts['row_explosion']} row-explosion entr(y/ies) — see #{out_path}."
+  exit 2
+end
+exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/ground-truth.twb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/ground-truth.twb
@@ -1,0 +1,205 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!-- Synthetic fixture for test-ground-truth-derive.rb (invented names, no
+     customer data). One federated datasource joining SALES_FACT to REGION_DIM
+     (left, single key) with a DATASOURCE-level filter on SEGMENT, plus a
+     second datasource (QUOTA) so one worksheet exercises the blend →
+     anchor-only classification. Worksheets cover the ledger classes:
+       - Sales by Region        plain SUM + dim + worksheet member filter → warehouse-sql
+       - Profit Ratio by Segment  user-agg calc (SUM/SUM) → warehouse-sql + calc deps
+       - Scaled Sales           calc referencing [Parameters].[Factor] → param default recorded
+       - Running Sales Trend    RUNNING_SUM window calc → vds
+       - Quota Attainment Blend two datasources → anchor-only -->
+<workbook source-build='2023.1.0' version='18.1'>
+  <datasources>
+    <datasource caption='Parameters' name='Parameters'>
+      <column caption='Factor' datatype='integer' name='[Parameter 1]' param-domain-type='range' role='measure' type='quantitative' value='3'>
+        <range granularity='1' max='10' min='1' />
+      </column>
+    </datasource>
+    <datasource caption='Ground Truth Demo' name='federated.gt01'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='snowflake' name='snowflake.gt01'>
+            <connection class='snowflake' dbname='ANALYTICS' schema='PUBLIC' server='example.snowflakecomputing.com' warehouse='WH_XS' />
+          </named-connection>
+        </named-connections>
+        <relation join='left' type='join'>
+          <clause type='join'>
+            <expression op='='>
+              <expression op='[SALES_FACT].[REGION_ID]' />
+              <expression op='[REGION_DIM].[REGION_ID]' />
+            </expression>
+          </clause>
+          <relation connection='snowflake.gt01' name='SALES_FACT' table='[PUBLIC].[SALES_FACT]' type='table'>
+            <columns>
+              <column datatype='integer' name='REGION_ID' />
+              <column datatype='string' name='SEGMENT' />
+              <column datatype='real' name='SALES' />
+              <column datatype='real' name='PROFIT' />
+              <column datatype='date' name='ORDER_DATE' />
+            </columns>
+          </relation>
+          <relation connection='snowflake.gt01' name='REGION_DIM' table='[PUBLIC].[REGION_DIM]' type='table'>
+            <columns>
+              <column datatype='integer' name='REGION_ID' />
+              <column datatype='string' name='REGION_NAME' />
+            </columns>
+          </relation>
+        </relation>
+      </connection>
+      <filter class='categorical' column='[SEGMENT]'>
+        <groupfilter function='union'>
+          <groupfilter function='member' member='&quot;Consumer&quot;' />
+          <groupfilter function='member' member='&quot;Corporate&quot;' />
+        </groupfilter>
+      </filter>
+      <column caption='Profit Ratio' datatype='real' name='[Calculation_200]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='SUM([PROFIT]) / SUM([SALES])' />
+      </column>
+      <column caption='Running Sales' datatype='real' name='[Calculation_201]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='RUNNING_SUM(SUM([SALES]))' />
+      </column>
+      <column caption='Scaled Sales' datatype='real' name='[Calculation_202]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='SUM([SALES]) * [Parameters].[Factor]' />
+      </column>
+    </datasource>
+    <datasource caption='Quota Source' name='federated.gt02'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='snowflake' name='snowflake.gt02'>
+            <connection class='snowflake' dbname='ANALYTICS' schema='PUBLIC' server='example.snowflakecomputing.com' warehouse='WH_XS' />
+          </named-connection>
+        </named-connections>
+        <relation connection='snowflake.gt02' name='QUOTA_DIM' table='[PUBLIC].[QUOTA_DIM]' type='table'>
+          <columns>
+            <column datatype='string' name='REGION_NAME' />
+            <column datatype='real' name='QUOTA' />
+          </columns>
+        </relation>
+      </connection>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Sales by Region'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Ground Truth Demo' name='federated.gt01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.gt01'>
+            <column datatype='string' name='[REGION_NAME]' role='dimension' type='nominal' />
+            <column datatype='real' name='[SALES]' role='measure' type='quantitative' />
+            <column-instance column='[REGION_NAME]' derivation='None' name='[none:REGION_NAME:nk]' pivot='key' type='nominal' />
+            <column-instance column='[SALES]' derivation='Sum' name='[sum:SALES:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.gt01].[none:REGION_NAME:nk]'>
+            <groupfilter function='union'>
+              <groupfilter function='member' member='&quot;East&quot;' />
+              <groupfilter function='member' member='&quot;West&quot;' />
+            </groupfilter>
+          </filter>
+        </view>
+        <panes><pane><mark class='Bar' /></pane></panes>
+        <rows>[federated.gt01].[sum:SALES:qk]</rows>
+        <cols>[federated.gt01].[none:REGION_NAME:nk]</cols>
+      </table>
+    </worksheet>
+    <worksheet name='Profit Ratio by Segment'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Ground Truth Demo' name='federated.gt01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.gt01'>
+            <column datatype='string' name='[SEGMENT]' role='dimension' type='nominal' />
+            <column caption='Profit Ratio' datatype='real' name='[Calculation_200]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='SUM([PROFIT]) / SUM([SALES])' />
+            </column>
+            <column-instance column='[SEGMENT]' derivation='None' name='[none:SEGMENT:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Calculation_200]' derivation='User' name='[usr:Calculation_200:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+        </view>
+        <panes><pane><mark class='Bar' /></pane></panes>
+        <rows>[federated.gt01].[usr:Calculation_200:qk]</rows>
+        <cols>[federated.gt01].[none:SEGMENT:nk]</cols>
+      </table>
+    </worksheet>
+    <worksheet name='Scaled Sales'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Ground Truth Demo' name='federated.gt01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.gt01'>
+            <column datatype='string' name='[REGION_NAME]' role='dimension' type='nominal' />
+            <column caption='Scaled Sales' datatype='real' name='[Calculation_202]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='SUM([SALES]) * [Parameters].[Factor]' />
+            </column>
+            <column-instance column='[REGION_NAME]' derivation='None' name='[none:REGION_NAME:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Calculation_202]' derivation='User' name='[usr:Calculation_202:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+        </view>
+        <panes><pane><mark class='Bar' /></pane></panes>
+        <rows>[federated.gt01].[usr:Calculation_202:qk]</rows>
+        <cols>[federated.gt01].[none:REGION_NAME:nk]</cols>
+      </table>
+    </worksheet>
+    <worksheet name='Running Sales Trend'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Ground Truth Demo' name='federated.gt01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.gt01'>
+            <column datatype='date' name='[ORDER_DATE]' role='dimension' type='ordinal' />
+            <column caption='Running Sales' datatype='real' name='[Calculation_201]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='RUNNING_SUM(SUM([SALES]))' />
+            </column>
+            <column-instance column='[ORDER_DATE]' derivation='Month-Trunc' name='[tmn:ORDER_DATE:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_201]' derivation='User' name='[usr:Calculation_201:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+        </view>
+        <panes><pane><mark class='Line' /></pane></panes>
+        <rows>[federated.gt01].[usr:Calculation_201:qk]</rows>
+        <cols>[federated.gt01].[tmn:ORDER_DATE:qk]</cols>
+      </table>
+    </worksheet>
+    <worksheet name='Quota Attainment Blend'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Ground Truth Demo' name='federated.gt01' />
+            <datasource caption='Quota Source' name='federated.gt02' />
+          </datasources>
+          <datasource-dependencies datasource='federated.gt01'>
+            <column datatype='string' name='[REGION_NAME]' role='dimension' type='nominal' />
+            <column datatype='real' name='[SALES]' role='measure' type='quantitative' />
+            <column-instance column='[REGION_NAME]' derivation='None' name='[none:REGION_NAME:nk]' pivot='key' type='nominal' />
+            <column-instance column='[SALES]' derivation='Sum' name='[sum:SALES:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <datasource-dependencies datasource='federated.gt02'>
+            <column datatype='real' name='[QUOTA]' role='measure' type='quantitative' />
+            <column-instance column='[QUOTA]' derivation='Sum' name='[sum:QUOTA:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+        </view>
+        <panes><pane><mark class='Bar' /></pane></panes>
+        <rows>[federated.gt01].[sum:SALES:qk]</rows>
+        <cols>[federated.gt01].[none:REGION_NAME:nk]</cols>
+      </table>
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Ground Truth Dash'>
+      <size maxheight='800' maxwidth='1200' minheight='800' minwidth='1200' sizing-mode='fixed' />
+      <zones>
+        <zone h='100000' id='1' w='100000' x='0' y='0'>
+          <zone h='40000' id='2' name='Sales by Region' w='50000' x='0' y='0' />
+          <zone h='40000' id='3' name='Profit Ratio by Segment' w='50000' x='50000' y='0' />
+          <zone h='30000' id='4' name='Scaled Sales' w='34000' x='0' y='40000' />
+          <zone h='30000' id='5' name='Running Sales Trend' w='33000' x='34000' y='40000' />
+          <zone h='30000' id='6' name='Quota Attainment Blend' w='33000' x='67000' y='40000' />
+        </zone>
+      </zones>
+    </dashboard>
+  </dashboards>
+</workbook>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-ground-truth-derive.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-ground-truth-derive.rb
@@ -1,0 +1,193 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-ground-truth-derive.rb — offline tests for the PR-5 part A ground-truth
+# DERIVATION (scripts/lib/ground_truth_sql.rb + scripts/derive-ground-truth.rb).
+#
+# Uses the synthetic test-fixtures/ground-truth.twb, runs the REAL
+# parse-twb-layout.rb over it (so the zone/meta shapes stay in lockstep with
+# the parser), then derives the ledger and asserts:
+#   - simple agg tile → correct SQL (dims, agg, worksheet + datasource filters,
+#     the .twb LEFT JOIN, GROUP BY)
+#   - user-agg calc tile → SQL with NULLIF-guarded ratio + calc-dependency
+#     provenance (name + formula_hash, calc-fields source priority)
+#   - parameter-referencing calc → default value substituted AND recorded
+#   - window-calc tile → classified vds (routes to the existing vds-oracle)
+#   - blend tile → anchor-only with a reason
+#   - tile with no source zone → unverifiable(reason)
+#   - COVERAGE COMPLETENESS: every parity-plan tile gets exactly one ledger
+#     entry with a valid classification — nothing silently drops out
+#   - smoke: the corpus orders-overview .twb derives a complete ledger too
+#
+# Run: ruby scripts/test-ground-truth-derive.rb
+
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPTS = __dir__
+FIXTURE = File.join(SCRIPTS, 'test-fixtures', 'ground-truth.twb')
+DERIVE  = File.join(SCRIPTS, 'derive-ground-truth.rb')
+PARSE   = File.join(SCRIPTS, 'parse-twb-layout.rb')
+CORPUS_TWB = File.expand_path('../../../../../corpus/tableau/orders-overview/workbook-content.twb', SCRIPTS)
+
+$fails = []
+def ok(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+Dir.mktmpdir do |dir|
+  # 1. Real layout parse over the synthetic .twb.
+  layout_path = File.join(dir, 'dashboard-layout.json')
+  _out, err, st = Open3.capture3(RbConfig.ruby, PARSE, FIXTURE, layout_path)
+  ok(st.exitstatus.zero?, "parse-twb-layout runs over the fixture (got #{st.exitstatus}: #{err.lines.first})")
+
+  # 2. Parity plan: the five worksheets + one tile with no source zone.
+  charts = [
+    { 'chart' => 'Sales by Region',         'tableau_view' => 'Sales by Region',         'sigma_element_id' => 'el-sales-by-region' },
+    { 'chart' => 'Profit Ratio by Segment', 'tableau_view' => 'Profit Ratio by Segment', 'sigma_element_id' => 'el-profit-ratio' },
+    { 'chart' => 'Scaled Sales',            'tableau_view' => 'Scaled Sales',            'sigma_element_id' => 'el-scaled' },
+    { 'chart' => 'Running Sales Trend',     'tableau_view' => 'Running Sales Trend',     'sigma_element_id' => 'el-running' },
+    { 'chart' => 'Quota Attainment Blend',  'tableau_view' => 'Quota Attainment Blend',  'sigma_element_id' => 'el-blend' },
+    { 'chart' => 'Ghost Tile',              'tableau_view' => 'Ghost Tile',              'sigma_element_id' => 'el-ghost' }
+  ]
+  File.write(File.join(dir, 'parity-plan.json'),
+             JSON.pretty_generate('extract' => false, 'charts' => charts))
+
+  # 3. calc-fields.json — the extracted-calc artifact (translation input the
+  #    DM build consumed). Profit Ratio present here AND in the .twb meta so
+  #    the calc-fields source wins the dependency provenance.
+  File.write(File.join(dir, 'calc-fields.json'), JSON.pretty_generate(
+    'calcs' => [
+      { 'name' => 'Profit Ratio', 'internal_name' => 'Calculation_200',
+        'formula' => 'SUM([PROFIT]) / SUM([SALES])' },
+      { 'name' => 'Running Sales', 'internal_name' => 'Calculation_201',
+        'formula' => 'RUNNING_SUM(SUM([SALES]))' },
+      { 'name' => 'Scaled Sales', 'internal_name' => 'Calculation_202',
+        'formula' => 'SUM([SALES]) * [Parameters].[Factor]' }
+    ]
+  ))
+
+  out_path = File.join(dir, 'ground-truth-plan.json')
+  out, err, st = Open3.capture3(RbConfig.ruby, DERIVE, '--workdir', dir, '--twb', FIXTURE, '--out', out_path)
+  ok(st.exitstatus.zero?, "derive-ground-truth exits 0 (got #{st.exitstatus}: #{err.lines.first})")
+  doc = JSON.parse(File.read(out_path))
+  by_chart = doc['entries'].each_with_object({}) { |e, h| h[e['chart']] = e }
+
+  puts '-- coverage ledger completeness --'
+  ok(doc['entries'].size == charts.size, "every parity-plan tile has exactly one ledger entry (#{doc['entries'].size}/#{charts.size})")
+  ok(doc['summary']['coverage_complete'] == true, 'summary.coverage_complete is true')
+  ok(doc['entries'].all? { |e| %w[warehouse-sql vds anchor-only unverifiable].include?(e['classification']) },
+     'every entry carries a valid classification (nothing silently drops out)')
+  ok(charts.map { |c| c['chart'] }.sort == doc['entries'].map { |e| e['chart'] }.sort,
+     'ledger charts == plan charts (1:1)')
+  ok(doc['generated_at'].to_s =~ /\A\d{4}-/ && doc['consumer'].to_s.include?('PR-6'),
+     'plan stamped with generated_at + PR-6 consumer pointer')
+
+  puts '-- simple agg tile → correct SQL --'
+  e = by_chart['Sales by Region']
+  ok(e['classification'] == 'warehouse-sql', "Sales by Region classified warehouse-sql (got #{e['classification']}: #{e['reason']})")
+  sql = e['sql'].to_s
+  ok(sql.include?('SUM(T1.SALES)'), "agg emitted (SUM over the fact column) — got:\n#{sql}")
+  ok(sql.include?('T2.REGION_NAME AS "REGION_NAME"'), 'dim emitted with a stable alias')
+  ok(sql.include?('FROM ANALYTICS.PUBLIC.SALES_FACT T1'), 'FROM = the .twb fact table FQN')
+  ok(sql.include?('LEFT JOIN ANALYTICS.PUBLIC.REGION_DIM T2 ON T1.REGION_ID = T2.REGION_ID'),
+     'JOIN per the .twb join spec (type + key pair)')
+  ok(sql.include?("T2.REGION_NAME IN ('East', 'West')"), 'worksheet member filter in WHERE')
+  ok(sql.include?("T1.SEGMENT IN ('Consumer', 'Corporate')"), 'DATASOURCE-level filter in WHERE (post-#414 parse)')
+  ok(sql.include?('GROUP BY 1'), 'GROUP BY the dims')
+  prov = e['provenance']
+  ok(prov['filters'].any? { |f| f['source'] == 'datasource' } && prov['filters'].any? { |f| f['source'] == 'worksheet' },
+     'provenance records which filters (worksheet + datasource) fed the SQL')
+  ok(prov['worksheet'] == 'Sales by Region' && prov['dashboard'].to_s == 'Ground Truth Dash',
+     'provenance names the source zone/worksheet')
+
+  puts '-- calc measure → SQL + dependency provenance --'
+  e = by_chart['Profit Ratio by Segment']
+  ok(e['classification'] == 'warehouse-sql', "Profit Ratio classified warehouse-sql (got #{e['classification']}: #{e['reason']})")
+  ok(e['sql'].to_s.include?('SUM(T1.PROFIT) / NULLIF(SUM(T1.SALES), 0)'),
+     "user-agg ratio translated with a NULLIF divide-by-zero guard — got:\n#{e['sql']}")
+  deps = e['provenance']['calc_dependencies']
+  ok(deps.any? { |d| d['name'] == 'Profit Ratio' && d['formula_hash'].to_s.length == 40 },
+     'calc dependency recorded with name + formula_hash (traceable common-mode residue)')
+  ok(deps.all? { |d| d['source'] == 'calc-fields' },
+     'dependency provenance names the calc-fields artifact as the formula source')
+
+  puts '-- parameter default substitution --'
+  e = by_chart['Scaled Sales']
+  ok(e['classification'] == 'warehouse-sql', "Scaled Sales classified warehouse-sql (got #{e['classification']}: #{e['reason']})")
+  ok(e['sql'].to_s.include?('SUM(T1.SALES) * 3'), "parameter default (Factor=3) substituted — got:\n#{e['sql']}")
+  ok(e['provenance']['parameters'] == { 'Factor' => '3' },
+     'parameter value recorded in provenance')
+
+  puts '-- window calc → vds --'
+  e = by_chart['Running Sales Trend']
+  ok(e['classification'] == 'vds', "RUNNING_SUM tile classified vds (got #{e['classification']})")
+  ok(e['reason'].to_s =~ /window|vds/i, 'vds reason routes to the vds-oracle path')
+  ok(e['sql'].nil?, 'no SQL emitted for a vds tile (Tableau computes it)')
+
+  puts '-- blend → anchor-only --'
+  e = by_chart['Quota Attainment Blend']
+  ok(e['classification'] == 'anchor-only', "blend tile classified anchor-only (got #{e['classification']})")
+  ok(e['reason'].to_s =~ /blend/i && e['reason'].to_s.include?('federated.gt02'),
+     "anchor-only reason names the blend (got #{e['reason'].inspect})")
+
+  puts '-- no source zone → unverifiable --'
+  e = by_chart['Ghost Tile']
+  ok(e['classification'] == 'unverifiable', "zoneless tile classified unverifiable (got #{e['classification']})")
+  ok(!e['reason'].to_s.empty?, 'unverifiable carries a reason')
+
+  ok(out.include?('derive-ground-truth:') && out.include?('warehouse-sql 3'),
+     'summary line reports the classification counts')
+
+  puts '-- independence: no builder imports --'
+  %w[lib/ground_truth_sql.rb derive-ground-truth.rb run-ground-truth.rb].each do |f|
+    src = File.read(File.join(SCRIPTS, f), encoding: 'UTF-8')
+    ok(src !~ /require(_relative)?\s*\(?\s*['"].*build[-_]charts/,
+       "#{f} requires nothing from the builder (independence contract)")
+  end
+end
+
+puts '-- corpus smoke: orders-overview derives a complete ledger --'
+if File.exist?(CORPUS_TWB)
+  Dir.mktmpdir do |dir|
+    layout_path = File.join(dir, 'dashboard-layout.json')
+    _out, err, st = Open3.capture3(RbConfig.ruby, PARSE, CORPUS_TWB, layout_path)
+    ok(st.exitstatus.zero?, "parse-twb-layout runs over the corpus .twb (got #{st.exitstatus}: #{err.lines.first})")
+    layout = JSON.parse(File.read(layout_path))
+    charts = layout.flat_map { |d| d['zones'] }
+                   .select { |z| z['kind'] == 'chart' && z['caption'] }
+                   .map { |z| { 'chart' => z['caption'], 'tableau_view' => z['caption'],
+                                'sigma_element_id' => "el-#{z['id']}" } }
+    ok(charts.size >= 3, "corpus dashboard yields chart tiles (got #{charts.size})")
+    File.write(File.join(dir, 'parity-plan.json'), JSON.pretty_generate('charts' => charts))
+    out_path = File.join(dir, 'ground-truth-plan.json')
+    _out, err, st = Open3.capture3(RbConfig.ruby, DERIVE, '--workdir', dir, '--twb', CORPUS_TWB,
+                                   '--db', 'DEMO_DB', '--schema', 'DEMO', '--out', out_path)
+    ok(st.exitstatus.zero?, "derive exits 0 on the corpus .twb (got #{st.exitstatus}: #{err.lines.first})")
+    doc = JSON.parse(File.read(out_path))
+    ok(doc['summary']['coverage_complete'] == true && doc['entries'].size == charts.size,
+       "corpus ledger complete: every tile classified (#{doc['entries'].size}/#{charts.size})")
+    ok(doc['entries'].all? { |e| %w[warehouse-sql vds anchor-only unverifiable].include?(e['classification']) },
+       'corpus classifications all valid')
+    ok(doc['entries'].none? { |e| e['classification'] == 'unverifiable' },
+       'corpus tiles all classify better than unverifiable (anchor-only reasons are named, not dead ends)')
+    ok(doc['entries'].all? { |e| e['classification'] == 'warehouse-sql' || !e['reason'].to_s.empty? },
+       'every non-SQL corpus entry names its reason')
+    counts = doc['entries'].group_by { |e| e['classification'] }.map { |k, v| "#{k}=#{v.size}" }.join(', ')
+    puts "  INFO  orders-overview classification mix: #{counts}"
+  end
+else
+  puts '  SKIP  corpus .twb not present in this checkout'
+end
+
+puts
+if $fails.empty?
+  puts 'ALL PASS — ground-truth derivation (ledger + SQL + classifications)'
+  exit 0
+else
+  puts "FAILURES (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-ground-truth-run.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-ground-truth-run.rb
@@ -1,0 +1,151 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-ground-truth-run.rb — offline tests for scripts/run-ground-truth.rb
+# (PR-5 part A execution), --fixture mode (canned per-entry results, the
+# probe-join-keys DIR/entry-<index>.json convention).
+#
+# Covers: per-entry results recorded (ok rows + columns; non-warehouse-sql
+# entries carried as skipped-<classification> so the actuals mirror the
+# ledger); missing-fixture entry → error + exit 2; row-explosion guard fires
+# LOUD (missing-GROUP-BY class, exit 2); total --timeout deadline expiry →
+# loud PARTIAL (exit 3, summary.complete=false); happy path exit 0 with the
+# PR-6 freshness stamp (plan_generated_at).
+#
+# Run: ruby scripts/test-ground-truth-run.rb
+
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPT = File.join(__dir__, 'run-ground-truth.rb')
+
+$fails = []
+def ok(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+def write_plan(dir, entries)
+  path = File.join(dir, 'ground-truth-plan.json')
+  File.write(path, JSON.pretty_generate(
+               'version' => 1, 'generated_at' => '2026-07-18T00:00:00Z', 'entries' => entries
+             ))
+  path
+end
+
+def entry(chart, cls, sql = nil)
+  e = { 'chart' => chart, 'sigma_element_id' => "el-#{chart.downcase.tr(' ', '-')}",
+        'classification' => cls, 'reason' => cls == 'warehouse-sql' ? nil : 'test reason' }
+  if sql
+    e['sql'] = sql
+    e['columns'] = [{ 'alias' => 'Region', 'role' => 'dim' }, { 'alias' => 'Sales (sum)', 'role' => 'measure' }]
+  end
+  e
+end
+
+SQL = "SELECT REGION_NAME AS \"Region\", SUM(SALES) AS \"Sales (sum)\"\nFROM ANALYTICS.PUBLIC.SALES_FACT T1\nGROUP BY 1"
+
+puts '-- fixture-mode execution: per-entry results + ledger mirroring --'
+Dir.mktmpdir do |dir|
+  plan = write_plan(dir, [
+    entry('Tile A', 'warehouse-sql', SQL),
+    entry('Tile Vds', 'vds'),
+    entry('Tile Anchor', 'anchor-only'),
+    entry('Tile B', 'warehouse-sql', SQL) # no fixture file → error
+  ])
+  fdir = File.join(dir, 'fx')
+  Dir.mkdir(fdir)
+  File.write(File.join(fdir, 'entry-0.json'),
+             JSON.pretty_generate('columns' => ['Region', 'Sales (sum)'],
+                                  'rows' => [['East', 100.5], ['West', 200.25]]))
+  out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--fixture', fdir)
+  ok(st.exitstatus == 2, "error entry present → exit 2 (got #{st.exitstatus})")
+  doc = JSON.parse(File.read(File.join(dir, 'ground-truth-actuals.json')))
+  ok(doc['version'] == 1 && doc['mode'] == 'fixture', 'actuals carry version + mode')
+  ok(doc['plan_generated_at'] == '2026-07-18T00:00:00Z',
+     'actuals stamped with plan_generated_at (PR-6 freshness binding)')
+  by_chart = doc['results'].each_with_object({}) { |r, h| h[r['chart']] = r }
+  a = by_chart['Tile A']
+  ok(a['status'] == 'ok' && a['rows'] == [['East', 100.5], ['West', 200.25]] && a['n_rows'] == 2,
+     'ok entry records its rows + row count')
+  ok(a['columns'] == ['Region', 'Sales (sum)'], 'ok entry records its columns')
+  ok(by_chart['Tile Vds']['status'] == 'skipped-vds' && by_chart['Tile Anchor']['status'] == 'skipped-anchor-only',
+     'non-warehouse-sql entries mirror their ledger classification (nothing silently drops out)')
+  ok(by_chart['Tile B']['status'] == 'error' && by_chart['Tile B']['error'].to_s.include?('entry-3'),
+     'missing fixture → error naming the fixture file')
+  ok(doc['summary']['ok'] == 1 && doc['summary']['error'] == 1 && doc['summary']['complete'] == false,
+     'summary counts ok/error and complete=false')
+  ok(out.include?('[1/2]') && out.include?('[2/2]'), 'per-entry progress lines printed')
+  ok(err.include?('[FAIL]'), 'stderr announces the failure')
+  ok(JSON.parse(File.read(plan))['entries'].size == 4, 'plan untouched by execution')
+end
+
+puts '-- happy path: all warehouse-sql entries ok → exit 0 --'
+Dir.mktmpdir do |dir|
+  write_plan(dir, [entry('Tile A', 'warehouse-sql', SQL), entry('Tile Vds', 'vds')])
+  fdir = File.join(dir, 'fx')
+  Dir.mkdir(fdir)
+  File.write(File.join(fdir, 'entry-0.json'),
+             JSON.pretty_generate('columns' => ['Region', 'Sales (sum)'], 'rows' => [['East', 1]]))
+  _out, _err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--fixture', fdir)
+  ok(st.exitstatus.zero?, "all ok → exit 0 (got #{st.exitstatus})")
+  doc = JSON.parse(File.read(File.join(dir, 'ground-truth-actuals.json')))
+  ok(doc['summary']['complete'] == true, 'summary.complete=true when every warehouse-sql entry returned rows')
+end
+
+puts '-- row-explosion guard (missing GROUP BY must fail LOUD, not hang) --'
+Dir.mktmpdir do |dir|
+  write_plan(dir, [entry('Tile Explode', 'warehouse-sql', SQL)])
+  fdir = File.join(dir, 'fx')
+  Dir.mkdir(fdir)
+  File.write(File.join(fdir, 'entry-0.json'),
+             JSON.pretty_generate('columns' => ['Region', 'Sales (sum)'],
+                                  'rows' => [['a', 1], ['b', 2], ['c', 3]]))
+  _out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--fixture', fdir, '--row-limit', '2')
+  ok(st.exitstatus == 2, "row explosion → exit 2 (got #{st.exitstatus})")
+  doc = JSON.parse(File.read(File.join(dir, 'ground-truth-actuals.json')))
+  r = doc['results'][0]
+  ok(r['status'] == 'row-explosion' && r['error'].to_s.include?('GROUP BY'),
+     'entry recorded row-explosion naming the missing-GROUP-BY cause')
+  ok(doc['summary']['row_explosion'] == 1 && doc['summary']['complete'] == false,
+     'summary counts the explosion; complete=false')
+  ok(err.include?('ROW-EXPLOSION'), 'stderr shouts ROW-EXPLOSION')
+  ok(r['rows'].nil?, 'exploded rows are NOT dumped into the actuals file')
+end
+
+puts '-- total deadline expiry → loud PARTIAL --'
+Dir.mktmpdir do |dir|
+  write_plan(dir, [entry('Tile A', 'warehouse-sql', SQL), entry('Tile B', 'warehouse-sql', SQL)])
+  fdir = File.join(dir, 'fx')
+  Dir.mkdir(fdir)
+  File.write(File.join(fdir, 'entry-0.json'), JSON.pretty_generate('columns' => %w[Region S], 'rows' => [['x', 1]]))
+  File.write(File.join(fdir, 'entry-1.json'), JSON.pretty_generate('columns' => %w[Region S], 'rows' => [['x', 1]]))
+  _out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--fixture', fdir, '--timeout', '0')
+  ok(st.exitstatus == 3, "deadline expired → exit 3 (got #{st.exitstatus})")
+  doc = JSON.parse(File.read(File.join(dir, 'ground-truth-actuals.json')))
+  ok(doc['results'].all? { |r| r['status'] == 'deadline-skipped' },
+     'entries past the deadline recorded deadline-skipped (never a hang)')
+  ok(doc['summary']['deadline_skipped'] == 2 && doc['summary']['complete'] == false,
+     'summary counts deadline skips; complete=false (honest partial)')
+  ok(err.include?('[PARTIAL]') && err.include?('INCOMPLETE'), 'stderr announces the loud partial')
+end
+
+puts '-- invocation guards --'
+Dir.mktmpdir do |dir|
+  _out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir)
+  ok(st.exitstatus == 1 && err.include?('usage'), 'no --connection-id/--fixture → usage exit 1')
+  _out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir, '--fixture', dir)
+  ok(st.exitstatus == 1 && err.include?('derive-ground-truth'),
+     'missing plan → exit 1 pointing at derive-ground-truth.rb')
+end
+
+puts
+if $fails.empty?
+  puts 'ALL PASS — run-ground-truth fixture-mode execution'
+  exit 0
+else
+  puts "FAILURES (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
PLAN-v3 **PR-5** (the centerpiece), part A: derive per-tile **ground-truth warehouse SQL from the .twb signals** — never from the built wb-spec — classify every tile, and execute the SQL entries. The comparison vs Sigma exports + the hard gate are PR-6 (no gate wired here; artifacts are stamped for PR-6 to consume).

## Design

**Independence.** New `scripts/lib/ground_truth_sql.rb` + driver `scripts/derive-ground-truth.rb` consume only: parse-twb-layout zones/meta (shelves, aggregations, worksheet filters, datasource/extract filters — post-#414), the raw .twb (physical `relation type='join'` clauses AND the 2020.2+ relationship/object-graph model), and the extracted calc formulas (`calc-fields.json`, meta fallback). Nothing is required from `build-charts-from-signals.rb` (test-enforced), so the oracle cannot share the builder's misreadings. Calc formulas are the documented common-mode residue: every dependency is recorded per tile as `provenance.calc_dependencies` (name + `formula_hash` + source artifact) so a translation bug is traceable; anchors remain the independent channel.

**The classification IS the coverage ledger.** Every parity-plan chart gets exactly one `ground-truth-plan.json` entry:
- `warehouse-sql` — `SELECT <dims>, <AGG(measure)> FROM <.twb-joined tables> WHERE <worksheet + datasource filters> GROUP BY <dims>` with per-tile provenance (zone/worksheet, dims, measures, which filters fed the WHERE, parameter defaults used)
- `vds` — window/table calcs (incl. pcto/rtot quick calcs) route to the existing `vds-oracle.rb` template path
- `anchor-only` — blends, LODs, relationship models with non-unique related tables, IF/CASE calcs and filter kinds outside the mechanical subset — **reason named**, never silent
- `unverifiable(reason)` — no source zone / no measures / no resolvable warehouse table

**Refuse-to-guess translation.** Only mechanical rewrites are emitted: plain aggregates, user-agg ratios with a `NULLIF` divide-by-zero guard, `ZN`→`COALESCE`, `COUNTD`→`COUNT(DISTINCT …)`, member/range/wildcard filters, `[Parameters].[X]` → recorded current defaults. Relationship-model joins derive only when every related table is unique-keyed (LEFT JOIN to a unique key cannot change fact grain — fan-out-safe without replicating per-viz join culling); otherwise anchor-only with the fan-out reason.

**Execution.** `scripts/run-ground-truth.rb` reuses the established probe-workbook Custom SQL seam (`probe-join-keys.rb` / `probe-custom-sql-columns.rb`) — no new credential path — with `--fixture DIR` offline mode (`entry-<index>.json`, the probe-join-keys convention). Bounded-exports lessons (#426): total `--timeout` deadline (expiry → loud `[PARTIAL]`, exit 3, never a hang), per-entry progress lines, `LIMIT`-guarded queries (row count > `--row-limit` = missing/exploded GROUP BY → `row-explosion`, exit 2). `ground-truth-actuals.json` is stamped with `plan_generated_at` so PR-6 binds actuals to the exact plan.

## Coverage on the test fixtures

Synthetic `test-fixtures/ground-truth.twb` (parsed by the real `parse-twb-layout.rb` in-test): 6 tiles → warehouse-sql 3 (plain agg incl. the .twb LEFT JOIN + worksheet member filter + datasource filter; SUM/SUM ratio calc with NULLIF + calc-deps provenance; parameter-substituted calc), vds 1 (RUNNING_SUM), anchor-only 1 (blend, reason names both datasources), unverifiable 1 (zoneless tile) — coverage_complete asserted.

Corpus `orders-overview` smoke (relationship-model, published-VC): 6/6 tiles classified, none unverifiable — anchor-only with precise reasons (non-unique-keyed DIM_TIME relationship; IF-tier dimension calcs outside the mechanical subset).

## Tests

- `scripts/test-ground-truth-derive.rb` — SQL correctness (dims/agg/joins/both filter scopes), calc-dependency + parameter provenance, vds/anchor-only/unverifiable routing, **coverage completeness**, builder-independence, corpus smoke
- `scripts/test-ground-truth-run.rb` — fixture execution, ledger mirroring in actuals, row-explosion guard, deadline loud-partial, invocation guards
- Full plugin suite: 156/157 pass (sole failure `test-calc-discovery.rb`, the standing environmental failure PLAN-v3 documents). `hygiene-sweep`, `lint-twb-encoding`, `check-shared` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)