### PR TITLE
tableau: fix the re-entry repeat-tax bundle (#422) — renames persist, banner opt-out, RCF patch/page persistence, source-PNG fallback

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -34,6 +34,17 @@
 #                    parity scripts. A chart tile renamed during conversion
 #                    otherwise fails the zone→element name match and silently
 #                    drops out of the layout (bead ddbq).
+#                    PERSISTED (#422): every --rename is merged into
+#                    <workdir>/layout-renames.json (beside --layout) and every
+#                    later invocation — orchestrator re-entry included — loads
+#                    and applies it automatically, so the operator never re-types
+#                    the mappings after a re-entry rebuild. CLI flags win over
+#                    the persisted file on conflict.
+#   --no-synthetic-title  never fabricate the page-name header band (the
+#                    synthetic title banner). Also AUTO-suppressed when a prior
+#                    layout.xml at --out carries no header band — i.e. the
+#                    operator removed the banner; a re-entry rebuild must
+#                    respect that last state instead of re-injecting it (#422).
 #   --chart-y0 PCT   top of the chart band as Tableau %  (default 29.7)
 #   --chart-y1 PCT   bottom of the chart band as Tableau % (default 100.0)
 #   --chart-row0 N   first grid row of the chart band     (default 6)
@@ -113,8 +124,57 @@ OptionParser.new do |p|
   p.on('--chart-y1 PCT', Float)   { |v| opts[:chart_y1] = v }
   p.on('--chart-row0 N', Integer) { |v| opts[:chart_row0] = v }
   p.on('--no-containers', 'force the geometry-banded layout even when the dashboard nests a filter/parameter rail') { opts[:no_containers] = true }
+  p.on('--no-synthetic-title', 'never fabricate the page-name header band (synthetic title banner)') { opts[:no_synthetic_title] = true }
 end.parse!
 %i[layout wb_ids out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+# ---- Rename persistence (#422 re-entry repeat-tax) --------------------------
+# Operator --rename mappings used to live only in the invocation: every
+# orchestrator re-entry rebuilt the layout WITHOUT them, silently dropping the
+# renamed tiles until the operator re-typed --rename by hand (live-measured 4x
+# per re-entry). Persist the merged map to <workdir>/layout-renames.json
+# (beside --layout, like the other sidecars) and auto-load it on every build.
+# CLI flags win over the file on conflict; the write-back accumulates.
+RENAMES_PATH = File.join(File.dirname(opts[:layout]), 'layout-renames.json')
+cli_renames = opts[:renames].dup
+if File.exist?(RENAMES_PATH)
+  begin
+    prior = JSON.parse(File.read(RENAMES_PATH))
+    if prior.is_a?(Hash) && prior.any?
+      opts[:renames] = prior.merge(cli_renames) # CLI wins
+      warn "loaded #{prior.size} persisted rename mapping(s) from #{RENAMES_PATH}"
+    end
+  rescue JSON::ParserError => e
+    warn "WARN: #{RENAMES_PATH} unreadable (#{e.message}) — persisted renames ignored this run"
+  end
+end
+if cli_renames.any?
+  begin
+    File.write(RENAMES_PATH, JSON.pretty_generate(opts[:renames]) + "\n")
+    warn "persisted #{opts[:renames].size} rename mapping(s) → #{RENAMES_PATH} (auto-applied on every rebuild, re-entry included)"
+  rescue StandardError => e
+    warn "WARN: could not persist renames to #{RENAMES_PATH}: #{e.class}: #{e.message}"
+  end
+end
+
+# ---- Synthetic-title prior-state suppression (#422) -------------------------
+# When a prior layout.xml exists at --out and shows NO header band (neither a
+# fabricated "-hdrtext" banner nor a "-hdr" band container), the operator
+# removed the banner — a rebuild must respect that last state, not re-inject it.
+unless opts[:no_synthetic_title]
+  begin
+    if File.exist?(opts[:out])
+      prior_xml = File.read(opts[:out])
+      if prior_xml.include?('<Page') && !prior_xml.include?('-hdrtext"') && !prior_xml.include?('-hdr"')
+        opts[:no_synthetic_title] = true
+        warn "prior #{opts[:out]} carries no header band — synthetic title banner auto-suppressed " \
+             '(operator last state respected; pass --no-synthetic-title to make it explicit)'
+      end
+    end
+  rescue StandardError
+    # unreadable prior layout → build as usual
+  end
+end
 
 # Row scaling / px-derived page height (v5.1 defect 1): the page row count is
 # now resolved PER DASHBOARD in the dash loop below — a dashboard with a fixed
@@ -138,7 +198,22 @@ wb_ids      = JSON.parse(File.read(opts[:wb_ids]))
 # overwrite a real display name. Best-effort: no file → no aliases.
 PROV_BY_ID = begin
   prov_path = File.join(File.dirname(opts[:layout]), 'chart-provenance.json')
-  File.exist?(prov_path) ? JSON.parse(File.read(prov_path)) : {}
+  if File.exist?(prov_path)
+    pj = JSON.parse(File.read(prov_path))
+    # ROOT CAUSE (#422 re-entry 1/6 match): build-charts-from-signals writes
+    # { "version": 1, "elements": { "<id>": {...} } } — this loader read the
+    # file FLAT, so every id lookup missed the "elements" envelope and #421's
+    # provenance matching silently never fired in the orchestrated flow (the
+    # unit fixture wrote the flat shape: a false green). Unwrap the envelope;
+    # a flat hand-authored map is still accepted.
+    if pj.is_a?(Hash) && pj['elements'].is_a?(Hash)
+      pj['elements']
+    else
+      pj.is_a?(Hash) ? pj : {}
+    end
+  else
+    {}
+  end
 rescue StandardError
   {}
 end
@@ -603,6 +678,10 @@ def build_page_from_tree(dashboard, page, opts)
     # already renders the source order (title art at its own geometry); a
     # fabricated page-name H1 here would duplicate the wordmark.
     hdr_rows = 0
+  elsif opts[:no_synthetic_title]
+    # #422: synthetic banner suppressed (flag or prior-state) — no fabricated
+    # page-name header; the body starts at the top of the grid.
+    hdr_rows = 0
   else
     # 3. Fabricated page-name header — only when the source has no banner-like
     # content in the top region at all.
@@ -997,12 +1076,13 @@ def build_page_synthesized(dashboard, page, opts, structure)
   # --- header band (rows 1..1+HEADER_ROWS) -----------------------------------
   hdr_style, hdr_dark = header_from_source(dashboard)
   hdr_id = "#{prefix}-hdr"
-  extra_els << container_el(hdr_id, hdr_style)
   hdr_ids = []
   if title_el
     placed << title_el['id']
     hdr_ids << title_el['id']
-  else
+  elsif !opts[:no_synthetic_title]
+    # #422: with --no-synthetic-title (or prior-state suppression) no page-name
+    # banner is fabricated; source header-text zones below still get a band.
     txt_id = "#{prefix}-hdrtext"
     extra_els << header_text_el(txt_id, page['name'], hdr_dark ? '#FFFFFF' : nil)
     hdr_ids << txt_id
@@ -1015,13 +1095,17 @@ def build_page_synthesized(dashboard, page, opts, structure)
     placed << el['id']
     hdr_ids << el['id']
   end
-  nh = hdr_ids.length
-  hdr_inner = hdr_ids.each_with_index.map do |eid, i|
-    c0 = 1 + (24 * i / nh.to_f).round
-    c1 = i == nh - 1 ? 25 : [1 + (24 * (i + 1) / nh.to_f).round, c0 + 1].max
-    le(eid, c0, c1, 1, 1 + HEADER_ROWS)
-  end.join("\n")
-  children << gc(hdr_id, 1, 25, 1, 1 + HEADER_ROWS, hdr_inner)
+  hdr_rows = hdr_ids.empty? ? 0 : HEADER_ROWS
+  unless hdr_ids.empty?
+    extra_els << container_el(hdr_id, hdr_style)
+    nh = hdr_ids.length
+    hdr_inner = hdr_ids.each_with_index.map do |eid, i|
+      c0 = 1 + (24 * i / nh.to_f).round
+      c1 = i == nh - 1 ? 25 : [1 + (24 * (i + 1) / nh.to_f).round, c0 + 1].max
+      le(eid, c0, c1, 1, 1 + hdr_rows)
+    end.join("\n")
+    children << gc(hdr_id, 1, 25, 1, 1 + hdr_rows, hdr_inner)
+  end
 
   # --- controls: sidebar rail vs top control band -----------------------------
   control_zones = zones.select { |z| %w[filter parameter].include?(z['kind'].to_s) }
@@ -1031,7 +1115,7 @@ def build_page_synthesized(dashboard, page, opts, structure)
   band_ctls    = page['elements'].select { |e| e['kind'] == 'control' && !rail_ctl_ids.include?(e['id']) }
 
   ctl_rows   = band_ctls.empty? ? 0 : 3
-  content_r0 = 1 + HEADER_ROWS + ctl_rows
+  content_r0 = 1 + hdr_rows + ctl_rows
   content_c0 = 1
   content_c1 = opts[:page_cols] + 1
   rail_cols  = 0
@@ -1052,7 +1136,7 @@ def build_page_synthesized(dashboard, page, opts, structure)
     end.join("\n")
     ctl_id = "#{prefix}-ctl"
     extra_els << container_el(ctl_id)
-    children << gc(ctl_id, content_c0, content_c1, 1 + HEADER_ROWS, 1 + HEADER_ROWS + ctl_rows, ctl_inner)
+    children << gc(ctl_id, content_c0, content_c1, 1 + hdr_rows, 1 + hdr_rows + ctl_rows, ctl_inner)
   end
 
   # --- content mapping ---------------------------------------------------------
@@ -1237,8 +1321,8 @@ def build_page_synthesized(dashboard, page, opts, structure)
       rail_r1 = [content_bottom, page_rows + 1].max
       rc0 = rail[:side] == :left ? 1 : content_c1
       rc1 = rail[:side] == :left ? 1 + rail_cols : opts[:page_cols] + 1
-      rail_rect = [rc0, rc1, 1 + HEADER_ROWS, rail_r1]
-      children << gc(rid, rc0, rc1, 1 + HEADER_ROWS, rail_r1, rail_inner, cols: 1)
+      rail_rect = [rc0, rc1, 1 + hdr_rows, rail_r1]
+      children << gc(rid, rc0, rc1, 1 + hdr_rows, rail_r1, rail_inner, cols: 1)
     end
   end
 
@@ -1253,7 +1337,7 @@ def build_page_synthesized(dashboard, page, opts, structure)
   end
   rects = []
   units.each_with_index { |u, i| rects << urects[i] unless u[:kind] == :text }
-  rects << [content_c0, content_c1, 1 + HEADER_ROWS, 1 + HEADER_ROWS + ctl_rows] unless band_ctls.empty?
+  rects << [content_c0, content_c1, 1 + hdr_rows, 1 + hdr_rows + ctl_rows] unless band_ctls.empty?
   rects << rail_rect if rail_rect
   rects << band_rect if band_rect
   fill = ZoneCensus.grid_fill_pct(rects, opts[:page_cols], page_rows)
@@ -1330,11 +1414,17 @@ def build_page_for_dashboard(dashboard, page, opts)
   # one; otherwise transparent — title on the canvas, no fabricated navy).
   hdr_style, hdr_dark = header_from_source(dashboard)
   hdr_id = "#{ov_prefix}-hdr"
-  extra_els << container_el(hdr_id, hdr_style)
+  hdr_rows = HEADER_ROWS
   if title_el
+    extra_els << container_el(hdr_id, hdr_style)
     children << header_band_xml(hdr_id, title_el['id'])
     placed << title_el['id']
+  elsif o[:no_synthetic_title]
+    # #422: synthetic banner suppressed (flag or prior-state) — no fabricated
+    # page-name header; content starts at the top of the grid.
+    hdr_rows = 0
   else
+    extra_els << container_el(hdr_id, hdr_style)
     txt_id = "#{ov_prefix}-hdrtext"
     extra_els << header_text_el(txt_id, page['name'], hdr_dark ? '#FFFFFF' : nil)
     children << header_band_xml(hdr_id, txt_id)
@@ -1353,7 +1443,7 @@ def build_page_for_dashboard(dashboard, page, opts)
     end.join("\n")
     ctl_id = "#{ov_prefix}-ctl"
     extra_els << container_el(ctl_id)
-    children << gc(ctl_id, 1, o[:page_cols] + 1, 1 + HEADER_ROWS, 1 + HEADER_ROWS + ctl_rows, inner)
+    children << gc(ctl_id, 1, o[:page_cols] + 1, 1 + hdr_rows, 1 + hdr_rows + ctl_rows, inner)
     placed.concat(ctl_els.map { |c| c['id'] })
   end
 
@@ -1366,7 +1456,7 @@ def build_page_for_dashboard(dashboard, page, opts)
   # pushes subsequent bands down; the grid stays collision-free.
   kind_by_id = page['elements'].each_with_object({}) { |e, h| h[e['id']] = e['kind'] }
   bands, min_exp = SigmaLayout.enforce_min_rows(bands, kind_by_id)
-  content_start = 1 + HEADER_ROWS + ctl_rows
+  content_start = 1 + hdr_rows + ctl_rows
   band_offset = bands.empty? ? 0 : content_start - bands.first.map { |i| i[3] }.min
   bands.each_with_index do |band, i|
     cid = "#{ov_prefix}-#{i + 1}"
@@ -1383,7 +1473,7 @@ def build_page_for_dashboard(dashboard, page, opts)
   text_els = page['elements'].select { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('text-') }
   unless text_els.empty?
     tn = text_els.length
-    r0 = 1 + HEADER_ROWS + ctl_rows + bands.sum { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min }
+    r0 = 1 + hdr_rows + ctl_rows + bands.sum { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min }
     inner = text_els.each_with_index.map do |e, i|
       c0 = 1 + (o[:page_cols] * i / tn.to_f).round
       c1 = i == tn - 1 ? o[:page_cols] + 1 : [1 + (o[:page_cols] * (i + 1) / tn.to_f).round, c0 + 1].max
@@ -1404,7 +1494,7 @@ def build_page_for_dashboard(dashboard, page, opts)
   # bottom band. An element in the built page but absent from the layout is
   # auto-flowed by Sigma as a stray white card (bottom-left), so NOTHING may
   # be left unreferenced.
-  content_bottom = 1 + HEADER_ROWS + ctl_rows +
+  content_bottom = 1 + hdr_rows + ctl_rows +
                    bands.sum { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min } +
                    (text_els.empty? ? 0 : 4)
   band_rect = safety_net_band(page, placed, extra_els, children, ov_prefix,
@@ -1421,7 +1511,7 @@ def build_page_for_dashboard(dashboard, page, opts)
   content_zones = ZoneCensus.content_zones(dashboard['zones'])
   placed_count = content_zones.count { |z| find_zone_el(els_by_name, z, o[:renames]) }
   content_rects = bands.flat_map { |b| b.map { |i| [i[1], i[2], i[3] + band_offset, i[4] + band_offset] } }
-  content_rects << [1, o[:page_cols] + 1, 1 + HEADER_ROWS, 1 + HEADER_ROWS + ctl_rows] if ctl_els.length.positive?
+  content_rects << [1, o[:page_cols] + 1, 1 + hdr_rows, 1 + hdr_rows + ctl_rows] if ctl_els.length.positive?
   content_rects << band_rect if band_rect # safety band holds real tiles → counts as filled
   fill = ZoneCensus.grid_fill_pct(content_rects, o[:page_cols], o[:page_rows])
   census = ZoneCensus.page_record(page['name'], content_zones.size, placed_count, fill)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
@@ -36,13 +36,21 @@
 # Recipes for each delta→fix live in refs/fidelity-recipes.md. See SKILL.md Phase 5g.
 #
 # Subcommands
-#   init        --workdir DIR --workbook-id ID --page-id ID [--source-image PNG]
+#   init        --workdir DIR --workbook-id ID [--page-id ID] [--source-image PNG]
 #               [--max-passes N (default 5)]
+#               --page-id omitted → auto-pick the page with the most VISIBLE
+#               (non-hidden) elements from <workdir>/wb-ids.json + wb-spec.json
+#               (#422: first-by-order picked a helper-table data page); ties
+#               warn. An explicit --page-id also OVERRIDES the page on an
+#               existing same-workbook ledger (entries preserved).
 #   render      --workdir DIR [--width 1920 --height 1500]   (needs a live workbook)
 #   record      --workdir DIR --dimension D --delta "..." --class C
 #               [--fix "..."] [--resolved]
 #   resolve     --workdir DIR (--entry N | --dimension D)    mark entry(ies) resolved
 #   apply-patch --workdir DIR --patch patch.json             GET→merge→normalize→PUT→guard→lint
+#               ALSO deep-merges the patch into <workdir>/wb-spec.json (when it
+#               exists and parses) so a re-entry full-spec PUT carries the fix
+#               instead of reverting it (#422: live-only patches were wiped).
 #               [--full-spec spec.json]  replace the whole spec instead of merging
 #               [--skip-style-normalize REASON]  waive the v5.1 style contract (named)
 #               [--resolves 0,2,3]       mark these ledger entries resolved on success
@@ -176,6 +184,31 @@ module FidelityLoop
   def no_data_delta?(delta)
     delta.to_s =~ NO_DATA_RX ? true : false
   end
+
+  # ---- RCF page picking (#422) ---------------------------------------------
+  # Elements that actually RENDER content on the page: hidden helpers carry
+  # visibleAsSource:false (the master + LOD/window helper tables), and a
+  # hidden:true element/page never renders. Everything else counts.
+  def visible_count(page)
+    (page['elements'] || []).count do |e|
+      e.is_a?(Hash) && e['visibleAsSource'] != false && e['hidden'] != true
+    end
+  end
+
+  # Pick the RCF page from an array of page hashes ({'id','name','elements'}):
+  # the page with the MOST visible elements — not first-by-order, which picked
+  # a second data page carrying only hidden helper tables (#422 live run).
+  # Returns [picked_page_or_nil, tied_pages] — tied_pages has >1 entry when
+  # several pages share the top count (caller warns; pick is first-by-order
+  # among the ties, deterministic).
+  def pick_rcf_page(pages)
+    cands = Array(pages).select { |p| p.is_a?(Hash) && p['id'] }
+    return [nil, []] if cands.empty?
+    scored = cands.map { |p| [visible_count(p), p] }
+    best = scored.map { |s, _| s }.max
+    top = scored.select { |s, _| s == best }.map { |_, p| p }
+    [top.first, top]
+  end
 end
 
 # ---------------------------------------------------------------------------
@@ -205,6 +238,34 @@ def save_ledger(dir, ledger)
   File.write(ledger_path(dir), JSON.pretty_generate(ledger))
 end
 
+# #422: --page-id omitted at init → pick the page with the most VISIBLE
+# (non-hidden) elements. Live page ids come from wb-ids.json (the readback);
+# element visibility (visibleAsSource:false hidden helpers) only lives in
+# wb-spec.json — join the two by page name. Dies (usage) when neither file
+# yields a page.
+def auto_pick_rcf_page(dir)
+  wb_ids  = (JSON.parse(File.read(File.join(dir, 'wb-ids.json'))) rescue nil)
+  wb_spec = (JSON.parse(File.read(File.join(dir, 'wb-spec.json'))) rescue nil)
+  spec_by_name = {}
+  ((wb_spec && wb_spec['pages']) || []).each { |p| spec_by_name[p['name']] = p if p.is_a?(Hash) }
+  pages = (((wb_ids && wb_ids['pages']) || (wb_spec && wb_spec['pages'])) || []).map do |p|
+    next nil unless p.is_a?(Hash) && p['id']
+    sp = spec_by_name[p['name']]
+    { 'id' => p['id'], 'name' => p['name'],
+      'elements' => ((sp && sp['elements']) || p['elements']) || [] }
+  end.compact
+  pick, top = FidelityLoop.pick_rcf_page(pages)
+  die 'no --page-id given and no pages found in <workdir>/wb-ids.json or wb-spec.json to auto-pick from', 2 unless pick
+  if top.length > 1
+    warn "WARN: #{top.length} pages tie at #{FidelityLoop.visible_count(pick)} visible element(s) " \
+         "(#{top.map { |p| p['name'] || p['id'] }.join(', ')}) — picked #{pick['name'] || pick['id']} " \
+         '(first-by-order); pass --page-id to override'
+  end
+  puts "auto-picked RCF page #{(pick['name'] || pick['id']).inspect} (#{pick['id']}) — " \
+       "most visible elements (#{FidelityLoop.visible_count(pick)}); --page-id overrides"
+  pick['id']
+end
+
 def print_rubric
   rubric = File.join(HERE, '..', 'refs', 'fidelity-rubric.md')
   puts
@@ -221,6 +282,29 @@ def print_rubric
        KPI/table-values accuracy].each { |d| puts "  - #{d}" }
   end
   puts '───────────────────────────────────────────────────────────'
+end
+
+# #422: a live-only apply-patch was REVERTED by the next re-entry full-spec
+# PUT (post-and-readback PUTs the workdir wb-spec.json wholesale) — the
+# operator had to hand-persist every RCF fix. Deep-merge the SAME patch into
+# <workdir>/wb-spec.json so re-entry carries prior fixes. Guard: only when
+# wb-spec.json exists and parses; never fails the apply.
+def persist_patch_to_wb_spec(dir, patch)
+  path = File.join(dir, 'wb-spec.json')
+  unless File.exist?(path)
+    puts "     (no #{path} — patch applied live only; a re-entry full-spec PUT will not carry it)"
+    return
+  end
+  begin
+    spec = JSON.parse(File.read(path))
+  rescue JSON::ParserError => e
+    warn "WARN: #{path} does not parse (#{e.message}) — patch NOT persisted; a re-entry full-spec PUT will revert this fix"
+    return
+  end
+  File.write(path, JSON.pretty_generate(FidelityLoop.deep_merge(spec, patch)) + "\n")
+  puts "[OK] patch persisted into #{path} (re-entry full-spec PUTs carry this fix)"
+rescue StandardError => e
+  warn "WARN: could not persist patch into #{path}: #{e.class}: #{e.message}"
 end
 
 cmd = ARGV.shift
@@ -254,24 +338,36 @@ die 'missing --workdir' unless opts[:dir]
 
 case cmd
 when 'init'
-  die '--workbook-id and --page-id required for init' unless opts[:wb] && opts[:page]
+  die '--workbook-id required for init' unless opts[:wb]
   # PRESERVE an existing ledger for the same workbook (field-caught: every
   # FAST PATH orchestrator re-entry re-ran init and WIPED the recorded deltas
   # — the natural fix-and-re-run loop destroyed its own audit trail). Only a
-  # DIFFERENT workbook id starts fresh; same-workbook re-init is a no-op.
-  # (direct file check — load_ledger die()s with SystemExit on a missing file,
-  # which `rescue nil` does NOT catch; a fresh init would exit 2)
+  # DIFFERENT workbook id starts fresh; same-workbook re-init is a no-op —
+  # except an explicit --page-id, which OVERRIDES the recorded page in place
+  # (#422: init used to offer no way to repoint an existing ledger at the
+  # right page). (direct file check — load_ledger die()s with SystemExit on a
+  # missing file, which `rescue nil` does NOT catch; a fresh init would exit 2)
   existing = File.exist?(ledger_path(opts[:dir])) ? (JSON.parse(File.read(ledger_path(opts[:dir]))) rescue nil) : nil
   if existing.is_a?(Hash) && existing['workbook_id'] == opts[:wb]
-    puts "[OK] fidelity ledger already initialized for #{opts[:wb]} " \
-         "(#{(existing['entries'] || []).length} entries, pass #{existing['pass']}/#{existing['max_passes']}) — preserved."
+    if opts[:page] && existing['page_id'] != opts[:page]
+      old = existing['page_id']
+      existing['page_id'] = opts[:page]
+      existing['source_image'] = opts[:src] if opts[:src]
+      save_ledger(opts[:dir], existing)
+      puts "[OK] fidelity ledger page OVERRIDDEN: #{old} → #{opts[:page]} " \
+           "(#{(existing['entries'] || []).length} entries preserved, pass #{existing['pass']}/#{existing['max_passes']})"
+    else
+      puts "[OK] fidelity ledger already initialized for #{opts[:wb]} " \
+           "(#{(existing['entries'] || []).length} entries, pass #{existing['pass']}/#{existing['max_passes']}) — preserved."
+    end
   else
+    page = opts[:page] || auto_pick_rcf_page(opts[:dir])
     ledger = FidelityLoop.new_ledger(
-      workbook_id: opts[:wb], page_id: opts[:page],
+      workbook_id: opts[:wb], page_id: page,
       source_image: opts[:src], max_passes: opts[:max] || 5
     )
     save_ledger(opts[:dir], ledger)
-    puts "[OK] initialized #{ledger_path(opts[:dir])} (max_passes=#{ledger['max_passes']})"
+    puts "[OK] initialized #{ledger_path(opts[:dir])} (page #{page}, max_passes=#{ledger['max_passes']})"
   end
 
 when 'render'
@@ -412,6 +508,7 @@ when 'apply-patch'
     out = opts[:out] || File.join(opts[:dir], 'rcf-merged-spec.json')
     File.write(out, JSON.pretty_generate(merged))
     puts "[DRY] merged spec → #{out} (no PUT, no lint)"
+    persist_patch_to_wb_spec(opts[:dir], patch) if opts[:patch] && patch
   else
     require_relative 'lib/sigma_rest'
     layout_was = merged['layout'].to_s
@@ -421,6 +518,9 @@ when 'apply-patch'
       die "PUT /v2/workbooks/#{wb}/spec failed (atomic — nothing written): #{e.message}", 4
     end
     puts "[OK] PUT merged spec to #{wb} (layout preserved: #{layout_was.empty? ? 'NONE' : "#{layout_was.scan(/<LayoutElement\b/).length} elements"})"
+    # Persist BEFORE the post-PUT guards: the fix is live either way, and an
+    # exit-5 guard failure must not leave wb-spec.json behind the live state.
+    persist_patch_to_wb_spec(opts[:dir], patch) if opts[:patch] && patch
 
     # Re-run the same guards post-and-readback runs on the initial POST.
     cols = Sigma.request(:get, "/v2/workbooks/#{wb}/columns") rescue nil

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -4047,22 +4047,23 @@ if rcf_passes.to_i <= 0
   line '      structure + data + a single visual verdict only — composition drift (palette, chart'
   line '      kind, KPI format) will NOT be iterated. --finalize will NOT require the fidelity ledger.'
 else
-  # Best-effort resolve the primary (first non-Data) page id + a source image to
-  # compare against, from the artifacts pass 1 already wrote.
-  wb_ids = (JSON.parse(File.read(File.join(WORK, 'wb-ids.json'))) rescue {})
-  primary_page = (wb_ids['pages'] || []).reject { |p| p['name'].to_s.downcase == 'data' }.first ||
-                 (wb_ids['pages'] || []).first
-  page_id = primary_page && primary_page['id']
+  # Best-effort resolve a source image to compare against from the artifacts
+  # pass 1 already wrote. The page is NOT pre-picked here any more (#422: the
+  # old first-non-"Data"-page pick landed on a second data page rendering a
+  # hidden helper table) — fidelity-loop.rb init auto-picks the page with the
+  # most VISIBLE elements from wb-ids.json + wb-spec.json, and an operator
+  # --page-id override now works even on an existing ledger.
   cmani = (JSON.parse(File.read(File.join(WORK, 'visual-qa', 'compare-manifest.json'))) rescue [])
   src_img = (cmani.find { |m| m['source_png'] } || {})['source_png']
-  if page_id
-    _, ist = run!(['ruby', File.join(HERE, 'fidelity-loop.rb'), 'init',
-                   '--workdir', WORK, '--workbook-id', wb_id, '--page-id', page_id,
-                   '--max-passes', rcf_passes.to_s] +
-                  (src_img ? ['--source-image', src_img] : []), allow_fail: true)
-    line "Phase 5g: RCF fidelity ledger initialized (page #{page_id}, budget #{rcf_passes})" if ist.success?
+  _, ist = run!(['ruby', File.join(HERE, 'fidelity-loop.rb'), 'init',
+                 '--workdir', WORK, '--workbook-id', wb_id,
+                 '--max-passes', rcf_passes.to_s] +
+                (src_img ? ['--source-image', src_img] : []), allow_fail: true)
+  if ist.success?
+    led_pg = (JSON.parse(File.read(File.join(WORK, 'fidelity-ledger.json')))['page_id'] rescue '?')
+    line "Phase 5g: RCF fidelity ledger initialized (page #{led_pg}, budget #{rcf_passes})"
   else
-    line 'Phase 5g: could not resolve a page id from wb-ids.json — init the ledger manually (see the prompt below)'
+    line 'Phase 5g: ledger init could not auto-pick a page — init manually with --page-id (see the prompt below)'
   end
   mark('phase5g-init')
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-loop.rb
@@ -132,6 +132,108 @@ Dir.mktmpdir do |dir|
   ok(st.exitstatus == 4, 'apply-patch refuses a live spec with no pages (exit 4)')
 end
 
+puts 'RCF page picking (#422):'
+helper_pg = { 'id' => 'pg-help', 'name' => 'Data Helpers', 'elements' => [
+  { 'id' => 'h1', 'kind' => 'table', 'visibleAsSource' => false },
+  { 'id' => 'h2', 'kind' => 'table', 'visibleAsSource' => false }
+] }
+content_pg = { 'id' => 'pg-main', 'name' => 'Overview', 'elements' => [
+  { 'id' => 'c1', 'kind' => 'bar-chart' }, { 'id' => 'c2', 'kind' => 'kpi-chart' },
+  { 'id' => 'ctl', 'kind' => 'control' }
+] }
+ok(FidelityLoop.visible_count(helper_pg).zero?, 'visibleAsSource:false helper tables count 0 visible')
+ok(FidelityLoop.visible_count(content_pg) == 3, 'content page counts its rendered elements')
+ok(FidelityLoop.visible_count('elements' => [{ 'id' => 'x', 'hidden' => true }]).zero?,
+   'hidden:true elements count 0 visible')
+pick, top = FidelityLoop.pick_rcf_page([helper_pg, content_pg])
+ok(pick && pick['id'] == 'pg-main' && top.length == 1,
+   'pick_rcf_page prefers the most-visible page over first-by-order')
+_, top2 = FidelityLoop.pick_rcf_page([content_pg, content_pg.merge('id' => 'pg-b', 'name' => 'B')])
+ok(top2.length == 2, 'equal visible counts reported as a tie')
+ok(FidelityLoop.pick_rcf_page([]) == [nil, []], 'no pages → [nil, []]')
+
+Dir.mktmpdir do |dir|
+  # wb-ids carries the LIVE page ids; visibility (visibleAsSource:false) only
+  # lives in wb-spec — the picker joins the two by page name. The hidden-helper
+  # data page comes FIRST: the exact shape that made the old first-by-order
+  # pick render a hidden helper table (#422 live run).
+  File.write(File.join(dir, 'wb-ids.json'), JSON.generate('pages' => [
+    { 'id' => 'live-data', 'name' => 'Data', 'elements' => [{ 'id' => 'master', 'kind' => 'table' }] },
+    { 'id' => 'live-help', 'name' => 'Data Helpers', 'elements' => [
+      { 'id' => 'h1', 'kind' => 'table' }, { 'id' => 'h2', 'kind' => 'table' }] },
+    { 'id' => 'live-main', 'name' => 'Overview', 'elements' => [
+      { 'id' => 'c1', 'kind' => 'bar-chart' }, { 'id' => 'c2', 'kind' => 'kpi-chart' }] }
+  ]))
+  File.write(File.join(dir, 'wb-spec.json'), JSON.generate('pages' => [
+    { 'id' => 'page-data', 'name' => 'Data', 'elements' => [
+      { 'id' => 'master', 'kind' => 'table', 'visibleAsSource' => false }] },
+    { 'id' => 'page-help', 'name' => 'Data Helpers', 'elements' => [
+      { 'id' => 'h1', 'kind' => 'table', 'visibleAsSource' => false },
+      { 'id' => 'h2', 'kind' => 'table', 'visibleAsSource' => false }] },
+    { 'id' => 'page-main', 'name' => 'Overview', 'elements' => [
+      { 'id' => 'c1', 'kind' => 'bar-chart' }, { 'id' => 'c2', 'kind' => 'kpi-chart' }] }
+  ]))
+  out, st = run('init', '--workbook-id', 'WB', dir: dir)
+  led = JSON.parse(File.read(File.join(dir, 'fidelity-ledger.json')))
+  ok(st.exitstatus.zero? && out.include?('auto-picked'), 'init without --page-id auto-picks a page')
+  ok(led['page_id'] == 'live-main',
+     'auto-pick chose the VISIBLE content page (live id), not the first-by-order helper page')
+
+  # --page-id override on the EXISTING ledger (entries preserved) — the old
+  # init had no way to repoint an already-initialized ledger.
+  run('record', '--dimension', 'palette', '--delta', 'x', '--class', 'ui-only', dir: dir)
+  out, st = run('init', '--workbook-id', 'WB', '--page-id', 'live-other', dir: dir)
+  led = JSON.parse(File.read(File.join(dir, 'fidelity-ledger.json')))
+  ok(st.exitstatus.zero? && out.include?('OVERRIDDEN'), 'init --page-id on an existing ledger overrides in place')
+  ok(led['page_id'] == 'live-other' && led['entries'].length == 1, 'override preserves the recorded entries')
+end
+
+Dir.mktmpdir do |dir|
+  _out, st = run('init', '--workbook-id', 'WB', dir: dir)
+  ok(st.exitstatus == 2, 'init dies (usage) with no --page-id and nothing to auto-pick from')
+end
+
+Dir.mktmpdir do |dir|
+  File.write(File.join(dir, 'wb-ids.json'), JSON.generate('pages' => [
+    { 'id' => 'live-a', 'name' => 'A', 'elements' => [{ 'id' => 'c1', 'kind' => 'bar-chart' }] },
+    { 'id' => 'live-b', 'name' => 'B', 'elements' => [{ 'id' => 'c2', 'kind' => 'bar-chart' }] }
+  ]))
+  out, st = run('init', '--workbook-id', 'WB', dir: dir)
+  led = JSON.parse(File.read(File.join(dir, 'fidelity-ledger.json')))
+  ok(st.exitstatus.zero? && out =~ /tie/ && led['page_id'] == 'live-a',
+     'tied visible counts WARN and pick first-by-order (deterministic)')
+end
+
+puts 'apply-patch dual-write (#422):'
+Dir.mktmpdir do |dir|
+  run('init', '--workbook-id', 'WB', '--page-id', 'PG', dir: dir)
+  wb_spec = { 'pages' => [{ 'id' => 'page-ov', 'elements' => [
+    { 'elementId' => 'k1', 'kind' => 'kpi-chart', 'style' => { 'x' => 1 } },
+    { 'elementId' => 'k2', 'kind' => 'bar-chart' }] }], 'themeName' => 'Light' }
+  File.write(File.join(dir, 'wb-spec.json'), JSON.generate(wb_spec))
+  live = { 'pages' => [{ 'id' => 'PG', 'elements' => [{ 'elementId' => 'k1', 'kind' => 'kpi-chart' }] }] }
+  File.write(File.join(dir, 'live.json'), JSON.generate(live))
+  File.write(File.join(dir, 'patch.json'),
+             JSON.generate('themeOverrides' => { 'categoricalScheme' => ['#0e7c7b'] }))
+  out, st = run('apply-patch', '--patch', File.join(dir, 'patch.json'), '--dry-run',
+                '--live-spec', File.join(dir, 'live.json'), '--out', File.join(dir, 'merged.json'), dir: dir)
+  ok(st.exitstatus.zero?, 'apply-patch (dual-write) exits 0')
+  ok(out.include?('persisted into'), 'apply-patch reports the wb-spec.json persistence')
+  ws = JSON.parse(File.read(File.join(dir, 'wb-spec.json')))
+  ok(ws['themeOverrides'] == { 'categoricalScheme' => ['#0e7c7b'] },
+     'patch deep-merged into wb-spec.json (a re-entry full-spec PUT now carries the fix)')
+  ok(ws['pages'][0]['elements'].length == 2 && ws['themeName'] == 'Light',
+     'wb-spec.json untouched keys/elements preserved by the merge')
+
+  # guard: unparseable wb-spec.json → warned, left untouched, apply still succeeds
+  File.write(File.join(dir, 'wb-spec.json'), '{ not json')
+  out, st = run('apply-patch', '--patch', File.join(dir, 'patch.json'), '--dry-run',
+                '--live-spec', File.join(dir, 'live.json'), '--out', File.join(dir, 'merged2.json'), dir: dir)
+  ok(st.exitstatus.zero? && out.include?('NOT persisted'),
+     'unparseable wb-spec.json → warn, apply-patch still succeeds')
+  ok(File.read(File.join(dir, 'wb-spec.json')) == '{ not json', 'unparseable wb-spec.json left untouched')
+end
+
 puts 'render budget:'
 Dir.mktmpdir do |dir|
   run('init', '--workbook-id', 'WB', '--page-id', 'PG', '--max-passes', '1', dir: dir)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-synthesis.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-synthesis.rb
@@ -35,11 +35,11 @@ def ok(name, cond)
   $fail += 1 unless cond
 end
 
-def build(dl, wb, dir)
+def build(dl, wb, dir, extra = [])
   File.write(File.join(dir, 'dl.json'), JSON.generate(dl))
   File.write(File.join(dir, 'wb.json'), JSON.generate(wb))
   out = File.join(dir, 'layout.xml')
-  log = `#{RUBY} #{BUILD} --layout #{File.join(dir, 'dl.json')} --wb-ids #{File.join(dir, 'wb.json')} --out #{out} 2>&1`
+  log = `#{RUBY} #{BUILD} --layout #{File.join(dir, 'dl.json')} --wb-ids #{File.join(dir, 'wb.json')} --out #{out} #{extra.join(' ')} 2>&1`
   xml = File.exist?(out) ? File.read(out) : nil
   census = File.exist?(File.join(dir, 'layout-census.json')) ? JSON.parse(File.read(File.join(dir, 'layout-census.json'))) : nil
   elements = File.exist?("#{out}.elements.json") ? File.read("#{out}.elements.json") : nil
@@ -391,8 +391,13 @@ Dir.mktmpdir do |d|
   dl = JSON.parse(JSON.generate(DL_TITLE))
   wb = JSON.parse(JSON.generate(WB_TITLE))
   wb['pages'][1]['elements'][1]['name'] = 'Gross Margin Trend (renamed)'
+  # REAL builder shape ({version, elements} envelope — build-charts-from-signals):
+  # the old fixture wrote a FLAT map, a false green that hid the #422 root cause
+  # (the loader read the envelope file flat and provenance never fired live).
   File.write(File.join(d, 'chart-provenance.json'), JSON.generate(
-    'el-1' => { 'worksheet' => 'Margin Trend', 'dashboard' => 'Profitability Watch' }))
+    'version' => 1, 'elements' => {
+      'el-1' => { 'worksheet' => 'Margin Trend', 'dashboard' => 'Profitability Watch' }
+    }))
   xml, census, log, _els = build(dl, wb, d)
   ok('builder produced layout XML (renamed tile + provenance)', !xml.nil?)
   next if xml.nil?
@@ -402,6 +407,123 @@ Dir.mktmpdir do |d|
   pg = census && census['pages'].first
   ok('census counts the renamed tile as placed (no drop)', pg && pg['dropped'] == 0)
   ok('census unplaced_elements empty', pg && pg['unplaced_elements'] == [])
+end
+
+# ---- 5. #422 re-entry repeat-tax regressions ---------------------------------
+puts '-- #422: provenance on re-entry, rename persistence, banner opt-out'
+
+# 5a. provenance matching on RE-ENTRY (the live 1/6 case): after a re-entry
+# readback, 5 of 6 tiles carry operator-renamed display names that match
+# neither the zone caption nor display_title. With the REAL nested
+# chart-provenance.json ({version, elements}) every tile must resolve via its
+# worksheet alias — main@208626b matched only the un-renamed tile because the
+# loader read the envelope file flat and the aliases never materialized.
+DL_SIX = [{
+  'dashboard' => 'Exec Overview',
+  'zones' => (1..6).map do |i|
+    { 'id' => "z#{i}", 'kind' => 'chart', 'caption' => "WS #{i}", 'chart_kind' => 'bar',
+      'measures' => ['m'], 'x_pct' => ((i - 1) % 3) * 33.4, 'y_pct' => 5 + ((i - 1) / 3) * 45,
+      'w_pct' => 33, 'h_pct' => 40 }
+  end,
+  'zone_tree' => []
+}]
+WB_SIX = { 'pages' => [
+  { 'name' => 'Data', 'id' => 'page-data', 'elements' => [{ 'id' => 'master', 'kind' => 'table', 'name' => 'M' }] },
+  { 'name' => 'Exec Overview', 'id' => 'page-ex', 'elements' =>
+    (1..6).map do |i|
+      { 'id' => "el-#{i}", 'kind' => 'bar-chart',
+        'name' => i == 1 ? 'WS 1' : "Operator Renamed #{i}" }
+    end }
+] }
+
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'chart-provenance.json'), JSON.generate(
+    'version' => 1,
+    'elements' => (1..6).each_with_object({}) do |i, h|
+      h["el-#{i}"] = { 'worksheet' => "WS #{i}", 'dashboard' => 'Exec Overview' }
+    end))
+  xml, census, log, _els = build(DL_SIX, WB_SIX, d)
+  ok('re-entry build produced layout XML (5/6 tiles renamed)', !xml.nil?)
+  unless xml.nil?
+    pg = census && census['pages'].first
+    ok('ALL 6 renamed tiles match via nested provenance (was 1/6 live)',
+       pg && pg['placed'] == 6 && pg['dropped'] == 0)
+    ok('no safety-net band needed for the renamed tiles', !xml.include?('-extra"'))
+    ok('no "no Sigma element matched" WARN', !log.include?('no Sigma element matched'))
+    ok('no collisions', collisions(xml).empty?)
+  end
+end
+
+# 5b. rename persistence round-trip: --rename on pass 1 lands in
+# layout-renames.json; a re-entry rebuild WITHOUT the flag auto-applies it
+# (the operator no longer re-types --rename x4 per re-entry).
+Dir.mktmpdir do |d|
+  dl = JSON.parse(JSON.generate(DL_TITLE))
+  wb = JSON.parse(JSON.generate(WB_TITLE))
+  wb['pages'][1]['elements'][1]['name'] = 'Net Margin Trend'
+  xml, _c, _log, = build(dl, wb, d, ["--rename 'Margin Trend=Net Margin Trend'"])
+  ok('pass 1 (--rename) placed the renamed tile',
+     !xml.nil? && xml.scan(/elementId="el-1"/).length == 1 && !xml.include?('-extra"'))
+  rn = File.join(d, 'layout-renames.json')
+  ok('renames persisted to layout-renames.json',
+     File.exist?(rn) && JSON.parse(File.read(rn)) == { 'Margin Trend' => 'Net Margin Trend' })
+  xml2, census2, log2, = build(dl, wb, d) # re-entry: NO --rename flags
+  pg2 = census2 && census2['pages'].first
+  ok('re-entry (no --rename) still matches via the persisted map',
+     !xml2.nil? && xml2.scan(/elementId="el-1"/).length == 1 && !xml2.include?('-extra"') &&
+     pg2 && pg2['dropped'] == 0)
+  ok('re-entry log notes the persisted renames were loaded', log2.include?('persisted rename mapping'))
+end
+
+# 5c. banner opt-out. Baseline (no title element, no source header zone) emits
+# the fabricated page-name banner; --no-synthetic-title suppresses it.
+WB_NOTITLE = JSON.parse(JSON.generate(WB_TITLE))
+WB_NOTITLE['pages'][1]['elements'] = WB_NOTITLE['pages'][1]['elements'].reject { |e| e['id'].to_s.start_with?('title') }
+
+Dir.mktmpdir do |d|
+  xml, _c, _log, = build(DL_TITLE, WB_NOTITLE, d)
+  ok('baseline: fabricated page-name banner emitted (-hdrtext)', !xml.nil? && xml.include?('-hdrtext"'))
+end
+Dir.mktmpdir do |d|
+  xml, census, _log, = build(DL_TITLE, WB_NOTITLE, d, ['--no-synthetic-title'])
+  ok('--no-synthetic-title: no fabricated banner, no header band',
+     !xml.nil? && !xml.include?('-hdrtext"') && !xml.include?('-hdr"'))
+  pg = census && census['pages'].first
+  ok('suppressed banner: charts still placed, nothing orphaned, no collisions',
+     pg && pg['placed'] == 2 && pg['unplaced_elements'] == [] && collisions(xml).empty?)
+end
+# synthesized path takes the same flag
+Dir.mktmpdir do |d|
+  dl = JSON.parse(JSON.generate(DL_KPI))
+  dl[0]['zones'] = dl[0]['zones'].reject { |z| z['id'] == 't1' }
+  wb = JSON.parse(JSON.generate(WB_KPI))
+  wb['pages'][1]['elements'] = wb['pages'][1]['elements'].reject { |e| %w[title-ov text-t1].include?(e['id']) }
+  xml, census, log, = build(dl, wb, d, ['--no-synthetic-title'])
+  ok('synthesized path honors --no-synthetic-title (no header band at all)',
+     !xml.nil? && log.include?('synthesized layout') && !xml.include?('-hdrtext"') && !xml.include?('-hdr"'))
+  pg = census && census['pages'].first
+  ok('synthesized suppression: nothing orphaned, no collisions',
+     pg && pg['unplaced_elements'] == [] && collisions(xml).empty?)
+end
+
+# 5d. prior-state auto-suppression: a prior layout.xml at --out with NO header
+# band (the operator removed the banner and re-PUT) must suppress re-injection
+# on the next rebuild — respect the operator's last state.
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'layout.xml'),
+             '<Page type="grid" gridTemplateColumns="repeat(24, 1fr)"><LayoutElement elementId="el-1" gridColumn="1 / 25" gridRow="1 / 9"/></Page>')
+  xml, _c, log, = build(DL_TITLE, WB_NOTITLE, d)
+  ok('prior-state: rebuild auto-suppresses the banner', log.include?('auto-suppressed'))
+  ok('prior-state: no fabricated banner in the rebuilt layout',
+     !xml.nil? && !xml.include?('-hdrtext"'))
+end
+# …but a prior layout WITH the banner keeps it (no false suppression).
+Dir.mktmpdir do |d|
+  xml1, _c1, _l1, = build(DL_TITLE, WB_NOTITLE, d)
+  ok('control: first build emits the banner', !xml1.nil? && xml1.include?('-hdrtext"'))
+  xml2, _c2, log2, = build(DL_TITLE, WB_NOTITLE, d)
+  ok('control: rebuild over a banner-bearing prior layout keeps the banner',
+     !xml2.nil? && xml2.include?('-hdrtext"') && !log2.include?('auto-suppressed'))
 end
 
 puts($fail.zero? ? "\nALL PASS — layout synthesis (bands, rail, KPI containers, min rows, determinism)" : "\n#{$fail} FAILED")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-visual-source-fallback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-visual-source-fallback.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-visual-source-fallback.rb — #422: verify-dashboard-visual.rb must stage
+# the SOURCE dashboard PNG from the discovery-saved dashboards/<name>.png when
+# the live Tableau fetch env is incomplete (a re-entry shell often lacks
+# TABLEAU_SITE_ID / TABLEAU_AUTH_TOKEN) instead of leaving the pair INCOMPLETE
+# with "TABLEAU_SITE_ID not set" — discovery already saved the image on disk.
+#
+# Offline, creds-free (the Sigma render side is skipped: no matching page).
+# Run: ruby scripts/test-visual-source-fallback.rb
+
+require 'json'
+require 'tmpdir'
+require 'fileutils'
+require 'open3'
+require 'rbconfig'
+
+SCRIPT = File.join(__dir__, 'verify-dashboard-visual.rb')
+RUBY   = RbConfig.ruby
+$fail = 0
+def ok(name, cond)
+  puts((cond ? '  ok  ' : 'FAIL  ') + name)
+  $fail += 1 unless cond
+end
+
+# Env WITHOUT any Tableau credentials — the re-entry shell shape.
+NO_TABLEAU_ENV = { 'TABLEAU_SITE_ID' => nil, 'TABLEAU_AUTH_TOKEN' => nil,
+                   'TABLEAU_SERVER_URL' => nil, 'TABLEAU_PAT_NAME' => nil,
+                   'TABLEAU_PAT_SECRET' => nil, 'TABLEAU_SITE_CONTENT_URL' => nil }.freeze
+
+def stage(dir, with_view:)
+  name = 'Exec Overview'
+  File.write(File.join(dir, 'dashboard-layout.json'),
+             JSON.generate([{ 'dashboard' => name, 'zones' => [] }]))
+  # Only a Data page → the Sigma render side is skipped (no page to render);
+  # this isolates the SOURCE staging path.
+  File.write(File.join(dir, 'wb-ids.json'),
+             JSON.generate('pages' => [{ 'id' => 'pg-d', 'name' => 'Data', 'elements' => [] }]))
+  if with_view
+    # get-workbook.json resolves a view id, so the script ATTEMPTS the live
+    # fetch — which raises the exact "TABLEAU_* not set" the live run hit.
+    File.write(File.join(dir, 'get-workbook.json'),
+               JSON.generate('views' => { 'view' => [{ 'name' => name, 'id' => 'v-1' }] }))
+  end
+  FileUtils.mkdir_p(File.join(dir, 'dashboards'))
+  # tableau-discover.rb 3b filename convention: non-word runs → underscore.
+  File.binwrite(File.join(dir, 'dashboards', 'Exec_Overview.png'), "\x89PNG-fake-bytes")
+  out, st = Open3.capture2e(NO_TABLEAU_ENV, RUBY, SCRIPT, '--workbook', 'WBID', '--tableau-dir', dir)
+  [out, st, File.join(dir, 'visual-qa', 'exec-overview.source.png')]
+end
+
+puts '-- discovery-PNG fallback, no view id resolvable (no get-workbook.json)'
+Dir.mktmpdir do |d|
+  out, _st, src = stage(d, with_view: false)
+  ok('source PNG staged from the discovery-saved dashboards/*.png', File.size?(src))
+  ok('fallback NOTE printed', out.include?('discovery-saved'))
+  man = JSON.parse(File.read(File.join(d, 'visual-qa', 'compare-manifest.json')))
+  ok('compare-manifest records the staged source_png', man[0]['source_png'] == src)
+end
+
+puts '-- discovery-PNG fallback after the live fetch fails (TABLEAU_* env missing)'
+Dir.mktmpdir do |d|
+  out, _st, src = stage(d, with_view: true)
+  ok('live fetch failed on the missing Tableau env (the #422 failure)',
+     out =~ /TABLEAU_\w+ not set/)
+  ok('…but the source PNG is STILL staged from dashboards/*.png', File.size?(src))
+  man = JSON.parse(File.read(File.join(d, 'visual-qa', 'compare-manifest.json')))
+  ok('compare-manifest records the staged source_png', man[0]['source_png'] == src)
+end
+
+puts($fail.zero? ? "\nALL PASS — visual source-PNG fallback" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-dashboard-visual.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-dashboard-visual.rb
@@ -72,6 +72,20 @@ dash_layout.each do |d|
   rescue StandardError => e
     warn "  WARN  source dashboard image failed for #{name.inspect}: #{e.class}: #{e.message}"
   end
+  # #422: the live fetch needs the Tableau env (a re-entry shell often lacks
+  # TABLEAU_SITE_ID/AUTH_TOKEN) — but discovery already saved every dashboard
+  # PNG to <tab>/dashboards/<name>.png (tableau-discover.rb 3b, same filename
+  # convention as render-baseline.rb). Fall back to it instead of failing the
+  # staging.
+  unless rec['source_png']
+    fb_name = name.to_s.strip.gsub(/[^\w.-]+/, '_').gsub(/\A_+|_+\z/, '')
+    fb = File.join(opts[:tab], 'dashboards', "#{fb_name}.png")
+    if File.size?(fb)
+      FileUtils.cp(fb, src_png)
+      rec['source_png'] = src_png
+      puts "  NOTE  source PNG for #{name.inspect} staged from the discovery-saved #{fb} (live Tableau fetch unavailable)"
+    end
+  end
 
   # 2) Sigma page render
   pid = page_id_by_name[name] || page_id_by_name.reject { |k, _| k == 'Data' }.values.first


### PR DESCRIPTION
Fixes the re-entry repeat-tax defect bundle from #422's second live validation (measured ~10 min of operator re-work per orchestrator re-entry). Scope: layout / RCF / orchestrator re-entry only — record-visual-check / probe-equivalence / assert-phase6-ran (D1–D3) are deliberately untouched.

## 1. Rename persistence (`build-dashboard-layout.rb`)
Every `--rename` is merged into `<workdir>/layout-renames.json` (beside `--layout`, like the other sidecars) and auto-loaded on every subsequent build — orchestrator re-entry included, since the phase-5 call site passes `--layout <WORK>/dashboard-layout.json`. CLI flags win on conflict; the file accumulates. No more re-typing `--rename` x4 per re-entry.

## 2. Root cause: why #421's provenance matching never fired on re-entry (the 1/6 case)
`build-charts-from-signals.rb` writes `chart-provenance.json` as `{"version":1,"elements":{"<id>":{...}}}` — but the layout builder's `PROV_BY_ID` loader read the file **flat**, so every element-id lookup landed on the `version`/`elements` envelope keys and missed. #421's provenance aliases therefore silently never materialized in the orchestrated flow; the unit fixture had written a **flat** map, a false green that hid it. On re-entry (readback names drifted by operator renames) name-matching then missed 5/6 tiles. The loader now unwraps the `elements` envelope (flat hand-authored maps still accepted); the fixture uses the real nested shape and a new 6-tile/5-renamed re-entry regression asserts **6/6 matched, no safety-net band**.

## 3. Banner opt-out (`build-dashboard-layout.rb`)
- `--no-synthetic-title` suppresses the fabricated page-name header band on all three layout paths (banded, container-tree, synthesized). Extracted **source** titles and source header-text zones still render — only the invented banner is suppressed.
- Prior-state auto-suppression: when a prior `layout.xml` at `--out` has pages but **no** header band (`-hdr`/`-hdrtext`), the operator removed the banner — the rebuild respects that last state instead of re-injecting it. A prior layout that still carries the banner keeps it (control test included).

## 4. RCF patch persistence (`fidelity-loop.rb apply-patch`)
The patch is additionally deep-merged (same `FidelityLoop.deep_merge` used for the live PUT) into `<workdir>/wb-spec.json`, so a re-entry full-spec PUT carries prior fixes instead of reverting them. Guard: only when `wb-spec.json` exists **and parses** (unparseable → loud WARN, file untouched, apply still succeeds; absent → note).

## 5. RCF init page picking (`fidelity-loop.rb init` + phase 5g call site)
- `--page-id` is now optional: init auto-picks the page with the most **VISIBLE** elements (`visibleAsSource:false` helpers and `hidden:true` count 0), joining `wb-ids.json` live page ids with `wb-spec.json` visibility by page name. Ties WARN and pick first-by-order (deterministic).
- An explicit `--page-id` now also **overrides** the page on an existing same-workbook ledger, entries preserved (previously impossible).
- `migrate-tableau.rb` phase 5g stops pre-picking "first non-Data page" (which rendered a hidden helper table when a second data page existed) and defers to init's auto-pick.

## 6. Source-PNG staging fallback (`verify-dashboard-visual.rb`)
When the live Tableau fetch env is incomplete (the `TABLEAU_SITE_ID not set` failure raised from `lib/tableau_rest.rb` via `Tableau.view_image`) or no view id resolves, the source side is staged from the discovery-saved `dashboards/<name>.png` (same filename convention as `tableau-discover.rb` 3b / `render-baseline.rb`), with a NOTE line and the pair recorded in `compare-manifest.json`.

## Tests
- `test-layout-synthesis.rb`: nested-provenance re-entry regression (6/6, was 1/6), rename persistence round-trip (build → `layout-renames.json` → flag-less rebuild auto-applies), banner suppressed via flag (banded + synthesized paths) and via prior state, plus a no-false-suppression control. Provenance fixture corrected to the real `{version, elements}` shape.
- `test-fidelity-loop.rb`: `visible_count`/`pick_rcf_page` pure tests, init auto-pick (hidden-helper page first → visible page chosen by live id), tie WARN, `--page-id` override on existing ledger with entries preserved, usage die with nothing to pick from, apply-patch dual-write + untouched-keys + unparseable-spec guard.
- New `test-visual-source-fallback.rb`: offline fallback staging with and without a resolvable view id (the latter exercises the exact `TABLEAU_* not set` live failure).

## Verification
- Full scripts test sweep: 163 test files, all green except `test-calc-discovery.rb`, which fails **identically on origin/main** (env-dependent: needs a live Tableau token + `/tmp/assessment-site` fixture) — pre-existing, unrelated.
- `corpus/run-corpus.sh --check`: **17/17**
- `tools/hygiene-sweep.sh`: clean (incl. staged diff)
- `tools/check-shared.rb`: OK — none of the touched files are shared-managed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
