### PR TITLE
tableau: PR-12 series color + number formats (ordered member→color schemes, .twb format mapping, formats-emitted.json)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/data-model-spec.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/data-model-spec.md
@@ -178,7 +178,18 @@ Use this pattern whenever the workbook needs to slice the fact by a dim attribut
 {"kind": "number", "formatString": "$,.2f", "currencySymbol": "$"}   // currency
 {"kind": "number", "formatString": ",.0f"}                           // integer
 {"kind": "number", "formatString": ",.2%"}                           // percent
+{"kind": "number", "formatString": ",.0f", "displayNullAs": "—"}     // nulls render as the literal
+{"kind": "datetime", "formatString": "%B %-d, %Y"}                   // date-time: d3-time ONLY
 ```
+
+`formatString` is d3-format grammar for numbers and **d3-time (strftime) for
+date-times**. Moment-style token strings (`"MMM D, YYYY"`) are NOT parsed —
+non-`%` characters print literally, so the column renders the token text
+instead of a date. When emitting DM columns from a Tableau source, map the
+column's `.twb` `default-format` through the skill's shared translator
+(`scripts/lib/format_map.rb`, PR-12): currency/percent/decimals/thousands and
+date tokens translate mechanically; anything the translator refuses is
+recorded (formats-coverage) rather than guessed.
 
 ## Response
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/fidelity-recipes.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/fidelity-recipes.md
@@ -39,6 +39,7 @@ Each row: **the visible delta** · the spec path · notes/gotcha.
 ### Canvas, theme & palette
 - **Page/canvas background wrong color** → `themeOverrides.colorOverrides.backgroundCanvas: "#RRGGBB"` (top-level workbook theme).
 - **Chart series / donut-pie slice colors are generic** → `themeOverrides.categoricalScheme: [...]` — a **positional** array applied in category-sort order. This is the **only** spec path to donut/pie slice colors (per-element `color.scheme` is silently dropped on donut/pie). Extract the source hexes from the `.twb` (`composition-recipe.md` §"Extract brand colors").
+- **Series colors INVERTED / swapped across members** (Top-500 gold on the Bottom-500 series) → the scheme must be **ordered ascending by member** so `scheme[i]` binds to the i-th category in Sigma's sort order. Where the `.twb` carries an explicit member→color map (`<encoding attr='color' type='palette'><map to='#hex'><bucket>…`), the builder now pins per-chart `color.scheme` AND orders `themeOverrides.categoricalScheme` mechanically (PR-12, `scripts/lib/series_colors.rb`); check `formats-emitted.json` → `series_color_maps` (`pinned|theme|unpinned`) before hand-fixing a `palette_match` delta. Frequency-ranked palettes only apply when no explicit map exists.
 - **Fonts don't match the source** → `themeOverrides.fonts.{textFont, dataFont}`. Map the Tableau family to a web-safe family (Tableau "Tableau Book"/"Benton"→`Inter`/`Helvetica Neue`; a serif → `Georgia`). Only families Sigma ships round-trip.
 - **Accent sprayed on every tile** (AI tell) → pull the tint back to the header band + the hero KPI only; default the rest to the neutral surface. See `layout-visual-qa.md` §3.
 
@@ -55,9 +56,37 @@ Each row: **the visible delta** · the spec path · notes/gotcha.
 
 ### KPIs & hero numbers
 - **KPI hero number too small / not the focal point** → `value.fontSize` up + transparent element `style` + widen the tile's `layout.anchor`/grid span.
-- **KPI value in the wrong format** (`$473.0k` vs source `$473.0K`) → emit an **exact-format text-formula column** (e.g. an uppercase-K suffix builder) and point the KPI value at it; don't rely on the number-format enum when the source uses a non-standard suffix. Format basics: money `$,.0f`; compact `$,.2s`.
+- **KPI value in the wrong format** (`$473.0k` vs source `$473.0K`) → emit an **exact-format text-formula column** (e.g. an uppercase-K suffix builder) and point the KPI value at it; don't rely on the number-format enum when the source uses a non-standard suffix. Format basics: money `$,.0f`; compact `$,.2s`. A KPI printing plain-raw where the source shows `$`/`%` is now a builder bug, not an RCF chore — the build maps the worksheet pill format and the column's `.twb` `default-format` mechanically (see §"Number & date formats" + `formats-emitted.json`).
 - **KPI shows its own title *and* the card label** (duplicated) → set the KPI value-column `name: ' '` (single space; `''` re-derives the title).
 - **KPI title clipped** → the tile is < ~5 grid rows; grow `gridRow`. Sparkline/comparison KPIs need ~8+ rows. NOTE on KPI sparklines + comparison/delta badges (live-probed 2026-07-11): the spec ACCEPTS `comparison`/`trend` FORMATTING blocks (spec/verify 200), but there is **no create-spec property that binds** the comparison column / trend axis, and the PUT rejects formatting-without-binding (`comparison.display: requires a comparison column or period comparison on the KPI`). Classify `ui-only` for creation; once a user binds it in the UI, the styling round-trips.
+
+### Number & date formats (mechanical since PR-12)
+- The one-shot build emits source formats mechanically: the worksheet's own pill `text-format`
+  first, then the column's `.twb` `default-format` (the fix for KPIs printing raw where the
+  source shows `$`), then master-map/name-heuristic. ONE translator: `scripts/lib/format_map.rb`
+  (parser + builder both delegate). Per-tile coverage lands in **`formats-emitted.json`** next to
+  the chart-spec output — `entries[]` (source format string → emitted format, `mapped|unmapped`;
+  an unmapped source string is **recorded, never guessed**) + `series_color_maps[]`. Read it
+  before hand-fixing a `numbers_formatted` delta.
+- Mapping table (Tableau → Sigma d3-format):
+
+  | Tableau source | Sigma format |
+  |---|---|
+  | `p0.0%` / `#,##0.0%` | `,.1%` |
+  | `$#,##0.00` / `€#,##0` / `C1033` | `$,.2f` / `$,.0f` + `currencySymbol` |
+  | `#,##0` / `0.00` | `,.0f` / `,.2f` |
+  | `pos;(neg)` | leading `(` sign modifier (parens on negative) |
+  | `#,##0,,,B` (scale-comma + suffix) | not d3-expressible → exact-format scaled column (KPI recipe above) |
+  | `yyyy-MM-dd` / `MMM yyyy` / `MMMM d, yyyy` | `%Y-%m-%d` / `%b %Y` / `%B %-d, %Y` |
+
+- **Sigma date-time formats are d3-time (strftime) strings** — `%B %-d, %Y`. Moment-style token
+  strings (`"MMM D, YYYY"`) are NOT a format language to Sigma: every non-`%` character prints
+  **literally**, so the tile renders the text `MMM D, YYYY` instead of a date (live-run
+  finding). Never author one; `format_map` refuses (returns nil → recorded unmapped) any string
+  it can't fully tokenize into `%`-directives.
+- **`displayNullAs` exists on number formats** — `{kind: 'number', formatString: ',.0f',
+  displayNullAs: '—'}` renders nulls as the literal. Use it when the source shows a dash/blank
+  for null cells; the translator maps a quoted 4th Tableau format segment (`…;;;"—"`) to it.
 
 ### Status, thresholds & tables
 - **Status chip / traffic-light cell** → `conditionalFormats` `type: single` with a **flat** `condition`/`value` (not nested).
@@ -78,7 +107,7 @@ Each row: **the visible delta** · the spec path · notes/gotcha.
 ### Controls & parameters
 - **Source has parameters/quick-filters but the workbook has 0 controls** → rebuild them (`composition-recipe.md` §"Controls & parameters"): list control, date-range control, wire `filters` to the base tables. This is a **functional** dimension — see the rubric.
 - **Dropdown vs segmented mismatch** → `controlType: list` (dropdown) vs a segmented/`button` control; match the source widget. Number-control refs are safe in `[ControlId]` arithmetic; date/list control refs hit the variant bug.
-- **`d3`/`strftime` format mismatch** → map the source's format token to Sigma's `d3`-format / date-format string (money `$,.0f`, compact `$,.2s`, date `%b %Y`→`MMM YYYY`).
+- **`d3`/`strftime` format mismatch** → map the source's format token to Sigma's `d3`-format / d3-time string (money `$,.0f`, compact `$,.2s`, date `%b %Y`). Date-times take d3-time `%`-directives ONLY — a moment-style `MMM YYYY` prints literally (see §"Number & date formats").
 
 ---
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-5g-rcf.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-5g-rcf.md
@@ -40,6 +40,12 @@ EXIT      zero unresolved spec-fixable deltas (ui-only / sigma-capability / data
 
 Convergence pattern: pass 1 fixes **structure** (missing tiles, wrong kinds); passes 2–3 fix
 **composition** (containers, tints, text); pass 4+ fixes **typography / number-format** detail.
+Before hand-fixing a `numbers_formatted` or `palette_match` delta, read the build's
+**`formats-emitted.json`** (next to the chart-spec output — PR-12): per tile it records every
+source format string → the emitted Sigma format (`mapped|unmapped`; unmapped = the translator
+refused, recorded never guessed) plus `series_color_maps` (member→color pinning status). A
+`mapped`/`pinned` entry that still renders wrong is a spec/render finding worth recording; an
+`unmapped` entry is the expected RCF chore.
 Only `spec-fixable` deltas block; classify UI-only / capability ceilings and move on — see the
 "When NOT to loop" list in `refs/fidelity-recipes.md`. Full rubric + classification table:
 `refs/fidelity-rubric.md`. Delta→fix catalog: `refs/fidelity-recipes.md`.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -59,6 +59,8 @@ require_relative 'learned-rules'
 require_relative 'lib/theme_derive'
 require_relative 'lib/png_classify'
 require_relative 'lib/zone_census'
+require_relative 'lib/format_map'     # PR-12: the ONE Tableau→Sigma format translator
+require_relative 'lib/series_colors'  # PR-12: ordered per-series color schemes
 require 'erb'
 
 opts = { master_id: 'master' }
@@ -1009,37 +1011,39 @@ views  = gw.dig('views', 'view') || []
 views  = [views] unless views.is_a?(Array)
 view_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v }
 
-# Translate a Tableau format-value string (already parsed by the parser's
-# translate_format) into a Sigma format hash. Done here so we don't fork the
-# parser logic — we just call into it via a duplicated minimal translator.
+# Translate a Tableau format-value string into a Sigma format hash. PR-12:
+# delegates to the shared lib/format_map.rb (the parser's translate_format
+# delegates there too — the old duplicated minimal translator had already
+# drifted on date handling). Sigma date-time formats are d3-time strings
+# ('%B %-d, %Y'); moment-style tokens ("MMM D, YYYY") print LITERALLY, so
+# FormatMap returns nil for anything it can't fully tokenize — unmapped
+# formats are RECORDED in formats-emitted.json, never guessed.
 def tableau_format_to_sigma(s)
-  return nil if s.nil? || s.empty?
-  segments = s.split(';')
-  pos = segments[0] || s
-  neg = segments[1]
-  prefix = (neg && neg.include?('(') && neg.include?(')')) ? '(' : ''
-  if (m = pos.match(/^p\d*(?:\.(\d+))?%$/i))
-    decimals = (m[1] || '').length
-    return { 'kind' => 'number', 'formatString' => "#{prefix},.#{decimals}%" }
-  end
-  if (m = pos.match(/^C\d+(?:\.(\d+))?%?$/))
-    decimals = (m[1] || '').length
-    return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f", 'currencySymbol' => '$' }
-  end
-  if pos =~ /^c?["\\]*\$/ || pos.start_with?('$')
-    decimals = (pos.match(/\.(0+)/) || [])[1].to_s.length
-    return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f", 'currencySymbol' => '$' }
-  end
-  if pos =~ /^[#,0]+(?:\.(0+))?$/
-    decimals = ($1 || '').length
-    return { 'kind' => 'number', 'formatString' => "#{prefix},.#{decimals}f" }
-  end
-  if s =~ /yyyy|MMM|MM|dd|HH/
-    f = s.gsub('yyyy','%Y').gsub('yy','%y').gsub('MMMM','%B').gsub('MMM','%b').gsub('MM','%m')
-         .gsub('dd','%d').gsub('HH','%H').gsub('mm','%M').gsub('ss','%S')
-    return { 'kind' => 'datetime', 'formatString' => f }
+  FormatMap.translate(s)
+end
+
+# PR-12: per-column DEFAULT formats from the .twb (<column default-format=…>,
+# parser meta 'column_formats': caption → raw Tableau format string). The
+# display ground truth wherever a sheet doesn't override per-pill — the fix
+# for the field failure where a one-shot KPI printed raw while the source
+# shows $-formatted. Populated after meta load; caption match mirrors
+# pick_tableau_format's normalized containment match.
+COLUMN_DEFAULT_FORMATS = {}
+(meta['column_formats'] || {}).each { |k, v| COLUMN_DEFAULT_FORMATS[k] = v }
+def pick_column_default_format_raw(header)
+  hkey = header.to_s.downcase.gsub(/\W+/, '')
+  return nil if hkey.empty?
+  COLUMN_DEFAULT_FORMATS.each do |capn, val|
+    ckey = capn.to_s.downcase.gsub(/\W+/, '')
+    next if ckey.empty?
+    return val if ckey == hkey || hkey.include?(ckey) || ckey.include?(hkey)
   end
   nil
+end
+
+def pick_column_default_format(header)
+  raw = pick_column_default_format_raw(header)
+  raw && tableau_format_to_sigma(raw)
 end
 
 # Tableau scale-comma + literal-suffix formats ('n#,##0,,,B;-#,##0,,,B'):
@@ -2518,7 +2522,10 @@ def build_pivot_element(z, meta, mmap, opts, warnings, data_elements = [])
     end
     col_obj = { 'id' => col_id, 'name' => display_name, 'formula' => formula }
     if field['role'] == 'measure'
-      tab_fmt = pick_tableau_format(z['formats'], m['name'])
+      # PR-12: fall back to the column's .twb default-format when the sheet
+      # has no per-pill format (still ahead of the master-map/heuristic).
+      tab_fmt = pick_tableau_format(z['formats'], m['name']) ||
+                pick_column_default_format(m['name'])
       col_obj['format'] = tab_fmt if tab_fmt
       col_obj['format'] ||= m['format'] if m['format'].is_a?(Hash)
       col_obj['format'] ||= { 'kind' => 'number', 'formatString' => ',.0f' }
@@ -3823,9 +3830,12 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
     'formula' => formula
   }
 
-  # Format: prefer Tableau format string for this measure, then master-map
+  # Format: prefer Tableau format string for this measure (worksheet pill
+  # format, then the column's .twb default-format — PR-12, the fix for the
+  # KPI-printed-raw-where-source-shows-$ field failure), then master-map
   # format, then heuristic by name.
-  tab_fmt = pick_tableau_format(z['formats'], master['name'])
+  tab_fmt = pick_tableau_format(z['formats'], master['name']) ||
+            pick_column_default_format(master['name'])
   measure_col['format'] = tab_fmt if tab_fmt
   measure_col['format'] ||= master['format'] if master['format'].is_a?(Hash)
   measure_col['format'] ||=
@@ -3845,7 +3855,9 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   # carries the EXACT rendering (trailing zeros + grouping intact) and the
   # KPI value points at it (raw column kept for anything else).
   fmt_columns = []
-  if tab_fmt.nil? && (raw_fmt = pick_tableau_format_raw(z['formats'], master['name'])) &&
+  if tab_fmt.nil? &&
+     (raw_fmt = pick_tableau_format_raw(z['formats'], master['name']) ||
+                pick_column_default_format_raw(master['name'])) &&
      (sspec = parse_scaled_suffix_format(raw_fmt))
     fmt_col_id = "#{measure_col_id}-fmt"
     fmt_columns << { 'id' => fmt_col_id, 'name' => "#{master['name'].to_s.strip} (fmt)" }
@@ -4826,7 +4838,11 @@ layout.each do |dash|
     #   2. explicit `format` on the master-map entry (DM/curated)
     #   3. heuristic by header name
     tab_fmt = pick_tableau_format(z['formats'], meas_hdr) ||
-              pick_tableau_format(z['formats'], meas['name'])
+              pick_tableau_format(z['formats'], meas['name']) ||
+              # PR-12: the column's .twb default-format (still source truth;
+              # outranks the DM-inferred master-map format + the name heuristic)
+              pick_column_default_format(meas_hdr) ||
+              pick_column_default_format(meas['name'])
     meas_col_obj['format'] = tab_fmt
     meas_col_obj['format'] ||= meas['format'] if meas['format'].is_a?(Hash)
     if meas_col_obj['format'].nil?
@@ -4969,6 +4985,12 @@ layout.each do |dash|
         'yAxis' => { 'columnIds' => ["y-#{el_id}"] },
         'color' => { 'by' => 'category', 'column' => "c-#{el_id}" }
       }
+      # PR-12: explicit .twb member→color assignments on the detail/color dim →
+      # ordered scheme (same contract as the bar/line category-color path).
+      if SeriesColors.field_matches?(z['series_color_field'], dim['name']) &&
+         (pinned = SeriesColors.ordered_scheme(z['series_colors']))
+        element['color']['scheme'] = pinned
+      end
       if size_field
         element['columns'] << { 'id' => "sz-#{el_id}", 'name' => size_field['name'],
                                 'formula' => "[#{src_name}/#{size_field['name']}]",
@@ -5004,8 +5026,11 @@ layout.each do |dash|
         'id'      => "y2-#{el_id}",
         'name'    => meas2['name'],
         'formula' => meas2_formula,
-        'format'  => meas2['format'].is_a?(Hash) ? meas2['format'] :
-                     ({ 'kind' => 'number', 'formatString' => ',.0f' })
+        # PR-12: source formats first (pill format, then column default-format)
+        'format'  => pick_tableau_format(z['formats'], meas2_hdr) ||
+                     pick_column_default_format(meas2['name']) ||
+                     (meas2['format'].is_a?(Hash) ? meas2['format'] :
+                      { 'kind' => 'number', 'formatString' => ',.0f' })
       }
       kind = 'combo-chart' unless %w[pie-chart donut-chart].include?(kind)
       # Sigma combo-chart dual-axis IS persisted in the spec — the secondary
@@ -5031,6 +5056,19 @@ layout.each do |dash|
     if color_col_obj && !%w[pie-chart donut-chart table pivot-table].include?(kind)
       element['columns'] << color_col_obj
       element['color'] = { 'by' => 'category', 'column' => color_col_obj['id'] }
+      # PR-12: pin the .twb's explicit member→color assignments as an ORDERED
+      # scheme (ascending member order = Sigma's positional category-sort
+      # application) so the member→color BINDING survives — the Top/Bottom-500
+      # inversion class. No explicit map ⇒ no scheme ⇒ theme palette applies
+      # (current derivation unchanged).
+      if SeriesColors.field_matches?(z['series_color_field'], color_col_obj['name']) &&
+         (pinned = SeriesColors.ordered_scheme(z['series_colors']))
+        element['color']['scheme'] = pinned
+        members = z['series_colors'].map { |p| p['member'] }.sort_by { |m| m.to_s.downcase }
+        warnings << "'#{cap}' series colors PINNED from the .twb member→color map " \
+                    "(ascending member order: #{members.join(' → ')}) — scheme[i] binds to the i-th " \
+                    'category in Sigma sort order'
+      end
     elsif color_scale && %w[bar-chart line-chart area-chart combo-chart].include?(kind)
       # By-measure color ramp: add a DUPLICATE measure column (Sigma forbids a
       # column on both yAxis and color) and point color:{by:scale} at it.
@@ -5196,6 +5234,16 @@ layout.each do |dash|
     elsif kind == 'pie-chart' || kind == 'donut-chart'
       element['color'] = { 'id' => dim_col_obj['id'] }
       element['value'] = { 'id' => meas_col_obj['id'] }
+      # PR-12: per-element color.scheme is SILENTLY DROPPED on pie/donut — the
+      # only slice-color path is themeOverrides.categoricalScheme, applied
+      # positionally in category-sort order. ThemeDerive orders the theme from
+      # this zone's explicit member→color map (SeriesColors
+      # .explicit_scheme_for_dashboard); surface the contract for the RCF pass.
+      if z['series_colors'].is_a?(Array) && z['series_colors'].size >= 2
+        warnings << "'#{cap}' pie/donut slice colors ride themeOverrides.categoricalScheme (per-element " \
+                    'color.scheme is dropped on pie/donut) — theme scheme is ordered ascending by the ' \
+                    ".twb member→color map; verify slice-color alignment in the render"
+      end
       if z['sort']
         dir = z.dig('sort', 'direction').to_s
         element['color']['sort'] = {
@@ -7465,6 +7513,29 @@ elements.each do |e|
     'dashboard' => e['_dashboard'],
     'name'      => (e['name'].is_a?(String) ? e['name'] : nil)
   }.compact
+end
+
+# PR-12: formats-emitted.json — the MECHANICAL counterpart for the blind
+# grader's `numbers_formatted` + `palette_match` dimensions, computed HERE
+# while elements still carry _worksheet (same seam as chart-provenance).
+# Per tile: every applicable source format string → the emitted Sigma format,
+# status mapped|unmapped (unmapped = the translator refused; the source string
+# is RECORDED, never guessed) + per-tile series-color pinning records. Always
+# written (empty entries = "no source formats", vs "builder predates the
+# artifact"). Consumed by the RCF loop and future gates.
+begin
+  fe = {
+    'version'           => 1,
+    'entries'           => FormatMap.emitted_records(elements, meta['worksheets'] || {}, COLUMN_DEFAULT_FORMATS),
+    'series_color_maps' => SeriesColors.records(elements, meta['worksheets'] || {})
+  }
+  fe_path = File.join(File.dirname(File.expand_path(opts[:out])), 'formats-emitted.json')
+  File.write(fe_path, JSON.pretty_generate(fe))
+  unmapped = fe['entries'].count { |r| r['status'] == 'unmapped' }
+  warn "wrote #{fe_path} (#{fe['entries'].size} format assignment(s), #{unmapped} unmapped — recorded, " \
+       "never guessed; #{fe['series_color_maps'].size} series-color map(s))"
+rescue => e
+  warnings << "formats-emitted sidecar error (formats coverage unrecorded): #{e.message}"
 end
 
 # ---- Output mode ----

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/format_map.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/format_map.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+#
+# format_map.rb — the ONE Tableau→Sigma format-string translator (PR-12).
+#
+# Before this lib the translator lived twice (parse-twb-layout.rb
+# translate_format + build-charts-from-signals.rb tableau_format_to_sigma) and
+# the copies had already drifted on date handling. Both now delegate here.
+#
+# Number formats → Sigma { kind: 'number', formatString: <d3-format>, ... }:
+#   p0.0%        → ,.1%          (Tableau percent shorthand)
+#   #,##0.0%     → ,.1%          (Excel-style percent mask)
+#   $#,##0.00    → $,.2f + currencySymbol '$'   (€/£ carried as the symbol)
+#   C1033        → $,.0f + currencySymbol '$'   (Tableau locale-currency code)
+#   #,##0        → ,.0f
+#   pos;(neg)    → leading '(' d3 sign modifier (parens-on-negative)
+#   pos;;;"—"    → displayNullAs '—' (4th segment, QUOTED literal only —
+#                  Sigma number formats support displayNullAs; live-verified)
+#   #,##0,,,B    → nil (scale-comma + literal suffix is NOT d3-expressible —
+#                  the builder's exact-format scaled-column recipe owns it;
+#                  a trailing scale-comma with no suffix is nil too, so it
+#                  routes to the same recipe instead of silently dropping /1e3)
+#
+# Date-time formats → Sigma { kind: 'datetime', formatString: <d3-time> }:
+#   CRITICAL (live-run knowledge, 2026-07): Sigma spec date-time formats are
+#   d3-time/strftime strings ('%B %-d, %Y'). Moment-style token strings
+#   ("MMM D, YYYY") are NOT a format language to Sigma — every non-% char
+#   prints LITERALLY, so the tile renders the text "MMM D, YYYY" instead of a
+#   date. This translator therefore:
+#     - maps Tableau/moment tokens (case-tolerant: yyyy/YYYY, d/D/dd/DD,
+#       MMM/mmm, ddd weekday, h/hh/H/HH, am/pm) to %-directives, and
+#     - REFUSES (returns nil) any string with an unmappable letter token —
+#       an unmapped format is recorded in formats-emitted.json, never guessed
+#       and never emitted as a literal-printing string.
+#
+# Pure: no I/O. Unit-tested by test-format-map.rb; consumed by
+# parse-twb-layout.rb, build-charts-from-signals.rb, and the formats-emitted
+# artifact writer.
+require 'strscan'
+
+module FormatMap
+  module_function
+
+  # ---- entry point ----------------------------------------------------------
+  # Tableau format strings carry up to 4 ';'-segments: positive;negative;zero;
+  # text. Returns a Sigma format hash or nil (= not confidently mappable).
+  def translate(tableau_fmt)
+    s = tableau_fmt.to_s
+    return nil if s.strip.empty?
+    segments = s.split(';', -1)
+    pos = segments[0].to_s.empty? ? s : segments[0]
+    neg = segments[1]
+    prefix = neg && neg.include?('(') && neg.include?(')') ? '(' : ''
+    out = number_format(pos, prefix) || datetime_format(s)
+    return nil unless out
+    if out['kind'] == 'number' && (nul = quoted_literal(segments[3]))
+      out['displayNullAs'] = nul
+    end
+    out
+  end
+
+  # ---- numbers --------------------------------------------------------------
+  CURRENCY_SYMBOLS = %w[$ € £].freeze
+
+  def number_format(pos, prefix = '')
+    p = pos.to_s.strip
+    return nil if p.empty?
+    # Tableau percent shorthand — p<int>[.<decimals>]%
+    if (m = p.match(/\A[n]?p\d*(?:\.(\d+))?%\z/i))
+      return { 'kind' => 'number', 'formatString' => "#{prefix},.#{m[1].to_s.length}%" }
+    end
+    # Tableau locale-currency code — C<locale>[.<decimals>] (C1033 = $#,##0)
+    if (m = p.match(/\AC\d+(?:\.(\d+))?%?\z/))
+      return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{m[1].to_s.length}f",
+               'currencySymbol' => '$' }
+    end
+    # Currency — leading $/€/£, optionally c"$"-quoted ('c' = Tableau currency class)
+    if (m = p.match(/\A[nc]?["\\']*([$€£])/))
+      sym = m[1]
+      decimals = (p.match(/\.(0+)/) || [])[1].to_s.length
+      return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f",
+               'currencySymbol' => sym }
+    end
+    # Excel-style percent mask — #,##0.0%
+    if (m = p.match(/\A[n]?[#,0]+(?:\.(0+))?%\z/))
+      return { 'kind' => 'number', 'formatString' => "#{prefix},.#{m[1].to_s.length}%" }
+    end
+    # Plain number mask — #,##0[.00]. A TRAILING scale-comma ('#,##0,,') is a
+    # /1000-per-comma display scale d3 can't express — refuse it (nil) so the
+    # scaled-suffix exact-format recipe owns it instead of a silently-unscaled
+    # ',.0f' (the pre-PR-12 behavior was off by 1e3 per comma).
+    if (m = p.match(/\A[n]?([#,0]+)(?:\.(0+))?\z/)) && !m[1].end_with?(',')
+      return { 'kind' => 'number', 'formatString' => "#{prefix},.#{m[2].to_s.length}f" }
+    end
+    nil
+  end
+
+  # ---- date-times -----------------------------------------------------------
+  # Letter-run tokenizer over the whole string; quoted chunks pass through as
+  # literals; ANY unmappable letter run → nil (never emit literal-printing
+  # pseudo-tokens). 'm'/'mm' is month before an hour token, minute after (the
+  # Tableau/Excel rule); 'M' is always month.
+  def datetime_format(s)
+    str = s.to_s
+    return nil unless str =~ /[A-Za-z]/
+    sc = StringScanner.new(str)
+    out = +''
+    hour_seen = false
+    mapped = false
+    until sc.eos?
+      if (q = sc.scan(/"[^"]*"|'[^']*'/))
+        lit = q[1..-2]
+        return nil if lit.include?('%') # a literal % would read as a directive
+        out << lit
+      elsif sc.scan(%r{AM/PM|am/pm|A/P|a/p})
+        out << '%p'
+        mapped = true
+      elsif (t = sc.scan(/[A-Za-z]+/))
+        d = date_token(t, hour_seen)
+        return nil unless d
+        hour_seen = true if %w[%H %-H %I %-I].include?(d)
+        mapped = true
+        out << d
+      else
+        ch = sc.getch
+        return nil if ch == '%'
+        out << ch
+      end
+    end
+    return nil unless mapped && out.include?('%')
+    { 'kind' => 'datetime', 'formatString' => out }
+  end
+
+  def date_token(t, hour_seen)
+    case t
+    when /\A[yY]{3,4}\z/    then '%Y'
+    when /\A[yY]{1,2}\z/    then '%y'
+    when 'MMMM', 'mmmm'     then '%B'
+    when 'MMM', 'mmm'       then '%b'
+    when 'MM'               then '%m'
+    when 'M'                then '%-m'
+    when 'mm'               then hour_seen ? '%M' : '%m'
+    when 'm'                then hour_seen ? '%-M' : '%-m'
+    when /\A[dD]{4}\z/      then '%A' # weekday name (dddd)
+    when /\A[dD]{3}\z/      then '%a'
+    when /\A[dD]{2}\z/      then '%d'
+    when /\A[dD]\z/         then '%-d'
+    when 'HH'               then '%H'
+    when 'H'                then '%-H'
+    when 'hh'               then '%I'
+    when 'h'                then '%-I'
+    when 'ss', 'SS'         then '%S'
+    when 's', 'S'           then '%-S'
+    when 'AM', 'PM', 'am', 'pm', 'tt', 'TT' then '%p'
+    end
+  end
+
+  def quoted_literal(seg)
+    m = seg.to_s.strip.match(/\A"([^"]*)"\z/)
+    m && m[1]
+  end
+
+  # ---- formats-emitted artifact (PR-12 mechanical check) --------------------
+  # Per-tile ledger giving the blind grader's `numbers_formatted` dimension a
+  # mechanical counterpart: for every source format string that applies to a
+  # built element, record the emitted Sigma format and whether the mapping is
+  # mechanical ('mapped') or the source string is beyond the translator
+  # ('unmapped' — recorded, never guessed; heuristic defaults may still ship
+  # but are NOT claimed as source-derived). Consumed by the RCF loop and
+  # future gates; written next to --out as formats-emitted.json.
+  #
+  # elements: built element hashes still carrying '_worksheet'/'_dashboard'.
+  # worksheets_meta: parse-twb-layout meta['worksheets'] (string keys).
+  # column_formats: meta['column_formats'] (caption → raw default-format).
+  def emitted_records(elements, worksheets_meta, column_formats = {})
+    recs = []
+    Array(elements).each do |el|
+      next unless el.is_a?(Hash) && !el['_worksheet'].to_s.empty?
+      ws = (worksheets_meta || {})[el['_worksheet'].to_s] || {}
+      cols = Array(el['columns']).select { |c| c.is_a?(Hash) }
+      sources = {}
+      (ws['formats'] || {}).each do |field, raw|
+        f = friendly_from_field_ref(field)
+        sources[f] = raw unless f.to_s.empty?
+      end
+      (column_formats || {}).each do |capn, raw|
+        next if sources.keys.any? { |k| keys_match?(k, capn) }
+        next unless cols.any? { |c| keys_match?(c['name'], capn) }
+        sources[capn] = raw
+      end
+      sources.each do |fname, raw|
+        col = cols.find { |c| keys_match?(c['name'], fname) }
+        emitted = col && col['format']
+        status = translate(raw) && emitted ? 'mapped' : 'unmapped'
+        recs << { 'element_id' => el['id'], 'worksheet' => el['_worksheet'],
+                  'dashboard' => el['_dashboard'], 'field' => fname,
+                  'source_format' => raw, 'emitted_format' => emitted,
+                  'status' => status }
+      end
+    end
+    recs
+  end
+
+  # Format-key ref (`[usr:Return Rate:qk]` / a bare caption) → friendly name.
+  def friendly_from_field_ref(field)
+    inner = field.to_s.scan(/\[([^\]]+)\]/).flatten.last || field.to_s
+    parts = inner.split(':')
+    parts.length >= 3 ? parts[1].to_s : inner
+  end
+
+  # Same fuzzy match pick_tableau_format uses (normalized equality/containment).
+  def keys_match?(a, b)
+    ka = norm_key(a)
+    kb = norm_key(b)
+    !ka.empty? && !kb.empty? && (ka == kb || ka.include?(kb) || kb.include?(ka))
+  end
+
+  def norm_key(s)
+    s.to_s.downcase.gsub(/\W+/, '')
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/series_colors.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/series_colors.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+#
+# series_colors.rb — ordered per-series color emission (PR-12).
+#
+# Tableau serializes EXPLICIT member→color assignments on the categorical
+# color encoding (worksheet style-rules):
+#
+#   <encoding attr='color' field='[fed].[none:Value Tier:nk]' type='palette'>
+#     <map to='#f2c037'><bucket>&quot;Top 500&quot;</bucket></map>
+#     <map to='#c9d1d3'><bucket>&quot;Bottom 500&quot;</bucket></map>
+#   </encoding>
+#
+# parse-twb-layout surfaces those as zone 'series_colors'
+# ([{member, color}, …] in .twb document order) + 'series_color_field' (the
+# encoded column's caption). The pre-PR-12 palette derivation was
+# frequency-ranked (extract_brand_palette) — the member→color BINDING was
+# lost, and on a two-series chart the scheme landed positionally, i.e. a
+# coin-flip: the field failure was Top/Bottom-500 colors INVERTED on a key
+# chart while "palette colors present" still read true.
+#
+# The fix is ordering, not colors: Sigma applies a categorical `scheme` (and
+# `themeOverrides.categoricalScheme`) POSITIONALLY in category-SORT order —
+# ascending by member value, which is Sigma's default legend/category order.
+# So an ordered scheme = members sorted ascending, each slot carrying that
+# member's .twb color. "Bottom 500" < "Top 500" ⇒ scheme[0] is Bottom's
+# color — the member→color mapping survives whatever the palette order was.
+#
+# Where the .twb has NO explicit assignment the caller keeps the current
+# frequency-ranked palette derivation unchanged (never worse).
+#
+# Pure: no I/O. Unit-tested by test-format-map.rb + the extraction/emission
+# tests; consumed by build-charts-from-signals.rb and lib/theme_derive.rb.
+module SeriesColors
+  module_function
+
+  HEX = /\A#[0-9a-f]{6}\z/.freeze
+
+  # Ordered scheme for one chart: members ascending (case-insensitive), one
+  # color per slot. nil unless there are ≥2 well-formed assignments.
+  def ordered_scheme(pairs)
+    good = Array(pairs).select do |p|
+      p.is_a?(Hash) && !p['member'].to_s.empty? && p['color'].to_s.downcase =~ HEX
+    end
+    return nil if good.size < 2
+    good.sort_by { |p| p['member'].to_s.downcase }.map { |p| p['color'].to_s.downcase }
+  end
+
+  # Does the .twb color-encoding field bind to THIS chart's color column?
+  # A blank field (encoding present but caption unresolved) matches — the map
+  # still came from this worksheet's only color encoding.
+  def field_matches?(field_caption, column_name)
+    f = norm(field_caption)
+    return true if f.empty?
+    c = norm(column_name)
+    !c.empty? && (f == c || f.include?(c) || c.include?(f))
+  end
+
+  # Dashboard-level ordered scheme for themeOverrides.categoricalScheme — the
+  # ONLY color path for pie/donut slices (per-element color.scheme is silently
+  # dropped there). Conservative: only when every explicitly-assigned zone
+  # colors by the SAME field (else positional theme matching is ill-defined →
+  # nil, caller falls back to the frequency-ranked palette). Member colors
+  # merge across zones, first assignment wins; order is ascending by member.
+  def explicit_scheme_for_dashboard(dash, cap = 20)
+    zones = dash.is_a?(Hash) ? dash['zones'] : nil
+    return nil unless zones.is_a?(Array)
+    assigned = zones.select do |z|
+      z.is_a?(Hash) && z['series_colors'].is_a?(Array) && z['series_colors'].size >= 2
+    end
+    return nil if assigned.empty?
+    fields = assigned.map { |z| norm(z['series_color_field']) }.uniq
+    return nil if fields.size > 1
+    members = {}
+    assigned.each do |z|
+      z['series_colors'].each do |p|
+        next unless p.is_a?(Hash)
+        m = p['member'].to_s
+        c = p['color'].to_s.downcase
+        members[m] = c if !m.empty? && c =~ HEX && !members.key?(m)
+      end
+    end
+    return nil if members.size < 2
+    members.keys.sort_by(&:downcase).map { |k| members[k] }.first(cap)
+  end
+
+  # Per-tile ledger rows for formats-emitted.json ('series_color_maps') — the
+  # mechanical counterpart for the blind grader's `palette_match` dimension:
+  # source member→color assignments vs the scheme the element actually
+  # carries. status: 'pinned' (ordered scheme emitted) | 'theme' (pie/donut —
+  # rides themeOverrides positionally) | 'unpinned'.
+  def records(elements, worksheets_meta)
+    Array(elements).map do |el|
+      next unless el.is_a?(Hash) && !el['_worksheet'].to_s.empty?
+      ws = (worksheets_meta || {})[el['_worksheet'].to_s] || {}
+      sc = ws['series_colors']
+      next unless sc.is_a?(Array) && sc.any?
+      scheme = el['color'].is_a?(Hash) ? el['color']['scheme'] : nil
+      status =
+        if scheme then 'pinned'
+        elsif %w[pie-chart donut-chart].include?(el['kind'].to_s) then 'theme'
+        else 'unpinned'
+        end
+      { 'element_id' => el['id'], 'worksheet' => el['_worksheet'],
+        'dashboard' => el['_dashboard'], 'field' => ws['series_color_field'],
+        'source_assignments' => sc, 'emitted_scheme' => scheme,
+        'status' => status }
+    end.compact
+  end
+
+  def norm(s)
+    s.to_s.downcase.gsub(/\W+/, '')
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/theme_derive.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/theme_derive.rb
@@ -22,6 +22,8 @@
 # Contract: returns {} when the source declares nothing (emit neither
 # themeName nor themeOverrides — an unstyled workbook gets pure Sigma
 # defaults, byte-identical to the pre-theme output).
+require_relative 'series_colors'
+
 module ThemeDerive
   module_function
 
@@ -94,10 +96,18 @@ module ThemeDerive
     c[0, 7].downcase
   end
 
-  # S1/S2 (brand palette from color encodings + categorical palettes,
+  # S0 (PR-12): EXPLICIT member→color assignments beat frequency ranking —
+  # themeOverrides.categoricalScheme applies POSITIONALLY in category-sort
+  # order, so when the .twb binds members to colors the scheme must be ordered
+  # ascending by member (the only slice-color path for pie/donut, and the fix
+  # for the series-inversion class). Conservative: only when every assigned
+  # zone colors by the same field (else nil → S1 frequency order unchanged).
+  # Then S1/S2 (brand palette from color encodings + categorical palettes,
   # frequency-ranked — parse-twb-layout) then S3 (container-tint fallback for
   # the region-card idiom), capped at SCHEME_CAP.
   def derive_scheme(d)
+    explicit = SeriesColors.explicit_scheme_for_dashboard(d, SCHEME_CAP)
+    return explicit if explicit
     brand = d['brand_palette']
     return brand.first(SCHEME_CAP) if brand.is_a?(Array) && brand.size >= 2
     palette = []

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -37,6 +37,7 @@ require 'json'
 # parses a 5 MB / 95-worksheet workbook in well under a second. See lib/twb_xml.rb.
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'twb_xml'
+require 'format_map' # PR-12: the ONE Tableau→Sigma format translator (lib/format_map.rb)
 
 # ---- Per-dashboard scoping ------------------------------------------------
 # `--dashboard "<name>"` (repeatable) and `--page <id>` let a LARGE workbook
@@ -218,6 +219,33 @@ xml.elements.each('//column') do |c|
     COL_BY_GUID[body] ||= { caption: (cap && !cap.empty? ? cap : body), datatype: dt }
     COL_BY_GUID[body][:formula] ||= cf if cf
   end
+end
+
+# ---- Per-column DEFAULT formats (PR-12) ------------------------------------
+# Tableau stores a column's default number/date format as a `default-format`
+# ATTRIBUTE on <column> (e.g. default-format='p0.00%' / '$#,##0') and, in
+# older serializations, as a column-scoped <format attr='…-format' value='…'/>
+# child (no field= attr — worksheet-level text-format entries DO carry field=
+# and are parsed per worksheet below). These are the display ground truth for
+# any sheet that doesn't override per-pill — the reason a one-shot KPI printed
+# raw where the source shows $-formatted. Keyed by caption; first (richest)
+# declaration wins. Shipped in the meta sidecar as 'column_formats'.
+COLUMN_FORMATS = {}
+xml.elements.each('//column') do |c|
+  cap = c.attributes['caption']
+  cap = c.attributes['name'].to_s.gsub(/^\[|\]$/, '') if cap.nil? || cap.empty?
+  next if cap.to_s.empty?
+  fmt = c.attributes['default-format'].to_s
+  if fmt.empty?
+    c.elements.each('.//format') do |f|
+      next unless f.attributes['field'].nil? && f.attributes['attr'].to_s =~ /-format\z/
+      v = f.attributes['value'].to_s
+      fmt = v unless v.empty?
+      break unless fmt.empty?
+    end
+  end
+  next if fmt.empty?
+  COLUMN_FORMATS[cap] ||= fmt
 end
 
 # Filter columns use a column-instance level reference like
@@ -1087,6 +1115,38 @@ xml.elements.each('//worksheet') do |ws|
     end
   end
 
+  # PR-12: explicit per-series COLOR ASSIGNMENTS — the member→color map Tableau
+  # serializes on the CATEGORICAL color encoding (type='palette'):
+  #   <encoding attr='color' field='[fed].[none:Value Tier:nk]' type='palette'>
+  #     <map to='#f2c037'><bucket>&quot;Top 500&quot;</bucket></map>
+  # Captured in .twb document order, verbatim; ramp encodings (type=
+  # '[custom-]interpolated', already surfaced as heat_scheme) are excluded —
+  # their <map> buckets are numeric breakpoints, not series members. The
+  # builder + theme derivation turn this into ORDERED schemes (ascending
+  # member order = Sigma's positional category-sort application), which is
+  # what kills the Top/Bottom-500 inversion class. No map ⇒ nil ⇒ the
+  # frequency-ranked brand-palette derivation applies unchanged.
+  series_colors = nil
+  series_color_field = nil
+  ws.elements.each(".//encoding[@attr='color']") do |enc|
+    next if enc.attributes['type'].to_s =~ /interpolated/
+    pairs = []
+    enc.elements.each('map') do |mp|
+      hex = mp.attributes['to'].to_s.strip.downcase
+      next unless hex =~ /\A#[0-9a-f]{6}\z/
+      bucket = mp.elements['bucket']
+      member = bucket && unquote_member(bucket.text)
+      next if member.nil? || member.empty?
+      pairs << { 'member' => member, 'color' => hex }
+    end
+    next if pairs.empty?
+    series_colors = pairs
+    g = guid_from_param(enc.attributes['field'].to_s)
+    info = g && COL_BY_GUID[g]
+    series_color_field = (info && info[:caption]) || g
+    break
+  end
+
   worksheets[name] = {
     mark_class:       mark_class,
     geo_role:         geo_role,
@@ -1097,6 +1157,9 @@ xml.elements.each('//worksheet') do |ws|
     shelf_sorts:      shelf_sorts,
     quick_calc_pcto:  quick_calc_pcto,
     heat_scheme:      heat_scheme,
+    # PR-12: explicit member→color assignments + the encoded column's caption
+    series_colors:      series_colors,
+    series_color_field: series_color_field,
     filters:          filters_info,
     hidden_filters:   hidden_filters,
     aggregations:     aggregations,
@@ -1123,62 +1186,17 @@ xml.elements.each('//worksheet') do |ws|
 end
 
 # ---- Tableau format → Sigma format translator -----------------------------
-# Tableau format codes (subset we see in the wild):
-#   p0%      → ,.0%
-#   p0.0%    → ,.1%
-#   p0.00%   → ,.2%
-#   0        → ,.0f
-#   0.0      → ,.1f
-#   #,##0    → ,.0f
-#   $#,##0   → $,.0f (currency)
-#   $#,##0.00→ $,.2f
-#   yyyy-MM-dd → %Y-%m-%d
-#   MMM yyyy   → %b %Y
-#   yyyy       → %Y
+# PR-12: delegates to the shared lib/format_map.rb (the ONE translator — the
+# builder's copy delegates there too, so the two can't drift again). Subset:
+#   p0.0% / #,##0.0% → ,.1%      $#,##0.00 / C1033 → $,.2f (+currencySymbol)
+#   #,##0 → ,.0f                 pos;(neg) → '(' paren-negative prefix
+#   yyyy-MM-dd → %Y-%m-%d        MMM yyyy → %b %Y
+# Date-times are d3-time/strftime strings ('%B %-d, %Y'); moment-style tokens
+# ("MMM D, YYYY") print LITERALLY in Sigma, so FormatMap refuses (nil) any
+# string it can't fully tokenize — unmapped formats are recorded downstream
+# (formats-emitted.json), never guessed.
 def translate_format(tableau_fmt)
-  s = tableau_fmt.to_s
-  return nil if s.empty?
-  # Tableau format strings can have multiple segments split by ';':
-  #   positive;negative;zero;text
-  # The negative segment encodes parens / explicit minus / [Red]. d3-format
-  # supports a `(` sign modifier that wraps negatives in parens. We detect that
-  # case and prepend `(` to the format string.
-  segments = s.split(';')
-  pos = segments[0] || s
-  neg = segments[1]
-  paren_negative = neg && neg.include?('(') && neg.include?(')')
-  prefix = paren_negative ? '(' : ''
-
-  # Percent — p<digits>[.<digits>]%
-  if (m = pos.match(/^p\d*(?:\.(\d+))?%$/i))
-    decimals = (m[1] || '').length
-    return { 'kind' => 'number', 'formatString' => "#{prefix},.#{decimals}%" }
-  end
-  # Tableau locale-currency code — C<locale>[.<digits>]% (e.g., C1033% = $#,##0)
-  if (m = pos.match(/^C\d+(?:\.(\d+))?%?$/))
-    decimals = (m[1] || '').length
-    return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f", 'currencySymbol' => '$' }
-  end
-  # Currency — leading $ or c"$" / c\"$\"
-  if pos =~ /^c?["\\]*\$/ || pos.start_with?('$')
-    # Look for #...0.00 to extract decimals
-    decimals = (pos.match(/\.(0+)/) || [])[1].to_s.length
-    return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f", 'currencySymbol' => '$' }
-  end
-  # Plain number — count decimals after the decimal point
-  if pos =~ /^[#,0]+(?:\.(0+))?$/
-    decimals = ($1 || '').length
-    return { 'kind' => 'number', 'formatString' => "#{prefix},.#{decimals}f" }
-  end
-  # Date formats — translate Tableau tokens to strftime
-  if s =~ /yyyy|MMM|MM|dd|HH/
-    f = s
-      .gsub('yyyy', '%Y').gsub('yy', '%y')
-      .gsub('MMMM','%B').gsub('MMM','%b').gsub('MM','%m')
-      .gsub('dd','%d').gsub('HH','%H').gsub('mm','%M').gsub('ss','%S')
-    return { 'kind' => 'datetime', 'formatString' => f }
-  end
-  nil
+  FormatMap.translate(tableau_fmt)
 end
 
 # Translate Tableau mark class + geo signals into a Sigma-relevant chart-kind label.
@@ -1627,6 +1645,9 @@ xml.elements.each('//dashboard') do |d|
       'shelf_sorts'    => (kind == 'chart' ? ws_meta&.dig(:shelf_sorts)   : nil),
       'quick_calc_pcto' => (kind == 'chart' ? ws_meta&.dig(:quick_calc_pcto) : nil),
       'heat_scheme'    => (kind == 'chart' ? ws_meta&.dig(:heat_scheme)   : nil),
+      # PR-12: explicit member→color map (nil = no assignment; keep palette derivation)
+      'series_colors'      => (kind == 'chart' ? ws_meta&.dig(:series_colors)      : nil),
+      'series_color_field' => (kind == 'chart' ? ws_meta&.dig(:series_color_field) : nil),
       # v5.1: zone show-title='false' = the source HIDES the worksheet title
       # (all 6 hero-art workbook tiles carry it; three rounds leaked "Sheet 9" because
       # nothing read the attribute). Absent attr = shown (fails safe).
@@ -1760,6 +1781,8 @@ if dashboards.empty? && !worksheets.empty?
         'sort'           => ws_meta[:sort],
         'shelf_sorts'    => ws_meta[:shelf_sorts],
         'quick_calc_pcto' => ws_meta[:quick_calc_pcto],
+        'series_colors'      => ws_meta[:series_colors],
+        'series_color_field' => ws_meta[:series_color_field],
         'filters'        => ws_meta[:filters],
         'hidden_filters' => ws_meta[:hidden_filters] || [],
         'aggregations'   => ws_meta[:aggregations],
@@ -2048,6 +2071,10 @@ meta = {
   'datasource_filters' => datasource_filters,
   'parameters'     => parameters,
   'column_aliases' => column_aliases,
+  # PR-12: per-column default number/date formats (caption → raw Tableau
+  # format string). build-charts-from-signals maps them to Sigma column/KPI
+  # formats (lib/format_map) when no worksheet-level pill format overrides.
+  'column_formats' => COLUMN_FORMATS,
   'columns_by_guid'=> COL_BY_GUID.transform_values { |v|
     h = { 'caption' => v[:caption], 'datatype' => v[:datatype] }
     h['formula'] = v[:formula] if v[:formula] # calc-ref deref (v5.1.1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
@@ -123,7 +123,7 @@ INVENTORY = [
   { name: 'Container background tint / colored header band', pat: /<format\s+attr='background-color'\s+value='#(?!(?:fff(?:fff)?|FFF(?:FFF)?)')/,
     status: :hint, blurb: 'Gap B2: a dashboard zone/container has a non-white background fill (region-card tints, colored title bands). NOT yet auto-emitted — parse-twb-layout should surface the fill and build-charts should emit container.style.backgroundColor + borderRadius (+ a header-bar element). Until then, recreate the tint manually.' },
   { name: 'Custom categorical color palette (discrete)', pat: /<encoding[^>]+(?:class|attr)='color'[\s\S]{0,400}?<map>/,
-    status: :hint, blurb: "Gap D1: a color encoding carries an explicit value→color map (custom categorical palette, e.g. per-region teal/pink/purple/orange). NOT yet auto-extracted — build-charts should emit themeOverrides.categoricalScheme + per-chart color.scheme in category sort order. Until then, Sigma defaults apply and per-category color won't match." },
+    status: :auto, blurb: "Gap D1 (auto since PR-12): a color encoding carries an explicit value→color map. parse-twb-layout extracts it (series_colors) and build-charts pins per-chart color.scheme + themeOverrides.categoricalScheme ORDERED ascending by member (Sigma applies schemes positionally in category-sort order). Verify via formats-emitted.json series_color_maps." },
   { name: 'Viz-in-tooltip (embedded chart in tooltip)', pat: /visual-tooltip|show-viz-in-tooltip/i,
     status: :manual, blurb: 'Gap F3: worksheet embeds a viz inside its tooltip. Sigma has no spec-API path for viz-in-tooltip (no persistence) — recreate manually post-publish or drop. Surfaced here so it is not silently lost.' }
 ].freeze

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-format-map.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-format-map.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+# Unit test for lib/format_map.rb (PR-12) — the ONE Tableau→Sigma format
+# translator (parse-twb-layout.rb translate_format and
+# build-charts-from-signals.rb tableau_format_to_sigma both delegate here).
+#
+# Covers:
+#   1. numbers: percent shorthand + Excel percent masks, currency (decimals,
+#      €/£ symbols, locale code C1033), thousands, paren-negative prefix,
+#      displayNullAs from a quoted 4th segment.
+#   2. scale-comma masks refuse (nil) — the exact-format scaled-column recipe
+#      owns them; a bare ',.0f' would be off by 1e3 per trailing comma.
+#   3. dates: Tableau tokens → d3-time (%-directives) — Sigma date-time
+#      formats are d3-time strings ('%B %-d, %Y').
+#   4. THE LITERAL-FORMAT HAZARD: moment-style token strings ("MMM D, YYYY")
+#      print LITERALLY in Sigma. The translator must either fully tokenize to
+#      %-directives (no bare letter residue) or refuse (nil) — it must NEVER
+#      emit a formatString with unmapped letter tokens.
+#
+# Usage:  ruby scripts/test-format-map.rb
+require_relative 'lib/format_map'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+t = ->(s) { FormatMap.translate(s) }
+fs = ->(s) { (t.call(s) || {})['formatString'] }
+
+# ---- 1. numbers -------------------------------------------------------------
+check(fs.call('p0%')    == ',.0%',  "p0% → ,.0% (got #{fs.call('p0%').inspect})", fails)
+check(fs.call('p0.0%')  == ',.1%',  'p0.0% → ,.1%', fails)
+check(fs.call('p0.00%') == ',.2%',  'p0.00% → ,.2%', fails)
+check(fs.call('#,##0.0%') == ',.1%', 'Excel percent mask #,##0.0% → ,.1%', fails)
+check(fs.call('#,##0')  == ',.0f',  '#,##0 → ,.0f', fails)
+check(fs.call('0.00')   == ',.2f',  '0.00 → ,.2f', fails)
+cur = t.call('$#,##0.00')
+check(cur == { 'kind' => 'number', 'formatString' => '$,.2f', 'currencySymbol' => '$' },
+      "$#,##0.00 → $,.2f + currencySymbol (got #{cur.inspect})", fails)
+eur = t.call('€#,##0')
+check(eur && eur['formatString'] == '$,.0f' && eur['currencySymbol'] == '€',
+      "€#,##0 → $,.0f + currencySymbol € (got #{eur.inspect})", fails)
+loc = t.call('C1033')
+check(loc && loc['formatString'] == '$,.0f' && loc['currencySymbol'] == '$',
+      'locale code C1033 → $,.0f + $', fails)
+check(fs.call('$#,##0;($#,##0)') == '($,.0f',
+      "paren-negative segment → leading '(' sign modifier (got #{fs.call('$#,##0;($#,##0)').inspect})", fails)
+nul = t.call('#,##0;-#,##0;0;"—"')
+check(nul && nul['displayNullAs'] == '—',
+      "quoted 4th segment → displayNullAs '—' (got #{nul.inspect})", fails)
+
+# ---- 2. scale-comma masks refuse (recorded, never guessed) ------------------
+check(t.call('#,##0,,,B;-#,##0,,,B').nil?,
+      'scale+suffix mask (#,##0,,,B) → nil (exact-format scaled-column recipe owns it)', fails)
+check(t.call('#,##0,,').nil?,
+      'bare trailing scale-commas (#,##0,,) → nil, NOT an unscaled ,.0f', fails)
+
+# ---- 3. dates → d3-time -----------------------------------------------------
+check(fs.call('yyyy-MM-dd') == '%Y-%m-%d', 'yyyy-MM-dd → %Y-%m-%d', fails)
+check(fs.call('MMM yyyy')   == '%b %Y',    'MMM yyyy → %b %Y', fails)
+check(fs.call('mmm yyyy')   == '%b %Y',    'lowercase mmm yyyy → %b %Y', fails)
+check(fs.call('yyyy')       == '%Y',       'yyyy → %Y', fails)
+check(fs.call('dd/mm/yyyy') == '%d/%m/%Y',
+      "dd/mm/yyyy → %d/%m/%Y (mm before an hour token is MONTH — the old fork emitted minute %M; got #{fs.call('dd/mm/yyyy').inspect})", fails)
+check(fs.call('HH:mm:ss')   == '%H:%M:%S', 'HH:mm:ss → %H:%M:%S (mm after hour = minute)', fails)
+check(fs.call('dddd, MMMM d, yyyy') == '%A, %B %-d, %Y',
+      "weekday+long month → %A, %B %-d, %Y (got #{fs.call('dddd, MMMM d, yyyy').inspect})", fails)
+
+# ---- 4. the literal-format hazard ------------------------------------------
+# "MMM D, YYYY" (moment style) previously leaked 'YYYY'/'D' literals through
+# the gsub chain ('%b D, YYYY'). Contract: fully-mapped d3-time OR nil.
+haz = t.call('MMM D, YYYY')
+check(haz && haz['formatString'] == '%b %-d, %Y',
+      "moment-style 'MMM D, YYYY' fully tokenizes → %b %-d, %Y (got #{haz.inspect})", fails)
+check(fs.call('MMMM D, YYYY') == '%B %-d, %Y', 'MMMM D, YYYY → %B %-d, %Y', fails)
+# Any translate() output must carry ZERO bare-letter residue outside %-directives.
+%w[MMM\ D,\ YYYY yyyy-MM-dd dddd,\ MMMM\ d,\ yyyy HH:mm:ss MMM\ yyyy].each do |s|
+  out = t.call(s)
+  next unless out && out['kind'] == 'datetime'
+  residue = out['formatString'].gsub(/%-?[A-Za-z]/, '')
+  check(residue !~ /[A-Za-z]/,
+        "no literal letter residue in translated #{s.inspect} (got #{out['formatString'].inspect})", fails)
+end
+# Unmappable strings refuse — never a literal-printing emission.
+check(t.call('MMM Qq, YYYY').nil?, "unmappable token run ('Qq') → nil, never emitted literally", fails)
+check(t.call('0.0△').nil?, 'non-format garbage → nil', fails)
+check(t.call('').nil? && t.call(nil).nil?, 'empty/nil → nil', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — FormatMap: numbers, dates→d3-time, literal-format hazard refused'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-series-color-extraction.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-series-color-extraction.rb
@@ -1,0 +1,173 @@
+#!/usr/bin/env ruby
+# Regression test for PR-12 extraction in parse-twb-layout.rb: per-series
+# color assignments + per-column default formats.
+#
+# Tableau serializes an EXPLICIT member→color map on the categorical color
+# encoding (worksheet style-rules):
+#
+#   <encoding attr='color' field='[fed].[none:<tier-guid>:nk]' type='palette'>
+#     <map to='#f2c037'><bucket>&quot;Top 500&quot;</bucket></map>
+#     <map to='#c9d1d3'><bucket>&quot;Bottom 500&quot;</bucket></map>
+#   </encoding>
+#
+# and a column's default number format as <column default-format='$#,##0.00'>.
+# Before PR-12 the member→color BINDING was dropped (only a frequency-ranked
+# palette survived) — the field failure was Top/Bottom-500 colors INVERTED on
+# a key chart — and default-formats were never read (a KPI printed raw where
+# the source shows $-formatted).
+#
+# Asserts, end-to-end through the ACTUAL parse-twb-layout.rb:
+#   1. chart zone carries series_colors verbatim (document order) + the
+#      encoded column's resolved caption (series_color_field).
+#   2. a ramp encoding (type='custom-interpolated') does NOT produce
+#      series_colors (its buckets are breakpoints, not members) — it stays
+#      heat_scheme.
+#   3. meta sidecar carries column_formats {caption → raw default-format}.
+#   4. ThemeDerive orders categoricalScheme ASCENDING BY MEMBER from the
+#      explicit map ("Bottom 500" slot first) — the positional contract that
+#      kills the inversion class (incl. the pie/donut theme-only path).
+#
+# Usage:  ruby scripts/test-series-color-extraction.rb
+require 'json'
+require 'tmpdir'
+require_relative 'lib/theme_derive'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='ORDER_FACT' name='federated.fact'>
+        <column caption='Net Bookings' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' default-format='$#,##0.00' />
+        <column caption='Order Date' name='[c2ec6b07-897e-39ab-9422-aa895d35a627]' datatype='date' role='dimension' type='ordinal' />
+        <column caption='Value Tier' name='[a1b2c3d4-1111-2222-3333-444455556666]' datatype='string' role='dimension' type='nominal' />
+        <column caption='Return Rate' name='[b2c3d4e5-2222-3333-4444-555566667777]' datatype='real' role='measure' type='quantitative' default-format='p0.0%' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Bookings by Tier'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Net Bookings' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+              <column caption='Value Tier' name='[a1b2c3d4-1111-2222-3333-444455556666]' datatype='string' role='dimension' type='nominal' />
+              <column-instance column='[a1b2c3d4-1111-2222-3333-444455556666]' derivation='None' name='[none:a1b2c3d4-1111-2222-3333-444455556666:nk]' pivot='key' type='nominal' />
+              <column-instance column='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' derivation='Sum' name='[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' pivot='key' type='quantitative' />
+            </datasource-dependencies>
+          </view>
+          <style>
+            <style-rule element='mark'>
+              <encoding attr='color' field='[federated.fact].[none:a1b2c3d4-1111-2222-3333-444455556666:nk]' type='palette'>
+                <map to='#f2c037'><bucket>&quot;Top 500&quot;</bucket></map>
+                <map to='#c9d1d3'><bucket>&quot;Bottom 500&quot;</bucket></map>
+              </encoding>
+            </style-rule>
+          </style>
+          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
+          <cols>[federated.fact].[none:a1b2c3d4-1111-2222-3333-444455556666:nk]</cols>
+          <pane>
+            <mark class='Bar' />
+            <encodings>
+              <encoding attr='color' column='[federated.fact].[none:a1b2c3d4-1111-2222-3333-444455556666:nk]' />
+            </encodings>
+          </pane>
+        </table>
+      </worksheet>
+      <worksheet name='Bookings Heatmap'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Net Bookings' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+            </datasource-dependencies>
+          </view>
+          <style>
+            <style-rule element='mark'>
+              <encoding attr='color' field='[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' type='custom-interpolated'>
+                <color-palette>
+                  <color>#f1f1f1</color>
+                  <color>#52baee</color>
+                </color-palette>
+                <map to='#f1f1f1'><bucket>0.0</bucket></map>
+                <map to='#52baee'><bucket>1000.0</bucket></map>
+              </encoding>
+            </style-rule>
+          </style>
+          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
+          <cols />
+          <pane><mark class='Square' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Tiers'>
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='2' name='Bookings by Tier' x='0' y='0' w='50000' h='100000' />
+            <zone id='3' name='Bookings Heatmap' x='50000' y='0' w='50000' h='100000' />
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+layout = nil
+meta = nil
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  File.write(twb, TWB)
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  layout = JSON.parse(File.read(lay))
+  meta   = JSON.parse(File.read(lay.sub(/\.json$/, '-meta.json')))
+end
+
+dash  = (layout || []).find { |x| x['dashboard'] == 'Tiers' }
+zones = (dash && dash['zones']) || []
+tier  = zones.find { |z| z['caption'] == 'Bookings by Tier' }
+heat  = zones.find { |z| z['caption'] == 'Bookings Heatmap' }
+
+# ---- 1. explicit member→color map, verbatim + document order ---------------
+sc = tier && tier['series_colors']
+check(sc == [{ 'member' => 'Top 500', 'color' => '#f2c037' },
+             { 'member' => 'Bottom 500', 'color' => '#c9d1d3' }],
+      "series_colors = member→color pairs in .twb document order (got #{sc.inspect})", fails)
+check(tier && tier['series_color_field'] == 'Value Tier',
+      "series_color_field resolves the encoding GUID → caption (got #{tier && tier['series_color_field'].inspect})", fails)
+
+# ---- 2. ramp encodings are NOT series maps ---------------------------------
+check(heat && heat['series_colors'].nil?,
+      "interpolated ramp encoding yields NO series_colors (got #{heat && heat['series_colors'].inspect})", fails)
+check(heat && heat['heat_scheme'] == %w[#f1f1f1 #52baee],
+      "ramp still lands in heat_scheme (got #{heat && heat['heat_scheme'].inspect})", fails)
+
+# ---- 3. per-column default-formats in the meta sidecar ----------------------
+cf = (meta || {})['column_formats'] || {}
+check(cf['Net Bookings'] == '$#,##0.00',
+      "meta column_formats carries the raw default-format (got #{cf['Net Bookings'].inspect})", fails)
+check(cf['Return Rate'] == 'p0.0%',
+      "percent default-format captured too (got #{cf['Return Rate'].inspect})", fails)
+
+# ---- 4. theme scheme ordered ASCENDING BY MEMBER ----------------------------
+theme = ThemeDerive.derive(layout)
+check(theme['categoricalScheme'] == %w[#c9d1d3 #f2c037],
+      "themeOverrides.categoricalScheme ordered ascending by member — 'Bottom 500' slot first " \
+      "(got #{theme['categoricalScheme'].inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — PR-12 extraction: series member→color map + column default-formats'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-series-scheme-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-series-scheme-emission.rb
@@ -1,0 +1,224 @@
+#!/usr/bin/env ruby
+# Regression test for PR-12 emission in build-charts-from-signals.rb:
+#   1. ORDERED series color scheme — a 3-channel bar (x=Month, color=Value
+#      Tier, y=Net Bookings) whose .twb carries the explicit member→color map
+#      {Top 500→#f2c037, Bottom 500→#c9d1d3} must emit color:{by:category,
+#      scheme:[...]} with the scheme ORDERED ASCENDING BY MEMBER — scheme[0]
+#      is "Bottom 500"'s grey. This is the mechanical kill for the field
+#      failure where Top/Bottom-500 colors came out INVERTED (positional
+#      scheme + unordered palette = a coin flip).
+#   2. NUMBER FORMATS from the .twb column default-format — the measure column
+#      carries $,.2f + currencySymbol (source '$#,##0.00'), NOT the name
+#      heuristic (which can't know decimals and misses non-$-named measures).
+#   3. formats-emitted.json — the mechanical formats-coverage artifact:
+#      mapped entry for the default-format, UNMAPPED (recorded, never guessed)
+#      entry for a non-translatable pill format, and a pinned series-color
+#      record for the tier chart.
+#   4. literal-format hazard sweep: NO emitted datetime formatString carries
+#      bare letter residue (moment-style tokens print literally in Sigma).
+#
+# Deterministic + offline: synthesizes a .twb + view CSVs, runs the ACTUAL
+# parse-twb-layout.rb + build-charts-from-signals.rb.
+#
+# Usage:  ruby scripts/test-series-scheme-emission.rb
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='ORDER_FACT' name='federated.fact'>
+        <connection class='federated'>
+          <named-connections>
+            <named-connection name='snow'><connection class='snowflake' dbname='DEMO_DB' schema='DEMO' /></named-connection>
+          </named-connections>
+          <relation connection='snow' name='ORDER_FACT' table='[DEMO].[ORDER_FACT]' type='table' />
+        </connection>
+        <column caption='Net Bookings' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' default-format='$#,##0.00' />
+        <column caption='Order Date' name='[c2ec6b07-897e-39ab-9422-aa895d35a627]' datatype='date' role='dimension' type='ordinal' />
+        <column caption='Value Tier' name='[a1b2c3d4-1111-2222-3333-444455556666]' datatype='string' role='dimension' type='nominal' />
+        <column caption='Region' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
+        <column caption='Weird Metric' name='[Weird Metric]' datatype='real' role='measure' type='quantitative' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Bookings by Tier'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Net Bookings' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+              <column caption='Order Date' name='[c2ec6b07-897e-39ab-9422-aa895d35a627]' datatype='date' role='dimension' type='ordinal' />
+              <column caption='Value Tier' name='[a1b2c3d4-1111-2222-3333-444455556666]' datatype='string' role='dimension' type='nominal' />
+              <column-instance column='[c2ec6b07-897e-39ab-9422-aa895d35a627]' derivation='Month-Trunc' name='[tmn:c2ec6b07-897e-39ab-9422-aa895d35a627:qk]' pivot='key' type='quantitative' />
+              <column-instance column='[a1b2c3d4-1111-2222-3333-444455556666]' derivation='None' name='[none:a1b2c3d4-1111-2222-3333-444455556666:nk]' pivot='key' type='nominal' />
+              <column-instance column='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' derivation='Sum' name='[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' pivot='key' type='quantitative' />
+            </datasource-dependencies>
+          </view>
+          <style>
+            <style-rule element='mark'>
+              <encoding attr='color' field='[federated.fact].[none:a1b2c3d4-1111-2222-3333-444455556666:nk]' type='palette'>
+                <map to='#f2c037'><bucket>&quot;Top 500&quot;</bucket></map>
+                <map to='#c9d1d3'><bucket>&quot;Bottom 500&quot;</bucket></map>
+              </encoding>
+            </style-rule>
+          </style>
+          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
+          <cols>[federated.fact].[tmn:c2ec6b07-897e-39ab-9422-aa895d35a627:qk]</cols>
+          <pane>
+            <mark class='Bar' />
+            <encodings>
+              <encoding attr='color' column='[federated.fact].[none:a1b2c3d4-1111-2222-3333-444455556666:nk]' />
+            </encodings>
+          </pane>
+        </table>
+      </worksheet>
+      <worksheet name='Weird Metric by Region'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Region' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
+              <column caption='Weird Metric' name='[Weird Metric]' datatype='real' role='measure' type='quantitative' />
+              <column-instance column='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' derivation='None' name='[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]' pivot='key' type='nominal' />
+              <column-instance column='[Weird Metric]' derivation='Sum' name='[sum:Weird Metric:qk]' pivot='key' type='quantitative' />
+            </datasource-dependencies>
+          </view>
+          <style>
+            <style-rule element='cell'>
+              <format attr='text-format' field='[federated.fact].[sum:Weird Metric:qk]' value='0.0△' />
+            </style-rule>
+          </style>
+          <rows>[federated.fact].[sum:Weird Metric:qk]</rows>
+          <cols>[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]</cols>
+          <pane><mark class='Bar' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Tiers'>
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='2' name='Bookings by Tier' x='0' y='0' w='50000' h='100000' />
+            <zone id='3' name='Weird Metric by Region' x='50000' y='0' w='50000' h='100000' />
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Net Bookings$' => { 'id' => 'm-nb',   'name' => 'Net Bookings' },
+  '(?i)^Order Date$'   => { 'id' => 'm-od',   'name' => 'Order Date' },
+  '(?i)^Value Tier$'   => { 'id' => 'm-vt',   'name' => 'Value Tier' },
+  '(?i)^Region$'       => { 'id' => 'm-reg',  'name' => 'Region' },
+  '(?i)^Weird Metric$' => { 'id' => 'm-wm',   'name' => 'Weird Metric' }
+}
+
+TIER_CSV = <<~CSV
+  Month of Order Date,Value Tier,Net Bookings
+  2024-01-01,Top 500,1200.50
+  2024-01-01,Bottom 500,300.25
+  2024-02-01,Top 500,1400.00
+  2024-02-01,Bottom 500,410.10
+CSV
+
+WEIRD_CSV = <<~CSV
+  Region,Weird Metric
+  East,12.5
+  West,9.1
+CSV
+
+build_out = nil
+build_log = ''
+formats_emitted = nil
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [
+               { 'id' => 'v1', 'name' => 'Bookings by Tier' },
+               { 'id' => 'v2', 'name' => 'Weird Metric by Region' }
+             ] }))
+  Dir.mkdir(File.join(d, 'views'))
+  File.write(File.join(d, 'views', 'v1.csv'), TIER_CSV)
+  File.write(File.join(d, 'views', 'v2.csv'), WEIRD_CSV)
+  File.write(File.join(d, 'png-read.json'),
+             JSON.dump('source_png' => 'views/v1.png',
+                       'tiles' => [{ 'title' => 'Bookings by Tier', 'kind' => 'bar-chart', 'orientation' => 'vertical' },
+                                   { 'title' => 'Weird Metric by Region', 'kind' => 'bar-chart', 'orientation' => 'vertical' }],
+                       'text_elements' => [], 'filter_shelf' => []))
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  out = File.join(d, 'specs.json')
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --out #{out} 2>&1`
+  build_out = JSON.parse(File.read(out)) if File.exist?(out)
+  fe_path = File.join(d, 'formats-emitted.json')
+  formats_emitted = JSON.parse(File.read(fe_path)) if File.exist?(fe_path)
+end
+
+els = build_out ? (build_out.is_a?(Array) ? build_out : (build_out['elements'] || (build_out['pages'] || []).flat_map { |p| p['elements'] || [] })) : []
+tier  = els.find { |e| e['name'].to_s.casecmp?('Bookings by Tier') }
+weird = els.find { |e| e['name'].to_s.casecmp?('Weird Metric by Region') }
+
+# ---- 1. ORDERED series scheme ----------------------------------------------
+color = tier && tier['color']
+check(color.is_a?(Hash) && color['by'] == 'category',
+      "tier chart colors by category (got #{color.inspect})", fails)
+check(color && color['scheme'] == %w[#c9d1d3 #f2c037],
+      "scheme ORDERED ascending by member — Bottom 500's grey first, Top 500's gold second " \
+      "(the inversion kill; got #{color && color['scheme'].inspect})", fails)
+check(build_log.include?('series colors PINNED'),
+      'builder logged the pinned member→color ordering', fails)
+
+# ---- 2. number format from the column default-format ------------------------
+ycol = tier && (tier['columns'] || []).find { |c| tier.dig('yAxis', 'columnIds')&.include?(c['id']) }
+check(ycol && ycol['format'] == { 'kind' => 'number', 'formatString' => '$,.2f', 'currencySymbol' => '$' },
+      "measure format from .twb default-format '$#,##0.00' → $,.2f + $ (got #{ycol && ycol['format'].inspect})", fails)
+
+# ---- 3. formats-emitted.json (mechanical coverage artifact) -----------------
+check(formats_emitted.is_a?(Hash) && formats_emitted['version'] == 1,
+      'formats-emitted.json written next to --out', fails)
+entries = (formats_emitted || {})['entries'] || []
+nb = entries.find { |r| r['field'] == 'Net Bookings' }
+check(nb && nb['status'] == 'mapped' && nb['source_format'] == '$#,##0.00' &&
+      nb.dig('emitted_format', 'formatString') == '$,.2f',
+      "Net Bookings entry: source string + emitted format + status=mapped (got #{nb.inspect})", fails)
+wm = entries.find { |r| r['field'].to_s =~ /weird metric/i }
+check(wm && wm['status'] == 'unmapped' && wm['source_format'] == '0.0△',
+      "non-translatable pill format RECORDED as unmapped, never guessed (got #{wm.inspect})", fails)
+scm = ((formats_emitted || {})['series_color_maps'] || []).find { |r| r['worksheet'] == 'Bookings by Tier' }
+check(scm && scm['status'] == 'pinned' && scm['emitted_scheme'] == %w[#c9d1d3 #f2c037],
+      "series-color map record: status=pinned + the ordered scheme (got #{scm.inspect})", fails)
+
+# ---- 4. literal-format hazard sweep -----------------------------------------
+bad = els.flat_map { |e| e['columns'] || [] }
+         .map { |c| c['format'] }
+         .select { |f| f.is_a?(Hash) && f['kind'] == 'datetime' }
+         .reject { |f| f['formatString'].to_s.gsub(/%-?[A-Za-z]/, '') !~ /[A-Za-z]/ }
+check(bad.empty?,
+      "no emitted datetime formatString carries bare letter residue (moment tokens print literally; got #{bad.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — PR-12 emission: ordered series scheme + source number formats + formats-emitted artifact'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build log (tail) ---"
+  puts build_log.to_s.lines.last(25).join
+  exit 1
+end


### PR DESCRIPTION
Implements PLAN-v3 **PR-12 — Series color + number formats** for the tableau-to-sigma converter.

Field failures this closes: series colors **inverted** (Top/Bottom-500 swapped on a key chart — the palette survived but the member→color *binding* didn't), and number formats unaddressed in the one-shot build (a KPI printed raw where the source shows $-formatted).

## Series → color map
- `parse-twb-layout.rb` extracts the explicit member→color assignments Tableau serializes on the categorical color encoding (`<encoding attr='color' type='palette'><map to='#hex'><bucket>…`) → zone `series_colors` (+ `series_color_field`, GUID→caption resolved). Ramp encodings (`[custom-]interpolated`) are excluded — they stay `heat_scheme`.
- `build-charts-from-signals.rb` pins per-chart `color.scheme` **ordered ascending by member** — Sigma applies categorical schemes positionally in category-sort order, so `scheme[i]` binds to the i-th category and the inversion class dies (`"Bottom 500" < "Top 500"` ⇒ grey first, gold second). New `scripts/lib/series_colors.rb`.
- `ThemeDerive` orders `themeOverrides.categoricalScheme` the same way when every assigned zone colors by one field (the **only** slice-color path for pie/donut, where per-element scheme is silently dropped); pie/donut builds surface the contract as a warning.
- No explicit map ⇒ frequency-ranked palette derivation **unchanged** (never worse).

## Number formats
- Parser reads per-column `default-format` attrs (+ column-scoped `<format>` children) → meta `column_formats`.
- New `scripts/lib/format_map.rb` is the ONE translator — the parser's `translate_format` and the builder's `tableau_format_to_sigma` both delegate (the two copies had already drifted on date handling).
- Builder cascade: worksheet pill `text-format` → column `.twb` `default-format` → master-map → name heuristic, wired at the chart-measure, pivot `add_col`, KPI (incl. the scale-suffix raw path), and dual-axis y2 seams.
- **d3-time hazard (live-run knowledge)**: Sigma date-time formats are d3-time strings (`%B %-d, %Y`); moment-style token strings (`"MMM D, YYYY"`) print **literally**. The translator fully tokenizes (case-tolerant, month-vs-minute aware) or **refuses** — unmapped strings are recorded, never guessed. Scale-comma masks (`#,##0,,`) now refuse instead of shipping an unscaled `,.0f`. `displayNullAs` supported (quoted 4th segment) and documented.

## Mechanical check
- `formats-emitted.json` written next to `--out` (chart-provenance seam, all output modes): per tile `source_format → emitted_format, mapped|unmapped` + `series_color_maps` (`pinned|theme|unpinned`) — the mechanical counterpart for the blind grader's `numbers_formatted` and `palette_match` dimensions. The RCF loop reads it (`refs/phase-5g-rcf.md`); gap-scan D1 flips to `:auto`.

## Mapping table (excerpt — full table in `refs/fidelity-recipes.md`)
| Tableau source | Sigma |
|---|---|
| `p0.0%` / `#,##0.0%` | `,.1%` |
| `$#,##0.00` / `€#,##0` / `C1033` | `$,.2f` / `$,.0f` + `currencySymbol` |
| `pos;(neg)` | leading `(` sign modifier |
| `#,##0,,,B` | refused → exact-format scaled column |
| `MMM yyyy` / `MMMM d, yyyy` | `%b %Y` / `%B %-d, %Y` (d3-time only) |

## Tests
- New: `test-format-map.rb` (numbers, dates→d3-time, the `MMM D, YYYY` literal-hazard contract), `test-series-color-extraction.rb` (parser fixture: ordered map, ramp exclusion, `column_formats`, theme ordering), `test-series-scheme-emission.rb` (e2e through the real parser+builder: ordered scheme, `$,.2f` from `default-format`, mapped/unmapped artifact entries, hazard sweep).
- Full skill suite green (`test-brand-palette`, `test-theme-derivation`, `test-style-normalize`, `test-container-tint` included); the only failure is the pre-existing env-dependent `test-calc-discovery` (fails identically on `origin/main`).
- Corpus `--check tableau` 7/7; `tools/check-shared.rb` clean (builder libs are plugin-local); hygiene sweep + twb-encoding + skill lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
