### PR TITLE
tableau: degradation ledger + GREEN/YELLOW/PARTIAL verdict model (PLAN-v3 PR-14)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -177,8 +177,9 @@
 #      A recorded `divergent` verdict passes this gate as RECORDED (the
 #      comparison happened; the gaps are acknowledged) but is INJECTED into
 #      the waiver census as `visual-divergent` and SPENDS waiver budget
-#      (exit 19) — GREEN requires the budget to hold; fix the gaps or accept
-#      YELLOW. Full verdict-capping (divergent → PARTIAL) is PLAN-v3 PR-14.
+#      (exit 19) — GREEN requires the budget to hold, and the recorded
+#      divergence joins the degradation ledger as a fidelity-residual, so the
+#      final verdict is at most YELLOW (PR-14 verdict model below).
 #  14  Layout fill / grid coverage failed (gate 8c; #259 item 1) — a page in
 #      layout-census.json dropped a tile (placed < zones) or ships under-filled
 #      (grid_fill_pct < --min-grid-fill, default 0.45), OR a dashboard layout was
@@ -446,6 +447,21 @@
 # Phase 1d). (d) closes the run-2 hole where all 11 anchors sat in 3 of 9 tiles
 # and the oracle vouched for 6 tiles nothing was watching.
 #
+# VERDICT MODEL (PLAN-v3 PR-14 — cumulative-degradation accounting): on every
+# run this gate derives <workdir>/degradation-ledger.json from the workdir's
+# artifacts (lib/degradation_ledger.rb — scope cuts, quality waivers, recorded
+# escapes, fidelity residuals, waived resolutions; deterministic, never
+# self-reported) and prints ONE verdict with the ledger inline:
+#   GREEN   — the ledger is EMPTY (waivers within budget alone is no longer
+#             enough: any recorded degradation forfeits GREEN);
+#   YELLOW  — quality degradations but no scope cut (a budget-exceeded run —
+#             exit 19, doctrine unchanged — is always at least YELLOW);
+#   PARTIAL — ANY scope cut (dropped tile / column / control / DM element)
+#             regardless of the waiver budget; PARTIAL+YELLOW when both.
+# The verdict string is stamped into phase6-success.json and parity-final.json;
+# verify-complete.rb re-derives the ledger offline and FAILS (its exit 6) when
+# a report's claims contradict it — the anti-"GREEN, 0 waivers" mechanism.
+#
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
 # UNRESOLVED ledger entry with class `data` hard-fails. Data-class residuals
@@ -461,6 +477,21 @@ require 'uri'
 require 'optparse'
 require 'rbconfig'
 require 'digest'
+
+# Degradation ledger (PLAN-v3 PR-14) — vendored at scripts/lib/ in adopting
+# plugins; the canonical checkout resolves it from shared/lib. A checkout
+# without it keeps the legacy final line (stated below, never silent).
+DEG_LEDGER_LOADED = begin
+  require_relative 'lib/degradation_ledger'
+  true
+rescue LoadError
+  begin
+    require_relative '../lib/degradation_ledger'
+    true
+  rescue LoadError
+    false
+  end
+end
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0, min_parity_score: 0.0, min_grid_fill: 0.45 }
@@ -658,7 +689,7 @@ WAIVER_HIDES = {
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--no-vision-waiver'         => 'gate 8b: the visual PASS was SELF-graded — no context-free blind grader ran (recorded by record-visual-check.rb --no-vision-waiver)',
-  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (verdict-capping divergent→PARTIAL is PLAN-v3 PR-14)',
+  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (joins the degradation ledger as a fidelity-residual; verdict at most YELLOW)',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
   '--accept-residuals'         => 'gate 8d: named RCF deltas shipped unresolved',
   '--skip-fidelity-gate'       => 'gate 8d: the RCF fidelity loop was never required — compositional deltas (palette, chart kind, KPI format) were never iterated (--rcf-passes 0 records this waiver)',
@@ -741,8 +772,9 @@ end
 # but acknowledged source-vs-target visual gaps riding to GREEN unqualified is
 # exactly the live-run failure this closes (blind grade FAIL 5/6, verdict
 # recorded divergent, final GREEN). Injected into the census as
-# `visual-divergent` so the budget line names it. Full verdict-capping
-# (divergent → PARTIAL) is PLAN-v3 PR-14 — until then the budget is the cap.
+# `visual-divergent` so the budget line names it; the degradation ledger
+# (PR-14) additionally records it as a fidelity-residual, capping the verdict
+# at YELLOW even when the budget holds.
 begin
   _pf_bgw = File.exist?(summary_path) ? JSON.parse(File.read(summary_path)) : nil
   waiver_flags << '--no-vision-waiver' if _pf_bgw.is_a?(Hash) && _pf_bgw['blind_grade_waiver'].is_a?(Hash) &&
@@ -763,6 +795,42 @@ budget_flags = waiver_flags.reject do |f|
     (f == '--skip-visual-comparison' && opts[:skip_visual_cmp].to_s =~ /verifier/i)
 end
 
+# Reasons census (PR-14): the flag → recorded-reason map rides into
+# parity-final.json beside the census, so the degradation ledger (derived
+# OFFLINE here and by verify-complete.rb) can explain each waiver and decide
+# the /verifier/i policy exclusion without re-parsing CLI flags.
+_reason_srcs = {
+  '--skip-parity-gate'         => opts[:skip_parity],
+  '--skip-orphan-check'        => opts[:skip_orphan],
+  '--skip-column-check'        => opts[:skip_column],
+  '--skip-layout-check'        => opts[:skip_layout],
+  '--skip-layout-lint'         => opts[:skip_lint],
+  '--skip-control-lint'        => opts[:skip_control_lint],
+  '--skip-control-flip'        => opts[:skip_control_flip],
+  '--skip-visual-gate'         => opts[:skip_visual],
+  '--skip-visual-comparison'   => opts[:skip_visual_cmp],
+  '--skip-layout-fill'         => opts[:skip_layout_fill],
+  '--skip-fidelity-gate'       => opts[:skip_fidelity],
+  '--skip-visual-tiles'        => opts[:skip_visual_tiles],
+  '--skip-telemetry-gate'      => opts[:skip_telemetry],
+  '--skip-postpublish-guide'   => opts[:skip_postpublish],
+  '--accept-deferred-elements' => opts[:accept_deferred],
+  '--skip-anchors-gate'        => opts[:skip_anchors],
+  '--allow-empty-tiles'        => opts[:allow_empty_tiles],
+  '--skip-visual-similarity'   => opts[:skip_vsim],
+  '--accept-residuals'         => (Array(opts[:accept_residuals]).any? ? "accepted RCF residual(s): #{Array(opts[:accept_residuals]).join(', ')}" : nil),
+  '--accept-manual-residues'   => (Array(opts[:accept_manual_residues]).any? ? "accepted unbuilt residue(s): #{Array(opts[:accept_manual_residues]).join(', ')}" : nil),
+  '--min-pass-rate'            => (opts[:min_pass_rate] < 1.0 ? "accepted pass rate #{opts[:min_pass_rate]}" : nil),
+  '--allow-missing-tiles'      => (opts[:allow_missing_tiles].to_i.positive? ? "tolerated #{opts[:allow_missing_tiles]} unmatched dashboard zone(s)" : nil),
+  '--allow-extract'            => (opts[:allow_extract] ? 'extract mode accepted (value drift tolerated)' : nil),
+  'layout-phase-skip'          => (layout_phase_stamp.is_a?(Hash) ? layout_phase_stamp['reason'] : nil)
+}
+waiver_reasons = {}
+waiver_flags.each do |f|
+  v = _reason_srcs[f]
+  waiver_reasons[f] = v.to_s.strip if v.is_a?(String) && !v.to_s.strip.empty?
+end
+
 # Stamp the census into parity-final.json on every run (best-effort — a
 # missing/malformed file is gate 1's problem, not the stamp's).
 if File.exist?(summary_path)
@@ -770,6 +838,7 @@ if File.exist?(summary_path)
     _pf = JSON.parse(File.read(summary_path))
     _pf['waivers'] = waiver_flags
     _pf['waiver_count'] = waiver_flags.length
+    _pf['waiver_reasons'] = waiver_reasons
     # Off-ramp telemetry fields (P2): where did this run defect? route comes from
     # the orchestrator's migrate-state.json ('orchestrated' | 'manual-authorized';
     # null for converters without the concept); manual_path_authorized records an
@@ -3243,6 +3312,24 @@ end
 # for this cap — reduce the waiver count by fixing the underlying issues, or
 # report the migration as YELLOW.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Degradation ledger + verdict (PLAN-v3 PR-14) — derived ONCE here, from the
+# artifacts on disk (the census stamped above included), and written to
+# <workdir>/degradation-ledger.json on every run that reaches this point, so
+# the budget-fail path below and the success path share one derivation and
+# verify-complete.rb can re-derive + cross-check offline.
+# ---------------------------------------------------------------------------
+deg_entries = nil
+if DEG_LEDGER_LOADED
+  begin
+    deg_entries = DegradationLedger.derive(opts[:tab])
+    DegradationLedger.write(opts[:tab], deg_entries)
+  rescue StandardError => e
+    warn "[WARN] degradation-ledger derivation failed (#{e.class}: #{e.message.lines.first.to_s.strip}) — verdict falls back to legacy print."
+    deg_entries = nil
+  end
+end
+
 if budget_flags.length > WAIVER_BUDGET
   warn "[FAIL] waiver budget exceeded — #{budget_flags.length} quality waiver/escape flag(s) on this run (budget #{WAIVER_BUDGET})."
   warn '       GREEN unavailable — too many waivers; the highest achievable result is YELLOW.'
@@ -3251,6 +3338,11 @@ if budget_flags.length > WAIVER_BUDGET
   warn '       Waivers are for impossibilities, not obstacles. Fix the underlying issues until'
   warn "       <= #{WAIVER_BUDGET} remain, or report this migration as YELLOW (never GREEN) and name"
   warn '       every waiver in the report. There is no escape flag for this cap.'
+  if deg_entries
+    v19 = DegradationLedger.verdict(deg_entries, budget_exceeded: true)
+    warn "       VERDICT: #{v19} — degradation ledger (#{deg_entries.length} entr#{deg_entries.length == 1 ? 'y' : 'ies'}):"
+    DegradationLedger.report_lines(deg_entries).each { |l| warn "       #{l}" }
+  end
   exit 19
 end
 
@@ -3261,25 +3353,34 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 # run_id scopes the marker to THIS run (see the at_exit stale-deletion above);
 # the waiver census rides along so a report can quote the marker verbatim.
+# The verdict (PR-14): all gates passed and the budget held, but GREEN belongs
+# only to an EMPTY degradation ledger — any scope cut caps the run at PARTIAL,
+# any other recorded degradation at YELLOW. The string rides in the success
+# marker (verify-complete.rb quotes and cross-checks it).
+final_verdict = deg_entries ? DegradationLedger.verdict(deg_entries) : nil
 begin
   _wd = opts[:tab]
   # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
   # reach here) so verify-complete.rb has a uniform element count across plugins.
   _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
   _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
-  File.write(File.join(_wd, 'phase6-success.json'),
-             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
-                                  'chartCount' => _cc,
-                                  'gates' => 'all-pass',
-                                  'run_id' => current_run_id,
-                                  'waivers' => waiver_flags,
-                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _succ = { 'workbookId' => (opts[:wb] || ''),
+            'chartCount' => _cc,
+            'gates' => 'all-pass',
+            'run_id' => current_run_id,
+            'waivers' => waiver_flags,
+            'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+  _succ['verdict'] = final_verdict if final_verdict
+  File.write(File.join(_wd, 'phase6-success.json'), JSON.pretty_generate(_succ))
   _pend = File.join(_wd, 'parity-pending.json')
   File.delete(_pend) if File.exist?(_pend)
-  # Flip the off-ramp telemetry field now that success is minted (P2).
+  # Flip the off-ramp telemetry field now that success is minted (P2), and
+  # stamp the derived verdict beside the census so a report that quotes
+  # parity-final.json carries it (verify-complete.rb cross-checks the claim).
   if File.exist?(File.join(_wd, 'parity-final.json'))
     begin
       _pf['success_sentinel'] = true
+      _pf['verdict'] = final_verdict if final_verdict
       File.write(File.join(_wd, 'parity-final.json'), JSON.pretty_generate(_pf))
     rescue StandardError
       nil
@@ -3289,6 +3390,23 @@ rescue StandardError
   # never fail the gate on sentinel bookkeeping
 end
 
-puts "[OK] all gates pass — conversion may declare GREEN" \
-     "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+if final_verdict.nil?
+  # Legacy checkout without lib/degradation_ledger.rb — stated, never silent.
+  puts "[OK] all gates pass — conversion may declare GREEN" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+  puts '     (lib/degradation_ledger.rb not vendored — no PR-14 verdict derived; re-vendor to enable.)'
+elsif final_verdict == 'GREEN'
+  puts "[OK] all gates pass — VERDICT: GREEN (degradation ledger empty — no scope cuts, no waivers, no residuals)"
+else
+  puts "[OK] all gates pass — VERDICT: #{final_verdict}" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget)" : ''}"
+  puts "     GREEN requires an EMPTY degradation ledger; this run recorded #{deg_entries.length} degradation(s):"
+  DegradationLedger.report_lines(deg_entries).each { |l| puts "     #{l}" }
+  if final_verdict.start_with?('PARTIAL')
+    puts '     PARTIAL: a scope cut shipped — the delivered workbook is a SUBSET of the source.'
+    puts '     Report this migration as PARTIAL (never GREEN) and quote the ledger verbatim.'
+  else
+    puts '     Report this migration as YELLOW (never GREEN) and name every entry in the report.'
+  end
+end
 exit 0

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/degradation_ledger.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+#
+# DegradationLedger — cumulative-degradation accounting → the PARTIAL verdict
+# (PLAN-v3 PR-14, the honesty capstone).
+#
+# WHY: a migration can pass every hard gate and still ship LESS than the source
+# — a dropped tile behind --allow-missing-tiles, a dropped control behind a
+# controls-waivers.json entry, a column the coverage census recorded as lost,
+# a --skip-* flag that quietly turned a verification off. Each degradation is
+# individually recorded somewhere, but nothing ever ADDED THEM UP — so a field
+# run once reported "GREEN, 0 waivers" after a --skip-ref-check and dropped
+# columns. This module derives ONE ledger from the workdir's artifacts and one
+# verdict from the ledger:
+#
+#   GREEN   — the ledger is EMPTY. No scope cuts, no quality waivers, no
+#             recorded escapes, no fidelity residuals, no waived resolutions.
+#   YELLOW  — quality degradations but no scope cut (any non-scope-cut entry;
+#             a budget-exceeded run — assert-phase6-ran exit 19, existing
+#             doctrine unchanged — is always at least YELLOW).
+#   PARTIAL — ANY scope-cut entry (a dropped tile / column / control /
+#             DM element), regardless of the waiver budget. A scope cut caps
+#             the verdict: the delivered workbook is a subset of the source.
+#   PARTIAL+YELLOW — both (scope cuts AND quality degradations); PARTIAL is
+#             the dominant verdict, YELLOW is noted.
+#
+# DERIVATION IS MECHANICAL — every entry comes from an artifact on disk that
+# some script recorded at decision time; nothing here accepts self-reported
+# claims. verify-complete.rb re-derives the ledger offline and FAILS when the
+# final report's claims (verdict / waiver census) contradict it — the
+# anti-"0 waivers" mechanism.
+#
+# Entry shape (stable):
+#   { "class" => scope-cut | quality-waiver | recorded-escape |
+#                fidelity-residual | resolution-waived,
+#     "item"            => <what was degraded — tile/column/control/flag name>,
+#     "reason"          => <the recorded reason, or a stated default>,
+#     "source_artifact" => <file the entry was derived from> }
+#
+# Artifact classes read (all optional; absent file → no entries):
+#   scope-cut         — coverage.json (dropped/degraded visuals+columns),
+#                       parity-final.json tile_census unmatched zones (minus
+#                       visual-verify oracle matches — gate 5's own logic),
+#                       *-controls-coverage.json non-emitted signals with their
+#                       control-scope.json / controls-waivers.json explanations
+#                       (or those two files directly when no census exists),
+#                       deferred-elements.json (quarantined DM elements).
+#   quality-waiver    — parity-final.json `waivers` census (stamped by
+#                       assert-phase6-ran on every run), minus the POLICY
+#                       exclusions (--skip-telemetry-gate; --skip-visual-
+#                       comparison under the sanctioned /verifier/i split) and
+#                       minus flags reclassified below.
+#   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
+#                       waivers, stale-skill, degraded fast path, and the
+#                       PR-14 `skip-flag-waived` records every closed --skip-*
+#                       straggler now writes), plus the census' run off-ramp
+#                       flags (--force-new-workbook / --force-route-switch /
+#                       --allow-manual-spec).
+#   fidelity-residual — parity-final.json visual_verdict=divergent, unresolved
+#                       fidelity-ledger.json deltas (accepted residuals ride
+#                       to DONE unresolved), layout-arrangement.json
+#                       violations (advisory WARNs), png-read.json
+#                       kind_waivers (recorded chart-family substitutions).
+#   resolution-waived — lod-audit.json / join-plan.json resolutions with
+#                       how=waived, agg-semantics.json how=faithful-to-source
+#                       (a documented source hazard shipping as-is),
+#                       manual-residues.json entries still unbuilt,
+#                       source-anchors.json + ground-truth-plan.json
+#                       coverage_waivers (tiles no numeric oracle watched).
+#
+# Canonical: shared/lib/degradation_ledger.rb — edit there and run
+# tools/sync-shared.rb. Ruby 2.6-compatible, stdlib-only, fully offline.
+
+require 'json'
+
+module DegradationLedger
+  VERSION = 1
+  CLASSES = %w[scope-cut quality-waiver recorded-escape fidelity-residual
+               resolution-waived].freeze
+
+  # Census flags that are POLICY, never quality (assert-phase6-ran budget
+  # doctrine): telemetry consent; the visual-comparison hand-off to a verifier
+  # session is excluded only when its recorded reason matches /verifier/i.
+  POLICY_FLAGS = ['--skip-telemetry-gate'].freeze
+  # Census flags that are run OFF-RAMPS, not gate-quality waivers — classed
+  # recorded-escape (they were honored by a script mid-run, mirrored into the
+  # census by the budget code).
+  CENSUS_ESCAPE_FLAGS = ['--force-new-workbook', '--force-route-switch',
+                         '--allow-manual-spec'].freeze
+  # Census flags whose degradation is derived (better) from an artifact —
+  # skipped in the census pass so one degradation never counts twice:
+  # visual-divergent is derived from parity-final's visual_verdict.
+  CENSUS_DERIVED_FLAGS = ['visual-divergent'].freeze
+
+  # offramps.jsonl kinds that are ESCAPES (a verification/protection turned
+  # off) as opposed to observability records (pass1-stop, workbook-handoff,
+  # loop-stop, …). force-new-workbook / route-switch-forced / manual-spec are
+  # deliberately absent: the census already mirrors them (see above).
+  ESCAPE_OFFRAMP_KINDS = %w[cred-gate-waived doctor-gate-waived
+                            tableau-gate-waived stale-skill-waived
+                            degraded-fastpath skip-flag-waived].freeze
+
+  module_function
+
+  def ledger_path(workdir)
+    File.join(workdir, 'degradation-ledger.json')
+  end
+
+  # Derive the full ledger (Array of entry Hashes) from the workdir's
+  # artifacts. Deterministic: same files → same entries, same order.
+  def derive(workdir)
+    entries = []
+    entries.concat(scope_cuts(workdir))
+    entries.concat(quality_waivers(workdir))
+    entries.concat(recorded_escapes(workdir))
+    entries.concat(fidelity_residuals(workdir))
+    entries.concat(resolution_waived(workdir))
+    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+  end
+
+  # Write <workdir>/degradation-ledger.json (entries + per-class counts).
+  # Never raises — bookkeeping must not sink a gate run.
+  def write(workdir, entries)
+    counts = Hash.new(0)
+    entries.each { |e| counts[e['class']] += 1 }
+    File.write(ledger_path(workdir),
+               JSON.pretty_generate('version' => VERSION,
+                                    'derivedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                    'counts' => counts,
+                                    'entries' => entries))
+    true
+  rescue StandardError
+    false
+  end
+
+  # The verdict string. Any scope cut → PARTIAL (dominant); any other entry —
+  # or a budget-exceeded run — → YELLOW; both → "PARTIAL+YELLOW"; empty ledger
+  # and budget intact → GREEN. GREEN requires an EMPTY ledger, full stop.
+  def verdict(entries, budget_exceeded: false)
+    partial = entries.any? { |e| e['class'] == 'scope-cut' }
+    yellow  = budget_exceeded || entries.any? { |e| e['class'] != 'scope-cut' }
+    return 'PARTIAL+YELLOW' if partial && yellow
+    return 'PARTIAL' if partial
+    return 'YELLOW' if yellow
+    'GREEN'
+  end
+
+  # One line per entry, for inline printing under the verdict.
+  def report_lines(entries)
+    entries.map do |e|
+      "  - [#{e['class']}] #{e['item']} — #{e['reason']} (#{e['source_artifact']})"
+    end
+  end
+
+  # ── class derivations ──────────────────────────────────────────────────────
+
+  def scope_cuts(wd)
+    out = []
+    # coverage.json — the build-step drop census: severity 'dropped' is a tile
+    # that produced NO Sigma element; 'degraded' built but LOST a column/field.
+    cov = read_json(wd, 'coverage.json')
+    Array(cov.is_a?(Hash) ? cov['unresolved'] : nil).each do |u|
+      next unless u.is_a?(Hash) && %w[dropped degraded].include?(u['severity'].to_s)
+      what = u['severity'].to_s == 'dropped' ? 'dropped visual' : 'degraded visual (lost column/field)'
+      out << entry('scope-cut', "#{what}: #{u['visual']}",
+                   u['detail'].to_s.empty? ? u['severity'].to_s : u['detail'].to_s,
+                   'coverage.json')
+    end
+    # tile census — unmatched dashboard zones (gate 5), minus zones the
+    # visual-verify oracle confirmed (same subtraction gate 5 applies).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? pf['tile_census'] : nil
+    if census.is_a?(Hash)
+      names = Array(census['unmatched_zone_names']).map(&:to_s)
+      vv = read_json(wd, File.join('visual-verify', 'manifest.json'))
+      vv_ok = Array(vv).select { |t| t.is_a?(Hash) && t['visual_verified'] == true }
+                       .map { |t| t['worksheet'].to_s }
+      (names - vv_ok).each do |n|
+        out << entry('scope-cut', "dropped tile: #{n}",
+                     'source dashboard zone with no matching chart (tile census)',
+                     'parity-final.json tile_census')
+      end
+    end
+    # controls — the source-vs-built census names every signal; a non-emitted
+    # row is a control the user had that the migration did not build. Its
+    # explanation (control-scope drop record / controls-waivers reason) rides
+    # into the entry; without a census the declaration files stand alone.
+    dropped_notes = control_scope_drops(wd)
+    ctl_waivers = controls_waivers(wd)
+    ctl_census_path = Dir[File.join(wd, '*-controls-coverage.json')].min
+    seen_controls = []
+    if ctl_census_path
+      doc = read_json_path(ctl_census_path)
+      Array(doc.is_a?(Hash) ? doc['detail'] : nil).each do |r|
+        next unless r.is_a?(Hash) && r['status'].to_s != 'emitted'
+        name = r['name'].to_s
+        key = norm(name)
+        reason = dropped_notes[key] ||
+                 (ctl_waivers[key] || ctl_waivers[norm("#{r['kind']}:#{name}")]) ||
+                 "census status: #{r['status']}"
+        seen_controls << key << norm("#{r['kind']}:#{name}")
+        out << entry('scope-cut', "dropped control: #{r['kind']}:#{name}", reason,
+                     File.basename(ctl_census_path))
+      end
+    end
+    dropped_notes.each do |key, reason|
+      next if seen_controls.include?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'control-scope.json')
+    end
+    ctl_waivers.each do |key, reason|
+      next if seen_controls.include?(key) || dropped_notes.key?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'controls-waivers.json')
+    end
+    # deferred-elements.json — DM elements quarantined at POST time; a
+    # non-empty file at DONE means the PARTIAL data model was accepted.
+    dd = read_json(wd, 'deferred-elements.json')
+    deferred = dd.is_a?(Hash) ? Array(dd['deferred']) : (dd.is_a?(Array) ? dd : [])
+    deferred.each do |el|
+      name = el.is_a?(Hash) ? (el['name'] || el['id'] || 'unnamed element') : el.to_s
+      out << entry('scope-cut', "dropped DM element: #{name}",
+                   'quarantined at DM POST (deferred-elements.json still non-empty)',
+                   'deferred-elements.json')
+    end
+    out
+  end
+
+  def quality_waivers(wd)
+    pf = read_json(wd, 'parity-final.json')
+    return [] unless pf.is_a?(Hash) && pf['waivers'].is_a?(Array)
+    reasons = pf['waiver_reasons'].is_a?(Hash) ? pf['waiver_reasons'] : {}
+    # waivers.json carries {flag, gate, reason} for gates waived via
+    # record_waiver — a second reason source for older parity-final stamps.
+    wj = read_json(wd, 'waivers.json')
+    wj = wj['waivers'] if wj.is_a?(Hash)
+    Array(wj).each do |w|
+      next unless w.is_a?(Hash) && w['flag']
+      reasons[w['flag'].to_s] ||= w['reason'].to_s unless w['reason'].to_s.empty?
+    end
+    out = []
+    pf['waivers'].map(&:to_s).uniq.each do |flag|
+      next if POLICY_FLAGS.include?(flag)
+      next if CENSUS_DERIVED_FLAGS.include?(flag)
+      next if CENSUS_ESCAPE_FLAGS.include?(flag) # classed recorded-escape below
+      next if flag == '--skip-visual-comparison' && reasons[flag].to_s =~ /verifier/i
+      reason = reasons[flag].to_s
+      reason = 'budget-counted quality waiver (no reason recorded)' if reason.empty?
+      out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
+    end
+    out
+  end
+
+  def recorded_escapes(wd)
+    out = []
+    # Census-mirrored run off-ramps (they also spend waiver budget there).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? Array(pf['waivers']).map(&:to_s) : []
+    (census & CENSUS_ESCAPE_FLAGS).each do |flag|
+      out << entry('recorded-escape', flag, 'run off-ramp honored mid-run (see offramps.jsonl)',
+                   'parity-final.json waivers')
+    end
+    # offramps.jsonl escape kinds — including the PR-14 skip-flag-waived
+    # records that make every --skip-* visible (the --skip-ref-check fix).
+    trail(wd).each do |r|
+      next unless ESCAPE_OFFRAMP_KINDS.include?(r['kind'].to_s)
+      item = r['kind'].to_s == 'skip-flag-waived' && !r['detail'].to_s.empty? ? r['detail'].to_s : r['kind'].to_s
+      reason = r['reason'].to_s.empty? ? 'NO REASON GIVEN' : r['reason'].to_s
+      out << entry('recorded-escape', item, reason, 'offramps.jsonl')
+    end
+    out.uniq { |e| [e['item'], e['reason']] }
+  end
+
+  def fidelity_residuals(wd)
+    out = []
+    pf = read_json(wd, 'parity-final.json')
+    if pf.is_a?(Hash) && pf['visual_verdict'].to_s == 'divergent'
+      out << entry('fidelity-residual', 'visual verdict: divergent',
+                   'recorded source-vs-target visual gaps ship in the render',
+                   'parity-final.json')
+    end
+    fl = read_json(wd, 'fidelity-ledger.json')
+    Array(fl.is_a?(Hash) ? fl['entries'] : nil).each do |e|
+      next unless e.is_a?(Hash) && !e['resolved']
+      out << entry('fidelity-residual',
+                   "RCF residual #{e['id']} [#{e['dimension'] || e['cls']}]",
+                   e['delta'].to_s.empty? ? "unresolved #{e['cls']} delta" : e['delta'].to_s,
+                   'fidelity-ledger.json')
+    end
+    arr = read_json(wd, 'layout-arrangement.json')
+    Array(arr.is_a?(Hash) ? arr['pages'] : nil).each do |p|
+      next unless p.is_a?(Hash)
+      Array(p['violations']).each do |v|
+        out << entry('fidelity-residual', "arrangement: #{p['page']}", v.to_s,
+                     'layout-arrangement.json')
+      end
+    end
+    pr = read_json(wd, 'png-read.json')
+    Array(pr.is_a?(Hash) ? pr['kind_waivers'] : nil).each do |w|
+      next unless w.is_a?(Hash)
+      out << entry('fidelity-residual', "chart-kind substitution: #{w['tile']}",
+                   w['reason'].to_s.empty? ? 'recorded at read time' : w['reason'].to_s,
+                   'png-read.json kind_waivers')
+    end
+    out
+  end
+
+  def resolution_waived(wd)
+    out = []
+    { 'lod-audit.json' => %w[waived], 'join-plan.json' => %w[waived],
+      'agg-semantics.json' => %w[faithful-to-source] }.each do |file, hows|
+      doc = read_json(wd, file)
+      list = doc.is_a?(Hash) ? doc['entries'] : doc
+      Array(list).each do |e|
+        next unless e.is_a?(Hash) && e['resolution'].is_a?(Hash)
+        how = e['resolution']['how'].to_s
+        next unless hows.include?(how)
+        item = e['calc'] || e['name'] ||
+               (e['left'] && e['right'] ? "#{e['left']}→#{e['right']}" : nil) ||
+               e['column'] || 'entry'
+        out << entry('resolution-waived', "#{item} (#{how})",
+                     e['resolution']['reason'].to_s.empty? ? 'no reason recorded' : e['resolution']['reason'].to_s,
+                     file)
+      end
+    end
+    mr = read_json(wd, 'manual-residues.json')
+    mr_list = mr.is_a?(Hash) ? mr['residues'] : mr
+    Array(mr_list).each do |e|
+      next unless e.is_a?(Hash) && e['status'].to_s == 'unbuilt'
+      out << entry('resolution-waived', "unbuilt custom-SQL residue: #{e['calc']}",
+                   'accepted unbuilt — its tile renders a magnitude proxy',
+                   'manual-residues.json')
+    end
+    { 'source-anchors.json' => 'no anchor watched this tile',
+      'ground-truth-plan.json' => 'no numeric oracle verified this tile' }.each do |file, why|
+      doc = read_json(wd, file)
+      Array(doc.is_a?(Hash) ? doc['coverage_waivers'] : nil).each do |w|
+        next unless w.is_a?(Hash)
+        out << entry('resolution-waived', "coverage waiver: #{w['tile']}",
+                     "#{why}#{w['reason'].to_s.empty? ? '' : " — #{w['reason']}"}",
+                     "#{file} coverage_waivers")
+      end
+    end
+    out
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def entry(cls, item, reason, source)
+    { 'class' => cls, 'item' => item.to_s, 'reason' => reason.to_s,
+      'source_artifact' => source.to_s }
+  end
+
+  def norm(s)
+    s.to_s.strip.downcase
+  end
+
+  def control_scope_drops(wd)
+    doc = read_json(wd, 'control-scope.json')
+    out = {}
+    Array(doc.is_a?(Hash) ? doc['dropped'] : nil).each do |d|
+      name = d.is_a?(Hash) ? d['name'] : d
+      next if name.to_s.strip.empty?
+      reason = d.is_a?(Hash) && !d['reason'].to_s.empty? ? d['reason'].to_s : 'dropped — recorded in control-scope.json'
+      out[norm(name)] = reason
+    end
+    out
+  end
+
+  def controls_waivers(wd)
+    doc = read_json(wd, 'controls-waivers.json')
+    doc = doc['waivers'] if doc.is_a?(Hash)
+    out = {}
+    Array(doc).each do |w|
+      next unless w.is_a?(Hash)
+      name = w['control'] || w['name']
+      next if name.to_s.strip.empty? || w['reason'].to_s.strip.empty?
+      out[norm(name)] = "waived: #{w['reason'].to_s.strip}"
+    end
+    out
+  end
+
+  def trail(wd)
+    path = File.join(wd, 'offramps.jsonl')
+    return [] unless File.exist?(path)
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+
+  def read_json(wd, rel)
+    read_json_path(File.join(wd, rel))
+  end
+
+  def read_json_path(path)
+    return nil unless File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue StandardError
+    nil
+  end
+end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/degradation_ledger.rb
@@ -107,6 +107,11 @@ module DegradationLedger
 
   # Derive the full ledger (Array of entry Hashes) from the workdir's
   # artifacts. Deterministic: same files → same entries, same order.
+  # Dedupe is by the FULL entry (class, item, reason, source) — the reason must
+  # participate: coverage.json legitimately records several distinct degraded
+  # rows under one generic `visual` label (field-observed: three "field/calc"
+  # header-fallback rows for three different tiles, distinguishable only by
+  # their detail), and an item-only key silently swallowed all but the first.
   def derive(workdir)
     entries = []
     entries.concat(scope_cuts(workdir))
@@ -114,7 +119,7 @@ module DegradationLedger
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
-    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+    entries.uniq { |e| [e['class'], e['item'], e['reason'], e['source_artifact']] }
   end
 
   # Write <workdir>/degradation-ledger.json (entries + per-class counts).

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -177,8 +177,9 @@
 #      A recorded `divergent` verdict passes this gate as RECORDED (the
 #      comparison happened; the gaps are acknowledged) but is INJECTED into
 #      the waiver census as `visual-divergent` and SPENDS waiver budget
-#      (exit 19) — GREEN requires the budget to hold; fix the gaps or accept
-#      YELLOW. Full verdict-capping (divergent → PARTIAL) is PLAN-v3 PR-14.
+#      (exit 19) — GREEN requires the budget to hold, and the recorded
+#      divergence joins the degradation ledger as a fidelity-residual, so the
+#      final verdict is at most YELLOW (PR-14 verdict model below).
 #  14  Layout fill / grid coverage failed (gate 8c; #259 item 1) — a page in
 #      layout-census.json dropped a tile (placed < zones) or ships under-filled
 #      (grid_fill_pct < --min-grid-fill, default 0.45), OR a dashboard layout was
@@ -446,6 +447,21 @@
 # Phase 1d). (d) closes the run-2 hole where all 11 anchors sat in 3 of 9 tiles
 # and the oracle vouched for 6 tiles nothing was watching.
 #
+# VERDICT MODEL (PLAN-v3 PR-14 — cumulative-degradation accounting): on every
+# run this gate derives <workdir>/degradation-ledger.json from the workdir's
+# artifacts (lib/degradation_ledger.rb — scope cuts, quality waivers, recorded
+# escapes, fidelity residuals, waived resolutions; deterministic, never
+# self-reported) and prints ONE verdict with the ledger inline:
+#   GREEN   — the ledger is EMPTY (waivers within budget alone is no longer
+#             enough: any recorded degradation forfeits GREEN);
+#   YELLOW  — quality degradations but no scope cut (a budget-exceeded run —
+#             exit 19, doctrine unchanged — is always at least YELLOW);
+#   PARTIAL — ANY scope cut (dropped tile / column / control / DM element)
+#             regardless of the waiver budget; PARTIAL+YELLOW when both.
+# The verdict string is stamped into phase6-success.json and parity-final.json;
+# verify-complete.rb re-derives the ledger offline and FAILS (its exit 6) when
+# a report's claims contradict it — the anti-"GREEN, 0 waivers" mechanism.
+#
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
 # UNRESOLVED ledger entry with class `data` hard-fails. Data-class residuals
@@ -461,6 +477,21 @@ require 'uri'
 require 'optparse'
 require 'rbconfig'
 require 'digest'
+
+# Degradation ledger (PLAN-v3 PR-14) — vendored at scripts/lib/ in adopting
+# plugins; the canonical checkout resolves it from shared/lib. A checkout
+# without it keeps the legacy final line (stated below, never silent).
+DEG_LEDGER_LOADED = begin
+  require_relative 'lib/degradation_ledger'
+  true
+rescue LoadError
+  begin
+    require_relative '../lib/degradation_ledger'
+    true
+  rescue LoadError
+    false
+  end
+end
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0, min_parity_score: 0.0, min_grid_fill: 0.45 }
@@ -658,7 +689,7 @@ WAIVER_HIDES = {
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--no-vision-waiver'         => 'gate 8b: the visual PASS was SELF-graded — no context-free blind grader ran (recorded by record-visual-check.rb --no-vision-waiver)',
-  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (verdict-capping divergent→PARTIAL is PLAN-v3 PR-14)',
+  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (joins the degradation ledger as a fidelity-residual; verdict at most YELLOW)',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
   '--accept-residuals'         => 'gate 8d: named RCF deltas shipped unresolved',
   '--skip-fidelity-gate'       => 'gate 8d: the RCF fidelity loop was never required — compositional deltas (palette, chart kind, KPI format) were never iterated (--rcf-passes 0 records this waiver)',
@@ -741,8 +772,9 @@ end
 # but acknowledged source-vs-target visual gaps riding to GREEN unqualified is
 # exactly the live-run failure this closes (blind grade FAIL 5/6, verdict
 # recorded divergent, final GREEN). Injected into the census as
-# `visual-divergent` so the budget line names it. Full verdict-capping
-# (divergent → PARTIAL) is PLAN-v3 PR-14 — until then the budget is the cap.
+# `visual-divergent` so the budget line names it; the degradation ledger
+# (PR-14) additionally records it as a fidelity-residual, capping the verdict
+# at YELLOW even when the budget holds.
 begin
   _pf_bgw = File.exist?(summary_path) ? JSON.parse(File.read(summary_path)) : nil
   waiver_flags << '--no-vision-waiver' if _pf_bgw.is_a?(Hash) && _pf_bgw['blind_grade_waiver'].is_a?(Hash) &&
@@ -763,6 +795,42 @@ budget_flags = waiver_flags.reject do |f|
     (f == '--skip-visual-comparison' && opts[:skip_visual_cmp].to_s =~ /verifier/i)
 end
 
+# Reasons census (PR-14): the flag → recorded-reason map rides into
+# parity-final.json beside the census, so the degradation ledger (derived
+# OFFLINE here and by verify-complete.rb) can explain each waiver and decide
+# the /verifier/i policy exclusion without re-parsing CLI flags.
+_reason_srcs = {
+  '--skip-parity-gate'         => opts[:skip_parity],
+  '--skip-orphan-check'        => opts[:skip_orphan],
+  '--skip-column-check'        => opts[:skip_column],
+  '--skip-layout-check'        => opts[:skip_layout],
+  '--skip-layout-lint'         => opts[:skip_lint],
+  '--skip-control-lint'        => opts[:skip_control_lint],
+  '--skip-control-flip'        => opts[:skip_control_flip],
+  '--skip-visual-gate'         => opts[:skip_visual],
+  '--skip-visual-comparison'   => opts[:skip_visual_cmp],
+  '--skip-layout-fill'         => opts[:skip_layout_fill],
+  '--skip-fidelity-gate'       => opts[:skip_fidelity],
+  '--skip-visual-tiles'        => opts[:skip_visual_tiles],
+  '--skip-telemetry-gate'      => opts[:skip_telemetry],
+  '--skip-postpublish-guide'   => opts[:skip_postpublish],
+  '--accept-deferred-elements' => opts[:accept_deferred],
+  '--skip-anchors-gate'        => opts[:skip_anchors],
+  '--allow-empty-tiles'        => opts[:allow_empty_tiles],
+  '--skip-visual-similarity'   => opts[:skip_vsim],
+  '--accept-residuals'         => (Array(opts[:accept_residuals]).any? ? "accepted RCF residual(s): #{Array(opts[:accept_residuals]).join(', ')}" : nil),
+  '--accept-manual-residues'   => (Array(opts[:accept_manual_residues]).any? ? "accepted unbuilt residue(s): #{Array(opts[:accept_manual_residues]).join(', ')}" : nil),
+  '--min-pass-rate'            => (opts[:min_pass_rate] < 1.0 ? "accepted pass rate #{opts[:min_pass_rate]}" : nil),
+  '--allow-missing-tiles'      => (opts[:allow_missing_tiles].to_i.positive? ? "tolerated #{opts[:allow_missing_tiles]} unmatched dashboard zone(s)" : nil),
+  '--allow-extract'            => (opts[:allow_extract] ? 'extract mode accepted (value drift tolerated)' : nil),
+  'layout-phase-skip'          => (layout_phase_stamp.is_a?(Hash) ? layout_phase_stamp['reason'] : nil)
+}
+waiver_reasons = {}
+waiver_flags.each do |f|
+  v = _reason_srcs[f]
+  waiver_reasons[f] = v.to_s.strip if v.is_a?(String) && !v.to_s.strip.empty?
+end
+
 # Stamp the census into parity-final.json on every run (best-effort — a
 # missing/malformed file is gate 1's problem, not the stamp's).
 if File.exist?(summary_path)
@@ -770,6 +838,7 @@ if File.exist?(summary_path)
     _pf = JSON.parse(File.read(summary_path))
     _pf['waivers'] = waiver_flags
     _pf['waiver_count'] = waiver_flags.length
+    _pf['waiver_reasons'] = waiver_reasons
     # Off-ramp telemetry fields (P2): where did this run defect? route comes from
     # the orchestrator's migrate-state.json ('orchestrated' | 'manual-authorized';
     # null for converters without the concept); manual_path_authorized records an
@@ -3243,6 +3312,24 @@ end
 # for this cap — reduce the waiver count by fixing the underlying issues, or
 # report the migration as YELLOW.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Degradation ledger + verdict (PLAN-v3 PR-14) — derived ONCE here, from the
+# artifacts on disk (the census stamped above included), and written to
+# <workdir>/degradation-ledger.json on every run that reaches this point, so
+# the budget-fail path below and the success path share one derivation and
+# verify-complete.rb can re-derive + cross-check offline.
+# ---------------------------------------------------------------------------
+deg_entries = nil
+if DEG_LEDGER_LOADED
+  begin
+    deg_entries = DegradationLedger.derive(opts[:tab])
+    DegradationLedger.write(opts[:tab], deg_entries)
+  rescue StandardError => e
+    warn "[WARN] degradation-ledger derivation failed (#{e.class}: #{e.message.lines.first.to_s.strip}) — verdict falls back to legacy print."
+    deg_entries = nil
+  end
+end
+
 if budget_flags.length > WAIVER_BUDGET
   warn "[FAIL] waiver budget exceeded — #{budget_flags.length} quality waiver/escape flag(s) on this run (budget #{WAIVER_BUDGET})."
   warn '       GREEN unavailable — too many waivers; the highest achievable result is YELLOW.'
@@ -3251,6 +3338,11 @@ if budget_flags.length > WAIVER_BUDGET
   warn '       Waivers are for impossibilities, not obstacles. Fix the underlying issues until'
   warn "       <= #{WAIVER_BUDGET} remain, or report this migration as YELLOW (never GREEN) and name"
   warn '       every waiver in the report. There is no escape flag for this cap.'
+  if deg_entries
+    v19 = DegradationLedger.verdict(deg_entries, budget_exceeded: true)
+    warn "       VERDICT: #{v19} — degradation ledger (#{deg_entries.length} entr#{deg_entries.length == 1 ? 'y' : 'ies'}):"
+    DegradationLedger.report_lines(deg_entries).each { |l| warn "       #{l}" }
+  end
   exit 19
 end
 
@@ -3261,25 +3353,34 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 # run_id scopes the marker to THIS run (see the at_exit stale-deletion above);
 # the waiver census rides along so a report can quote the marker verbatim.
+# The verdict (PR-14): all gates passed and the budget held, but GREEN belongs
+# only to an EMPTY degradation ledger — any scope cut caps the run at PARTIAL,
+# any other recorded degradation at YELLOW. The string rides in the success
+# marker (verify-complete.rb quotes and cross-checks it).
+final_verdict = deg_entries ? DegradationLedger.verdict(deg_entries) : nil
 begin
   _wd = opts[:tab]
   # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
   # reach here) so verify-complete.rb has a uniform element count across plugins.
   _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
   _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
-  File.write(File.join(_wd, 'phase6-success.json'),
-             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
-                                  'chartCount' => _cc,
-                                  'gates' => 'all-pass',
-                                  'run_id' => current_run_id,
-                                  'waivers' => waiver_flags,
-                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _succ = { 'workbookId' => (opts[:wb] || ''),
+            'chartCount' => _cc,
+            'gates' => 'all-pass',
+            'run_id' => current_run_id,
+            'waivers' => waiver_flags,
+            'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+  _succ['verdict'] = final_verdict if final_verdict
+  File.write(File.join(_wd, 'phase6-success.json'), JSON.pretty_generate(_succ))
   _pend = File.join(_wd, 'parity-pending.json')
   File.delete(_pend) if File.exist?(_pend)
-  # Flip the off-ramp telemetry field now that success is minted (P2).
+  # Flip the off-ramp telemetry field now that success is minted (P2), and
+  # stamp the derived verdict beside the census so a report that quotes
+  # parity-final.json carries it (verify-complete.rb cross-checks the claim).
   if File.exist?(File.join(_wd, 'parity-final.json'))
     begin
       _pf['success_sentinel'] = true
+      _pf['verdict'] = final_verdict if final_verdict
       File.write(File.join(_wd, 'parity-final.json'), JSON.pretty_generate(_pf))
     rescue StandardError
       nil
@@ -3289,6 +3390,23 @@ rescue StandardError
   # never fail the gate on sentinel bookkeeping
 end
 
-puts "[OK] all gates pass — conversion may declare GREEN" \
-     "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+if final_verdict.nil?
+  # Legacy checkout without lib/degradation_ledger.rb — stated, never silent.
+  puts "[OK] all gates pass — conversion may declare GREEN" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+  puts '     (lib/degradation_ledger.rb not vendored — no PR-14 verdict derived; re-vendor to enable.)'
+elsif final_verdict == 'GREEN'
+  puts "[OK] all gates pass — VERDICT: GREEN (degradation ledger empty — no scope cuts, no waivers, no residuals)"
+else
+  puts "[OK] all gates pass — VERDICT: #{final_verdict}" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget)" : ''}"
+  puts "     GREEN requires an EMPTY degradation ledger; this run recorded #{deg_entries.length} degradation(s):"
+  DegradationLedger.report_lines(deg_entries).each { |l| puts "     #{l}" }
+  if final_verdict.start_with?('PARTIAL')
+    puts '     PARTIAL: a scope cut shipped — the delivered workbook is a SUBSET of the source.'
+    puts '     Report this migration as PARTIAL (never GREEN) and quote the ledger verbatim.'
+  else
+    puts '     Report this migration as YELLOW (never GREEN) and name every entry in the report.'
+  end
+end
 exit 0

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/degradation_ledger.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+#
+# DegradationLedger — cumulative-degradation accounting → the PARTIAL verdict
+# (PLAN-v3 PR-14, the honesty capstone).
+#
+# WHY: a migration can pass every hard gate and still ship LESS than the source
+# — a dropped tile behind --allow-missing-tiles, a dropped control behind a
+# controls-waivers.json entry, a column the coverage census recorded as lost,
+# a --skip-* flag that quietly turned a verification off. Each degradation is
+# individually recorded somewhere, but nothing ever ADDED THEM UP — so a field
+# run once reported "GREEN, 0 waivers" after a --skip-ref-check and dropped
+# columns. This module derives ONE ledger from the workdir's artifacts and one
+# verdict from the ledger:
+#
+#   GREEN   — the ledger is EMPTY. No scope cuts, no quality waivers, no
+#             recorded escapes, no fidelity residuals, no waived resolutions.
+#   YELLOW  — quality degradations but no scope cut (any non-scope-cut entry;
+#             a budget-exceeded run — assert-phase6-ran exit 19, existing
+#             doctrine unchanged — is always at least YELLOW).
+#   PARTIAL — ANY scope-cut entry (a dropped tile / column / control /
+#             DM element), regardless of the waiver budget. A scope cut caps
+#             the verdict: the delivered workbook is a subset of the source.
+#   PARTIAL+YELLOW — both (scope cuts AND quality degradations); PARTIAL is
+#             the dominant verdict, YELLOW is noted.
+#
+# DERIVATION IS MECHANICAL — every entry comes from an artifact on disk that
+# some script recorded at decision time; nothing here accepts self-reported
+# claims. verify-complete.rb re-derives the ledger offline and FAILS when the
+# final report's claims (verdict / waiver census) contradict it — the
+# anti-"0 waivers" mechanism.
+#
+# Entry shape (stable):
+#   { "class" => scope-cut | quality-waiver | recorded-escape |
+#                fidelity-residual | resolution-waived,
+#     "item"            => <what was degraded — tile/column/control/flag name>,
+#     "reason"          => <the recorded reason, or a stated default>,
+#     "source_artifact" => <file the entry was derived from> }
+#
+# Artifact classes read (all optional; absent file → no entries):
+#   scope-cut         — coverage.json (dropped/degraded visuals+columns),
+#                       parity-final.json tile_census unmatched zones (minus
+#                       visual-verify oracle matches — gate 5's own logic),
+#                       *-controls-coverage.json non-emitted signals with their
+#                       control-scope.json / controls-waivers.json explanations
+#                       (or those two files directly when no census exists),
+#                       deferred-elements.json (quarantined DM elements).
+#   quality-waiver    — parity-final.json `waivers` census (stamped by
+#                       assert-phase6-ran on every run), minus the POLICY
+#                       exclusions (--skip-telemetry-gate; --skip-visual-
+#                       comparison under the sanctioned /verifier/i split) and
+#                       minus flags reclassified below.
+#   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
+#                       waivers, stale-skill, degraded fast path, and the
+#                       PR-14 `skip-flag-waived` records every closed --skip-*
+#                       straggler now writes), plus the census' run off-ramp
+#                       flags (--force-new-workbook / --force-route-switch /
+#                       --allow-manual-spec).
+#   fidelity-residual — parity-final.json visual_verdict=divergent, unresolved
+#                       fidelity-ledger.json deltas (accepted residuals ride
+#                       to DONE unresolved), layout-arrangement.json
+#                       violations (advisory WARNs), png-read.json
+#                       kind_waivers (recorded chart-family substitutions).
+#   resolution-waived — lod-audit.json / join-plan.json resolutions with
+#                       how=waived, agg-semantics.json how=faithful-to-source
+#                       (a documented source hazard shipping as-is),
+#                       manual-residues.json entries still unbuilt,
+#                       source-anchors.json + ground-truth-plan.json
+#                       coverage_waivers (tiles no numeric oracle watched).
+#
+# Canonical: shared/lib/degradation_ledger.rb — edit there and run
+# tools/sync-shared.rb. Ruby 2.6-compatible, stdlib-only, fully offline.
+
+require 'json'
+
+module DegradationLedger
+  VERSION = 1
+  CLASSES = %w[scope-cut quality-waiver recorded-escape fidelity-residual
+               resolution-waived].freeze
+
+  # Census flags that are POLICY, never quality (assert-phase6-ran budget
+  # doctrine): telemetry consent; the visual-comparison hand-off to a verifier
+  # session is excluded only when its recorded reason matches /verifier/i.
+  POLICY_FLAGS = ['--skip-telemetry-gate'].freeze
+  # Census flags that are run OFF-RAMPS, not gate-quality waivers — classed
+  # recorded-escape (they were honored by a script mid-run, mirrored into the
+  # census by the budget code).
+  CENSUS_ESCAPE_FLAGS = ['--force-new-workbook', '--force-route-switch',
+                         '--allow-manual-spec'].freeze
+  # Census flags whose degradation is derived (better) from an artifact —
+  # skipped in the census pass so one degradation never counts twice:
+  # visual-divergent is derived from parity-final's visual_verdict.
+  CENSUS_DERIVED_FLAGS = ['visual-divergent'].freeze
+
+  # offramps.jsonl kinds that are ESCAPES (a verification/protection turned
+  # off) as opposed to observability records (pass1-stop, workbook-handoff,
+  # loop-stop, …). force-new-workbook / route-switch-forced / manual-spec are
+  # deliberately absent: the census already mirrors them (see above).
+  ESCAPE_OFFRAMP_KINDS = %w[cred-gate-waived doctor-gate-waived
+                            tableau-gate-waived stale-skill-waived
+                            degraded-fastpath skip-flag-waived].freeze
+
+  module_function
+
+  def ledger_path(workdir)
+    File.join(workdir, 'degradation-ledger.json')
+  end
+
+  # Derive the full ledger (Array of entry Hashes) from the workdir's
+  # artifacts. Deterministic: same files → same entries, same order.
+  def derive(workdir)
+    entries = []
+    entries.concat(scope_cuts(workdir))
+    entries.concat(quality_waivers(workdir))
+    entries.concat(recorded_escapes(workdir))
+    entries.concat(fidelity_residuals(workdir))
+    entries.concat(resolution_waived(workdir))
+    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+  end
+
+  # Write <workdir>/degradation-ledger.json (entries + per-class counts).
+  # Never raises — bookkeeping must not sink a gate run.
+  def write(workdir, entries)
+    counts = Hash.new(0)
+    entries.each { |e| counts[e['class']] += 1 }
+    File.write(ledger_path(workdir),
+               JSON.pretty_generate('version' => VERSION,
+                                    'derivedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                    'counts' => counts,
+                                    'entries' => entries))
+    true
+  rescue StandardError
+    false
+  end
+
+  # The verdict string. Any scope cut → PARTIAL (dominant); any other entry —
+  # or a budget-exceeded run — → YELLOW; both → "PARTIAL+YELLOW"; empty ledger
+  # and budget intact → GREEN. GREEN requires an EMPTY ledger, full stop.
+  def verdict(entries, budget_exceeded: false)
+    partial = entries.any? { |e| e['class'] == 'scope-cut' }
+    yellow  = budget_exceeded || entries.any? { |e| e['class'] != 'scope-cut' }
+    return 'PARTIAL+YELLOW' if partial && yellow
+    return 'PARTIAL' if partial
+    return 'YELLOW' if yellow
+    'GREEN'
+  end
+
+  # One line per entry, for inline printing under the verdict.
+  def report_lines(entries)
+    entries.map do |e|
+      "  - [#{e['class']}] #{e['item']} — #{e['reason']} (#{e['source_artifact']})"
+    end
+  end
+
+  # ── class derivations ──────────────────────────────────────────────────────
+
+  def scope_cuts(wd)
+    out = []
+    # coverage.json — the build-step drop census: severity 'dropped' is a tile
+    # that produced NO Sigma element; 'degraded' built but LOST a column/field.
+    cov = read_json(wd, 'coverage.json')
+    Array(cov.is_a?(Hash) ? cov['unresolved'] : nil).each do |u|
+      next unless u.is_a?(Hash) && %w[dropped degraded].include?(u['severity'].to_s)
+      what = u['severity'].to_s == 'dropped' ? 'dropped visual' : 'degraded visual (lost column/field)'
+      out << entry('scope-cut', "#{what}: #{u['visual']}",
+                   u['detail'].to_s.empty? ? u['severity'].to_s : u['detail'].to_s,
+                   'coverage.json')
+    end
+    # tile census — unmatched dashboard zones (gate 5), minus zones the
+    # visual-verify oracle confirmed (same subtraction gate 5 applies).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? pf['tile_census'] : nil
+    if census.is_a?(Hash)
+      names = Array(census['unmatched_zone_names']).map(&:to_s)
+      vv = read_json(wd, File.join('visual-verify', 'manifest.json'))
+      vv_ok = Array(vv).select { |t| t.is_a?(Hash) && t['visual_verified'] == true }
+                       .map { |t| t['worksheet'].to_s }
+      (names - vv_ok).each do |n|
+        out << entry('scope-cut', "dropped tile: #{n}",
+                     'source dashboard zone with no matching chart (tile census)',
+                     'parity-final.json tile_census')
+      end
+    end
+    # controls — the source-vs-built census names every signal; a non-emitted
+    # row is a control the user had that the migration did not build. Its
+    # explanation (control-scope drop record / controls-waivers reason) rides
+    # into the entry; without a census the declaration files stand alone.
+    dropped_notes = control_scope_drops(wd)
+    ctl_waivers = controls_waivers(wd)
+    ctl_census_path = Dir[File.join(wd, '*-controls-coverage.json')].min
+    seen_controls = []
+    if ctl_census_path
+      doc = read_json_path(ctl_census_path)
+      Array(doc.is_a?(Hash) ? doc['detail'] : nil).each do |r|
+        next unless r.is_a?(Hash) && r['status'].to_s != 'emitted'
+        name = r['name'].to_s
+        key = norm(name)
+        reason = dropped_notes[key] ||
+                 (ctl_waivers[key] || ctl_waivers[norm("#{r['kind']}:#{name}")]) ||
+                 "census status: #{r['status']}"
+        seen_controls << key << norm("#{r['kind']}:#{name}")
+        out << entry('scope-cut', "dropped control: #{r['kind']}:#{name}", reason,
+                     File.basename(ctl_census_path))
+      end
+    end
+    dropped_notes.each do |key, reason|
+      next if seen_controls.include?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'control-scope.json')
+    end
+    ctl_waivers.each do |key, reason|
+      next if seen_controls.include?(key) || dropped_notes.key?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'controls-waivers.json')
+    end
+    # deferred-elements.json — DM elements quarantined at POST time; a
+    # non-empty file at DONE means the PARTIAL data model was accepted.
+    dd = read_json(wd, 'deferred-elements.json')
+    deferred = dd.is_a?(Hash) ? Array(dd['deferred']) : (dd.is_a?(Array) ? dd : [])
+    deferred.each do |el|
+      name = el.is_a?(Hash) ? (el['name'] || el['id'] || 'unnamed element') : el.to_s
+      out << entry('scope-cut', "dropped DM element: #{name}",
+                   'quarantined at DM POST (deferred-elements.json still non-empty)',
+                   'deferred-elements.json')
+    end
+    out
+  end
+
+  def quality_waivers(wd)
+    pf = read_json(wd, 'parity-final.json')
+    return [] unless pf.is_a?(Hash) && pf['waivers'].is_a?(Array)
+    reasons = pf['waiver_reasons'].is_a?(Hash) ? pf['waiver_reasons'] : {}
+    # waivers.json carries {flag, gate, reason} for gates waived via
+    # record_waiver — a second reason source for older parity-final stamps.
+    wj = read_json(wd, 'waivers.json')
+    wj = wj['waivers'] if wj.is_a?(Hash)
+    Array(wj).each do |w|
+      next unless w.is_a?(Hash) && w['flag']
+      reasons[w['flag'].to_s] ||= w['reason'].to_s unless w['reason'].to_s.empty?
+    end
+    out = []
+    pf['waivers'].map(&:to_s).uniq.each do |flag|
+      next if POLICY_FLAGS.include?(flag)
+      next if CENSUS_DERIVED_FLAGS.include?(flag)
+      next if CENSUS_ESCAPE_FLAGS.include?(flag) # classed recorded-escape below
+      next if flag == '--skip-visual-comparison' && reasons[flag].to_s =~ /verifier/i
+      reason = reasons[flag].to_s
+      reason = 'budget-counted quality waiver (no reason recorded)' if reason.empty?
+      out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
+    end
+    out
+  end
+
+  def recorded_escapes(wd)
+    out = []
+    # Census-mirrored run off-ramps (they also spend waiver budget there).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? Array(pf['waivers']).map(&:to_s) : []
+    (census & CENSUS_ESCAPE_FLAGS).each do |flag|
+      out << entry('recorded-escape', flag, 'run off-ramp honored mid-run (see offramps.jsonl)',
+                   'parity-final.json waivers')
+    end
+    # offramps.jsonl escape kinds — including the PR-14 skip-flag-waived
+    # records that make every --skip-* visible (the --skip-ref-check fix).
+    trail(wd).each do |r|
+      next unless ESCAPE_OFFRAMP_KINDS.include?(r['kind'].to_s)
+      item = r['kind'].to_s == 'skip-flag-waived' && !r['detail'].to_s.empty? ? r['detail'].to_s : r['kind'].to_s
+      reason = r['reason'].to_s.empty? ? 'NO REASON GIVEN' : r['reason'].to_s
+      out << entry('recorded-escape', item, reason, 'offramps.jsonl')
+    end
+    out.uniq { |e| [e['item'], e['reason']] }
+  end
+
+  def fidelity_residuals(wd)
+    out = []
+    pf = read_json(wd, 'parity-final.json')
+    if pf.is_a?(Hash) && pf['visual_verdict'].to_s == 'divergent'
+      out << entry('fidelity-residual', 'visual verdict: divergent',
+                   'recorded source-vs-target visual gaps ship in the render',
+                   'parity-final.json')
+    end
+    fl = read_json(wd, 'fidelity-ledger.json')
+    Array(fl.is_a?(Hash) ? fl['entries'] : nil).each do |e|
+      next unless e.is_a?(Hash) && !e['resolved']
+      out << entry('fidelity-residual',
+                   "RCF residual #{e['id']} [#{e['dimension'] || e['cls']}]",
+                   e['delta'].to_s.empty? ? "unresolved #{e['cls']} delta" : e['delta'].to_s,
+                   'fidelity-ledger.json')
+    end
+    arr = read_json(wd, 'layout-arrangement.json')
+    Array(arr.is_a?(Hash) ? arr['pages'] : nil).each do |p|
+      next unless p.is_a?(Hash)
+      Array(p['violations']).each do |v|
+        out << entry('fidelity-residual', "arrangement: #{p['page']}", v.to_s,
+                     'layout-arrangement.json')
+      end
+    end
+    pr = read_json(wd, 'png-read.json')
+    Array(pr.is_a?(Hash) ? pr['kind_waivers'] : nil).each do |w|
+      next unless w.is_a?(Hash)
+      out << entry('fidelity-residual', "chart-kind substitution: #{w['tile']}",
+                   w['reason'].to_s.empty? ? 'recorded at read time' : w['reason'].to_s,
+                   'png-read.json kind_waivers')
+    end
+    out
+  end
+
+  def resolution_waived(wd)
+    out = []
+    { 'lod-audit.json' => %w[waived], 'join-plan.json' => %w[waived],
+      'agg-semantics.json' => %w[faithful-to-source] }.each do |file, hows|
+      doc = read_json(wd, file)
+      list = doc.is_a?(Hash) ? doc['entries'] : doc
+      Array(list).each do |e|
+        next unless e.is_a?(Hash) && e['resolution'].is_a?(Hash)
+        how = e['resolution']['how'].to_s
+        next unless hows.include?(how)
+        item = e['calc'] || e['name'] ||
+               (e['left'] && e['right'] ? "#{e['left']}→#{e['right']}" : nil) ||
+               e['column'] || 'entry'
+        out << entry('resolution-waived', "#{item} (#{how})",
+                     e['resolution']['reason'].to_s.empty? ? 'no reason recorded' : e['resolution']['reason'].to_s,
+                     file)
+      end
+    end
+    mr = read_json(wd, 'manual-residues.json')
+    mr_list = mr.is_a?(Hash) ? mr['residues'] : mr
+    Array(mr_list).each do |e|
+      next unless e.is_a?(Hash) && e['status'].to_s == 'unbuilt'
+      out << entry('resolution-waived', "unbuilt custom-SQL residue: #{e['calc']}",
+                   'accepted unbuilt — its tile renders a magnitude proxy',
+                   'manual-residues.json')
+    end
+    { 'source-anchors.json' => 'no anchor watched this tile',
+      'ground-truth-plan.json' => 'no numeric oracle verified this tile' }.each do |file, why|
+      doc = read_json(wd, file)
+      Array(doc.is_a?(Hash) ? doc['coverage_waivers'] : nil).each do |w|
+        next unless w.is_a?(Hash)
+        out << entry('resolution-waived', "coverage waiver: #{w['tile']}",
+                     "#{why}#{w['reason'].to_s.empty? ? '' : " — #{w['reason']}"}",
+                     "#{file} coverage_waivers")
+      end
+    end
+    out
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def entry(cls, item, reason, source)
+    { 'class' => cls, 'item' => item.to_s, 'reason' => reason.to_s,
+      'source_artifact' => source.to_s }
+  end
+
+  def norm(s)
+    s.to_s.strip.downcase
+  end
+
+  def control_scope_drops(wd)
+    doc = read_json(wd, 'control-scope.json')
+    out = {}
+    Array(doc.is_a?(Hash) ? doc['dropped'] : nil).each do |d|
+      name = d.is_a?(Hash) ? d['name'] : d
+      next if name.to_s.strip.empty?
+      reason = d.is_a?(Hash) && !d['reason'].to_s.empty? ? d['reason'].to_s : 'dropped — recorded in control-scope.json'
+      out[norm(name)] = reason
+    end
+    out
+  end
+
+  def controls_waivers(wd)
+    doc = read_json(wd, 'controls-waivers.json')
+    doc = doc['waivers'] if doc.is_a?(Hash)
+    out = {}
+    Array(doc).each do |w|
+      next unless w.is_a?(Hash)
+      name = w['control'] || w['name']
+      next if name.to_s.strip.empty? || w['reason'].to_s.strip.empty?
+      out[norm(name)] = "waived: #{w['reason'].to_s.strip}"
+    end
+    out
+  end
+
+  def trail(wd)
+    path = File.join(wd, 'offramps.jsonl')
+    return [] unless File.exist?(path)
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+
+  def read_json(wd, rel)
+    read_json_path(File.join(wd, rel))
+  end
+
+  def read_json_path(path)
+    return nil unless File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue StandardError
+    nil
+  end
+end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/degradation_ledger.rb
@@ -107,6 +107,11 @@ module DegradationLedger
 
   # Derive the full ledger (Array of entry Hashes) from the workdir's
   # artifacts. Deterministic: same files → same entries, same order.
+  # Dedupe is by the FULL entry (class, item, reason, source) — the reason must
+  # participate: coverage.json legitimately records several distinct degraded
+  # rows under one generic `visual` label (field-observed: three "field/calc"
+  # header-fallback rows for three different tiles, distinguishable only by
+  # their detail), and an item-only key silently swallowed all but the first.
   def derive(workdir)
     entries = []
     entries.concat(scope_cuts(workdir))
@@ -114,7 +119,7 @@ module DegradationLedger
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
-    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+    entries.uniq { |e| [e['class'], e['item'], e['reason'], e['source_artifact']] }
   end
 
   # Write <workdir>/degradation-ledger.json (entries + per-class counts).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -177,8 +177,9 @@
 #      A recorded `divergent` verdict passes this gate as RECORDED (the
 #      comparison happened; the gaps are acknowledged) but is INJECTED into
 #      the waiver census as `visual-divergent` and SPENDS waiver budget
-#      (exit 19) — GREEN requires the budget to hold; fix the gaps or accept
-#      YELLOW. Full verdict-capping (divergent → PARTIAL) is PLAN-v3 PR-14.
+#      (exit 19) — GREEN requires the budget to hold, and the recorded
+#      divergence joins the degradation ledger as a fidelity-residual, so the
+#      final verdict is at most YELLOW (PR-14 verdict model below).
 #  14  Layout fill / grid coverage failed (gate 8c; #259 item 1) — a page in
 #      layout-census.json dropped a tile (placed < zones) or ships under-filled
 #      (grid_fill_pct < --min-grid-fill, default 0.45), OR a dashboard layout was
@@ -446,6 +447,21 @@
 # Phase 1d). (d) closes the run-2 hole where all 11 anchors sat in 3 of 9 tiles
 # and the oracle vouched for 6 tiles nothing was watching.
 #
+# VERDICT MODEL (PLAN-v3 PR-14 — cumulative-degradation accounting): on every
+# run this gate derives <workdir>/degradation-ledger.json from the workdir's
+# artifacts (lib/degradation_ledger.rb — scope cuts, quality waivers, recorded
+# escapes, fidelity residuals, waived resolutions; deterministic, never
+# self-reported) and prints ONE verdict with the ledger inline:
+#   GREEN   — the ledger is EMPTY (waivers within budget alone is no longer
+#             enough: any recorded degradation forfeits GREEN);
+#   YELLOW  — quality degradations but no scope cut (a budget-exceeded run —
+#             exit 19, doctrine unchanged — is always at least YELLOW);
+#   PARTIAL — ANY scope cut (dropped tile / column / control / DM element)
+#             regardless of the waiver budget; PARTIAL+YELLOW when both.
+# The verdict string is stamped into phase6-success.json and parity-final.json;
+# verify-complete.rb re-derives the ledger offline and FAILS (its exit 6) when
+# a report's claims contradict it — the anti-"GREEN, 0 waivers" mechanism.
+#
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
 # UNRESOLVED ledger entry with class `data` hard-fails. Data-class residuals
@@ -461,6 +477,21 @@ require 'uri'
 require 'optparse'
 require 'rbconfig'
 require 'digest'
+
+# Degradation ledger (PLAN-v3 PR-14) — vendored at scripts/lib/ in adopting
+# plugins; the canonical checkout resolves it from shared/lib. A checkout
+# without it keeps the legacy final line (stated below, never silent).
+DEG_LEDGER_LOADED = begin
+  require_relative 'lib/degradation_ledger'
+  true
+rescue LoadError
+  begin
+    require_relative '../lib/degradation_ledger'
+    true
+  rescue LoadError
+    false
+  end
+end
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0, min_parity_score: 0.0, min_grid_fill: 0.45 }
@@ -658,7 +689,7 @@ WAIVER_HIDES = {
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--no-vision-waiver'         => 'gate 8b: the visual PASS was SELF-graded — no context-free blind grader ran (recorded by record-visual-check.rb --no-vision-waiver)',
-  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (verdict-capping divergent→PARTIAL is PLAN-v3 PR-14)',
+  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (joins the degradation ledger as a fidelity-residual; verdict at most YELLOW)',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
   '--accept-residuals'         => 'gate 8d: named RCF deltas shipped unresolved',
   '--skip-fidelity-gate'       => 'gate 8d: the RCF fidelity loop was never required — compositional deltas (palette, chart kind, KPI format) were never iterated (--rcf-passes 0 records this waiver)',
@@ -741,8 +772,9 @@ end
 # but acknowledged source-vs-target visual gaps riding to GREEN unqualified is
 # exactly the live-run failure this closes (blind grade FAIL 5/6, verdict
 # recorded divergent, final GREEN). Injected into the census as
-# `visual-divergent` so the budget line names it. Full verdict-capping
-# (divergent → PARTIAL) is PLAN-v3 PR-14 — until then the budget is the cap.
+# `visual-divergent` so the budget line names it; the degradation ledger
+# (PR-14) additionally records it as a fidelity-residual, capping the verdict
+# at YELLOW even when the budget holds.
 begin
   _pf_bgw = File.exist?(summary_path) ? JSON.parse(File.read(summary_path)) : nil
   waiver_flags << '--no-vision-waiver' if _pf_bgw.is_a?(Hash) && _pf_bgw['blind_grade_waiver'].is_a?(Hash) &&
@@ -763,6 +795,42 @@ budget_flags = waiver_flags.reject do |f|
     (f == '--skip-visual-comparison' && opts[:skip_visual_cmp].to_s =~ /verifier/i)
 end
 
+# Reasons census (PR-14): the flag → recorded-reason map rides into
+# parity-final.json beside the census, so the degradation ledger (derived
+# OFFLINE here and by verify-complete.rb) can explain each waiver and decide
+# the /verifier/i policy exclusion without re-parsing CLI flags.
+_reason_srcs = {
+  '--skip-parity-gate'         => opts[:skip_parity],
+  '--skip-orphan-check'        => opts[:skip_orphan],
+  '--skip-column-check'        => opts[:skip_column],
+  '--skip-layout-check'        => opts[:skip_layout],
+  '--skip-layout-lint'         => opts[:skip_lint],
+  '--skip-control-lint'        => opts[:skip_control_lint],
+  '--skip-control-flip'        => opts[:skip_control_flip],
+  '--skip-visual-gate'         => opts[:skip_visual],
+  '--skip-visual-comparison'   => opts[:skip_visual_cmp],
+  '--skip-layout-fill'         => opts[:skip_layout_fill],
+  '--skip-fidelity-gate'       => opts[:skip_fidelity],
+  '--skip-visual-tiles'        => opts[:skip_visual_tiles],
+  '--skip-telemetry-gate'      => opts[:skip_telemetry],
+  '--skip-postpublish-guide'   => opts[:skip_postpublish],
+  '--accept-deferred-elements' => opts[:accept_deferred],
+  '--skip-anchors-gate'        => opts[:skip_anchors],
+  '--allow-empty-tiles'        => opts[:allow_empty_tiles],
+  '--skip-visual-similarity'   => opts[:skip_vsim],
+  '--accept-residuals'         => (Array(opts[:accept_residuals]).any? ? "accepted RCF residual(s): #{Array(opts[:accept_residuals]).join(', ')}" : nil),
+  '--accept-manual-residues'   => (Array(opts[:accept_manual_residues]).any? ? "accepted unbuilt residue(s): #{Array(opts[:accept_manual_residues]).join(', ')}" : nil),
+  '--min-pass-rate'            => (opts[:min_pass_rate] < 1.0 ? "accepted pass rate #{opts[:min_pass_rate]}" : nil),
+  '--allow-missing-tiles'      => (opts[:allow_missing_tiles].to_i.positive? ? "tolerated #{opts[:allow_missing_tiles]} unmatched dashboard zone(s)" : nil),
+  '--allow-extract'            => (opts[:allow_extract] ? 'extract mode accepted (value drift tolerated)' : nil),
+  'layout-phase-skip'          => (layout_phase_stamp.is_a?(Hash) ? layout_phase_stamp['reason'] : nil)
+}
+waiver_reasons = {}
+waiver_flags.each do |f|
+  v = _reason_srcs[f]
+  waiver_reasons[f] = v.to_s.strip if v.is_a?(String) && !v.to_s.strip.empty?
+end
+
 # Stamp the census into parity-final.json on every run (best-effort — a
 # missing/malformed file is gate 1's problem, not the stamp's).
 if File.exist?(summary_path)
@@ -770,6 +838,7 @@ if File.exist?(summary_path)
     _pf = JSON.parse(File.read(summary_path))
     _pf['waivers'] = waiver_flags
     _pf['waiver_count'] = waiver_flags.length
+    _pf['waiver_reasons'] = waiver_reasons
     # Off-ramp telemetry fields (P2): where did this run defect? route comes from
     # the orchestrator's migrate-state.json ('orchestrated' | 'manual-authorized';
     # null for converters without the concept); manual_path_authorized records an
@@ -3243,6 +3312,24 @@ end
 # for this cap — reduce the waiver count by fixing the underlying issues, or
 # report the migration as YELLOW.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Degradation ledger + verdict (PLAN-v3 PR-14) — derived ONCE here, from the
+# artifacts on disk (the census stamped above included), and written to
+# <workdir>/degradation-ledger.json on every run that reaches this point, so
+# the budget-fail path below and the success path share one derivation and
+# verify-complete.rb can re-derive + cross-check offline.
+# ---------------------------------------------------------------------------
+deg_entries = nil
+if DEG_LEDGER_LOADED
+  begin
+    deg_entries = DegradationLedger.derive(opts[:tab])
+    DegradationLedger.write(opts[:tab], deg_entries)
+  rescue StandardError => e
+    warn "[WARN] degradation-ledger derivation failed (#{e.class}: #{e.message.lines.first.to_s.strip}) — verdict falls back to legacy print."
+    deg_entries = nil
+  end
+end
+
 if budget_flags.length > WAIVER_BUDGET
   warn "[FAIL] waiver budget exceeded — #{budget_flags.length} quality waiver/escape flag(s) on this run (budget #{WAIVER_BUDGET})."
   warn '       GREEN unavailable — too many waivers; the highest achievable result is YELLOW.'
@@ -3251,6 +3338,11 @@ if budget_flags.length > WAIVER_BUDGET
   warn '       Waivers are for impossibilities, not obstacles. Fix the underlying issues until'
   warn "       <= #{WAIVER_BUDGET} remain, or report this migration as YELLOW (never GREEN) and name"
   warn '       every waiver in the report. There is no escape flag for this cap.'
+  if deg_entries
+    v19 = DegradationLedger.verdict(deg_entries, budget_exceeded: true)
+    warn "       VERDICT: #{v19} — degradation ledger (#{deg_entries.length} entr#{deg_entries.length == 1 ? 'y' : 'ies'}):"
+    DegradationLedger.report_lines(deg_entries).each { |l| warn "       #{l}" }
+  end
   exit 19
 end
 
@@ -3261,25 +3353,34 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 # run_id scopes the marker to THIS run (see the at_exit stale-deletion above);
 # the waiver census rides along so a report can quote the marker verbatim.
+# The verdict (PR-14): all gates passed and the budget held, but GREEN belongs
+# only to an EMPTY degradation ledger — any scope cut caps the run at PARTIAL,
+# any other recorded degradation at YELLOW. The string rides in the success
+# marker (verify-complete.rb quotes and cross-checks it).
+final_verdict = deg_entries ? DegradationLedger.verdict(deg_entries) : nil
 begin
   _wd = opts[:tab]
   # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
   # reach here) so verify-complete.rb has a uniform element count across plugins.
   _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
   _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
-  File.write(File.join(_wd, 'phase6-success.json'),
-             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
-                                  'chartCount' => _cc,
-                                  'gates' => 'all-pass',
-                                  'run_id' => current_run_id,
-                                  'waivers' => waiver_flags,
-                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _succ = { 'workbookId' => (opts[:wb] || ''),
+            'chartCount' => _cc,
+            'gates' => 'all-pass',
+            'run_id' => current_run_id,
+            'waivers' => waiver_flags,
+            'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+  _succ['verdict'] = final_verdict if final_verdict
+  File.write(File.join(_wd, 'phase6-success.json'), JSON.pretty_generate(_succ))
   _pend = File.join(_wd, 'parity-pending.json')
   File.delete(_pend) if File.exist?(_pend)
-  # Flip the off-ramp telemetry field now that success is minted (P2).
+  # Flip the off-ramp telemetry field now that success is minted (P2), and
+  # stamp the derived verdict beside the census so a report that quotes
+  # parity-final.json carries it (verify-complete.rb cross-checks the claim).
   if File.exist?(File.join(_wd, 'parity-final.json'))
     begin
       _pf['success_sentinel'] = true
+      _pf['verdict'] = final_verdict if final_verdict
       File.write(File.join(_wd, 'parity-final.json'), JSON.pretty_generate(_pf))
     rescue StandardError
       nil
@@ -3289,6 +3390,23 @@ rescue StandardError
   # never fail the gate on sentinel bookkeeping
 end
 
-puts "[OK] all gates pass — conversion may declare GREEN" \
-     "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+if final_verdict.nil?
+  # Legacy checkout without lib/degradation_ledger.rb — stated, never silent.
+  puts "[OK] all gates pass — conversion may declare GREEN" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+  puts '     (lib/degradation_ledger.rb not vendored — no PR-14 verdict derived; re-vendor to enable.)'
+elsif final_verdict == 'GREEN'
+  puts "[OK] all gates pass — VERDICT: GREEN (degradation ledger empty — no scope cuts, no waivers, no residuals)"
+else
+  puts "[OK] all gates pass — VERDICT: #{final_verdict}" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget)" : ''}"
+  puts "     GREEN requires an EMPTY degradation ledger; this run recorded #{deg_entries.length} degradation(s):"
+  DegradationLedger.report_lines(deg_entries).each { |l| puts "     #{l}" }
+  if final_verdict.start_with?('PARTIAL')
+    puts '     PARTIAL: a scope cut shipped — the delivered workbook is a SUBSET of the source.'
+    puts '     Report this migration as PARTIAL (never GREEN) and quote the ledger verbatim.'
+  else
+    puts '     Report this migration as YELLOW (never GREEN) and name every entry in the report.'
+  end
+end
 exit 0

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/degradation_ledger.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+#
+# DegradationLedger — cumulative-degradation accounting → the PARTIAL verdict
+# (PLAN-v3 PR-14, the honesty capstone).
+#
+# WHY: a migration can pass every hard gate and still ship LESS than the source
+# — a dropped tile behind --allow-missing-tiles, a dropped control behind a
+# controls-waivers.json entry, a column the coverage census recorded as lost,
+# a --skip-* flag that quietly turned a verification off. Each degradation is
+# individually recorded somewhere, but nothing ever ADDED THEM UP — so a field
+# run once reported "GREEN, 0 waivers" after a --skip-ref-check and dropped
+# columns. This module derives ONE ledger from the workdir's artifacts and one
+# verdict from the ledger:
+#
+#   GREEN   — the ledger is EMPTY. No scope cuts, no quality waivers, no
+#             recorded escapes, no fidelity residuals, no waived resolutions.
+#   YELLOW  — quality degradations but no scope cut (any non-scope-cut entry;
+#             a budget-exceeded run — assert-phase6-ran exit 19, existing
+#             doctrine unchanged — is always at least YELLOW).
+#   PARTIAL — ANY scope-cut entry (a dropped tile / column / control /
+#             DM element), regardless of the waiver budget. A scope cut caps
+#             the verdict: the delivered workbook is a subset of the source.
+#   PARTIAL+YELLOW — both (scope cuts AND quality degradations); PARTIAL is
+#             the dominant verdict, YELLOW is noted.
+#
+# DERIVATION IS MECHANICAL — every entry comes from an artifact on disk that
+# some script recorded at decision time; nothing here accepts self-reported
+# claims. verify-complete.rb re-derives the ledger offline and FAILS when the
+# final report's claims (verdict / waiver census) contradict it — the
+# anti-"0 waivers" mechanism.
+#
+# Entry shape (stable):
+#   { "class" => scope-cut | quality-waiver | recorded-escape |
+#                fidelity-residual | resolution-waived,
+#     "item"            => <what was degraded — tile/column/control/flag name>,
+#     "reason"          => <the recorded reason, or a stated default>,
+#     "source_artifact" => <file the entry was derived from> }
+#
+# Artifact classes read (all optional; absent file → no entries):
+#   scope-cut         — coverage.json (dropped/degraded visuals+columns),
+#                       parity-final.json tile_census unmatched zones (minus
+#                       visual-verify oracle matches — gate 5's own logic),
+#                       *-controls-coverage.json non-emitted signals with their
+#                       control-scope.json / controls-waivers.json explanations
+#                       (or those two files directly when no census exists),
+#                       deferred-elements.json (quarantined DM elements).
+#   quality-waiver    — parity-final.json `waivers` census (stamped by
+#                       assert-phase6-ran on every run), minus the POLICY
+#                       exclusions (--skip-telemetry-gate; --skip-visual-
+#                       comparison under the sanctioned /verifier/i split) and
+#                       minus flags reclassified below.
+#   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
+#                       waivers, stale-skill, degraded fast path, and the
+#                       PR-14 `skip-flag-waived` records every closed --skip-*
+#                       straggler now writes), plus the census' run off-ramp
+#                       flags (--force-new-workbook / --force-route-switch /
+#                       --allow-manual-spec).
+#   fidelity-residual — parity-final.json visual_verdict=divergent, unresolved
+#                       fidelity-ledger.json deltas (accepted residuals ride
+#                       to DONE unresolved), layout-arrangement.json
+#                       violations (advisory WARNs), png-read.json
+#                       kind_waivers (recorded chart-family substitutions).
+#   resolution-waived — lod-audit.json / join-plan.json resolutions with
+#                       how=waived, agg-semantics.json how=faithful-to-source
+#                       (a documented source hazard shipping as-is),
+#                       manual-residues.json entries still unbuilt,
+#                       source-anchors.json + ground-truth-plan.json
+#                       coverage_waivers (tiles no numeric oracle watched).
+#
+# Canonical: shared/lib/degradation_ledger.rb — edit there and run
+# tools/sync-shared.rb. Ruby 2.6-compatible, stdlib-only, fully offline.
+
+require 'json'
+
+module DegradationLedger
+  VERSION = 1
+  CLASSES = %w[scope-cut quality-waiver recorded-escape fidelity-residual
+               resolution-waived].freeze
+
+  # Census flags that are POLICY, never quality (assert-phase6-ran budget
+  # doctrine): telemetry consent; the visual-comparison hand-off to a verifier
+  # session is excluded only when its recorded reason matches /verifier/i.
+  POLICY_FLAGS = ['--skip-telemetry-gate'].freeze
+  # Census flags that are run OFF-RAMPS, not gate-quality waivers — classed
+  # recorded-escape (they were honored by a script mid-run, mirrored into the
+  # census by the budget code).
+  CENSUS_ESCAPE_FLAGS = ['--force-new-workbook', '--force-route-switch',
+                         '--allow-manual-spec'].freeze
+  # Census flags whose degradation is derived (better) from an artifact —
+  # skipped in the census pass so one degradation never counts twice:
+  # visual-divergent is derived from parity-final's visual_verdict.
+  CENSUS_DERIVED_FLAGS = ['visual-divergent'].freeze
+
+  # offramps.jsonl kinds that are ESCAPES (a verification/protection turned
+  # off) as opposed to observability records (pass1-stop, workbook-handoff,
+  # loop-stop, …). force-new-workbook / route-switch-forced / manual-spec are
+  # deliberately absent: the census already mirrors them (see above).
+  ESCAPE_OFFRAMP_KINDS = %w[cred-gate-waived doctor-gate-waived
+                            tableau-gate-waived stale-skill-waived
+                            degraded-fastpath skip-flag-waived].freeze
+
+  module_function
+
+  def ledger_path(workdir)
+    File.join(workdir, 'degradation-ledger.json')
+  end
+
+  # Derive the full ledger (Array of entry Hashes) from the workdir's
+  # artifacts. Deterministic: same files → same entries, same order.
+  def derive(workdir)
+    entries = []
+    entries.concat(scope_cuts(workdir))
+    entries.concat(quality_waivers(workdir))
+    entries.concat(recorded_escapes(workdir))
+    entries.concat(fidelity_residuals(workdir))
+    entries.concat(resolution_waived(workdir))
+    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+  end
+
+  # Write <workdir>/degradation-ledger.json (entries + per-class counts).
+  # Never raises — bookkeeping must not sink a gate run.
+  def write(workdir, entries)
+    counts = Hash.new(0)
+    entries.each { |e| counts[e['class']] += 1 }
+    File.write(ledger_path(workdir),
+               JSON.pretty_generate('version' => VERSION,
+                                    'derivedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                    'counts' => counts,
+                                    'entries' => entries))
+    true
+  rescue StandardError
+    false
+  end
+
+  # The verdict string. Any scope cut → PARTIAL (dominant); any other entry —
+  # or a budget-exceeded run — → YELLOW; both → "PARTIAL+YELLOW"; empty ledger
+  # and budget intact → GREEN. GREEN requires an EMPTY ledger, full stop.
+  def verdict(entries, budget_exceeded: false)
+    partial = entries.any? { |e| e['class'] == 'scope-cut' }
+    yellow  = budget_exceeded || entries.any? { |e| e['class'] != 'scope-cut' }
+    return 'PARTIAL+YELLOW' if partial && yellow
+    return 'PARTIAL' if partial
+    return 'YELLOW' if yellow
+    'GREEN'
+  end
+
+  # One line per entry, for inline printing under the verdict.
+  def report_lines(entries)
+    entries.map do |e|
+      "  - [#{e['class']}] #{e['item']} — #{e['reason']} (#{e['source_artifact']})"
+    end
+  end
+
+  # ── class derivations ──────────────────────────────────────────────────────
+
+  def scope_cuts(wd)
+    out = []
+    # coverage.json — the build-step drop census: severity 'dropped' is a tile
+    # that produced NO Sigma element; 'degraded' built but LOST a column/field.
+    cov = read_json(wd, 'coverage.json')
+    Array(cov.is_a?(Hash) ? cov['unresolved'] : nil).each do |u|
+      next unless u.is_a?(Hash) && %w[dropped degraded].include?(u['severity'].to_s)
+      what = u['severity'].to_s == 'dropped' ? 'dropped visual' : 'degraded visual (lost column/field)'
+      out << entry('scope-cut', "#{what}: #{u['visual']}",
+                   u['detail'].to_s.empty? ? u['severity'].to_s : u['detail'].to_s,
+                   'coverage.json')
+    end
+    # tile census — unmatched dashboard zones (gate 5), minus zones the
+    # visual-verify oracle confirmed (same subtraction gate 5 applies).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? pf['tile_census'] : nil
+    if census.is_a?(Hash)
+      names = Array(census['unmatched_zone_names']).map(&:to_s)
+      vv = read_json(wd, File.join('visual-verify', 'manifest.json'))
+      vv_ok = Array(vv).select { |t| t.is_a?(Hash) && t['visual_verified'] == true }
+                       .map { |t| t['worksheet'].to_s }
+      (names - vv_ok).each do |n|
+        out << entry('scope-cut', "dropped tile: #{n}",
+                     'source dashboard zone with no matching chart (tile census)',
+                     'parity-final.json tile_census')
+      end
+    end
+    # controls — the source-vs-built census names every signal; a non-emitted
+    # row is a control the user had that the migration did not build. Its
+    # explanation (control-scope drop record / controls-waivers reason) rides
+    # into the entry; without a census the declaration files stand alone.
+    dropped_notes = control_scope_drops(wd)
+    ctl_waivers = controls_waivers(wd)
+    ctl_census_path = Dir[File.join(wd, '*-controls-coverage.json')].min
+    seen_controls = []
+    if ctl_census_path
+      doc = read_json_path(ctl_census_path)
+      Array(doc.is_a?(Hash) ? doc['detail'] : nil).each do |r|
+        next unless r.is_a?(Hash) && r['status'].to_s != 'emitted'
+        name = r['name'].to_s
+        key = norm(name)
+        reason = dropped_notes[key] ||
+                 (ctl_waivers[key] || ctl_waivers[norm("#{r['kind']}:#{name}")]) ||
+                 "census status: #{r['status']}"
+        seen_controls << key << norm("#{r['kind']}:#{name}")
+        out << entry('scope-cut', "dropped control: #{r['kind']}:#{name}", reason,
+                     File.basename(ctl_census_path))
+      end
+    end
+    dropped_notes.each do |key, reason|
+      next if seen_controls.include?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'control-scope.json')
+    end
+    ctl_waivers.each do |key, reason|
+      next if seen_controls.include?(key) || dropped_notes.key?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'controls-waivers.json')
+    end
+    # deferred-elements.json — DM elements quarantined at POST time; a
+    # non-empty file at DONE means the PARTIAL data model was accepted.
+    dd = read_json(wd, 'deferred-elements.json')
+    deferred = dd.is_a?(Hash) ? Array(dd['deferred']) : (dd.is_a?(Array) ? dd : [])
+    deferred.each do |el|
+      name = el.is_a?(Hash) ? (el['name'] || el['id'] || 'unnamed element') : el.to_s
+      out << entry('scope-cut', "dropped DM element: #{name}",
+                   'quarantined at DM POST (deferred-elements.json still non-empty)',
+                   'deferred-elements.json')
+    end
+    out
+  end
+
+  def quality_waivers(wd)
+    pf = read_json(wd, 'parity-final.json')
+    return [] unless pf.is_a?(Hash) && pf['waivers'].is_a?(Array)
+    reasons = pf['waiver_reasons'].is_a?(Hash) ? pf['waiver_reasons'] : {}
+    # waivers.json carries {flag, gate, reason} for gates waived via
+    # record_waiver — a second reason source for older parity-final stamps.
+    wj = read_json(wd, 'waivers.json')
+    wj = wj['waivers'] if wj.is_a?(Hash)
+    Array(wj).each do |w|
+      next unless w.is_a?(Hash) && w['flag']
+      reasons[w['flag'].to_s] ||= w['reason'].to_s unless w['reason'].to_s.empty?
+    end
+    out = []
+    pf['waivers'].map(&:to_s).uniq.each do |flag|
+      next if POLICY_FLAGS.include?(flag)
+      next if CENSUS_DERIVED_FLAGS.include?(flag)
+      next if CENSUS_ESCAPE_FLAGS.include?(flag) # classed recorded-escape below
+      next if flag == '--skip-visual-comparison' && reasons[flag].to_s =~ /verifier/i
+      reason = reasons[flag].to_s
+      reason = 'budget-counted quality waiver (no reason recorded)' if reason.empty?
+      out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
+    end
+    out
+  end
+
+  def recorded_escapes(wd)
+    out = []
+    # Census-mirrored run off-ramps (they also spend waiver budget there).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? Array(pf['waivers']).map(&:to_s) : []
+    (census & CENSUS_ESCAPE_FLAGS).each do |flag|
+      out << entry('recorded-escape', flag, 'run off-ramp honored mid-run (see offramps.jsonl)',
+                   'parity-final.json waivers')
+    end
+    # offramps.jsonl escape kinds — including the PR-14 skip-flag-waived
+    # records that make every --skip-* visible (the --skip-ref-check fix).
+    trail(wd).each do |r|
+      next unless ESCAPE_OFFRAMP_KINDS.include?(r['kind'].to_s)
+      item = r['kind'].to_s == 'skip-flag-waived' && !r['detail'].to_s.empty? ? r['detail'].to_s : r['kind'].to_s
+      reason = r['reason'].to_s.empty? ? 'NO REASON GIVEN' : r['reason'].to_s
+      out << entry('recorded-escape', item, reason, 'offramps.jsonl')
+    end
+    out.uniq { |e| [e['item'], e['reason']] }
+  end
+
+  def fidelity_residuals(wd)
+    out = []
+    pf = read_json(wd, 'parity-final.json')
+    if pf.is_a?(Hash) && pf['visual_verdict'].to_s == 'divergent'
+      out << entry('fidelity-residual', 'visual verdict: divergent',
+                   'recorded source-vs-target visual gaps ship in the render',
+                   'parity-final.json')
+    end
+    fl = read_json(wd, 'fidelity-ledger.json')
+    Array(fl.is_a?(Hash) ? fl['entries'] : nil).each do |e|
+      next unless e.is_a?(Hash) && !e['resolved']
+      out << entry('fidelity-residual',
+                   "RCF residual #{e['id']} [#{e['dimension'] || e['cls']}]",
+                   e['delta'].to_s.empty? ? "unresolved #{e['cls']} delta" : e['delta'].to_s,
+                   'fidelity-ledger.json')
+    end
+    arr = read_json(wd, 'layout-arrangement.json')
+    Array(arr.is_a?(Hash) ? arr['pages'] : nil).each do |p|
+      next unless p.is_a?(Hash)
+      Array(p['violations']).each do |v|
+        out << entry('fidelity-residual', "arrangement: #{p['page']}", v.to_s,
+                     'layout-arrangement.json')
+      end
+    end
+    pr = read_json(wd, 'png-read.json')
+    Array(pr.is_a?(Hash) ? pr['kind_waivers'] : nil).each do |w|
+      next unless w.is_a?(Hash)
+      out << entry('fidelity-residual', "chart-kind substitution: #{w['tile']}",
+                   w['reason'].to_s.empty? ? 'recorded at read time' : w['reason'].to_s,
+                   'png-read.json kind_waivers')
+    end
+    out
+  end
+
+  def resolution_waived(wd)
+    out = []
+    { 'lod-audit.json' => %w[waived], 'join-plan.json' => %w[waived],
+      'agg-semantics.json' => %w[faithful-to-source] }.each do |file, hows|
+      doc = read_json(wd, file)
+      list = doc.is_a?(Hash) ? doc['entries'] : doc
+      Array(list).each do |e|
+        next unless e.is_a?(Hash) && e['resolution'].is_a?(Hash)
+        how = e['resolution']['how'].to_s
+        next unless hows.include?(how)
+        item = e['calc'] || e['name'] ||
+               (e['left'] && e['right'] ? "#{e['left']}→#{e['right']}" : nil) ||
+               e['column'] || 'entry'
+        out << entry('resolution-waived', "#{item} (#{how})",
+                     e['resolution']['reason'].to_s.empty? ? 'no reason recorded' : e['resolution']['reason'].to_s,
+                     file)
+      end
+    end
+    mr = read_json(wd, 'manual-residues.json')
+    mr_list = mr.is_a?(Hash) ? mr['residues'] : mr
+    Array(mr_list).each do |e|
+      next unless e.is_a?(Hash) && e['status'].to_s == 'unbuilt'
+      out << entry('resolution-waived', "unbuilt custom-SQL residue: #{e['calc']}",
+                   'accepted unbuilt — its tile renders a magnitude proxy',
+                   'manual-residues.json')
+    end
+    { 'source-anchors.json' => 'no anchor watched this tile',
+      'ground-truth-plan.json' => 'no numeric oracle verified this tile' }.each do |file, why|
+      doc = read_json(wd, file)
+      Array(doc.is_a?(Hash) ? doc['coverage_waivers'] : nil).each do |w|
+        next unless w.is_a?(Hash)
+        out << entry('resolution-waived', "coverage waiver: #{w['tile']}",
+                     "#{why}#{w['reason'].to_s.empty? ? '' : " — #{w['reason']}"}",
+                     "#{file} coverage_waivers")
+      end
+    end
+    out
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def entry(cls, item, reason, source)
+    { 'class' => cls, 'item' => item.to_s, 'reason' => reason.to_s,
+      'source_artifact' => source.to_s }
+  end
+
+  def norm(s)
+    s.to_s.strip.downcase
+  end
+
+  def control_scope_drops(wd)
+    doc = read_json(wd, 'control-scope.json')
+    out = {}
+    Array(doc.is_a?(Hash) ? doc['dropped'] : nil).each do |d|
+      name = d.is_a?(Hash) ? d['name'] : d
+      next if name.to_s.strip.empty?
+      reason = d.is_a?(Hash) && !d['reason'].to_s.empty? ? d['reason'].to_s : 'dropped — recorded in control-scope.json'
+      out[norm(name)] = reason
+    end
+    out
+  end
+
+  def controls_waivers(wd)
+    doc = read_json(wd, 'controls-waivers.json')
+    doc = doc['waivers'] if doc.is_a?(Hash)
+    out = {}
+    Array(doc).each do |w|
+      next unless w.is_a?(Hash)
+      name = w['control'] || w['name']
+      next if name.to_s.strip.empty? || w['reason'].to_s.strip.empty?
+      out[norm(name)] = "waived: #{w['reason'].to_s.strip}"
+    end
+    out
+  end
+
+  def trail(wd)
+    path = File.join(wd, 'offramps.jsonl')
+    return [] unless File.exist?(path)
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+
+  def read_json(wd, rel)
+    read_json_path(File.join(wd, rel))
+  end
+
+  def read_json_path(path)
+    return nil unless File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue StandardError
+    nil
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/degradation_ledger.rb
@@ -107,6 +107,11 @@ module DegradationLedger
 
   # Derive the full ledger (Array of entry Hashes) from the workdir's
   # artifacts. Deterministic: same files → same entries, same order.
+  # Dedupe is by the FULL entry (class, item, reason, source) — the reason must
+  # participate: coverage.json legitimately records several distinct degraded
+  # rows under one generic `visual` label (field-observed: three "field/calc"
+  # header-fallback rows for three different tiles, distinguishable only by
+  # their detail), and an item-only key silently swallowed all but the first.
   def derive(workdir)
     entries = []
     entries.concat(scope_cuts(workdir))
@@ -114,7 +119,7 @@ module DegradationLedger
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
-    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+    entries.uniq { |e| [e['class'], e['item'], e['reason'], e['source_artifact']] }
   end
 
   # Write <workdir>/degradation-ledger.json (entries + per-class counts).

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -177,8 +177,9 @@
 #      A recorded `divergent` verdict passes this gate as RECORDED (the
 #      comparison happened; the gaps are acknowledged) but is INJECTED into
 #      the waiver census as `visual-divergent` and SPENDS waiver budget
-#      (exit 19) — GREEN requires the budget to hold; fix the gaps or accept
-#      YELLOW. Full verdict-capping (divergent → PARTIAL) is PLAN-v3 PR-14.
+#      (exit 19) — GREEN requires the budget to hold, and the recorded
+#      divergence joins the degradation ledger as a fidelity-residual, so the
+#      final verdict is at most YELLOW (PR-14 verdict model below).
 #  14  Layout fill / grid coverage failed (gate 8c; #259 item 1) — a page in
 #      layout-census.json dropped a tile (placed < zones) or ships under-filled
 #      (grid_fill_pct < --min-grid-fill, default 0.45), OR a dashboard layout was
@@ -446,6 +447,21 @@
 # Phase 1d). (d) closes the run-2 hole where all 11 anchors sat in 3 of 9 tiles
 # and the oracle vouched for 6 tiles nothing was watching.
 #
+# VERDICT MODEL (PLAN-v3 PR-14 — cumulative-degradation accounting): on every
+# run this gate derives <workdir>/degradation-ledger.json from the workdir's
+# artifacts (lib/degradation_ledger.rb — scope cuts, quality waivers, recorded
+# escapes, fidelity residuals, waived resolutions; deterministic, never
+# self-reported) and prints ONE verdict with the ledger inline:
+#   GREEN   — the ledger is EMPTY (waivers within budget alone is no longer
+#             enough: any recorded degradation forfeits GREEN);
+#   YELLOW  — quality degradations but no scope cut (a budget-exceeded run —
+#             exit 19, doctrine unchanged — is always at least YELLOW);
+#   PARTIAL — ANY scope cut (dropped tile / column / control / DM element)
+#             regardless of the waiver budget; PARTIAL+YELLOW when both.
+# The verdict string is stamped into phase6-success.json and parity-final.json;
+# verify-complete.rb re-derives the ledger offline and FAILS (its exit 6) when
+# a report's claims contradict it — the anti-"GREEN, 0 waivers" mechanism.
+#
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
 # UNRESOLVED ledger entry with class `data` hard-fails. Data-class residuals
@@ -461,6 +477,21 @@ require 'uri'
 require 'optparse'
 require 'rbconfig'
 require 'digest'
+
+# Degradation ledger (PLAN-v3 PR-14) — vendored at scripts/lib/ in adopting
+# plugins; the canonical checkout resolves it from shared/lib. A checkout
+# without it keeps the legacy final line (stated below, never silent).
+DEG_LEDGER_LOADED = begin
+  require_relative 'lib/degradation_ledger'
+  true
+rescue LoadError
+  begin
+    require_relative '../lib/degradation_ledger'
+    true
+  rescue LoadError
+    false
+  end
+end
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0, min_parity_score: 0.0, min_grid_fill: 0.45 }
@@ -658,7 +689,7 @@ WAIVER_HIDES = {
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--no-vision-waiver'         => 'gate 8b: the visual PASS was SELF-graded — no context-free blind grader ran (recorded by record-visual-check.rb --no-vision-waiver)',
-  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (verdict-capping divergent→PARTIAL is PLAN-v3 PR-14)',
+  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (joins the degradation ledger as a fidelity-residual; verdict at most YELLOW)',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
   '--accept-residuals'         => 'gate 8d: named RCF deltas shipped unresolved',
   '--skip-fidelity-gate'       => 'gate 8d: the RCF fidelity loop was never required — compositional deltas (palette, chart kind, KPI format) were never iterated (--rcf-passes 0 records this waiver)',
@@ -741,8 +772,9 @@ end
 # but acknowledged source-vs-target visual gaps riding to GREEN unqualified is
 # exactly the live-run failure this closes (blind grade FAIL 5/6, verdict
 # recorded divergent, final GREEN). Injected into the census as
-# `visual-divergent` so the budget line names it. Full verdict-capping
-# (divergent → PARTIAL) is PLAN-v3 PR-14 — until then the budget is the cap.
+# `visual-divergent` so the budget line names it; the degradation ledger
+# (PR-14) additionally records it as a fidelity-residual, capping the verdict
+# at YELLOW even when the budget holds.
 begin
   _pf_bgw = File.exist?(summary_path) ? JSON.parse(File.read(summary_path)) : nil
   waiver_flags << '--no-vision-waiver' if _pf_bgw.is_a?(Hash) && _pf_bgw['blind_grade_waiver'].is_a?(Hash) &&
@@ -763,6 +795,42 @@ budget_flags = waiver_flags.reject do |f|
     (f == '--skip-visual-comparison' && opts[:skip_visual_cmp].to_s =~ /verifier/i)
 end
 
+# Reasons census (PR-14): the flag → recorded-reason map rides into
+# parity-final.json beside the census, so the degradation ledger (derived
+# OFFLINE here and by verify-complete.rb) can explain each waiver and decide
+# the /verifier/i policy exclusion without re-parsing CLI flags.
+_reason_srcs = {
+  '--skip-parity-gate'         => opts[:skip_parity],
+  '--skip-orphan-check'        => opts[:skip_orphan],
+  '--skip-column-check'        => opts[:skip_column],
+  '--skip-layout-check'        => opts[:skip_layout],
+  '--skip-layout-lint'         => opts[:skip_lint],
+  '--skip-control-lint'        => opts[:skip_control_lint],
+  '--skip-control-flip'        => opts[:skip_control_flip],
+  '--skip-visual-gate'         => opts[:skip_visual],
+  '--skip-visual-comparison'   => opts[:skip_visual_cmp],
+  '--skip-layout-fill'         => opts[:skip_layout_fill],
+  '--skip-fidelity-gate'       => opts[:skip_fidelity],
+  '--skip-visual-tiles'        => opts[:skip_visual_tiles],
+  '--skip-telemetry-gate'      => opts[:skip_telemetry],
+  '--skip-postpublish-guide'   => opts[:skip_postpublish],
+  '--accept-deferred-elements' => opts[:accept_deferred],
+  '--skip-anchors-gate'        => opts[:skip_anchors],
+  '--allow-empty-tiles'        => opts[:allow_empty_tiles],
+  '--skip-visual-similarity'   => opts[:skip_vsim],
+  '--accept-residuals'         => (Array(opts[:accept_residuals]).any? ? "accepted RCF residual(s): #{Array(opts[:accept_residuals]).join(', ')}" : nil),
+  '--accept-manual-residues'   => (Array(opts[:accept_manual_residues]).any? ? "accepted unbuilt residue(s): #{Array(opts[:accept_manual_residues]).join(', ')}" : nil),
+  '--min-pass-rate'            => (opts[:min_pass_rate] < 1.0 ? "accepted pass rate #{opts[:min_pass_rate]}" : nil),
+  '--allow-missing-tiles'      => (opts[:allow_missing_tiles].to_i.positive? ? "tolerated #{opts[:allow_missing_tiles]} unmatched dashboard zone(s)" : nil),
+  '--allow-extract'            => (opts[:allow_extract] ? 'extract mode accepted (value drift tolerated)' : nil),
+  'layout-phase-skip'          => (layout_phase_stamp.is_a?(Hash) ? layout_phase_stamp['reason'] : nil)
+}
+waiver_reasons = {}
+waiver_flags.each do |f|
+  v = _reason_srcs[f]
+  waiver_reasons[f] = v.to_s.strip if v.is_a?(String) && !v.to_s.strip.empty?
+end
+
 # Stamp the census into parity-final.json on every run (best-effort — a
 # missing/malformed file is gate 1's problem, not the stamp's).
 if File.exist?(summary_path)
@@ -770,6 +838,7 @@ if File.exist?(summary_path)
     _pf = JSON.parse(File.read(summary_path))
     _pf['waivers'] = waiver_flags
     _pf['waiver_count'] = waiver_flags.length
+    _pf['waiver_reasons'] = waiver_reasons
     # Off-ramp telemetry fields (P2): where did this run defect? route comes from
     # the orchestrator's migrate-state.json ('orchestrated' | 'manual-authorized';
     # null for converters without the concept); manual_path_authorized records an
@@ -3243,6 +3312,24 @@ end
 # for this cap — reduce the waiver count by fixing the underlying issues, or
 # report the migration as YELLOW.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Degradation ledger + verdict (PLAN-v3 PR-14) — derived ONCE here, from the
+# artifacts on disk (the census stamped above included), and written to
+# <workdir>/degradation-ledger.json on every run that reaches this point, so
+# the budget-fail path below and the success path share one derivation and
+# verify-complete.rb can re-derive + cross-check offline.
+# ---------------------------------------------------------------------------
+deg_entries = nil
+if DEG_LEDGER_LOADED
+  begin
+    deg_entries = DegradationLedger.derive(opts[:tab])
+    DegradationLedger.write(opts[:tab], deg_entries)
+  rescue StandardError => e
+    warn "[WARN] degradation-ledger derivation failed (#{e.class}: #{e.message.lines.first.to_s.strip}) — verdict falls back to legacy print."
+    deg_entries = nil
+  end
+end
+
 if budget_flags.length > WAIVER_BUDGET
   warn "[FAIL] waiver budget exceeded — #{budget_flags.length} quality waiver/escape flag(s) on this run (budget #{WAIVER_BUDGET})."
   warn '       GREEN unavailable — too many waivers; the highest achievable result is YELLOW.'
@@ -3251,6 +3338,11 @@ if budget_flags.length > WAIVER_BUDGET
   warn '       Waivers are for impossibilities, not obstacles. Fix the underlying issues until'
   warn "       <= #{WAIVER_BUDGET} remain, or report this migration as YELLOW (never GREEN) and name"
   warn '       every waiver in the report. There is no escape flag for this cap.'
+  if deg_entries
+    v19 = DegradationLedger.verdict(deg_entries, budget_exceeded: true)
+    warn "       VERDICT: #{v19} — degradation ledger (#{deg_entries.length} entr#{deg_entries.length == 1 ? 'y' : 'ies'}):"
+    DegradationLedger.report_lines(deg_entries).each { |l| warn "       #{l}" }
+  end
   exit 19
 end
 
@@ -3261,25 +3353,34 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 # run_id scopes the marker to THIS run (see the at_exit stale-deletion above);
 # the waiver census rides along so a report can quote the marker verbatim.
+# The verdict (PR-14): all gates passed and the budget held, but GREEN belongs
+# only to an EMPTY degradation ledger — any scope cut caps the run at PARTIAL,
+# any other recorded degradation at YELLOW. The string rides in the success
+# marker (verify-complete.rb quotes and cross-checks it).
+final_verdict = deg_entries ? DegradationLedger.verdict(deg_entries) : nil
 begin
   _wd = opts[:tab]
   # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
   # reach here) so verify-complete.rb has a uniform element count across plugins.
   _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
   _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
-  File.write(File.join(_wd, 'phase6-success.json'),
-             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
-                                  'chartCount' => _cc,
-                                  'gates' => 'all-pass',
-                                  'run_id' => current_run_id,
-                                  'waivers' => waiver_flags,
-                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _succ = { 'workbookId' => (opts[:wb] || ''),
+            'chartCount' => _cc,
+            'gates' => 'all-pass',
+            'run_id' => current_run_id,
+            'waivers' => waiver_flags,
+            'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+  _succ['verdict'] = final_verdict if final_verdict
+  File.write(File.join(_wd, 'phase6-success.json'), JSON.pretty_generate(_succ))
   _pend = File.join(_wd, 'parity-pending.json')
   File.delete(_pend) if File.exist?(_pend)
-  # Flip the off-ramp telemetry field now that success is minted (P2).
+  # Flip the off-ramp telemetry field now that success is minted (P2), and
+  # stamp the derived verdict beside the census so a report that quotes
+  # parity-final.json carries it (verify-complete.rb cross-checks the claim).
   if File.exist?(File.join(_wd, 'parity-final.json'))
     begin
       _pf['success_sentinel'] = true
+      _pf['verdict'] = final_verdict if final_verdict
       File.write(File.join(_wd, 'parity-final.json'), JSON.pretty_generate(_pf))
     rescue StandardError
       nil
@@ -3289,6 +3390,23 @@ rescue StandardError
   # never fail the gate on sentinel bookkeeping
 end
 
-puts "[OK] all gates pass — conversion may declare GREEN" \
-     "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+if final_verdict.nil?
+  # Legacy checkout without lib/degradation_ledger.rb — stated, never silent.
+  puts "[OK] all gates pass — conversion may declare GREEN" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+  puts '     (lib/degradation_ledger.rb not vendored — no PR-14 verdict derived; re-vendor to enable.)'
+elsif final_verdict == 'GREEN'
+  puts "[OK] all gates pass — VERDICT: GREEN (degradation ledger empty — no scope cuts, no waivers, no residuals)"
+else
+  puts "[OK] all gates pass — VERDICT: #{final_verdict}" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget)" : ''}"
+  puts "     GREEN requires an EMPTY degradation ledger; this run recorded #{deg_entries.length} degradation(s):"
+  DegradationLedger.report_lines(deg_entries).each { |l| puts "     #{l}" }
+  if final_verdict.start_with?('PARTIAL')
+    puts '     PARTIAL: a scope cut shipped — the delivered workbook is a SUBSET of the source.'
+    puts '     Report this migration as PARTIAL (never GREEN) and quote the ledger verbatim.'
+  else
+    puts '     Report this migration as YELLOW (never GREEN) and name every entry in the report.'
+  end
+end
 exit 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/degradation_ledger.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+#
+# DegradationLedger — cumulative-degradation accounting → the PARTIAL verdict
+# (PLAN-v3 PR-14, the honesty capstone).
+#
+# WHY: a migration can pass every hard gate and still ship LESS than the source
+# — a dropped tile behind --allow-missing-tiles, a dropped control behind a
+# controls-waivers.json entry, a column the coverage census recorded as lost,
+# a --skip-* flag that quietly turned a verification off. Each degradation is
+# individually recorded somewhere, but nothing ever ADDED THEM UP — so a field
+# run once reported "GREEN, 0 waivers" after a --skip-ref-check and dropped
+# columns. This module derives ONE ledger from the workdir's artifacts and one
+# verdict from the ledger:
+#
+#   GREEN   — the ledger is EMPTY. No scope cuts, no quality waivers, no
+#             recorded escapes, no fidelity residuals, no waived resolutions.
+#   YELLOW  — quality degradations but no scope cut (any non-scope-cut entry;
+#             a budget-exceeded run — assert-phase6-ran exit 19, existing
+#             doctrine unchanged — is always at least YELLOW).
+#   PARTIAL — ANY scope-cut entry (a dropped tile / column / control /
+#             DM element), regardless of the waiver budget. A scope cut caps
+#             the verdict: the delivered workbook is a subset of the source.
+#   PARTIAL+YELLOW — both (scope cuts AND quality degradations); PARTIAL is
+#             the dominant verdict, YELLOW is noted.
+#
+# DERIVATION IS MECHANICAL — every entry comes from an artifact on disk that
+# some script recorded at decision time; nothing here accepts self-reported
+# claims. verify-complete.rb re-derives the ledger offline and FAILS when the
+# final report's claims (verdict / waiver census) contradict it — the
+# anti-"0 waivers" mechanism.
+#
+# Entry shape (stable):
+#   { "class" => scope-cut | quality-waiver | recorded-escape |
+#                fidelity-residual | resolution-waived,
+#     "item"            => <what was degraded — tile/column/control/flag name>,
+#     "reason"          => <the recorded reason, or a stated default>,
+#     "source_artifact" => <file the entry was derived from> }
+#
+# Artifact classes read (all optional; absent file → no entries):
+#   scope-cut         — coverage.json (dropped/degraded visuals+columns),
+#                       parity-final.json tile_census unmatched zones (minus
+#                       visual-verify oracle matches — gate 5's own logic),
+#                       *-controls-coverage.json non-emitted signals with their
+#                       control-scope.json / controls-waivers.json explanations
+#                       (or those two files directly when no census exists),
+#                       deferred-elements.json (quarantined DM elements).
+#   quality-waiver    — parity-final.json `waivers` census (stamped by
+#                       assert-phase6-ran on every run), minus the POLICY
+#                       exclusions (--skip-telemetry-gate; --skip-visual-
+#                       comparison under the sanctioned /verifier/i split) and
+#                       minus flags reclassified below.
+#   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
+#                       waivers, stale-skill, degraded fast path, and the
+#                       PR-14 `skip-flag-waived` records every closed --skip-*
+#                       straggler now writes), plus the census' run off-ramp
+#                       flags (--force-new-workbook / --force-route-switch /
+#                       --allow-manual-spec).
+#   fidelity-residual — parity-final.json visual_verdict=divergent, unresolved
+#                       fidelity-ledger.json deltas (accepted residuals ride
+#                       to DONE unresolved), layout-arrangement.json
+#                       violations (advisory WARNs), png-read.json
+#                       kind_waivers (recorded chart-family substitutions).
+#   resolution-waived — lod-audit.json / join-plan.json resolutions with
+#                       how=waived, agg-semantics.json how=faithful-to-source
+#                       (a documented source hazard shipping as-is),
+#                       manual-residues.json entries still unbuilt,
+#                       source-anchors.json + ground-truth-plan.json
+#                       coverage_waivers (tiles no numeric oracle watched).
+#
+# Canonical: shared/lib/degradation_ledger.rb — edit there and run
+# tools/sync-shared.rb. Ruby 2.6-compatible, stdlib-only, fully offline.
+
+require 'json'
+
+module DegradationLedger
+  VERSION = 1
+  CLASSES = %w[scope-cut quality-waiver recorded-escape fidelity-residual
+               resolution-waived].freeze
+
+  # Census flags that are POLICY, never quality (assert-phase6-ran budget
+  # doctrine): telemetry consent; the visual-comparison hand-off to a verifier
+  # session is excluded only when its recorded reason matches /verifier/i.
+  POLICY_FLAGS = ['--skip-telemetry-gate'].freeze
+  # Census flags that are run OFF-RAMPS, not gate-quality waivers — classed
+  # recorded-escape (they were honored by a script mid-run, mirrored into the
+  # census by the budget code).
+  CENSUS_ESCAPE_FLAGS = ['--force-new-workbook', '--force-route-switch',
+                         '--allow-manual-spec'].freeze
+  # Census flags whose degradation is derived (better) from an artifact —
+  # skipped in the census pass so one degradation never counts twice:
+  # visual-divergent is derived from parity-final's visual_verdict.
+  CENSUS_DERIVED_FLAGS = ['visual-divergent'].freeze
+
+  # offramps.jsonl kinds that are ESCAPES (a verification/protection turned
+  # off) as opposed to observability records (pass1-stop, workbook-handoff,
+  # loop-stop, …). force-new-workbook / route-switch-forced / manual-spec are
+  # deliberately absent: the census already mirrors them (see above).
+  ESCAPE_OFFRAMP_KINDS = %w[cred-gate-waived doctor-gate-waived
+                            tableau-gate-waived stale-skill-waived
+                            degraded-fastpath skip-flag-waived].freeze
+
+  module_function
+
+  def ledger_path(workdir)
+    File.join(workdir, 'degradation-ledger.json')
+  end
+
+  # Derive the full ledger (Array of entry Hashes) from the workdir's
+  # artifacts. Deterministic: same files → same entries, same order.
+  def derive(workdir)
+    entries = []
+    entries.concat(scope_cuts(workdir))
+    entries.concat(quality_waivers(workdir))
+    entries.concat(recorded_escapes(workdir))
+    entries.concat(fidelity_residuals(workdir))
+    entries.concat(resolution_waived(workdir))
+    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+  end
+
+  # Write <workdir>/degradation-ledger.json (entries + per-class counts).
+  # Never raises — bookkeeping must not sink a gate run.
+  def write(workdir, entries)
+    counts = Hash.new(0)
+    entries.each { |e| counts[e['class']] += 1 }
+    File.write(ledger_path(workdir),
+               JSON.pretty_generate('version' => VERSION,
+                                    'derivedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                    'counts' => counts,
+                                    'entries' => entries))
+    true
+  rescue StandardError
+    false
+  end
+
+  # The verdict string. Any scope cut → PARTIAL (dominant); any other entry —
+  # or a budget-exceeded run — → YELLOW; both → "PARTIAL+YELLOW"; empty ledger
+  # and budget intact → GREEN. GREEN requires an EMPTY ledger, full stop.
+  def verdict(entries, budget_exceeded: false)
+    partial = entries.any? { |e| e['class'] == 'scope-cut' }
+    yellow  = budget_exceeded || entries.any? { |e| e['class'] != 'scope-cut' }
+    return 'PARTIAL+YELLOW' if partial && yellow
+    return 'PARTIAL' if partial
+    return 'YELLOW' if yellow
+    'GREEN'
+  end
+
+  # One line per entry, for inline printing under the verdict.
+  def report_lines(entries)
+    entries.map do |e|
+      "  - [#{e['class']}] #{e['item']} — #{e['reason']} (#{e['source_artifact']})"
+    end
+  end
+
+  # ── class derivations ──────────────────────────────────────────────────────
+
+  def scope_cuts(wd)
+    out = []
+    # coverage.json — the build-step drop census: severity 'dropped' is a tile
+    # that produced NO Sigma element; 'degraded' built but LOST a column/field.
+    cov = read_json(wd, 'coverage.json')
+    Array(cov.is_a?(Hash) ? cov['unresolved'] : nil).each do |u|
+      next unless u.is_a?(Hash) && %w[dropped degraded].include?(u['severity'].to_s)
+      what = u['severity'].to_s == 'dropped' ? 'dropped visual' : 'degraded visual (lost column/field)'
+      out << entry('scope-cut', "#{what}: #{u['visual']}",
+                   u['detail'].to_s.empty? ? u['severity'].to_s : u['detail'].to_s,
+                   'coverage.json')
+    end
+    # tile census — unmatched dashboard zones (gate 5), minus zones the
+    # visual-verify oracle confirmed (same subtraction gate 5 applies).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? pf['tile_census'] : nil
+    if census.is_a?(Hash)
+      names = Array(census['unmatched_zone_names']).map(&:to_s)
+      vv = read_json(wd, File.join('visual-verify', 'manifest.json'))
+      vv_ok = Array(vv).select { |t| t.is_a?(Hash) && t['visual_verified'] == true }
+                       .map { |t| t['worksheet'].to_s }
+      (names - vv_ok).each do |n|
+        out << entry('scope-cut', "dropped tile: #{n}",
+                     'source dashboard zone with no matching chart (tile census)',
+                     'parity-final.json tile_census')
+      end
+    end
+    # controls — the source-vs-built census names every signal; a non-emitted
+    # row is a control the user had that the migration did not build. Its
+    # explanation (control-scope drop record / controls-waivers reason) rides
+    # into the entry; without a census the declaration files stand alone.
+    dropped_notes = control_scope_drops(wd)
+    ctl_waivers = controls_waivers(wd)
+    ctl_census_path = Dir[File.join(wd, '*-controls-coverage.json')].min
+    seen_controls = []
+    if ctl_census_path
+      doc = read_json_path(ctl_census_path)
+      Array(doc.is_a?(Hash) ? doc['detail'] : nil).each do |r|
+        next unless r.is_a?(Hash) && r['status'].to_s != 'emitted'
+        name = r['name'].to_s
+        key = norm(name)
+        reason = dropped_notes[key] ||
+                 (ctl_waivers[key] || ctl_waivers[norm("#{r['kind']}:#{name}")]) ||
+                 "census status: #{r['status']}"
+        seen_controls << key << norm("#{r['kind']}:#{name}")
+        out << entry('scope-cut', "dropped control: #{r['kind']}:#{name}", reason,
+                     File.basename(ctl_census_path))
+      end
+    end
+    dropped_notes.each do |key, reason|
+      next if seen_controls.include?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'control-scope.json')
+    end
+    ctl_waivers.each do |key, reason|
+      next if seen_controls.include?(key) || dropped_notes.key?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'controls-waivers.json')
+    end
+    # deferred-elements.json — DM elements quarantined at POST time; a
+    # non-empty file at DONE means the PARTIAL data model was accepted.
+    dd = read_json(wd, 'deferred-elements.json')
+    deferred = dd.is_a?(Hash) ? Array(dd['deferred']) : (dd.is_a?(Array) ? dd : [])
+    deferred.each do |el|
+      name = el.is_a?(Hash) ? (el['name'] || el['id'] || 'unnamed element') : el.to_s
+      out << entry('scope-cut', "dropped DM element: #{name}",
+                   'quarantined at DM POST (deferred-elements.json still non-empty)',
+                   'deferred-elements.json')
+    end
+    out
+  end
+
+  def quality_waivers(wd)
+    pf = read_json(wd, 'parity-final.json')
+    return [] unless pf.is_a?(Hash) && pf['waivers'].is_a?(Array)
+    reasons = pf['waiver_reasons'].is_a?(Hash) ? pf['waiver_reasons'] : {}
+    # waivers.json carries {flag, gate, reason} for gates waived via
+    # record_waiver — a second reason source for older parity-final stamps.
+    wj = read_json(wd, 'waivers.json')
+    wj = wj['waivers'] if wj.is_a?(Hash)
+    Array(wj).each do |w|
+      next unless w.is_a?(Hash) && w['flag']
+      reasons[w['flag'].to_s] ||= w['reason'].to_s unless w['reason'].to_s.empty?
+    end
+    out = []
+    pf['waivers'].map(&:to_s).uniq.each do |flag|
+      next if POLICY_FLAGS.include?(flag)
+      next if CENSUS_DERIVED_FLAGS.include?(flag)
+      next if CENSUS_ESCAPE_FLAGS.include?(flag) # classed recorded-escape below
+      next if flag == '--skip-visual-comparison' && reasons[flag].to_s =~ /verifier/i
+      reason = reasons[flag].to_s
+      reason = 'budget-counted quality waiver (no reason recorded)' if reason.empty?
+      out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
+    end
+    out
+  end
+
+  def recorded_escapes(wd)
+    out = []
+    # Census-mirrored run off-ramps (they also spend waiver budget there).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? Array(pf['waivers']).map(&:to_s) : []
+    (census & CENSUS_ESCAPE_FLAGS).each do |flag|
+      out << entry('recorded-escape', flag, 'run off-ramp honored mid-run (see offramps.jsonl)',
+                   'parity-final.json waivers')
+    end
+    # offramps.jsonl escape kinds — including the PR-14 skip-flag-waived
+    # records that make every --skip-* visible (the --skip-ref-check fix).
+    trail(wd).each do |r|
+      next unless ESCAPE_OFFRAMP_KINDS.include?(r['kind'].to_s)
+      item = r['kind'].to_s == 'skip-flag-waived' && !r['detail'].to_s.empty? ? r['detail'].to_s : r['kind'].to_s
+      reason = r['reason'].to_s.empty? ? 'NO REASON GIVEN' : r['reason'].to_s
+      out << entry('recorded-escape', item, reason, 'offramps.jsonl')
+    end
+    out.uniq { |e| [e['item'], e['reason']] }
+  end
+
+  def fidelity_residuals(wd)
+    out = []
+    pf = read_json(wd, 'parity-final.json')
+    if pf.is_a?(Hash) && pf['visual_verdict'].to_s == 'divergent'
+      out << entry('fidelity-residual', 'visual verdict: divergent',
+                   'recorded source-vs-target visual gaps ship in the render',
+                   'parity-final.json')
+    end
+    fl = read_json(wd, 'fidelity-ledger.json')
+    Array(fl.is_a?(Hash) ? fl['entries'] : nil).each do |e|
+      next unless e.is_a?(Hash) && !e['resolved']
+      out << entry('fidelity-residual',
+                   "RCF residual #{e['id']} [#{e['dimension'] || e['cls']}]",
+                   e['delta'].to_s.empty? ? "unresolved #{e['cls']} delta" : e['delta'].to_s,
+                   'fidelity-ledger.json')
+    end
+    arr = read_json(wd, 'layout-arrangement.json')
+    Array(arr.is_a?(Hash) ? arr['pages'] : nil).each do |p|
+      next unless p.is_a?(Hash)
+      Array(p['violations']).each do |v|
+        out << entry('fidelity-residual', "arrangement: #{p['page']}", v.to_s,
+                     'layout-arrangement.json')
+      end
+    end
+    pr = read_json(wd, 'png-read.json')
+    Array(pr.is_a?(Hash) ? pr['kind_waivers'] : nil).each do |w|
+      next unless w.is_a?(Hash)
+      out << entry('fidelity-residual', "chart-kind substitution: #{w['tile']}",
+                   w['reason'].to_s.empty? ? 'recorded at read time' : w['reason'].to_s,
+                   'png-read.json kind_waivers')
+    end
+    out
+  end
+
+  def resolution_waived(wd)
+    out = []
+    { 'lod-audit.json' => %w[waived], 'join-plan.json' => %w[waived],
+      'agg-semantics.json' => %w[faithful-to-source] }.each do |file, hows|
+      doc = read_json(wd, file)
+      list = doc.is_a?(Hash) ? doc['entries'] : doc
+      Array(list).each do |e|
+        next unless e.is_a?(Hash) && e['resolution'].is_a?(Hash)
+        how = e['resolution']['how'].to_s
+        next unless hows.include?(how)
+        item = e['calc'] || e['name'] ||
+               (e['left'] && e['right'] ? "#{e['left']}→#{e['right']}" : nil) ||
+               e['column'] || 'entry'
+        out << entry('resolution-waived', "#{item} (#{how})",
+                     e['resolution']['reason'].to_s.empty? ? 'no reason recorded' : e['resolution']['reason'].to_s,
+                     file)
+      end
+    end
+    mr = read_json(wd, 'manual-residues.json')
+    mr_list = mr.is_a?(Hash) ? mr['residues'] : mr
+    Array(mr_list).each do |e|
+      next unless e.is_a?(Hash) && e['status'].to_s == 'unbuilt'
+      out << entry('resolution-waived', "unbuilt custom-SQL residue: #{e['calc']}",
+                   'accepted unbuilt — its tile renders a magnitude proxy',
+                   'manual-residues.json')
+    end
+    { 'source-anchors.json' => 'no anchor watched this tile',
+      'ground-truth-plan.json' => 'no numeric oracle verified this tile' }.each do |file, why|
+      doc = read_json(wd, file)
+      Array(doc.is_a?(Hash) ? doc['coverage_waivers'] : nil).each do |w|
+        next unless w.is_a?(Hash)
+        out << entry('resolution-waived', "coverage waiver: #{w['tile']}",
+                     "#{why}#{w['reason'].to_s.empty? ? '' : " — #{w['reason']}"}",
+                     "#{file} coverage_waivers")
+      end
+    end
+    out
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def entry(cls, item, reason, source)
+    { 'class' => cls, 'item' => item.to_s, 'reason' => reason.to_s,
+      'source_artifact' => source.to_s }
+  end
+
+  def norm(s)
+    s.to_s.strip.downcase
+  end
+
+  def control_scope_drops(wd)
+    doc = read_json(wd, 'control-scope.json')
+    out = {}
+    Array(doc.is_a?(Hash) ? doc['dropped'] : nil).each do |d|
+      name = d.is_a?(Hash) ? d['name'] : d
+      next if name.to_s.strip.empty?
+      reason = d.is_a?(Hash) && !d['reason'].to_s.empty? ? d['reason'].to_s : 'dropped — recorded in control-scope.json'
+      out[norm(name)] = reason
+    end
+    out
+  end
+
+  def controls_waivers(wd)
+    doc = read_json(wd, 'controls-waivers.json')
+    doc = doc['waivers'] if doc.is_a?(Hash)
+    out = {}
+    Array(doc).each do |w|
+      next unless w.is_a?(Hash)
+      name = w['control'] || w['name']
+      next if name.to_s.strip.empty? || w['reason'].to_s.strip.empty?
+      out[norm(name)] = "waived: #{w['reason'].to_s.strip}"
+    end
+    out
+  end
+
+  def trail(wd)
+    path = File.join(wd, 'offramps.jsonl')
+    return [] unless File.exist?(path)
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+
+  def read_json(wd, rel)
+    read_json_path(File.join(wd, rel))
+  end
+
+  def read_json_path(path)
+    return nil unless File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue StandardError
+    nil
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/degradation_ledger.rb
@@ -107,6 +107,11 @@ module DegradationLedger
 
   # Derive the full ledger (Array of entry Hashes) from the workdir's
   # artifacts. Deterministic: same files → same entries, same order.
+  # Dedupe is by the FULL entry (class, item, reason, source) — the reason must
+  # participate: coverage.json legitimately records several distinct degraded
+  # rows under one generic `visual` label (field-observed: three "field/calc"
+  # header-fallback rows for three different tiles, distinguishable only by
+  # their detail), and an item-only key silently swallowed all but the first.
   def derive(workdir)
     entries = []
     entries.concat(scope_cuts(workdir))
@@ -114,7 +119,7 @@ module DegradationLedger
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
-    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+    entries.uniq { |e| [e['class'], e['item'], e['reason'], e['source_artifact']] }
   end
 
   # Write <workdir>/degradation-ledger.json (entries + per-class counts).

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/QUICKSTART.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/QUICKSTART.md
@@ -389,7 +389,7 @@ ruby scripts/assert-phase6-ran.rb --tableau ~/tableau-migration/<slug>
 
 ![tts_hard_gate](assets/tts_hard_gate.png)
 
-Exit 0 means the conversion may declare GREEN. Any non-zero exit means downgrade to YELLOW or RED with a documented reason.
+Exit 0 means the gates passed — the verdict on the final line is what you report: GREEN only when the degradation ledger is empty; YELLOW for quality waivers/residuals; PARTIAL whenever a scope cut (dropped tile/column/control) shipped. Any non-zero exit means downgrade to YELLOW or RED with a documented reason.
 
 **Phase E (opt-in) — Enhance.** Once everything is GREEN you can opt into the
 enhancement pass: add `--enhance` to the `migrate-tableau.rb --finalize` command to

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -348,7 +348,7 @@ the map of what the orchestrator runs.
 | Script | Purpose |
 |---|---|
 | `scripts/migrate-tableau.rb` | **The one command** — chains the whole scripted spine (gap gate → DM-reuse scan → DM → workbook → layout → two-pass parity → cleanup + census gate) and stops with exact instructions where agent judgment is required. See "One command" above. |
-| `scripts/verify-complete.rb` | **The single offline "are we done?" check** — exit 0 / ✅ DONE only when `phase6-success.json` is present (stamped by `assert-phase6-ran.rb` exit 0) and no `parity-pending.json` remains. A clean PASS 1 (exit 12) reports NOT DONE. Also prints the run's off-ramp trail. Run before claiming success. |
+| `scripts/verify-complete.rb` | **The single offline "are we done?" check** — exit 0 / ✅ DONE only when `phase6-success.json` is present (stamped by `assert-phase6-ran.rb` exit 0) and no `parity-pending.json` remains. A clean PASS 1 (exit 12) reports NOT DONE. PR-14: re-derives the degradation ledger, prints the verdict (GREEN/YELLOW/PARTIAL) with the ledger inline, and **exits 6 when the report's claims (verdict / waiver census) contradict the derivation** — the anti-"GREEN, 0 waivers" cross-check. Also prints the run's off-ramp trail. Run before claiming success. |
 | `scripts/lib/offramp.rb` + `offramps.jsonl` | **Observability trail** — every point a run leaves the golden path (cred/doctor waiver, PASS-1 stop, converter-stop, workbook-handoff, degraded fast path, manual-spec) appends a structured record to `<WORK>/offramps.jsonl`. Read it (or `verify-complete.rb`) to pinpoint *where* a run defected. |
 | `scripts/setup.rb` | One-time Sigma credential setup |
 | `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` for `SIGMA_API_TOKEN` (~1h TTL) — **bash only** |
@@ -749,6 +749,19 @@ to the recorded visual verdict (details: `refs/visual-similarity.md`). Escape
 > policy exclusions), and **data-class fidelity residuals can never be waived at
 > all** — the numbers are wrong; fix or reclassify with evidence. Reaching for a
 > third waiver means the run is telling you something: stop and fix.
+
+> **Verdict model (PR-14) — GREEN / YELLOW / PARTIAL.** On every gate run,
+> `lib/degradation_ledger.rb` derives `<WORK>/degradation-ledger.json` from the
+> artifacts (scope cuts, quality waivers, recorded `--skip-*` escapes, fidelity
+> residuals, waived resolutions — mechanical, never self-reported) and the gate
+> prints ONE verdict with the ledger inline. **GREEN requires an EMPTY ledger.**
+> Any non-scope-cut entry (or an exceeded budget) → **YELLOW**. **Any scope cut
+> — a dropped tile, column, control, or DM element — caps the verdict at
+> PARTIAL** regardless of the waiver budget (`PARTIAL+YELLOW` when both). The
+> verdict is stamped into `phase6-success.json` + `parity-final.json`, and
+> `verify-complete.rb` re-derives the ledger offline and **fails (exit 6) if
+> your report's claims contradict it** — never report GREEN, a waiver count, or
+> a verdict the ledger doesn't support; quote the ledger verbatim instead.
 
 ### Phase 5g — RCF (render-compare-fix) fidelity loop — `refs/phase-5g-rcf.md`
 After the workbook renders, iterate composition to convergence: `fidelity-loop.rb render`

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-dashboard-read.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-dashboard-read.rb
@@ -46,6 +46,15 @@ if opts[:skip]
   puts "[SKIP] dashboard-read gate WAIVED via --skip-dashboard-read (#{opts[:skip]})."
   puts '       Name this waiver in your migration report — the workbook was built WITHOUT'
   puts '       confirming its tiles/text/filters against the source dashboard PNG.'
+  # PR-14: every honored --skip-* leaves a record on the off-ramp trail.
+  begin
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'offramp'
+    Offramp.log(opts[:dir], kind: 'skip-flag-waived', reason: opts[:skip],
+                detail: '--skip-dashboard-read')
+  rescue LoadError
+    warn '       WARN: lib/offramp.rb not vendored — the waiver could not be recorded to offramps.jsonl.'
+  end
   exit 0
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-doctor-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-doctor-ran.rb
@@ -36,6 +36,19 @@ end.parse!
 
 if opts[:skip]
   puts "[SKIP] environment gate WAIVED (#{opts[:skip]}) — name this in your report."
+  # PR-14: every honored --skip-* leaves a record on the off-ramp trail. (The
+  # orchestrator also records doctor-gate-waived when it drives this waiver;
+  # this covers the standalone invocation.)
+  if opts[:dir]
+    begin
+      $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+      require 'offramp'
+      Offramp.log(opts[:dir], kind: 'skip-flag-waived', reason: opts[:skip],
+                  detail: '--skip-doctor-gate')
+    rescue LoadError
+      warn '       WARN: lib/offramp.rb not vendored — the waiver could not be recorded to offramps.jsonl.'
+    end
+  end
   exit 0
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -177,8 +177,9 @@
 #      A recorded `divergent` verdict passes this gate as RECORDED (the
 #      comparison happened; the gaps are acknowledged) but is INJECTED into
 #      the waiver census as `visual-divergent` and SPENDS waiver budget
-#      (exit 19) — GREEN requires the budget to hold; fix the gaps or accept
-#      YELLOW. Full verdict-capping (divergent → PARTIAL) is PLAN-v3 PR-14.
+#      (exit 19) — GREEN requires the budget to hold, and the recorded
+#      divergence joins the degradation ledger as a fidelity-residual, so the
+#      final verdict is at most YELLOW (PR-14 verdict model below).
 #  14  Layout fill / grid coverage failed (gate 8c; #259 item 1) — a page in
 #      layout-census.json dropped a tile (placed < zones) or ships under-filled
 #      (grid_fill_pct < --min-grid-fill, default 0.45), OR a dashboard layout was
@@ -446,6 +447,21 @@
 # Phase 1d). (d) closes the run-2 hole where all 11 anchors sat in 3 of 9 tiles
 # and the oracle vouched for 6 tiles nothing was watching.
 #
+# VERDICT MODEL (PLAN-v3 PR-14 — cumulative-degradation accounting): on every
+# run this gate derives <workdir>/degradation-ledger.json from the workdir's
+# artifacts (lib/degradation_ledger.rb — scope cuts, quality waivers, recorded
+# escapes, fidelity residuals, waived resolutions; deterministic, never
+# self-reported) and prints ONE verdict with the ledger inline:
+#   GREEN   — the ledger is EMPTY (waivers within budget alone is no longer
+#             enough: any recorded degradation forfeits GREEN);
+#   YELLOW  — quality degradations but no scope cut (a budget-exceeded run —
+#             exit 19, doctrine unchanged — is always at least YELLOW);
+#   PARTIAL — ANY scope cut (dropped tile / column / control / DM element)
+#             regardless of the waiver budget; PARTIAL+YELLOW when both.
+# The verdict string is stamped into phase6-success.json and parity-final.json;
+# verify-complete.rb re-derives the ledger offline and FAILS (its exit 6) when
+# a report's claims contradict it — the anti-"GREEN, 0 waivers" mechanism.
+#
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
 # UNRESOLVED ledger entry with class `data` hard-fails. Data-class residuals
@@ -461,6 +477,21 @@ require 'uri'
 require 'optparse'
 require 'rbconfig'
 require 'digest'
+
+# Degradation ledger (PLAN-v3 PR-14) — vendored at scripts/lib/ in adopting
+# plugins; the canonical checkout resolves it from shared/lib. A checkout
+# without it keeps the legacy final line (stated below, never silent).
+DEG_LEDGER_LOADED = begin
+  require_relative 'lib/degradation_ledger'
+  true
+rescue LoadError
+  begin
+    require_relative '../lib/degradation_ledger'
+    true
+  rescue LoadError
+    false
+  end
+end
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0, min_parity_score: 0.0, min_grid_fill: 0.45 }
@@ -658,7 +689,7 @@ WAIVER_HIDES = {
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--no-vision-waiver'         => 'gate 8b: the visual PASS was SELF-graded — no context-free blind grader ran (recorded by record-visual-check.rb --no-vision-waiver)',
-  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (verdict-capping divergent→PARTIAL is PLAN-v3 PR-14)',
+  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (joins the degradation ledger as a fidelity-residual; verdict at most YELLOW)',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
   '--accept-residuals'         => 'gate 8d: named RCF deltas shipped unresolved',
   '--skip-fidelity-gate'       => 'gate 8d: the RCF fidelity loop was never required — compositional deltas (palette, chart kind, KPI format) were never iterated (--rcf-passes 0 records this waiver)',
@@ -741,8 +772,9 @@ end
 # but acknowledged source-vs-target visual gaps riding to GREEN unqualified is
 # exactly the live-run failure this closes (blind grade FAIL 5/6, verdict
 # recorded divergent, final GREEN). Injected into the census as
-# `visual-divergent` so the budget line names it. Full verdict-capping
-# (divergent → PARTIAL) is PLAN-v3 PR-14 — until then the budget is the cap.
+# `visual-divergent` so the budget line names it; the degradation ledger
+# (PR-14) additionally records it as a fidelity-residual, capping the verdict
+# at YELLOW even when the budget holds.
 begin
   _pf_bgw = File.exist?(summary_path) ? JSON.parse(File.read(summary_path)) : nil
   waiver_flags << '--no-vision-waiver' if _pf_bgw.is_a?(Hash) && _pf_bgw['blind_grade_waiver'].is_a?(Hash) &&
@@ -763,6 +795,42 @@ budget_flags = waiver_flags.reject do |f|
     (f == '--skip-visual-comparison' && opts[:skip_visual_cmp].to_s =~ /verifier/i)
 end
 
+# Reasons census (PR-14): the flag → recorded-reason map rides into
+# parity-final.json beside the census, so the degradation ledger (derived
+# OFFLINE here and by verify-complete.rb) can explain each waiver and decide
+# the /verifier/i policy exclusion without re-parsing CLI flags.
+_reason_srcs = {
+  '--skip-parity-gate'         => opts[:skip_parity],
+  '--skip-orphan-check'        => opts[:skip_orphan],
+  '--skip-column-check'        => opts[:skip_column],
+  '--skip-layout-check'        => opts[:skip_layout],
+  '--skip-layout-lint'         => opts[:skip_lint],
+  '--skip-control-lint'        => opts[:skip_control_lint],
+  '--skip-control-flip'        => opts[:skip_control_flip],
+  '--skip-visual-gate'         => opts[:skip_visual],
+  '--skip-visual-comparison'   => opts[:skip_visual_cmp],
+  '--skip-layout-fill'         => opts[:skip_layout_fill],
+  '--skip-fidelity-gate'       => opts[:skip_fidelity],
+  '--skip-visual-tiles'        => opts[:skip_visual_tiles],
+  '--skip-telemetry-gate'      => opts[:skip_telemetry],
+  '--skip-postpublish-guide'   => opts[:skip_postpublish],
+  '--accept-deferred-elements' => opts[:accept_deferred],
+  '--skip-anchors-gate'        => opts[:skip_anchors],
+  '--allow-empty-tiles'        => opts[:allow_empty_tiles],
+  '--skip-visual-similarity'   => opts[:skip_vsim],
+  '--accept-residuals'         => (Array(opts[:accept_residuals]).any? ? "accepted RCF residual(s): #{Array(opts[:accept_residuals]).join(', ')}" : nil),
+  '--accept-manual-residues'   => (Array(opts[:accept_manual_residues]).any? ? "accepted unbuilt residue(s): #{Array(opts[:accept_manual_residues]).join(', ')}" : nil),
+  '--min-pass-rate'            => (opts[:min_pass_rate] < 1.0 ? "accepted pass rate #{opts[:min_pass_rate]}" : nil),
+  '--allow-missing-tiles'      => (opts[:allow_missing_tiles].to_i.positive? ? "tolerated #{opts[:allow_missing_tiles]} unmatched dashboard zone(s)" : nil),
+  '--allow-extract'            => (opts[:allow_extract] ? 'extract mode accepted (value drift tolerated)' : nil),
+  'layout-phase-skip'          => (layout_phase_stamp.is_a?(Hash) ? layout_phase_stamp['reason'] : nil)
+}
+waiver_reasons = {}
+waiver_flags.each do |f|
+  v = _reason_srcs[f]
+  waiver_reasons[f] = v.to_s.strip if v.is_a?(String) && !v.to_s.strip.empty?
+end
+
 # Stamp the census into parity-final.json on every run (best-effort — a
 # missing/malformed file is gate 1's problem, not the stamp's).
 if File.exist?(summary_path)
@@ -770,6 +838,7 @@ if File.exist?(summary_path)
     _pf = JSON.parse(File.read(summary_path))
     _pf['waivers'] = waiver_flags
     _pf['waiver_count'] = waiver_flags.length
+    _pf['waiver_reasons'] = waiver_reasons
     # Off-ramp telemetry fields (P2): where did this run defect? route comes from
     # the orchestrator's migrate-state.json ('orchestrated' | 'manual-authorized';
     # null for converters without the concept); manual_path_authorized records an
@@ -3243,6 +3312,24 @@ end
 # for this cap — reduce the waiver count by fixing the underlying issues, or
 # report the migration as YELLOW.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Degradation ledger + verdict (PLAN-v3 PR-14) — derived ONCE here, from the
+# artifacts on disk (the census stamped above included), and written to
+# <workdir>/degradation-ledger.json on every run that reaches this point, so
+# the budget-fail path below and the success path share one derivation and
+# verify-complete.rb can re-derive + cross-check offline.
+# ---------------------------------------------------------------------------
+deg_entries = nil
+if DEG_LEDGER_LOADED
+  begin
+    deg_entries = DegradationLedger.derive(opts[:tab])
+    DegradationLedger.write(opts[:tab], deg_entries)
+  rescue StandardError => e
+    warn "[WARN] degradation-ledger derivation failed (#{e.class}: #{e.message.lines.first.to_s.strip}) — verdict falls back to legacy print."
+    deg_entries = nil
+  end
+end
+
 if budget_flags.length > WAIVER_BUDGET
   warn "[FAIL] waiver budget exceeded — #{budget_flags.length} quality waiver/escape flag(s) on this run (budget #{WAIVER_BUDGET})."
   warn '       GREEN unavailable — too many waivers; the highest achievable result is YELLOW.'
@@ -3251,6 +3338,11 @@ if budget_flags.length > WAIVER_BUDGET
   warn '       Waivers are for impossibilities, not obstacles. Fix the underlying issues until'
   warn "       <= #{WAIVER_BUDGET} remain, or report this migration as YELLOW (never GREEN) and name"
   warn '       every waiver in the report. There is no escape flag for this cap.'
+  if deg_entries
+    v19 = DegradationLedger.verdict(deg_entries, budget_exceeded: true)
+    warn "       VERDICT: #{v19} — degradation ledger (#{deg_entries.length} entr#{deg_entries.length == 1 ? 'y' : 'ies'}):"
+    DegradationLedger.report_lines(deg_entries).each { |l| warn "       #{l}" }
+  end
   exit 19
 end
 
@@ -3261,25 +3353,34 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 # run_id scopes the marker to THIS run (see the at_exit stale-deletion above);
 # the waiver census rides along so a report can quote the marker verbatim.
+# The verdict (PR-14): all gates passed and the budget held, but GREEN belongs
+# only to an EMPTY degradation ledger — any scope cut caps the run at PARTIAL,
+# any other recorded degradation at YELLOW. The string rides in the success
+# marker (verify-complete.rb quotes and cross-checks it).
+final_verdict = deg_entries ? DegradationLedger.verdict(deg_entries) : nil
 begin
   _wd = opts[:tab]
   # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
   # reach here) so verify-complete.rb has a uniform element count across plugins.
   _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
   _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
-  File.write(File.join(_wd, 'phase6-success.json'),
-             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
-                                  'chartCount' => _cc,
-                                  'gates' => 'all-pass',
-                                  'run_id' => current_run_id,
-                                  'waivers' => waiver_flags,
-                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _succ = { 'workbookId' => (opts[:wb] || ''),
+            'chartCount' => _cc,
+            'gates' => 'all-pass',
+            'run_id' => current_run_id,
+            'waivers' => waiver_flags,
+            'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+  _succ['verdict'] = final_verdict if final_verdict
+  File.write(File.join(_wd, 'phase6-success.json'), JSON.pretty_generate(_succ))
   _pend = File.join(_wd, 'parity-pending.json')
   File.delete(_pend) if File.exist?(_pend)
-  # Flip the off-ramp telemetry field now that success is minted (P2).
+  # Flip the off-ramp telemetry field now that success is minted (P2), and
+  # stamp the derived verdict beside the census so a report that quotes
+  # parity-final.json carries it (verify-complete.rb cross-checks the claim).
   if File.exist?(File.join(_wd, 'parity-final.json'))
     begin
       _pf['success_sentinel'] = true
+      _pf['verdict'] = final_verdict if final_verdict
       File.write(File.join(_wd, 'parity-final.json'), JSON.pretty_generate(_pf))
     rescue StandardError
       nil
@@ -3289,6 +3390,23 @@ rescue StandardError
   # never fail the gate on sentinel bookkeeping
 end
 
-puts "[OK] all gates pass — conversion may declare GREEN" \
-     "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+if final_verdict.nil?
+  # Legacy checkout without lib/degradation_ledger.rb — stated, never silent.
+  puts "[OK] all gates pass — conversion may declare GREEN" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+  puts '     (lib/degradation_ledger.rb not vendored — no PR-14 verdict derived; re-vendor to enable.)'
+elsif final_verdict == 'GREEN'
+  puts "[OK] all gates pass — VERDICT: GREEN (degradation ledger empty — no scope cuts, no waivers, no residuals)"
+else
+  puts "[OK] all gates pass — VERDICT: #{final_verdict}" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget)" : ''}"
+  puts "     GREEN requires an EMPTY degradation ledger; this run recorded #{deg_entries.length} degradation(s):"
+  DegradationLedger.report_lines(deg_entries).each { |l| puts "     #{l}" }
+  if final_verdict.start_with?('PARTIAL')
+    puts '     PARTIAL: a scope cut shipped — the delivered workbook is a SUBSET of the source.'
+    puts '     Report this migration as PARTIAL (never GREEN) and quote the ledger verbatim.'
+  else
+    puts '     Report this migration as YELLOW (never GREEN) and name every entry in the report.'
+  end
+end
 exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-run-state.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-run-state.rb
@@ -53,6 +53,15 @@ end
 
 if opts[:skip]
   puts "[SKIP] run-state chain audit WAIVED (#{opts[:skip]}) — name this in your report."
+  # PR-14: every honored --skip-* leaves a record on the off-ramp trail.
+  begin
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'offramp'
+    Offramp.log(opts[:dir], kind: 'skip-flag-waived', reason: opts[:skip],
+                detail: '--skip-run-state')
+  rescue LoadError
+    warn '       WARN: lib/offramp.rb not vendored — the waiver could not be recorded to offramps.jsonl.'
+  end
   exit 0
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
@@ -40,10 +40,15 @@
 # Usage:
 #   ruby assert-wb-refs-resolve.rb --wb-spec <spec.json> \
 #     ( --dm-ids <dm-ids.json> | --dm-id <dataModelId> ) \
+#     [--workdir DIR]             # workdir for the off-ramp trail (the
+#                                 # orchestrator passes it; a waived run
+#                                 # records itself to offramps.jsonl)
 #     [--skip-ref-check REASON]   # waive — REQUIRED reason; name it in your report
 #
 # Exit codes:
-#   0  all refs resolve (or waived)
+#   0  all refs resolve (or waived — a waiver with --workdir writes a
+#      skip-flag-waived record to offramps.jsonl: PR-14 closed the escape that
+#      let a --skip-ref-check run report "GREEN, 0 waivers")
 #   1  one or more refs do not resolve against the live DM
 #   2  usage error
 require 'json'
@@ -55,12 +60,27 @@ OptionParser.new do |p|
   p.on('--wb-spec PATH')  { |v| opts[:spec] = v }
   p.on('--dm-ids PATH')   { |v| opts[:dm_ids] = v }
   p.on('--dm-id ID')      { |v| opts[:dm_id] = v }
+  p.on('--workdir DIR', 'workdir for the off-ramp trail (a waiver is recorded there)') { |v| opts[:workdir] = v }
   p.on('--skip-ref-check REASON',
        'waive the ref-resolution gate — REQUIRED reason; name it in your report') { |v| opts[:skip] = v }
 end.parse!
 
 if opts[:skip]
   puts "[SKIP] workbook ref-resolution gate WAIVED (#{opts[:skip]}) — name this in your report."
+  # PR-14: a skipped verification must leave a record — this exact flag once
+  # produced a false "GREEN, 0 waivers" final because nothing wrote one.
+  if opts[:workdir]
+    begin
+      $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+      require 'offramp'
+      Offramp.log(opts[:workdir], kind: 'skip-flag-waived', reason: opts[:skip],
+                  detail: '--skip-ref-check')
+    rescue LoadError
+      warn '       WARN: lib/offramp.rb not vendored — the waiver could not be recorded to offramps.jsonl.'
+    end
+  else
+    warn '       WARN: no --workdir given — the waiver was NOT recorded to offramps.jsonl (pass --workdir).'
+  end
   exit 0
 end
 abort 'usage: --wb-spec PATH and (--dm-ids PATH | --dm-id ID)' unless opts[:spec] && (opts[:dm_ids] || opts[:dm_id])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -109,6 +109,15 @@ require_relative 'lib/dashboard_read'
 require_relative 'lib/recipe_multimetric' # rollup_flag validator + caption-variant helpers
 if opts[:skip_dashboard_read]
   warn "[SKIP] dashboard-read gate WAIVED (#{opts[:skip_dashboard_read]}) — name this in your migration report."
+  # PR-14: every honored --skip-* leaves a record on the off-ramp trail.
+  begin
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'offramp'
+    Offramp.log(opts[:tab], kind: 'skip-flag-waived', reason: opts[:skip_dashboard_read],
+                detail: '--skip-dashboard-read')
+  rescue LoadError
+    warn '       WARN: lib/offramp.rb not vendored — the waiver could not be recorded to offramps.jsonl.'
+  end
 else
   dr_ok, dr_errs = DashboardRead.validate(opts[:tab])
   unless dr_ok

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
@@ -491,6 +491,14 @@ when 'apply-patch'
   # waives (named), matching the post-and-readback flag.
   if opts[:skip_style_normalize]
     warn "WARN: style-normalize SKIPPED (--skip-style-normalize: #{opts[:skip_style_normalize]}) — quality waiver."
+    # PR-14: every honored --skip-* leaves a record on the off-ramp trail.
+    begin
+      require_relative 'lib/offramp'
+      Offramp.log(opts[:dir], kind: 'skip-flag-waived', reason: opts[:skip_style_normalize],
+                  detail: '--skip-style-normalize')
+    rescue LoadError
+      warn 'WARN: lib/offramp.rb not vendored — the waiver could not be recorded to offramps.jsonl.'
+    end
   else
     begin
       require_relative 'lib/style_normalize'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/degradation_ledger.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+#
+# DegradationLedger — cumulative-degradation accounting → the PARTIAL verdict
+# (PLAN-v3 PR-14, the honesty capstone).
+#
+# WHY: a migration can pass every hard gate and still ship LESS than the source
+# — a dropped tile behind --allow-missing-tiles, a dropped control behind a
+# controls-waivers.json entry, a column the coverage census recorded as lost,
+# a --skip-* flag that quietly turned a verification off. Each degradation is
+# individually recorded somewhere, but nothing ever ADDED THEM UP — so a field
+# run once reported "GREEN, 0 waivers" after a --skip-ref-check and dropped
+# columns. This module derives ONE ledger from the workdir's artifacts and one
+# verdict from the ledger:
+#
+#   GREEN   — the ledger is EMPTY. No scope cuts, no quality waivers, no
+#             recorded escapes, no fidelity residuals, no waived resolutions.
+#   YELLOW  — quality degradations but no scope cut (any non-scope-cut entry;
+#             a budget-exceeded run — assert-phase6-ran exit 19, existing
+#             doctrine unchanged — is always at least YELLOW).
+#   PARTIAL — ANY scope-cut entry (a dropped tile / column / control /
+#             DM element), regardless of the waiver budget. A scope cut caps
+#             the verdict: the delivered workbook is a subset of the source.
+#   PARTIAL+YELLOW — both (scope cuts AND quality degradations); PARTIAL is
+#             the dominant verdict, YELLOW is noted.
+#
+# DERIVATION IS MECHANICAL — every entry comes from an artifact on disk that
+# some script recorded at decision time; nothing here accepts self-reported
+# claims. verify-complete.rb re-derives the ledger offline and FAILS when the
+# final report's claims (verdict / waiver census) contradict it — the
+# anti-"0 waivers" mechanism.
+#
+# Entry shape (stable):
+#   { "class" => scope-cut | quality-waiver | recorded-escape |
+#                fidelity-residual | resolution-waived,
+#     "item"            => <what was degraded — tile/column/control/flag name>,
+#     "reason"          => <the recorded reason, or a stated default>,
+#     "source_artifact" => <file the entry was derived from> }
+#
+# Artifact classes read (all optional; absent file → no entries):
+#   scope-cut         — coverage.json (dropped/degraded visuals+columns),
+#                       parity-final.json tile_census unmatched zones (minus
+#                       visual-verify oracle matches — gate 5's own logic),
+#                       *-controls-coverage.json non-emitted signals with their
+#                       control-scope.json / controls-waivers.json explanations
+#                       (or those two files directly when no census exists),
+#                       deferred-elements.json (quarantined DM elements).
+#   quality-waiver    — parity-final.json `waivers` census (stamped by
+#                       assert-phase6-ran on every run), minus the POLICY
+#                       exclusions (--skip-telemetry-gate; --skip-visual-
+#                       comparison under the sanctioned /verifier/i split) and
+#                       minus flags reclassified below.
+#   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
+#                       waivers, stale-skill, degraded fast path, and the
+#                       PR-14 `skip-flag-waived` records every closed --skip-*
+#                       straggler now writes), plus the census' run off-ramp
+#                       flags (--force-new-workbook / --force-route-switch /
+#                       --allow-manual-spec).
+#   fidelity-residual — parity-final.json visual_verdict=divergent, unresolved
+#                       fidelity-ledger.json deltas (accepted residuals ride
+#                       to DONE unresolved), layout-arrangement.json
+#                       violations (advisory WARNs), png-read.json
+#                       kind_waivers (recorded chart-family substitutions).
+#   resolution-waived — lod-audit.json / join-plan.json resolutions with
+#                       how=waived, agg-semantics.json how=faithful-to-source
+#                       (a documented source hazard shipping as-is),
+#                       manual-residues.json entries still unbuilt,
+#                       source-anchors.json + ground-truth-plan.json
+#                       coverage_waivers (tiles no numeric oracle watched).
+#
+# Canonical: shared/lib/degradation_ledger.rb — edit there and run
+# tools/sync-shared.rb. Ruby 2.6-compatible, stdlib-only, fully offline.
+
+require 'json'
+
+module DegradationLedger
+  VERSION = 1
+  CLASSES = %w[scope-cut quality-waiver recorded-escape fidelity-residual
+               resolution-waived].freeze
+
+  # Census flags that are POLICY, never quality (assert-phase6-ran budget
+  # doctrine): telemetry consent; the visual-comparison hand-off to a verifier
+  # session is excluded only when its recorded reason matches /verifier/i.
+  POLICY_FLAGS = ['--skip-telemetry-gate'].freeze
+  # Census flags that are run OFF-RAMPS, not gate-quality waivers — classed
+  # recorded-escape (they were honored by a script mid-run, mirrored into the
+  # census by the budget code).
+  CENSUS_ESCAPE_FLAGS = ['--force-new-workbook', '--force-route-switch',
+                         '--allow-manual-spec'].freeze
+  # Census flags whose degradation is derived (better) from an artifact —
+  # skipped in the census pass so one degradation never counts twice:
+  # visual-divergent is derived from parity-final's visual_verdict.
+  CENSUS_DERIVED_FLAGS = ['visual-divergent'].freeze
+
+  # offramps.jsonl kinds that are ESCAPES (a verification/protection turned
+  # off) as opposed to observability records (pass1-stop, workbook-handoff,
+  # loop-stop, …). force-new-workbook / route-switch-forced / manual-spec are
+  # deliberately absent: the census already mirrors them (see above).
+  ESCAPE_OFFRAMP_KINDS = %w[cred-gate-waived doctor-gate-waived
+                            tableau-gate-waived stale-skill-waived
+                            degraded-fastpath skip-flag-waived].freeze
+
+  module_function
+
+  def ledger_path(workdir)
+    File.join(workdir, 'degradation-ledger.json')
+  end
+
+  # Derive the full ledger (Array of entry Hashes) from the workdir's
+  # artifacts. Deterministic: same files → same entries, same order.
+  def derive(workdir)
+    entries = []
+    entries.concat(scope_cuts(workdir))
+    entries.concat(quality_waivers(workdir))
+    entries.concat(recorded_escapes(workdir))
+    entries.concat(fidelity_residuals(workdir))
+    entries.concat(resolution_waived(workdir))
+    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+  end
+
+  # Write <workdir>/degradation-ledger.json (entries + per-class counts).
+  # Never raises — bookkeeping must not sink a gate run.
+  def write(workdir, entries)
+    counts = Hash.new(0)
+    entries.each { |e| counts[e['class']] += 1 }
+    File.write(ledger_path(workdir),
+               JSON.pretty_generate('version' => VERSION,
+                                    'derivedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                    'counts' => counts,
+                                    'entries' => entries))
+    true
+  rescue StandardError
+    false
+  end
+
+  # The verdict string. Any scope cut → PARTIAL (dominant); any other entry —
+  # or a budget-exceeded run — → YELLOW; both → "PARTIAL+YELLOW"; empty ledger
+  # and budget intact → GREEN. GREEN requires an EMPTY ledger, full stop.
+  def verdict(entries, budget_exceeded: false)
+    partial = entries.any? { |e| e['class'] == 'scope-cut' }
+    yellow  = budget_exceeded || entries.any? { |e| e['class'] != 'scope-cut' }
+    return 'PARTIAL+YELLOW' if partial && yellow
+    return 'PARTIAL' if partial
+    return 'YELLOW' if yellow
+    'GREEN'
+  end
+
+  # One line per entry, for inline printing under the verdict.
+  def report_lines(entries)
+    entries.map do |e|
+      "  - [#{e['class']}] #{e['item']} — #{e['reason']} (#{e['source_artifact']})"
+    end
+  end
+
+  # ── class derivations ──────────────────────────────────────────────────────
+
+  def scope_cuts(wd)
+    out = []
+    # coverage.json — the build-step drop census: severity 'dropped' is a tile
+    # that produced NO Sigma element; 'degraded' built but LOST a column/field.
+    cov = read_json(wd, 'coverage.json')
+    Array(cov.is_a?(Hash) ? cov['unresolved'] : nil).each do |u|
+      next unless u.is_a?(Hash) && %w[dropped degraded].include?(u['severity'].to_s)
+      what = u['severity'].to_s == 'dropped' ? 'dropped visual' : 'degraded visual (lost column/field)'
+      out << entry('scope-cut', "#{what}: #{u['visual']}",
+                   u['detail'].to_s.empty? ? u['severity'].to_s : u['detail'].to_s,
+                   'coverage.json')
+    end
+    # tile census — unmatched dashboard zones (gate 5), minus zones the
+    # visual-verify oracle confirmed (same subtraction gate 5 applies).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? pf['tile_census'] : nil
+    if census.is_a?(Hash)
+      names = Array(census['unmatched_zone_names']).map(&:to_s)
+      vv = read_json(wd, File.join('visual-verify', 'manifest.json'))
+      vv_ok = Array(vv).select { |t| t.is_a?(Hash) && t['visual_verified'] == true }
+                       .map { |t| t['worksheet'].to_s }
+      (names - vv_ok).each do |n|
+        out << entry('scope-cut', "dropped tile: #{n}",
+                     'source dashboard zone with no matching chart (tile census)',
+                     'parity-final.json tile_census')
+      end
+    end
+    # controls — the source-vs-built census names every signal; a non-emitted
+    # row is a control the user had that the migration did not build. Its
+    # explanation (control-scope drop record / controls-waivers reason) rides
+    # into the entry; without a census the declaration files stand alone.
+    dropped_notes = control_scope_drops(wd)
+    ctl_waivers = controls_waivers(wd)
+    ctl_census_path = Dir[File.join(wd, '*-controls-coverage.json')].min
+    seen_controls = []
+    if ctl_census_path
+      doc = read_json_path(ctl_census_path)
+      Array(doc.is_a?(Hash) ? doc['detail'] : nil).each do |r|
+        next unless r.is_a?(Hash) && r['status'].to_s != 'emitted'
+        name = r['name'].to_s
+        key = norm(name)
+        reason = dropped_notes[key] ||
+                 (ctl_waivers[key] || ctl_waivers[norm("#{r['kind']}:#{name}")]) ||
+                 "census status: #{r['status']}"
+        seen_controls << key << norm("#{r['kind']}:#{name}")
+        out << entry('scope-cut', "dropped control: #{r['kind']}:#{name}", reason,
+                     File.basename(ctl_census_path))
+      end
+    end
+    dropped_notes.each do |key, reason|
+      next if seen_controls.include?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'control-scope.json')
+    end
+    ctl_waivers.each do |key, reason|
+      next if seen_controls.include?(key) || dropped_notes.key?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'controls-waivers.json')
+    end
+    # deferred-elements.json — DM elements quarantined at POST time; a
+    # non-empty file at DONE means the PARTIAL data model was accepted.
+    dd = read_json(wd, 'deferred-elements.json')
+    deferred = dd.is_a?(Hash) ? Array(dd['deferred']) : (dd.is_a?(Array) ? dd : [])
+    deferred.each do |el|
+      name = el.is_a?(Hash) ? (el['name'] || el['id'] || 'unnamed element') : el.to_s
+      out << entry('scope-cut', "dropped DM element: #{name}",
+                   'quarantined at DM POST (deferred-elements.json still non-empty)',
+                   'deferred-elements.json')
+    end
+    out
+  end
+
+  def quality_waivers(wd)
+    pf = read_json(wd, 'parity-final.json')
+    return [] unless pf.is_a?(Hash) && pf['waivers'].is_a?(Array)
+    reasons = pf['waiver_reasons'].is_a?(Hash) ? pf['waiver_reasons'] : {}
+    # waivers.json carries {flag, gate, reason} for gates waived via
+    # record_waiver — a second reason source for older parity-final stamps.
+    wj = read_json(wd, 'waivers.json')
+    wj = wj['waivers'] if wj.is_a?(Hash)
+    Array(wj).each do |w|
+      next unless w.is_a?(Hash) && w['flag']
+      reasons[w['flag'].to_s] ||= w['reason'].to_s unless w['reason'].to_s.empty?
+    end
+    out = []
+    pf['waivers'].map(&:to_s).uniq.each do |flag|
+      next if POLICY_FLAGS.include?(flag)
+      next if CENSUS_DERIVED_FLAGS.include?(flag)
+      next if CENSUS_ESCAPE_FLAGS.include?(flag) # classed recorded-escape below
+      next if flag == '--skip-visual-comparison' && reasons[flag].to_s =~ /verifier/i
+      reason = reasons[flag].to_s
+      reason = 'budget-counted quality waiver (no reason recorded)' if reason.empty?
+      out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
+    end
+    out
+  end
+
+  def recorded_escapes(wd)
+    out = []
+    # Census-mirrored run off-ramps (they also spend waiver budget there).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? Array(pf['waivers']).map(&:to_s) : []
+    (census & CENSUS_ESCAPE_FLAGS).each do |flag|
+      out << entry('recorded-escape', flag, 'run off-ramp honored mid-run (see offramps.jsonl)',
+                   'parity-final.json waivers')
+    end
+    # offramps.jsonl escape kinds — including the PR-14 skip-flag-waived
+    # records that make every --skip-* visible (the --skip-ref-check fix).
+    trail(wd).each do |r|
+      next unless ESCAPE_OFFRAMP_KINDS.include?(r['kind'].to_s)
+      item = r['kind'].to_s == 'skip-flag-waived' && !r['detail'].to_s.empty? ? r['detail'].to_s : r['kind'].to_s
+      reason = r['reason'].to_s.empty? ? 'NO REASON GIVEN' : r['reason'].to_s
+      out << entry('recorded-escape', item, reason, 'offramps.jsonl')
+    end
+    out.uniq { |e| [e['item'], e['reason']] }
+  end
+
+  def fidelity_residuals(wd)
+    out = []
+    pf = read_json(wd, 'parity-final.json')
+    if pf.is_a?(Hash) && pf['visual_verdict'].to_s == 'divergent'
+      out << entry('fidelity-residual', 'visual verdict: divergent',
+                   'recorded source-vs-target visual gaps ship in the render',
+                   'parity-final.json')
+    end
+    fl = read_json(wd, 'fidelity-ledger.json')
+    Array(fl.is_a?(Hash) ? fl['entries'] : nil).each do |e|
+      next unless e.is_a?(Hash) && !e['resolved']
+      out << entry('fidelity-residual',
+                   "RCF residual #{e['id']} [#{e['dimension'] || e['cls']}]",
+                   e['delta'].to_s.empty? ? "unresolved #{e['cls']} delta" : e['delta'].to_s,
+                   'fidelity-ledger.json')
+    end
+    arr = read_json(wd, 'layout-arrangement.json')
+    Array(arr.is_a?(Hash) ? arr['pages'] : nil).each do |p|
+      next unless p.is_a?(Hash)
+      Array(p['violations']).each do |v|
+        out << entry('fidelity-residual', "arrangement: #{p['page']}", v.to_s,
+                     'layout-arrangement.json')
+      end
+    end
+    pr = read_json(wd, 'png-read.json')
+    Array(pr.is_a?(Hash) ? pr['kind_waivers'] : nil).each do |w|
+      next unless w.is_a?(Hash)
+      out << entry('fidelity-residual', "chart-kind substitution: #{w['tile']}",
+                   w['reason'].to_s.empty? ? 'recorded at read time' : w['reason'].to_s,
+                   'png-read.json kind_waivers')
+    end
+    out
+  end
+
+  def resolution_waived(wd)
+    out = []
+    { 'lod-audit.json' => %w[waived], 'join-plan.json' => %w[waived],
+      'agg-semantics.json' => %w[faithful-to-source] }.each do |file, hows|
+      doc = read_json(wd, file)
+      list = doc.is_a?(Hash) ? doc['entries'] : doc
+      Array(list).each do |e|
+        next unless e.is_a?(Hash) && e['resolution'].is_a?(Hash)
+        how = e['resolution']['how'].to_s
+        next unless hows.include?(how)
+        item = e['calc'] || e['name'] ||
+               (e['left'] && e['right'] ? "#{e['left']}→#{e['right']}" : nil) ||
+               e['column'] || 'entry'
+        out << entry('resolution-waived', "#{item} (#{how})",
+                     e['resolution']['reason'].to_s.empty? ? 'no reason recorded' : e['resolution']['reason'].to_s,
+                     file)
+      end
+    end
+    mr = read_json(wd, 'manual-residues.json')
+    mr_list = mr.is_a?(Hash) ? mr['residues'] : mr
+    Array(mr_list).each do |e|
+      next unless e.is_a?(Hash) && e['status'].to_s == 'unbuilt'
+      out << entry('resolution-waived', "unbuilt custom-SQL residue: #{e['calc']}",
+                   'accepted unbuilt — its tile renders a magnitude proxy',
+                   'manual-residues.json')
+    end
+    { 'source-anchors.json' => 'no anchor watched this tile',
+      'ground-truth-plan.json' => 'no numeric oracle verified this tile' }.each do |file, why|
+      doc = read_json(wd, file)
+      Array(doc.is_a?(Hash) ? doc['coverage_waivers'] : nil).each do |w|
+        next unless w.is_a?(Hash)
+        out << entry('resolution-waived', "coverage waiver: #{w['tile']}",
+                     "#{why}#{w['reason'].to_s.empty? ? '' : " — #{w['reason']}"}",
+                     "#{file} coverage_waivers")
+      end
+    end
+    out
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def entry(cls, item, reason, source)
+    { 'class' => cls, 'item' => item.to_s, 'reason' => reason.to_s,
+      'source_artifact' => source.to_s }
+  end
+
+  def norm(s)
+    s.to_s.strip.downcase
+  end
+
+  def control_scope_drops(wd)
+    doc = read_json(wd, 'control-scope.json')
+    out = {}
+    Array(doc.is_a?(Hash) ? doc['dropped'] : nil).each do |d|
+      name = d.is_a?(Hash) ? d['name'] : d
+      next if name.to_s.strip.empty?
+      reason = d.is_a?(Hash) && !d['reason'].to_s.empty? ? d['reason'].to_s : 'dropped — recorded in control-scope.json'
+      out[norm(name)] = reason
+    end
+    out
+  end
+
+  def controls_waivers(wd)
+    doc = read_json(wd, 'controls-waivers.json')
+    doc = doc['waivers'] if doc.is_a?(Hash)
+    out = {}
+    Array(doc).each do |w|
+      next unless w.is_a?(Hash)
+      name = w['control'] || w['name']
+      next if name.to_s.strip.empty? || w['reason'].to_s.strip.empty?
+      out[norm(name)] = "waived: #{w['reason'].to_s.strip}"
+    end
+    out
+  end
+
+  def trail(wd)
+    path = File.join(wd, 'offramps.jsonl')
+    return [] unless File.exist?(path)
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+
+  def read_json(wd, rel)
+    read_json_path(File.join(wd, rel))
+  end
+
+  def read_json_path(path)
+    return nil unless File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue StandardError
+    nil
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/degradation_ledger.rb
@@ -107,6 +107,11 @@ module DegradationLedger
 
   # Derive the full ledger (Array of entry Hashes) from the workdir's
   # artifacts. Deterministic: same files → same entries, same order.
+  # Dedupe is by the FULL entry (class, item, reason, source) — the reason must
+  # participate: coverage.json legitimately records several distinct degraded
+  # rows under one generic `visual` label (field-observed: three "field/calc"
+  # header-fallback rows for three different tiles, distinguishable only by
+  # their detail), and an item-only key silently swallowed all but the first.
   def derive(workdir)
     entries = []
     entries.concat(scope_cuts(workdir))
@@ -114,7 +119,7 @@ module DegradationLedger
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
-    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+    entries.uniq { |e| [e['class'], e['item'], e['reason'], e['source_artifact']] }
   end
 
   # Write <workdir>/degradation-ledger.json (entries + per-class counts).

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1954,6 +1954,9 @@ if mechanical
       elsif opts[:skip_extract_landing]
         line "WARN: embedded-extract sources with NO landing manifest — proceeding on --skip-extract-landing " \
              "(#{opts[:skip_extract_landing]}); the DM's table paths are on you (--db/--schema)"
+        # PR-14: every honored --skip-* leaves a record on the off-ramp trail.
+        Offramp.log(WORK, kind: 'skip-flag-waived', reason: opts[:skip_extract_landing],
+                    detail: '--skip-extract-landing')
       else
         puts <<~MSG
 
@@ -2983,6 +2986,9 @@ if FASTPATH
   RunState.skip(WORK, 'phase-1d', 'FAST PATH (--reuse-dm + --wb-spec)')
 elsif opts[:skip_dashboard_read]
   line "dashboard-read gate WAIVED (--skip-dashboard-read: #{opts[:skip_dashboard_read]}) — name this in your report"
+  # PR-14: every honored --skip-* leaves a record on the off-ramp trail.
+  Offramp.log(WORK, kind: 'skip-flag-waived', reason: opts[:skip_dashboard_read],
+              detail: '--skip-dashboard-read')
 elsif DashboardRead.expected?(WORK)
   # Seed a DRAFT png-read.json from the .twb zone tree if none exists yet, so the
   # agent EDITS a starting point instead of writing from scratch (finding #8). The
@@ -3765,7 +3771,8 @@ begin
   # collapse left 550 refs unresolvable). Catch it here with the full list; the
   # WorkbookBuildError this raises routes to the friendly rebuild-against-DM handoff.
   ref_cmd = ['ruby', File.join(HERE, 'assert-wb-refs-resolve.rb'),
-             '--wb-spec', wb_spec_path, '--dm-ids', dm_ids_path]
+             '--wb-spec', wb_spec_path, '--dm-ids', dm_ids_path,
+             '--workdir', WORK] # PR-14: a waived run records itself to offramps.jsonl
   ref_cmd += ['--skip-ref-check', opts[:skip_ref_check]] if opts[:skip_ref_check]
   run_wb!(ref_cmd)
   par_cmd = ['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -105,6 +105,19 @@ if !_orchestrated && File.exist?(File.join(opts[:workdir], 'migrate-state.json')
   Offramp.log(opts[:workdir], kind: 'manual-spec', reason: "waiver: #{opts[:allow_manual_spec]}") if defined?(Offramp)
 end
 
+# PR-14: every honored --skip-* leaves a record on the off-ramp trail (they
+# are workbook-path waivers; DM runs never honor them, so nothing is logged).
+if opts[:type] == 'workbook' && defined?(Offramp)
+  { '--skip-spec-verify'     => opts[:skip_spec_verify],
+    '--skip-style-normalize' => opts[:skip_style_normalize],
+    '--skip-layout-lint'     => opts[:skip_lint],
+    '--skip-control-lint'    => opts[:skip_control_lint] }.each do |flag, val|
+    next unless val
+    Offramp.log(opts[:workdir], kind: 'skip-flag-waived',
+                reason: (val.is_a?(String) ? val : nil), detail: flag)
+  end
+end
+
 QUARANTINE = opts[:quarantine] && opts[:type] == 'datamodel'
 DEFERRED_PATH = File.join(opts[:workdir], 'deferred-elements.json')
 warn 'NOTE: --quarantine-on-failure only applies to --type datamodel; ignored.' if opts[:quarantine] && opts[:type] != 'datamodel'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-assert-phase6-gates.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-assert-phase6-gates.rb
@@ -1439,6 +1439,106 @@ Dir.mktmpdir do |dir|
         'no migrate-state stamp → gate 7b keeps the opt-in SKIP (back-compat)', fails)
 end
 
+# =============================================================================
+# PR-14 — degradation ledger + verdict model (GREEN / YELLOW / PARTIAL).
+# The gate derives <workdir>/degradation-ledger.json on every run and prints
+# ONE verdict; GREEN requires an EMPTY ledger; any scope cut caps at PARTIAL
+# regardless of the waiver budget; the success marker records the verdict.
+# =============================================================================
+
+# clean baseline → VERDICT: GREEN, empty ledger written, verdict stamped.
+Dir.mktmpdir do |dir|
+  base_workdir(dir)
+  out, _err, st = run_gate(dir)
+  check(st.success? && out.include?('VERDICT: GREEN'), 'clean run → VERDICT: GREEN on the final line', fails)
+  led = JSON.parse(File.read(File.join(dir, 'degradation-ledger.json')))
+  check(led['entries'] == [], 'clean run writes an EMPTY degradation-ledger.json (presence proves derivation ran)', fails)
+  succ = JSON.parse(File.read(File.join(dir, 'phase6-success.json')))
+  check(succ['verdict'] == 'GREEN', 'the DONE marker records the GREEN verdict string', fails)
+  pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
+  check(pf['verdict'] == 'GREEN', 'parity-final.json carries the verdict beside the census', fails)
+end
+
+# 1 within-budget quality waiver → gates pass, but GREEN is forfeited: YELLOW.
+Dir.mktmpdir do |dir|
+  base_workdir(dir)
+  out, _err, st = run_gate(dir, '--skip-orphan-check', 'multi-workbook estate by design')
+  check(st.success?, "1 waiver still passes the gates (got #{st.exitstatus})", fails)
+  check(out.include?('VERDICT: YELLOW') && out.include?('GREEN requires an EMPTY degradation ledger'),
+        '1 quality waiver → VERDICT: YELLOW (empty-ledger doctrine)', fails)
+  check(out.include?('[quality-waiver] --skip-orphan-check — multi-workbook estate by design'),
+        'the ledger prints inline with the waiver reason', fails)
+  succ = JSON.parse(File.read(File.join(dir, 'phase6-success.json')))
+  check(succ['verdict'] == 'YELLOW', 'the DONE marker records YELLOW', fails)
+  pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
+  check(pf['waiver_reasons'].is_a?(Hash) && pf['waiver_reasons']['--skip-orphan-check'] == 'multi-workbook estate by design',
+        'the reasons census is stamped into parity-final.json (offline derivation input)', fails)
+end
+
+# 3 quality waivers → budget exceeded (exit 19, doctrine unchanged), YELLOW.
+Dir.mktmpdir do |dir|
+  base_workdir(dir)
+  _out, err, st = run_gate(dir, '--skip-orphan-check', 'a', '--skip-column-check', 'b',
+                           '--skip-layout-check', 'c')
+  check(st.exitstatus == 19, "3 quality waivers → exit 19 (got #{st.exitstatus})", fails)
+  check(err.include?('VERDICT: YELLOW'), 'budget-exceeded run prints VERDICT: YELLOW with the ledger', fails)
+  check(File.exist?(File.join(dir, 'degradation-ledger.json')),
+        'the ledger is written even on the budget-fail path', fails)
+end
+
+# 1 dropped tile (coverage.json) + 0 waivers → PARTIAL: a scope cut caps the
+# verdict even on a run that spends NO waiver budget.
+Dir.mktmpdir do |dir|
+  base_workdir(dir)
+  File.write(File.join(dir, 'coverage.json'), JSON.pretty_generate(
+    'summary' => { 'sourceVisuals' => 3, 'dropped' => 1 },
+    'unresolved' => [{ 'visual' => 'Region Map', 'severity' => 'dropped', 'detail' => 'no basemap support' }]))
+  out, _err, st = run_gate(dir)
+  check(st.success?, "dropped tile with 0 waivers still passes the gates (got #{st.exitstatus})", fails)
+  check(out.include?('VERDICT: PARTIAL') && !out.include?('VERDICT: PARTIAL+YELLOW'),
+        '1 dropped tile + 0 waivers → VERDICT: PARTIAL (not YELLOW)', fails)
+  check(out.include?('[scope-cut]') && out.include?('Region Map'),
+        'the scope cut prints inline, named', fails)
+  check(out.include?('SUBSET of the source'), 'PARTIAL explains the scope-cut meaning', fails)
+  succ = JSON.parse(File.read(File.join(dir, 'phase6-success.json')))
+  check(succ['verdict'] == 'PARTIAL', 'the DONE marker records PARTIAL', fails)
+end
+
+# scope cut + within-budget waiver → both co-occur: PARTIAL+YELLOW, exit 0.
+Dir.mktmpdir do |dir|
+  base_workdir(dir)
+  File.write(File.join(dir, 'coverage.json'), JSON.pretty_generate(
+    'unresolved' => [{ 'visual' => 'Trend', 'severity' => 'dropped', 'detail' => 'empty view CSV' }]))
+  out, _err, st = run_gate(dir, '--skip-orphan-check', 'estate')
+  check(st.success? && out.include?('VERDICT: PARTIAL+YELLOW'),
+        'scope cut + quality waiver → VERDICT: PARTIAL+YELLOW (PARTIAL dominant, YELLOW noted)', fails)
+end
+
+# scope cut + budget exceeded → exit 19 still names PARTIAL+YELLOW.
+Dir.mktmpdir do |dir|
+  base_workdir(dir)
+  File.write(File.join(dir, 'coverage.json'), JSON.pretty_generate(
+    'unresolved' => [{ 'visual' => 'Trend', 'severity' => 'dropped', 'detail' => 'x' }]))
+  _out, err, st = run_gate(dir, '--skip-orphan-check', 'a', '--skip-column-check', 'b',
+                           '--skip-layout-check', 'c')
+  check(st.exitstatus == 19 && err.include?('VERDICT: PARTIAL+YELLOW'),
+        'scope cut + budget exceeded → exit 19 names PARTIAL+YELLOW', fails)
+end
+
+# a ledger-waived dropped control (gate 7c passes on the ledger waiver, no
+# budget flags) is still a scope cut → PARTIAL.
+Dir.mktmpdir do |dir|
+  base_workdir(dir)
+  File.write(File.join(dir, 'wb-controls-coverage.json'), JSON.pretty_generate(
+    'detail' => [{ 'kind' => 'filter', 'name' => 'Region', 'status' => 'unbuilt' }]))
+  File.write(File.join(dir, 'controls-waivers.json'), JSON.pretty_generate(
+    [{ 'control' => 'filter:Region', 'reason' => 'single-value in the source data' }]))
+  out, _err, st = run_gate(dir)
+  check(st.success?, "ledger-waived control passes gate 7c (got #{st.exitstatus})", fails)
+  check(out.include?('VERDICT: PARTIAL') && out.include?('dropped control: filter:Region'),
+        'a ledger-waived control is a scope cut → PARTIAL with the control named', fails)
+end
+
 # ---- source-level pins: the finalize plumbing (migrate-tableau.rb) -----------
 mig_src = File.read(File.join(__dir__, 'migrate-tableau.rb'))
 check(mig_src.include?("['--require-fidelity-ledger'] : ['--skip-fidelity-gate', 'RCF loop disabled at pass 1 via --rcf-passes 0']"),
@@ -1450,7 +1550,7 @@ check(mig_src.include?("'control_flip_required' => true"),
 
 puts
 if fails.empty?
-  puts 'ALL PASS — assert-phase6-ran gate 8b vision precondition + PR-9 blind-grade binding + divergent-verdict budget injection + gate 11 post-publish guide + gate 16 join-cardinality ledger + gate 17 LOD translation ledger + gate 18 ground-truth numeric coverage + gate 19 aggregation-semantics ledger + gate 20 semantic-edit equivalence ledger (incl. withdrawn entries) + gate 21 chart-kind parity (png-read vs readback, kind_waivers ledger) + PR-11 gate 8d default-on / gate 4b layout-phase sentinel (exit 30) / gate 8e arrangement parity (exit 29) + PR-13 gate 7c controls census (exit 31, ledger doctrine) / gate 7b flip test default-on (marker-or-waiver, budget-counted)'
+  puts 'ALL PASS — assert-phase6-ran gate 8b vision precondition + PR-9 blind-grade binding + divergent-verdict budget injection + gate 11 post-publish guide + gate 16 join-cardinality ledger + gate 17 LOD translation ledger + gate 18 ground-truth numeric coverage + gate 19 aggregation-semantics ledger + gate 20 semantic-edit equivalence ledger (incl. withdrawn entries) + gate 21 chart-kind parity (png-read vs readback, kind_waivers ledger) + PR-11 gate 8d default-on / gate 4b layout-phase sentinel (exit 30) / gate 8e arrangement parity (exit 29) + PR-13 gate 7c controls census (exit 31, ledger doctrine) / gate 7b flip test default-on (marker-or-waiver, budget-counted) + PR-14 degradation ledger + GREEN/YELLOW/PARTIAL verdict model (empty-ledger GREEN, scope-cut PARTIAL cap, verdict-stamped DONE marker)'
   exit 0
 else
   puts "FAILURES (#{fails.length}):"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-degradation-ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-degradation-ledger.rb
@@ -50,6 +50,32 @@ Dir.mktmpdir do |wd|
   check(DegradationLedger.verdict(entries) == 'PARTIAL', 'coverage drop → PARTIAL', fails)
 end
 
+# ---- scope-cut: distinct degradations under one generic `visual` label -------
+# Field-observed (e2e twin B/B3 coverage.json): several degraded rows carry the
+# same generic visual label ("field/calc") and differ only in their detail —
+# each is a distinct recorded degradation and every one must reach the ledger.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'coverage.json'), JSON.pretty_generate(
+    'summary' => { 'sourceVisuals' => 3, 'degraded' => 3 },
+    'unresolved' => [
+      { 'visual' => 'field/calc', 'severity' => 'degraded',
+        'detail' => "no master column matched dim header 'Order Date (Level)' for 'Weekly Deposits Trend'" },
+      { 'visual' => 'field/calc', 'severity' => 'degraded',
+        'detail' => "no master column matched dim header 'Order Date (Level)' for 'Risk Score Trend'" },
+      { 'visual' => 'field/calc', 'severity' => 'degraded',
+        'detail' => "no master column matched dim header 'Category' for 'Legend Notes'" }
+    ]))
+  entries = DegradationLedger.derive(wd)
+  cuts = entries.select { |e| e['class'] == 'scope-cut' }
+  check(cuts.length == 3,
+        "3 degraded rows sharing one generic visual label derive 3 scope-cuts (got #{cuts.length})", fails)
+  # True duplicates (same class+item+reason+source) still dedupe to one entry.
+  dup = cuts.first
+  check(DegradationLedger.derive(wd).uniq { |e| e } .length == 3 &&
+        (entries + [dup]).uniq { |e| [e['class'], e['item'], e['reason'], e['source_artifact']] }.length == entries.length,
+        'identical entries still dedupe (reason participates in the key)', fails)
+end
+
 # ---- scope-cut: tile census unmatched zones, minus the visual-verify oracle --
 Dir.mktmpdir do |wd|
   File.write(File.join(wd, 'parity-final.json'), JSON.pretty_generate(

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-degradation-ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-degradation-ledger.rb
@@ -1,0 +1,228 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Unit tests for scripts/lib/degradation_ledger.rb (PLAN-v3 PR-14) — the
+# cumulative-degradation accounting behind the GREEN / YELLOW / PARTIAL
+# verdict model. Each artifact class is derived from fixtures in a scratch
+# workdir; the verdict matrix is exercised directly. Fully offline.
+#
+# Usage: ruby scripts/test-degradation-ledger.rb
+require 'json'
+require 'tmpdir'
+require_relative 'lib/degradation_ledger'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+def classes(entries)
+  entries.map { |e| e['class'] }.sort.uniq
+end
+
+def items(entries)
+  entries.map { |e| e['item'] }
+end
+
+# ---- empty workdir → empty ledger → GREEN ------------------------------------
+Dir.mktmpdir do |wd|
+  entries = DegradationLedger.derive(wd)
+  check(entries == [], 'empty workdir derives an empty ledger', fails)
+  check(DegradationLedger.verdict(entries) == 'GREEN', 'empty ledger → GREEN', fails)
+end
+
+# ---- scope-cut: coverage.json dropped + degraded (approximated is NOT a cut) -
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'coverage.json'), JSON.pretty_generate(
+    'summary' => { 'sourceVisuals' => 3, 'dropped' => 1, 'degraded' => 1, 'approximated' => 1 },
+    'unresolved' => [
+      { 'visual' => 'Region Map', 'severity' => 'dropped', 'detail' => 'no basemap support' },
+      { 'visual' => 'Trend', 'severity' => 'degraded', 'detail' => 'lost column Forecast' },
+      { 'visual' => 'Treemap', 'severity' => 'approximated', 'detail' => 'built as bar' }
+    ]))
+  entries = DegradationLedger.derive(wd)
+  cuts = entries.select { |e| e['class'] == 'scope-cut' }
+  check(cuts.length == 2, "coverage.json dropped+degraded → 2 scope-cuts (got #{cuts.length})", fails)
+  check(items(cuts).any? { |i| i.include?('Region Map') } && items(cuts).any? { |i| i.include?('Trend') },
+        'scope-cuts name the dropped visual and the degraded (lost-column) visual', fails)
+  check(items(entries).none? { |i| i.include?('Treemap') },
+        'an approximated visual (carried over) is NOT a scope cut', fails)
+  check(DegradationLedger.verdict(entries) == 'PARTIAL', 'coverage drop → PARTIAL', fails)
+end
+
+# ---- scope-cut: tile census unmatched zones, minus the visual-verify oracle --
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'parity-final.json'), JSON.pretty_generate(
+    'tile_census' => { 'zones_total' => 3, 'charts_built' => 1, 'zones_unmatched' => 2,
+                       'unmatched_zone_names' => ['Lost Tile', 'Oracle Tile'] }))
+  Dir.mkdir(File.join(wd, 'visual-verify'))
+  File.write(File.join(wd, 'visual-verify', 'manifest.json'), JSON.pretty_generate(
+    [{ 'worksheet' => 'Oracle Tile', 'visual_verified' => true }]))
+  entries = DegradationLedger.derive(wd)
+  check(entries.length == 1 && entries[0]['item'] == 'dropped tile: Lost Tile',
+        'tile census → scope-cut per unmatched zone, oracle-matched zones exempt', fails)
+  check(DegradationLedger.verdict(entries) == 'PARTIAL', 'dropped tile → PARTIAL', fails)
+end
+
+# ---- scope-cut: controls census (dropped-declared + ledger-waived) -----------
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'x-controls-coverage.json'), JSON.pretty_generate(
+    'detail' => [{ 'kind' => 'parameter', 'name' => 'Top N', 'status' => 'emitted' },
+                 { 'kind' => 'filter', 'name' => 'Region', 'status' => 'unbuilt' },
+                 { 'kind' => 'filter', 'name' => 'Segment', 'status' => 'unbuilt' }]))
+  File.write(File.join(wd, 'control-scope.json'), JSON.pretty_generate(
+    'controls' => [], 'dropped' => [{ 'name' => 'Region', 'reason' => 'unreachable root' }]))
+  File.write(File.join(wd, 'controls-waivers.json'), JSON.pretty_generate(
+    [{ 'control' => 'filter:Segment', 'reason' => 'single-value in source data' }]))
+  entries = DegradationLedger.derive(wd)
+  cuts = entries.select { |e| e['class'] == 'scope-cut' }
+  check(cuts.length == 2, "controls census → 2 dropped-control scope-cuts (got #{cuts.length})", fails)
+  check(items(cuts).none? { |i| i.include?('Top N') }, 'an emitted control is never a scope cut', fails)
+  region = cuts.find { |e| e['item'].include?('Region') }
+  segment = cuts.find { |e| e['item'].include?('Segment') }
+  check(region && region['reason'].include?('unreachable root'),
+        'dropped control carries its control-scope.json reason', fails)
+  check(segment && segment['reason'].include?('single-value'),
+        'waived control carries its controls-waivers.json reason', fails)
+end
+
+# ---- scope-cut: declaration files stand alone when no census exists ----------
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'control-scope.json'), JSON.pretty_generate(
+    'dropped' => ['Category']))
+  File.write(File.join(wd, 'controls-waivers.json'), JSON.pretty_generate(
+    'waivers' => [{ 'name' => 'Ship Mode', 'reason' => 'operator waived' }]))
+  entries = DegradationLedger.derive(wd)
+  check(entries.length == 2 && classes(entries) == ['scope-cut'],
+        'control-scope dropped + controls-waivers entries derive without a census', fails)
+end
+
+# ---- scope-cut: deferred DM elements -----------------------------------------
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'deferred-elements.json'), JSON.pretty_generate(
+    'deferred' => [{ 'name' => 'Broken Element' }]))
+  entries = DegradationLedger.derive(wd)
+  check(entries.length == 1 && entries[0]['item'] == 'dropped DM element: Broken Element',
+        'deferred-elements.json → scope-cut per quarantined element', fails)
+end
+
+# ---- quality-waiver: the stamped census, minus policy + derived flags --------
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'parity-final.json'), JSON.pretty_generate(
+    'waivers' => ['--skip-anchors-gate', '--skip-telemetry-gate',
+                  '--skip-visual-comparison', 'visual-divergent', '--force-new-workbook'],
+    'waiver_count' => 5,
+    'waiver_reasons' => { '--skip-anchors-gate' => 'source PNG untranscribable',
+                          '--skip-visual-comparison' => 'verifier session records the verdict' },
+    'visual_verdict' => 'divergent'))
+  entries = DegradationLedger.derive(wd)
+  qw = entries.select { |e| e['class'] == 'quality-waiver' }
+  check(qw.length == 1 && qw[0]['item'] == '--skip-anchors-gate',
+        'census → quality-waiver entries; telemetry (policy) + verifier-split comparison excluded', fails)
+  check(qw[0]['reason'].include?('untranscribable'), 'quality waiver carries its recorded reason', fails)
+  fr = entries.select { |e| e['class'] == 'fidelity-residual' }
+  check(fr.length == 1 && fr[0]['item'].include?('divergent'),
+        'divergent visual verdict → fidelity-residual (not quality-waiver)', fails)
+  re = entries.select { |e| e['class'] == 'recorded-escape' }
+  check(re.length == 1 && re[0]['item'] == '--force-new-workbook',
+        'census run off-ramp flag → recorded-escape', fails)
+  check(DegradationLedger.verdict(entries) == 'YELLOW', 'waivers without scope cuts → YELLOW', fails)
+end
+
+# ---- recorded-escape: offramps.jsonl (the --skip-ref-check fix) --------------
+Dir.mktmpdir do |wd|
+  File.open(File.join(wd, 'offramps.jsonl'), 'a') do |f|
+    f.puts(JSON.generate('kind' => 'skip-flag-waived', 'reason' => 'refs known-unresolvable',
+                         'detail' => '--skip-ref-check'))
+    f.puts(JSON.generate('kind' => 'doctor-gate-waived', 'reason' => 'CI'))
+    f.puts(JSON.generate('kind' => 'pass1-stop', 'detail' => 'informational — not an escape'))
+  end
+  entries = DegradationLedger.derive(wd)
+  re = entries.select { |e| e['class'] == 'recorded-escape' }
+  check(re.length == 2, "escape offramp kinds → recorded-escape entries (got #{re.length})", fails)
+  check(items(re).include?('--skip-ref-check'),
+        'a skip-flag-waived record surfaces under its flag name (--skip-ref-check is visible)', fails)
+  check(items(entries).none? { |i| i.include?('pass1-stop') },
+        'observability offramp kinds (pass1-stop) are not escapes', fails)
+  check(DegradationLedger.verdict(entries) == 'YELLOW', 'recorded escapes → YELLOW, never GREEN', fails)
+end
+
+# ---- fidelity-residual: RCF residuals, arrangement WARNs, kind waivers -------
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'fidelity-ledger.json'), JSON.pretty_generate(
+    'pass' => 2, 'entries' => [
+      { 'id' => 'f1', 'cls' => 'spec-fixable', 'dimension' => 'palette', 'delta' => 'royal blue vs brand', 'resolved' => false },
+      { 'id' => 'f2', 'cls' => 'spec-fixable', 'dimension' => 'kpi', 'delta' => 'fixed', 'resolved' => true }
+    ]))
+  File.write(File.join(wd, 'layout-arrangement.json'), JSON.pretty_generate(
+    'pages' => [{ 'page' => 'Overview', 'violations' => ['controls-shelf class mismatch (top vs sidebar)'] }]))
+  File.write(File.join(wd, 'png-read.json'), JSON.pretty_generate(
+    'kind_waivers' => [{ 'tile' => 'Donut', 'reason' => 'Sigma pie substitution' }]))
+  entries = DegradationLedger.derive(wd)
+  fr = entries.select { |e| e['class'] == 'fidelity-residual' }
+  check(fr.length == 3, "unresolved RCF + arrangement WARN + kind waiver → 3 fidelity-residuals (got #{fr.length})", fails)
+  check(items(fr).any? { |i| i.include?('f1') } && items(entries).none? { |i| i.include?('f2') },
+        'resolved RCF entries are excluded; unresolved ride', fails)
+  check(DegradationLedger.verdict(entries) == 'YELLOW', 'fidelity residuals → YELLOW', fails)
+end
+
+# ---- resolution-waived: lod / join / agg / manual residues / coverage waivers -
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'lod-audit.json'), JSON.pretty_generate(
+    'entries' => [
+      { 'calc' => 'Entities Fixed', 'class' => 'silently-dropped',
+        'resolution' => { 'how' => 'waived', 'reason' => 'not plotted anywhere' } },
+      { 'calc' => 'Handled', 'class' => 'suspect-alias',
+        'resolution' => { 'how' => 'manual', 'reason' => 'rebuilt by hand' } }
+    ]))
+  File.write(File.join(wd, 'join-plan.json'), JSON.pretty_generate(
+    'entries' => [{ 'left' => 'ORDERS', 'right' => 'RETURNS', 'status' => 'non-unique',
+                    'resolution' => { 'how' => 'waived', 'reason' => 'operator accepted' } },
+                  { 'left' => 'ORDERS', 'right' => 'DATES', 'status' => 'unique' }]))
+  File.write(File.join(wd, 'agg-semantics.json'), JSON.pretty_generate(
+    'entries' => [{ 'calc' => 'Pct KPI', 'resolution' => { 'how' => 'faithful-to-source', 'reason' => 'source mixes grains' } },
+                  { 'calc' => 'Other', 'resolution' => { 'how' => 'n/a', 'reason' => 'does not apply' } }]))
+  File.write(File.join(wd, 'manual-residues.json'), JSON.pretty_generate(
+    'residues' => [{ 'calc' => 'Running Total', 'status' => 'unbuilt' },
+                   { 'calc' => 'Rank', 'status' => 'built' }]))
+  File.write(File.join(wd, 'source-anchors.json'), JSON.pretty_generate(
+    'anchors' => [], 'coverage_waivers' => [{ 'tile' => 'Legend Box', 'reason' => 'no printed value' }]))
+  File.write(File.join(wd, 'ground-truth-plan.json'), JSON.pretty_generate(
+    'coverage_waivers' => [{ 'tile' => 'Static Text', 'reason' => 'non-numeric tile' }]))
+  entries = DegradationLedger.derive(wd)
+  rw = entries.select { |e| e['class'] == 'resolution-waived' }
+  check(rw.length == 6, "waived lod + waived join + faithful agg + unbuilt residue + 2 coverage waivers → 6 (got #{rw.length}: #{items(rw).join(' | ')})", fails)
+  check(items(rw).none? { |i| i.include?('Handled') }, 'a manual (fixed) LOD resolution is not a degradation', fails)
+  check(items(rw).none? { |i| i.include?('Other') }, "an n/a agg resolution is not a degradation", fails)
+  check(items(rw).none? { |i| i.include?('Rank') }, 'a built residue is not a degradation', fails)
+  check(DegradationLedger.verdict(entries) == 'YELLOW', 'resolution waivers → YELLOW', fails)
+end
+
+# ---- verdict matrix ----------------------------------------------------------
+cut  = { 'class' => 'scope-cut', 'item' => 'dropped tile: X', 'reason' => 'r', 'source_artifact' => 'a' }
+qw   = { 'class' => 'quality-waiver', 'item' => '--skip-anchors-gate', 'reason' => 'r', 'source_artifact' => 'a' }
+check(DegradationLedger.verdict([]) == 'GREEN', 'matrix: clean → GREEN', fails)
+check(DegradationLedger.verdict([qw, qw, qw]) == 'YELLOW', 'matrix: quality waivers only → YELLOW', fails)
+check(DegradationLedger.verdict([cut]) == 'PARTIAL', 'matrix: 1 dropped tile + 0 waivers → PARTIAL', fails)
+check(DegradationLedger.verdict([cut, qw]) == 'PARTIAL+YELLOW', 'matrix: both → PARTIAL+YELLOW (PARTIAL dominant)', fails)
+check(DegradationLedger.verdict([], budget_exceeded: true) == 'YELLOW',
+      'matrix: budget-exceeded run is always at least YELLOW', fails)
+check(DegradationLedger.verdict([cut], budget_exceeded: true) == 'PARTIAL+YELLOW',
+      'matrix: budget-exceeded + scope cut → PARTIAL+YELLOW', fails)
+
+# ---- write() round-trips + counts --------------------------------------------
+Dir.mktmpdir do |wd|
+  DegradationLedger.write(wd, [cut, qw])
+  doc = JSON.parse(File.read(DegradationLedger.ledger_path(wd)))
+  check(doc['entries'].length == 2 && doc['counts'] == { 'scope-cut' => 1, 'quality-waiver' => 1 },
+        'write() persists entries + per-class counts', fails)
+  check(DegradationLedger.report_lines([cut]).first.include?('[scope-cut] dropped tile: X'),
+        'report_lines renders one line per entry with its class', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS — degradation ledger derivation (every artifact class) + verdict matrix'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-skip-flag-audit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-skip-flag-audit.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# PR-14 skip-flag audit — EVERY --skip-* flag in this plugin must leave a
+# record when honored. The field failure this enforces against: a run reported
+# "GREEN, 0 waivers" because --skip-ref-check exited 0 with a puts and nothing
+# else — invisible to the waiver census, the off-ramp trail, and the report.
+#
+# Two layers:
+#   1. STATIC — every `.on('--skip-…')` definition across scripts/*.rb must be
+#      classified here, and its recording mechanism must be present in the
+#      source. An UNCLASSIFIED flag fails: adding a new --skip-* flag without
+#      deciding how it is recorded is exactly how the next invisible escape
+#      ships.
+#   2. RUNTIME — each standalone gate script that honors a skip flag is run
+#      with it and must append a skip-flag-waived record to offramps.jsonl.
+#
+# Mechanisms:
+#   :budget    the flag is an assert-phase6-ran.rb gate flag — counted in the
+#              waiver census stamped into parity-final.json (exit-19 budget)
+#   :offramp   the honoring script writes a skip-flag-waived offramps record
+#   :forwards  the orchestrator forwards the flag to a script that records it
+#              (ref-check → assert-wb-refs-resolve.rb --workdir)
+#   :gate      the orchestrator forwards it to assert-phase6-ran.rb (census)
+#   :policy    consent policy, never quality (telemetry) — census-visible at
+#              gate 10, excluded from the budget by doctrine
+#   :mode      NOT an escape: a discovery/build mode that does not turn off a
+#              verification (--skip-reuse-scan builds a FRESH DM — more work,
+#              not less; --skip-images/--skip-content scope the discovery
+#              fetch and the downstream gates still demand their artifacts)
+#
+# Usage: ruby scripts/test-skip-flag-audit.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+DIR = __dir__
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# ---- layer 1: static classification ------------------------------------------
+CLASSIFICATION = {
+  'assert-phase6-ran.rb'         => :budget, # every gate skip flag → waiver census
+  'assert-telemetry-ran.rb'      => { '--skip-telemetry-gate' => :policy },
+  'migrate-tableau.rb'           => {
+    '--skip-reuse-scan'          => :mode,
+    '--skip-dashboard-read'      => :offramp,
+    '--skip-doctor-gate'         => :offramp, # records kind doctor-gate-waived
+    '--skip-ref-check'           => :forwards, # → assert-wb-refs-resolve.rb --workdir
+    '--skip-extract-landing'     => :offramp,
+    '--skip-postpublish-guide'   => :gate,     # → assert-phase6-ran census
+    '--skip-flip-test'           => :gate      # → --skip-control-flip census
+  },
+  'assert-wb-refs-resolve.rb'    => { '--skip-ref-check' => :offramp },
+  'assert-dashboard-read.rb'     => { '--skip-dashboard-read' => :offramp },
+  'assert-doctor-ran.rb'         => { '--skip-doctor-gate' => :offramp },
+  'assert-run-state.rb'          => { '--skip-run-state' => :offramp },
+  'build-charts-from-signals.rb' => { '--skip-dashboard-read' => :offramp },
+  'fidelity-loop.rb'             => { '--skip-style-normalize' => :offramp },
+  'post-and-readback.rb'         => { '--skip-layout-lint' => :offramp,
+                                      '--skip-control-lint' => :offramp,
+                                      '--skip-spec-verify' => :offramp,
+                                      '--skip-style-normalize' => :offramp },
+  'tableau-discover.rb'          => { '--skip-images' => :mode,
+                                      '--skip-content' => :mode }
+}.freeze
+
+found = Hash.new { |h, k| h[k] = [] }
+Dir[File.join(DIR, '*.rb')].sort.each do |path|
+  base = File.basename(path)
+  next if base.start_with?('test-')
+  File.read(path).scan(/\.on\(\s*'(--skip-[a-z-]+)/) { |(flag)| found[base] << flag }
+  found[base].uniq!
+end
+
+found.each do |file, flags|
+  spec = CLASSIFICATION[file]
+  flags.each do |flag|
+    mech = spec.is_a?(Symbol) ? spec : (spec.is_a?(Hash) ? spec[flag] : nil)
+    if mech.nil?
+      check(false, "#{file} defines #{flag} but the audit has NO classification — decide how it is " \
+                   'recorded (offramp/census) and classify it here before shipping', fails)
+      next
+    end
+    src = File.read(File.join(DIR, file))
+    case mech
+    when :offramp
+      recorded = src.include?('skip-flag-waived') ||
+                 (file == 'migrate-tableau.rb' && flag == '--skip-doctor-gate' && src.include?('doctor-gate-waived'))
+      check(recorded, "#{file} #{flag} (:offramp) — source writes a recorded escape", fails)
+    when :forwards
+      check(src.include?("'--workdir', WORK") && File.read(File.join(DIR, 'assert-wb-refs-resolve.rb')).include?('skip-flag-waived'),
+            "#{file} #{flag} (:forwards) — forwarded with --workdir to a recording script", fails)
+    when :budget
+      check(src.include?('waiver_flags') && src.include?('waiver_count'),
+            "#{file} #{flag} (:budget) — counted in the stamped waiver census", fails)
+    when :gate
+      check(src.include?(flag == '--skip-flip-test' ? '--skip-control-flip' : flag),
+            "#{file} #{flag} (:gate) — forwarded to the assert-phase6-ran census", fails)
+    when :policy, :mode
+      check(true, "#{file} #{flag} (:#{mech}) — classified non-escape (documented)", fails)
+    end
+  end
+end
+
+# Classification hygiene: nothing classified that no longer exists.
+CLASSIFICATION.each do |file, spec|
+  next unless spec.is_a?(Hash)
+  spec.each_key do |flag|
+    check(found[file].include?(flag),
+          "classified #{file} #{flag} still exists in the source (stale audit entry otherwise)", fails)
+  end
+end
+
+# ---- layer 2: runtime — each standalone honor path leaves a record -----------
+def offramp_records(wd)
+  path = File.join(wd, 'offramps.jsonl')
+  return [] unless File.exist?(path)
+  File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+end
+
+RUNTIME = [
+  ['assert-wb-refs-resolve.rb', ['--wb-spec', 'unused.json', '--dm-ids', 'unused.json',
+                                 '--skip-ref-check', 'refs pre-validated'], '--skip-ref-check'],
+  ['assert-dashboard-read.rb',  ['--skip-dashboard-read', 'no source PNG obtainable'], '--skip-dashboard-read'],
+  ['assert-run-state.rb',       ['--skip-run-state', 'legacy workdir'], '--skip-run-state'],
+  ['assert-doctor-ran.rb',      ['--skip-doctor-gate', 'CI environment'], '--skip-doctor-gate']
+].freeze
+
+RUNTIME.each do |script, args, flag|
+  Dir.mktmpdir do |wd|
+    _out, _err, st = Open3.capture3(RbConfig.ruby, File.join(DIR, script), '--workdir', wd, *args)
+    rec = offramp_records(wd).find { |r| r['kind'] == 'skip-flag-waived' && r['detail'] == flag }
+    check(st.success? && !rec.nil?,
+          "#{script} #{flag} → exit 0 AND a skip-flag-waived record in offramps.jsonl", fails)
+    check(rec && !rec['reason'].to_s.empty?, "#{script} #{flag} record carries the operator's reason", fails)
+  end
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS — every --skip-* flag is classified and leaves a record when honored (PR-14)'
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-complete.rb
@@ -1,11 +1,16 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-# Regression test for the run-scoped completion sentinel (2026-07-09).
+# Regression test for the run-scoped completion sentinel (2026-07-09) and the
+# PR-14 verdict model + report cross-check.
 #
 # "Done" must be a fact on disk, not a narration. verify-complete.rb reports
-# GREEN only when phase6-success.json is present AND no parity-pending.json
+# DONE only when phase6-success.json is present AND no parity-pending.json
 # remains — the two markers PASS 1 (exit 12) and assert-phase6-ran.rb (exit 0)
-# maintain. This drives verify-complete.rb across the four states. Offline.
+# maintain. This drives verify-complete.rb across the four states, then the
+# PR-14 additions: the degradation ledger is re-derived offline, the verdict
+# (GREEN/YELLOW/PARTIAL) is printed with the ledger inline, and a report whose
+# claims contradict the derivation fails with exit 6 (the anti-"GREEN,
+# 0 waivers" mechanism). Offline.
 #
 # Usage: ruby scripts/test-verify-complete.rb
 
@@ -59,6 +64,101 @@ Dir.mktmpdir do |wd|
   File.delete(File.join(wd, 'phase6-success.json'))
   code, = run_vc(VC, wd)
   check(code == 3, "re-run PASS 1 flips DONE back to NOT DONE (got #{code})", fails)
+end
+
+# ---------------------------------------------------------------------------
+# PR-14 — verdict surfacing + report cross-check (exit 6).
+# ---------------------------------------------------------------------------
+
+def success_marker(wd, extra = {})
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate({ 'workbookId' => 'wb-1', 'gates' => 'all-pass',
+                             'generatedAt' => '2026-07-19T00:00:00Z' }.merge(extra)))
+end
+
+# Clean workdir → DONE with VERDICT: GREEN and an explicitly-empty ledger.
+Dir.mktmpdir do |wd|
+  success_marker(wd, 'verdict' => 'GREEN')
+  code, out = run_vc(VC, wd)
+  check(code == 0, "clean workdir + GREEN claim => exit 0 (got #{code})", fails)
+  check(out.include?('VERDICT: GREEN'), 'DONE line prints the GREEN verdict', fails)
+  check(out.include?('ledger   : empty'), 'empty ledger is stated explicitly', fails)
+end
+
+# Legacy marker (no verdict/waivers keys) over a clean workdir stays DONE and
+# gets the derived verdict printed — absent claims are never contradictions.
+Dir.mktmpdir do |wd|
+  success_marker(wd)
+  code, out = run_vc(VC, wd)
+  check(code == 0, "legacy marker without verdict key => exit 0 (got #{code})", fails)
+  check(out.include?('VERDICT: GREEN'), 'legacy marker still gets the derived verdict printed', fails)
+end
+
+# Scope cut (coverage.json dropped tile) + consistent PARTIAL claims → DONE,
+# verdict PARTIAL, ledger entry printed inline.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'coverage.json'), JSON.generate(
+    'unresolved' => [{ 'visual' => 'Region Map', 'severity' => 'dropped', 'detail' => 'no basemap' }]))
+  File.write(File.join(wd, 'parity-final.json'), JSON.generate(
+    'status' => 'PASS', 'waivers' => [], 'waiver_count' => 0, 'verdict' => 'PARTIAL'))
+  success_marker(wd, 'verdict' => 'PARTIAL', 'waivers' => [])
+  code, out = run_vc(VC, wd)
+  check(code == 0, "dropped tile + honest PARTIAL claims => exit 0 (got #{code})", fails)
+  check(out.include?('VERDICT: PARTIAL'), 'verdict PARTIAL surfaces on the DONE line', fails)
+  check(out.include?('[scope-cut]') && out.include?('Region Map'), 'the ledger entry prints inline, one line', fails)
+  check(out.include?('SUBSET of the source'), 'PARTIAL names the scope-cut meaning', fails)
+end
+
+# THE LIE (field case): a report claiming GREEN + 0 waivers over a workdir
+# whose off-ramp trail recorded a --skip-ref-check → exit 6, contradiction.
+Dir.mktmpdir do |wd|
+  File.open(File.join(wd, 'offramps.jsonl'), 'a') do |f|
+    f.puts(JSON.generate('kind' => 'skip-flag-waived', 'reason' => 'refs pre-validated by hand',
+                         'detail' => '--skip-ref-check'))
+  end
+  File.write(File.join(wd, 'parity-final.json'), JSON.generate(
+    'status' => 'PASS', 'waivers' => [], 'waiver_count' => 0, 'verdict' => 'GREEN'))
+  success_marker(wd, 'verdict' => 'GREEN', 'waivers' => [])
+  code, out = run_vc(VC, wd)
+  check(code == 6, "\"GREEN, 0 waivers\" over a recorded --skip-ref-check => exit 6 (got #{code})", fails)
+  check(out.include?('REPORT CONTRADICTS LEDGER'), 'contradiction failure names itself', fails)
+  check(out.include?('claims verdict GREEN') && out.include?('YELLOW'),
+        'failure names the claimed vs derived verdict', fails)
+  check(out.include?('0 waivers but the artifacts record'),
+        'the zero-waiver claim is called out against the recorded escape', fails)
+  check(out.include?('--skip-ref-check'), 'the ledger inline shows the hidden skip flag', fails)
+end
+
+# Census arithmetic: waiver_count must equal the census it counts.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'parity-final.json'), JSON.generate(
+    'status' => 'PASS', 'waivers' => ['--skip-anchors-gate'], 'waiver_count' => 0))
+  success_marker(wd)
+  code, out = run_vc(VC, wd)
+  check(code == 6, "waiver_count=0 over a 1-entry census => exit 6 (got #{code})", fails)
+  check(out.include?('its own census lists 1'), 'census arithmetic contradiction is named', fails)
+end
+
+# Marker census drift: phase6-success waivers != parity-final waivers → exit 6.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'parity-final.json'), JSON.generate(
+    'status' => 'PASS', 'waivers' => ['--skip-anchors-gate'], 'waiver_count' => 1))
+  success_marker(wd, 'waivers' => [])
+  code, out = run_vc(VC, wd)
+  check(code == 6, "marker census drifted from parity-final census => exit 6 (got #{code})", fails)
+end
+
+# Tampered ledger: degradation-ledger.json edited to empty while the artifacts
+# still derive an entry → exit 6.
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'coverage.json'), JSON.generate(
+    'unresolved' => [{ 'visual' => 'Trend', 'severity' => 'dropped', 'detail' => 'x' }]))
+  File.write(File.join(wd, 'degradation-ledger.json'), JSON.generate(
+    'version' => 1, 'counts' => {}, 'entries' => []))
+  success_marker(wd)
+  code, out = run_vc(VC, wd)
+  check(code == 6, "hand-emptied degradation-ledger.json => exit 6 (got #{code})", fails)
+  check(out.include?('does not match a fresh derivation'), 'tampered ledger is named', fails)
 end
 
 puts

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
@@ -71,6 +71,23 @@ rc, = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [{ 'formula' => '[M
                DM, '--skip-ref-check', '"known, building manually"')
 check(rc == 0, '--skip-ref-check waives (exit 0)')
 
+# PR-14: a waiver with --workdir writes a skip-flag-waived off-ramp record —
+# the "GREEN, 0 waivers after --skip-ref-check" escape is closed: the skip is
+# visible to the degradation ledger and verify-complete's cross-check.
+Dir.mktmpdir do |wd|
+  rc, = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [{ 'formula' => '[Master/Partner Name]' }] }] }] },
+                 DM, '--workdir', wd, '--skip-ref-check', 'known, building manually')
+  check(rc == 0, '--skip-ref-check + --workdir still waives (exit 0)')
+  recs = File.readlines(File.join(wd, 'offramps.jsonl')).map { |l| JSON.parse(l) }
+  rec = recs.find { |r| r['kind'] == 'skip-flag-waived' && r['detail'] == '--skip-ref-check' }
+  check(!rec.nil? && rec['reason'].include?('known'),
+        'waived run records skip-flag-waived (--skip-ref-check) with its reason in offramps.jsonl')
+end
+# without --workdir the waiver still works but WARNS it went unrecorded
+rc, out = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [{ 'formula' => '[Master/Partner Name]' }] }] }] },
+                   DM, '--skip-ref-check', 'reason')
+check(rc == 0 && out.include?('NOT recorded'), 'waiver without --workdir warns the skip went unrecorded')
+
 # ---- merged capabilities (from the deleted assert-refs-resolve.rb) ----------
 
 # INTERNAL master ref: a master-level calc column absent from the DM by design

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-complete.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-complete.rb
@@ -14,24 +14,43 @@
 #   * assert-phase6-ran.rb (at --finalize, exit 0) writes <workdir>/phase6-success.json
 #     and clears the pending marker
 #
-# So the ONLY state that reports GREEN here is: success marker present, no pending
+# So the ONLY state that reports DONE here is: success marker present, no pending
 # marker. The SKILL's definition of done is "verify-complete.rb exits 0" —
-# nothing else counts. It is fully offline (reads two files); run it before
-# claiming completion or handing off.
+# nothing else counts. It is fully offline; run it before claiming completion
+# or handing off.
+#
+# VERDICT + LEDGER CROSS-CHECK (PLAN-v3 PR-14): DONE is not the same as GREEN.
+# This script RE-DERIVES the degradation ledger from the workdir's artifacts
+# (lib/degradation_ledger.rb — scope cuts, quality waivers, recorded escapes,
+# fidelity residuals, waived resolutions; deterministic, never self-reported),
+# prints the verdict (GREEN / YELLOW / PARTIAL / PARTIAL+YELLOW) with every
+# ledger entry inline, and FAILS (exit 6) when the run's own reports contradict
+# the derivation — a phase6-success.json / parity-final.json claiming a verdict
+# or waiver census the artifacts don't support, or a degradation-ledger.json
+# that no longer matches a fresh derivation. This is the anti-"GREEN, 0
+# waivers" mechanism: a report can no longer claim clean over a workdir whose
+# artifacts recorded scope cuts or escapes.
 #
 # Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
 #
 # Exit codes:
-#   0  DONE   — phase6-success.json present (and matches --workbook-id if given)
+#   0  DONE   — phase6-success.json present (and matches --workbook-id if given);
+#      the derived verdict + ledger are printed (GREEN only on an empty ledger)
 #   2  NOT DONE — the hard gate never stamped success (finalize not run / failed)
 #   3  NOT DONE — still at PASS 1 (parity-pending.json present); run --finalize
 #   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
 #   5  NOT DONE — loop-log.jsonl records the SAME failure signature 3+ times
 #      (the stop-at-2 loop breaker was breached; an operator must resolve it)
+#   6  REPORT CONTRADICTS LEDGER — a completion claim (phase6-success.json /
+#      parity-final.json / degradation-ledger.json) is inconsistent with the
+#      ledger derived fresh from the artifacts; the report is lying about the
+#      run's degradations. Fix the report (or the tampered artifact), never
+#      the ledger.
 
 require 'json'
 require 'optparse'
 require_relative 'lib/offramp'
+require_relative 'lib/degradation_ledger'
 
 # Print the off-ramp trail + any gate waivers for this workdir — the "where did
 # this run leave the golden path" readout. Advisory; shown under every verdict.
@@ -105,12 +124,77 @@ if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
   exit 4
 end
 
-puts '✅ DONE — assert-phase6-ran.rb passed all gates for this run.'
+# ---------------------------------------------------------------------------
+# PR-14 — re-derive the degradation ledger and cross-check every completion
+# claim against it. Derivation is mechanical (artifacts only), so any claim it
+# contradicts is a report lying about the run. Absent claims (legacy markers
+# with no verdict key) are not failures — the derived verdict is printed for
+# them; an EXPLICIT contradicting claim is exit 6.
+# ---------------------------------------------------------------------------
+deg_entries = DegradationLedger.derive(wd)
+derived_verdict = DegradationLedger.verdict(deg_entries)
+pf = load(File.join(wd, 'parity-final.json'))
+contradictions = []
+
+# Internal census arithmetic: waiver_count must equal the census it counts.
+if pf.key?('waiver_count') && pf['waivers'].is_a?(Array) &&
+   pf['waiver_count'].to_i != pf['waivers'].length
+  contradictions << "parity-final.json claims waiver_count=#{pf['waiver_count']} but its own census lists #{pf['waivers'].length} waiver(s)"
+end
+# The success marker's census must match parity-final's (both are stamped by
+# the gate on the same run; drift means one was edited after the fact).
+if sj['waivers'].is_a?(Array) && pf['waivers'].is_a?(Array) && sj['waivers'] != pf['waivers']
+  contradictions << "phase6-success.json waiver census (#{sj['waivers'].length}) differs from parity-final.json (#{pf['waivers'].length})"
+end
+# Claimed verdicts must match the derivation.
+{ 'phase6-success.json' => sj['verdict'], 'parity-final.json' => pf['verdict'] }.each do |src, claim|
+  next if claim.to_s.empty?
+  if claim.to_s != derived_verdict
+    contradictions << "#{src} claims verdict #{claim} but the artifacts derive #{derived_verdict}"
+  end
+end
+# A zero-waiver claim over a ledger that records waivers/escapes is the exact
+# field lie this closes ("GREEN, 0 waivers" after --skip-ref-check).
+if pf.key?('waiver_count') && pf['waiver_count'].to_i.zero? &&
+   deg_entries.any? { |e| %w[quality-waiver recorded-escape].include?(e['class']) }
+  contradictions << 'parity-final.json claims 0 waivers but the artifacts record waiver/escape degradations'
+end
+# A stored ledger that drifted from a fresh derivation was edited by hand.
+stored = begin
+  JSON.parse(File.read(DegradationLedger.ledger_path(wd)))
+rescue StandardError
+  nil
+end
+if stored.is_a?(Hash) && stored['entries'].is_a?(Array) && stored['entries'] != deg_entries
+  contradictions << "degradation-ledger.json on disk (#{stored['entries'].length} entr#{stored['entries'].length == 1 ? 'y' : 'ies'}) does not match a fresh derivation (#{deg_entries.length}) — the ledger was edited, not re-derived"
+end
+
+if contradictions.any?
+  warn '⛔ REPORT CONTRADICTS LEDGER — completion claims are inconsistent with the degradations'
+  warn '   derived from this workdir\'s artifacts (the ledger is mechanical; the claims are not):'
+  contradictions.each { |c| warn "   • #{c}" }
+  warn "   Derived verdict: #{derived_verdict} — ledger (#{deg_entries.length} entr#{deg_entries.length == 1 ? 'y' : 'ies'}):"
+  DegradationLedger.report_lines(deg_entries).each { |l| warn "   #{l}" }
+  warn '   Re-run assert-phase6-ran.rb to re-stamp honest claims. Never edit the ledger or the'
+  warn '   markers by hand — fix the underlying artifacts (or the report) instead.'
+  exit 6
+end
+
+puts "✅ DONE — assert-phase6-ran.rb passed all gates for this run. VERDICT: #{derived_verdict}"
 puts "   workbook : #{sj['workbookId']}"
 puts "   gates    : #{sj['gates']}"
 puts "   run id   : #{sj['run_id']}" if sj['run_id']
 puts "   waivers  : #{sj['waivers'].join(', ')}" if sj['waivers'].is_a?(Array) && sj['waivers'].any?
 puts "   stamped  : #{sj['generatedAt']}"
-puts '   Quote this marker (workbook + run id) in your completion report.'
-print_offramps(wd) # even a GREEN run can carry waivers/degradations — surface them
+if deg_entries.empty?
+  puts '   ledger   : empty — no scope cuts, no waivers, no residuals (GREEN)'
+else
+  puts "   ledger   : #{deg_entries.length} degradation(s) — GREEN requires an empty ledger:"
+  DegradationLedger.report_lines(deg_entries).each { |l| puts "   #{l}" }
+  if derived_verdict.start_with?('PARTIAL')
+    puts '   PARTIAL: a scope cut shipped — the delivered workbook is a SUBSET of the source.'
+  end
+end
+puts '   Quote this marker (workbook + run id + verdict) and the ledger in your completion report.'
+print_offramps(wd) # even a DONE run can carry waivers/degradations — surface them
 exit 0

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -177,8 +177,9 @@
 #      A recorded `divergent` verdict passes this gate as RECORDED (the
 #      comparison happened; the gaps are acknowledged) but is INJECTED into
 #      the waiver census as `visual-divergent` and SPENDS waiver budget
-#      (exit 19) — GREEN requires the budget to hold; fix the gaps or accept
-#      YELLOW. Full verdict-capping (divergent → PARTIAL) is PLAN-v3 PR-14.
+#      (exit 19) — GREEN requires the budget to hold, and the recorded
+#      divergence joins the degradation ledger as a fidelity-residual, so the
+#      final verdict is at most YELLOW (PR-14 verdict model below).
 #  14  Layout fill / grid coverage failed (gate 8c; #259 item 1) — a page in
 #      layout-census.json dropped a tile (placed < zones) or ships under-filled
 #      (grid_fill_pct < --min-grid-fill, default 0.45), OR a dashboard layout was
@@ -446,6 +447,21 @@
 # Phase 1d). (d) closes the run-2 hole where all 11 anchors sat in 3 of 9 tiles
 # and the oracle vouched for 6 tiles nothing was watching.
 #
+# VERDICT MODEL (PLAN-v3 PR-14 — cumulative-degradation accounting): on every
+# run this gate derives <workdir>/degradation-ledger.json from the workdir's
+# artifacts (lib/degradation_ledger.rb — scope cuts, quality waivers, recorded
+# escapes, fidelity residuals, waived resolutions; deterministic, never
+# self-reported) and prints ONE verdict with the ledger inline:
+#   GREEN   — the ledger is EMPTY (waivers within budget alone is no longer
+#             enough: any recorded degradation forfeits GREEN);
+#   YELLOW  — quality degradations but no scope cut (a budget-exceeded run —
+#             exit 19, doctrine unchanged — is always at least YELLOW);
+#   PARTIAL — ANY scope cut (dropped tile / column / control / DM element)
+#             regardless of the waiver budget; PARTIAL+YELLOW when both.
+# The verdict string is stamped into phase6-success.json and parity-final.json;
+# verify-complete.rb re-derives the ledger offline and FAILS (its exit 6) when
+# a report's claims contradict it — the anti-"GREEN, 0 waivers" mechanism.
+#
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
 # UNRESOLVED ledger entry with class `data` hard-fails. Data-class residuals
@@ -461,6 +477,21 @@ require 'uri'
 require 'optparse'
 require 'rbconfig'
 require 'digest'
+
+# Degradation ledger (PLAN-v3 PR-14) — vendored at scripts/lib/ in adopting
+# plugins; the canonical checkout resolves it from shared/lib. A checkout
+# without it keeps the legacy final line (stated below, never silent).
+DEG_LEDGER_LOADED = begin
+  require_relative 'lib/degradation_ledger'
+  true
+rescue LoadError
+  begin
+    require_relative '../lib/degradation_ledger'
+    true
+  rescue LoadError
+    false
+  end
+end
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0, min_parity_score: 0.0, min_grid_fill: 0.45 }
@@ -658,7 +689,7 @@ WAIVER_HIDES = {
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--no-vision-waiver'         => 'gate 8b: the visual PASS was SELF-graded — no context-free blind grader ran (recorded by record-visual-check.rb --no-vision-waiver)',
-  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (verdict-capping divergent→PARTIAL is PLAN-v3 PR-14)',
+  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (joins the degradation ledger as a fidelity-residual; verdict at most YELLOW)',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
   '--accept-residuals'         => 'gate 8d: named RCF deltas shipped unresolved',
   '--skip-fidelity-gate'       => 'gate 8d: the RCF fidelity loop was never required — compositional deltas (palette, chart kind, KPI format) were never iterated (--rcf-passes 0 records this waiver)',
@@ -741,8 +772,9 @@ end
 # but acknowledged source-vs-target visual gaps riding to GREEN unqualified is
 # exactly the live-run failure this closes (blind grade FAIL 5/6, verdict
 # recorded divergent, final GREEN). Injected into the census as
-# `visual-divergent` so the budget line names it. Full verdict-capping
-# (divergent → PARTIAL) is PLAN-v3 PR-14 — until then the budget is the cap.
+# `visual-divergent` so the budget line names it; the degradation ledger
+# (PR-14) additionally records it as a fidelity-residual, capping the verdict
+# at YELLOW even when the budget holds.
 begin
   _pf_bgw = File.exist?(summary_path) ? JSON.parse(File.read(summary_path)) : nil
   waiver_flags << '--no-vision-waiver' if _pf_bgw.is_a?(Hash) && _pf_bgw['blind_grade_waiver'].is_a?(Hash) &&
@@ -763,6 +795,42 @@ budget_flags = waiver_flags.reject do |f|
     (f == '--skip-visual-comparison' && opts[:skip_visual_cmp].to_s =~ /verifier/i)
 end
 
+# Reasons census (PR-14): the flag → recorded-reason map rides into
+# parity-final.json beside the census, so the degradation ledger (derived
+# OFFLINE here and by verify-complete.rb) can explain each waiver and decide
+# the /verifier/i policy exclusion without re-parsing CLI flags.
+_reason_srcs = {
+  '--skip-parity-gate'         => opts[:skip_parity],
+  '--skip-orphan-check'        => opts[:skip_orphan],
+  '--skip-column-check'        => opts[:skip_column],
+  '--skip-layout-check'        => opts[:skip_layout],
+  '--skip-layout-lint'         => opts[:skip_lint],
+  '--skip-control-lint'        => opts[:skip_control_lint],
+  '--skip-control-flip'        => opts[:skip_control_flip],
+  '--skip-visual-gate'         => opts[:skip_visual],
+  '--skip-visual-comparison'   => opts[:skip_visual_cmp],
+  '--skip-layout-fill'         => opts[:skip_layout_fill],
+  '--skip-fidelity-gate'       => opts[:skip_fidelity],
+  '--skip-visual-tiles'        => opts[:skip_visual_tiles],
+  '--skip-telemetry-gate'      => opts[:skip_telemetry],
+  '--skip-postpublish-guide'   => opts[:skip_postpublish],
+  '--accept-deferred-elements' => opts[:accept_deferred],
+  '--skip-anchors-gate'        => opts[:skip_anchors],
+  '--allow-empty-tiles'        => opts[:allow_empty_tiles],
+  '--skip-visual-similarity'   => opts[:skip_vsim],
+  '--accept-residuals'         => (Array(opts[:accept_residuals]).any? ? "accepted RCF residual(s): #{Array(opts[:accept_residuals]).join(', ')}" : nil),
+  '--accept-manual-residues'   => (Array(opts[:accept_manual_residues]).any? ? "accepted unbuilt residue(s): #{Array(opts[:accept_manual_residues]).join(', ')}" : nil),
+  '--min-pass-rate'            => (opts[:min_pass_rate] < 1.0 ? "accepted pass rate #{opts[:min_pass_rate]}" : nil),
+  '--allow-missing-tiles'      => (opts[:allow_missing_tiles].to_i.positive? ? "tolerated #{opts[:allow_missing_tiles]} unmatched dashboard zone(s)" : nil),
+  '--allow-extract'            => (opts[:allow_extract] ? 'extract mode accepted (value drift tolerated)' : nil),
+  'layout-phase-skip'          => (layout_phase_stamp.is_a?(Hash) ? layout_phase_stamp['reason'] : nil)
+}
+waiver_reasons = {}
+waiver_flags.each do |f|
+  v = _reason_srcs[f]
+  waiver_reasons[f] = v.to_s.strip if v.is_a?(String) && !v.to_s.strip.empty?
+end
+
 # Stamp the census into parity-final.json on every run (best-effort — a
 # missing/malformed file is gate 1's problem, not the stamp's).
 if File.exist?(summary_path)
@@ -770,6 +838,7 @@ if File.exist?(summary_path)
     _pf = JSON.parse(File.read(summary_path))
     _pf['waivers'] = waiver_flags
     _pf['waiver_count'] = waiver_flags.length
+    _pf['waiver_reasons'] = waiver_reasons
     # Off-ramp telemetry fields (P2): where did this run defect? route comes from
     # the orchestrator's migrate-state.json ('orchestrated' | 'manual-authorized';
     # null for converters without the concept); manual_path_authorized records an
@@ -3243,6 +3312,24 @@ end
 # for this cap — reduce the waiver count by fixing the underlying issues, or
 # report the migration as YELLOW.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Degradation ledger + verdict (PLAN-v3 PR-14) — derived ONCE here, from the
+# artifacts on disk (the census stamped above included), and written to
+# <workdir>/degradation-ledger.json on every run that reaches this point, so
+# the budget-fail path below and the success path share one derivation and
+# verify-complete.rb can re-derive + cross-check offline.
+# ---------------------------------------------------------------------------
+deg_entries = nil
+if DEG_LEDGER_LOADED
+  begin
+    deg_entries = DegradationLedger.derive(opts[:tab])
+    DegradationLedger.write(opts[:tab], deg_entries)
+  rescue StandardError => e
+    warn "[WARN] degradation-ledger derivation failed (#{e.class}: #{e.message.lines.first.to_s.strip}) — verdict falls back to legacy print."
+    deg_entries = nil
+  end
+end
+
 if budget_flags.length > WAIVER_BUDGET
   warn "[FAIL] waiver budget exceeded — #{budget_flags.length} quality waiver/escape flag(s) on this run (budget #{WAIVER_BUDGET})."
   warn '       GREEN unavailable — too many waivers; the highest achievable result is YELLOW.'
@@ -3251,6 +3338,11 @@ if budget_flags.length > WAIVER_BUDGET
   warn '       Waivers are for impossibilities, not obstacles. Fix the underlying issues until'
   warn "       <= #{WAIVER_BUDGET} remain, or report this migration as YELLOW (never GREEN) and name"
   warn '       every waiver in the report. There is no escape flag for this cap.'
+  if deg_entries
+    v19 = DegradationLedger.verdict(deg_entries, budget_exceeded: true)
+    warn "       VERDICT: #{v19} — degradation ledger (#{deg_entries.length} entr#{deg_entries.length == 1 ? 'y' : 'ies'}):"
+    DegradationLedger.report_lines(deg_entries).each { |l| warn "       #{l}" }
+  end
   exit 19
 end
 
@@ -3261,25 +3353,34 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 # run_id scopes the marker to THIS run (see the at_exit stale-deletion above);
 # the waiver census rides along so a report can quote the marker verbatim.
+# The verdict (PR-14): all gates passed and the budget held, but GREEN belongs
+# only to an EMPTY degradation ledger — any scope cut caps the run at PARTIAL,
+# any other recorded degradation at YELLOW. The string rides in the success
+# marker (verify-complete.rb quotes and cross-checks it).
+final_verdict = deg_entries ? DegradationLedger.verdict(deg_entries) : nil
 begin
   _wd = opts[:tab]
   # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
   # reach here) so verify-complete.rb has a uniform element count across plugins.
   _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
   _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
-  File.write(File.join(_wd, 'phase6-success.json'),
-             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
-                                  'chartCount' => _cc,
-                                  'gates' => 'all-pass',
-                                  'run_id' => current_run_id,
-                                  'waivers' => waiver_flags,
-                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _succ = { 'workbookId' => (opts[:wb] || ''),
+            'chartCount' => _cc,
+            'gates' => 'all-pass',
+            'run_id' => current_run_id,
+            'waivers' => waiver_flags,
+            'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+  _succ['verdict'] = final_verdict if final_verdict
+  File.write(File.join(_wd, 'phase6-success.json'), JSON.pretty_generate(_succ))
   _pend = File.join(_wd, 'parity-pending.json')
   File.delete(_pend) if File.exist?(_pend)
-  # Flip the off-ramp telemetry field now that success is minted (P2).
+  # Flip the off-ramp telemetry field now that success is minted (P2), and
+  # stamp the derived verdict beside the census so a report that quotes
+  # parity-final.json carries it (verify-complete.rb cross-checks the claim).
   if File.exist?(File.join(_wd, 'parity-final.json'))
     begin
       _pf['success_sentinel'] = true
+      _pf['verdict'] = final_verdict if final_verdict
       File.write(File.join(_wd, 'parity-final.json'), JSON.pretty_generate(_pf))
     rescue StandardError
       nil
@@ -3289,6 +3390,23 @@ rescue StandardError
   # never fail the gate on sentinel bookkeeping
 end
 
-puts "[OK] all gates pass — conversion may declare GREEN" \
-     "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+if final_verdict.nil?
+  # Legacy checkout without lib/degradation_ledger.rb — stated, never silent.
+  puts "[OK] all gates pass — conversion may declare GREEN" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+  puts '     (lib/degradation_ledger.rb not vendored — no PR-14 verdict derived; re-vendor to enable.)'
+elsif final_verdict == 'GREEN'
+  puts "[OK] all gates pass — VERDICT: GREEN (degradation ledger empty — no scope cuts, no waivers, no residuals)"
+else
+  puts "[OK] all gates pass — VERDICT: #{final_verdict}" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget)" : ''}"
+  puts "     GREEN requires an EMPTY degradation ledger; this run recorded #{deg_entries.length} degradation(s):"
+  DegradationLedger.report_lines(deg_entries).each { |l| puts "     #{l}" }
+  if final_verdict.start_with?('PARTIAL')
+    puts '     PARTIAL: a scope cut shipped — the delivered workbook is a SUBSET of the source.'
+    puts '     Report this migration as PARTIAL (never GREEN) and quote the ledger verbatim.'
+  else
+    puts '     Report this migration as YELLOW (never GREEN) and name every entry in the report.'
+  end
+end
 exit 0

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/degradation_ledger.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+#
+# DegradationLedger — cumulative-degradation accounting → the PARTIAL verdict
+# (PLAN-v3 PR-14, the honesty capstone).
+#
+# WHY: a migration can pass every hard gate and still ship LESS than the source
+# — a dropped tile behind --allow-missing-tiles, a dropped control behind a
+# controls-waivers.json entry, a column the coverage census recorded as lost,
+# a --skip-* flag that quietly turned a verification off. Each degradation is
+# individually recorded somewhere, but nothing ever ADDED THEM UP — so a field
+# run once reported "GREEN, 0 waivers" after a --skip-ref-check and dropped
+# columns. This module derives ONE ledger from the workdir's artifacts and one
+# verdict from the ledger:
+#
+#   GREEN   — the ledger is EMPTY. No scope cuts, no quality waivers, no
+#             recorded escapes, no fidelity residuals, no waived resolutions.
+#   YELLOW  — quality degradations but no scope cut (any non-scope-cut entry;
+#             a budget-exceeded run — assert-phase6-ran exit 19, existing
+#             doctrine unchanged — is always at least YELLOW).
+#   PARTIAL — ANY scope-cut entry (a dropped tile / column / control /
+#             DM element), regardless of the waiver budget. A scope cut caps
+#             the verdict: the delivered workbook is a subset of the source.
+#   PARTIAL+YELLOW — both (scope cuts AND quality degradations); PARTIAL is
+#             the dominant verdict, YELLOW is noted.
+#
+# DERIVATION IS MECHANICAL — every entry comes from an artifact on disk that
+# some script recorded at decision time; nothing here accepts self-reported
+# claims. verify-complete.rb re-derives the ledger offline and FAILS when the
+# final report's claims (verdict / waiver census) contradict it — the
+# anti-"0 waivers" mechanism.
+#
+# Entry shape (stable):
+#   { "class" => scope-cut | quality-waiver | recorded-escape |
+#                fidelity-residual | resolution-waived,
+#     "item"            => <what was degraded — tile/column/control/flag name>,
+#     "reason"          => <the recorded reason, or a stated default>,
+#     "source_artifact" => <file the entry was derived from> }
+#
+# Artifact classes read (all optional; absent file → no entries):
+#   scope-cut         — coverage.json (dropped/degraded visuals+columns),
+#                       parity-final.json tile_census unmatched zones (minus
+#                       visual-verify oracle matches — gate 5's own logic),
+#                       *-controls-coverage.json non-emitted signals with their
+#                       control-scope.json / controls-waivers.json explanations
+#                       (or those two files directly when no census exists),
+#                       deferred-elements.json (quarantined DM elements).
+#   quality-waiver    — parity-final.json `waivers` census (stamped by
+#                       assert-phase6-ran on every run), minus the POLICY
+#                       exclusions (--skip-telemetry-gate; --skip-visual-
+#                       comparison under the sanctioned /verifier/i split) and
+#                       minus flags reclassified below.
+#   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
+#                       waivers, stale-skill, degraded fast path, and the
+#                       PR-14 `skip-flag-waived` records every closed --skip-*
+#                       straggler now writes), plus the census' run off-ramp
+#                       flags (--force-new-workbook / --force-route-switch /
+#                       --allow-manual-spec).
+#   fidelity-residual — parity-final.json visual_verdict=divergent, unresolved
+#                       fidelity-ledger.json deltas (accepted residuals ride
+#                       to DONE unresolved), layout-arrangement.json
+#                       violations (advisory WARNs), png-read.json
+#                       kind_waivers (recorded chart-family substitutions).
+#   resolution-waived — lod-audit.json / join-plan.json resolutions with
+#                       how=waived, agg-semantics.json how=faithful-to-source
+#                       (a documented source hazard shipping as-is),
+#                       manual-residues.json entries still unbuilt,
+#                       source-anchors.json + ground-truth-plan.json
+#                       coverage_waivers (tiles no numeric oracle watched).
+#
+# Canonical: shared/lib/degradation_ledger.rb — edit there and run
+# tools/sync-shared.rb. Ruby 2.6-compatible, stdlib-only, fully offline.
+
+require 'json'
+
+module DegradationLedger
+  VERSION = 1
+  CLASSES = %w[scope-cut quality-waiver recorded-escape fidelity-residual
+               resolution-waived].freeze
+
+  # Census flags that are POLICY, never quality (assert-phase6-ran budget
+  # doctrine): telemetry consent; the visual-comparison hand-off to a verifier
+  # session is excluded only when its recorded reason matches /verifier/i.
+  POLICY_FLAGS = ['--skip-telemetry-gate'].freeze
+  # Census flags that are run OFF-RAMPS, not gate-quality waivers — classed
+  # recorded-escape (they were honored by a script mid-run, mirrored into the
+  # census by the budget code).
+  CENSUS_ESCAPE_FLAGS = ['--force-new-workbook', '--force-route-switch',
+                         '--allow-manual-spec'].freeze
+  # Census flags whose degradation is derived (better) from an artifact —
+  # skipped in the census pass so one degradation never counts twice:
+  # visual-divergent is derived from parity-final's visual_verdict.
+  CENSUS_DERIVED_FLAGS = ['visual-divergent'].freeze
+
+  # offramps.jsonl kinds that are ESCAPES (a verification/protection turned
+  # off) as opposed to observability records (pass1-stop, workbook-handoff,
+  # loop-stop, …). force-new-workbook / route-switch-forced / manual-spec are
+  # deliberately absent: the census already mirrors them (see above).
+  ESCAPE_OFFRAMP_KINDS = %w[cred-gate-waived doctor-gate-waived
+                            tableau-gate-waived stale-skill-waived
+                            degraded-fastpath skip-flag-waived].freeze
+
+  module_function
+
+  def ledger_path(workdir)
+    File.join(workdir, 'degradation-ledger.json')
+  end
+
+  # Derive the full ledger (Array of entry Hashes) from the workdir's
+  # artifacts. Deterministic: same files → same entries, same order.
+  def derive(workdir)
+    entries = []
+    entries.concat(scope_cuts(workdir))
+    entries.concat(quality_waivers(workdir))
+    entries.concat(recorded_escapes(workdir))
+    entries.concat(fidelity_residuals(workdir))
+    entries.concat(resolution_waived(workdir))
+    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+  end
+
+  # Write <workdir>/degradation-ledger.json (entries + per-class counts).
+  # Never raises — bookkeeping must not sink a gate run.
+  def write(workdir, entries)
+    counts = Hash.new(0)
+    entries.each { |e| counts[e['class']] += 1 }
+    File.write(ledger_path(workdir),
+               JSON.pretty_generate('version' => VERSION,
+                                    'derivedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                    'counts' => counts,
+                                    'entries' => entries))
+    true
+  rescue StandardError
+    false
+  end
+
+  # The verdict string. Any scope cut → PARTIAL (dominant); any other entry —
+  # or a budget-exceeded run — → YELLOW; both → "PARTIAL+YELLOW"; empty ledger
+  # and budget intact → GREEN. GREEN requires an EMPTY ledger, full stop.
+  def verdict(entries, budget_exceeded: false)
+    partial = entries.any? { |e| e['class'] == 'scope-cut' }
+    yellow  = budget_exceeded || entries.any? { |e| e['class'] != 'scope-cut' }
+    return 'PARTIAL+YELLOW' if partial && yellow
+    return 'PARTIAL' if partial
+    return 'YELLOW' if yellow
+    'GREEN'
+  end
+
+  # One line per entry, for inline printing under the verdict.
+  def report_lines(entries)
+    entries.map do |e|
+      "  - [#{e['class']}] #{e['item']} — #{e['reason']} (#{e['source_artifact']})"
+    end
+  end
+
+  # ── class derivations ──────────────────────────────────────────────────────
+
+  def scope_cuts(wd)
+    out = []
+    # coverage.json — the build-step drop census: severity 'dropped' is a tile
+    # that produced NO Sigma element; 'degraded' built but LOST a column/field.
+    cov = read_json(wd, 'coverage.json')
+    Array(cov.is_a?(Hash) ? cov['unresolved'] : nil).each do |u|
+      next unless u.is_a?(Hash) && %w[dropped degraded].include?(u['severity'].to_s)
+      what = u['severity'].to_s == 'dropped' ? 'dropped visual' : 'degraded visual (lost column/field)'
+      out << entry('scope-cut', "#{what}: #{u['visual']}",
+                   u['detail'].to_s.empty? ? u['severity'].to_s : u['detail'].to_s,
+                   'coverage.json')
+    end
+    # tile census — unmatched dashboard zones (gate 5), minus zones the
+    # visual-verify oracle confirmed (same subtraction gate 5 applies).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? pf['tile_census'] : nil
+    if census.is_a?(Hash)
+      names = Array(census['unmatched_zone_names']).map(&:to_s)
+      vv = read_json(wd, File.join('visual-verify', 'manifest.json'))
+      vv_ok = Array(vv).select { |t| t.is_a?(Hash) && t['visual_verified'] == true }
+                       .map { |t| t['worksheet'].to_s }
+      (names - vv_ok).each do |n|
+        out << entry('scope-cut', "dropped tile: #{n}",
+                     'source dashboard zone with no matching chart (tile census)',
+                     'parity-final.json tile_census')
+      end
+    end
+    # controls — the source-vs-built census names every signal; a non-emitted
+    # row is a control the user had that the migration did not build. Its
+    # explanation (control-scope drop record / controls-waivers reason) rides
+    # into the entry; without a census the declaration files stand alone.
+    dropped_notes = control_scope_drops(wd)
+    ctl_waivers = controls_waivers(wd)
+    ctl_census_path = Dir[File.join(wd, '*-controls-coverage.json')].min
+    seen_controls = []
+    if ctl_census_path
+      doc = read_json_path(ctl_census_path)
+      Array(doc.is_a?(Hash) ? doc['detail'] : nil).each do |r|
+        next unless r.is_a?(Hash) && r['status'].to_s != 'emitted'
+        name = r['name'].to_s
+        key = norm(name)
+        reason = dropped_notes[key] ||
+                 (ctl_waivers[key] || ctl_waivers[norm("#{r['kind']}:#{name}")]) ||
+                 "census status: #{r['status']}"
+        seen_controls << key << norm("#{r['kind']}:#{name}")
+        out << entry('scope-cut', "dropped control: #{r['kind']}:#{name}", reason,
+                     File.basename(ctl_census_path))
+      end
+    end
+    dropped_notes.each do |key, reason|
+      next if seen_controls.include?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'control-scope.json')
+    end
+    ctl_waivers.each do |key, reason|
+      next if seen_controls.include?(key) || dropped_notes.key?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'controls-waivers.json')
+    end
+    # deferred-elements.json — DM elements quarantined at POST time; a
+    # non-empty file at DONE means the PARTIAL data model was accepted.
+    dd = read_json(wd, 'deferred-elements.json')
+    deferred = dd.is_a?(Hash) ? Array(dd['deferred']) : (dd.is_a?(Array) ? dd : [])
+    deferred.each do |el|
+      name = el.is_a?(Hash) ? (el['name'] || el['id'] || 'unnamed element') : el.to_s
+      out << entry('scope-cut', "dropped DM element: #{name}",
+                   'quarantined at DM POST (deferred-elements.json still non-empty)',
+                   'deferred-elements.json')
+    end
+    out
+  end
+
+  def quality_waivers(wd)
+    pf = read_json(wd, 'parity-final.json')
+    return [] unless pf.is_a?(Hash) && pf['waivers'].is_a?(Array)
+    reasons = pf['waiver_reasons'].is_a?(Hash) ? pf['waiver_reasons'] : {}
+    # waivers.json carries {flag, gate, reason} for gates waived via
+    # record_waiver — a second reason source for older parity-final stamps.
+    wj = read_json(wd, 'waivers.json')
+    wj = wj['waivers'] if wj.is_a?(Hash)
+    Array(wj).each do |w|
+      next unless w.is_a?(Hash) && w['flag']
+      reasons[w['flag'].to_s] ||= w['reason'].to_s unless w['reason'].to_s.empty?
+    end
+    out = []
+    pf['waivers'].map(&:to_s).uniq.each do |flag|
+      next if POLICY_FLAGS.include?(flag)
+      next if CENSUS_DERIVED_FLAGS.include?(flag)
+      next if CENSUS_ESCAPE_FLAGS.include?(flag) # classed recorded-escape below
+      next if flag == '--skip-visual-comparison' && reasons[flag].to_s =~ /verifier/i
+      reason = reasons[flag].to_s
+      reason = 'budget-counted quality waiver (no reason recorded)' if reason.empty?
+      out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
+    end
+    out
+  end
+
+  def recorded_escapes(wd)
+    out = []
+    # Census-mirrored run off-ramps (they also spend waiver budget there).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? Array(pf['waivers']).map(&:to_s) : []
+    (census & CENSUS_ESCAPE_FLAGS).each do |flag|
+      out << entry('recorded-escape', flag, 'run off-ramp honored mid-run (see offramps.jsonl)',
+                   'parity-final.json waivers')
+    end
+    # offramps.jsonl escape kinds — including the PR-14 skip-flag-waived
+    # records that make every --skip-* visible (the --skip-ref-check fix).
+    trail(wd).each do |r|
+      next unless ESCAPE_OFFRAMP_KINDS.include?(r['kind'].to_s)
+      item = r['kind'].to_s == 'skip-flag-waived' && !r['detail'].to_s.empty? ? r['detail'].to_s : r['kind'].to_s
+      reason = r['reason'].to_s.empty? ? 'NO REASON GIVEN' : r['reason'].to_s
+      out << entry('recorded-escape', item, reason, 'offramps.jsonl')
+    end
+    out.uniq { |e| [e['item'], e['reason']] }
+  end
+
+  def fidelity_residuals(wd)
+    out = []
+    pf = read_json(wd, 'parity-final.json')
+    if pf.is_a?(Hash) && pf['visual_verdict'].to_s == 'divergent'
+      out << entry('fidelity-residual', 'visual verdict: divergent',
+                   'recorded source-vs-target visual gaps ship in the render',
+                   'parity-final.json')
+    end
+    fl = read_json(wd, 'fidelity-ledger.json')
+    Array(fl.is_a?(Hash) ? fl['entries'] : nil).each do |e|
+      next unless e.is_a?(Hash) && !e['resolved']
+      out << entry('fidelity-residual',
+                   "RCF residual #{e['id']} [#{e['dimension'] || e['cls']}]",
+                   e['delta'].to_s.empty? ? "unresolved #{e['cls']} delta" : e['delta'].to_s,
+                   'fidelity-ledger.json')
+    end
+    arr = read_json(wd, 'layout-arrangement.json')
+    Array(arr.is_a?(Hash) ? arr['pages'] : nil).each do |p|
+      next unless p.is_a?(Hash)
+      Array(p['violations']).each do |v|
+        out << entry('fidelity-residual', "arrangement: #{p['page']}", v.to_s,
+                     'layout-arrangement.json')
+      end
+    end
+    pr = read_json(wd, 'png-read.json')
+    Array(pr.is_a?(Hash) ? pr['kind_waivers'] : nil).each do |w|
+      next unless w.is_a?(Hash)
+      out << entry('fidelity-residual', "chart-kind substitution: #{w['tile']}",
+                   w['reason'].to_s.empty? ? 'recorded at read time' : w['reason'].to_s,
+                   'png-read.json kind_waivers')
+    end
+    out
+  end
+
+  def resolution_waived(wd)
+    out = []
+    { 'lod-audit.json' => %w[waived], 'join-plan.json' => %w[waived],
+      'agg-semantics.json' => %w[faithful-to-source] }.each do |file, hows|
+      doc = read_json(wd, file)
+      list = doc.is_a?(Hash) ? doc['entries'] : doc
+      Array(list).each do |e|
+        next unless e.is_a?(Hash) && e['resolution'].is_a?(Hash)
+        how = e['resolution']['how'].to_s
+        next unless hows.include?(how)
+        item = e['calc'] || e['name'] ||
+               (e['left'] && e['right'] ? "#{e['left']}→#{e['right']}" : nil) ||
+               e['column'] || 'entry'
+        out << entry('resolution-waived', "#{item} (#{how})",
+                     e['resolution']['reason'].to_s.empty? ? 'no reason recorded' : e['resolution']['reason'].to_s,
+                     file)
+      end
+    end
+    mr = read_json(wd, 'manual-residues.json')
+    mr_list = mr.is_a?(Hash) ? mr['residues'] : mr
+    Array(mr_list).each do |e|
+      next unless e.is_a?(Hash) && e['status'].to_s == 'unbuilt'
+      out << entry('resolution-waived', "unbuilt custom-SQL residue: #{e['calc']}",
+                   'accepted unbuilt — its tile renders a magnitude proxy',
+                   'manual-residues.json')
+    end
+    { 'source-anchors.json' => 'no anchor watched this tile',
+      'ground-truth-plan.json' => 'no numeric oracle verified this tile' }.each do |file, why|
+      doc = read_json(wd, file)
+      Array(doc.is_a?(Hash) ? doc['coverage_waivers'] : nil).each do |w|
+        next unless w.is_a?(Hash)
+        out << entry('resolution-waived', "coverage waiver: #{w['tile']}",
+                     "#{why}#{w['reason'].to_s.empty? ? '' : " — #{w['reason']}"}",
+                     "#{file} coverage_waivers")
+      end
+    end
+    out
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def entry(cls, item, reason, source)
+    { 'class' => cls, 'item' => item.to_s, 'reason' => reason.to_s,
+      'source_artifact' => source.to_s }
+  end
+
+  def norm(s)
+    s.to_s.strip.downcase
+  end
+
+  def control_scope_drops(wd)
+    doc = read_json(wd, 'control-scope.json')
+    out = {}
+    Array(doc.is_a?(Hash) ? doc['dropped'] : nil).each do |d|
+      name = d.is_a?(Hash) ? d['name'] : d
+      next if name.to_s.strip.empty?
+      reason = d.is_a?(Hash) && !d['reason'].to_s.empty? ? d['reason'].to_s : 'dropped — recorded in control-scope.json'
+      out[norm(name)] = reason
+    end
+    out
+  end
+
+  def controls_waivers(wd)
+    doc = read_json(wd, 'controls-waivers.json')
+    doc = doc['waivers'] if doc.is_a?(Hash)
+    out = {}
+    Array(doc).each do |w|
+      next unless w.is_a?(Hash)
+      name = w['control'] || w['name']
+      next if name.to_s.strip.empty? || w['reason'].to_s.strip.empty?
+      out[norm(name)] = "waived: #{w['reason'].to_s.strip}"
+    end
+    out
+  end
+
+  def trail(wd)
+    path = File.join(wd, 'offramps.jsonl')
+    return [] unless File.exist?(path)
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+
+  def read_json(wd, rel)
+    read_json_path(File.join(wd, rel))
+  end
+
+  def read_json_path(path)
+    return nil unless File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue StandardError
+    nil
+  end
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/degradation_ledger.rb
@@ -107,6 +107,11 @@ module DegradationLedger
 
   # Derive the full ledger (Array of entry Hashes) from the workdir's
   # artifacts. Deterministic: same files → same entries, same order.
+  # Dedupe is by the FULL entry (class, item, reason, source) — the reason must
+  # participate: coverage.json legitimately records several distinct degraded
+  # rows under one generic `visual` label (field-observed: three "field/calc"
+  # header-fallback rows for three different tiles, distinguishable only by
+  # their detail), and an item-only key silently swallowed all but the first.
   def derive(workdir)
     entries = []
     entries.concat(scope_cuts(workdir))
@@ -114,7 +119,7 @@ module DegradationLedger
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
-    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+    entries.uniq { |e| [e['class'], e['item'], e['reason'], e['source_artifact']] }
   end
 
   # Write <workdir>/degradation-ledger.json (entries + per-class counts).

--- a/shared/lib/degradation_ledger.rb
+++ b/shared/lib/degradation_ledger.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+#
+# DegradationLedger — cumulative-degradation accounting → the PARTIAL verdict
+# (PLAN-v3 PR-14, the honesty capstone).
+#
+# WHY: a migration can pass every hard gate and still ship LESS than the source
+# — a dropped tile behind --allow-missing-tiles, a dropped control behind a
+# controls-waivers.json entry, a column the coverage census recorded as lost,
+# a --skip-* flag that quietly turned a verification off. Each degradation is
+# individually recorded somewhere, but nothing ever ADDED THEM UP — so a field
+# run once reported "GREEN, 0 waivers" after a --skip-ref-check and dropped
+# columns. This module derives ONE ledger from the workdir's artifacts and one
+# verdict from the ledger:
+#
+#   GREEN   — the ledger is EMPTY. No scope cuts, no quality waivers, no
+#             recorded escapes, no fidelity residuals, no waived resolutions.
+#   YELLOW  — quality degradations but no scope cut (any non-scope-cut entry;
+#             a budget-exceeded run — assert-phase6-ran exit 19, existing
+#             doctrine unchanged — is always at least YELLOW).
+#   PARTIAL — ANY scope-cut entry (a dropped tile / column / control /
+#             DM element), regardless of the waiver budget. A scope cut caps
+#             the verdict: the delivered workbook is a subset of the source.
+#   PARTIAL+YELLOW — both (scope cuts AND quality degradations); PARTIAL is
+#             the dominant verdict, YELLOW is noted.
+#
+# DERIVATION IS MECHANICAL — every entry comes from an artifact on disk that
+# some script recorded at decision time; nothing here accepts self-reported
+# claims. verify-complete.rb re-derives the ledger offline and FAILS when the
+# final report's claims (verdict / waiver census) contradict it — the
+# anti-"0 waivers" mechanism.
+#
+# Entry shape (stable):
+#   { "class" => scope-cut | quality-waiver | recorded-escape |
+#                fidelity-residual | resolution-waived,
+#     "item"            => <what was degraded — tile/column/control/flag name>,
+#     "reason"          => <the recorded reason, or a stated default>,
+#     "source_artifact" => <file the entry was derived from> }
+#
+# Artifact classes read (all optional; absent file → no entries):
+#   scope-cut         — coverage.json (dropped/degraded visuals+columns),
+#                       parity-final.json tile_census unmatched zones (minus
+#                       visual-verify oracle matches — gate 5's own logic),
+#                       *-controls-coverage.json non-emitted signals with their
+#                       control-scope.json / controls-waivers.json explanations
+#                       (or those two files directly when no census exists),
+#                       deferred-elements.json (quarantined DM elements).
+#   quality-waiver    — parity-final.json `waivers` census (stamped by
+#                       assert-phase6-ran on every run), minus the POLICY
+#                       exclusions (--skip-telemetry-gate; --skip-visual-
+#                       comparison under the sanctioned /verifier/i split) and
+#                       minus flags reclassified below.
+#   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
+#                       waivers, stale-skill, degraded fast path, and the
+#                       PR-14 `skip-flag-waived` records every closed --skip-*
+#                       straggler now writes), plus the census' run off-ramp
+#                       flags (--force-new-workbook / --force-route-switch /
+#                       --allow-manual-spec).
+#   fidelity-residual — parity-final.json visual_verdict=divergent, unresolved
+#                       fidelity-ledger.json deltas (accepted residuals ride
+#                       to DONE unresolved), layout-arrangement.json
+#                       violations (advisory WARNs), png-read.json
+#                       kind_waivers (recorded chart-family substitutions).
+#   resolution-waived — lod-audit.json / join-plan.json resolutions with
+#                       how=waived, agg-semantics.json how=faithful-to-source
+#                       (a documented source hazard shipping as-is),
+#                       manual-residues.json entries still unbuilt,
+#                       source-anchors.json + ground-truth-plan.json
+#                       coverage_waivers (tiles no numeric oracle watched).
+#
+# Canonical: shared/lib/degradation_ledger.rb — edit there and run
+# tools/sync-shared.rb. Ruby 2.6-compatible, stdlib-only, fully offline.
+
+require 'json'
+
+module DegradationLedger
+  VERSION = 1
+  CLASSES = %w[scope-cut quality-waiver recorded-escape fidelity-residual
+               resolution-waived].freeze
+
+  # Census flags that are POLICY, never quality (assert-phase6-ran budget
+  # doctrine): telemetry consent; the visual-comparison hand-off to a verifier
+  # session is excluded only when its recorded reason matches /verifier/i.
+  POLICY_FLAGS = ['--skip-telemetry-gate'].freeze
+  # Census flags that are run OFF-RAMPS, not gate-quality waivers — classed
+  # recorded-escape (they were honored by a script mid-run, mirrored into the
+  # census by the budget code).
+  CENSUS_ESCAPE_FLAGS = ['--force-new-workbook', '--force-route-switch',
+                         '--allow-manual-spec'].freeze
+  # Census flags whose degradation is derived (better) from an artifact —
+  # skipped in the census pass so one degradation never counts twice:
+  # visual-divergent is derived from parity-final's visual_verdict.
+  CENSUS_DERIVED_FLAGS = ['visual-divergent'].freeze
+
+  # offramps.jsonl kinds that are ESCAPES (a verification/protection turned
+  # off) as opposed to observability records (pass1-stop, workbook-handoff,
+  # loop-stop, …). force-new-workbook / route-switch-forced / manual-spec are
+  # deliberately absent: the census already mirrors them (see above).
+  ESCAPE_OFFRAMP_KINDS = %w[cred-gate-waived doctor-gate-waived
+                            tableau-gate-waived stale-skill-waived
+                            degraded-fastpath skip-flag-waived].freeze
+
+  module_function
+
+  def ledger_path(workdir)
+    File.join(workdir, 'degradation-ledger.json')
+  end
+
+  # Derive the full ledger (Array of entry Hashes) from the workdir's
+  # artifacts. Deterministic: same files → same entries, same order.
+  def derive(workdir)
+    entries = []
+    entries.concat(scope_cuts(workdir))
+    entries.concat(quality_waivers(workdir))
+    entries.concat(recorded_escapes(workdir))
+    entries.concat(fidelity_residuals(workdir))
+    entries.concat(resolution_waived(workdir))
+    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+  end
+
+  # Write <workdir>/degradation-ledger.json (entries + per-class counts).
+  # Never raises — bookkeeping must not sink a gate run.
+  def write(workdir, entries)
+    counts = Hash.new(0)
+    entries.each { |e| counts[e['class']] += 1 }
+    File.write(ledger_path(workdir),
+               JSON.pretty_generate('version' => VERSION,
+                                    'derivedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                                    'counts' => counts,
+                                    'entries' => entries))
+    true
+  rescue StandardError
+    false
+  end
+
+  # The verdict string. Any scope cut → PARTIAL (dominant); any other entry —
+  # or a budget-exceeded run — → YELLOW; both → "PARTIAL+YELLOW"; empty ledger
+  # and budget intact → GREEN. GREEN requires an EMPTY ledger, full stop.
+  def verdict(entries, budget_exceeded: false)
+    partial = entries.any? { |e| e['class'] == 'scope-cut' }
+    yellow  = budget_exceeded || entries.any? { |e| e['class'] != 'scope-cut' }
+    return 'PARTIAL+YELLOW' if partial && yellow
+    return 'PARTIAL' if partial
+    return 'YELLOW' if yellow
+    'GREEN'
+  end
+
+  # One line per entry, for inline printing under the verdict.
+  def report_lines(entries)
+    entries.map do |e|
+      "  - [#{e['class']}] #{e['item']} — #{e['reason']} (#{e['source_artifact']})"
+    end
+  end
+
+  # ── class derivations ──────────────────────────────────────────────────────
+
+  def scope_cuts(wd)
+    out = []
+    # coverage.json — the build-step drop census: severity 'dropped' is a tile
+    # that produced NO Sigma element; 'degraded' built but LOST a column/field.
+    cov = read_json(wd, 'coverage.json')
+    Array(cov.is_a?(Hash) ? cov['unresolved'] : nil).each do |u|
+      next unless u.is_a?(Hash) && %w[dropped degraded].include?(u['severity'].to_s)
+      what = u['severity'].to_s == 'dropped' ? 'dropped visual' : 'degraded visual (lost column/field)'
+      out << entry('scope-cut', "#{what}: #{u['visual']}",
+                   u['detail'].to_s.empty? ? u['severity'].to_s : u['detail'].to_s,
+                   'coverage.json')
+    end
+    # tile census — unmatched dashboard zones (gate 5), minus zones the
+    # visual-verify oracle confirmed (same subtraction gate 5 applies).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? pf['tile_census'] : nil
+    if census.is_a?(Hash)
+      names = Array(census['unmatched_zone_names']).map(&:to_s)
+      vv = read_json(wd, File.join('visual-verify', 'manifest.json'))
+      vv_ok = Array(vv).select { |t| t.is_a?(Hash) && t['visual_verified'] == true }
+                       .map { |t| t['worksheet'].to_s }
+      (names - vv_ok).each do |n|
+        out << entry('scope-cut', "dropped tile: #{n}",
+                     'source dashboard zone with no matching chart (tile census)',
+                     'parity-final.json tile_census')
+      end
+    end
+    # controls — the source-vs-built census names every signal; a non-emitted
+    # row is a control the user had that the migration did not build. Its
+    # explanation (control-scope drop record / controls-waivers reason) rides
+    # into the entry; without a census the declaration files stand alone.
+    dropped_notes = control_scope_drops(wd)
+    ctl_waivers = controls_waivers(wd)
+    ctl_census_path = Dir[File.join(wd, '*-controls-coverage.json')].min
+    seen_controls = []
+    if ctl_census_path
+      doc = read_json_path(ctl_census_path)
+      Array(doc.is_a?(Hash) ? doc['detail'] : nil).each do |r|
+        next unless r.is_a?(Hash) && r['status'].to_s != 'emitted'
+        name = r['name'].to_s
+        key = norm(name)
+        reason = dropped_notes[key] ||
+                 (ctl_waivers[key] || ctl_waivers[norm("#{r['kind']}:#{name}")]) ||
+                 "census status: #{r['status']}"
+        seen_controls << key << norm("#{r['kind']}:#{name}")
+        out << entry('scope-cut', "dropped control: #{r['kind']}:#{name}", reason,
+                     File.basename(ctl_census_path))
+      end
+    end
+    dropped_notes.each do |key, reason|
+      next if seen_controls.include?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'control-scope.json')
+    end
+    ctl_waivers.each do |key, reason|
+      next if seen_controls.include?(key) || dropped_notes.key?(key)
+      out << entry('scope-cut', "dropped control: #{key}", reason, 'controls-waivers.json')
+    end
+    # deferred-elements.json — DM elements quarantined at POST time; a
+    # non-empty file at DONE means the PARTIAL data model was accepted.
+    dd = read_json(wd, 'deferred-elements.json')
+    deferred = dd.is_a?(Hash) ? Array(dd['deferred']) : (dd.is_a?(Array) ? dd : [])
+    deferred.each do |el|
+      name = el.is_a?(Hash) ? (el['name'] || el['id'] || 'unnamed element') : el.to_s
+      out << entry('scope-cut', "dropped DM element: #{name}",
+                   'quarantined at DM POST (deferred-elements.json still non-empty)',
+                   'deferred-elements.json')
+    end
+    out
+  end
+
+  def quality_waivers(wd)
+    pf = read_json(wd, 'parity-final.json')
+    return [] unless pf.is_a?(Hash) && pf['waivers'].is_a?(Array)
+    reasons = pf['waiver_reasons'].is_a?(Hash) ? pf['waiver_reasons'] : {}
+    # waivers.json carries {flag, gate, reason} for gates waived via
+    # record_waiver — a second reason source for older parity-final stamps.
+    wj = read_json(wd, 'waivers.json')
+    wj = wj['waivers'] if wj.is_a?(Hash)
+    Array(wj).each do |w|
+      next unless w.is_a?(Hash) && w['flag']
+      reasons[w['flag'].to_s] ||= w['reason'].to_s unless w['reason'].to_s.empty?
+    end
+    out = []
+    pf['waivers'].map(&:to_s).uniq.each do |flag|
+      next if POLICY_FLAGS.include?(flag)
+      next if CENSUS_DERIVED_FLAGS.include?(flag)
+      next if CENSUS_ESCAPE_FLAGS.include?(flag) # classed recorded-escape below
+      next if flag == '--skip-visual-comparison' && reasons[flag].to_s =~ /verifier/i
+      reason = reasons[flag].to_s
+      reason = 'budget-counted quality waiver (no reason recorded)' if reason.empty?
+      out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
+    end
+    out
+  end
+
+  def recorded_escapes(wd)
+    out = []
+    # Census-mirrored run off-ramps (they also spend waiver budget there).
+    pf = read_json(wd, 'parity-final.json')
+    census = pf.is_a?(Hash) ? Array(pf['waivers']).map(&:to_s) : []
+    (census & CENSUS_ESCAPE_FLAGS).each do |flag|
+      out << entry('recorded-escape', flag, 'run off-ramp honored mid-run (see offramps.jsonl)',
+                   'parity-final.json waivers')
+    end
+    # offramps.jsonl escape kinds — including the PR-14 skip-flag-waived
+    # records that make every --skip-* visible (the --skip-ref-check fix).
+    trail(wd).each do |r|
+      next unless ESCAPE_OFFRAMP_KINDS.include?(r['kind'].to_s)
+      item = r['kind'].to_s == 'skip-flag-waived' && !r['detail'].to_s.empty? ? r['detail'].to_s : r['kind'].to_s
+      reason = r['reason'].to_s.empty? ? 'NO REASON GIVEN' : r['reason'].to_s
+      out << entry('recorded-escape', item, reason, 'offramps.jsonl')
+    end
+    out.uniq { |e| [e['item'], e['reason']] }
+  end
+
+  def fidelity_residuals(wd)
+    out = []
+    pf = read_json(wd, 'parity-final.json')
+    if pf.is_a?(Hash) && pf['visual_verdict'].to_s == 'divergent'
+      out << entry('fidelity-residual', 'visual verdict: divergent',
+                   'recorded source-vs-target visual gaps ship in the render',
+                   'parity-final.json')
+    end
+    fl = read_json(wd, 'fidelity-ledger.json')
+    Array(fl.is_a?(Hash) ? fl['entries'] : nil).each do |e|
+      next unless e.is_a?(Hash) && !e['resolved']
+      out << entry('fidelity-residual',
+                   "RCF residual #{e['id']} [#{e['dimension'] || e['cls']}]",
+                   e['delta'].to_s.empty? ? "unresolved #{e['cls']} delta" : e['delta'].to_s,
+                   'fidelity-ledger.json')
+    end
+    arr = read_json(wd, 'layout-arrangement.json')
+    Array(arr.is_a?(Hash) ? arr['pages'] : nil).each do |p|
+      next unless p.is_a?(Hash)
+      Array(p['violations']).each do |v|
+        out << entry('fidelity-residual', "arrangement: #{p['page']}", v.to_s,
+                     'layout-arrangement.json')
+      end
+    end
+    pr = read_json(wd, 'png-read.json')
+    Array(pr.is_a?(Hash) ? pr['kind_waivers'] : nil).each do |w|
+      next unless w.is_a?(Hash)
+      out << entry('fidelity-residual', "chart-kind substitution: #{w['tile']}",
+                   w['reason'].to_s.empty? ? 'recorded at read time' : w['reason'].to_s,
+                   'png-read.json kind_waivers')
+    end
+    out
+  end
+
+  def resolution_waived(wd)
+    out = []
+    { 'lod-audit.json' => %w[waived], 'join-plan.json' => %w[waived],
+      'agg-semantics.json' => %w[faithful-to-source] }.each do |file, hows|
+      doc = read_json(wd, file)
+      list = doc.is_a?(Hash) ? doc['entries'] : doc
+      Array(list).each do |e|
+        next unless e.is_a?(Hash) && e['resolution'].is_a?(Hash)
+        how = e['resolution']['how'].to_s
+        next unless hows.include?(how)
+        item = e['calc'] || e['name'] ||
+               (e['left'] && e['right'] ? "#{e['left']}→#{e['right']}" : nil) ||
+               e['column'] || 'entry'
+        out << entry('resolution-waived', "#{item} (#{how})",
+                     e['resolution']['reason'].to_s.empty? ? 'no reason recorded' : e['resolution']['reason'].to_s,
+                     file)
+      end
+    end
+    mr = read_json(wd, 'manual-residues.json')
+    mr_list = mr.is_a?(Hash) ? mr['residues'] : mr
+    Array(mr_list).each do |e|
+      next unless e.is_a?(Hash) && e['status'].to_s == 'unbuilt'
+      out << entry('resolution-waived', "unbuilt custom-SQL residue: #{e['calc']}",
+                   'accepted unbuilt — its tile renders a magnitude proxy',
+                   'manual-residues.json')
+    end
+    { 'source-anchors.json' => 'no anchor watched this tile',
+      'ground-truth-plan.json' => 'no numeric oracle verified this tile' }.each do |file, why|
+      doc = read_json(wd, file)
+      Array(doc.is_a?(Hash) ? doc['coverage_waivers'] : nil).each do |w|
+        next unless w.is_a?(Hash)
+        out << entry('resolution-waived', "coverage waiver: #{w['tile']}",
+                     "#{why}#{w['reason'].to_s.empty? ? '' : " — #{w['reason']}"}",
+                     "#{file} coverage_waivers")
+      end
+    end
+    out
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def entry(cls, item, reason, source)
+    { 'class' => cls, 'item' => item.to_s, 'reason' => reason.to_s,
+      'source_artifact' => source.to_s }
+  end
+
+  def norm(s)
+    s.to_s.strip.downcase
+  end
+
+  def control_scope_drops(wd)
+    doc = read_json(wd, 'control-scope.json')
+    out = {}
+    Array(doc.is_a?(Hash) ? doc['dropped'] : nil).each do |d|
+      name = d.is_a?(Hash) ? d['name'] : d
+      next if name.to_s.strip.empty?
+      reason = d.is_a?(Hash) && !d['reason'].to_s.empty? ? d['reason'].to_s : 'dropped — recorded in control-scope.json'
+      out[norm(name)] = reason
+    end
+    out
+  end
+
+  def controls_waivers(wd)
+    doc = read_json(wd, 'controls-waivers.json')
+    doc = doc['waivers'] if doc.is_a?(Hash)
+    out = {}
+    Array(doc).each do |w|
+      next unless w.is_a?(Hash)
+      name = w['control'] || w['name']
+      next if name.to_s.strip.empty? || w['reason'].to_s.strip.empty?
+      out[norm(name)] = "waived: #{w['reason'].to_s.strip}"
+    end
+    out
+  end
+
+  def trail(wd)
+    path = File.join(wd, 'offramps.jsonl')
+    return [] unless File.exist?(path)
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+
+  def read_json(wd, rel)
+    read_json_path(File.join(wd, rel))
+  end
+
+  def read_json_path(path)
+    return nil unless File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue StandardError
+    nil
+  end
+end

--- a/shared/lib/degradation_ledger.rb
+++ b/shared/lib/degradation_ledger.rb
@@ -107,6 +107,11 @@ module DegradationLedger
 
   # Derive the full ledger (Array of entry Hashes) from the workdir's
   # artifacts. Deterministic: same files → same entries, same order.
+  # Dedupe is by the FULL entry (class, item, reason, source) — the reason must
+  # participate: coverage.json legitimately records several distinct degraded
+  # rows under one generic `visual` label (field-observed: three "field/calc"
+  # header-fallback rows for three different tiles, distinguishable only by
+  # their detail), and an item-only key silently swallowed all but the first.
   def derive(workdir)
     entries = []
     entries.concat(scope_cuts(workdir))
@@ -114,7 +119,7 @@ module DegradationLedger
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
-    entries.uniq { |e| [e['class'], e['item'], e['source_artifact']] }
+    entries.uniq { |e| [e['class'], e['item'], e['reason'], e['source_artifact']] }
   end
 
   # Write <workdir>/degradation-ledger.json (entries + per-class counts).

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -100,6 +100,17 @@
    ]
   },
   {
+   "canonical": "shared/lib/degradation_ledger.rb",
+   "targets": [
+    "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/degradation_ledger.rb",
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/degradation_ledger.rb",
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/degradation_ledger.rb",
+    "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/degradation_ledger.rb",
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/degradation_ledger.rb",
+    "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/degradation_ledger.rb"
+   ]
+  },
+  {
    "canonical": "shared/lib/control_lint.rb",
    "targets": [
     "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb",

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -177,8 +177,9 @@
 #      A recorded `divergent` verdict passes this gate as RECORDED (the
 #      comparison happened; the gaps are acknowledged) but is INJECTED into
 #      the waiver census as `visual-divergent` and SPENDS waiver budget
-#      (exit 19) — GREEN requires the budget to hold; fix the gaps or accept
-#      YELLOW. Full verdict-capping (divergent → PARTIAL) is PLAN-v3 PR-14.
+#      (exit 19) — GREEN requires the budget to hold, and the recorded
+#      divergence joins the degradation ledger as a fidelity-residual, so the
+#      final verdict is at most YELLOW (PR-14 verdict model below).
 #  14  Layout fill / grid coverage failed (gate 8c; #259 item 1) — a page in
 #      layout-census.json dropped a tile (placed < zones) or ships under-filled
 #      (grid_fill_pct < --min-grid-fill, default 0.45), OR a dashboard layout was
@@ -446,6 +447,21 @@
 # Phase 1d). (d) closes the run-2 hole where all 11 anchors sat in 3 of 9 tiles
 # and the oracle vouched for 6 tiles nothing was watching.
 #
+# VERDICT MODEL (PLAN-v3 PR-14 — cumulative-degradation accounting): on every
+# run this gate derives <workdir>/degradation-ledger.json from the workdir's
+# artifacts (lib/degradation_ledger.rb — scope cuts, quality waivers, recorded
+# escapes, fidelity residuals, waived resolutions; deterministic, never
+# self-reported) and prints ONE verdict with the ledger inline:
+#   GREEN   — the ledger is EMPTY (waivers within budget alone is no longer
+#             enough: any recorded degradation forfeits GREEN);
+#   YELLOW  — quality degradations but no scope cut (a budget-exceeded run —
+#             exit 19, doctrine unchanged — is always at least YELLOW);
+#   PARTIAL — ANY scope cut (dropped tile / column / control / DM element)
+#             regardless of the waiver budget; PARTIAL+YELLOW when both.
+# The verdict string is stamped into phase6-success.json and parity-final.json;
+# verify-complete.rb re-derives the ledger offline and FAILS (its exit 6) when
+# a report's claims contradict it — the anti-"GREEN, 0 waivers" mechanism.
+#
 # DATA-CLASS RCF residuals (part of gate 8d, exit 15, but enforced whenever
 # fidelity-ledger.json EXISTS — even without --require-fidelity-ledger): any
 # UNRESOLVED ledger entry with class `data` hard-fails. Data-class residuals
@@ -461,6 +477,21 @@ require 'uri'
 require 'optparse'
 require 'rbconfig'
 require 'digest'
+
+# Degradation ledger (PLAN-v3 PR-14) — vendored at scripts/lib/ in adopting
+# plugins; the canonical checkout resolves it from shared/lib. A checkout
+# without it keeps the legacy final line (stated below, never silent).
+DEG_LEDGER_LOADED = begin
+  require_relative 'lib/degradation_ledger'
+  true
+rescue LoadError
+  begin
+    require_relative '../lib/degradation_ledger'
+    true
+  rescue LoadError
+    false
+  end
+end
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0, min_parity_score: 0.0, min_grid_fill: 0.45 }
@@ -658,7 +689,7 @@ WAIVER_HIDES = {
   '--skip-visual-gate'         => 'gate 8: no rendered PNG was required',
   '--skip-visual-comparison'   => 'gate 8b: no source-vs-target visual verdict was required',
   '--no-vision-waiver'         => 'gate 8b: the visual PASS was SELF-graded — no context-free blind grader ran (recorded by record-visual-check.rb --no-vision-waiver)',
-  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (verdict-capping divergent→PARTIAL is PLAN-v3 PR-14)',
+  'visual-divergent'           => 'gate 8b: the recorded visual verdict is DIVERGENT — acknowledged source-vs-target visual gaps ship in the render (joins the degradation ledger as a fidelity-residual; verdict at most YELLOW)',
   '--skip-layout-fill'         => 'gate 8c: dropped/under-filled pages were accepted',
   '--accept-residuals'         => 'gate 8d: named RCF deltas shipped unresolved',
   '--skip-fidelity-gate'       => 'gate 8d: the RCF fidelity loop was never required — compositional deltas (palette, chart kind, KPI format) were never iterated (--rcf-passes 0 records this waiver)',
@@ -741,8 +772,9 @@ end
 # but acknowledged source-vs-target visual gaps riding to GREEN unqualified is
 # exactly the live-run failure this closes (blind grade FAIL 5/6, verdict
 # recorded divergent, final GREEN). Injected into the census as
-# `visual-divergent` so the budget line names it. Full verdict-capping
-# (divergent → PARTIAL) is PLAN-v3 PR-14 — until then the budget is the cap.
+# `visual-divergent` so the budget line names it; the degradation ledger
+# (PR-14) additionally records it as a fidelity-residual, capping the verdict
+# at YELLOW even when the budget holds.
 begin
   _pf_bgw = File.exist?(summary_path) ? JSON.parse(File.read(summary_path)) : nil
   waiver_flags << '--no-vision-waiver' if _pf_bgw.is_a?(Hash) && _pf_bgw['blind_grade_waiver'].is_a?(Hash) &&
@@ -763,6 +795,42 @@ budget_flags = waiver_flags.reject do |f|
     (f == '--skip-visual-comparison' && opts[:skip_visual_cmp].to_s =~ /verifier/i)
 end
 
+# Reasons census (PR-14): the flag → recorded-reason map rides into
+# parity-final.json beside the census, so the degradation ledger (derived
+# OFFLINE here and by verify-complete.rb) can explain each waiver and decide
+# the /verifier/i policy exclusion without re-parsing CLI flags.
+_reason_srcs = {
+  '--skip-parity-gate'         => opts[:skip_parity],
+  '--skip-orphan-check'        => opts[:skip_orphan],
+  '--skip-column-check'        => opts[:skip_column],
+  '--skip-layout-check'        => opts[:skip_layout],
+  '--skip-layout-lint'         => opts[:skip_lint],
+  '--skip-control-lint'        => opts[:skip_control_lint],
+  '--skip-control-flip'        => opts[:skip_control_flip],
+  '--skip-visual-gate'         => opts[:skip_visual],
+  '--skip-visual-comparison'   => opts[:skip_visual_cmp],
+  '--skip-layout-fill'         => opts[:skip_layout_fill],
+  '--skip-fidelity-gate'       => opts[:skip_fidelity],
+  '--skip-visual-tiles'        => opts[:skip_visual_tiles],
+  '--skip-telemetry-gate'      => opts[:skip_telemetry],
+  '--skip-postpublish-guide'   => opts[:skip_postpublish],
+  '--accept-deferred-elements' => opts[:accept_deferred],
+  '--skip-anchors-gate'        => opts[:skip_anchors],
+  '--allow-empty-tiles'        => opts[:allow_empty_tiles],
+  '--skip-visual-similarity'   => opts[:skip_vsim],
+  '--accept-residuals'         => (Array(opts[:accept_residuals]).any? ? "accepted RCF residual(s): #{Array(opts[:accept_residuals]).join(', ')}" : nil),
+  '--accept-manual-residues'   => (Array(opts[:accept_manual_residues]).any? ? "accepted unbuilt residue(s): #{Array(opts[:accept_manual_residues]).join(', ')}" : nil),
+  '--min-pass-rate'            => (opts[:min_pass_rate] < 1.0 ? "accepted pass rate #{opts[:min_pass_rate]}" : nil),
+  '--allow-missing-tiles'      => (opts[:allow_missing_tiles].to_i.positive? ? "tolerated #{opts[:allow_missing_tiles]} unmatched dashboard zone(s)" : nil),
+  '--allow-extract'            => (opts[:allow_extract] ? 'extract mode accepted (value drift tolerated)' : nil),
+  'layout-phase-skip'          => (layout_phase_stamp.is_a?(Hash) ? layout_phase_stamp['reason'] : nil)
+}
+waiver_reasons = {}
+waiver_flags.each do |f|
+  v = _reason_srcs[f]
+  waiver_reasons[f] = v.to_s.strip if v.is_a?(String) && !v.to_s.strip.empty?
+end
+
 # Stamp the census into parity-final.json on every run (best-effort — a
 # missing/malformed file is gate 1's problem, not the stamp's).
 if File.exist?(summary_path)
@@ -770,6 +838,7 @@ if File.exist?(summary_path)
     _pf = JSON.parse(File.read(summary_path))
     _pf['waivers'] = waiver_flags
     _pf['waiver_count'] = waiver_flags.length
+    _pf['waiver_reasons'] = waiver_reasons
     # Off-ramp telemetry fields (P2): where did this run defect? route comes from
     # the orchestrator's migrate-state.json ('orchestrated' | 'manual-authorized';
     # null for converters without the concept); manual_path_authorized records an
@@ -3243,6 +3312,24 @@ end
 # for this cap — reduce the waiver count by fixing the underlying issues, or
 # report the migration as YELLOW.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Degradation ledger + verdict (PLAN-v3 PR-14) — derived ONCE here, from the
+# artifacts on disk (the census stamped above included), and written to
+# <workdir>/degradation-ledger.json on every run that reaches this point, so
+# the budget-fail path below and the success path share one derivation and
+# verify-complete.rb can re-derive + cross-check offline.
+# ---------------------------------------------------------------------------
+deg_entries = nil
+if DEG_LEDGER_LOADED
+  begin
+    deg_entries = DegradationLedger.derive(opts[:tab])
+    DegradationLedger.write(opts[:tab], deg_entries)
+  rescue StandardError => e
+    warn "[WARN] degradation-ledger derivation failed (#{e.class}: #{e.message.lines.first.to_s.strip}) — verdict falls back to legacy print."
+    deg_entries = nil
+  end
+end
+
 if budget_flags.length > WAIVER_BUDGET
   warn "[FAIL] waiver budget exceeded — #{budget_flags.length} quality waiver/escape flag(s) on this run (budget #{WAIVER_BUDGET})."
   warn '       GREEN unavailable — too many waivers; the highest achievable result is YELLOW.'
@@ -3251,6 +3338,11 @@ if budget_flags.length > WAIVER_BUDGET
   warn '       Waivers are for impossibilities, not obstacles. Fix the underlying issues until'
   warn "       <= #{WAIVER_BUDGET} remain, or report this migration as YELLOW (never GREEN) and name"
   warn '       every waiver in the report. There is no escape flag for this cap.'
+  if deg_entries
+    v19 = DegradationLedger.verdict(deg_entries, budget_exceeded: true)
+    warn "       VERDICT: #{v19} — degradation ledger (#{deg_entries.length} entr#{deg_entries.length == 1 ? 'y' : 'ies'}):"
+    DegradationLedger.report_lines(deg_entries).each { |l| warn "       #{l}" }
+  end
   exit 19
 end
 
@@ -3261,25 +3353,34 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 # run_id scopes the marker to THIS run (see the at_exit stale-deletion above);
 # the waiver census rides along so a report can quote the marker verbatim.
+# The verdict (PR-14): all gates passed and the budget held, but GREEN belongs
+# only to an EMPTY degradation ledger — any scope cut caps the run at PARTIAL,
+# any other recorded degradation at YELLOW. The string rides in the success
+# marker (verify-complete.rb quotes and cross-checks it).
+final_verdict = deg_entries ? DegradationLedger.verdict(deg_entries) : nil
 begin
   _wd = opts[:tab]
   # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
   # reach here) so verify-complete.rb has a uniform element count across plugins.
   _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
   _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
-  File.write(File.join(_wd, 'phase6-success.json'),
-             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
-                                  'chartCount' => _cc,
-                                  'gates' => 'all-pass',
-                                  'run_id' => current_run_id,
-                                  'waivers' => waiver_flags,
-                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _succ = { 'workbookId' => (opts[:wb] || ''),
+            'chartCount' => _cc,
+            'gates' => 'all-pass',
+            'run_id' => current_run_id,
+            'waivers' => waiver_flags,
+            'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }
+  _succ['verdict'] = final_verdict if final_verdict
+  File.write(File.join(_wd, 'phase6-success.json'), JSON.pretty_generate(_succ))
   _pend = File.join(_wd, 'parity-pending.json')
   File.delete(_pend) if File.exist?(_pend)
-  # Flip the off-ramp telemetry field now that success is minted (P2).
+  # Flip the off-ramp telemetry field now that success is minted (P2), and
+  # stamp the derived verdict beside the census so a report that quotes
+  # parity-final.json carries it (verify-complete.rb cross-checks the claim).
   if File.exist?(File.join(_wd, 'parity-final.json'))
     begin
       _pf['success_sentinel'] = true
+      _pf['verdict'] = final_verdict if final_verdict
       File.write(File.join(_wd, 'parity-final.json'), JSON.pretty_generate(_pf))
     rescue StandardError
       nil
@@ -3289,6 +3390,23 @@ rescue StandardError
   # never fail the gate on sentinel bookkeeping
 end
 
-puts "[OK] all gates pass — conversion may declare GREEN" \
-     "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+if final_verdict.nil?
+  # Legacy checkout without lib/degradation_ledger.rb — stated, never silent.
+  puts "[OK] all gates pass — conversion may declare GREEN" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget — name them in the report: #{waiver_flags.join(', ')})" : ''}"
+  puts '     (lib/degradation_ledger.rb not vendored — no PR-14 verdict derived; re-vendor to enable.)'
+elsif final_verdict == 'GREEN'
+  puts "[OK] all gates pass — VERDICT: GREEN (degradation ledger empty — no scope cuts, no waivers, no residuals)"
+else
+  puts "[OK] all gates pass — VERDICT: #{final_verdict}" \
+       "#{waiver_flags.any? ? " (#{budget_flags.length}/#{waiver_flags.length} waiver(s) within budget)" : ''}"
+  puts "     GREEN requires an EMPTY degradation ledger; this run recorded #{deg_entries.length} degradation(s):"
+  DegradationLedger.report_lines(deg_entries).each { |l| puts "     #{l}" }
+  if final_verdict.start_with?('PARTIAL')
+    puts '     PARTIAL: a scope cut shipped — the delivered workbook is a SUBSET of the source.'
+    puts '     Report this migration as PARTIAL (never GREEN) and quote the ledger verbatim.'
+  else
+    puts '     Report this migration as YELLOW (never GREEN) and name every entry in the report.'
+  end
+end
 exit 0


### PR DESCRIPTION
# PR-14 — cumulative-degradation accounting → the PARTIAL verdict (honesty capstone)

Field evidence this closes: one run reported **"GREEN, 0 waivers"** after a `--skip-ref-check` (which recorded nothing anywhere) and dropped columns; a recent run correctly went YELLOW on 3 waivers, but **PARTIAL** — the verdict for *scope cuts* — did not exist. Individually every degradation was recorded somewhere; nothing ever added them up, and no mechanism stopped a final report from contradicting the artifacts.

## 1. Degradation ledger (`shared/lib/degradation_ledger.rb`, vendored to the 6 gate plugins)

Derives `<workdir>/degradation-ledger.json` **mechanically from artifacts — never self-reported**. Entries `{class, item, reason, source_artifact}`:

| class | derived from |
|---|---|
| `scope-cut` | `coverage.json` dropped/degraded visuals (column drops); `parity-final.json` `tile_census` unmatched zones (minus the visual-verify oracle, gate 5's own subtraction); non-emitted controls in `*-controls-coverage.json` with their `control-scope.json` / `controls-waivers.json` explanations (declaration files stand alone when no census); `deferred-elements.json` quarantined DM elements |
| `quality-waiver` | the `parity-final.json` waiver census, minus policy exclusions (telemetry; the `/verifier/i` visual-comparison split — now decidable **offline** via the new `waiver_reasons` stamp) |
| `recorded-escape` | `offramps.jsonl` escape kinds incl. the new `skip-flag-waived` records; census run off-ramps (`--force-new-workbook` / `--force-route-switch` / `--allow-manual-spec`) |
| `fidelity-residual` | recorded `divergent` visual verdict; unresolved `fidelity-ledger.json` deltas; `layout-arrangement.json` WARNs; `png-read.json` `kind_waivers` |
| `resolution-waived` | `lod-audit.json` / `join-plan.json` `how=waived`; `agg-semantics.json` `faithful-to-source`; unbuilt `manual-residues.json`; `source-anchors.json` + `ground-truth-plan.json` `coverage_waivers` |

## 2. Verdict model

- **GREEN = empty ledger.** Within-budget waivers no longer reach GREEN.
- **YELLOW** = quality degradations, or the exceeded budget (exit-19 doctrine unchanged).
- **PARTIAL** = **any scope-cut entry, regardless of the waiver budget**; `PARTIAL+YELLOW` when both (PARTIAL dominant).

`assert-phase6-ran.rb` prints the verdict with the full ledger inline (one line per entry) on both the exit-0 and exit-19 paths, and stamps the verdict string into `phase6-success.json` (the ✅ DONE marker) and `parity-final.json`.

## 3. Report cross-check (`verify-complete.rb`, new **exit 6**)

Re-derives the ledger offline and fails when: a claimed verdict contradicts the derivation; `waiver_count` disagrees with its own census; the marker census drifted from `parity-final.json`; a zero-waiver claim sits over recorded waiver/escape degradations; or `degradation-ledger.json` was hand-edited (fresh-derivation mismatch). **"GREEN, 0 waivers" over a recorded `--skip-ref-check` is now mechanically impossible.** Legacy markers without verdict keys stay DONE (absent claims are never contradictions) and get the derived verdict printed.

## 4. Skip-flag audit — every `--skip-*` leaves a record

Stragglers found (recorded **nothing** before) and closed with `skip-flag-waived` off-ramp records:
- `--skip-ref-check` — the "0 waivers" lie; `assert-wb-refs-resolve.rb` gains `--workdir` (orchestrator passes it), warns when omitted
- `--skip-dashboard-read` (orchestrator + `assert-dashboard-read.rb` + `build-charts-from-signals.rb`), `--skip-extract-landing`, `--skip-run-state`, standalone `--skip-doctor-gate`, `post-and-readback.rb`'s four workbook-path skips, `fidelity-loop.rb --skip-style-normalize`

Classified non-escapes (documented in the audit test): `--skip-reuse-scan` (builds a *fresh* DM — more verification, not less), `tableau-discover --skip-images/--skip-content` (discovery scope; downstream gates still demand the artifacts), `--skip-telemetry-gate` (consent policy).

## 5. Tests

- **`test-degradation-ledger.rb`** (new): fixture derivation for every artifact class + the verdict matrix — clean→GREEN; waivers→YELLOW; **1 dropped tile + 0 waivers→PARTIAL**; both→PARTIAL+YELLOW; budget-exceeded→at least YELLOW.
- **`test-assert-phase6-gates.rb`** (+9): verdict through the real gate — empty ledger written on clean runs; 1 within-budget waiver → exit 0 but YELLOW; 3 waivers → exit 19 naming YELLOW; coverage-drop + 0 waivers → PARTIAL with the tile named; ledger-waived control (gate 7c) → PARTIAL; verdict stamped in the DONE marker + `waiver_reasons` stamped.
- **`test-verify-complete.rb`** (+7 blocks): verdict surfacing + every exit-6 contradiction, including the frozen "GREEN, 0 waivers after `--skip-ref-check`" lie.
- **`test-skip-flag-audit.rb`** (new): static classification of EVERY `--skip-*` definition in the plugin — an unclassified new flag **fails the audit** — plus runtime checks that each standalone gate script leaves its record.
- **`test-wb-refs-resolve.rb`** (+3): waiver writes the off-ramp record; no `--workdir` warns "NOT recorded".

## Verification

`check-shared` (399 copies), `lint-skills`, `hygiene-sweep`, corpus 17/17, full tableau suite, and the looker/quicksight/thoughtspot `test-verify-complete` suites all green. (`test-calc-discovery.rb` needs a live Tableau fixture and fails identically on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
