### PR TITLE
tableau: re-vendor converter — per-invocation id scoping + 64-char id clamp (W2.4)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "2de9ff4",
-  "source_commit_date": "2026-07-18",
+  "source_commit": "e619f53",
+  "source_commit_date": "2026-07-19",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "tableau.mjs",
   "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
@@ -2123,6 +2123,16 @@ function encodeBase62(n, len) {
   }
   return s.padStart(len, SIGMA_CHARS[0]);
 }
+function fnv1a32(s) {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+var NS_MODULUS = 62 ** 4;
+var NS_BLOCK = 1e6;
 var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "a",
   "an",
@@ -2146,9 +2156,15 @@ var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "via",
   "per"
 ]);
-function resetIds() {
+function resetIds(seed) {
   _usedIds.clear();
-  _idCounter = 0;
+  _idCounter = seed == null ? 0 : fnv1a32(seed) % NS_MODULUS * NS_BLOCK;
+}
+function clampId(id, max = 64) {
+  if (id.length <= max)
+    return id;
+  const suffix = "~" + encodeBase62(fnv1a32(id) % 62 ** 6, 6);
+  return id.slice(0, max - suffix.length) + suffix;
 }
 function sigmaShortId(len = 10) {
   let id;
@@ -2160,7 +2176,7 @@ function sigmaShortId(len = 10) {
 }
 function sigmaInodeId(identifier, casing = "upper") {
   const phys = casing === "lower" ? identifier.toLowerCase() : identifier.toUpperCase();
-  return `inode-${sigmaShortId(22)}/${phys}`;
+  return clampId(`inode-${sigmaShortId(22)}/${phys}`);
 }
 function sigmaDisplayName(s) {
   const normalized = (s || "").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
@@ -2987,7 +3003,7 @@ function tableauFormulaIsRls(formula) {
 
 // ../dm-mcp/build/tableau.js
 function paramControlId(rawName) {
-  return "ctl-" + rawName.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-|-$/g, "").toLowerCase();
+  return clampId("ctl-" + rawName.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-|-$/g, "").toLowerCase());
 }
 var xmlParser = new import_fast_xml_parser.XMLParser({
   ignoreAttributes: false,
@@ -4173,8 +4189,9 @@ function buildMultiDatasourceModel(xmlContent, options, datasources) {
   };
 }
 function convertTableauToSigma(xmlContent, options = {}) {
-  if (!options.__multiDsChild)
-    resetIds();
+  if (!options.__multiDsChild) {
+    resetIds(`ds${options.datasourceIndex ?? 0}\0${xmlContent}`);
+  }
   const { connectionId = "", database = "", schema = "", datasourceIndex = 0, tableMapping = {} } = options;
   _tableMapping = tableMapping || {};
   const dbOverride = database || "";
@@ -5104,7 +5121,7 @@ ${joinSql}
       } else if (top.countControl) {
         const param = parameters.find((p) => p.name.toUpperCase() === top.countControl.toUpperCase() || p.rawName?.toUpperCase() === top.countControl.toUpperCase() || sigmaDisplayName(p.name).toUpperCase() === sigmaDisplayName(top.countControl).toUpperCase());
         const ctlSourceName = param?.name || top.countControl;
-        const cidBase = sigmaDisplayName(ctlSourceName).replace(/\s+/g, "-");
+        const cidBase = clampId(sigmaDisplayName(ctlSourceName).replace(/\s+/g, "-"));
         controlId = cidBase;
         const defaultVal = parseInt(param?.defaultVal || "10", 10) || 10;
         if (param)


### PR DESCRIPTION
## What

Re-vendors `converter/tableau.mjs` from **twells89/sigma-data-model-mcp#108** (`tableau: per-invocation id-space scoping + 64-char id clamp`), the upstream fix for PLAN-v3 **PR-16 / W2.4**. Same vendor path as #107: fix upstream, rebuild, `tools/vendor-converters.sh`, commit the bundle + `PROVENANCE.json` (now stamped `e619f53`). Two files change — the bundle and its provenance.

## Why

The converter's module-global id counter caused two id defects:

1. **Cross-invocation collisions** — two independent top-level conversions in one process minted byte-identical id sequences (counter reset to 0 each time) → merged specs failed the DM POST on duplicate ids. #107 fixed the *within-conversion* multi-datasource child case; #108 fixes independent top-level converts by **seeding the counter per-invocation** (different input ⇒ disjoint id-space; same input ⇒ same ids, deterministic).
2. **ids over Sigma's 64-char limit** — a long physical column name pushed `inode-{22}/{PHYS}` past 64. On **this repo's own fixtures, 286 ids were over 64 chars pre-fix** (orders-overview alone: 133); now **0**, clamped with a deterministic hash suffix (uniqueness + readability preserved).

## E2E (offline, run before opening this PR)

**1. Vendored converter over every `corpus/tableau/*` + `scripts/test-fixtures/*.twb`:**

| | before (main bundle) | after (this PR) |
|---|---|---|
| ids > 64 chars | 286 | **0** |
| definition-id collisions | 0 | 0 |

`orders-overview` normalized output is byte-identical to the prior golden **except** the intended clamp of long inode suffixes — every `formula` and `name` unchanged (`corpus_check.py diff` shows only inode-`id` lines change).

**2. Converter-dependent suite — all green:**

- `test-converter-fixtures` · `test-join-coalesce-synthesis` · `test-multi-ds-routing` · `test-multi-ds-detection` · `test-element-id-namespacing`
- `corpus/run-corpus.sh --check` → **17/17**
- `tools/check-shared.rb` (445 shared copies) · `tools/hygiene-sweep.sh` (clean, 48 patterns / 1654 files + staged diff) · `tools/lint-twb-encoding.rb`

## Corpus goldens — intentionally NOT regenerated

The one DM golden that this id change touches (`corpus/tableau/orders-overview/golden/data-model.json`) would shift **id-format only** (long inode suffixes clamped). It is **left unchanged** because it already predates recent converter evolution — the shipped `main` bundle produces 229 columns / 26 metrics / 18 warnings vs the golden's MANIFEST expectation of 230 / 3 / 15, a **structural** drift that exists **independent of this PR** (verified against the `main` bundle). Regenerating would entangle that unrelated churn and force MANIFEST changes out of scope here. `run-corpus.sh --check` validates the golden against its MANIFEST counts, which this id-only change does not affect → stays **17/17**.

## Upstream

twells89/sigma-data-model-mcp#108 (base `main`) — code fix + `src/tableau.id-scoping.test.ts` (7 new tests, green; tsc clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
