### PR TITLE
tableau/parity: pivot JSON-export fallback + live-drift warn + finalize flags (#422)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/collect-parity-actuals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/collect-parity-actuals.rb
@@ -41,10 +41,26 @@
 # unmappable columns) are listed on stdout — the agent supplies those via
 # mcp-v2 (phase6-parity prints the exact queries).
 #
+# PIVOT-TOTALS JSON FALLBACK (SPEED — issue #422). Sigma's element CSV export
+# 500s server-side for ANY pivot carrying a `totals` key (probe-isolated live;
+# verify-anchors works around it by PUT-stripping the totals for the export
+# window and restoring after). Here we take the cheaper, non-mutating route: the
+# element's JSON export is UNAFFECTED by the totals key and returns the same
+# long-form rows, so we simply read that instead — no PUT, no restore. Two entry
+# points, both automatic (no agent mediation, no retry loop against the doomed
+# CSV):
+#   * PROACTIVE — the workbook spec shows the element carries a non-empty
+#     `totals` key: skip the CSV round-trip entirely and read JSON straight away.
+#     This is the recurring-time-sink fix: prior runs paid a failed CSV export +
+#     agent-mediated re-collection on every totals pivot.
+#   * REACTIVE — a CSV export that nonetheless 5xx's (a totals key we couldn't
+#     see, control-driven pivots) falls back to the JSON export before giving up.
+# When JSON returns real rows the chart is collected as :ok exactly like any
+# other; only if JSON ALSO fails does the render-verify marker below apply.
+#
 # KNOWN-PLATFORM-BUG FALLBACK (SKILL_IMPROVEMENT_PLAN_V3 §D4): the element CSV
-# export returns HTTP 500 for some pivots (control-driven pivots;
-# totals.showGrandTotals:hidden — probe-isolated live) or an EMPTY/HTML body
-# (large pivots) while the rendered values are CORRECT. That must not fail the
+# export returns an EMPTY/HTML body (large pivots) — or BOTH the CSV and its JSON
+# fallback 500 — while the rendered values are CORRECT. That must not fail the
 # run and must not push agents into ad-hoc --min-pass-rate waivers: such charts
 # are marked in --out as
 #   { "status": "render-verify-required",
@@ -64,7 +80,8 @@ require 'csv'
 require 'optparse'
 require 'thread'
 
-opts = { pool: 5, timeout: 600, row_limit: 100_000 }
+DEFAULT_DRIFT_WARN_MIN = (ENV['PARITY_DRIFT_WARN_MINUTES'] || '30').to_f
+opts = { pool: 5, timeout: 600, row_limit: 100_000, drift_warn_min: DEFAULT_DRIFT_WARN_MIN }
 OptionParser.new do |p|
   p.on('--plan PATH')          { |v| opts[:plan] = v }
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -73,6 +90,7 @@ OptionParser.new do |p|
   p.on('--pool N', Integer)    { |v| opts[:pool] = v }
   p.on('--timeout S', Integer, 'TOTAL wall-clock budget for the whole run (default 600). One deadline computed at start; every poll, download, and retry checks it. On expiry: per-chart "timeout" markers, partial actuals written, exit 3.') { |v| opts[:timeout] = v }
   p.on('--row-limit N', Integer, 'row cap per element CSV export (Sigma export rowLimit; default 100000, 0 = uncapped). A chart whose export is TRUNCATED at the cap is marked "too-large-for-export" and routed to the agent-mediated/warehouse path — parity over partial data is meaningless.') { |v| opts[:row_limit] = v }
+  p.on('--drift-warn-minutes N', Float, 'ADVISORY live-drift threshold (default 30, or $PARITY_DRIFT_WARN_MINUTES; 0 = off). If the source captures the parity `expected` was built from are older than N minutes when these Sigma actuals are collected, emit a loud WARN — against a LIVE warehouse the data may have moved, so an expected/=actual gap can be drift, not a translation bug. Never a gate.') { |v| opts[:drift_warn_min] = v }
 end.parse!
 %i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
 
@@ -84,6 +102,46 @@ ROW_LIMIT = opts[:row_limit].to_i.positive? ? [opts[:row_limit].to_i, ExportPool
 
 plan = JSON.parse(File.read(opts[:plan]))
 charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+
+# LIVE-DRIFT ADVISORY (issue #422). The parity `expected` values come from source
+# view CSVs captured earlier (auto-parity-plan stamps the plan with
+# `source_csv_max_mtime` = the newest source-capture time). We are collecting the
+# Sigma actuals NOW. Against a LIVE warehouse the underlying data can move between
+# those two reads, so an expected/=actual gap may be DRIFT, not a translation bug
+# — a class phase-6 keeps rediscovering as if it were one. Warn LOUDLY (advisory,
+# never a gate) when the gap exceeds the threshold, and name the remedy.
+def source_capture_epoch(plan, plan_path)
+  stamped = (plan['source_csv_max_mtime'] if plan.is_a?(Hash))
+  return stamped.to_i if stamped
+  # Fallback: newest source view CSV mtime under the workdir (the plan's dir).
+  csvs = Dir.glob(File.join(File.dirname(plan_path), 'views', '*.csv'))
+  csvs.map { |f| File.mtime(f).to_i }.max
+end
+
+if opts[:drift_warn_min].to_f.positive?
+  src_epoch = source_capture_epoch(plan, opts[:plan])
+  gap_min = src_epoch ? (Time.now.to_i - src_epoch) / 60.0 : nil
+  if gap_min && gap_min > opts[:drift_warn_min]
+    warn ''
+    warn '=' * 70
+    warn format('⚠️  LIVE-DRIFT RISK — source captured %.0f min ago (> %g min threshold)',
+                gap_min, opts[:drift_warn_min])
+    warn '=' * 70
+    warn format('The parity `expected` values were built from source captures at %s,',
+                Time.at(src_epoch).strftime('%Y-%m-%dT%H:%M:%S%z'))
+    warn 'but the Sigma actuals are being collected NOW. If the warehouse is LIVE, its'
+    warn 'data may have changed in between — a resulting expected/=actual gap is DRIFT,'
+    warn 'NOT a translation bug. Do not rabbit-hole on it as one.'
+    warn 'REMEDY (synchronized recapture): re-export the source view CSVs immediately'
+    warn 'before this collection (or snapshot/freeze the warehouse), rebuild the plan'
+    warn 'with phase6-parity --regen-plan so `expected` reflects the same data window,'
+    warn 'then re-collect these actuals.'
+    warn '(advisory only — tune with --drift-warn-minutes / $PARITY_DRIFT_WARN_MINUTES; 0 disables)'
+    warn '=' * 70
+    warn ''
+  end
+end
+
 spec = JSON.parse(File.read(opts[:spec]))
 elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
 el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
@@ -105,9 +163,54 @@ RETRYABLE = /\b(429|408|50[234])\b|Too Many Requests|timed? ?out|Timeout/i
 SERVER_ERR = /\b5\d\d\b|Internal Server Error/i
 RENDER_VERIFY_REASON = 'pivot CSV export 500/empty (known Sigma limitation)'
 
+# Map a set of long-form export rows (already split into a header row + body
+# rows of cells) onto the plan's wanted columns by DISPLAY NAME, consuming
+# indices so duplicate names (x + color both "Region") bind in order. Shared by
+# the CSV and JSON paths so both produce identical actuals tuples.
+# Returns [:ok, rows] or [:fail, reason].
+def map_columns(headers, body_rows, want_names)
+  used = []
+  idxs = want_names.map do |n|
+    i = headers.each_index.find { |j| !used.include?(j) && headers[j].casecmp?(n) }
+    used << i if i
+    i
+  end
+  return [:fail, "export headers #{headers.inspect[0, 120]} missing column(s) #{want_names.zip(idxs).select { |_, i| i.nil? }.map(&:first).join(', ')}"] if idxs.any?(&:nil?)
+  [:ok, body_rows.map { |r| idxs.map { |i| parse_cell(r[i]) } }]
+end
+
+# Pivot JSON-export fallback (issue #422). Reads the element's JSON export (long-
+# form row objects, unaffected by the totals key that 500s the CSV export) and
+# reshapes to the same actuals tuples the CSV path produces. Same return
+# contract as collect_chart. NEVER retries — a JSON 5xx degrades straight to the
+# render-verify marker (the CSV path already exhausted / skipped its retries).
+def collect_chart_json(element_id, want_names, wb, deadline)
+  return [:timeout, "total --timeout (#{deadline.budget.round}s) deadline reached before JSON export"] if deadline.expired?
+  qid = ExportPool.start_json_export(wb, element_id, ROW_LIMIT)
+  return [:fail, 'JSON export POST returned no queryId'] unless qid
+  status, body = ExportPool.poll_json_download(qid, deadline)
+  return [:timeout, "JSON export poll hit the total --timeout (#{deadline.budget.round}s) deadline"] if status == :timeout
+  return [:manual, RENDER_VERIFY_REASON] if status == :html
+  objs = ExportPool.parse_json_rows(body)
+  return [:manual, RENDER_VERIFY_REASON] if objs.empty?
+  # Truncated at the row cap → a huge flat grid, not a comparable aggregate.
+  if ROW_LIMIT && objs.length >= ROW_LIMIT
+    return [:toolarge, "element JSON export truncated at rowLimit #{ROW_LIMIT} — parity over partial data is meaningless"]
+  end
+  headers = objs.first.keys.map { |h| h.to_s.strip }
+  # Objects are uniform (one shape per export); align each row's values to the
+  # first object's key order so map_columns' by-name index matching applies.
+  body_rows = objs.map { |o| headers.map { |h| o[o.keys.find { |k| k.to_s.strip == h }] } }
+  map_columns(headers, body_rows, want_names)
+rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+  msg = e.message.lines.first.to_s
+  return [:manual, RENDER_VERIFY_REASON] if msg =~ SERVER_ERR
+  [:fail, msg[0, 160]]
+end
+
 # One chart: export → poll → download → map plan columns by display name.
 # Returns [:ok, rows] / [:skip, reason] / [:fail, reason] /
-# [:manual, reason] (export 500/empty/HTML → render-verify fallback) /
+# [:manual, reason] (export empty/HTML, or CSV+JSON both 5xx → render-verify) /
 # [:toolarge, reason] (export truncated at ROW_LIMIT — parity over partial
 # data is meaningless; agent-mediated/warehouse path) /
 # [:timeout, reason] (the shared total deadline expired).
@@ -118,6 +221,14 @@ def collect_chart(c, el_by_id, wb, deadline)
   name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
   want_names = (c['sigma_columns'] || []).map { |id| name_for[id] }
   return [:fail, "plan column id(s) missing from element: #{(c['sigma_columns'] || []).zip(want_names).select { |_, n| n.nil? }.map(&:first).join(', ')}"] if want_names.any?(&:nil?)
+
+  # PROACTIVE pivot-totals fallback (SPEED — issue #422): a `totals` key 500s
+  # this element's CSV export every time, so skip the doomed round-trip + retry
+  # and read the JSON export straight away.
+  if el.is_a?(Hash) && el.key?('totals') && !el['totals'].nil? &&
+     !(el['totals'].respond_to?(:empty?) && el['totals'].empty?)
+    return collect_chart_json(c['sigma_element_id'], want_names, wb, deadline)
+  end
 
   attempts = 0
   begin
@@ -143,16 +254,9 @@ def collect_chart(c, el_by_id, wb, deadline)
     return [:manual, RENDER_VERIFY_REASON] if rows.empty?
     headers = rows.shift.map { |h| h.to_s.strip }
     return [:manual, RENDER_VERIFY_REASON] if rows.empty?
-    # Map each plan column to a CSV index by display name, consuming indices so
-    # duplicate names (x + color both "Region") bind in order.
-    used = []
-    idxs = want_names.map do |n|
-      i = headers.each_index.find { |j| !used.include?(j) && headers[j].casecmp?(n) }
-      used << i if i
-      i
-    end
-    return [:fail, "export headers #{headers.inspect[0, 120]} missing column(s) #{want_names.zip(idxs).select { |_, i| i.nil? }.map(&:first).join(', ')}"] if idxs.any?(&:nil?)
-    [:ok, rows.map { |r2| idxs.map { |i| parse_cell(r2[i]) } }]
+    # Map each plan column to a CSV index by display name (shared with the JSON
+    # path so both emit identical actuals tuples).
+    map_columns(headers, rows, want_names)
   rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT, CSV::MalformedCSVError => e
     msg = e.message.lines.first.to_s
     if attempts < 4 && msg =~ RETRYABLE && !deadline.expired?
@@ -162,8 +266,9 @@ def collect_chart(c, el_by_id, wb, deadline)
       retry
     end
     # A persistent 5xx (500 immediately; 502/503/504 after retries) is the known
-    # pivot-export platform bug — degrade to render-verify, don't fail the run.
-    return [:manual, RENDER_VERIFY_REASON] if msg =~ SERVER_ERR
+    # pivot-export platform bug — try the JSON export (issue #422) before giving
+    # up; only if THAT also fails does the render-verify marker apply.
+    return collect_chart_json(c['sigma_element_id'], want_names, wb, deadline) if msg =~ SERVER_ERR
     [:fail, msg[0, 160]]
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -261,6 +261,11 @@ OptionParser.new do |o|
                              'no-op for single-page workbooks)') { opts[:per_page_masters] = true }
   o.on('--finalize')         {     opts[:finalize] = true }
   o.on('--actuals PATH')     { |v| opts[:actuals] = File.expand_path(v) }
+  # Finalize ergonomics (issue #422): forward two flags phase6-parity /
+  # assert-phase6-ran already accept but the orchestrator previously swallowed,
+  # blocking operators mid-finalize.
+  o.on('--regen-plan', 'force phase6-parity to REBUILD parity-plan.json from scratch (forwarded to phase6-parity.rb). Use after a workbook re-POST changes element ids, or to discard a stale plan.') { opts[:regen_plan] = true }
+  o.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent) at --finalize — REQUIRED reason; forwarded to assert-phase6-ran.rb (census-visible policy exclusion, NOT a quality waiver). Use ONLY when the run cannot prompt (e.g. unattended CI); name it in your report.') { |v| opts[:skip_telemetry] = v }
   o.on('--allow-missing-tiles N', Integer) { |v| opts[:allow_missing_tiles] = v }
   o.on('--min-pass-rate F', Float, 'accept a parity pass-rate below 1.0 at the gate — ONLY for honest, ' \
                                    'NAMED divergences (LOD placeholders / cross-grain semantics)') { |v| opts[:min_pass_rate] = v }
@@ -939,6 +944,7 @@ if opts[:finalize]
   p6 = ['ruby', File.join(HERE, 'phase6-parity.rb'), '--tableau', WORK,
         '--finalize', '--actuals', opts[:actuals]]
   p6 += ['--extract-mode', '--extract-tol', '0.30'] if state['extract_mode']
+  p6 += ['--regen-plan'] if opts[:regen_plan]
   _, p6st = sigma_run!(p6, allow_fail: true)
   line "phase6-parity finalize: #{p6st.success? ? 'PASS' : "FAIL (exit #{p6st.exitstatus})"}"
   mark('phase6-finalize')
@@ -991,6 +997,9 @@ if opts[:finalize]
   # Gate 11 (post-publish interactivity guide) waiver pass-through — the gate
   # itself decides whether the source's actions require POSTPUBLISH_GUIDE.md.
   gate += ['--skip-postpublish-guide', opts[:skip_postpublish_guide]] if opts[:skip_postpublish_guide]
+  # Telemetry consent waiver pass-through (issue #422) — census-visible at gate
+  # 10 (policy exclusion, excluded from the quality-waiver budget by doctrine).
+  gate += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]
   # --fast: stamp the two visual-gate waivers with the operator's reason (recorded
   # in parity-final.json's waivers[] and counted toward the >2-waiver budget cap).
   gate += ['--skip-visual-gate', opts[:fast], '--skip-visual-comparison', opts[:fast]] if opts[:fast]
@@ -4167,6 +4176,7 @@ end
 p6 = ['ruby', File.join(HERE, 'phase6-parity.rb'),
       '--tableau', WORK, '--workbook-id', wb_id]
 p6 += ['--extract-mode', '--extract-tol', '0.30'] if has_extracts
+p6 += ['--regen-plan'] if opts[:regen_plan]
 if FASTPATH && (FAST[:degraded] || []).any?
   # Degraded fast path (--yes, discovery artifacts missing): the plan may be
   # unbuildable without the view CSVs / layout. Degrade LOUDLY, never re-fetch.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-export-robustness.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-export-robustness.rb
@@ -1,0 +1,221 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Parity/export-robustness bundle (issue #422). Three items, one coherent PR:
+#
+#   1. SPEED — pivot CSV-export 500 → JSON-export fallback in
+#      collect-parity-actuals.rb. Sigma's element CSV export 500s server-side
+#      for any pivot carrying a `totals` key; the JSON export is unaffected and
+#      returns long-form rows. Two automatic paths (no agent mediation, no
+#      retry loop against the doomed CSV):
+#        * PROACTIVE — the workbook spec shows a `totals` key → skip the CSV
+#          round-trip entirely and read JSON straight away (the recurring time
+#          sink this removes).
+#        * REACTIVE — a CSV 5xx we couldn't foresee falls back to JSON.
+#      Only if the JSON export ALSO 5xx's does the render-verify marker apply.
+#
+#   2. Live-drift auto-warn. collect-parity-actuals stamps nothing new but reads
+#      the plan's source-capture time (source_csv_max_mtime) and emits a LOUD
+#      advisory WARN when the Sigma actuals are collected > N minutes later
+#      (default 30, --drift-warn-minutes / $PARITY_DRIFT_WARN_MINUTES; 0 = off).
+#      Advisory, never a gate.
+#
+#   3. Finalize-flag ergonomics — migrate-tableau.rb --finalize now forwards
+#      --regen-plan (→ phase6-parity.rb) and --skip-telemetry-gate (→
+#      assert-phase6-ran.rb), which the children already accept.
+#
+# The Sigma REST layer is stubbed per element+format; no network. Every export
+# POST (element id + format + rowLimit) is logged so we can prove the CSV
+# round-trip is SKIPPED for a totals pivot and never retried.
+#   ruby scripts/test-parity-export-robustness.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPTS = __dir__
+REAL_SIGMA_REST = File.expand_path('lib/sigma_rest.rb', SCRIPTS)
+RENDER_VERIFY_REASON = 'pivot CSV export 500/empty (known Sigma limitation)'
+COLLECT = File.join(SCRIPTS, 'collect-parity-actuals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Stub sigma_rest: loaded FIRST (ruby -I <stub> -r sigma_rest); it then marks the
+# real lib as already-required so the script's own `require 'sigma_rest'` no-ops.
+# POST /export logs {eid, fmt, rowLimit} to STUB_LOG and returns a format-tagged
+# queryId; GET /query/<qid>/download serves the body for that queryId.
+#   el-ok          → CSV works (bar chart)
+#   el-piv500      → CSV 500s, JSON works (REACTIVE fallback → real rows)
+#   el-totals      → carries a `totals` key; JSON works (PROACTIVE — no CSV POST)
+#   el-both500     → CSV 500s AND JSON 500s (→ render-verify marker)
+STUB = <<~'RUBY'
+  require 'json'
+  module Sigma
+    class Error < StandardError; end
+    def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
+      if method == :post && path.include?('/export')
+        req = JSON.parse(body)
+        eid = req['elementId']
+        fmt = req.dig('format', 'type')
+        File.open(ENV['STUB_LOG'], 'a') do |f|
+          f.puts(JSON.generate('eid' => eid, 'fmt' => fmt, 'rowLimit' => req['rowLimit']))
+        end
+        if fmt == 'csv'
+          raise Error, "POST #{path} -> 500 Internal Server Error\n{}" if %w[el-piv500 el-both500 el-totals].include?(eid)
+          return { 'queryId' => "#{eid}::csv" }
+        else # json
+          raise Error, "POST #{path} -> 500 Internal Server Error\n{}" if eid == 'el-both500'
+          return { 'queryId' => "#{eid}::json" }
+        end
+      end
+      if method == :get && path.start_with?('/v2/query/')
+        case path.split('/')[3]
+        when 'el-ok::csv'      then return "Region,Revenue\nEast,100\nWest,200\n"
+        when 'el-piv500::json' then return JSON.generate([{ 'Region' => 'East', 'Revenue' => 100 },
+                                                          { 'Region' => 'West', 'Revenue' => 200 }])
+        when 'el-totals::json' then return JSON.generate([{ 'Quarter' => 'Q1', 'Net' => 10 },
+                                                          { 'Quarter' => 'Q2', 'Net' => 20 }])
+        end
+      end
+      raise Error, "stub: unexpected #{method} #{path}"
+    end
+  end
+  real = ENV['REAL_SIGMA_REST']
+  $LOADED_FEATURES << real if real && !$LOADED_FEATURES.include?(real)
+RUBY
+
+SPEC = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-ok',      'columns' => [{ 'id' => 'c-r', 'name' => 'Region' }, { 'id' => 'c-v', 'name' => 'Revenue' }] },
+  { 'id' => 'el-piv500',  'columns' => [{ 'id' => 'c-r', 'name' => 'Region' }, { 'id' => 'c-v', 'name' => 'Revenue' }] },
+  # A pivot carrying a totals key — CSV export would 500; collect must go
+  # straight to JSON without ever POSTing the CSV export.
+  { 'id' => 'el-totals',  'totals' => { 'showGrandTotals' => true },
+    'columns' => [{ 'id' => 'c-q', 'name' => 'Quarter' }, { 'id' => 'c-n', 'name' => 'Net' }] },
+  { 'id' => 'el-both500', 'columns' => [{ 'id' => 'c-a', 'name' => 'A' }, { 'id' => 'c-b', 'name' => 'B' }] }
+] }] }.freeze
+
+PLAN_CHARTS = [
+  { 'chart' => 'OK Chart',       'sigma_kind' => 'bar-chart', 'sigma_element_id' => 'el-ok',      'sigma_columns' => %w[c-r c-v] },
+  { 'chart' => 'Pivot 500',      'sigma_kind' => 'table',     'sigma_element_id' => 'el-piv500',  'sigma_columns' => %w[c-r c-v] },
+  { 'chart' => 'Totals Pivot',   'sigma_kind' => 'table',     'sigma_element_id' => 'el-totals',  'sigma_columns' => %w[c-q c-n] },
+  { 'chart' => 'Both 500',       'sigma_kind' => 'table',     'sigma_element_id' => 'el-both500', 'sigma_columns' => %w[c-a c-b] }
+].freeze
+
+def run_collect(dir, extra_env, *extra_args)
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir) unless Dir.exist?(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), STUB)
+  Open3.capture3(
+    { 'REAL_SIGMA_REST' => REAL_SIGMA_REST, 'SIGMA_BASE_URL' => 'https://stub.invalid',
+      'SIGMA_API_TOKEN' => 'stub' }.merge(extra_env),
+    RbConfig.ruby, '-I', stub_dir, '-r', 'sigma_rest', COLLECT, *extra_args)
+end
+
+# ============================================================================
+# Part 1 — pivot CSV 500 → JSON fallback (SPEED win)
+# ============================================================================
+puts '-- Part 1: pivot CSV-export 500 → JSON fallback --'
+Dir.mktmpdir do |dir|
+  plan_path = File.join(dir, 'parity-plan.json')
+  spec_path = File.join(dir, 'wb-readback.json')
+  out_path  = File.join(dir, 'parity-actuals.json')
+  log       = File.join(dir, 'stub-log.jsonl')
+  # Fresh source capture (now) so the drift advisory stays silent here.
+  File.write(plan_path, JSON.pretty_generate('charts' => PLAN_CHARTS, 'source_csv_max_mtime' => Time.now.to_i))
+  File.write(spec_path, JSON.pretty_generate(SPEC))
+
+  out, err, st = run_collect(dir, { 'STUB_LOG' => log },
+                             '--plan', plan_path, '--workbook-id', 'wb',
+                             '--workbook-spec', spec_path, '--out', out_path)
+  check(st.success?, "collect exits 0 (got #{st.exitstatus}: #{err.lines.grep(/rror/).first})", fails)
+  actuals = JSON.parse(File.read(out_path))
+
+  check(actuals['OK Chart'] == [['East', 100.0], ['West', 200.0]], 'healthy CSV chart collected as rows', fails)
+  check(actuals['Pivot 500'] == [['East', 100.0], ['West', 200.0]],
+        "REACTIVE: CSV 500 → JSON fallback → correct rows (got #{actuals['Pivot 500'].inspect})", fails)
+  check(actuals['Totals Pivot'] == [['Q1', 10.0], ['Q2', 20.0]],
+        "PROACTIVE: totals pivot → JSON → correct rows (got #{actuals['Totals Pivot'].inspect})", fails)
+  check(actuals['Both 500'] == { 'status' => 'render-verify-required', 'reason' => RENDER_VERIFY_REASON },
+        'CSV 500 AND JSON 500 → render-verify marker (safety net preserved)', fails)
+
+  posts = File.readlines(log).map { |l| JSON.parse(l) }
+  # PROACTIVE speed win: the totals pivot never wastes a CSV export round-trip.
+  totals_posts = posts.select { |p| p['eid'] == 'el-totals' }
+  check(totals_posts.map { |p| p['fmt'] } == ['json'],
+        "totals pivot: NO CSV export POST, exactly one JSON POST (got #{totals_posts.map { |p| p['fmt'] }.inspect})", fails)
+  # NO RETRY LOOP: a CSV 500 is attempted exactly once before the JSON fallback.
+  piv500_csv = posts.select { |p| p['eid'] == 'el-piv500' && p['fmt'] == 'csv' }
+  piv500_json = posts.select { |p| p['eid'] == 'el-piv500' && p['fmt'] == 'json' }
+  check(piv500_csv.length == 1, "reactive path: CSV 500 tried once, NOT retried (got #{piv500_csv.length})", fails)
+  check(piv500_json.length == 1, 'reactive path: exactly one JSON fallback POST', fails)
+  # bounded rowLimit still carried on the JSON export.
+  check(piv500_json.first['rowLimit'] == 100_000, 'JSON export carries the bounded rowLimit', fails)
+end
+
+# ============================================================================
+# Part 2 — live-drift advisory WARN (past threshold loud, within silent)
+# ============================================================================
+puts '-- Part 2: live-drift advisory --'
+DRIFT_RE = /LIVE-DRIFT RISK/
+def drift_run(env_extra, *args)
+  Dir.mktmpdir do |dir|
+    plan_path = File.join(dir, 'parity-plan.json')
+    spec_path = File.join(dir, 'wb-readback.json')
+    out_path  = File.join(dir, 'parity-actuals.json')
+    File.write(plan_path, JSON.pretty_generate('charts' => [], 'source_csv_max_mtime' => yield))
+    File.write(spec_path, JSON.pretty_generate('pages' => []))
+    _o, err, st = run_collect(dir, env_extra.merge('STUB_LOG' => File.join(dir, 'log.jsonl')),
+                              '--plan', plan_path, '--workbook-id', 'wb',
+                              '--workbook-spec', spec_path, '--out', out_path, *args)
+    [err, st]
+  end
+end
+
+err, st = drift_run({}) { (Time.now - 40 * 60).to_i } # 40 min old, default 30 min threshold
+check(st.success?, 'drift run still exits 0 (advisory, never a gate)', fails)
+check(err.match?(DRIFT_RE), 'source captured 40 min ago (> 30) → loud WARN fires', fails)
+check(err.include?('synchronized recapture') && err.include?('--regen-plan'),
+      'WARN names the drift risk AND the synchronized-recapture remedy', fails)
+
+err, _st = drift_run({}) { Time.now.to_i } # fresh capture
+check(!err.match?(DRIFT_RE), 'fresh capture → NO warn (byte-identical to main path)', fails)
+
+err, _st = drift_run({}, '--drift-warn-minutes', '60') { (Time.now - 40 * 60).to_i } # below higher threshold
+check(!err.match?(DRIFT_RE), 'gap below --drift-warn-minutes threshold → silent', fails)
+
+err, _st = drift_run({}, '--drift-warn-minutes', '0') { (Time.now - 999 * 60).to_i } # disabled
+check(!err.match?(DRIFT_RE), '--drift-warn-minutes 0 disables the advisory entirely', fails)
+
+err, _st = drift_run({ 'PARITY_DRIFT_WARN_MINUTES' => '5' }) { (Time.now - 10 * 60).to_i } # env lowers default
+check(err.match?(DRIFT_RE), '$PARITY_DRIFT_WARN_MINUTES lowers the default threshold (10 > 5 → warn)', fails)
+
+# ============================================================================
+# Part 3 — finalize-flag ergonomics: migrate-tableau forwards both flags
+# ============================================================================
+puts '-- Part 3: finalize-flag forwarding --'
+migrate_src = File.read(File.join(SCRIPTS, 'migrate-tableau.rb'))
+phase6_src  = File.read(File.join(SCRIPTS, 'phase6-parity.rb'))
+gate_src    = File.read(File.join(SCRIPTS, 'assert-phase6-ran.rb'))
+
+check(migrate_src.include?("o.on('--regen-plan'"), 'migrate-tableau ACCEPTS --regen-plan', fails)
+check(migrate_src.include?("o.on('--skip-telemetry-gate REASON'"), 'migrate-tableau ACCEPTS --skip-telemetry-gate', fails)
+check(migrate_src.scan(/p6 \+= \['--regen-plan'\] if opts\[:regen_plan\]/).length >= 2,
+      '--regen-plan forwarded to phase6-parity on BOTH the pass-1 and finalize invocations', fails)
+check(migrate_src.include?("gate += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]"),
+      '--skip-telemetry-gate forwarded to the assert-phase6-ran gate', fails)
+# Receivers already accept them (regression guard against a silent rename).
+check(phase6_src.include?("p.on('--regen-plan'"), 'phase6-parity still accepts --regen-plan', fails)
+check(gate_src.include?("p.on('--skip-telemetry-gate REASON'"), 'assert-phase6-ran still accepts --skip-telemetry-gate', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — parity/export robustness bundle (JSON fallback · drift advisory · finalize flags)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-skip-flag-audit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-skip-flag-audit.rb
@@ -52,7 +52,8 @@ CLASSIFICATION = {
     '--skip-ref-check'           => :forwards, # → assert-wb-refs-resolve.rb --workdir
     '--skip-extract-landing'     => :offramp,
     '--skip-postpublish-guide'   => :gate,     # → assert-phase6-ran census
-    '--skip-flip-test'           => :gate      # → --skip-control-flip census
+    '--skip-flip-test'           => :gate,     # → --skip-control-flip census
+    '--skip-telemetry-gate'      => :gate      # #422: → assert-phase6-ran (gate 10 consent, policy exclusion)
   },
   'assert-wb-refs-resolve.rb'    => { '--skip-ref-check' => :offramp },
   'assert-dashboard-read.rb'     => { '--skip-dashboard-read' => :offramp },

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 

--- a/shared/lib/export_pool.rb
+++ b/shared/lib/export_pool.rb
@@ -62,7 +62,23 @@ module ExportPool
   # POST the export, bounded to row_limit rows (nil = unbounded, discouraged).
   # Returns the queryId or nil.
   def start_csv_export(wb, element_id, row_limit)
-    body = { elementId: element_id, format: { type: 'csv' } }
+    start_export(wb, element_id, 'csv', row_limit)
+  end
+
+  # JSON twin of start_csv_export. Sigma's element JSON export returns the
+  # element's LONG-FORM rows (one object per row keyed by column display name),
+  # and — unlike the CSV export — it does NOT 500 on a pivot carrying a `totals`
+  # key. That makes it the automatic fallback for the pivot CSV-export platform
+  # bug (see collect-parity-actuals.rb). Same POST shape, format.type = json.
+  def start_json_export(wb, element_id, row_limit)
+    start_export(wb, element_id, 'json', row_limit)
+  end
+
+  # POST /v2/workbooks/{wb}/export for one element in the given format
+  # ('csv' | 'json'), bounded to row_limit rows (nil = unbounded). Returns the
+  # queryId or nil.
+  def start_export(wb, element_id, fmt, row_limit)
+    body = { elementId: element_id, format: { type: fmt } }
     body[:rowLimit] = row_limit if row_limit
     r = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
     r && r['queryId']
@@ -73,6 +89,21 @@ module ExportPool
   # renderer error). Raises Sigma::Error for non-404 HTTP failures (callers
   # keep their own retry/fallback policies).
   def poll_csv_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'text/csv', poll_interval: poll_interval)
+  end
+
+  # JSON twin of poll_csv_download — same bounded-poll/download contract, same
+  # return shape, only the Accept header differs.
+  def poll_json_download(qid, deadline, poll_interval: 1.0)
+    poll_download(qid, deadline, accept: 'application/json', poll_interval: poll_interval)
+  end
+
+  # Poll for the rendered export body and download it, bounded by the shared
+  # deadline. `accept` selects the wire format ('text/csv' | 'application/json'
+  # — both stream identically). Returns [:ok, body] | [:timeout, nil] |
+  # [:html, nil] (HTML behind a 200 = renderer error). Raises Sigma::Error for
+  # non-404 HTTP failures (callers keep their own retry/fallback policies).
+  def poll_download(qid, deadline, accept:, poll_interval: 1.0)
     loop do
       return [:timeout, nil] if deadline.expired?
       sleep([poll_interval, [deadline.remaining, 0.05].max].min)
@@ -83,7 +114,7 @@ module ExportPool
         # remaining budget (previously an unbounded multi-hundred-MB body read
         # was the first half of the silent hang).
         b = Timeout.timeout([deadline.remaining, 1.0].max) do
-          Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          Sigma.request(:get, "/v2/query/#{qid}/download", accept: accept, binary: true)
         end
         next if b.to_s.empty? # still rendering
         return [:html, nil] if b.to_s.lstrip.start_with?('<')
@@ -93,6 +124,25 @@ module ExportPool
       rescue Sigma::Error => e
         raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
       end
+    end
+  end
+
+  # Parse a Sigma JSON-export body into an array of row hashes (each keyed by
+  # column display name). Handles both `format.type:"json"` (one JSON array of
+  # objects) and `"jsonl"`/NDJSON (one object per line), plus a defensive
+  # {"rows"|"data": [...]} wrapper. Returns [] for a blank/empty body.
+  def parse_json_rows(body)
+    s = body.to_s.strip
+    return [] if s.empty?
+    parsed = (JSON.parse(s) rescue nil)
+    case parsed
+    when Array then parsed.select { |r| r.is_a?(Hash) }
+    when Hash
+      rows = parsed['rows'] || parsed['data']
+      rows.is_a?(Array) ? rows.select { |r| r.is_a?(Hash) } : [parsed]
+    else
+      # NDJSON: one JSON object per line.
+      s.each_line.map { |ln| JSON.parse(ln) rescue nil }.select { |r| r.is_a?(Hash) }
     end
   end
 


### PR DESCRIPTION
Parity/export robustness bundle from the #422 backlog — three items, one coherent PR. LOCAL e2e validated (plus a live confirmation of the JSON-export mechanic) before opening.

## 1. SPEED WIN — pivot CSV-export 500 → JSON-export fallback
Sigma's element **CSV** export 500s server-side for any pivot carrying a `totals` key. Every prior live run wasted the round-trip and then fell back to agent-mediated mcp-v2 collection — a recurring minutes-long stall. `verify-anchors.rb` already worked around this by PUT-stripping totals for the export window; `collect-parity-actuals.rb` did **not**.

Now `collect-parity-actuals.rb`:
- **PROACTIVE** — sees a `totals` key in the workbook spec and skips the doomed CSV round-trip entirely, reading the JSON export straight away. This is the time-sink removal.
- **REACTIVE** — a CSV `5xx` we couldn't foresee falls back to the JSON export before giving up (no retry loop against the 500).

The **JSON** export is unaffected by the totals key and returns long-form rows, reshaped to the same actuals tuples the CSV path produces — no agent mediation. Only if the JSON export **also** `5xx`'s does the existing render-verify marker apply (safety net intact). `export_pool.rb` gains generic `start_json_export` / `poll_json_download` / `parse_json_rows` (synced to all migrators); the CSV path is behavior-identical (`start_export`/`poll_download` refactor with the same wire calls).

## 2. Live-drift auto-warn
`collect-parity-actuals.rb` reads the plan's source-capture time (`source_csv_max_mtime`) and emits a loud **advisory** WARN when the Sigma actuals are collected more than N minutes later (default 30; `--drift-warn-minutes` / `$PARITY_DRIFT_WARN_MINUTES`; `0` = off), naming the live-warehouse drift risk and the synchronized-recapture remedy. Advisory, never a gate — stops agents rabbit-holing on drift as if it were a translation bug.

## 3. Finalize-flag ergonomics
`migrate-tableau.rb --finalize` now forwards `--regen-plan` (→ `phase6-parity.rb`, both invocations) and `--skip-telemetry-gate` (→ `assert-phase6-ran.rb`), which the children already accept. Operators are no longer blocked mid-finalize.

## Tests & checks
- New `test-parity-export-robustness.rb` (stubbed export layer): pivot 500 → JSON path → correct rows with **no retry loop**; totals pivot → JSON with **no CSV POST**; JSON-also-500 → render-verify marker; drift warn fires past threshold / silent within / disabled at 0 / env-tunable; finalize forwards both flags. 24/24 pass.
- `test-skip-flag-audit.rb` classifies the new `--skip-telemetry-gate`.
- Touched-area suite green (`test-parity-*`, `test-verify-*`, `test-bounded-exports`, `test-anchors-*`, `test-finalize-*`, `test-fastpath-flags`, `test-parity-render-verify-fallback`).
- corpus **17/17**; `check-shared` / hygiene-sweep / `lint-twb-encoding` clean.
- **Byte-identical guard**: a run with no pivot/totals and a fresh capture takes only the unchanged CSV path and the silent advisory branch — behaves identically to `origin/main`.

## Live confirmation
Against live Sigma, a real pivot's **JSON** export returned **540 long-form rows** (array-of-hashes, 25 cols) parsed by the actual `ExportPool.parse_json_rows`, vs the 39-line wide CSV grid — confirming the fallback's core mechanic end-to-end. No totals-bearing pivot was present in the 60-workbook scan window to exercise the live CSV-500 itself; that behavior is already probe-isolated in prior runs and the reactive path triggers on any CSV `5xx`.

## Out of scope (pre-existing)
`test-skip-flag-audit.rb` still flags `intake.rb --skip-bootstrap-gate` as unclassified — this predates the PR on `origin/main` (that flag exists there, unclassified) and is unrelated to parity/export; left untouched to keep this PR coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
