### PR TITLE
tableau: resolve KPI/measure formats by internal-id↔caption bridge (+percent heuristic guard)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1086,6 +1086,34 @@ end
 # pick_tableau_format's normalized containment match.
 COLUMN_DEFAULT_FORMATS = {}
 (meta['column_formats'] || {}).each { |k, v| COLUMN_DEFAULT_FORMATS[k] = v }
+
+# Worksheet per-pill format keys are keyed by the field's INTERNAL id
+# (`[usr:Calculation_AvgBal:qk]`), but measure/KPI columns are named by CAPTION
+# ("Avg Balance per User"). Without this bridge the friendly match compares the
+# internal id to the caption, misses, and the column falls to a name-based
+# heuristic — the field failure where a KPI printed raw (or, worse, got a `$` on
+# a percentage) while the source .twb carried the real format. Map internal id →
+# caption from columns_by_guid so a format key can also match on its caption.
+FORMAT_KEY_CAPTIONS = {}
+(meta['columns_by_guid'] || {}).each do |gid, ci|
+  cap = ci.is_a?(Hash) ? ci['caption'].to_s : ''
+  FORMAT_KEY_CAPTIONS[gid.to_s] = cap unless cap.empty?
+end
+
+# The human name(s) a worksheet format-key can match a column header on: its own
+# friendly token AND — bridged through columns_by_guid — the caption its
+# internal id resolves to. Returns NORMALIZED keys (downcased, \W stripped).
+def format_key_match_keys(field)
+  inner = field.to_s.scan(/\[([^\]]+)\]/).flatten.last.to_s
+  parts = inner.split(':')
+  token = parts.length >= 3 ? parts[1].to_s : ''
+  return [] if token.empty?
+  names = [token]
+  cap = FORMAT_KEY_CAPTIONS[token]
+  names << cap if cap && !cap.empty?
+  names.map { |n| n.downcase.gsub(/\W+/, '') }.reject(&:empty?).uniq
+end
+
 def pick_column_default_format_raw(header)
   hkey = header.to_s.downcase.gsub(/\W+/, '')
   return nil if hkey.empty?
@@ -1100,6 +1128,22 @@ end
 def pick_column_default_format(header)
   raw = pick_column_default_format_raw(header)
   raw && tableau_format_to_sigma(raw)
+end
+
+# Last-resort number format when NO source format resolves (no pill format, no
+# .twb default, no master-map format): guess by header name. Percent detection
+# — a literal '%' in the caption OR a percent/rate/ratio word — WINS over the
+# currency guess, so a percentage NEVER gets a currency symbol (the
+# '% Customers with Profit' matched /profit/ and got a bogus '$' field failure).
+def heuristic_number_format(name)
+  n = name.to_s
+  if n.include?('%') || n.downcase =~ /(rate|margin|pct|percent|ratio)/
+    { 'kind' => 'number', 'formatString' => ',.1%' }
+  elsif n.downcase =~ /(revenue|profit|cost|sales|amount|spend)/
+    { 'kind' => 'number', 'formatString' => '$,.0f', 'currencySymbol' => '$' }
+  else
+    { 'kind' => 'number', 'formatString' => ',.0f' }
+  end
 end
 
 # Tableau scale-comma + literal-suffix formats ('n#,##0,,,B;-#,##0,,,B'):
@@ -2352,14 +2396,13 @@ end
 def pick_tableau_format(formats, header)
   return nil if formats.nil? || formats.empty?
   hkey = header.to_s.downcase.gsub(/\W+/, '')
+  return nil if hkey.empty?
   formats.each do |field, val|
-    body = field.to_s.downcase
-    # Friendly-name match: format key looks like `[usr:Return Rate:qk]`. Pull
-    # the human chunk and compare to header.
-    inner = body.scan(/\[([^\]]+)\]/).flatten.last.to_s
-    parts = inner.split(':')
-    friendly = parts.length >= 3 ? parts[1].to_s.gsub(/\W+/, '') : ''
-    if !friendly.empty? && (friendly == hkey || hkey.include?(friendly) || friendly.include?(hkey))
+    # Friendly-name match: format key looks like `[usr:Return Rate:qk]` OR is
+    # keyed by an internal id (`[usr:Calculation_AvgBal:qk]`) the KPI/measure
+    # column carries under its CAPTION — format_key_match_keys bridges both.
+    format_key_match_keys(field).each do |fkey|
+      next unless fkey == hkey || hkey.include?(fkey) || fkey.include?(hkey)
       sigma = tableau_format_to_sigma(val)
       return sigma if sigma
     end
@@ -2373,11 +2416,11 @@ end
 def pick_tableau_format_raw(formats, header)
   return nil if formats.nil? || formats.empty?
   hkey = header.to_s.downcase.gsub(/\W+/, '')
+  return nil if hkey.empty?
   formats.each do |field, val|
-    inner = field.to_s.downcase.scan(/\[([^\]]+)\]/).flatten.last.to_s
-    parts = inner.split(':')
-    friendly = parts.length >= 3 ? parts[1].to_s.gsub(/\W+/, '') : ''
-    return val if !friendly.empty? && (friendly == hkey || hkey.include?(friendly) || friendly.include?(hkey))
+    format_key_match_keys(field).each do |fkey|
+      return val if fkey == hkey || hkey.include?(fkey) || fkey.include?(hkey)
+    end
   end
   nil
 end
@@ -3894,15 +3937,7 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
             pick_column_default_format(master['name'])
   measure_col['format'] = tab_fmt if tab_fmt
   measure_col['format'] ||= master['format'] if master['format'].is_a?(Hash)
-  measure_col['format'] ||=
-    case master['name'].downcase
-    when /(revenue|profit|cost|sales|amount|spend)/
-      { 'kind' => 'number', 'formatString' => '$,.0f', 'currencySymbol' => '$' }
-    when /(rate|margin|pct|percent|ratio)/
-      { 'kind' => 'number', 'formatString' => ',.1%' }
-    else
-      { 'kind' => 'number', 'formatString' => ',.0f' }
-    end
+  measure_col['format'] ||= heuristic_number_format(master['name'])
 
   # Scale-comma + literal-suffix source format ('#,##0,,,B' → "1B"): the d3
   # enum can't render it (,.2s shows 'G' for 1e9), so the enum translator
@@ -4916,17 +4951,7 @@ layout.each do |dash|
               pick_column_default_format(meas['name'])
     meas_col_obj['format'] = tab_fmt
     meas_col_obj['format'] ||= meas['format'] if meas['format'].is_a?(Hash)
-    if meas_col_obj['format'].nil?
-      meas_col_obj['format'] =
-        case meas['name'].downcase
-        when /(revenue|profit|cost|sales|amount|spend)/
-          { 'kind' => 'number', 'formatString' => '$,.0f', 'currencySymbol' => '$' }
-        when /(rate|margin|pct|percent|ratio)/
-          { 'kind' => 'number', 'formatString' => ',.1%' }
-        else
-          { 'kind' => 'number', 'formatString' => ',.0f' }
-        end
-    end
+    meas_col_obj['format'] ||= heuristic_number_format(meas['name'])
     # Allow `format` on map entries to be either a Sigma format object OR a
     # bare formatString string for convenience.
     if meas['format'].is_a?(String)
@@ -7743,7 +7768,7 @@ end
 begin
   fe = {
     'version'           => 1,
-    'entries'           => FormatMap.emitted_records(elements, meta['worksheets'] || {}, COLUMN_DEFAULT_FORMATS),
+    'entries'           => FormatMap.emitted_records(elements, meta['worksheets'] || {}, COLUMN_DEFAULT_FORMATS, meta['columns_by_guid'] || {}),
     'series_color_maps' => SeriesColors.records(elements, meta['worksheets'] || {})
   }
   fe_path = File.join(File.dirname(File.expand_path(opts[:out])), 'formats-emitted.json')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/format_map.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/format_map.rb
@@ -171,7 +171,16 @@ module FormatMap
   # elements: built element hashes still carrying '_worksheet'/'_dashboard'.
   # worksheets_meta: parse-twb-layout meta['worksheets'] (string keys).
   # column_formats: meta['column_formats'] (caption → raw default-format).
-  def emitted_records(elements, worksheets_meta, column_formats = {})
+  # columns_by_guid: meta['columns_by_guid'] — bridges a format key's INTERNAL
+  #   id (`Calculation_AvgBal`) to the CAPTION its column is named by, so the
+  #   ledger stops false-reporting caption-named KPI/measure columns as
+  #   'unmapped' (mirrors build-charts pick_tableau_format's id→caption bridge).
+  def emitted_records(elements, worksheets_meta, column_formats = {}, columns_by_guid = {})
+    id2cap = {}
+    (columns_by_guid || {}).each do |gid, ci|
+      cap = ci.is_a?(Hash) ? ci['caption'].to_s : ''
+      id2cap[gid.to_s] = cap unless cap.empty?
+    end
     recs = []
     Array(elements).each do |el|
       next unless el.is_a?(Hash) && !el['_worksheet'].to_s.empty?
@@ -188,7 +197,10 @@ module FormatMap
         sources[capn] = raw
       end
       sources.each do |fname, raw|
-        col = cols.find { |c| keys_match?(c['name'], fname) }
+        # match the column by the format-key's internal id OR the caption it
+        # resolves to through columns_by_guid.
+        names = [fname, id2cap[fname.to_s]].compact
+        col = cols.find { |c| names.any? { |nm| keys_match?(c['name'], nm) } }
         emitted = col && col['format']
         status = translate(raw) && emitted ? 'mapped' : 'unmapped'
         recs << { 'element_id' => el['id'], 'worksheet' => el['_worksheet'],

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-format-map.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-format-map.rb
@@ -87,6 +87,34 @@ check(t.call('MMM Qq, YYYY').nil?, "unmappable token run ('Qq') → nil, never e
 check(t.call('0.0△').nil?, 'non-format garbage → nil', fails)
 check(t.call('').nil? && t.call(nil).nil?, 'empty/nil → nil', fails)
 
+# ---- 5. emitted_records: internal-id ↔ caption bridge -----------------------
+# Worksheet per-pill format keys are keyed by the field's INTERNAL id
+# (`[usr:Calculation_AOV:qk]`); KPI/measure columns are named by CAPTION
+# ("Average Order Value"). The ledger must resolve the id→caption via
+# columns_by_guid, else it false-reports a correctly-formatted column 'unmapped'.
+kpi_el = {
+  'id' => 'el-kpi-aov', '_worksheet' => 'KPI Panel', '_dashboard' => 'Overview',
+  'columns' => [{ 'id' => 'k1', 'name' => 'Average Order Value',
+                  'format' => { 'kind' => 'number', 'formatString' => '$,.2f', 'currencySymbol' => '$' } }]
+}
+ws_meta = { 'KPI Panel' => { 'formats' => {
+  '[federated.demo].[usr:Calculation_AOV:qk]' => 'n"$"#,##0.00'
+} } }
+cbg = { 'Calculation_AOV' => { 'caption' => 'Average Order Value' } }
+
+with_bridge = FormatMap.emitted_records([kpi_el], ws_meta, {}, cbg)
+rec = with_bridge.first
+check(rec && rec['field'] == 'Calculation_AOV' && rec['source_format'] == 'n"$"#,##0.00' &&
+      rec['status'] == 'mapped' && rec.dig('emitted_format', 'formatString') == '$,.2f',
+      "id→caption bridge: caption-named KPI col maps its internal-id-keyed $ format (got #{rec.inspect})", fails)
+
+# Without the bridge (no columns_by_guid) the internal id cannot reach the
+# caption, so the same row falls back to unmapped — this is exactly the
+# false-negative the bridge removes.
+no_bridge = FormatMap.emitted_records([kpi_el], ws_meta, {})
+check(no_bridge.first && no_bridge.first['status'] == 'unmapped',
+      'without columns_by_guid the internal-id key cannot match the caption (pre-fix behavior)', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — FormatMap: numbers, dates→d3-time, literal-format hazard refused'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-value-fidelity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-value-fidelity.rb
@@ -129,7 +129,10 @@ check(translate_kpi_measure_formula('[Ghost Col]/[Cost (copy)_30000000003]', RMM
 # ---- v5.0 exact-format Text() columns for scale-comma + suffix formats ------
 # Tableau '#,##0,,,B' renders "1B"; Sigma's d3 enum can't (,.2s shows SI 'G').
 # The mechanized fidelity recipe: parse the scale/suffix, emit a Text() column.
-%w[parse_scaled_suffix_format scaled_suffix_column pick_tableau_format_raw].each do |fn|
+# FORMAT_KEY_CAPTIONS is normally built from meta['columns_by_guid'] at load;
+# stub it empty so format_key_match_keys resolves format keys on their own token.
+FORMAT_KEY_CAPTIONS = {} unless defined?(FORMAT_KEY_CAPTIONS)
+%w[format_key_match_keys parse_scaled_suffix_format scaled_suffix_column pick_tableau_format_raw].each do |fn|
   m = SRC.match(/^def #{fn}\b.*?\n^end$/m) or abort("could not extract #{fn}")
   eval(m[0]) # rubocop:disable Security/Eval
 end


### PR DESCRIPTION
## What

KPI/measure columns whose Tableau **source format is keyed by the field's internal calc id** were shipping the wrong number format — a currency KPI printed raw (`,.0f`, no `$`, no decimals) and a percentage that contained a currency word got a bogus `$`. They only rendered correctly after a manual spec patch. This makes the source format resolve **mechanically**.

## Root cause

A worksheet's per-pill format map is keyed by the field's **internal id** (`[usr:Calculation_AvgBal:qk]`), but a KPI/measure column is named by its **caption** (e.g. "Avg Balance per User"). `pick_tableau_format` compared the internal id against the caption, missed, and fell through to the name-based heuristic. So:

- a `n"$"#,##0.00` KPI → heuristic `,.0f` (raw)
- a `n#,##0.00` KPI → heuristic `,.0f`
- a `p0.0%` KPI whose caption contained a currency word → heuristic **`$,.0f`** (a `$` on a percentage)

The format translator itself already maps all of these strings correctly — the gap was **upstream name resolution**, so this change does **not** touch `translate()`.

## Fix

- **id↔caption bridge** (`format_key_match_keys`): resolve a format key's internal id → caption via `columns_by_guid`, so `pick_tableau_format` / `pick_tableau_format_raw` match on either the key's own token **or** its caption. The source format now reaches the translator for caption-named columns.
- **ledger**: `FormatMap.emitted_records` takes `columns_by_guid` and applies the same bridge, so the mechanical formats-coverage artifact stops false-reporting correctly-formatted columns as `unmapped`.
- **heuristic guard**: the last-resort name heuristic (unified in `heuristic_number_format`) now lets **percent detection win over the currency guess** — a percentage never gets a currency symbol again.

## Before → after (same inputs, mechanical build, no hand-patch)

| KPI source format | before (heuristic) | after (source, mechanical) |
|---|---|---|
| `n"$"#,##0.00` | `,.0f` | `$,.2f` + `$` |
| `n#,##0.00` | `,.0f` | `,.2f` |
| `p0.0%` (currency-word caption) | `$,.0f` (bogus `$`) | `,.1%` |

`formats-emitted.json`: the primary KPI rows flip `unmapped` → `mapped`.

## Validation

- **Local**: `test-format-map` (new id↔caption bridge case + pre-fix negative), `test-kpi-value-fidelity`, `test-series-scheme-emission`, `test-brand-palette`, `test-theme-derivation`, `test-style-normalize` green; full unit suite 172 pass (the 2 remaining failures pre-exist on `main` and are unrelated — one needs a Tableau token/fixture, one is a governance-audit gap).
- **Byte-identical**: a workbook with no currency/percent KPI formats builds byte-for-byte identically to `main` (17,585-byte chart-specs, `cmp` clean).
- **Corpus 17/17**; `check-shared`, `hygiene-sweep`, `lint-twb-encoding` clean.
- **Live** (currency-KPI workbook, DM-sourced tiles): the KPIs render **`$167.89` / `1.03` / `103.3%`** mechanically from the `.twb`, with **no format hand-patch**. Readback confirms the emitted formats `$,.2f` + `$` / `,.2f` / `,.1%`.
- **Speed**: pure lookup-path change — no new build/layout round-trips, single build pass unchanged. `build-charts` phase mean wall-time 155 ms (base) vs 163 ms (fix) over 3 runs — within run-to-run noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
