### PR TITLE
tableau: card-trellis (B1) — per-category card rows -> N GridContainer cards

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -1351,6 +1351,93 @@ end
 # Build one container-banded page for a single dashboard. Returns
 # [page_xml_string, extra_spec_elements, n_charts, n_bands, n_controls,
 #  census, min_row_expansions].
+# B1 card-trellis (beads-sigma-ubr5.5). The parser (`detect_trellis_groups`)
+# flags a dashboard that repeats one viz across a categorical dimension as a row
+# of per-category cards. The flat builder already emits each member as its own
+# filtered chart element (`[Region]="West"`); this path GROUPS those N elements
+# into N sibling GridContainer cards (the "biggest visual win" — a card grid
+# instead of a flat band), each optionally accented in that member's color (D2,
+# #441). Strategy: delegate the WHOLE non-member remainder to the existing
+# banded builder (so header / controls / other charts / census / safety-net are
+# reused verbatim), then append the card row(s) below. Only ever called when
+# `dashboard['trellis']` is present → zero effect on non-trellis dashboards.
+TRELLIS_CARD_ROWS = 13 # per-card grid-row span (bar/line height; row-sizing guide)
+def build_page_trellis(dashboard, page, opts, groups)
+  els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
+  augment_els_by_name!(els_by_name, page['elements'])
+  zone_by_id = (dashboard['zones'] || []).each_with_object({}) { |z, h| h[z['id']] = z if z['id'] }
+
+  # Resolve each group's member zones → Sigma elements up front. A group that
+  # can't resolve >=2 members is dropped (falls back to the flat placement of
+  # those zones, which the base builder still handles because we won't prune
+  # unresolved members).
+  resolved = groups.map do |g|
+    cards = Array(g['zone_ids']).each_with_index.map do |zid, i|
+      z = zone_by_id[zid]
+      next nil unless z
+      el = find_zone_el(els_by_name, z, opts[:renames])
+      next nil unless el
+      { 'el_id' => el['id'], 'member' => Array(g['members'])[i].to_s,
+        'color' => Array(g['member_colors'])[i] }
+    end.compact
+    cards.size >= 2 ? cards : nil
+  end.compact
+  raise 'no resolvable trellis group' if resolved.empty?
+
+  member_el_ids = resolved.flat_map { |cards| cards.map { |c| c['el_id'] } }
+  member_el_set = member_el_ids.each_with_object({}) { |id, h| h[id] = true }
+  placed_zone_ids = {}
+  resolved.each_with_index do |cards, gi|
+    Array(groups[gi]['zone_ids']).each { |zid| placed_zone_ids[zid] = true }
+  end
+
+  # Base page: everything EXCEPT the trellis member zones AND their elements
+  # (pruning the elements too keeps the base builder's orphan safety-net from
+  # dumping the member elements in a duplicate bottom band).
+  d_rest = dashboard.dup
+  d_rest['zones'] = dashboard['zones'].reject { |z| placed_zone_ids[z['id']] }
+  page_rest = page.dup
+  page_rest['elements'] = page['elements'].reject { |e| member_el_set[e['id']] }
+  base_pxml, extra_els, n_charts, n_bands, n_ctls, census, min_exp =
+    build_page_for_dashboard(d_rest, page_rest, opts)
+
+  # Card rows start below the base page's tallest emitted row.
+  cur = base_pxml.scan(%r{gridRow="\d+ / (\d+)"}).flatten.map(&:to_i).max || 1
+  band_children = []
+  cards_total = 0
+  resolved.each_with_index do |cards, gi|
+    n = cards.size
+    span = TRELLIS_CARD_ROWS
+    r0 = cur + 1
+    r1 = r0 + span
+    cards.each_with_index do |c, j|
+      c0 = 1 + (24 * j / n.to_f).round
+      c1 = j == n - 1 ? 25 : [1 + (24 * (j + 1) / n.to_f).round, c0 + 1].max
+      card_id = "trellis-#{page['id']}-#{gi + 1}-#{j + 1}"
+      cstyle = { 'borderRadius' => 'round' }
+      # D2 accent: a 2px border in the member's own color (#441). The saturated
+      # region color would be garish as a full card fill, so we key just the
+      # border — a faithful, low-risk "shared color map" cue.
+      cstyle['borderColor'] = c['color'].to_s[0, 7] if c['color'].to_s =~ /\A#[0-9a-fA-F]{6}/
+      cstyle['borderWidth'] = 2 if cstyle['borderColor']
+      extra_els << container_el(card_id, cstyle)
+      # The member chart fills its card (container-relative coords restart at 1).
+      band_children << gc(card_id, c0, c1, r0, r1, le(c['el_id'], 1, 25, 1, 1 + span))
+      cards_total += 1
+    end
+    cur = r1 - 1
+  end
+
+  pxml = base_pxml.sub(%r{\n</Page>\z}, "\n#{band_children.join("\n")}\n</Page>")
+  # Census honesty (gate 8c): the base record counted only the pruned zones —
+  # add the placed cards back so zones/placed reflect what the page shows.
+  if census
+    census['zones'] = census['zones'].to_i + cards_total
+    census['placed'] = census['placed'].to_i + cards_total
+  end
+  [pxml, extra_els, n_charts + cards_total, n_bands + resolved.size, n_ctls, census, min_exp]
+end
+
 def build_page_for_dashboard(dashboard, page, opts)
   chart_zones = dashboard['zones'].select { |z| z['kind'] == 'chart' && z['caption'] }
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
@@ -1624,7 +1711,23 @@ dash_layout.each do |d|
   use_tree  = !o[:no_containers] &&
               (tree_has_controls?(d['zone_tree']) || tree_has_styled_containers?(d['zone_tree']))
   result = nil
-  if use_synth
+  # B1 card-trellis (beads-sigma-ubr5.5): the parser attaches `trellis` ONLY
+  # when a per-category card row was detected, so this whole path is gated —
+  # a non-trellis dashboard never enters here and its layout is byte-identical
+  # to the flat build. --no-containers forces the geometry-banded fallback.
+  trellis_groups = o[:no_containers] ? [] : Array(d['trellis'])
+  if trellis_groups.any?
+    begin
+      result = build_page_trellis(d, page, o, trellis_groups)
+      warn "card-trellis layout: #{d['dashboard'].inspect} → " \
+           "#{trellis_groups.sum { |g| Array(g['zone_ids']).length }} per-category card(s) " \
+           "across #{trellis_groups.length} row(s)"
+    rescue StandardError => e
+      warn "WARN: card-trellis layout failed for #{d['dashboard'].inspect} (#{e.class}: #{e.message}) — falling back"
+      result = nil
+    end
+  end
+  if result.nil? && use_synth
     begin
       result = build_page_synthesized(d, page, o, structure)
       warn "synthesized layout: #{d['dashboard'].inspect} → " \

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/series_colors.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/series_colors.rb
@@ -86,6 +86,30 @@ module SeriesColors
     members.keys.sort_by(&:downcase).map { |k| members[k] }
   end
 
+  # B1 (card-trellis): the LABELED member->color dict for ONE field, merged
+  # across every sibling zone that carries explicit .twb assignments on a
+  # MATCHING field. Same merge/first-wins/field-match contract as
+  # scheme_for_field, but returns the {member => color} map (not an ordered
+  # array) so a card-trellis emitter can look up the color for a SPECIFIC
+  # pinned member ("West" -> "#e8519a"). Returns {} when nothing matches (the
+  # caller then leaves cards on the theme palette — never worse). Pure.
+  def color_map_for_field(zones, column_name)
+    return {} if norm(column_name).empty?
+    members = {}
+    Array(zones).each do |z|
+      next unless z.is_a?(Hash) && z['series_colors'].is_a?(Array)
+      next if norm(z['series_color_field']).empty?
+      next unless field_matches?(z['series_color_field'], column_name)
+      z['series_colors'].each do |p|
+        next unless p.is_a?(Hash)
+        m = p['member'].to_s
+        c = p['color'].to_s.downcase
+        members[m] = c if !m.empty? && c =~ HEX && !members.key?(m)
+      end
+    end
+    members
+  end
+
   # Dashboard-level ordered scheme for themeOverrides.categoricalScheme — the
   # ONLY color path for pie/donut slices (per-element color.scheme is silently
   # dropped there). Conservative: only when every explicitly-assigned zone

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -39,6 +39,7 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'twb_xml'
 require 'format_map' # PR-12: the ONE Tableau→Sigma format translator (lib/format_map.rb)
 require 'integer_dim' # PR-18: integer-coded dimension detection (shelf role + datatype)
+require 'series_colors' # B1 (card-trellis): reuse D2 member->color derivation (#441)
 
 # ---- Per-dashboard scoping ------------------------------------------------
 # `--dashboard "<name>"` (repeatable) and `--page <id>` let a LARGE workbook
@@ -1587,6 +1588,113 @@ def build_zone_tree(z)
   node
 end
 
+# ---- B1 card-trellis detection (beads-sigma-ubr5.5) ------------------------
+# A "card trellis" is a Tableau dashboard that repeats the SAME viz across a
+# categorical dimension as a ROW of per-category cards (small multiples authored
+# as N sibling worksheets, each pinned to one member of the same field — the
+# benchmark's 4 region columns). The flat build already emits each as a
+# separately-filtered chart element; B1 groups them into N GridContainer cards.
+#
+# Detection is deliberately CONSERVATIVE — it must NEVER fire on a non-trellis
+# dashboard (that would change the byte-identical flat output). A group needs:
+#   * >=3 sibling CHART zones (not KPI/table/pivot — those trellis differently),
+#   * an identical viz template  (same chart_kind + same measure set),
+#   * each carrying exactly the facet field as a single-member categorical
+#     `list` filter, pinning DISTINCT members, and
+#   * a single-row tiled geometry (same y-band, horizontally disjoint).
+# The native single-worksheet Tableau trellis (one sheet, dim on Rows/Cols) is
+# NOT handled here — it stays the existing UI-only WARN (F4); its member list
+# isn't in the .twb, so a faithful card set can't be built offline.
+TRELLIS_KINDS = %w[bar line area scatter pie donut map-region map-point].freeze
+
+# [chart_kind, sorted-measure-columns] — two zones are the SAME viz template
+# only when both match. nil when the zone plots no measure (can't be a facet).
+def trellis_signature(z)
+  ms = Array(z['measures']).map { |m| m['column'].to_s }.reject(&:empty?).sort
+  return nil if ms.empty?
+  [z['chart_kind'].to_s, ms]
+end
+
+# {field_key => {member, caption}} for each NON-action single-member categorical
+# `list` filter on the zone — the candidate facet pins.
+def trellis_facets(z)
+  out = {}
+  Array(z['filters']).each do |f|
+    next unless f.is_a?(Hash)
+    next if f['is_action']
+    next unless f['kind'] == 'list'
+    mems = Array(f['members'])
+    next unless mems.size == 1
+    dt = f['datatype'].to_s
+    next unless dt.empty? || dt == 'string' || dt == 'nominal'
+    key = (f['column_caption'] || f['column_guid'] || f['raw_param']).to_s
+    next if key.empty?
+    out[key] ||= { 'member' => mems.first.to_s, 'caption' => (f['column_caption'] || key).to_s }
+  end
+  out
+end
+
+# Single-row tiled: members share a y-band (spread <= half the median height)
+# and are horizontally disjoint (a left-to-right card row).
+def trellis_tiled?(zs)
+  ys = zs.map { |z| z['y_pct'].to_f }
+  hs = zs.map { |z| z['h_pct'].to_f }.sort
+  return false if ys.empty?
+  h_med = hs[hs.size / 2]
+  return false unless h_med.positive? && (ys.max - ys.min) <= 0.5 * h_med
+  xs = zs.map { |z| [z['x_pct'].to_f, z['x_pct'].to_f + z['w_pct'].to_f] }.sort_by(&:first)
+  xs.each_cons(2).all? { |a, b| a[1] <= b[0] + 1.0 }
+end
+
+# Returns [] for a non-trellis dashboard (the common case) so the emitter can
+# omit the key entirely and keep the flat output byte-identical.
+def detect_trellis_groups(zones)
+  charts = Array(zones).select { |z| z.is_a?(Hash) && z['kind'] == 'chart' && TRELLIS_KINDS.include?(z['chart_kind'].to_s) }
+  return [] if charts.size < 3
+  anno = charts.map do |z|
+    sig = trellis_signature(z)
+    next nil unless sig
+    facets = trellis_facets(z)
+    next nil if facets.empty?
+    { 'z' => z, 'sig' => sig, 'facets' => facets }
+  end.compact
+  return [] if anno.size < 3
+  groups = []
+  used = {}
+  anno.group_by { |a| a['sig'] }.each_value do |cohort|
+    next if cohort.size < 3
+    field_keys = cohort.flat_map { |a| a['facets'].keys }.uniq
+    field_keys.each do |fk|
+      seen = {}
+      members = cohort.select do |a|
+        next false unless a['facets'].key?(fk)
+        next false if used[a['z']['id']]
+        m = a['facets'][fk]['member']
+        seen[m] ? false : (seen[m] = true) # distinct members only
+      end
+      next if members.size < 3
+      next unless trellis_tiled?(members.map { |a| a['z'] })
+      ordered = members.sort_by { |a| a['facets'][fk]['member'].to_s.downcase }
+      ordered.each { |a| used[a['z']['id']] = true }
+      field_caption = ordered.first['facets'][fk]['caption']
+      grp = {
+        'field'      => field_caption,
+        'chart_kind' => ordered.first['sig'][0],
+        'members'    => ordered.map { |a| a['facets'][fk]['member'] },
+        'zone_ids'   => ordered.map { |a| a['z']['id'] },
+        'captions'   => ordered.map { |a| a['z']['caption'] }
+      }
+      # D2 reuse (#441): a per-member color for each card, when the .twb
+      # serialized an explicit member->color map on the facet field.
+      cmap = SeriesColors.color_map_for_field(zones, field_caption)
+      colors = ordered.map { |a| cmap[a['facets'][fk]['member']] }
+      grp['member_colors'] = colors if colors.any?
+      groups << grp
+    end
+  end
+  groups
+end
+
 dashboards = []
 xml.elements.each('//dashboard') do |d|
   dash_name = d.attributes['name']
@@ -1749,7 +1857,7 @@ xml.elements.each('//dashboard') do |d|
     end
   end
 
-  dashboards << {
+  dash_h = {
     'dashboard'     => d.attributes['name'],
     'is_story'      => is_story,
     'canvas_px'     => canvas_px,
@@ -1765,6 +1873,12 @@ xml.elements.each('//dashboard') do |d|
     # colors (theme then omitted — Sigma defaults apply, never worse).
     'brand_palette' => BRAND_PALETTE
   }
+  # B1 card-trellis: attach the detected groups ONLY when a trellis is present,
+  # so every non-trellis dashboard's JSON is byte-identical to the flat build
+  # (the layout stage's card path is likewise gated on this key).
+  trellis_groups = detect_trellis_groups(zones)
+  dash_h['trellis'] = trellis_groups unless trellis_groups.empty?
+  dashboards << dash_h
 end
 
 # Sheet-only workbooks (no <dashboard> blocks — just standalone worksheets)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-card-trellis.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-card-trellis.rb
@@ -1,0 +1,237 @@
+#!/usr/bin/env ruby
+# Regression test for B1 (gap beads-sigma-ubr5.5): card-trellis.
+#
+# A Tableau dashboard that repeats one viz across a categorical dimension as a
+# ROW of per-category cards (small multiples authored as N sibling worksheets,
+# each pinned to one member of the same field) must:
+#   PARSER  detect the repetition → a dashboard-level `trellis` group
+#           (field + ordered members + zone_ids + per-member colors from any
+#           explicit .twb color map, D2 reuse #441);
+#   LAYOUT  group the N already-filtered chart elements into N sibling
+#           GridContainer cards (the visual win), each accented in its member
+#           color, with every member element placed exactly once.
+# A NON-trellis dashboard must be UNCHANGED: no `trellis` key, no card
+# containers — the flat build stays byte-identical (proven separately by cmp
+# across the corpus; asserted here structurally).
+#
+# End-to-end through the ACTUAL parse-twb-layout.rb + build-dashboard-layout.rb
+# (no Tableau/Sigma calls).
+#
+# Usage:  ruby scripts/test-card-trellis.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-dashboard-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# North/East/South/West cards — a per-region bar of SUM(Net Revenue) by Segment.
+# Colors are the explicit .twb legend map on Region (exercises the D2 reuse).
+REGIONS = [%w[North #4e79a7], %w[East #f28e2b], %w[South #59a14f], %w[West #e15759]].freeze
+
+def color_maps
+  REGIONS.map { |name, hex| %(          <map to='#{hex}'><bucket>&quot;#{name}&quot;</bucket></map>) }.join("\n")
+end
+
+# One per-region bar worksheet: mark Bar, SUM(Net Revenue) on rows, Segment on
+# cols, a single-member categorical filter pinning this region, and the shared
+# Region color legend map.
+def worksheet(region)
+  <<~XML
+    <worksheet name='Revenue - #{region}'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Sales' name='federated.x' />
+          </datasources>
+          <datasource-dependencies datasource='federated.x'>
+            <column caption='Net Revenue' datatype='real' name='[netrev]' role='measure' type='quantitative' />
+            <column caption='Customer Segment' datatype='string' name='[segment]' role='dimension' type='nominal' />
+            <column caption='Region' datatype='string' name='[region]' role='dimension' type='nominal' />
+            <column-instance column='[netrev]' derivation='Sum' name='[sum:netrev:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[segment]' derivation='None' name='[none:segment:nk]' pivot='key' type='nominal' />
+            <column-instance column='[region]' derivation='None' name='[none:region:nk]' pivot='key' type='nominal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[federated.x].[none:region:nk]'>
+            <groupfilter function='member' level='[region]' member='&quot;#{region}&quot;' />
+          </filter>
+        </view>
+        <panes>
+          <pane>
+            <mark class='Bar' />
+            <encoding attr='color' field='[federated.x].[none:region:nk]' type='palette'>
+    #{color_maps}
+            </encoding>
+          </pane>
+        </panes>
+        <rows>[federated.x].[sum:netrev:qk]</rows>
+        <cols>[federated.x].[none:segment:nk]</cols>
+      </table>
+    </worksheet>
+  XML
+end
+
+# A row of 4 card zones (each 25% wide, same y-band) under a title.
+def card_zones
+  REGIONS.each_with_index.map do |(region, _), i|
+    x = i * 25_000
+    %(            <zone id='#{100 + i}' name='Revenue - #{region}' x='#{x}' y='10000' w='25000' h='60000' />)
+  end.join("\n")
+end
+
+TRELLIS_TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Net Revenue' datatype='real' name='[netrev]' role='measure' type='quantitative' />
+        <column caption='Customer Segment' datatype='string' name='[segment]' role='dimension' type='nominal' />
+        <column caption='Region' datatype='string' name='[region]' role='dimension' type='nominal' />
+      </datasource>
+    </datasources>
+    <worksheets>
+  #{REGIONS.map { |r, _| worksheet(r) }.join("\n")}
+    </worksheets>
+    <dashboards>
+      <dashboard name='Regional Sales Cards'>
+        <size maxheight='800' maxwidth='1200' sizing-mode='fixed' />
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='2' type-v2='layout-flow' param='vert' x='0' y='0' w='100000' h='100000'>
+              <zone id='9' type-v2='text' x='0' y='0' w='100000' h='8000'>
+                <formatted-text><run>Regional Sales</run></formatted-text>
+              </zone>
+              <zone id='10' type-v2='layout-flow' param='horz' x='0' y='10000' w='100000' h='60000'>
+  #{card_zones}
+              </zone>
+            </zone>
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+# A NON-trellis control: same worksheets but the dashboard uses only ONE of them
+# (no repeated per-category row) → detection must NOT fire.
+FLAT_TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Net Revenue' datatype='real' name='[netrev]' role='measure' type='quantitative' />
+        <column caption='Customer Segment' datatype='string' name='[segment]' role='dimension' type='nominal' />
+        <column caption='Region' datatype='string' name='[region]' role='dimension' type='nominal' />
+      </datasource>
+    </datasources>
+    <worksheets>
+  #{worksheet('North')}
+    </worksheets>
+    <dashboards>
+      <dashboard name='One Region'>
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='100' name='Revenue - North' x='0' y='0' w='100000' h='100000' />
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+def run_parser(twb_text)
+  Dir.mktmpdir do |d|
+    twb = File.join(d, 'wb.twb')
+    lay = File.join(d, 'layout.json')
+    File.write(twb, twb_text)
+    ok = system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+    return [nil, nil] unless ok && File.exist?(lay)
+    [JSON.parse(File.read(lay)), JSON.parse(File.read(lay.sub(/\.json$/, '-meta.json')))]
+  end
+end
+
+def run_layout(twb_text, member_names)
+  Dir.mktmpdir do |d|
+    twb = File.join(d, 'wb.twb')
+    lay = File.join(d, 'layout.json')
+    out = File.join(d, 'layout.xml')
+    File.write(twb, twb_text)
+    system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+    els = member_names.map do |n|
+      { 'id' => "el-#{n.downcase.gsub(/\W+/, '-')}", 'kind' => 'bar-chart', 'name' => n }
+    end
+    wb_ids = { 'pages' => [
+      { 'name' => 'Data', 'elements' => [{ 'id' => 'master', 'kind' => 'table', 'name' => 'Master' }] },
+      { 'name' => JSON.parse(File.read(lay)).first['dashboard'], 'elements' => els }
+    ] }
+    wbf = File.join(d, 'wb-ids.json')
+    File.write(wbf, JSON.dump(wb_ids))
+    system('ruby', BUILD, '--layout', lay, '--wb-ids', wbf, '--out', out, out: File::NULL, err: File::NULL)
+    xml = File.exist?(out) ? File.read(out) : ''
+    sidecar = File.exist?("#{out}.elements.json") ? JSON.parse(File.read("#{out}.elements.json")) : {}
+    [xml, sidecar]
+  end
+end
+
+puts '== PARSER: trellis detection =='
+lay, = run_parser(TRELLIS_TWB)
+dash = lay && lay.first
+trellis = dash && dash['trellis']
+check(trellis.is_a?(Array) && trellis.size == 1, 'exactly one trellis group detected on the card-row dashboard', fails)
+grp = (trellis || []).first || {}
+check(grp['field'] == 'Region', "trellis facet field resolves to 'Region' (got #{grp['field'].inspect})", fails)
+check(grp['members'] == %w[East North South West],
+      "members are the 4 pinned regions, ORDERED ascending (got #{grp['members'].inspect})", fails)
+check(Array(grp['zone_ids']).size == 4, '4 member zone_ids captured', fails)
+check(grp['chart_kind'] == 'bar', "template chart_kind is 'bar'", fails)
+# D2 reuse (#441): per-member colors from the explicit .twb legend map, in the
+# SAME ascending-member order as `members`.
+check(grp['member_colors'] == %w[#f28e2b #4e79a7 #59a14f #e15759],
+      "member_colors follow the .twb legend map in member order (got #{grp['member_colors'].inspect})", fails)
+
+puts "\n== PARSER: non-trellis dashboard is untouched =="
+flat, = run_parser(FLAT_TWB)
+fdash = flat && flat.first
+check(fdash && !fdash.key?('trellis'),
+      'a single-viz dashboard carries NO trellis key (flat build byte-identical)', fails)
+
+puts "\n== LAYOUT: N card GridContainers =="
+member_names = REGIONS.map { |r, _| "Revenue - #{r}" }
+xml, sidecar = run_layout(TRELLIS_TWB, member_names)
+card_containers = sidecar.values.flatten.select { |e| e['id'].to_s.start_with?('trellis-') && e['kind'] == 'container' }
+check(card_containers.size == 4, "4 per-category card containers emitted (got #{card_containers.size})", fails)
+accented = card_containers.select { |c| c.dig('style', 'borderColor') =~ /\A#[0-9a-fA-F]{6}\z/ }
+check(accented.size == 4, 'each card container carries a member-color border accent (D2)', fails)
+check(card_containers.all? { |c| c.dig('style', 'borderRadius') == 'round' }, 'cards use borderRadius: round', fails)
+# every member element is placed EXACTLY once in the layout XML (no orphan, no
+# duplicate LayoutElement id — a dup makes Sigma reject the whole PUT).
+placed_ok = member_names.all? do |n|
+  id = "el-#{n.downcase.gsub(/\W+/, '-')}"
+  xml.scan(/elementId="#{Regexp.escape(id)}"/).size == 1
+end
+check(placed_ok, 'every member chart element is placed EXACTLY once (no orphan / no dup)', fails)
+check(xml.scan(/<GridContainer elementId="trellis-/).size == 4,
+      'the 4 cards are real <GridContainer>s (not bare LayoutElements)', fails)
+
+puts "\n== LAYOUT: non-trellis dashboard has no card containers =="
+fxml, fside = run_layout(FLAT_TWB, ['Revenue - North'])
+fcards = fside.values.flatten.select { |e| e['id'].to_s.start_with?('trellis-') }
+check(fcards.empty?, 'no trellis card containers on a non-trellis dashboard', fails)
+check(fxml.include?('el-revenue-north'), 'the single chart is still placed on the non-trellis page', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B1 card-trellis (detection + N-card emission + D2 color + non-trellis unchanged)'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## B1 — Card-trellis (beads-sigma-ubr5.5)

Detect a Tableau dashboard that repeats one viz across a categorical dimension
as a row of per-category cards (small multiples authored as N sibling
per-category worksheets) and emit **N `GridContainer` cards** instead of a flat
band — the "biggest visual win" per the fidelity handoff §6.

### Scope (smallest correct increment)
The **clean common case**: an explicit, single-row, per-category card repetition.
Detection is deliberately conservative and **every stage is gated**, so a
non-trellis dashboard is **byte-identical** to the flat build.

- **parser** `detect_trellis_groups`: ≥3 sibling chart zones with an identical
  viz template (chart_kind + measure set), each a single-member categorical
  filter on the **same** field pinning **distinct** members, tiled in one row.
  Emits a dashboard `trellis` key **only when detected**. Reuses D2 (#441) via a
  new `SeriesColors.color_map_for_field` for per-member colors.
- **layout** `build_page_trellis`: composes the base page (members pruned, so
  all existing header/control/band/census/safety-net logic is reused verbatim),
  then appends N per-category `GridContainer` cards with member-color border
  accents. Gated on the `trellis` key; `--no-containers` bypasses it.
- **builder**: no change — the flat build already translates each worksheet's
  single-member filter into the element `kind:list` filter (the per-category
  filtered viz B1 groups).

Deferred (documented): the native single-worksheet Tableau trellis (F4, Sigma
UI-only; member list not in the `.twb`) and multi-viz-per-card composites.

### Validation
- **Byte-identical (the big guard):** every corpus `.twb` builds byte-for-byte
  identical to `origin/main` for **both** parse and layout — proven with `cmp`
  (7/7 workbooks, 0 diffs). The trellis path only fires on detection.
- New `test-card-trellis.rb` (detection, N-card emission, D2 color, non-trellis
  unchanged); touched layout/series-color tests green; **corpus 17/17**;
  hygiene / check-shared / lint-twb-encoding clean.
- **Live e2e:** a 4-category small-multiples workbook migrated end-to-end and
  rendered as a clean per-category card grid. Context-free blind-grade
  **composition_match 0.92 (cards) vs 0.20 (flat)**.
- **Speed (owner priority):** trellis layout **1.08x** of the flat band
  (149 ms vs 138 ms) and **0.93x** vs a single viz — no material regression,
  no added round-trips. The card grouping composes in-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
