### PR TITLE
resolver: re-mint budget + full error on the PDS-resolve 401 path (#422)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -206,6 +206,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-hydrate-custom-sql.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-pds-resolve-retry.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-score.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-aggregate-dimension.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/resolve-published-ds.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/resolve-published-ds.rb
@@ -84,6 +84,44 @@ def descriptor_from_tds(tds_text)
   end
 end
 
+# --- transient-401 survivability -------------------------------------------
+# The PDS-resolve Tableau calls below used to run with ONLY lib/tableau_rest.rb's
+# single inline 401 refresh (request: res.code==401 && attempts==1 → refresh_token!).
+# A 401 that RACES that one retry — a startup / session-signin race, common when a
+# freshly minted token is used before its server-side session is fully live —
+# escaped with no cushion. And because a dropped PDS is (correctly) treated as
+# "abort rather than fabricate a phantom relation" (refs/multi-datasource.md), a
+# single transient 401 on this path took the WHOLE migration down. The discovery
+# path never had this problem: tableau-discover.rb#run_task gives every fetch an
+# outer re-mint budget on a 401 that escapes the lib retry. Give the two PDS
+# calls the SAME budget here. A genuine NON-401 failure (e.g. 403 "no Download
+# capability") is NOT retried — it re-raises at once so the abort-don't-fabricate
+# contract still fails loudly rather than being masked.
+def with_remint_on_401(label, max_attempts: 3)
+  attempts = 0
+  begin
+    attempts += 1
+    yield
+  rescue Tableau::Error => e
+    if attempts < max_attempts && e.message.to_s =~ /\b401\b/
+      warn "  ↻ #{label}: 401 escaped the lib retry — re-minting token (attempt #{attempts}/#{max_attempts})"
+      Tableau.refresh_token! rescue nil
+      sleep 1.0 + rand * 0.5
+      retry
+    end
+    raise
+  end
+end
+
+# Generously-excerpted Tableau error for the log — NOT `e.message.lines.first`,
+# which dropped everything after the status line (the HTTP status detail AND the
+# response body), making a real 403 "no Download capability" indistinguishable
+# from a transient signin-race 401. Tableau error bodies never carry credential
+# values, so the excerpt is safe to log verbatim; the cap just bounds a runaway body.
+def tableau_error_detail(e, limit: 800)
+  e.message.to_s.strip[0, limit]
+end
+
 doc = REXML::Document.new(File.read(opts[:twb], encoding: 'UTF-8'))
 descriptors = []
 seen = {}
@@ -96,9 +134,11 @@ doc.each_element('/workbook/datasources/datasource') do |ds|
   seen[content_url] = true
 
   rec = begin
-    Tableau.find_datasource_by_content_url(content_url)
+    with_remint_on_401("PDS lookup for contentUrl=#{content_url.inspect}") do
+      Tableau.find_datasource_by_content_url(content_url)
+    end
   rescue Tableau::Error => e
-    warn "  ⚠ PDS lookup failed for contentUrl=#{content_url.inspect}: #{e.message.lines.first&.chomp}"
+    warn "  ⚠ PDS lookup failed for contentUrl=#{content_url.inspect}: #{tableau_error_detail(e)}"
     nil
   end
   unless rec && rec['id']
@@ -107,7 +147,9 @@ doc.each_element('/workbook/datasources/datasource') do |ds|
   end
 
   begin
-    bytes = Tableau.download_datasource_content(rec['id'])
+    bytes = with_remint_on_401("content download for PDS #{content_url.inspect}") do
+      Tableau.download_datasource_content(rec['id'])
+    end
     tds = tds_text_from(bytes)
     d = tds && descriptor_from_tds(tds)
     unless d
@@ -122,7 +164,7 @@ doc.each_element('/workbook/datasources/datasource') do |ds|
     detail = d['relationType'] == 'text' ? "Custom SQL, #{d['columns'].size} col(s)" : "table #{d['table']}"
     warn "  resolved PDS #{rec['name'].inspect} (#{content_url}) → #{detail}"
   rescue Tableau::Error => e
-    warn "  ⚠ content download failed for PDS #{content_url.inspect}: #{e.message.lines.first&.chomp}"
+    warn "  ⚠ content download failed for PDS #{content_url.inspect}: #{tableau_error_detail(e)}"
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-pds-resolve-retry.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-pds-resolve-retry.rb
@@ -1,0 +1,176 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the PDS-resolver 401 retry asymmetry (issue #422).
+#
+# resolve-published-ds.rb makes two Tableau calls per published data source —
+# find_datasource_by_content_url (the PDS lookup) and download_datasource_content
+# (the content download). They USED to run with ONLY lib/tableau_rest.rb#request's
+# single inline 401-refresh, unlike the discovery path (tableau-discover.rb#run_task)
+# which additionally re-mints on a 401 that escapes the lib retry. So a single
+# transient signin-race 401 on the resolve path had no cushion, and — because a
+# dropped PDS is (correctly) treated as "abort rather than fabricate a phantom
+# relation" — it took the whole migration down. The rescued error was also
+# truncated to `e.message.lines.first`, dropping the HTTP body, so a real 403
+# "no Download capability" looked identical to a transient 401 in the log.
+#
+# The fix: with_remint_on_401 gives both calls the discovery-path re-mint budget,
+# and tableau_error_detail logs a generous excerpt (status + body), not line 1.
+#
+# Proven with a STUBBED Tableau lib (the script + its real hydrate/zip libs are
+# copied to a tmpdir whose lib/ carries a stub tableau_rest.rb, so no network is
+# possible). Each scenario is driven by ENV read by the stub. Offline.
+#
+# Usage: ruby scripts/test-pds-resolve-retry.rb
+
+require 'json'
+require 'tmpdir'
+require 'fileutils'
+require 'rbconfig'
+
+DIR = __dir__
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+# Stub Tableau REST: no network. Behaviour is selected by ENV['STUB_SCENARIO'];
+# every re-mint is appended to STUB_LOG so the test can assert the outer 401
+# budget actually fired. Classic method defs — the skills target Ruby 2.6.
+STUB = <<~'RUBY'
+  require 'json'
+  module Tableau
+    class Error < StandardError; end
+    @lookup_calls = 0
+    @download_calls = 0
+    @remints = 0
+
+    def self.rec_remint
+      @remints += 1
+      File.open(ENV.fetch('STUB_LOG'), 'a') { |f| f.puts("REMINT #{@remints}") }
+    end
+
+    # A realistic lib-shaped error: status line THEN response body on later lines,
+    # exactly like lib/tableau_rest.rb#request builds ("METHOD path -> CODE msg\nbody").
+    def self.err(code, msg, body)
+      Error.new("GET /api/3.22/sites/s/datasources -> #{code} #{msg}\n#{body}")
+    end
+
+    def self.find_datasource_by_content_url(content_url)
+      @lookup_calls += 1
+      case ENV['STUB_SCENARIO']
+      when 'lookup_401_then_ok'
+        raise err(401, 'Unauthorized', '<error><summary>Signin race</summary></error>') if @lookup_calls == 1
+      end
+      { 'id' => 'ds-luid-1', 'name' => 'PubOrders' }
+    end
+
+    def self.download_datasource_content(_id, include_extract: false)
+      @download_calls += 1
+      case ENV['STUB_SCENARIO']
+      when 'download_401_then_ok'
+        raise err(401, 'Unauthorized', '<error><summary>Session not live yet</summary></error>') if @download_calls == 1
+      when 'download_403_persistent'
+        raise err(403, 'Forbidden',
+                  '<error><summary>User does not have the Download capability on this datasource</summary></error>')
+      when 'download_401_exhaust'
+        raise err(401, 'Unauthorized', '<error><summary>persistent signin failure</summary></error>')
+      end
+      # bare .tds (no zip) with a real table relation → a valid descriptor.
+      <<~TDS
+        <datasource>
+          <connection class='snowflake' dbname='ANALYTICS' schema='PUBLIC'>
+            <relation type='table' table='[PUBLIC].[ORDERS]' name='ORDERS'/>
+          </connection>
+        </datasource>
+      TDS
+    end
+
+    def self.refresh_token!
+      rec_remint
+      'new-token'
+    end
+  end
+RUBY
+
+# A minimal .twb: ONE datasource on a sqlproxy connection with no real relation
+# and a dbname (== the PDS contentUrl) — exactly what resolve-published-ds.rb
+# treats as a published-DS placeholder to resolve.
+TWB = <<~'XML'
+  <?xml version='1.0' encoding='utf-8'?>
+  <workbook>
+    <datasources>
+      <datasource caption='Published Orders' name='federated.pub'>
+        <connection class='sqlproxy' dbname='pub_orders_contenturl'>
+          <relation type='table' table='[sqlproxy]' name='sqlproxy'/>
+        </connection>
+      </datasource>
+    </datasources>
+  </workbook>
+XML
+
+def run_resolve(script, scenario, twb_path, out_path, log_path)
+  env = { 'STUB_SCENARIO' => scenario, 'STUB_LOG' => log_path }
+  cmd = [RbConfig.ruby, script, '--twb', twb_path, '--out', out_path]
+  out = IO.popen(env, cmd, err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+Dir.mktmpdir do |tmp|
+  FileUtils.mkdir_p(File.join(tmp, 'lib'))
+  script = File.join(tmp, 'resolve-published-ds.rb')
+  FileUtils.cp(File.join(DIR, 'resolve-published-ds.rb'), script)
+  # Real libs the script require_relatives; the stub REPLACES tableau_rest.rb.
+  FileUtils.cp(File.join(DIR, 'hydrate-custom-sql.rb'), File.join(tmp, 'hydrate-custom-sql.rb'))
+  FileUtils.cp(File.join(DIR, 'lib', 'zip_extract.rb'), File.join(tmp, 'lib', 'zip_extract.rb'))
+  File.write(File.join(tmp, 'lib', 'tableau_rest.rb'), STUB)
+  twb = File.join(tmp, 'workbook-content.twb')
+  File.write(twb, TWB)
+
+  run = lambda do |scenario|
+    out_path = File.join(tmp, "#{scenario}.json")
+    log_path = File.join(tmp, "#{scenario}.log")
+    File.write(log_path, '')
+    code, out = run_resolve(script, scenario, twb, out_path, log_path)
+    descriptors = File.exist?(out_path) ? JSON.parse(File.read(out_path)) : nil
+    remints = File.exist?(log_path) ? File.readlines(log_path).count { |l| l.start_with?('REMINT') } : 0
+    { code: code, out: out, descriptors: descriptors, remints: remints }
+  end
+
+  # (a1) lookup 401-then-success: re-mint on the PDS-lookup call → resolve succeeds.
+  r = run.call('lookup_401_then_ok')
+  check(r[:code] == 0, "(a1) lookup 401→ok: completes (exit #{r[:code]})", fails)
+  check(r[:descriptors]&.size == 1, "(a1) lookup 401→ok: PDS resolved (no abort), got #{r[:descriptors]&.size.inspect}", fails)
+  check(r[:remints] == 1, "(a1) lookup 401→ok: exactly one re-mint fired (got #{r[:remints]})", fails)
+  check(r[:out].include?('re-minting token'), '(a1) lookup 401→ok: re-mint is logged', fails)
+
+  # (a2) download 401-then-success: re-mint on the content-download call → resolve succeeds.
+  r = run.call('download_401_then_ok')
+  check(r[:code] == 0, "(a2) download 401→ok: completes (exit #{r[:code]})", fails)
+  check(r[:descriptors]&.size == 1, "(a2) download 401→ok: PDS resolved (no abort), got #{r[:descriptors]&.size.inspect}", fails)
+  check(r[:descriptors]&.first&.dig('table') == '[PUBLIC].[ORDERS]', '(a2) download 401→ok: descriptor carries the real relation', fails)
+  check(r[:remints] == 1, "(a2) download 401→ok: exactly one re-mint fired (got #{r[:remints]})", fails)
+
+  # (b) persistent 403 (no Download capability): still aborts (descriptor DROPPED,
+  #     never fabricated), and the FULL error — status AND body — is surfaced.
+  r = run.call('download_403_persistent')
+  check(r[:code] == 0, "(b) 403: script completes cleanly (exit #{r[:code]})", fails)
+  check(r[:descriptors] == [], "(b) 403: descriptor DROPPED not fabricated (got #{r[:descriptors].inspect})", fails)
+  check(r[:remints].zero?, "(b) 403: a non-401 is NOT re-minted (got #{r[:remints]} re-mints)", fails)
+  check(r[:out].include?('403'), '(b) 403: HTTP status present in the log', fails)
+  check(r[:out].include?('Download capability'),
+        '(b) 403: response BODY surfaced (full error, not just line 1)', fails)
+
+  # (c) 401 exhausting the budget: still aborts loudly — descriptor DROPPED, and
+  #     the 401 is surfaced after the re-mint budget is spent.
+  r = run.call('download_401_exhaust')
+  check(r[:code] == 0, "(c) 401-exhaust: script completes cleanly (exit #{r[:code]})", fails)
+  check(r[:descriptors] == [], "(c) 401-exhaust: descriptor DROPPED not fabricated (got #{r[:descriptors].inspect})", fails)
+  check(r[:remints] >= 2, "(c) 401-exhaust: re-mint budget was exercised (got #{r[:remints]} re-mints)", fails)
+  check(r[:out].include?('401') && r[:out].include?('content download failed'),
+        '(c) 401-exhaust: the exhausted 401 is surfaced loudly', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end


### PR DESCRIPTION
## PDS resolver 401 retry asymmetry (#422)

Fixes the defect AlienAllSpark (MoxiWorks) diagnosed in [#422](https://github.com/twells89/sigma-migration-skills/issues/422#issuecomment-5027333903). Their diagnosis was correct on both counts.

### The bug
`scripts/resolve-published-ds.rb`'s two Tableau calls — `find_datasource_by_content_url` (the PDS lookup) and `download_datasource_content` (the content download) — ran with **only** `lib/tableau_rest.rb#request`'s single inline 401-refresh (`res.code==401 && attempts==1 -> refresh_token!`). The discovery path, `tableau-discover.rb#run_task`, *additionally* re-mints on a 401 that **escapes** that inline retry, so every discovery REST call self-heals a startup / session-signin race.

The resolve path had no such cushion. One unlucky transient 401 escaped, and because a dropped PDS is (correctly) treated as **abort rather than fabricate a phantom relation** (`refs/multi-datasource.md`), that single 401 took the whole migration down. Meanwhile the rescued error was truncated to `e.message.lines.first`, dropping the HTTP status detail and response body — so a genuine `403 no-Download-capability` looked identical to a transient signin-race 401 in the log.

### The fix (small, per the reporter's suggestion)
1. **`with_remint_on_401`** wraps both PDS-resolve Tableau calls with the same outer re-mint budget `run_task` gives discovery: on a 401 that escapes the lib retry, re-mint the token (reusing the PAT the lib resolves from env / the neutral `~/.sigma-migration/env` cred file) and retry, max 3 attempts. A genuine **non-401** failure re-raises at once — the abort-rather-than-fabricate contract still fails loudly, nothing is masked.
2. **`tableau_error_detail`** replaces `e.message.lines.first` — a generous, bounded excerpt (HTTP status **and** response body) is now logged, so a real capability/permission failure is legible vs a transient 401. Tableau error bodies carry no credential values.

### Tests
New `scripts/test-pds-resolve-retry.rb` (offline, stubbed Tableau lib — no network):
- **(a)** 401-then-success on **both** the lookup and the download call paths -> the PDS resolves with a re-mint logged (no abort).
- **(b)** persistent `403` (no Download capability) -> descriptor **dropped, never fabricated**, with the FULL error (status + body) surfaced — asserts the body text is present, not just line 1.
- **(c)** 401 exhausting the budget -> aborts loudly, the 401 surfaced after the budget is spent.

Wired into the creds-free `unit-tests` CI allowlist.

### Gates
corpus 17/17; `check-shared` / `hygiene` / `lint-twb-encoding` / `lint-skills` clean; touched-area tests (`test-hydrate-custom-sql`, `test-skill-coverage`, `test-multi-datasource-gap`) green; repo-wide `ruby -c` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
