### PR TITLE
tableau/shared: stop emitting {min:null,max:null} number-range + C7 hard-gate (#422)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -228,6 +228,8 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bootstrap.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-intake.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-skill-coverage.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-number-range-filter-emission.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -5971,12 +5971,25 @@ layout.each do |dash|
           warnings << "'#{cap}' relative-date window #{f['first_period']}..#{f['last_period']} #{period}s is shifted/spanning — no rolling mode fits → mode:between (#{fields['startDate'][0..9]}..#{fields['endDate'][0..9]}); FROZEN — re-run to refresh"
         end
       when 'number-range'
+        # An UNRESTRICTED Tableau quantitative filter carries no min/max (the
+        # <filter class='quantitative'> has no explicit bounds) → "all values".
+        # Emitting {min:null, max:null} on a mode:between number-range 400s the
+        # whole POST (issue #422 — recurred across workbooks). A range
+        # that filters nothing is a NO-OP, so mirror the categorical "All"
+        # handling above and emit NO element filter; where a bound IS present,
+        # emit only the non-nil key(s) so the shape never carries a null bound.
+        fmin = f['min']
+        fmax = f['max']
+        if fmin.nil? && fmax.nil?
+          warnings << "'#{cap}' quantitative quick filter on '#{fcap}' is UNRESTRICTED (no min/max — Tableau 'All') — no Sigma element filter emitted (an unbounded number-range with null bounds 400s the POST; #422)"
+          next
+        end
         fcol = el_filter_col_for.call(m)
         next if fcol.nil? # helper-sourced chart, column unreachable (warned in el_filter_col_for)
-        el_filters << {
-          'columnId' => fcol, 'kind' => 'number-range', 'mode' => 'between',
-          'min' => f['min'], 'max' => f['max'], 'includeNulls' => 'never'
-        }
+        nr = { 'columnId' => fcol, 'kind' => 'number-range', 'mode' => 'between', 'includeNulls' => 'never' }
+        nr['min'] = fmin unless fmin.nil?
+        nr['max'] = fmax unless fmax.nil?
+        el_filters << nr
       when 'wildcard'
         # D5/P0.6 (parsed pattern; the unparseable shape was intercepted above).
         # Worksheet-scoped wildcard → hidden Contains/StartsWith/EndsWith match

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-number-range-filter-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-number-range-filter-emission.rb
@@ -1,0 +1,161 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for QUANTITATIVE quick-filter emission (issue #422).
+#
+# An UNRESTRICTED Tableau quantitative quick-filter (`<filter
+# class='quantitative'>` with NO min/max attributes → "all values") used to
+# migrate to a Sigma number-range ELEMENT filter carrying `{min:null, max:null}`,
+# which 400s the whole workbook POST. The defect recurred across workbooks
+# because the builder emitted min/max UNCONDITIONALLY (unlike the guarded
+# control paths) and the C7 preflight lint didn't hard-block the shape.
+#
+# The fix (build-charts-from-signals.rb number-range element-filter branch):
+#   - both bounds absent (unrestricted "All") → emit NO element filter (a range
+#     that filters nothing is a no-op; mirrors the categorical "All" handling)
+#     with a loud warning — never the {min:null,max:null} 400 shape.
+#   - a bound present → emit only the non-nil key(s), so no null bound ever ships.
+# And preflight_lint C7 now HARD-errors any number-range (control OR element
+# filter) whose min AND max are both present-and-null.
+#
+# Deterministic + offline + creds-free: synthetic .twb through the ACTUAL parser
+# + builder, then the built spec through preflight_lint. Neutral fixture names.
+#
+# Usage:  ruby scripts/test-number-range-filter-emission.rb
+require 'json'
+require 'tmpdir'
+require_relative 'lib/preflight_lint'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Two worksheets: one carries an UNRESTRICTED quantitative filter (no min/max),
+# one a BOUNDED quantitative filter (min=10, max=90) — both on Total Revenue.
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+    <datasources>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Region' name='[REGION]' datatype='string' role='dimension' />
+        <column caption='Total Revenue' name='[TOTALREV]' datatype='real' role='measure' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Unrestricted Sheet'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.x' />
+            <filter class='quantitative' column='[federated.x].[none:TOTALREV:qk]' />
+          </view>
+          <rows>[federated.x].[sum:TOTALREV:qk]</rows>
+          <cols>[federated.x].[none:REGION:nk]</cols>
+          <pane><mark class='Bar' /></pane>
+        </table>
+      </worksheet>
+      <worksheet name='Bounded Sheet'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.x' />
+            <filter class='quantitative' column='[federated.x].[none:TOTALREV:qk]' min='10' max='90' />
+          </view>
+          <rows>[federated.x].[sum:TOTALREV:qk]</rows>
+          <cols>[federated.x].[none:REGION:nk]</cols>
+          <pane><mark class='Bar' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Dash'>
+        <zones>
+          <zone id='1' name='Unrestricted Sheet' x='0' y='0' w='50000' h='100000' />
+          <zone id='2' name='Bounded Sheet' x='50000' y='0' w='50000' h='100000' />
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Region$'        => { 'id' => 'm-region', 'name' => 'Region' },
+  '(?i)^Total Revenue$' => { 'id' => 'm-rev',    'name' => 'Total Revenue' }
+}
+
+meta = nil
+build_out = nil
+build_log = ''
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [
+               { 'id' => 'v1', 'name' => 'Unrestricted Sheet' },
+               { 'id' => 'v2', 'name' => 'Bounded Sheet' }
+             ] }))
+  Dir.mkdir(File.join(d, 'views'))
+  File.write(File.join(d, 'views', 'v1.csv'), '') # empty → build from .twb signals
+  File.write(File.join(d, 'views', 'v2.csv'), '')
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  meta = JSON.parse(File.read(lay.sub(/\.json$/, '-meta.json')))
+  out = File.join(d, 'specs.json')
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --skip-dashboard-read unit-test --auto-controls --title Dash --out #{out} 2>&1`
+  build_log = build_log.to_s.force_encoding('UTF-8')
+  build_out = JSON.parse(File.read(out)) if File.exist?(out)
+end
+
+# ---- Parser: unrestricted quantitative → number-range with nil bounds --------
+uf = (meta.dig('worksheets', 'Unrestricted Sheet', 'filters') || []).find { |f| f['kind'] == 'number-range' }
+check(uf && uf['min'].nil? && uf['max'].nil?,
+      "parser: unrestricted quantitative filter → number-range min:nil/max:nil (got #{uf.inspect})", fails)
+bf = (meta.dig('worksheets', 'Bounded Sheet', 'filters') || []).find { |f| f['kind'] == 'number-range' }
+check(bf && !bf['min'].nil? && !bf['max'].nil?,
+      "parser: bounded quantitative filter → number-range with min+max (got #{bf.inspect})", fails)
+
+els = build_out ? (build_out.is_a?(Array) ? build_out : (build_out['elements'] || (build_out['pages'] || []).flat_map { |p| p['elements'] || [] })) : []
+check(!els.empty?, 'builder produced elements', fails)
+
+nr_filters = els.flat_map { |e| (e['filters'] || []).select { |f| f['kind'] == 'number-range' } }
+
+# ---- CORE ASSERTION: no number-range element filter ships null bounds --------
+bad = nr_filters.select { |f| f['min'].nil? && f['max'].nil? }
+check(bad.empty?, "no number-range element filter carries {min:null,max:null} (got #{bad.inspect})", fails)
+partial = nr_filters.select { |f| (f.key?('min') && f['min'].nil?) || (f.key?('max') && f['max'].nil?) }
+check(partial.empty?, "no number-range element filter carries a present-but-null bound (got #{partial.inspect})", fails)
+
+# ---- REMEDY: the unrestricted filter is DROPPED (no-op), announced loudly -----
+unrestricted_el = els.find { |e| e['name'].to_s.casecmp?('Unrestricted Sheet') }
+u_nr = unrestricted_el ? (unrestricted_el['filters'] || []).find { |f| f['kind'] == 'number-range' } : nil
+check(u_nr.nil?, "unrestricted quantitative filter emits NO number-range element filter (got #{u_nr.inspect})", fails)
+check(build_log =~ /UNRESTRICTED/i && build_log =~ /#422/,
+      'builder loudly warns the unrestricted filter was dropped (cites #422)', fails)
+
+# ---- The BOUNDED filter still emits a valid number-range with both bounds -----
+bounded_el = els.find { |e| e['name'].to_s.casecmp?('Bounded Sheet') }
+b_nr = bounded_el ? (bounded_el['filters'] || []).find { |f| f['kind'] == 'number-range' } : nil
+check(b_nr && !b_nr['min'].nil? && !b_nr['max'].nil?,
+      "bounded quantitative filter → number-range with concrete min+max (got #{b_nr.inspect})", fails)
+
+# ---- The whole built spec passes preflight_lint C7 (would-be POST is clean) ---
+spec_for_lint = build_out.is_a?(Hash) && build_out['pages'] ? build_out : { 'pages' => [{ 'elements' => els }] }
+c7 = lint(spec_for_lint).select { |e| e.start_with?('C7 ') }
+check(c7.empty?, "preflight_lint C7 clean on the built spec (got #{c7.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — unrestricted quantitative filter drops cleanly (no {min:null,max:null}); bounded still emits; C7 clean'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build log (tail) ---"
+  puts build_log.to_s.lines.last(40).join
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
@@ -292,6 +292,77 @@ check(rule(lint(s), 'C7').any? { |e| e.include?('low`/`high') }, 'C7: range-slid
 rs['low'] = 0; rs['high'] = 100
 check(rule(lint(s), 'C7').empty?, 'C7: range-slider with low/high → clean', fails)
 
+# ---- C7: unbounded number-range {min:null,max:null} → HARD error (#422) ------
+# The recurring #422 defect: an UNRESTRICTED Tableau quantitative
+# quick-filter produced a number-range with min AND max present-and-null, which
+# 400s the whole POST. C7 must HARD-error it (in lint(), the FAIL set), name the
+# fix, and NEVER flag the valid keys-omitted unbounded form.
+def number_range_ctl(s)
+  ctl = s['pages'][0]['elements'][4]
+  ctl['controlType'] = 'number-range'
+  ctl.delete('selectionMode')
+  ctl.delete('value')
+  ctl.delete('mode')
+  ctl
+end
+# min:null AND max:null control → hard C7 violation naming the fix.
+s = valid_spec
+ctl = number_range_ctl(s)
+ctl['min'] = nil
+ctl['max'] = nil
+c7nr = rule(lint(s), 'C7')
+check(c7nr.size == 1, "C7: number-range control with min:null and max:null → 1 HARD violation (got #{lint(s).inspect})", fails)
+check(c7nr.first.to_s.include?('min:null and max:null') && c7nr.first.to_s.include?('#422'),
+      'C7 number-range message names the {min:null,max:null} 400 shape and the issue', fails)
+check(c7nr.first.to_s.include?('valid unbounded number-range') && c7nr.first.to_s.include?('never null bounds'),
+      'C7 number-range message names the remedy (omit the keys / concrete bounds, never null)', fails)
+# non-empty errs → the CLI would exit non-zero: assert it is a FAIL, not a warn.
+check(lint_warnings(s).none? { |x| x.start_with?('C7 ') }, 'C7 number-range null-bounds is a hard error, never a warning', fails)
+
+# a number-range with the min/max keys OMITTED is a VALID unbounded control — no C7.
+s = valid_spec
+number_range_ctl(s) # controlType only, no min/max keys
+check(rule(lint(s), 'C7').empty?, 'C7: number-range with min/max keys OMITTED → valid unbounded, no violation', fails)
+
+# a BOUNDED number-range still passes clean.
+s = valid_spec
+ctl = number_range_ctl(s)
+ctl['min'] = 0
+ctl['max'] = 100000
+check(rule(lint(s), 'C7').empty?, 'C7: bounded number-range (min:0,max:100000) → clean', fails)
+
+# only ONE bound present-and-null (partial) is still the unbounded trap → hard error.
+s = valid_spec
+ctl = number_range_ctl(s)
+ctl['min'] = nil # max key absent
+check(rule(lint(s), 'C7').size == 1, 'C7: number-range with min:null (max absent) → hard violation', fails)
+
+# ---- C7: unbounded number-range ELEMENT FILTER {min:null,max:null} (#422) ----
+# The exact shape the builder used to emit for a worksheet-scoped unrestricted
+# quantitative quick-filter — an ELEMENT filter, not a control. C7 must catch it
+# too (element filters were previously unlinted).
+s = valid_spec
+s['pages'][0]['elements'][1]['filters'] = [
+  { 'columnId' => 'col-kpi-val', 'kind' => 'number-range', 'mode' => 'between',
+    'min' => nil, 'max' => nil, 'includeNulls' => 'never' }
+]
+c7ef = rule(lint(s), 'C7')
+check(c7ef.size == 1 && c7ef.first.include?('filter[0]') && c7ef.first.include?('#422'),
+      "C7: number-range ELEMENT filter with min:null/max:null → 1 HARD violation naming filter[0] (got #{lint(s).inspect})", fails)
+check(c7ef.first.to_s.include?('drop the filter'),
+      'C7 element-filter message names the fix (drop the no-op filter)', fails)
+# a bounded number-range element filter passes; keys-omitted passes.
+s = valid_spec
+s['pages'][0]['elements'][1]['filters'] = [
+  { 'columnId' => 'col-kpi-val', 'kind' => 'number-range', 'mode' => 'between', 'min' => 1, 'max' => 9, 'includeNulls' => 'never' }
+]
+check(rule(lint(s), 'C7').empty?, 'C7: bounded number-range element filter → clean', fails)
+s = valid_spec
+s['pages'][0]['elements'][1]['filters'] = [
+  { 'columnId' => 'col-kpi-val', 'kind' => 'list', 'mode' => 'include', 'values' => %w[a b] }
+]
+check(rule(lint(s), 'C7').empty?, 'C7: non-number-range element filter → clean', fails)
+
 # ---- C8: includeNulls placement --------------------------------------------
 s = valid_spec
 s['pages'][0]['elements'][4]['includeNulls'] = true    # on a `list` control (off-schema)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)

--- a/shared/lib/preflight_lint.rb
+++ b/shared/lib/preflight_lint.rb
@@ -33,7 +33,13 @@
 #   C6  a control with an unknown controlType, or the docs-only `top-n` type that
 #       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
 #   C7  a control missing a REQUIRED field for its type: `mode` on
-#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider.
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
 #   C8  `includeNulls` on a controlType where it is off-schema.
 #   N1  an element or column whose `name` is empty/whitespace-only — breaks
 #       parity header matching and blank-renders axes (title hiding belongs on
@@ -196,6 +202,19 @@ def lint(spec)
         end
       end
 
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
       if kind == 'control'
         %w[id controlId controlType].each do |f|
           errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
@@ -252,6 +271,15 @@ def lint(spec)
           # C7: a range-slider without track bounds silently filters every row out.
           if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
             errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
           end
           # C8: includeNulls only valid on a specific subset.
           if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)


### PR DESCRIPTION
## Problem (#422, recurring)

An **unrestricted** Tableau quantitative quick-filter (`<filter class='quantitative'>` with no `min`/`max` → "all values") migrated to a Sigma `number-range` **element filter** carrying `{min:null, max:null}`, which **400s the whole workbook POST**. Reported repeatedly on #422 and reproduced across workbooks.

PR #408/#413 added the C-class control-shape preflight checks, but C7 never covered this shape and the builder still emitted it — so the lint warned at best while the bad control kept shipping.

## Root cause (builder, not just the lint)

- `parse-twb-layout.rb` yields `{kind:'number-range', min:nil, max:nil}` for an unrestricted quantitative filter.
- `build-charts-from-signals.rb` (number-range **element-filter** branch) set `'min'=>f['min'], 'max'=>f['max']` **unconditionally** — unlike every control path, which guards with `if`. That is the sole source of the literal `{min:null,max:null}` shape.

## Fix

**Builder** (`build-charts-from-signals.rb`, localized to the number-range element-filter branch):
- An unbounded range filters nothing, so mirror the existing categorical **"All"** handling — emit **no** element filter when both bounds are absent (with a loud warning citing #422), and where a bound is present emit only the non-nil key(s). A null bound is never emitted again.

**Preflight lint C7** (`shared/lib/preflight_lint.rb`, synced to all 9 plugin twins):
- **HARD-error** (in `lint()`, exit non-zero) any `number-range` — **control OR element filter** — whose `min` **and** `max` are both present-and-null. Element filters were previously unlinted; they are now covered too, so the shape can never reach POST from any code path.
- Keys **omitted** remain a valid unbounded control (per `refs/workbook-layout.md`); only null-**valued** bounds are flagged — no false positives on the valid form.

## Tests
- New `test-number-range-filter-emission.rb`: drives the real parser + builder — unrestricted → dropped (no `{min:null,max:null}`, no partial-null); bounded → valid `min`/`max`; the built spec is C7-clean.
- `test-preflight-lint.rb`: new C7 cases — control and element-filter `min:null/max:null` hard-error (naming the fix); keys-omitted and bounded pass; asserts hard-error (never a dismissible warn).
- Both registered in the offline creds-free CI suite.

## Gates
`corpus --check` 17/17 · `check-shared` (twins synced, 445 copies match) · full governance suite · hygiene — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
