### PR TITLE
trellis: shared TrellisEmit emitter + sigma-workbooks recipe + cross-converter plan

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -206,6 +206,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-native-trellis.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-trellis-emit.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-hydrate-custom-sql.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-pds-resolve-retry.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-score.rb

--- a/docs/trellis-cross-converter-plan.md
+++ b/docs/trellis-cross-converter-plan.md
@@ -1,0 +1,68 @@
+# Native trellis: cross-converter fan-out plan
+
+The tableau→sigma converter now emits Sigma's **native `trellis`** (single viz
+element + `rowsBy`/`columnsBy` facet) via the shared, converter-agnostic
+`shared/lib/trellis_emit.rb` (`TrellisEmit.apply`). This doc surveys the **other**
+converters: does the source tool have a small-multiples / trellis concept, where
+detection would live in that converter's parse path, the difficulty, and the
+emission step (always `TrellisEmit.apply`). It is a **plan, not an
+implementation** — each converter needs its own source-side *detection* plus a
+live *round-trip e2e* (Sigma silently strips `trellis` on unsupported kinds), so
+they land in a later wave, one PR each.
+
+## Background the plan builds on
+
+- **Supported Sigma kinds** (trellis survives readback): `bar-chart`,
+  `line-chart`, `area-chart`, `combo-chart`, `scatter-chart`, `donut-chart`.
+  Fallbacks: pie→donut, kpi→N sibling KPIs, pivot→own shelves, table→flat. Full
+  matrix: `docs/sigma-trellis-chart-support.md`.
+- **The emitter is already shared.** `TrellisEmit.apply(element,
+  facet_column_id:, orientation:)` sets `element['trellis']` on a supported kind
+  (or converts pie→donut), else returns a fallback signal
+  (`:needs_sibling_fanout` / `:needs_pivot_shelves` / `:flat`). A 2-D grid passes
+  a two-element `[rowId, colId]` and `orientation: :grid`.
+- **Silent-stripping is the shared risk.** Every converter that emits `trellis`
+  must re-read the spec and assert the key survived (generalize
+  `verify-trellis-survived.rb`, which already reads a converter-neutral
+  `native-trellis-emitted.json` sidecar).
+- **Several converters currently document trellis as "Sigma UI-only"** — a belief
+  that predates the native `rowsBy`/`columnsBy` finding (#460/#462). Those notes
+  (Looker `SKILL.md`, Power BI `measure-patterns.md`, Looker/QuickSight enhance
+  phases) are now **stale** and should be corrected as each converter adopts the
+  native path.
+
+## Per-converter survey (ranked by value)
+
+| Rank | Converter | Source small-multiples concept | Detection site (parse path) | Difficulty | Emission |
+|------|-----------|--------------------------------|-----------------------------|------------|----------|
+| 1 | **Power BI** | **First-class "Small multiples"** field well on cartesian visuals (bar/column/line); category splits the visual into a panel grid. Also multi-page "by" duplication. | `build-workbook-from-pbir.rb` / `build-charts-from-signals.rb` — read the visual's `smallMultiples` / `SmallMultiples` well from the PBIR `visual.json` at chart-build. | **Low–Med** — explicit property, no geometry inference. | `TrellisEmit.apply` |
+| 2 | **Qlik** | **Native "Trellis"** — chart-level trellis (a dimension splits one chart into a grid) plus the **trellis-container** object. Strong, explicit concept. | `build-sigma-workbook.py` — read the chart's trellis dimension / trellis-container children from the app object model (QVF layout JSON). | **Low–Med** — explicit; container variant needs a member→panel mapping. | `TrellisEmit.apply` |
+| 3 | **Looker** | **`looker_donut_multiples`** (donut small multiples) and **row/column `pivots`** that render as repeated panels. | `parse_lookml_dashboard.py` → `build_looker_dashboard*.py` — read `type: looker_donut_multiples` and the `pivots` list on each dashboard element. | **Med** — donut-multiples maps cleanly (donut is supported); pivots-as-facet needs care not to collide with a real pivot table. | `TrellisEmit.apply` (donut path is the sweet spot) |
+| 4 | **QuickSight** | **"Small multiples"** field well (`SmallMultiplesOptions`) on bar/line/combo visuals. | `build-workbook-from-quicksight.rb` / `build-charts-from-signals.rb` — read the visual's small-multiples field from the analysis/definition JSON. | **Low–Med** — explicit property. | `TrellisEmit.apply` |
+| 5 | **MicroStrategy** | Weaker: grid/graph "pages-by" (page-by axis) repeats a viz per member; no dedicated trellis object. | `convert.py` — read the `page-by` template axis members. | **Med** — page-by semantics differ from a panel grid; validate the mapping. | `TrellisEmit.apply` |
+| 6 | **Cognos** | No first-class trellis; **master-detail** relationships and list/crosstab repeaters approximate it. | `convert`/build path — detect a master-detail block wrapping a single chart. | **Med–High** — must distinguish master-detail-of-a-chart from unrelated nesting. | `TrellisEmit.apply` (only when the detail body is one supported chart) |
+| 7 | **GoodData** | **`repeater`** viz type is the nearest concept, but it is table/tile-oriented (already flagged→table), not a chart panel grid. | `convert.py` — the `local:repeater` mapping already exists (currently flagged). | **Med** — only worthwhile if the repeater body is a single supported chart; otherwise keep the table flag. | `TrellisEmit.apply` where the body is a chart; else keep flag |
+| 8 | **Sisense** | No native small-multiples/trellis widget; would rely on multiple same-widget instances split by a dimension. | `convert.py` — would need dashboard-level detection of N sibling widgets sharing a spec (Tableau-style geometry inference). | **High** — no explicit signal; inference-heavy, high false-positive risk. | `TrellisEmit.apply` (only after a conservative detector) |
+| 9 | **ThoughtSpot** | No native trellis; charts "split by" an attribute render as series, not a panel grid. | `convert_model.mjs` / build path — no reliable trellis signal. | **High / low value** — likely skip; a split-by is closer to color/series than to a trellis. | n/a until a real signal exists |
+
+## Recommended wave order
+
+1. **Power BI** and **Qlik** first — explicit source properties, common in real
+   workbooks, lowest inference risk, biggest fidelity win.
+2. **Looker** (`looker_donut_multiples` → donut trellis is a clean, supported
+   mapping) and **QuickSight** (`SmallMultiplesOptions`) next.
+3. **MicroStrategy** page-by and **Cognos** master-detail as judgment calls.
+4. **GoodData** only when the repeater body is a single chart; **Sisense** only
+   behind a conservative geometry detector; **ThoughtSpot** likely out of scope.
+
+## Shared per-converter checklist (each future PR)
+
+1. **Detect** the source facet in that converter's parse path → produce a
+   per-element `{ facet_column_id, orientation }` signal (converter-specific).
+2. **Emit** by calling `TrellisEmit.apply` at chart-build time (no per-tool
+   trellis logic — the supported set + fallbacks live once in the shared lib).
+3. **Guard** the round-trip: write the neutral `native-trellis-emitted.json`
+   sidecar and run the (generalized) `verify-trellis-survived.rb` after readback.
+4. **Correct** any stale "trellis is Sigma UI-only" note in that converter's docs.
+5. **Test**: an offline before/after fixture (parser→build emits the single
+   trellised element) + a live e2e asserting the key survived readback.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/charts.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/charts.md
@@ -279,7 +279,7 @@ Chart-wide fallbacks `barStyle`, `lineAreaStyle`, `pointStyle`, and `gap` also e
 Each of these is a top-level key on cartesian charts; one-liner here, full sub-fields via the kind recipe at the top of this file.
 
 - `orientation: horizontal` on `bar-chart` — horizontal bars. Omit for the default vertical bars.
-- `trellis: { column, row, share?, tileSize? }` — **styles a UI-configured trellis only.** `tileSize` and the `column`/`row` guide styling (`labels`, `border`, `title`) round-trip, but the facet *column binding* cannot be set via spec — `columnId`/`id` inside `column`/`row` are silently stripped (live-verified 2026-06-11). Configure the facets in the editor; the spec can then style them.
+- `trellis: { rowsBy | columnsBy: [{ columnId }] }` — **native small multiples / faceting, authorable from spec** (see the "Trellis / small multiples" section below). This is the `rowsBy`/`columnsBy` form. Do NOT confuse it with the legacy `trellis: { column, row, share?, tileSize? }` *styling* object, which only styles a UI-configured trellis and whose facet `columnId`/`id` binding is silently stripped — use `rowsBy`/`columnsBy` to bind the facet from spec.
 - `legend: { visibility, position, ... }` — legend placement and styling.
 - `tooltip: { columnNames?, multiSeries?, valueFormat? }` — hover-tooltip content. Support is config-dependent (live-verified 2026-06-11): `columnNames` round-trips broadly; `multiSeries` round-trips on line charts but is silently stripped on bar-with-color; `valueFormat` is rejected or stripped in most configurations. Verify the readback after setting anything beyond `columnNames`.
 
@@ -322,6 +322,63 @@ The correct shape binds the scatter to a **grouping**: source a table element th
 ```
 
 `color` always takes the `{ by: single|category|scale, column, ... }` form (see "Bar chart with custom category colors") — a bare `{ id }` / `{ columnId }` is rejected. **Validate a scatter by querying it for >1 distinct x**, not by POST status alone.
+
+## Trellis / small multiples
+
+A **trellis** (small multiples) repeats the same viz once per member of a categorical dimension. Sigma authors this natively from spec with the element-level `trellis` property — **ONE viz element**, the facet dimension added as a `columns[]` entry, and `rowsBy` / `columnsBy` pointing at that column by `columnId`. Do **not** clone one element per member.
+
+```jsonc
+{
+  "id": "el-revenue-by-subregion",
+  "kind": "bar-chart",
+  "source": { "kind": "table", "elementId": "master" },
+  "columns": [
+    { "id": "c-cat", "name": "Region",     "formula": "[Master/Region]" },
+    { "id": "c-x",   "name": "Sub-Region", "formula": "[Master/Sub-Region]" },
+    { "id": "c-y",   "name": "Revenue",    "formula": "Sum([Master/Revenue])" }
+  ],
+  "xAxis": { "columnId": "c-x" },
+  "yAxis": { "columnIds": ["c-y"] },
+  "trellis": { "rowsBy": [ { "columnId": "c-cat" } ] }
+}
+```
+
+With a 3-member `Region` (Region A / Region B / Region C), this renders one bar panel per region, stacked in rows.
+
+- `rowsBy` alone → **vertical** small multiples (panels stacked in rows).
+- `columnsBy` alone → **horizontal** small multiples (panels side by side).
+- **both**, pointing at **two different** columns → a **2-D grid** (rows × columns).
+- The facet reference key is **`columnId`** (a `columns[]` id on the element). This is a different mechanism from the `pivot-table`'s own `rowsBy`/`columnsBy` cross-tab shelves, which key on `id`.
+
+### Supported chart kinds (emit `trellis` for these only)
+
+The native `trellis` key round-trips (survives readback and renders faceted) on exactly these kinds:
+
+| Kind | Trellis |
+|------|---------|
+| `bar-chart` (incl. `stacking: stacked` / `normalized`) | ✅ supported |
+| `line-chart` | ✅ supported |
+| `area-chart` | ✅ supported |
+| `combo-chart` | ✅ supported |
+| `scatter-chart` | ✅ key round-trips (validate the grouping/render separately — see the Scatter section) |
+| `donut-chart` | ✅ supported (one donut per member) |
+| `pie-chart` | ❌ **stripped** → emit a `donut-chart` instead |
+| `kpi-chart` | ❌ stripped → fan out to N sibling KPI elements |
+| `pivot-table` | ❌ stripped → use the pivot's own `rowsBy`/`columnsBy` shelves |
+| `table` | ❌ stripped → keep flat / model the facet as a grouping |
+
+The empirical coverage matrix (how each kind was verified live, POST + readback + render) is the source of truth: **`docs/sigma-trellis-chart-support.md`**.
+
+### Fallbacks for the unsupported kinds
+
+- **`pie-chart` → `donut-chart`.** Pie and donut are both circular (`value` + `color`), but only donut trellises. If the intent is a faceted pie, emit a `donut-chart` with the same `trellis`.
+- **`kpi-chart` → N sibling KPIs.** There is no native KPI trellis. For "one KPI per category," lay out N separate `kpi-chart` elements, one filtered to each member.
+- **`pivot-table` → its own shelves.** The pivot's element-level `rowsBy`/`columnsBy` cross-tab shelves (keyed on `id`) already are the native faceting — do not add a separate `trellis` key.
+- **`table` → keep flat** or add the facet as an extra grouping/row dimension.
+
+### ⚠️ Silent-stripping caveat — ALWAYS re-read and verify
+
+Sigma returns **`200` on POST even for the unsupported kinds**, then **silently drops the `trellis` key** on readback and renders a single un-faceted chart — no error. **POST success is NOT proof the trellis applied.** Any spec that emits a native `trellis` must GET the workbook spec back after create and assert the element still carries its `trellis` key (with the same axis) before treating the trellis as applied; if it was stripped, fall back to the routes above. (Converters do this with a round-trip survival guard.)
 
 ## Other chart kinds
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -66,6 +66,7 @@ require_relative 'lib/format_map'     # PR-12: the ONE Tableau→Sigma format tr
 require_relative 'lib/series_colors'  # PR-12: ordered per-series color schemes
 require_relative 'lib/threshold_halo'  # C2: threshold-halo (computed-boolean color) detection
 require_relative 'lib/integer_dim'    # PR-18: integer-coded dimension decode-to-text routing
+require_relative 'lib/trellis_emit'   # shared native-trellis emitter (supported-kind gate + fallbacks)
 require 'erb'
 
 opts = { master_id: 'master' }
@@ -7964,30 +7965,30 @@ end
                   'element — trellis NOT collapsed (member charts stay flat)'
       next
     end
-    # Native `trellis` survives readback ONLY on these element kinds (empirical
+    # Native `trellis` survives readback ONLY on the readback-safe kinds (empirical
     # coverage matrix — docs/sigma-trellis-chart-support.md). On pie/kpi/pivot/
     # table the POST returns 200 but Sigma SILENTLY STRIPS the key and renders
-    # flat, so we must NOT emit it there:
+    # flat, so we must NOT emit it there. The supported set + fallback rules are
+    # the single source of truth in shared/lib/trellis_emit.rb (TrellisEmit):
     #   * pie-chart → convert the base to a DONUT (donut supports trellis) and
-    #     collapse as usual (the faithful faceted-pie shape);
+    #     collapse as usual (the faithful faceted-pie shape) — TrellisEmit.apply
+    #     does the kind flip below;
     #   * kpi-chart → leave the N sibling KPI elements FLAT (fanning out to N
     #     per-member KPIs IS the correct Sigma shape — do not collapse);
     #   * pivot-table/table → leave flat (pivot's own rowsBy/columnsBy shelves
     #     and table→postpublish are the documented follow-up mechanisms).
     # NOTE: the POST→readback round-trip must still ASSERT the key survived on
     # supported kinds (silent stripping) — enforced in the live e2e + verify.
-    trellis_supported = %w[bar-chart line-chart area-chart combo-chart scatter-chart donut-chart].freeze
-    if base_el['kind'] == 'pie-chart'
-      base_el['kind'] = 'donut-chart'
-      warnings << "native trellis on '#{dash['dashboard']}': base '#{base_cap}' is a PIE — converted to DONUT " \
-                  '(pie silently strips the trellis key on readback; donut supports it) before faceting'
-    end
-    unless trellis_supported.include?(base_el['kind'].to_s)
+    unless TrellisEmit.trellises?(base_el['kind'])
       warnings << "native trellis on '#{dash['dashboard']}': base kind '#{base_el['kind']}' does NOT support a " \
                   "native trellis (Sigma strips the key on readback) — left the #{caps.size} member " \
                   "#{base_el['kind']} element(s) FLAT " \
                   "(#{base_el['kind'] == 'kpi-chart' ? 'N sibling KPIs is the correct faceted shape' : 'pivot→own shelves / table→postpublish is the follow-up'})"
       next
+    end
+    if base_el['kind'] == 'pie-chart'
+      warnings << "native trellis on '#{dash['dashboard']}': base '#{base_cap}' is a PIE — converted to DONUT " \
+                  '(pie silently strips the trellis key on readback; donut supports it) before faceting'
     end
     field = grp['field'].to_s
     base_el['columns'] ||= []
@@ -8008,12 +8009,13 @@ end
     Array(base_el['filters']).each do |f|
       f['values'] = [] if f.is_a?(Hash) && f['columnId'] == cat_col['id'] && f['kind'] == 'list'
     end
-    # Source arrangement → Sigma trellis axis. A single facet field faces ONE
-    # axis (rowsBy XOR columnsBy — emitting BOTH on the same column is
-    # degenerate); a 'grid' arrangement of one field maps to columnsBy, which
-    # Sigma wraps into a tile grid on its own.
-    axis_key = grp['orientation'].to_s == 'rows' ? 'rowsBy' : 'columnsBy'
-    base_el['trellis'] = { axis_key => [{ 'columnId' => cat_col['id'] }] }
+    # Source arrangement → Sigma trellis axis via the shared emitter. A single
+    # facet field faces ONE axis (rowsBy XOR columnsBy — emitting BOTH on the same
+    # column is degenerate); a 'grid' arrangement of one field maps to columnsBy,
+    # which Sigma wraps into a tile grid on its own. TrellisEmit.apply also does
+    # the pie→donut kind flip (a no-op here — already gated/flipped above).
+    TrellisEmit.apply(base_el, facet_column_id: cat_col['id'], orientation: grp['orientation'])
+    axis_key = base_el['trellis'].keys.first
     # Round-trip guard record: Sigma SILENTLY strips an unsupported trellis on
     # readback, so the post-publish verifier re-reads the spec and asserts each
     # of these survived (verify-trellis-survived.rb).

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/trellis_emit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/trellis_emit.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+#
+# TrellisEmit — the converter-agnostic emitter for Sigma's NATIVE element
+# `trellis` property (small multiples / faceting). ONE source of truth for
+#   (a) which chart kinds actually support a spec-authored trellis, and
+#   (b) what to do on the kinds that DON'T (the documented fallbacks).
+#
+# Empirical basis: docs/sigma-trellis-chart-support.md. Sigma accepts a POST with
+# an element `trellis` key (200 OK) but SILENTLY STRIPS it on unsupported kinds —
+# the key is simply gone on readback and the tile renders flat, no error. So the
+# supported set below is a hard gate, and every caller that emits a native trellis
+# MUST re-read the spec and assert the key survived (see verify-trellis-survived).
+#
+# The correct Sigma shape is ONE viz element with the facet dimension as a column
+# and `trellis: { rowsBy | columnsBy: [{ columnId }] }` (a 2-D grid points rowsBy
+# and columnsBy at two DIFFERENT columns). This is distinct from the pivot-table's
+# own `rowsBy`/`columnsBy` cross-tab shelves (keyed on `id`, a separate mechanism).
+#
+# Interface (converter-agnostic; mutates the element hash in place):
+#   TrellisEmit.apply(element, facet_column_id:, orientation:)
+#     element          — the Sigma element spec Hash (needs 'kind'; 'trellis' set here)
+#     facet_column_id  — a columns[] id String, OR a 2-element [rowId, colId] Array
+#                        for a true 2-D grid
+#     orientation      — :rows | :cols | :grid   (Strings 'rows'/'cols'/'grid' ok)
+#   → returns one of RESULTS:
+#     :trellised             — supported kind; element['trellis'] set
+#     :fallback_donut        — kind was pie-chart → converted to donut + trellis set
+#     :needs_sibling_fanout  — kpi-chart → caller should fan out to N sibling KPIs
+#     :needs_pivot_shelves   — pivot-table → caller should use its own rowsBy/columnsBy
+#     :flat                  — table / anything else → leave flat (no-op)
+#   On the three no-op results the element is left UNTOUCHED (no trellis key, no
+#   kind change), so a caller can branch on the result and take the fallback path.
+#
+# Pure + stdlib-only + unit-tested (test-trellis-emit.rb). Canonical lives in
+# shared/lib; edit there, run tools/sync-shared.rb.
+
+module TrellisEmit
+  module_function
+
+  # Kinds whose native `trellis` key round-trips (survives readback). Emit ONLY
+  # for these; the rest silently strip it. (docs/sigma-trellis-chart-support.md)
+  SUPPORTED_KINDS = %w[
+    bar-chart line-chart area-chart combo-chart scatter-chart donut-chart
+  ].freeze
+
+  # Fallback rule per unsupported kind → the action the emitter takes / signals.
+  #   :convert_to_donut  pie has no native trellis but donut does → convert, then trellis
+  #   :sibling_fanout    kpi has no native trellis → fan out to N per-member KPI elements
+  #   :pivot_shelves     pivot-table faceting is its OWN rowsBy/columnsBy shelves
+  #   :flat              table (and any other kind) → keep flat
+  FALLBACKS = {
+    'pie-chart'   => :convert_to_donut,
+    'kpi-chart'   => :sibling_fanout,
+    'pivot-table' => :pivot_shelves,
+    'table'       => :flat
+  }.freeze
+
+  RESULTS = %i[trellised fallback_donut needs_sibling_fanout needs_pivot_shelves flat].freeze
+
+  # Non-mutating: what WILL apply do for this kind? Lets a caller gate the
+  # element-specific work (adding the facet column, emptying member filters,
+  # dropping siblings) to only the kinds that actually trellis.
+  def disposition(kind)
+    k = kind.to_s
+    return :trellised if SUPPORTED_KINDS.include?(k)
+
+    case FALLBACKS[k]
+    when :convert_to_donut then :fallback_donut
+    when :sibling_fanout   then :needs_sibling_fanout
+    when :pivot_shelves    then :needs_pivot_shelves
+    else :flat
+    end
+  end
+
+  # True when apply will set a native trellis (supported kind, or pie→donut).
+  def trellises?(kind)
+    d = disposition(kind)
+    d == :trellised || d == :fallback_donut
+  end
+
+  # Mutating. On a supported kind (or pie→donut) sets element['trellis'] and
+  # returns :trellised / :fallback_donut. On kpi/pivot/table leaves the element
+  # untouched and returns the signal so the caller runs the documented fallback.
+  def apply(element, facet_column_id:, orientation:)
+    kind = element['kind'].to_s
+    result =
+      if kind == 'pie-chart'
+        element['kind'] = 'donut-chart' # donut trellises natively; pie strips the key
+        :fallback_donut
+      elsif SUPPORTED_KINDS.include?(kind)
+        :trellised
+      else
+        return disposition(kind) # no-op: needs_sibling_fanout / needs_pivot_shelves / flat
+      end
+    element['trellis'] = trellis_object(facet_column_id, orientation)
+    result
+  end
+
+  # Build the `trellis` value for the given facet(s) + orientation.
+  #   :rows → { rowsBy: [ref] }                     vertical small-multiples
+  #   :cols → { columnsBy: [ref] }                  horizontal small-multiples
+  #   :grid → two facet ids  → { rowsBy:[a], columnsBy:[b] }  a true 2-D grid
+  #           one facet id   → { columnsBy: [ref] }  single field wraps into a tile grid
+  # A single facet always faces ONE axis (rowsBy XOR columnsBy — emitting both on
+  # the SAME column is degenerate).
+  def trellis_object(facet_column_id, orientation)
+    ids = Array(facet_column_id)
+    case orientation.to_s
+    when 'rows'
+      { 'rowsBy' => [ref(ids.first)] }
+    when 'grid'
+      if ids.length >= 2
+        { 'rowsBy' => [ref(ids[0])], 'columnsBy' => [ref(ids[1])] }
+      else
+        { 'columnsBy' => [ref(ids.first)] }
+      end
+    else # 'cols' and any other single-axis default
+      { 'columnsBy' => [ref(ids.first)] }
+    end
+  end
+
+  def ref(column_id)
+    { 'columnId' => column_id }
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-trellis-emit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-trellis-emit.rb
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-trellis-emit.rb — unit test for TrellisEmit (the shared native-trellis
+# emitter). Converter-agnostic, pure, no network. Canonical in shared/scripts;
+# edit there, run tools/sync-shared.rb.
+# Run: ruby scripts/test-trellis-emit.rb
+require_relative 'lib/trellis_emit'
+
+$fail = 0
+def ok(name, cond); puts((cond ? '  ok  ' : 'FAIL  ') + name); $fail += 1 unless cond; end
+
+def el(kind, cols = [{ 'id' => 'c-cat' }])
+  { 'id' => 'el-1', 'kind' => kind, 'columns' => cols }
+end
+
+# ---- supported kinds → trellis set, right axis per orientation --------------
+%w[bar-chart line-chart area-chart combo-chart scatter-chart donut-chart].each do |k|
+  e = el(k)
+  r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :rows)
+  ok("#{k}: rows → :trellised + trellis.rowsBy", r == :trellised &&
+     e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-cat' }] })
+
+  e2 = el(k)
+  r2 = TrellisEmit.apply(e2, facet_column_id: 'c-cat', orientation: :cols)
+  ok("#{k}: cols → trellis.columnsBy (and NOT rowsBy)", r2 == :trellised &&
+     e2['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+end
+
+# String orientation is accepted the same as the symbol.
+e = el('bar-chart')
+TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: 'rows')
+ok('orientation may be a String', e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-cat' }] })
+
+# ---- pie-chart → donut + trellis (fallback) ---------------------------------
+e = el('pie-chart')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('pie-chart → :fallback_donut', r == :fallback_donut)
+ok('pie-chart kind flipped to donut-chart', e['kind'] == 'donut-chart')
+ok('pie→donut carries the native trellis', e['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+ok('pie-chart trellises? is true (converts)', TrellisEmit.trellises?('pie-chart'))
+
+# ---- kpi-chart → needs-sibling signal, element untouched --------------------
+e = el('kpi-chart')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('kpi-chart → :needs_sibling_fanout', r == :needs_sibling_fanout)
+ok('kpi-chart left UNTOUCHED (no trellis, kind unchanged)',
+   !e.key?('trellis') && e['kind'] == 'kpi-chart')
+ok('kpi-chart trellises? is false', !TrellisEmit.trellises?('kpi-chart'))
+
+# ---- pivot-table → needs-shelves signal, untouched --------------------------
+e = el('pivot-table')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :rows)
+ok('pivot-table → :needs_pivot_shelves', r == :needs_pivot_shelves)
+ok('pivot-table left UNTOUCHED', !e.key?('trellis') && e['kind'] == 'pivot-table')
+
+# ---- table → flat no-op -----------------------------------------------------
+e = el('table')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('table → :flat', r == :flat)
+ok('table left UNTOUCHED', !e.key?('trellis'))
+
+# ---- unknown kind → flat (default fallback) ---------------------------------
+e = el('funnel-chart')
+ok('unknown kind → :flat disposition', TrellisEmit.disposition('funnel-chart') == :flat)
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('unknown kind → :flat + untouched', r == :flat && !e.key?('trellis'))
+
+# ---- 2-D grid → BOTH keys, two different columns ----------------------------
+e = el('bar-chart', [{ 'id' => 'c-row' }, { 'id' => 'c-col' }])
+r = TrellisEmit.apply(e, facet_column_id: %w[c-row c-col], orientation: :grid)
+ok('grid + two facet ids → :trellised', r == :trellised)
+ok('grid → rowsBy AND columnsBy on the two distinct columns',
+   e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-row' }],
+                     'columnsBy' => [{ 'columnId' => 'c-col' }] })
+
+# A single-field grid wraps into a tile grid → columnsBy only (tableau parity).
+e = el('bar-chart')
+TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :grid)
+ok('grid + single facet id → columnsBy only (single-field tile grid)',
+   e['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+
+# ---- disposition is the single source of truth (non-mutating) ---------------
+ok('disposition(bar-chart) == :trellised', TrellisEmit.disposition('bar-chart') == :trellised)
+ok('disposition(pie-chart) == :fallback_donut', TrellisEmit.disposition('pie-chart') == :fallback_donut)
+ok('disposition(kpi-chart) == :needs_sibling_fanout',
+   TrellisEmit.disposition('kpi-chart') == :needs_sibling_fanout)
+ok('disposition(pivot-table) == :needs_pivot_shelves',
+   TrellisEmit.disposition('pivot-table') == :needs_pivot_shelves)
+ok('disposition(table) == :flat', TrellisEmit.disposition('table') == :flat)
+ok('SUPPORTED_KINDS is the documented readback-safe set',
+   TrellisEmit::SUPPORTED_KINDS == %w[bar-chart line-chart area-chart combo-chart scatter-chart donut-chart])
+
+puts
+if $fail.zero?
+  puts 'ALL PASS — TrellisEmit (supported→trellis by orientation; pie→donut; ' \
+       'kpi/pivot/table fallbacks; 2-D grid → both keys)'
+  exit 0
+else
+  puts "#{$fail} FAILURE(S)"
+  exit 1
+end

--- a/shared/lib/trellis_emit.rb
+++ b/shared/lib/trellis_emit.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+#
+# TrellisEmit — the converter-agnostic emitter for Sigma's NATIVE element
+# `trellis` property (small multiples / faceting). ONE source of truth for
+#   (a) which chart kinds actually support a spec-authored trellis, and
+#   (b) what to do on the kinds that DON'T (the documented fallbacks).
+#
+# Empirical basis: docs/sigma-trellis-chart-support.md. Sigma accepts a POST with
+# an element `trellis` key (200 OK) but SILENTLY STRIPS it on unsupported kinds —
+# the key is simply gone on readback and the tile renders flat, no error. So the
+# supported set below is a hard gate, and every caller that emits a native trellis
+# MUST re-read the spec and assert the key survived (see verify-trellis-survived).
+#
+# The correct Sigma shape is ONE viz element with the facet dimension as a column
+# and `trellis: { rowsBy | columnsBy: [{ columnId }] }` (a 2-D grid points rowsBy
+# and columnsBy at two DIFFERENT columns). This is distinct from the pivot-table's
+# own `rowsBy`/`columnsBy` cross-tab shelves (keyed on `id`, a separate mechanism).
+#
+# Interface (converter-agnostic; mutates the element hash in place):
+#   TrellisEmit.apply(element, facet_column_id:, orientation:)
+#     element          — the Sigma element spec Hash (needs 'kind'; 'trellis' set here)
+#     facet_column_id  — a columns[] id String, OR a 2-element [rowId, colId] Array
+#                        for a true 2-D grid
+#     orientation      — :rows | :cols | :grid   (Strings 'rows'/'cols'/'grid' ok)
+#   → returns one of RESULTS:
+#     :trellised             — supported kind; element['trellis'] set
+#     :fallback_donut        — kind was pie-chart → converted to donut + trellis set
+#     :needs_sibling_fanout  — kpi-chart → caller should fan out to N sibling KPIs
+#     :needs_pivot_shelves   — pivot-table → caller should use its own rowsBy/columnsBy
+#     :flat                  — table / anything else → leave flat (no-op)
+#   On the three no-op results the element is left UNTOUCHED (no trellis key, no
+#   kind change), so a caller can branch on the result and take the fallback path.
+#
+# Pure + stdlib-only + unit-tested (test-trellis-emit.rb). Canonical lives in
+# shared/lib; edit there, run tools/sync-shared.rb.
+
+module TrellisEmit
+  module_function
+
+  # Kinds whose native `trellis` key round-trips (survives readback). Emit ONLY
+  # for these; the rest silently strip it. (docs/sigma-trellis-chart-support.md)
+  SUPPORTED_KINDS = %w[
+    bar-chart line-chart area-chart combo-chart scatter-chart donut-chart
+  ].freeze
+
+  # Fallback rule per unsupported kind → the action the emitter takes / signals.
+  #   :convert_to_donut  pie has no native trellis but donut does → convert, then trellis
+  #   :sibling_fanout    kpi has no native trellis → fan out to N per-member KPI elements
+  #   :pivot_shelves     pivot-table faceting is its OWN rowsBy/columnsBy shelves
+  #   :flat              table (and any other kind) → keep flat
+  FALLBACKS = {
+    'pie-chart'   => :convert_to_donut,
+    'kpi-chart'   => :sibling_fanout,
+    'pivot-table' => :pivot_shelves,
+    'table'       => :flat
+  }.freeze
+
+  RESULTS = %i[trellised fallback_donut needs_sibling_fanout needs_pivot_shelves flat].freeze
+
+  # Non-mutating: what WILL apply do for this kind? Lets a caller gate the
+  # element-specific work (adding the facet column, emptying member filters,
+  # dropping siblings) to only the kinds that actually trellis.
+  def disposition(kind)
+    k = kind.to_s
+    return :trellised if SUPPORTED_KINDS.include?(k)
+
+    case FALLBACKS[k]
+    when :convert_to_donut then :fallback_donut
+    when :sibling_fanout   then :needs_sibling_fanout
+    when :pivot_shelves    then :needs_pivot_shelves
+    else :flat
+    end
+  end
+
+  # True when apply will set a native trellis (supported kind, or pie→donut).
+  def trellises?(kind)
+    d = disposition(kind)
+    d == :trellised || d == :fallback_donut
+  end
+
+  # Mutating. On a supported kind (or pie→donut) sets element['trellis'] and
+  # returns :trellised / :fallback_donut. On kpi/pivot/table leaves the element
+  # untouched and returns the signal so the caller runs the documented fallback.
+  def apply(element, facet_column_id:, orientation:)
+    kind = element['kind'].to_s
+    result =
+      if kind == 'pie-chart'
+        element['kind'] = 'donut-chart' # donut trellises natively; pie strips the key
+        :fallback_donut
+      elsif SUPPORTED_KINDS.include?(kind)
+        :trellised
+      else
+        return disposition(kind) # no-op: needs_sibling_fanout / needs_pivot_shelves / flat
+      end
+    element['trellis'] = trellis_object(facet_column_id, orientation)
+    result
+  end
+
+  # Build the `trellis` value for the given facet(s) + orientation.
+  #   :rows → { rowsBy: [ref] }                     vertical small-multiples
+  #   :cols → { columnsBy: [ref] }                  horizontal small-multiples
+  #   :grid → two facet ids  → { rowsBy:[a], columnsBy:[b] }  a true 2-D grid
+  #           one facet id   → { columnsBy: [ref] }  single field wraps into a tile grid
+  # A single facet always faces ONE axis (rowsBy XOR columnsBy — emitting both on
+  # the SAME column is degenerate).
+  def trellis_object(facet_column_id, orientation)
+    ids = Array(facet_column_id)
+    case orientation.to_s
+    when 'rows'
+      { 'rowsBy' => [ref(ids.first)] }
+    when 'grid'
+      if ids.length >= 2
+        { 'rowsBy' => [ref(ids[0])], 'columnsBy' => [ref(ids[1])] }
+      else
+        { 'columnsBy' => [ref(ids.first)] }
+      end
+    else # 'cols' and any other single-axis default
+      { 'columnsBy' => [ref(ids.first)] }
+    end
+  end
+
+  def ref(column_id)
+    { 'columnId' => column_id }
+  end
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -419,6 +419,18 @@
    ]
   },
   {
+   "canonical": "shared/lib/trellis_emit.rb",
+   "targets": [
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/trellis_emit.rb"
+   ]
+  },
+  {
+   "canonical": "shared/scripts/test-trellis-emit.rb",
+   "targets": [
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-trellis-emit.rb"
+   ]
+  },
+  {
    "canonical": "shared/scripts/test-coverage-gate.rb",
    "targets": [
     "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-coverage-gate.rb",

--- a/shared/scripts/test-trellis-emit.rb
+++ b/shared/scripts/test-trellis-emit.rb
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-trellis-emit.rb — unit test for TrellisEmit (the shared native-trellis
+# emitter). Converter-agnostic, pure, no network. Canonical in shared/scripts;
+# edit there, run tools/sync-shared.rb.
+# Run: ruby scripts/test-trellis-emit.rb
+require_relative 'lib/trellis_emit'
+
+$fail = 0
+def ok(name, cond); puts((cond ? '  ok  ' : 'FAIL  ') + name); $fail += 1 unless cond; end
+
+def el(kind, cols = [{ 'id' => 'c-cat' }])
+  { 'id' => 'el-1', 'kind' => kind, 'columns' => cols }
+end
+
+# ---- supported kinds → trellis set, right axis per orientation --------------
+%w[bar-chart line-chart area-chart combo-chart scatter-chart donut-chart].each do |k|
+  e = el(k)
+  r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :rows)
+  ok("#{k}: rows → :trellised + trellis.rowsBy", r == :trellised &&
+     e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-cat' }] })
+
+  e2 = el(k)
+  r2 = TrellisEmit.apply(e2, facet_column_id: 'c-cat', orientation: :cols)
+  ok("#{k}: cols → trellis.columnsBy (and NOT rowsBy)", r2 == :trellised &&
+     e2['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+end
+
+# String orientation is accepted the same as the symbol.
+e = el('bar-chart')
+TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: 'rows')
+ok('orientation may be a String', e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-cat' }] })
+
+# ---- pie-chart → donut + trellis (fallback) ---------------------------------
+e = el('pie-chart')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('pie-chart → :fallback_donut', r == :fallback_donut)
+ok('pie-chart kind flipped to donut-chart', e['kind'] == 'donut-chart')
+ok('pie→donut carries the native trellis', e['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+ok('pie-chart trellises? is true (converts)', TrellisEmit.trellises?('pie-chart'))
+
+# ---- kpi-chart → needs-sibling signal, element untouched --------------------
+e = el('kpi-chart')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('kpi-chart → :needs_sibling_fanout', r == :needs_sibling_fanout)
+ok('kpi-chart left UNTOUCHED (no trellis, kind unchanged)',
+   !e.key?('trellis') && e['kind'] == 'kpi-chart')
+ok('kpi-chart trellises? is false', !TrellisEmit.trellises?('kpi-chart'))
+
+# ---- pivot-table → needs-shelves signal, untouched --------------------------
+e = el('pivot-table')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :rows)
+ok('pivot-table → :needs_pivot_shelves', r == :needs_pivot_shelves)
+ok('pivot-table left UNTOUCHED', !e.key?('trellis') && e['kind'] == 'pivot-table')
+
+# ---- table → flat no-op -----------------------------------------------------
+e = el('table')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('table → :flat', r == :flat)
+ok('table left UNTOUCHED', !e.key?('trellis'))
+
+# ---- unknown kind → flat (default fallback) ---------------------------------
+e = el('funnel-chart')
+ok('unknown kind → :flat disposition', TrellisEmit.disposition('funnel-chart') == :flat)
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('unknown kind → :flat + untouched', r == :flat && !e.key?('trellis'))
+
+# ---- 2-D grid → BOTH keys, two different columns ----------------------------
+e = el('bar-chart', [{ 'id' => 'c-row' }, { 'id' => 'c-col' }])
+r = TrellisEmit.apply(e, facet_column_id: %w[c-row c-col], orientation: :grid)
+ok('grid + two facet ids → :trellised', r == :trellised)
+ok('grid → rowsBy AND columnsBy on the two distinct columns',
+   e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-row' }],
+                     'columnsBy' => [{ 'columnId' => 'c-col' }] })
+
+# A single-field grid wraps into a tile grid → columnsBy only (tableau parity).
+e = el('bar-chart')
+TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :grid)
+ok('grid + single facet id → columnsBy only (single-field tile grid)',
+   e['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+
+# ---- disposition is the single source of truth (non-mutating) ---------------
+ok('disposition(bar-chart) == :trellised', TrellisEmit.disposition('bar-chart') == :trellised)
+ok('disposition(pie-chart) == :fallback_donut', TrellisEmit.disposition('pie-chart') == :fallback_donut)
+ok('disposition(kpi-chart) == :needs_sibling_fanout',
+   TrellisEmit.disposition('kpi-chart') == :needs_sibling_fanout)
+ok('disposition(pivot-table) == :needs_pivot_shelves',
+   TrellisEmit.disposition('pivot-table') == :needs_pivot_shelves)
+ok('disposition(table) == :flat', TrellisEmit.disposition('table') == :flat)
+ok('SUPPORTED_KINDS is the documented readback-safe set',
+   TrellisEmit::SUPPORTED_KINDS == %w[bar-chart line-chart area-chart combo-chart scatter-chart donut-chart])
+
+puts
+if $fail.zero?
+  puts 'ALL PASS — TrellisEmit (supported→trellis by orientation; pie→donut; ' \
+       'kpi/pivot/table fallbacks; 2-D grid → both keys)'
+  exit 0
+else
+  puts "#{$fail} FAILURE(S)"
+  exit 1
+end


### PR DESCRIPTION
Builds on the native single-element trellis (#462) and the empirical coverage matrix (#460, `docs/sigma-trellis-chart-support.md`).

## Deliverable 1 — sigma-workbooks recipe
`plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/charts.md` gains a **"Trellis / small multiples"** recipe documenting the native `element.trellis` property:
- exact spec shape (ONE viz element + facet dimension as a column + `rowsBy`/`columnsBy`/2-D grid), with a neutral JSON example (Region A/B/C);
- the supported-vs-unsupported chart-kind matrix (points at the coverage doc);
- the fallbacks (pie→donut, kpi→N siblings, pivot→own shelves, table→flat);
- the **silent-stripping caveat** — POST returns 200 but the key is dropped on readback for unsupported kinds → always re-read and verify.

Also corrects the stale "trellis facet binding is Sigma UI-only" note.

## Deliverable 2 — shared TrellisEmit emitter
New `shared/lib/trellis_emit.rb` — converter-agnostic:

```
TrellisEmit.apply(element, facet_column_id:, orientation:)  # :rows | :cols | :grid
#  → :trellised | :fallback_donut | :needs_sibling_fanout | :needs_pivot_shelves | :flat
```

Sets `element['trellis']` on the readback-safe kinds (bar/line/area/combo/scatter/donut), converts pie→donut, and signals the fallback for kpi/pivot/table. The supported set + fallback rules live here as the **single source of truth** (`SUPPORTED_KINDS` + `FALLBACKS`), plus a non-mutating `disposition`/`trellises?` predicate.

The tableau `build-charts-from-signals.rb` collapse step now **calls** `TrellisEmit.trellises?`/`apply` instead of its inline supported-set + axis logic.

**Byte-identical-after-refactor proof:** the e2e-b1 trellis fixtures (horizontal → `columnsBy`, vertical → `rowsBy`, pie → donut) emit an **identical** chart-spec before vs after the refactor:

```
horz: IDENTICAL (2442 bytes)
vert: IDENTICAL (2439 bytes)
pie:  IDENTICAL (2401 bytes)
```

Synced to the tableau lib copy via `tools/sync-shared.rb` (+ manifest entry); the round-trip guard `verify-trellis-survived.rb` is unchanged (already reads a neutral sidecar).

## Deliverable 3 — cross-converter fan-out survey
`docs/trellis-cross-converter-plan.md` — for powerbi / qlik / looker / quicksight / cognos / microstrategy / gooddata / sisense / thoughtspot: the source small-multiples concept, where detection would live in that converter's parse path, difficulty, and that emission = `TrellisEmit.apply`. Ranked by value (Power BI + Qlik first). Plan only — each converter is a later wave (own detection + live e2e). Notes that several converters currently call trellis "Sigma UI-only" — now stale.

## Tests
- `test-trellis-emit.rb` unit (supported kind → trellis by orientation; pie→donut+trellis; kpi→needs-sibling; pivot→needs-shelves; table→flat; 2-D → both keys) — added to the offline CI allowlist and synced.
- `test-native-trellis.rb` regression still passes.
- corpus 17/17; `check-shared` (new lib synced + manifest-registered); hygiene + skill/esm/agent-variant/twb-encoding lints all clean.

No live migration needed — the tableau live path was proven in #462; this refactor is byte-identical-guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
