### PR TITLE
tableau-to-sigma: gate 17 classify() — a filter-condition ref is not reference-derived (#452)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -219,6 +219,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-sql-quoting.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-audit.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sql-ident-check.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-quarantine.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-lod-calcs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-lod-calcs.rb
@@ -144,8 +144,18 @@ blocking.each do |e, i|
   if e['class'] == 'suspect-alias'
     warn "  emitted as #{e.dig('evidence', 'column').inspect} on #{e.dig('evidence', 'element').inspect}" \
          " (#{e.dig('evidence', 'spec')}): #{e.dig('evidence', 'formula')}"
-    warn "  reads #{Array(e['suspect_refs']).join(', ')} — NOT in the LOD expression's own reference set" \
-         " (#{Array(e['reference_set']).join(', ')}). The numbers are silently WRONG."
+    # Two suspect-alias shapes of the same silent-alias failure: a ref OUTSIDE
+    # the LOD's reference set, or a non-aggregating passthrough of a column that
+    # is inside it but appears ONLY in the LOD's FILTER CONDITION (#452).
+    refs = Array(e['suspect_refs'])
+    ref_set_n = Array(e['reference_set']).map { |r| LodAudit.norm(r) }
+    if refs.any? { |r| ref_set_n.include?(LodAudit.norm(r)) }
+      warn "  reads #{refs.join(', ')} — a column named only in the LOD expression's FILTER CONDITION," \
+           " not its aggregated output (#{Array(e['reference_set']).join(', ')}). The numbers are silently WRONG."
+    else
+      warn "  reads #{refs.join(', ')} — NOT in the LOD expression's own reference set" \
+           " (#{Array(e['reference_set']).join(', ')}). The numbers are silently WRONG."
+    end
   else
     warn '  no emitted dm-spec/wb-spec translation and no manual-residues.json entry — the calc'
     warn '  was DROPPED with no signal; every tile that plotted it is missing or mis-built.'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/lod_audit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/lod_audit.rb
@@ -28,12 +28,17 @@
 #                     entry declares the calc a manual translation (gate 15
 #                     polices built/unbuilt; this ledger only requires the
 #                     declaration to be EXPLICIT).
-#   reference-derived resolved — the emitted formula is built strictly from the
-#                     LOD expression's OWN reference set (e.g. a re-aggregation
-#                     of the LOD's base measure at chart grain).
-#   suspect-alias     UNRESOLVED — an emitted column carries the calc's name
-#                     but its formula references a base/physical column that is
-#                     NOT in the LOD expression's own reference set: the
+#   reference-derived resolved — the emitted formula RE-AGGREGATES the LOD
+#                     expression's OWN OUTPUT field (e.g. a re-aggregation of the
+#                     LOD's base measure at chart grain). A non-aggregating
+#                     passthrough of a column that appears ONLY in the LOD's
+#                     filter condition does NOT qualify — that is a fuzzy alias
+#                     (#452), classified suspect-alias below.
+#   suspect-alias     UNRESOLVED — an emitted column carries the calc's name but
+#                     its formula either references a base/physical column that
+#                     is NOT in the LOD expression's own reference set, OR is a
+#                     non-aggregating passthrough of a column that appears only
+#                     in the LOD expression's filter condition (#452): the
 #                     fuzzy-alias case, numbers silently wrong.
 #   silently-dropped  UNRESOLVED — no emitted translation and no manual-residue
 #                     declaration anywhere.
@@ -66,6 +71,17 @@ module LodAudit
   LOD_REL_REF_RE = %r{\[[^\]]+/\s*(?:FIXED|INCLUDE|EXCLUDE)[^/\]]*/[^\]]+\]}i
   WINDOW_FN_RE   = /\b(?:Lag|Lead|Rank|RankDense|RankPercentile|RowNumber|PercentOfTotal|
                        Cumulative\w+|Moving\w+|FirstNonNull|LastNonNull|First|Last)\s*\(/xi
+
+  # Aggregation functions whose presence in an EMITTED formula proves it
+  # RE-AGGREGATES the LOD's measure (a genuine reference-derivation) rather than
+  # merely passing a raw column through. Tableau + Sigma spellings.
+  AGG_FN_RE = /\b(?:COUNTDISTINCT|COUNTD|COUNT|SUM|AVG|AVERAGE|MIN|MAX|
+                    MEDIAN|STDEV\w*|VAR\w*|ATTR|TOTAL)\s*\(/xi
+
+  # Comparison operators that mark a bracket ref as a FILTER PREDICATE (the
+  # IF/CASE/boolean condition that GATES an LOD aggregate — e.g. [flag] = "X").
+  # Multi-char operators are listed first so the alternation matches greedily.
+  COMPARATOR_RE = /(?:<=|>=|<>|!=|==|=|<|>)/.freeze
 
   module_function
 
@@ -204,9 +220,24 @@ module LodAudit
     matches.each do |c|
       next if synth.include?(c)
       terms = terminal_refs(c['formula'])
-      next if terms.empty? || terms.all? { |t| norm(t) == name_n } # passthrough — not evidence
+      next if terms.empty? || terms.all? { |t| norm(t) == name_n } # passthrough of own name — not evidence
       alien = terms.reject { |t| allowed.include?(norm(t)) }
-      alien.empty? ? derived << c : suspect << [c, alien]
+      unless alien.empty?
+        suspect << [c, alien, :alien] # reads a column OUTSIDE the LOD's reference set
+        next
+      end
+      # Every ref is INSIDE the LOD's own reference set — but that alone is not
+      # enough to call the column reference-derived (#452). "reference-derived"
+      # means the emitted formula RE-AGGREGATES the LOD's OUTPUT field; an
+      # emitted formula that merely NAMES a column appearing only in the LOD's
+      # FILTER CONDITION (a non-aggregating passthrough of a filter-predicate
+      # column) is the same silent-alias failure as #423 — flag it, don't
+      # resolve it.
+      if reference_derived?(c, calc, name_n)
+        derived << c
+      else
+        suspect << [c, filter_alias_refs(c, calc, name_n), :filter]
+      end
     end
 
     entry = {
@@ -226,13 +257,12 @@ module LodAudit
       entry['evidence'] = { 'kind' => 'manual-residues.json', 'calc' => residues[name_n]['calc'],
                             'residue_status' => residues[name_n]['status'].to_s }
     elsif suspect.any?
-      col, alien = suspect.first
+      col, refs, kind = suspect.first
       entry['class']  = 'suspect-alias'
       entry['status'] = 'unresolved'
       entry['evidence'] = evidence(col)
-      entry['suspect_refs'] = alien
-      entry['detail'] = "emitted formula reads #{alien.map { |a| a.inspect }.join(', ')} — not in the " \
-                        'LOD expression\'s own reference set (fuzzy name-alias: the numbers are silently wrong)'
+      entry['suspect_refs'] = refs
+      entry['detail'] = suspect_detail(refs, kind)
     elsif derived.any?
       entry['class']  = 'reference-derived'
       entry['status'] = 'resolved'
@@ -246,10 +276,25 @@ module LodAudit
     # A resolved calc can STILL have a mis-aliased twin column somewhere — keep
     # that visible without blocking (the operator verifies it at Phase 6).
     if entry['status'] == 'resolved' && suspect.any?
-      col, alien = suspect.first
-      entry['also_suspect'] = evidence(col).merge('suspect_refs' => alien)
+      col, refs, = suspect.first
+      entry['also_suspect'] = evidence(col).merge('suspect_refs' => refs)
     end
     entry
+  end
+
+  # Human-readable detail for a suspect-alias entry: the two shapes of the same
+  # silent-alias failure — reading a column OUTSIDE the LOD's reference set, or a
+  # non-aggregating passthrough of one of its FILTER-CONDITION columns (#452).
+  def suspect_detail(refs, kind)
+    quoted = Array(refs).map(&:inspect).join(', ')
+    if kind == :filter
+      "emitted formula is a non-aggregating passthrough of #{quoted} — a column named only in the " \
+        "LOD expression's FILTER CONDITION, not its aggregated output (fuzzy filter-alias: the " \
+        'numbers are silently wrong)'
+    else
+      "emitted formula reads #{quoted} — not in the LOD expression's own reference set " \
+        '(fuzzy name-alias: the numbers are silently wrong)'
+    end
   end
 
   def synth_evidence(col)
@@ -267,6 +312,82 @@ module LodAudit
       seg = r.split('/').last.to_s.strip
       seg =~ /\Actl-/ ? nil : seg
     end.compact.reject(&:empty?).uniq
+  end
+
+  # True when the emitted column is a GENUINE re-aggregation of the LOD's own
+  # output: either it applies an aggregation function itself, or (non-aggregating)
+  # every non-name ref it carries is one of the LOD's aggregated-output /
+  # dimension refs — NOT a column that appears ONLY in the LOD's filter condition
+  # (#452: a bare passthrough of a filter-predicate column is a fuzzy alias, not
+  # a translation of the COUNTD/SUM output).
+  def reference_derived?(col, calc, name_n)
+    return true if col['formula'].to_s =~ AGG_FN_RE
+    outputs = agg_output_refs(calc['formula']).map { |r| norm(r) }
+    preds   = filter_predicate_refs(calc['formula']).map { |r| norm(r) }
+    emitted = terminal_refs(col['formula']).map { |t| norm(t) }.reject { |t| t.empty? || t == name_n }
+    # a ref used ONLY as a filter predicate (never as the aggregated output) is
+    # not evidence of derivation.
+    emitted.none? { |r| preds.include?(r) && !outputs.include?(r) }
+  end
+
+  # The emitted formula's terminal refs that name a filter-predicate-ONLY column
+  # of the LOD — the fuzzy filter-alias evidence for #452 (original casing).
+  def filter_alias_refs(col, calc, name_n)
+    outputs = agg_output_refs(calc['formula']).map { |r| norm(r) }
+    preds   = filter_predicate_refs(calc['formula']).map { |r| norm(r) }
+    terminal_refs(col['formula']).select do |t|
+      tn = norm(t)
+      tn != name_n && preds.include?(tn) && !outputs.include?(tn)
+    end
+  end
+
+  # Refs used as a FILTER PREDICATE inside the LOD expression: a bracket ref on
+  # either side of a comparison operator — the IF/CASE/boolean condition that
+  # GATES the aggregate (e.g. [flag] = "X"). These are NOT the aggregated
+  # measure; a bare passthrough of one is a fuzzy alias, not a translation of the
+  # LOD's aggregated output (#452).
+  def filter_predicate_refs(formula)
+    f = formula.to_s
+    refs = []
+    f.scan(/\[([^\]]+)\]\s*#{COMPARATOR_RE}/) { |m| refs << m[0] }
+    f.scan(/#{COMPARATOR_RE}\s*\[([^\]]+)\]/) { |m| refs << m[0] }
+    refs.map { |r| r.split('/').last.to_s.strip }.reject(&:empty?).uniq
+  end
+
+  # Bracket refs that are the AGGREGATED OUTPUT of the LOD: refs appearing inside
+  # an aggregation function's argument, minus any used only as filter predicates.
+  # For {FIXED d: COUNTD(IF [flag] = "X" THEN [key] END)} the output is [key],
+  # not [flag].
+  def agg_output_refs(formula)
+    preds = filter_predicate_refs(formula).map { |r| norm(r) }
+    agg_argument_refs(formula).reject { |r| preds.include?(norm(r)) }
+  end
+
+  # Terminal names of every bracket ref inside any aggregation function call.
+  def agg_argument_refs(formula)
+    f = formula.to_s
+    refs = []
+    f.scan(AGG_FN_RE) do
+      m = Regexp.last_match
+      refs.concat(terminal_refs(balanced_paren_slice(f, m.end(0) - 1)))
+    end
+    refs.uniq
+  end
+
+  # The substring inside the balanced parentheses that OPEN at open_idx (the
+  # index of a '(' in str). Paren-matching is literal (string literals are not
+  # treated specially) — adequate for the LOD shapes we classify.
+  def balanced_paren_slice(str, open_idx)
+    depth = 0
+    i = open_idx
+    while i < str.length
+      c = str[i]
+      depth += 1 if c == '('
+      depth -= 1 if c == ')'
+      return str[(open_idx + 1)...i] if depth.zero?
+      i += 1
+    end
+    str[(open_idx + 1)..-1] || ''
   end
 
   def evidence(col)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-audit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-audit.rb
@@ -145,6 +145,71 @@ e4 = LodAudit.derive(calcs, dm_spec: nil, wb_spec: wb4, manual_residues: nil)
 d4 = e4.find { |x| x['calc'] == 'Dropped Seats' }
 check(d4 && d4['class'] == 'silently-dropped', 'bare passthrough ref alone → still silently-dropped', fails)
 
+puts 'Part B5 — #452: an emitted look-alike of a FILTER-CONDITION column is NOT reference-derived'
+# The common field shape: {FIXED dims: COUNTD(IF <flag> = "X" THEN <key> END)}.
+# The flag column ('Status Flag') is a filter PREDICATE that GATES the count; the
+# counted OUTPUT is the key ('Seat Id'). A raw look-alike column 'STATUS_FLAG'
+# exists in the warehouse, so the calc's caption can collide downstream with a
+# BARE PASSTHROUGH of that flag — which reads the raw flag, not the COUNTD
+# (silently wrong numbers). 'Status Flag' is inside the LOD's reference_set, so
+# pre-#452 classify() wrongly marked this passthrough reference-derived/resolved.
+GATED_FIELDS = {
+  'calcs' => [
+    { 'name' => 'Gated Seats', 'internal_name' => '[Calculation_200]',
+      'formula' => '{FIXED [Account Name]: COUNTD(IF [Status Flag] = "ACTIVE" ' \
+                   'OR [Status Flag] = "PENDING" THEN [Seat Id] END)}', 'is_lod' => true }
+  ]
+}.freeze
+gcalcs = LodAudit.lod_calcs(GATED_FIELDS)
+gated  = gcalcs.first
+check(gated && gated['reference_set'].sort == ['Account Name', 'Seat Id', 'Status Flag'],
+      "reference set includes the filter-predicate column (got #{gated && gated['reference_set'].inspect})", fails)
+
+# (a) the fuzzy filter-alias: a bare passthrough of the FILTER-CONDITION column.
+dm_filter = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-f', 'kind' => 'table', 'name' => 'Seat Fact',
+    'source' => { 'kind' => 'warehouse-table', 'path' => %w[DEMO_DB PUBLIC SEAT_FACT] },
+    'columns' => [
+      { 'id' => 'g1', 'name' => 'Gated Seats', 'formula' => '[SEAT_FACT/STATUS_FLAG]' }
+    ] }
+] }] }
+ef = LodAudit.derive(gcalcs, dm_spec: JSON.parse(JSON.generate(dm_filter)), wb_spec: nil, manual_residues: nil)
+gf = ef.find { |x| x['calc'] == 'Gated Seats' }
+check(gf && gf['class'] == 'suspect-alias' && gf['status'] == 'unresolved',
+      "(a) passthrough of the LOD's filter-condition column → suspect-alias (gate 17 blocks) (got #{gf && gf['class']})", fails)
+check(gf && Array(gf['suspect_refs']) == ['STATUS_FLAG'],
+      "suspect-alias names the aliased filter column (got #{gf && gf['suspect_refs'].inspect})", fails)
+check(gf && gf['detail'].to_s.include?('FILTER CONDITION'),
+      'detail explains the filter-condition alias (distinct from the plain out-of-refs alias)', fails)
+check(gf && !LodAudit.resolved?(gf), 'the filter-alias entry is unresolved until an operator resolves it', fails)
+
+# (b) a GENUINE reference-derivation of the SAME LOD (re-aggregation of the
+#     OUTPUT field) still passes — the fix must not over-flag the honest case.
+wb_ok = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-k', 'kind' => 'kpi-chart', 'name' => 'Gated KPI',
+    'columns' => [
+      { 'id' => 'gk', 'name' => 'Gated Seats', 'formula' => 'CountDistinct([Seat Fact/Seat Id])' }
+    ] }
+] }] }
+eo = LodAudit.derive(gcalcs, dm_spec: nil, wb_spec: JSON.parse(JSON.generate(wb_ok)), manual_residues: nil)
+go = eo.find { |x| x['calc'] == 'Gated Seats' }
+check(go && go['class'] == 'reference-derived' && go['status'] == 'resolved',
+      "(b) re-aggregation of the LOD's OUTPUT field still → reference-derived (got #{go && go['class']})", fails)
+
+# (c) a non-aggregating passthrough of the LOD's OUTPUT column (not a filter
+#     column) is NOT the #452 failure — left as-is (still reference-derived),
+#     so the fix stays surgical to the filter-condition blind spot.
+wb_out = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-o', 'kind' => 'table', 'name' => 'Out',
+    'columns' => [
+      { 'id' => 'oc', 'name' => 'Gated Seats', 'formula' => '[Seat Fact/Seat Id]' }
+    ] }
+] }] }
+ep = LodAudit.derive(gcalcs, dm_spec: nil, wb_spec: JSON.parse(JSON.generate(wb_out)), manual_residues: nil)
+gp = ep.find { |x| x['calc'] == 'Gated Seats' }
+check(gp && gp['class'] == 'reference-derived',
+      "output-column passthrough is not the filter-alias failure (got #{gp && gp['class']})", fails)
+
 puts 'Part C — .twb fallback census'
 TWB = <<~XML
   <workbook>


### PR DESCRIPTION
## What & why

Follow-up to #423/#425. Gate 17's LOD translation ledger (`lib/lod_audit.rb`, `classify()`) had a blind spot reported in #452: it built the `allowed` set from the LOD calc's whole `reference_set`, which naturally includes every column named in the calc's **own filter/condition**. So an emitted look-alike column that was a bare passthrough of a *filter-predicate* column — the common `{FIXED d: COUNTD(IF [flag] = "X" THEN [key] END)}` "count distinct gated by a status flag" shape — had its terminal ref land inside `allowed`, `alien` came back empty, and the entry was classified **reference-derived/resolved**. That is exactly the #423 silent-alias failure (numbers silently wrong) slipping past gate 17.

**Fix:** `reference-derived` now requires the emitted formula to **re-aggregate the LOD's OUTPUT field** — either it applies an aggregation function itself, or every non-name ref it carries is one of the LOD's aggregated-output/dimension refs. A non-aggregating passthrough of a column that appears **only** in the LOD's filter condition is classified `suspect-alias` (UNRESOLVED), so gate 17 (exit 24) blocks it. Genuine reference-derivations and every prior #423/#425 classification are unchanged (the fix is surgical to the filter-condition blind spot).

## Scope

- Plugin(s) touched: `tableau-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

Changes:
- `scripts/lib/lod_audit.rb` — split the LOD expression's refs into filter-predicate refs (bracket refs adjacent to a comparison operator) vs aggregated-output refs (refs inside an aggregation call, minus predicates); a non-aggregating passthrough of a predicate-only column is now `suspect-alias` with a distinct detail. New helpers `reference_derived?`, `filter_alias_refs`, `filter_predicate_refs`, `agg_output_refs`, `agg_argument_refs`, `balanced_paren_slice`, `suspect_detail`; `AGG_FN_RE` / `COMPARATOR_RE`.
- `scripts/audit-lod-calcs.rb` — the FATAL block distinguishes the filter-condition alias from the out-of-reference-set alias (the plain-alias line is byte-identical, so the pinned corpus goldens are unaffected).
- `scripts/test-lod-audit.rb` — new **Part B5** covering the #452 shape (filter-condition passthrough → `suspect-alias`/unresolved; a genuine re-aggregation of the output field still → `reference-derived`; an output-column passthrough is not the filter-alias failure).
- `.github/workflows/corpus-check.yml` — wire the (offline, creds-free) `test-lod-audit.rb` into CI so the guard actually runs.

## Checklist

- [x] `ruby tools/check-shared.rb` — green (447 copies match; `lod_audit.rb` is not a shared/vendored lib)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green, 17/17 (incl. `tableau/preagg-kpi`)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in
- [x] Hygiene sweep + twb-encoding lint clean

Fixes #452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
