### PR TITLE
tableau: case-disambiguate column-id slugifier — no spurious "Duplicate id" on differently-cased columns (#455)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -203,6 +203,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-brand-palette.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-header-derivation.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-namespacing.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-id-slug-case.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-native-trellis.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -31,6 +31,7 @@
 require 'set'
 require 'json'
 require 'open3'
+require 'zlib' # CRC32 — a cross-run-STABLE hash for case-disambiguating column ids (#455)
 require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 require_relative 'lib/theme_derive' # shared theme derivation/emission (v5.0)
 
@@ -58,6 +59,49 @@ module MechanicalSpecs
 
   def slug(s)
     s.to_s.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/^-|-$/, '')
+  end
+
+  # --- case-disambiguating, 64-char-clamped column-id minting (#455) -----------
+  # `slug` deliberately downcases, so two SOURCE columns that differ only in case
+  # ("userId" vs "UserID", "Value" vs "value" — legitimately distinct columns from
+  # a schema that evolved, or a view exposing an original + renamed column) both
+  # slug to ONE base id. Within a single element that is a hard error: the id is
+  # either silently dropped (data loss) or POSTs a "Duplicate id" 400 at the DM /
+  # workbook builder. These helpers keep the plain lowercase slug for the FIRST
+  # name that claims a base id (so already-shipped ids stay STABLE) and hand every
+  # differently-cased sibling a DETERMINISTIC suffix, so distinct columns always
+  # get distinct ids. The final id is clamped to 64 chars so it composes with the
+  # converter's own 64-char clampId (#445/PR-16) — the two id spaces stay valid
+  # independently, and a long name + a disambiguator can never overflow.
+
+  # Cross-run-STABLE short tag of a string's exact bytes. Distinguishes names that
+  # share a base slug but differ in case. CRC32 (deterministic) — NOT String#hash,
+  # which is per-process randomized and would make ids unstable across runs.
+  def case_tag(s)
+    Zlib.crc32(s.to_s).to_s(36)[0, 6]
+  end
+
+  # Deterministic 64-char clamp for workbook-local slug ids. Same shape as the
+  # converter's clampId (readable head + stable hash tail), applied to the Ruby
+  # side so disambiguated ids can never exceed the limit.
+  def clamp_id(id, max = 64)
+    return id if id.length <= max
+    tail = "~#{case_tag(id)}"
+    id[0, max - tail.length] + tail
+  end
+
+  # Mint a case-disambiguated, clamped id "<prefix><slug(name)>" against a per-
+  # build registry (base id -> the first exact-case name that claimed it). The
+  # first claimant keeps the plain slug; a later name that slugs to the same base
+  # but differs in CASE gets "<base>-<case_tag>"; the SAME exact name reuses its
+  # id (true duplicates still collapse — callers dedup those upstream).
+  def mint_id(prefix, name, registry)
+    base = "#{prefix}#{slug(name)}"
+    owner = registry[base]
+    chosen = (owner.nil? || owner == name.to_s) ? base : "#{base}-#{case_tag(name)}"
+    registry[base] ||= name.to_s
+    registry[chosen] ||= name.to_s
+    clamp_id(chosen)
   end
 
   # A header-matching regex for a display name that ALSO tolerates a Tableau CSV
@@ -1411,7 +1455,9 @@ module MechanicalSpecs
     fact_name = 'Custom SQL' if fact_name.to_s.strip.empty?
     master_columns = []
     mmap = {}
-    seen = {}
+    seen = {}          # downcased-name coverage (reuse-union bare check + LOD skip)
+    seen_exact = {}     # EXACT-name dedup: true duplicates collapse, case-variants survive (#455)
+    id_owner = {}       # base id -> first exact name, shared across master/LOD/metric mints (#455)
     used_regex = {}
     untranslated = []
     guid_idx = guid_display_index(fact_el, base_el)
@@ -1444,14 +1490,19 @@ module MechanicalSpecs
     add = lambda do |dname, format, real_label = nil|
       return if dname.nil? || dname.to_s.empty?
       return if dname =~ GUID_RE
-      key = dname.downcase
-      return if seen[key]
-      seen[key] = true
-      id = "m-#{slug(dname)}"
+      # Dedup on the EXACT display name (#455): genuine same-name duplicates still
+      # collapse, but two columns differing only in CASE both survive. `seen` still
+      # tracks the downcased name so the reuse-union bare-coverage check and the
+      # FIXED-LOD skip below keep working unchanged.
+      return if seen_exact[dname]
+      seen_exact[dname] = true
+      dkey = dname.downcase
+      seen[dkey] = true
+      id = mint_id('m-', dname, id_owner)
       master_columns << { 'id' => id, 'name' => dname, 'formula' => real_for.call(dname, real_label) }
       entry = { 'id' => id, 'name' => dname }
       entry['format'] = format if format
-      entry['grain'] = grain_for[key] if grain_for[key]
+      entry['grain'] = grain_for[dkey] if grain_for[dkey]
       rx = header_regex(dname)
       unless used_regex[rx]
         mmap[rx] = entry
@@ -1511,7 +1562,8 @@ module MechanicalSpecs
           key = dn.downcase
           next if seen[key]
           seen[key] = true
-          id = "m-#{slug(dn)}"
+          seen_exact[dn] = true
+          id = mint_id('m-', dn, id_owner)
           master_columns << { 'id' => id, 'name' => dn, 'formula' => "[#{fact_name}/#{rel['name']}/#{dn}]" }
           entry = { 'id' => id, 'name' => dn }
           entry['format'] = hc['format'] if hc['format']
@@ -1539,7 +1591,7 @@ module MechanicalSpecs
           untranslated << nm
           next
         end
-        entry = { 'id' => "m-#{slug(nm)}", 'name' => nm, 'formula' => formula }
+        entry = { 'id' => mint_id('m-', nm, id_owner), 'name' => nm, 'formula' => formula }
         entry['format'] = m['format'] if m['format']
         mmap[rx] = entry
         used_regex[rx] = true

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-id-slug-case.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-id-slug-case.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Regression test for the CASE-INSENSITIVE column-id slugifier (#455). Offline +
+# deterministic. Guards the master-table builder against a class of spurious
+# "Duplicate id" 400s: two SOURCE columns whose names differ ONLY in case
+# ("userId" vs "UserID", "Value" vs "value" — legitimately distinct columns from a
+# schema that evolved, or a view exposing an original + renamed column) both
+# slug to one lowercase base id. Before the fix, `derive_master` either dropped
+# the second column (silent data loss, via a downcased dedup) or minted a
+# duplicate id that 400s at the DM/workbook POST.
+#
+# The fix keeps the plain lowercase slug for the FIRST name to claim a base id
+# (so already-shipped ids stay stable) and hands every differently-cased sibling a
+# DETERMINISTIC, 64-char-clamped suffix — so genuinely-distinct columns always get
+# distinct ids, while a genuine same-name duplicate still collapses to one id.
+#
+# Usage:  ruby scripts/test-column-id-slug-case.rb
+require_relative 'mechanical-specs'
+
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+def fact(cols)
+  { 'id' => 'fact', 'name' => 'Order Fact', 'kind' => 'sql',
+    'columns' => cols.each_with_index.map do |nm, i|
+      { 'id' => "conv-#{i}", 'name' => nm, 'formula' => "[Order Fact/#{nm}]" }
+    end, 'metrics' => [] }
+end
+
+puts 'Part A — case-collision helpers (unit)'
+# slug still downcases (unchanged — stability contract for non-colliding names).
+check(MechanicalSpecs.slug('Region') == 'region', 'slug("Region") == "region" (unchanged)', fails)
+check(MechanicalSpecs.slug('UserID') == 'userid', 'slug still downcases (case is lost at the slug layer)', fails)
+# mint_id: first claimant keeps the plain slug; a differently-cased sibling is
+# disambiguated; the SAME exact name reuses its id.
+reg = {}
+id_a = MechanicalSpecs.mint_id('m-', 'userId', reg)
+id_b = MechanicalSpecs.mint_id('m-', 'UserID', reg)
+id_a2 = MechanicalSpecs.mint_id('m-', 'userId', reg)
+check(id_a == 'm-userid', 'first claimant keeps the plain slug ("m-userid")', fails)
+check(id_b != id_a, 'differently-cased sibling gets a DISTINCT id', fails)
+check(id_b.start_with?('m-userid-'), 'disambiguated id keeps the readable base + a suffix', fails)
+check(id_a2 == id_a, 'same exact name re-mints the SAME id (deterministic)', fails)
+check(MechanicalSpecs.mint_id('m-', 'UserID', {}) == 'm-userid', 'a lone differently-cased name (no prior claim) keeps the plain slug', fails)
+# clamp: a disambiguator can never overflow the 64-char id limit (#445 compose).
+long = 'A' * 80
+long_reg = { "m-#{'a' * 80}" => 'x' } # base already claimed by a different name -> forces the suffix path
+long_id = MechanicalSpecs.mint_id('m-', long, long_reg)
+check(long_id.length <= 64, 'a disambiguated LONG name still clamps to <= 64 chars', fails)
+
+puts 'Part B — derive_master: two case-differing columns -> two distinct ids'
+d = MechanicalSpecs.derive_master(fact(%w[userId UserID Region]), 'Order Fact')
+ids = d['master_columns'].map { |c| c['id'] }
+names = d['master_columns'].map { |c| c['name'] }
+check(ids.size == ids.uniq.size, 'no duplicate master-column ids (would 400 at POST)', fails)
+check(names.include?('userId') && names.include?('UserID'), 'BOTH differently-cased columns survive (no silent drop)', fails)
+check(ids.include?('m-region'), 'a non-colliding name keeps its stable id ("m-region")', fails)
+check(ids.count { |i| i == 'm-userid' } == 1, 'exactly one column owns the plain "m-userid" id', fails)
+check(ids.all? { |i| i.length <= 64 }, 'every master-column id is within the 64-char clamp', fails)
+
+puts 'Part C — genuine same-name duplicate still collapses'
+d2 = MechanicalSpecs.derive_master(fact(['Region', 'Region', 'Sales']), 'Order Fact')
+reg_cols = d2['master_columns'].select { |c| c['name'] == 'Region' }
+check(reg_cols.size == 1, 'two identical "Region" columns collapse to ONE master column', fails)
+check(d2['master_columns'].map { |c| c['id'] }.uniq.size == d2['master_columns'].size, 'no duplicate ids after collapse', fails)
+
+puts 'Part D — determinism across runs'
+r1 = MechanicalSpecs.derive_master(fact(%w[Value value Amount]), 'Order Fact').dig('master_columns').map { |c| c['id'] }
+r2 = MechanicalSpecs.derive_master(fact(%w[Value value Amount]), 'Order Fact').dig('master_columns').map { |c| c['id'] }
+check(r1 == r2, 'the same source yields the SAME ids on every run', fails)
+check(r1.uniq.size == r1.size, '"Value"/"value" get distinct, stable ids', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "FAILURES (#{fails.size}):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
Fixes #455.

### Problem
The master-table builder's column-id slugifier (`MechanicalSpecs.slug`) downcases, so two SOURCE columns that differ only in case — `userId` vs `UserID`, `Value` vs `value` (legitimately distinct columns from a schema that evolved, or a view exposing an original + renamed column) — collapse to one base id. In `derive_master` this either silently **dropped** the second column (a downcased `seen` dedup) or minted a **duplicate id** that 400s with "Duplicate id" at the DM/workbook POST.

### Fix
Deterministic, stable, and composes with the converter's 64-char `clampId` (#445/PR-16):

- New `mint_id` / `case_tag` / `clamp_id` helpers. The **first** name to claim a base slug keeps the plain lowercase id (existing ids stay stable — `Region` → `m-region`); a later **differently-cased** sibling gets a deterministic `<base>-<crc32>` suffix, so distinct columns always get distinct ids. The result is clamped to 64 chars.
- `derive_master` now dedups on the **exact** display name (`seen_exact`), so genuine same-name duplicates still collapse but case-variants both survive. The master-column, FIXED-LOD, and metric mints share one per-build id registry. CRC32 (not `String#hash`) keeps the suffix stable across runs.

### Tests
- New `test-column-id-slug-case.rb` (registered in the CI unit-test allow-list): two case-differing columns → two distinct ids, same-name still collapses, first claimant stays stable, 64-char clamp holds, deterministic across runs.
- Green locally: `corpus 17/17`, `check-shared`, `hygiene-sweep`, and the existing id / element-id-namespacing suites.

Reported by @AlienAllSpark (MoxiWorks) — thanks for the precise repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
