### PR TITLE
tableau: resolve bare SELECT* PDS + honor warehouse class in hydration (#453, #454)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/hydrate-custom-sql.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/hydrate-custom-sql.rb
@@ -42,29 +42,85 @@ require 'rexml/document'
 module HydrateCustomSql
   module_function
 
-  # Upper-snake alias for a warehouse output column — mirrors the converter's
+  # Canonicalize a Tableau connection class / Sigma connection type to a warehouse
+  # family key. A tiny local map (hydrate stays offline / self-contained — no
+  # dependency on rank-connections). Only the distinction this module needs:
+  # case-preserving (Databricks family) vs the upper-folding default (Snowflake).
+  def canon_warehouse_class(cls)
+    k = cls.to_s.strip.downcase.gsub(/[^a-z0-9]/, '')
+    return 'databricks' if %w[databricks spark sparksql databrickssql delta].include?(k)
+    return 'snowflake'  if k.empty? # unknown/absent → Snowflake convention (back-compat default)
+    k
+  end
+
+  # Does this warehouse PRESERVE identifier case? Snowflake folds unquoted
+  # identifiers to UPPER, so a table/column spelled `foo` resolves as FOO and
+  # hydration upper-normalizes to match. Databricks (and the Spark/Delta family)
+  # keep identifiers verbatim — uppercasing them yields a name the warehouse
+  # genuinely doesn't have, which 404s at DM POST (#454). Everything else keeps
+  # the historical upper default (zero regression for currently-working paths).
+  def case_preserving_warehouse?(warehouse_class)
+    canon_warehouse_class(warehouse_class) == 'databricks'
+  end
+
+  # Snake alias for a warehouse output column — mirrors the converter's
   # normalizeColumnName so the spliced metadata-record remote-names line up with
-  # the SQL output identifiers the converter expects.
-  def alias_for(name)
-    name.to_s.gsub(/[^A-Za-z0-9]+/, '_').gsub(/\A_+|_+\z/, '').upcase
+  # the SQL output identifiers the converter expects. Upper-cased for case-folding
+  # warehouses (Snowflake); case PRESERVED for case-preserving ones (Databricks,
+  # #454) so a lowercase source identifier isn't mis-cased into a 404.
+  def alias_for(name, warehouse_class = 'snowflake')
+    base = name.to_s.gsub(/[^A-Za-z0-9]+/, '_').gsub(/\A_+|_+\z/, '')
+    case_preserving_warehouse?(warehouse_class) ? base : base.upcase
   end
 
   # Quote a source column reference only when it is NOT already a safe bare
-  # identifier (has spaces / mixed case / punctuation / leading digit). Matches
-  # the "only quote when needed" rule in the converter's identifier fix, so
-  # already-uppercase columns pass through untouched.
-  def quote_ref(name)
-    a = alias_for(name)
+  # identifier (has spaces / punctuation / leading digit, or — on a case-folding
+  # warehouse — mixed case). Matches the "only quote when needed" rule in the
+  # converter's identifier fix, so identifiers already in the warehouse's native
+  # case pass through untouched.
+  def quote_ref(name, warehouse_class = 'snowflake')
+    a = alias_for(name, warehouse_class)
     (name.to_s == a && name.to_s !~ /\A[0-9]/) ? name.to_s : %("#{name}")
   end
 
-  # Wrap the original Custom SQL and project its output columns with upper-snake
+  # Wrap the original Custom SQL and project its output columns with snake
   # aliases. The original query is preserved verbatim inside the subquery, so
   # arbitrarily complex SQL (joins, CTEs, expressions) is untouched.
-  def wrap_sql(query, columns)
+  def wrap_sql(query, columns, warehouse_class = 'snowflake')
     raise ArgumentError, 'no output columns' if columns.nil? || columns.empty?
-    proj = columns.map { |c| "#{quote_ref(c)} AS #{alias_for(c)}" }.join(', ')
+    proj = columns.map { |c| "#{quote_ref(c, warehouse_class)} AS #{alias_for(c, warehouse_class)}" }.join(', ')
     "SELECT #{proj} FROM (\n#{query.to_s.strip}\n) t"
+  end
+
+  # A published-DS Custom SQL body that is nothing more than `SELECT * FROM <table>`
+  # is semantically identical to just reading <table>. parse_sql_columns can't
+  # statically enumerate `*`, which would strand the PDS with 0 columns and hard-
+  # abort the whole migration even though the underlying table is fully resolvable
+  # (#453). When the body is EXACTLY a bare star-select of a SINGLE table/view (no
+  # JOIN / WHERE / GROUP / UNION / subquery / expression), return that table token
+  # so the caller can resolve it as a normal table relation (the warehouse catalog
+  # then supplies the columns). Returns nil for anything more than a plain star-
+  # select — the caller keeps it as Custom SQL / falls back to a probe / aborts,
+  # so we never fabricate a table where the SQL actually did more.
+  def bare_select_star_table(sql)
+    s = sql.to_s.gsub(/\s+/, ' ').strip.sub(/;+\s*\z/, '')
+    m = s.match(/\ASELECT\s+(?:DISTINCT\s+)?\*\s+FROM\s+(.+?)\z/i)
+    return nil unless m
+    rest = m[1].strip
+    # A subquery or a comma-separated table list is not a single-table read.
+    return nil if rest.include?('(') || rest.include?(',')
+    # Any further clause / join / set-op means expansion would change semantics.
+    return nil if rest =~ /\b(?:JOIN|WHERE|GROUP\s+BY|ORDER\s+BY|HAVING|UNION|EXCEPT|INTERSECT|LIMIT|QUALIFY|ON|USING|CROSS|NATURAL|PIVOT|UNPIVOT|TABLESAMPLE)\b/i
+    toks = rest.split(' ')
+    table = case toks.length
+            when 1 then toks[0]                                # <table>
+            when 2 then toks[0]                                # <table> <alias>
+            when 3 then (toks[1] =~ /\AAS\z/i ? toks[0] : nil) # <table> AS <alias>
+            end
+    return nil unless table
+    # Must look like an identifier path (bracketed / quoted / dotted), not an expr.
+    return nil unless table =~ /\A[\[\]"`\w.$]+\z/
+    table
   end
 
   # Derive the OUTPUT column names of a SELECT. A published DS's Custom SQL is the
@@ -270,6 +326,19 @@ module HydrateCustomSql
                   columns: [], warehouse_class: 'snowflake')
     conn = ds.elements['connection']
     return false unless conn
+
+    # VALIDATE BEFORE MUTATING. If the splice can't complete (no table path, or an
+    # empty-column Custom SQL relation we won't fabricate), leave the sqlproxy
+    # placeholder untouched — the migrate phantom guard relies on an unresolved PDS
+    # still LOOKING like sqlproxy to abort loudly, rather than being partially
+    # rewritten into a class='<warehouse>' connection with no relation that slips
+    # past the guard and emits a broken element (#453).
+    if relation_type == 'table'
+      return false if table_path.to_s.strip.empty?
+    elsif sql.to_s.strip.empty? || columns.nil? || columns.empty?
+      return false
+    end
+
     rel_name = conn.elements['.//relation']&.attributes&.[]('name')
     rel_name = nil if rel_name.to_s.empty? || rel_name.to_s.downcase == 'sqlproxy'
     rel_name ||= (ds.attributes['caption'] || 'PublishedDS').to_s
@@ -287,13 +356,11 @@ module HydrateCustomSql
     rel.add_attribute('name', rel_name)
 
     if relation_type == 'table'
-      return false if table_path.to_s.strip.empty?
       rel.add_attribute('type', 'table')
       rel.add_attribute('table', qualify_table(table_path, db, schema))
     else
-      return false if sql.to_s.strip.empty? || columns.nil? || columns.empty?
       rel.add_attribute('type', 'text')
-      rel.text = wrap_sql(sql, columns)
+      rel.text = wrap_sql(sql, columns, warehouse_class)
     end
     conn.add_element(rel)
     mr = conn.elements['metadata-records']
@@ -323,23 +390,23 @@ module HydrateCustomSql
           cap = (m.get_text('caption')&.value || '').strip
           info = { 'ltype' => (m.get_text('local-type')&.value || '').strip,
                    'agg'   => (m.get_text('aggregation')&.value || '').strip }
-          cached[alias_for(rn)] = info unless rn.empty?
+          cached[alias_for(rn, warehouse_class)] = info unless rn.empty?
           cached[cap.downcase] = info unless cap.empty?
         end
         existing&.remove
         mrs = REXML::Element.new('metadata-records')
         columns.each do |c|
-          info = cached[alias_for(c)] || cached[c.to_s.downcase] || {}
+          info = cached[alias_for(c, warehouse_class)] || cached[c.to_s.downcase] || {}
           # ALWAYS class='column': the converter's Custom-SQL column build SKIPS
           # any metadata-record whose class != 'column' (tableau.ts), so a cached
           # class='measure' would silently DROP that column from the DM element —
           # and a Switch measure referencing it then can't resolve (live-caught
           # 2026-07-07: Amount USD/PROFIT vanished). Keep the local-type hint.
           rec = mrs.add_element('metadata-record', 'class' => 'column')
-          rec.add_element('remote-name').text = alias_for(c)
+          rec.add_element('remote-name').text = alias_for(c, warehouse_class)
           rec.add_element('local-name').text = "[#{c}]"
           rec.add_element('parent-name').text = "[#{rel_name}]"
-          rec.add_element('remote-alias').text = alias_for(c)
+          rec.add_element('remote-alias').text = alias_for(c, warehouse_class)
           rec.add_element('local-type').text = (info['ltype'].to_s.empty? ? 'string' : info['ltype'])
           rec.add_element('aggregation').text = info['agg'] unless info['agg'].to_s.empty?
           rec.add_element('caption').text = c
@@ -351,7 +418,7 @@ module HydrateCustomSql
         existing.each_element('metadata-record') do |m|
           rn = m.get_text('remote-name')
           next unless rn
-          m.elements['remote-name'].text = alias_for(rn.value.strip)
+          m.elements['remote-name'].text = alias_for(rn.value.strip, warehouse_class)
         end
       end
     end
@@ -395,12 +462,28 @@ module HydrateCustomSql
       url = pds_content_url(ds).to_s.downcase
       d = by_url[url]
       next unless d
+      # #454: each descriptor carries its OWN warehouse class (read from the PDS
+      # .tds connection); prefer it over the caller default so a Databricks PDS
+      # isn't case-normalized with Snowflake's upper-folding rules.
+      wcls = d['warehouseClass'].to_s.empty? ? warehouse_class : d['warehouseClass']
       rtype = d['relationType'].to_s == 'table' ? 'table' : 'text'
       cols = d['columns'] || (rtype == 'text' ? parse_sql_columns(d['sql']) : [])
+      table_path = d['table']
+      # #453 downstream fallback: a bare `SELECT * FROM <table>` custom-SQL body we
+      # couldn't column-expand is semantically just that table — resolve it as a
+      # table relation (warehouse catalog supplies the columns) rather than handing
+      # splice_pds! an empty-column Custom SQL relation (which it correctly refuses,
+      # stranding the PDS → hard abort). Genuinely-unresolvable SQL (multi-table,
+      # expressions, filters) returns nil here and still aborts loudly.
+      if rtype == 'text' && (cols.nil? || cols.empty?) && (star = bare_select_star_table(d['sql']))
+        rtype = 'table'
+        table_path = star
+        cols = []
+      end
       d_db = d['db'].to_s.empty? ? db : d['db']
       d_schema = d['schema'].to_s.empty? ? schema : d['schema']
-      ok = splice_pds!(ds, relation_type: rtype, sql: d['sql'], table_path: d['table'],
-                       columns: cols, db: d_db, schema: d_schema, warehouse_class: warehouse_class)
+      ok = splice_pds!(ds, relation_type: rtype, sql: d['sql'], table_path: table_path,
+                       columns: cols, db: d_db, schema: d_schema, warehouse_class: wcls)
       next unless ok
       hydrated << { 'caption' => (ds.attributes['caption'] || '').to_s, 'contentUrl' => d['contentUrl'],
                     'relationType' => rtype, 'columns' => cols.size, 'source' => 'rest-content' }
@@ -450,6 +533,9 @@ if __FILE__ == $PROGRAM_NAME
     o.on('--db NAME')          { |v| opts[:db] = v }
     o.on('--schema NAME')      { |v| opts[:schema] = v }
     o.on('--warehouse-class C'){ |v| opts[:wcls] = v }
+    # Alias (#454): callers may name it per-connection. Same meaning — the target
+    # warehouse's identifier-casing family for the PDS splice.
+    o.on('--pds-warehouse-class C'){ |v| opts[:wcls] = v }
     o.on('--out PATH')         { |v| opts[:out] = v }
   end.parse!
   abort 'usage: --twb PATH --out PATH (--pds DESCRIPTORS.json  and/or  --custom-sql BLOCKS.json) [--db DB --schema SCHEMA]' \

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -2064,6 +2064,20 @@ if mechanical
     end
     hyd_args += ['--pds', pds_json] if File.exist?(pds_json)
     hyd_args += ['--custom-sql', hcsql] if File.exist?(hcsql)
+    # #454: derive the target warehouse class from the resolved PDS metadata and
+    # pass it as the splice default. Each descriptor also carries its own class
+    # (hydrate_pds! prefers that per-PDS); this default covers the GraphQL-fallback
+    # splice and any classless descriptor, so a case-preserving warehouse
+    # (Databricks) is never normalized with Snowflake's upper-folding rules.
+    if File.exist?(pds_json)
+      pds_wcls = begin
+        ds_list = JSON.parse(File.read(pds_json, encoding: 'UTF-8'))
+        ds_list.is_a?(Array) ? ds_list.map { |d| d['warehouseClass'] }.compact.map(&:to_s).reject(&:empty?).first : nil
+      rescue StandardError
+        nil
+      end
+      hyd_args += ['--warehouse-class', pds_wcls] if pds_wcls
+    end
     if hyd_args.include?('--pds') || hyd_args.include?('--custom-sql')
       _out, hst = run!(hyd_args, allow_fail: true)
       conv_twb = hyd_twb if hst.success? && File.exist?(hyd_twb) && File.read(hyd_twb, encoding: 'UTF-8') != File.read(twb, encoding: 'UTF-8')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/resolve-published-ds.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/resolve-published-ds.rb
@@ -76,11 +76,28 @@ def descriptor_from_tds(tds_text)
   conn ||= doc.elements['//connection']
   db = conn && conn.attributes['dbname'].to_s
   schema = conn && conn.attributes['schema'].to_s
+  # #454: the PDS's real warehouse class (snowflake / databricks / …) lives on this
+  # connection. Carry it into the descriptor so hydration case-normalizes with the
+  # right rules per-PDS (a case-preserving warehouse must not be upper-folded).
+  wcls = HydrateCustomSql.canon_warehouse_class(conn && conn.attributes['class'])
   if text_rel
-    { 'relationType' => 'text', 'sql' => rel.text.to_s.strip, 'db' => db, 'schema' => schema,
-      'columns' => HydrateCustomSql.parse_sql_columns(rel.text.to_s) }
+    sql = rel.text.to_s.strip
+    cols = HydrateCustomSql.parse_sql_columns(sql)
+    star_table = cols.empty? ? HydrateCustomSql.bare_select_star_table(sql) : nil
+    if star_table
+      # #453: a bare `SELECT * FROM <table>` PDS is semantically just <table>.
+      # parse_sql_columns can't enumerate `*`, so resolve it as a TABLE relation
+      # (the warehouse catalog supplies the columns downstream) instead of emitting
+      # a 0-column Custom SQL relation that would hard-abort the migration.
+      { 'relationType' => 'table', 'table' => star_table, 'db' => db, 'schema' => schema,
+        'columns' => [], 'warehouseClass' => wcls, 'expandedFrom' => 'select-star' }
+    else
+      { 'relationType' => 'text', 'sql' => sql, 'db' => db, 'schema' => schema,
+        'columns' => cols, 'warehouseClass' => wcls }
+    end
   else
-    { 'relationType' => 'table', 'table' => rel.attributes['table'].to_s, 'db' => db, 'schema' => schema, 'columns' => [] }
+    { 'relationType' => 'table', 'table' => rel.attributes['table'].to_s, 'db' => db,
+      'schema' => schema, 'columns' => [], 'warehouseClass' => wcls }
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-hydrate-custom-sql.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-hydrate-custom-sql.rb
@@ -186,6 +186,84 @@ check(hrecs['AMOUNT_USD'].attributes['class'] == 'column', 'class forced to "col
 check(hrecs['AMOUNT_USD'].get_text('local-type').value == 'real', 'cached local-type=real PRESERVED (not downgraded to string)', fails)
 check(hrecs['SALES_REGION'].get_text('local-type').value == 'string' && hrecs['SALES_REGION'].attributes['class'] == 'column', 'uncached column defaults to string/column', fails)
 
+puts 'Part I — warehouse-class case sensitivity (#454)'
+check(H.canon_warehouse_class('snowflake') == 'snowflake', 'canon snowflake', fails)
+check(H.canon_warehouse_class('Databricks') == 'databricks', 'canon Databricks (case/punct-insensitive)', fails)
+check(H.canon_warehouse_class('spark') == 'databricks', 'canon spark→databricks family', fails)
+check(H.canon_warehouse_class('') == 'snowflake', 'canon empty→snowflake default (back-compat)', fails)
+check(!H.case_preserving_warehouse?('snowflake'), 'snowflake is NOT case-preserving (upper-folds)', fails)
+check(H.case_preserving_warehouse?('databricks'), 'databricks IS case-preserving', fails)
+check(!H.case_preserving_warehouse?('redshift'), 'unknown/other warehouse keeps upper default (no regression)', fails)
+check(H.alias_for('Order Date', 'snowflake') == 'ORDER_DATE', 'alias_for uppercases for snowflake', fails)
+check(H.alias_for('Order Date') == 'ORDER_DATE', 'alias_for defaults to snowflake (upper) when no class', fails)
+check(H.alias_for('order_date', 'databricks') == 'order_date', 'alias_for preserves lowercase for databricks (#454)', fails)
+check(H.alias_for('Region Name', 'databricks') == 'Region_Name', 'alias_for preserves case (snake punctuation) for databricks', fails)
+check(H.quote_ref('order_date', 'databricks') == 'order_date', 'quote_ref leaves databricks-native lowercase bare', fails)
+check(H.quote_ref('order_date', 'snowflake') == '"order_date"', 'quote_ref quotes non-upper for snowflake', fails)
+dbx_wrap = H.wrap_sql('SELECT * FROM reporting.curated.foo', ['customer_id', 'Region Name'], 'databricks')
+check(dbx_wrap.include?('customer_id AS customer_id'), 'databricks wrap: lowercase col stays bare + preserved (not uppercased)', fails)
+check(dbx_wrap.include?('"Region Name" AS Region_Name'), 'databricks wrap: mixed-case preserved (quoted src, case-kept alias)', fails)
+sf_wrap = H.wrap_sql('SELECT * FROM T', ['customer_id'], 'snowflake')
+check(sf_wrap.include?('"customer_id" AS CUSTOMER_ID'), 'snowflake wrap still uppercases (unchanged behavior)', fails)
+
+puts 'Part J — bare SELECT * expansion helper (#453)'
+check(H.bare_select_star_table('SELECT * FROM analytics_db.reporting.foo') == 'analytics_db.reporting.foo', 'bare star → dotted table token', fails)
+check(H.bare_select_star_table('select   *   from   [DB].[SC].[T]') == '[DB].[SC].[T]', 'bare star (bracketed, extra whitespace) → table', fails)
+check(H.bare_select_star_table('SELECT * FROM foo AS f') == 'foo', 'bare star + AS alias → table', fails)
+check(H.bare_select_star_table('SELECT * FROM foo f') == 'foo', 'bare star + bare alias → table', fails)
+check(H.bare_select_star_table('SELECT DISTINCT * FROM foo') == 'foo', 'bare DISTINCT star → table', fails)
+check(H.bare_select_star_table('SELECT * FROM foo;') == 'foo', 'trailing semicolon tolerated', fails)
+check(H.bare_select_star_table('SELECT * FROM a JOIN b ON a.id=b.id').nil?, 'star with JOIN → nil (semantics differ)', fails)
+check(H.bare_select_star_table('SELECT * FROM foo WHERE x=1').nil?, 'star with WHERE → nil (would drop the filter)', fails)
+check(H.bare_select_star_table('SELECT * FROM (SELECT 1) t').nil?, 'star over a subquery → nil', fails)
+check(H.bare_select_star_table('SELECT a, b FROM foo').nil?, 'explicit projection → nil (not a star)', fails)
+check(H.bare_select_star_table('SELECT * FROM a, b').nil?, 'comma table list → nil', fails)
+
+puts 'Part K — hydrate_pds! expands bare SELECT * (no abort) + case-preserving warehouse (#453/#454)'
+star_twb = <<~XML
+  <workbook><datasources>
+    <datasource caption='Bare'>
+      <repository-location id='PDS_BARE'/>
+      <connection class='sqlproxy' dbname='PDS_BARE'><relation name='sqlproxy' table='[sqlproxy]' type='table'/></connection>
+    </datasource>
+    <datasource caption='Unresolvable'>
+      <repository-location id='PDS_BAD'/>
+      <connection class='sqlproxy' dbname='PDS_BAD'><relation name='sqlproxy' table='[sqlproxy]' type='table'/></connection>
+    </datasource>
+  </datasources></workbook>
+XML
+sdoc = REXML::Document.new(star_twb)
+sdescs = [
+  { 'contentUrl' => 'PDS_BARE', 'relationType' => 'text',
+    'sql' => 'SELECT * FROM analytics_db.reporting.order_events',
+    'db' => 'analytics_db', 'schema' => 'reporting', 'columns' => [], 'warehouseClass' => 'databricks' },
+  { 'contentUrl' => 'PDS_BAD', 'relationType' => 'text',
+    'sql' => 'SELECT * FROM a JOIN b ON a.id = b.id', 'db' => 'RAW', 'schema' => 'ING', 'columns' => [] }
+]
+sh = H.hydrate_pds!(sdoc, descriptors: sdescs, db: 'DB', schema: 'SC')
+check(sh.size == 1, 'only the resolvable (bare SELECT*) PDS hydrated; the unresolvable one is dropped', fails)
+check(sh.first['relationType'] == 'table', 'bare SELECT* resolved to a TABLE relation (no abort) (#453)', fails)
+bare_conn = sdoc.elements["/workbook/datasources/datasource[@caption='Bare']/connection"]
+bare_rel = nil; bare_conn.each_element('.//relation') { |r| bare_rel = r }
+check(bare_rel.attributes['type'] == 'table', 'Bare PDS spliced as a table relation', fails)
+check(bare_rel.attributes['table'] == '[analytics_db].[reporting].[order_events]', 'table qualified, lowercase PRESERVED (databricks, #454)', fails)
+check(bare_conn.attributes['class'] == 'databricks', 'connection stamped with the databricks class (#454)', fails)
+bad_conn = sdoc.elements["/workbook/datasources/datasource[@caption='Unresolvable']/connection"]
+check(bad_conn.attributes['class'] == 'sqlproxy' && bad_conn.to_s.include?('[sqlproxy]'),
+      'genuinely-unresolvable PDS left as sqlproxy placeholder → migrate hard-aborts loudly', fails)
+
+# Databricks Custom SQL with explicit columns: aliases + metadata remote-names case-preserved.
+ddoc = REXML::Document.new("<workbook><datasources><datasource caption='DBX'><repository-location id='PDS_DBX'/><connection class='sqlproxy' dbname='PDS_DBX'><relation name='sqlproxy' table='[sqlproxy]' type='table'/></connection></datasource></datasources></workbook>")
+H.hydrate_pds!(ddoc, descriptors: [{ 'contentUrl' => 'PDS_DBX', 'relationType' => 'text',
+  'sql' => 'SELECT customer_id, "Region Name" FROM analytics_db.reporting.t',
+  'columns' => ['customer_id', 'Region Name'], 'warehouseClass' => 'databricks' }], db: 'DB', schema: 'SC')
+dconn = ddoc.elements["/workbook/datasources/datasource[@caption='DBX']/connection"]
+check(dconn.attributes['class'] == 'databricks', 'databricks custom-SQL PDS: connection class=databricks', fails)
+drel = nil; dconn.each_element('.//relation') { |r| drel = r if r.attributes['type'] == 'text' }
+check(drel.text.to_s.include?('customer_id AS customer_id'), 'databricks custom SQL: lowercase col preserved (not uppercased)', fails)
+dremotes = []; dconn.each_element('.//metadata-records/metadata-record') { |m| dremotes << m.get_text('remote-name').value }
+check(dremotes == %w[customer_id Region_Name], 'databricks custom SQL: metadata remote-names case-preserved', fails)
+
 puts
 if fails.empty?
   puts "ALL PASS (#{`grep -c 'check(' #{__FILE__}`.to_i - 1} assertions)"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-pds-resolve-retry.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-pds-resolve-retry.rb
@@ -72,6 +72,26 @@ STUB = <<~'RUBY'
                   '<error><summary>User does not have the Download capability on this datasource</summary></error>')
       when 'download_401_exhaust'
         raise err(401, 'Unauthorized', '<error><summary>persistent signin failure</summary></error>')
+      when 'download_select_star_databricks'
+        # #453/#454: a Databricks PDS whose Custom SQL is a bare `SELECT * FROM
+        # <lowercase table>`. parse can't enumerate `*`, but the table IS resolvable.
+        return <<~TDS
+          <datasource>
+            <connection class='databricks' dbname='analytics_db' schema='reporting'>
+              <relation type='text' name='Custom SQL Query'>SELECT * FROM analytics_db.reporting.account_facts</relation>
+            </connection>
+          </datasource>
+        TDS
+      when 'download_unresolvable_star'
+        # A genuinely-unresolvable Custom SQL (multi-table join under SELECT *) —
+        # expansion would change semantics, so it stays 0-column text → hard abort.
+        return <<~TDS
+          <datasource>
+            <connection class='databricks' dbname='analytics_db' schema='reporting'>
+              <relation type='text' name='Custom SQL Query'>SELECT * FROM reporting.a JOIN reporting.b ON a.id = b.id</relation>
+            </connection>
+          </datasource>
+        TDS
       end
       # bare .tds (no zip) with a real table relation → a valid descriptor.
       <<~TDS
@@ -166,6 +186,28 @@ Dir.mktmpdir do |tmp|
   check(r[:remints] >= 2, "(c) 401-exhaust: re-mint budget was exercised (got #{r[:remints]} re-mints)", fails)
   check(r[:out].include?('401') && r[:out].include?('content download failed'),
         '(c) 401-exhaust: the exhausted 401 is surfaced loudly', fails)
+
+  # (d) bare `SELECT * FROM <table>` (Databricks): resolves — NO abort — to the
+  #     TABLE (expanded), with the lowercase table PRESERVED and the warehouse
+  #     class captured from the PDS metadata (#453 + #454).
+  r = run.call('download_select_star_databricks')
+  d = r[:descriptors]&.first
+  check(r[:code] == 0, "(d) select*: script completes (exit #{r[:code]})", fails)
+  check(r[:descriptors]&.size == 1, "(d) select*: PDS resolved (no abort), got #{r[:descriptors]&.size.inspect}", fails)
+  check(d && d['relationType'] == 'table', "(d) select*: bare SELECT* EXPANDED to a table relation (#453), got #{d && d['relationType']}", fails)
+  check(d && d['table'] == 'analytics_db.reporting.account_facts',
+        "(d) select*: table extracted, lowercase PRESERVED, got #{d && d['table'].inspect}", fails)
+  check(d && d['warehouseClass'] == 'databricks', "(d) select*: warehouse class captured from PDS metadata (#454), got #{d && d['warehouseClass'].inspect}", fails)
+  check(r[:out].include?('table analytics_db.reporting.account_facts'),
+        '(d) select*: resolution logged as a table (not an empty Custom SQL)', fails)
+
+  # (e) genuinely-unresolvable `SELECT *` (multi-table JOIN): NOT expanded — stays
+  #     a 0-column Custom SQL descriptor, so hydration refuses it and migrate
+  #     hard-aborts loudly (never fabricated into a phantom table).
+  r = run.call('download_unresolvable_star')
+  d = r[:descriptors]&.first
+  check(d && d['relationType'] == 'text', "(e) unresolvable star: kept as Custom SQL (not expanded), got #{d && d['relationType']}", fails)
+  check(d && (d['columns'] || []).empty?, "(e) unresolvable star: 0 columns → hydration refuses → hard abort preserved, got #{d && d['columns'].inspect}", fails)
 end
 
 puts


### PR DESCRIPTION
## What

Fixes two coupled gaps in the tableau-to-sigma custom-SQL / published-datasource (sqlproxy) hydration path, both reported by @AlienAllSpark against the same Databricks-backed workbooks.

### #453 — bare `SELECT *` PDS hard-aborted despite a fully resolvable table
When a published DS's Custom SQL is a bare `SELECT * FROM <table>`, `parse_sql_columns` correctly returns `[]` (it can't statically enumerate `*`), so `splice_pds!` refused the 0-column Custom SQL relation and `migrate-tableau.rb` hard-aborted (`FATAL … sqlproxy … could not be resolved`) even though the underlying warehouse table is fully queryable.

- New `HydrateCustomSql.bare_select_star_table` recognizes a body that is **only** `SELECT [DISTINCT] * FROM <single table>` (optional alias / trailing `;`) and returns that table token; returns `nil` for anything with a JOIN / WHERE / GROUP / UNION / subquery / comma-list / expression — expanding those would change semantics, so we never fabricate.
- `resolve-published-ds.rb` **expands** such a PDS into a **table descriptor** (the warehouse catalog then supplies the columns downstream) instead of a 0-column Custom SQL descriptor; `hydrate_pds!` carries the same fallback so older descriptors self-heal.
- A genuinely-unresolvable body stays 0-column text → hydration refuses → the phantom-guard abort **still fires loudly**.

### #454 — hydration hardcoded `--warehouse-class snowflake`, breaking case-preserving warehouses
`alias_for` unconditionally UPPER-folded identifiers and the splice defaulted to snowflake, so against Databricks (case-preserving, lowercase tables) the derived identifiers 404'd at DM POST.

- `resolve-published-ds.rb` captures each PDS's real warehouse class from the `.tds` `<connection class=…>` into the descriptor (`warehouseClass`); `hydrate_pds!` prefers it per-PDS; `migrate-tableau.rb` derives + passes it as the splice default.
- `alias_for` / `quote_ref` / `wrap_sql` are now case-aware: Snowflake still upper-folds (unchanged default), the Databricks/Spark/Delta family preserves case. Added a `--pds-warehouse-class` CLI alias.

### Hardening
`splice_pds!` now **validates before mutating** — an unspliceable PDS leaves the sqlproxy placeholder intact, so the phantom guard can't be bypassed by a partially-rewritten, relation-less connection in a mixed workbook.

## Tests
- `test-hydrate-custom-sql.rb` (+36 assertions): helper parsing, case preservation (snowflake vs databricks), bare-star expansion, no-abort-when-resolvable vs still-abort-when-not.
- `test-pds-resolve-retry.rb`: stubbed Databricks bare-`SELECT *` → table descriptor (lowercase preserved, class captured); unresolvable-join → 0-col text (abort preserved).
- `corpus` 17/17; `check-shared`; hygiene / lint all clean.
- Vendored converter (`converter/tableau.mjs`) untouched.

Closes #453
Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
