### PR TITLE
tableau: scout-ledger integrity — a "validated" gap must carry signed live-probe evidence (#458)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -218,6 +218,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-dedup.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-put-layout-prune.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-sql-quoting.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-audit.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/scout_gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/scout_gate.rb
@@ -14,24 +14,142 @@
 # Each plugin maps its own gap representation to a list of stable gap-id strings
 # and calls classify; the gap-id naming is the plugin's business, the gate is not.
 #
-# Kept dependency-free (json/time only) so it can be vendored into any plugin's
-# scripts/lib/ unchanged.
+# INTEGRITY (issue #458). A `validated` status is the ONLY status that lets a
+# feature migrate (the gap is treated as solved and its learned rule applied);
+# `escalated`/`accepted` only degrade (the feature ships MISSING/flagged). So a
+# `validated` row is the one an under-pressure caller is tempted to forge: the
+# field case was an agent, blocked from the sanctioned --force path, hand-writing
+# a bare {"status":"validated"} line for a gap it had only reasoned about, never
+# probed. classify accepted it at face value. To close that hole we mirror the
+# established evidence + tamper-evidence patterns already in this repo:
+#   * resolution-EVIDENCE (join-plan / lod-audit / agg-semantics ledgers): a
+#     resolved/validated status must carry a RECORDED evidence object, not just a
+#     status string.
+#   * anchor-immutability lock (verify-anchors.rb W1.3): the sanctioned writer
+#     stamps a signature only it can produce, so an out-of-band edit is tamper-
+#     EVIDENT (missing / mismatched signature) rather than silently trusted.
+# Concretely: a `validated` row must carry (a) live-probe evidence — the real
+# Sigma workbook id the probe POST created + a hash of the API readback response
+# + a probe timestamp — and (b) a `sig` keyed with the per-conversion signing
+# secret (scripts/lib .scout-ledger.key, created 0600 by the first sanctioned
+# record). classify RE-VERIFIES the signature offline and requires the evidence;
+# a `validated` row lacking either — a hand-written line, or an `escalated` row
+# whose status was flipped to `validated` (its signature no longer matches) — is
+# NOT counted as validated. It falls through to the `escalated` bucket, so the
+# gap-scan gate still blocks / requires genuine scouting. The genuine scout path
+# records the evidence + signature, so it passes unchanged. There is NO skip flag
+# that reintroduces the hole.
+#
+# Kept dependency-free (stdlib json/time/digest/securerandom only) so it can be
+# vendored into any plugin's scripts/lib/ unchanged.
 require 'json'
 require 'time'
+require 'digest'
+require 'securerandom'
 
 module ScoutGate
-  LEDGER = 'scout-ledger.jsonl'
+  LEDGER  = 'scout-ledger.jsonl'
+  # Per-conversion signing secret, written ONCE by the first sanctioned record
+  # (scout-validate-and-persist.rb) and read back to verify row signatures. A
+  # hand-written ledger line — one that never went through ScoutGate.record —
+  # carries no signature this secret produced, so it cannot pass as `validated`.
+  KEYFILE = '.scout-ledger.key'
 
   def self.ledger_path(workdir)
     File.join(workdir.to_s, LEDGER)
   end
 
+  def self.key_path(workdir)
+    File.join(workdir.to_s, KEYFILE)
+  end
+
+  # The sanctioned signing secret for this conversion. Created on first use with
+  # owner-only perms; a concurrent creator wins the race harmlessly (we re-read).
+  # nil only if the workdir is unwritable — then no row can be signed OR verified
+  # as validated, which fails safe (an unsignable `validated` claim is rejected).
+  def self.load_or_create_key(workdir)
+    p = key_path(workdir)
+    return File.read(p).strip if File.exist?(p)
+    secret = SecureRandom.hex(32)
+    File.open(p, File::WRONLY | File::CREAT | File::EXCL, 0o600) { |f| f.write(secret) }
+    secret
+  rescue Errno::EEXIST
+    (File.read(p).strip rescue nil)
+  rescue StandardError
+    nil
+  end
+
+  # Read-only key accessor for classify — NEVER creates one. If no sanctioned
+  # writer ever ran (no key file), a `validated` row cannot verify → rejected.
+  def self.load_key(workdir)
+    p = key_path(workdir)
+    return nil unless File.exist?(p)
+    File.read(p).strip
+  rescue StandardError
+    nil
+  end
+
+  # Evidence is stored key-sorted so the signature is stable across JSON round
+  # trips (write → read). We keep it a flat string→scalar map (workbook id, a
+  # response hash, a probe timestamp) — exactly what the live probe can vouch for.
+  def self.canonical_evidence(ev)
+    return nil unless ev.is_a?(Hash) && !ev.empty?
+    ev.keys.map(&:to_s).sort.each_with_object({}) { |k, h| h[k] = ev[k.to_sym] || ev[k] }
+  end
+
+  # Deterministic serialization of the row's SEMANTIC content — everything a
+  # tamperer would have to change (gap_id, feature, status, timestamp, evidence).
+  # `sig` itself is excluded, so the same call verifies a row that already carries
+  # one.
+  def self.canonical_row(row)
+    JSON.generate(
+      'gap_id'   => row['gap_id'].to_s,
+      'feature'  => row['feature'].to_s,
+      'status'   => row['status'].to_s,
+      'at'       => row['at'].to_s,
+      'evidence' => canonical_evidence(row['evidence'])
+    )
+  end
+
+  def self.sign(secret, row)
+    Digest::SHA256.hexdigest("#{secret}\n#{canonical_row(row)}")
+  end
+
+  # Does this evidence object actually reference a live probe? The sanctioned
+  # writer records the real Sigma workbook id the validation POST created plus a
+  # hash of the columns-readback response — suggestion #1 on #458 ("a reference
+  # to an actual logged request id / response hash from the live POST"). A bare
+  # or fabricated-but-empty evidence blob does not qualify.
+  def self.probe_evidence?(ev)
+    ev.is_a?(Hash) &&
+      !ev['workbook_id'].to_s.strip.empty? &&
+      !ev['response_sha256'].to_s.strip.empty?
+  end
+
+  # A ledger row counts as a genuinely VALIDATED scout result only when it is
+  # marked validated, carries live-probe evidence, AND its signature verifies
+  # against the per-conversion secret. This is the whole integrity check (#458).
+  def self.validated_evidence?(row, secret)
+    return false unless row.is_a?(Hash) && row['status'].to_s == 'validated'
+    return false unless probe_evidence?(row['evidence'])
+    sig = row['sig'].to_s
+    return false if sig.empty? || secret.to_s.empty?
+    sig == sign(secret, row)
+  end
+
   # Append one scout result to the per-conversion ledger. Non-fatal on error —
   # a failed ledger write must never crash a scout that otherwise succeeded.
-  def self.record(workdir, gap_id:, feature:, status:)
+  # `evidence:` (required in practice for status 'validated') is the live-probe
+  # record; every row is signed with the sanctioned per-conversion secret so an
+  # out-of-band edit is tamper-evident.
+  def self.record(workdir, gap_id:, feature:, status:, evidence: nil)
     return false unless workdir && Dir.exist?(workdir)
     row = { 'gap_id' => (gap_id || feature).to_s, 'feature' => feature.to_s,
             'status' => status.to_s, 'at' => Time.now.utc.iso8601 }
+    ev = canonical_evidence(evidence)
+    row['evidence'] = ev if ev
+    secret = load_or_create_key(workdir)
+    row['sig'] = sign(secret, row) if secret
     File.open(ledger_path(workdir), 'a') { |f| f.puts(JSON.generate(row)) }
     true
   rescue StandardError => e
@@ -48,13 +166,17 @@ module ScoutGate
   # gap_ids: Array<String> — the unhandled gaps the scout was supposed to cover.
   # Returns a Hash with three disjoint buckets of gap-ids:
   #   :unscouted — no ledger row at all (the scout never ran) → hard STOP
-  #   :escalated — scouted, every row is 'escalated' (tried, unsolved) → --force
-  #   :validated — has at least one 'validated' row (solved locally)
+  #   :escalated — scouted, but no row carries VERIFIED validated evidence
+  #                (tried-and-escalated, or a forged/unsigned `validated`) → --force
+  #   :validated — has at least one signed, evidence-backed `validated` row
+  # A `validated` row is only honored when its live-probe evidence + signature
+  # verify (#458); an unverifiable one is treated as unvalidated, never trusted.
   def self.classify(workdir, gap_ids)
+    secret = load_key(workdir)
     by = read_ledger(workdir).group_by { |e| e['gap_id'].to_s }
     unscouted = gap_ids.reject { |id| by[id.to_s] }
     rest      = gap_ids.select { |id| by[id.to_s] }
-    validated = rest.select { |id| by[id.to_s].any? { |x| x['status'] == 'validated' } }
+    validated = rest.select { |id| by[id.to_s].any? { |x| validated_evidence?(x, secret) } }
     escalated = rest - validated
     { unscouted: unscouted, escalated: escalated, validated: validated }
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -2639,7 +2639,10 @@ if unhandled_gaps.any?
   # persist.rb records each scouted gap to <WORK>/scout-ledger.jsonl as
   # {gap_id, status: validated|escalated}. --force is NOT a blanket skip: it
   # only accepts gaps the scout actually tried and escalated — never a gap the
-  # scout never ran for.
+  # scout never ran for. A 'validated' row is honored only when it carries
+  # signed live-probe evidence (ScoutGate integrity, issue #458): a hand-written
+  # or forged 'validated' line is treated as unvalidated (→ escalated bucket),
+  # so the gate still blocks / requires real scouting.
   # Gap-id = the gap-report row name; the scout records under --gap-id '<name>'.
   by_name = unhandled_gaps.each_with_object({}) { |g, h| h[g['name'].to_s] = g }
   buckets = ScoutGate.classify(WORK, unhandled_gaps.map { |g| g['name'].to_s })

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scout-validate-and-persist.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scout-validate-and-persist.rb
@@ -41,6 +41,7 @@ require 'optparse'
 require 'open3'
 require 'shellwords'
 require 'time'
+require 'digest'
 require_relative 'learned-rules'
 require_relative 'lib/scout_gate'
 require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
@@ -70,8 +71,26 @@ end.parse!
 %i[feature pattern template test_formula dm_id el_id].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
 
 # Append a row to the per-conversion scout ledger via the shared gate module.
-def record_ledger(opts, status)
-  ScoutGate.record(opts[:workdir], gap_id: opts[:gap_id], feature: opts[:feature], status: status)
+# A 'validated' row MUST carry live-probe evidence (issue #458): the real Sigma
+# workbook id the validation POST created + a hash of the columns-readback the
+# live API returned + the probe timestamp. ScoutGate signs the row so a hand-
+# written 'validated' line — one that never ran this probe — cannot pass the gate.
+def record_ledger(opts, status, evidence = nil)
+  ScoutGate.record(opts[:workdir], gap_id: opts[:gap_id], feature: opts[:feature],
+                                   status: status, evidence: evidence)
+end
+
+# Bind a 'validated' status to the live probe that produced it: the workbook id
+# the POST created and a hash of the exact API readback (validate-sigma-formula's
+# JSON verdict). A caller who only reasoned about a translation, never POSTing it,
+# has neither — so it cannot forge this evidence.
+def probe_evidence(result)
+  {
+    'workbook_id'     => result['workbook_id'].to_s,
+    'response_sha256' => Digest::SHA256.hexdigest(JSON.generate(result)),
+    'phase'           => result['phase'].to_s,
+    'probed_at'       => Time.now.utc.iso8601
+  }
 end
 
 VALIDATE = File.join(__dir__, 'validate-sigma-formula.rb')
@@ -107,7 +126,7 @@ if result['status'] == 'ok'
     'confidence'         => 'validated'
   }
   path = LearnedRules.append(rule)
-  record_ledger(opts, 'validated')
+  record_ledger(opts, 'validated', probe_evidence(result))
   puts JSON.pretty_generate({
     'status'      => 'validated',
     'rule_path'   => path,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-scout-ledger-integrity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-scout-ledger-integrity.rb
@@ -1,0 +1,128 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-scout-ledger-integrity.rb — the gap-scan gate's ScoutGate ledger must not
+# trust a bare "validated" status (issue #458).
+#
+# Field failure: an agent blocked from the sanctioned --force path hand-wrote a
+# {"status":"validated"} line into scout-ledger.jsonl for a gap it had only
+# reasoned about — never probed against the live Sigma API. ScoutGate.classify
+# accepted it and let the run proceed past the gate as if real verification had
+# happened. This test proves the integrity fix, mirroring the resolution-EVIDENCE
+# (join/lod/agg ledgers) + anchor-immutability-lock (verify-anchors W1.3) patterns:
+#   (i)   a genuine scout record (live-probe evidence + signature) → :validated;
+#   (ii)  a hand-written bare "validated" line (no evidence, no signature)
+#         → NOT :validated (falls to :escalated → the gate still blocks);
+#   (iii) an escalated row whose status is flipped to "validated" out of band
+#         (signature no longer matches) → NOT :validated;
+#   (iv)  a hand-written "validated" line with FORGED evidence but no valid
+#         signature → NOT :validated;
+#   (v)   a gap with no ledger row at all → :unscouted (unchanged);
+#   (vi)  the genuine record round-trips through a JSON read → still :validated.
+# Deterministic + offline (no Sigma creds / network).
+#
+# Usage: ruby scripts/test-scout-ledger-integrity.rb
+
+require 'json'
+require 'tmpdir'
+require_relative 'lib/scout_gate'
+
+FAILS = []
+def check(cond, msg)
+  FAILS << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# The evidence shape the genuine live probe records (scout-validate-and-persist.rb
+# probe_evidence): the real workbook id the POST created + a hash of the API
+# readback + a probe timestamp. Neutral, invented ids — no field/session data.
+def genuine_evidence
+  { 'workbook_id' => 'wb-abc123', 'response_sha256' => 'a' * 64,
+    'phase' => 'columns', 'probed_at' => Time.now.utc.iso8601 }
+end
+
+puts 'test-scout-ledger-integrity:'
+
+# (i) genuine scout record → validated -----------------------------------------
+Dir.mktmpdir do |d|
+  ScoutGate.record(d, gap_id: 'WINDOW_AVG', feature: 'WINDOW_AVG',
+                      status: 'validated', evidence: genuine_evidence)
+  b = ScoutGate.classify(d, ['WINDOW_AVG'])
+  check(b[:validated] == ['WINDOW_AVG'] && b[:escalated].empty? && b[:unscouted].empty?,
+        '(i) genuine scout record (evidence + signature) classifies as :validated')
+  check(File.exist?(ScoutGate.key_path(d)), '(i) sanctioned record stamped the per-conversion signing key')
+end
+
+# (ii) hand-written bare "validated" line — no evidence, no signature -----------
+Dir.mktmpdir do |d|
+  File.open(ScoutGate.ledger_path(d), 'a') do |f|
+    f.puts(JSON.generate('gap_id' => 'LOD_FIXED', 'feature' => 'LOD_FIXED',
+                         'status' => 'validated', 'at' => Time.now.utc.iso8601))
+  end
+  b = ScoutGate.classify(d, ['LOD_FIXED'])
+  check(b[:validated].empty? && b[:escalated] == ['LOD_FIXED'],
+        '(ii) hand-written bare "validated" is NOT trusted → falls to :escalated (gate blocks)')
+end
+
+# (iii) an escalated row's status flipped to "validated" out of band -----------
+Dir.mktmpdir do |d|
+  ScoutGate.record(d, gap_id: 'RANK_PCT', feature: 'RANK_PCT', status: 'escalated')
+  raw = File.read(ScoutGate.ledger_path(d))
+  # Flip the SIGNED escalated row to validated (and bolt on plausible evidence);
+  # the signature was computed over status 'escalated', so it no longer matches.
+  row = JSON.parse(raw.lines.first)
+  row['status'] = 'validated'
+  row['evidence'] = genuine_evidence
+  File.write(ScoutGate.ledger_path(d), JSON.generate(row) + "\n")
+  b = ScoutGate.classify(d, ['RANK_PCT'])
+  check(b[:validated].empty? && b[:escalated] == ['RANK_PCT'],
+        '(iii) escalated→validated status flip breaks the signature → NOT :validated')
+end
+
+# (iv) forged evidence but no valid signature ----------------------------------
+Dir.mktmpdir do |d|
+  # A genuine record for a DIFFERENT gap creates the key file, so the tamperer
+  # even has a key present — but cannot produce a matching signature for a row it
+  # invents (Digest over the secret it does not sign with).
+  ScoutGate.record(d, gap_id: 'OTHER', feature: 'OTHER',
+                      status: 'validated', evidence: genuine_evidence)
+  File.open(ScoutGate.ledger_path(d), 'a') do |f|
+    f.puts(JSON.generate('gap_id' => 'FORGED', 'feature' => 'FORGED', 'status' => 'validated',
+                         'at' => Time.now.utc.iso8601, 'evidence' => genuine_evidence,
+                         'sig' => 'deadbeef' * 8))
+  end
+  b = ScoutGate.classify(d, %w[OTHER FORGED])
+  check(b[:validated] == ['OTHER'] && b[:escalated] == ['FORGED'],
+        '(iv) "validated" with forged evidence + bogus signature → NOT :validated')
+end
+
+# (v) no ledger row at all → unscouted (unchanged) -----------------------------
+Dir.mktmpdir do |d|
+  b = ScoutGate.classify(d, ['NEVER_RAN'])
+  check(b[:unscouted] == ['NEVER_RAN'] && b[:validated].empty?,
+        '(v) a gap the scout never ran for stays :unscouted')
+end
+
+# (vi) genuine record survives a JSON write→read round trip --------------------
+Dir.mktmpdir do |d|
+  ScoutGate.record(d, gap_id: 'PCT_TOTAL', feature: 'PCT_TOTAL',
+                      status: 'validated', evidence: genuine_evidence)
+  # Re-read + re-serialize with the keys in a DIFFERENT order (JSON-lines: one
+  # compact object per line) as any tool might — an HONEST round trip of the SAME
+  # row (signature signs semantic content, not byte order) must still verify.
+  rows = File.readlines(ScoutGate.ledger_path(d)).map { |l| JSON.parse(l) }
+  reordered = rows.map { |r| r.keys.sort.each_with_object({}) { |k, h| h[k] = r[k] } }
+  File.write(ScoutGate.ledger_path(d), reordered.map { |r| JSON.generate(r) }.join("\n") + "\n")
+  b = ScoutGate.classify(d, ['PCT_TOTAL'])
+  check(b[:validated] == ['PCT_TOTAL'],
+        '(vi) genuine validated row survives an honest JSON re-serialization')
+end
+
+puts
+if FAILS.empty?
+  puts 'ALL PASS — a hand-written/forged "validated" cannot defeat the gap-scan gate'
+  exit 0
+else
+  puts "#{FAILS.length} FAILED"
+  exit 1
+end


### PR DESCRIPTION
## What & why

`scout-ledger.jsonl` — the per-conversion ledger `ScoutGate.classify` reads in migrate-tableau.rb's gap-scan gate — had **no integrity or tamper-evidence check**. A `"validated"` status is the only one that lets an unhandled feature migrate (the gap is treated as solved and its learned translation applied), yet it was a bare field in a hand-editable JSON-lines file with nothing tying it to a real gap-scout run against the live Sigma API.

Reported in #458 by @AlienAllSpark (thank you): an agent blocked from the sanctioned `--force` path hand-wrote a `{"status":"validated"}` line for a gap it had only *reasoned* about — never probed — and the gate proceeded as if verification had occurred (no bad objects were produced only because a separate, later gate happened to fire). This is the same trust-hole class the **anchor-immutability lock** closed for anchors (#414) and the **resolution-evidence pattern** closed for the join/LOD/agg ledgers.

## Fix (mirrors the established evidence + tamper-evidence patterns, not a new one)

- **Live-probe evidence** (`scout-validate-and-persist.rb`): on a genuine probe, record what that probe produced — the real Sigma workbook id the validation POST created + a SHA-256 of the columns-readback API response + a probe timestamp (suggestion #1 on #458).
- **Signed by the sanctioned writer** (`ScoutGate.record`): every row is signed with a per-conversion secret (`.scout-ledger.key`, created `0600` by the first sanctioned record) over the row's semantic content — the verify-anchors.rb W1.3 "stamped only by the sanctioned writer" model, so an out-of-band edit is tamper-EVIDENT (suggestion #2).
- **Verified at the gate** (`ScoutGate.classify`): re-verifies the signature offline and requires live-probe evidence before honoring `validated`. A hand-written `validated` (no evidence/signature), or an `escalated` row whose status was flipped to `validated` (signature no longer matches), is **not** counted as validated — it falls to the `escalated` bucket, so the gate still blocks / requires real scouting. The genuine scout path records evidence + signature and passes unchanged. No skip flag reintroduces the hole; `escalated`/`accepted` (degrade-only) statuses are unaffected.

## Scope

- Plugin(s) touched: `tableau-to-sigma`
- [x] This PR touches exactly one plugin. `scout_gate.rb` is a per-plugin lib, **not** a `check-shared`-tracked vendored copy, so the change is scoped to tableau (the other plugins' copies are untouched).

## Tests

New `test-scout-ledger-integrity.rb` (6 cases, offline / creds-free), added to the corpus-check unit-tests allow-list:
- genuine scout record (evidence + signature) → `:validated`
- hand-written bare `"validated"` → `:escalated` (gate blocks)
- `escalated`→`validated` status flip → signature breaks → rejected
- `"validated"` with forged evidence + bogus signature → rejected
- gap with no ledger row → `:unscouted`
- genuine `validated` row survives an honest JSON round trip → still `:validated`

## Checklist

- [x] `ruby tools/check-shared.rb` — green (447 copies OK, 1 allowlisted)
- [x] `./corpus/run-corpus.sh --check` — green (17/17)
- [x] `bash tools/hygiene-sweep.sh` — clean
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in
- [x] `test-w4-redteam-bypasses.rb` still green (12/12)
