### PR TITLE
qlik-to-sigma: emit Sigma native trellis (rank-2 cross-converter plan)

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -294,6 +294,23 @@ MANUAL. The builder emits the **`control-scope.json` sidecar** (contract:
 `sourceFilterSignals`, per-control `mustReach` over every chart on every page
 (static proof of global reach), and `unbound` entries with reasons.
 
+**Native trellis (small multiples).** A Qlik **chart-level trellis** (a chart
+whose Appearance>Trellis splits it into a panel grid by a dimension) and the
+native **trellis-container** object both collapse to Sigma's **native element
+`trellis`** — ONE viz element + `rowsBy`/`columnsBy` faceting, NOT N cloned
+charts. Discovery records the neutral signal `chart["trellis"] = {field,
+orientation, secondary?, label?}`; `build-sigma-workbook.py`'s `emit_trellis`
+adds the facet dimension as a column and calls the shared **`TrellisEmit`**
+(`scripts/lib/trellis_emit.py`, a byte-identical mirror of the Ruby
+`shared/lib/trellis_emit.rb`) — the single source of truth for the supported
+kinds (`bar/line/area/combo/scatter/donut`) and the fallbacks (pie→donut,
+kpi→N sibling KPIs, pivot→own shelves, table→flat). Sigma **silently strips**
+an unsupported `trellis` on readback, so the build writes the neutral
+`native-trellis-emitted.json` sidecar and the round-trip is asserted by
+`verify-trellis-survived.rb` (converter-neutral) against the readback spec. A
+non-trellis app is byte-identical (no signal → no-op → no sidecar). See
+`docs/sigma-trellis-chart-support.md` + `docs/trellis-cross-converter-plan.md`.
+
 ## Phase 5 — Parity (hard gate)
 Three checks, led by the **freshness banner** (Phase 1.5 — read it before any
 side-by-side):

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -59,6 +59,14 @@ TEMPORAL = re.compile(r"DATE|MONTH|YEAR|QUARTER|WEEK|DAY", re.I)
 # beads-sigma-93ps contract: catalog = data, code = thin resolver/predicates.
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import coverage_catalog as _cc  # noqa: E402
+import trellis_emit as _te      # noqa: E402  shared native-trellis emitter (supported-kind gate + fallbacks)
+
+# Native-trellis round-trip sidecar records (element_id/kind/name/axis/columnId).
+# Populated by emit_trellis; written to native-trellis-emitted.json ONLY when a
+# trellis was actually emitted — a non-trellis app stays byte-identical (no file).
+# Sigma silently STRIPS an unsupported trellis on readback, so verify-trellis-
+# survived.rb re-reads the posted spec and asserts each of these survived.
+_TRELLIS_RECORDS = []
 _CAT_DIR = _cc.default_catalog_dir(__file__)
 VIZ_CAT  = _cc.load(_CAT_DIR, "viz-kind")       # Qlik vizType     -> Sigma element kind
 AGG_CAT  = _cc.load(_CAT_DIR, "aggregation")    # Qlik agg fn      -> Sigma aggregate fn
@@ -346,6 +354,112 @@ def qlik_refmarks(c):
                 rm["label"] = {"visibility": "shown", "text": r["label"]}
             out.append(rm)
     return out
+
+# ---- native trellis (small multiples) — detection + emission ---------------
+# Qlik has TWO trellis shapes, both of which faithfully become Sigma's NATIVE
+# element `trellis` (ONE viz element + rowsBy/columnsBy facet — NOT N cloned
+# charts):
+#   (a) CHART-LEVEL trellis — a chart (bar/line/area/combo/…) whose properties
+#       carry a trellis dimension that splits the one chart into a panel grid.
+#       qlik-discover records this as chart["trellis"].
+#   (b) TRELLIS-CONTAINER object — a native "trellis container"/"grid container"
+#       whose single child chart is repeated per member of a facet dimension.
+#       Recorded as vizType "trellis-container"/"sn-trellis-container" with the
+#       base chart in children[] and the facet in ["trellis"].
+# The discovered signal is converter-neutral:
+#   chart["trellis"] = {"field": <qlik dim def / libId>, "orientation":
+#                       "rows"|"cols"|"grid", "secondary": <optional 2nd dim>,
+#                       "label": <optional axis label>}
+# EMISSION is delegated to the shared TrellisEmit (supported-kind gate + the
+# pie->donut / kpi->siblings / pivot->shelves / table->flat fallbacks) — no
+# per-tool trellis logic. When a chart carries NO trellis signal every function
+# here is a no-op, so a non-trellis app builds BYTE-IDENTICAL to before.
+_TRELLIS_KINDS = ("trellis-container", "sn-trellis-container")
+
+def trellis_child_ids(charts):
+    """Object ids that are the BASE child of some trellis-container — they are
+    emitted THROUGH their container (one faceted element), never standalone."""
+    return {ch for ct in charts.values() if ct.get("vizType") in _TRELLIS_KINDS
+            for ch in (ct.get("children") or [])}
+
+def trellis_base(c, charts, warnings):
+    """A Qlik trellis-CONTAINER -> its base child chart carrying the container's
+    facet signal, so the normal build path emits ONE faceted element. A plain
+    chart (container or not) is returned unchanged. Returns None to skip."""
+    if c.get("vizType") not in _TRELLIS_KINDS:
+        return c
+    base = next((charts.get(k) for k in (c.get("children") or []) if charts.get(k)), None)
+    if base is None:
+        warnings.append(f"trellis-container '{c.get('title') or c['id']}': no base child chart "
+                        "discovered — skipped (nothing to facet)")
+        return None
+    b = json.loads(json.dumps(base))        # don't mutate the shared charts record
+    b["id"] = c["id"]                        # keep the container's layout slot + element id
+    if c.get("title"): b["title"] = c["title"]
+    b["trellis"] = c.get("trellis") or base.get("trellis")   # container facet wins
+    return b
+
+def emit_trellis(el, c, resolve, warnings):
+    """Attach Sigma's native `trellis` to a built element from the Qlik trellis
+    signal, via the shared TrellisEmit. No-op (byte-identical) when the chart has
+    no signal. Records the emit for the readback survival guard."""
+    sig = c.get("trellis")
+    if not isinstance(sig, dict) or not sig:
+        return
+    field = sig.get("field")
+    dn = resolve(field) if field else None
+    if not dn:
+        warnings.append(f"trellis on '{el.get('name')}': facet field {field!r} not on the denorm "
+                        "element — chart left un-trellised (flat), not faceted on a wrong column")
+        return
+    kind = el.get("kind")
+    # Scatter's Qlik shape sources a HIDDEN grouped table (not the master), so a
+    # bare [Master/<facet>] facet column would dangle — defer it loudly.
+    if el.get("source", {}).get("elementId") != MASTER_ID:
+        warnings.append(f"trellis on '{el.get('name')}' ({kind}): base element sources a derived "
+                        "table (e.g. scatter's grouped source) — native trellis DEFERRED (facet the "
+                        "grouped source by hand); chart left flat")
+        return
+    # Supported-kind gate lives ONCE in TrellisEmit. Unsupported kinds strip the
+    # key silently on readback → take the documented fallback (leave flat).
+    if not _te.trellises(kind):
+        follow = ("N sibling KPIs is the correct faceted shape" if kind == "kpi-chart"
+                  else "pivot uses its own rowsBy/columnsBy shelves" if kind == "pivot-table"
+                  else "no native table trellis")
+        warnings.append(f"trellis on '{el.get('name')}': base kind '{kind}' does NOT support a native "
+                        f"trellis (Sigma strips the key on readback) — left FLAT ({follow})")
+        return
+    if kind == "pie-chart":
+        warnings.append(f"trellis on '{el.get('name')}': base is a PIE — converted to DONUT "
+                        "(pie silently strips the trellis key on readback; donut supports it) before faceting")
+    # Add the facet dimension as a column (reuse an existing column of the same
+    # display name if the chart already plots it).
+    el.setdefault("columns", [])
+    facet_col = next((col for col in el["columns"]
+                      if str(col.get("name", "")).strip().casefold() == str(dn).strip().casefold()), None)
+    if facet_col is None:
+        facet_col = {"id": nid("tr"), "name": sig.get("label") or dn, "formula": f"[{MASTER}/{dn}]"}
+        el["columns"].append(facet_col)
+    ids = facet_col["id"]
+    orientation = sig.get("orientation") or "cols"
+    # A secondary facet field -> a true 2-D grid (rowsBy × columnsBy).
+    sec = sig.get("secondary")
+    if sec:
+        sdn = resolve(sec)
+        if sdn:
+            scol = {"id": nid("tr"), "name": sdn, "formula": f"[{MASTER}/{sdn}]"}
+            el["columns"].append(scol)
+            ids = [facet_col["id"], scol["id"]]
+            orientation = "grid"
+        else:
+            warnings.append(f"trellis on '{el.get('name')}': secondary facet {sec!r} not on the "
+                            "denorm element — emitted a single-axis trellis (no 2-D grid)")
+    _te.apply(el, ids, orientation)          # sets el['trellis'] (or flips pie->donut)
+    axis_key = next(iter(el["trellis"].keys()))
+    _TRELLIS_RECORDS.append({"element_id": el["id"], "kind": el["kind"], "name": el.get("name"),
+                             "axis": axis_key, "columnId": facet_col["id"]})
+    warnings.append(f"native trellis: '{el.get('name')}' -> ONE {el['kind']} element with "
+                    f"trellis.{axis_key} (orientation={orientation}, facet column {facet_col['id']})")
 
 def build_element(c, resolve, warnings):
     """One Qlik chart object -> one Sigma element (or None + warning)."""
@@ -737,6 +851,9 @@ def main():
                                             scope, unbound, seen_fields)
                               for lb in lbs) if el]
 
+    # Base children owned by a trellis-container are emitted THROUGH the
+    # container (one faceted element), never standalone.
+    tr_children = trellis_child_ids(charts)
     if sheets:
         for si, sheet in enumerate(sheets):
             pid = f"pg-{si + 1}"
@@ -744,6 +861,7 @@ def main():
             for cell in sorted(sheet["cells"], key=lambda c: (c["row"], c["col"])):
                 c = charts.get(cell["objectId"])
                 if c is None: continue
+                if cell["objectId"] in tr_children: continue   # emitted via its container
                 if c["vizType"] in ("filterpane", "listbox"):
                     n_signals += 1
                     ctls = controls_for(c)
@@ -752,10 +870,15 @@ def main():
                         placed.append((control_subcell(cell, i, len(ctls)), ctl))
                     n_controls += len(ctls)
                     continue
+                # Resolve a trellis-container to its base child chart (carrying
+                # the container's facet); a plain chart passes through unchanged.
+                c = trellis_base(c, charts, warnings)
+                if c is None: continue
                 if c["vizType"] not in CHARTY and not (c.get("measures") or c.get("dimensions")):
                     warnings.append(f"skip '{cell['objectId']}' ({c['vizType']}): not a chart"); continue
                 el = build_element(c, resolve, warnings)
                 if el is None: continue
+                emit_trellis(el, c, resolve, warnings)   # native trellis (no-op if no signal)
                 elems.append(el); placed.append((cell, el))
                 emap.append({"elementId": el["id"], "pageId": pid, "kind": el["kind"],
                              "name": el["name"], "valueColumnName": el["columns"][0].get("name"),
@@ -775,15 +898,19 @@ def main():
         child_ids = {ch for c in charts.values() if c["vizType"] == "filterpane"
                      for ch in (c.get("children") or [])}
         for c in charts.values():
+            if c["id"] in tr_children: continue   # base child emitted via its container
             if c["vizType"] == "filterpane" or (c["vizType"] == "listbox" and c["id"] not in child_ids):
                 n_signals += 1
                 ctls = controls_for(c)
                 elems.extend(ctls)
                 n_controls += len(ctls)
                 continue
+            c = trellis_base(c, charts, warnings)   # container -> its base child chart
+            if c is None: continue
             if not (c.get("measures")): continue
             el = build_element(c, resolve, warnings)
             if el is None: continue
+            emit_trellis(el, c, resolve, warnings)   # native trellis (no-op if no signal)
             elems.append(el)
             emap.append({"elementId": el["id"], "pageId": pid, "kind": el["kind"],
                          "name": el["name"], "valueColumnName": el["columns"][0].get("name"),
@@ -807,6 +934,18 @@ def main():
     json.dump(spec, open(a.spec_out, "w"), indent=2)
     open(a.layout_out, "w").write('<?xml version="1.0" encoding="utf-8"?>\n' + "\n".join(layout_pages))
     json.dump(emap, open(a.element_map, "w"), indent=2)
+    # native-trellis-emitted.json — round-trip guard sidecar. Written ONLY when a
+    # native trellis was actually emitted (a non-trellis app stays byte-identical:
+    # no file). Sigma silently STRIPS an unsupported trellis on readback, and this
+    # build path does NOT re-read the posted spec, so the guard is external:
+    # verify-trellis-survived.rb re-reads GET /v2/workbooks/{id}/spec and asserts
+    # each element below still carries its `trellis.<axis>` key.
+    if _TRELLIS_RECORDS:
+        nt_path = os.path.join(os.path.dirname(os.path.abspath(a.spec_out)), "native-trellis-emitted.json")
+        json.dump({"version": 1, "source": "qlik", "elements": _TRELLIS_RECORDS},
+                  open(nt_path, "w"), indent=2)
+        print(f"wrote {nt_path} ({len(_TRELLIS_RECORDS)} native trellis element(s) — "
+              "verify survives readback with verify-trellis-survived.rb)", file=sys.stderr)
     # control-scope.json — the intended-scope contract sidecar (schema: the
     # CONTRACT block in scripts/lib/control_lint.rb + refs/control-parity.md).
     # Qlik selections are GLOBAL (associative model), so every wired control
@@ -834,6 +973,7 @@ def main():
     result = {"workbookId": None, "pages": len(pages), "elements": n_elem,
               "kpis": sum(1 for e in emap if e["kind"] == "kpi-chart"),
               "controls": n_controls, "controlScope": scope_path,
+              "nativeTrellis": len(_TRELLIS_RECORDS),
               "warnings": warnings, "layoutFile": a.layout_out, "elementMap": a.element_map}
     if a.dry_run:
         print(f"DRY RUN: spec -> {a.spec_out} ({len(pages)} pages, {n_elem} elements)", file=sys.stderr)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/trellis_emit.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/trellis_emit.py
@@ -1,0 +1,126 @@
+"""TrellisEmit — the converter-agnostic emitter for Sigma's NATIVE element
+`trellis` property (small multiples / faceting). ONE source of truth for
+  (a) which chart kinds actually support a spec-authored trellis, and
+  (b) what to do on the kinds that DON'T (the documented fallbacks).
+
+BYTE-COMPATIBLE PYTHON MIRROR of shared/lib/trellis_emit.rb — same supported set,
+same fallbacks, same disposition semantics, same results. The Ruby copy is used
+by the Ruby builders (tableau); the Qlik / Power-BI builders are Python, so they
+call this. The scout_gate.rb / scout_gate.py pair is the precedent for a shared
+cross-language lib: the two sides must agree exactly on the contract. Ruby's
+result SYMBOLS (:trellised, :fallback_donut, :needs_sibling_fanout,
+:needs_pivot_shelves, :flat) are mirrored here as the identical STRINGS.
+
+Empirical basis: docs/sigma-trellis-chart-support.md. Sigma accepts a POST with
+an element `trellis` key (200 OK) but SILENTLY STRIPS it on unsupported kinds —
+the key is simply gone on readback and the tile renders flat, no error. So the
+supported set below is a hard gate, and every caller that emits a native trellis
+MUST re-read the spec and assert the key survived (see verify-trellis-survived).
+
+The correct Sigma shape is ONE viz element with the facet dimension as a column
+and `trellis: { rowsBy | columnsBy: [{ columnId }] }` (a 2-D grid points rowsBy
+and columnsBy at two DIFFERENT columns). This is distinct from the pivot-table's
+own `rowsBy`/`columnsBy` cross-tab shelves (keyed on `id`, a separate mechanism).
+
+Interface (converter-agnostic; mutates the element dict in place):
+  apply(element, facet_column_id, orientation)
+    element          — the Sigma element spec dict (needs 'kind'; 'trellis' set here)
+    facet_column_id  — a columns[] id str, OR a 2-element [rowId, colId] list for
+                       a true 2-D grid
+    orientation      — 'rows' | 'cols' | 'grid'
+  -> returns one of RESULTS:
+    "trellised"             — supported kind; element['trellis'] set
+    "fallback_donut"        — kind was pie-chart -> converted to donut + trellis set
+    "needs_sibling_fanout"  — kpi-chart -> caller should fan out to N sibling KPIs
+    "needs_pivot_shelves"   — pivot-table -> caller should use its own rowsBy/columnsBy
+    "flat"                  — table / anything else -> leave flat (no-op)
+  On the three no-op results the element is left UNTOUCHED (no trellis key, no
+  kind change), so a caller can branch on the result and take the fallback path.
+
+Pure + stdlib-only + unit-tested (test_trellis_emit.py). Canonical lives in
+shared/lib; edit there, run tools/sync-shared.rb.
+"""
+
+# Kinds whose native `trellis` key round-trips (survives readback). Emit ONLY
+# for these; the rest silently strip it. (docs/sigma-trellis-chart-support.md)
+SUPPORTED_KINDS = (
+    "bar-chart", "line-chart", "area-chart", "combo-chart", "scatter-chart", "donut-chart",
+)
+
+# Fallback rule per unsupported kind -> the action the emitter takes / signals.
+#   convert_to_donut  pie has no native trellis but donut does -> convert, then trellis
+#   sibling_fanout    kpi has no native trellis -> fan out to N per-member KPI elements
+#   pivot_shelves     pivot-table faceting is its OWN rowsBy/columnsBy shelves
+#   flat              table (and any other kind) -> keep flat
+FALLBACKS = {
+    "pie-chart": "convert_to_donut",
+    "kpi-chart": "sibling_fanout",
+    "pivot-table": "pivot_shelves",
+    "table": "flat",
+}
+
+RESULTS = ("trellised", "fallback_donut", "needs_sibling_fanout", "needs_pivot_shelves", "flat")
+
+
+def disposition(kind):
+    """Non-mutating: what WILL apply do for this kind? Lets a caller gate the
+    element-specific work (adding the facet column, emptying member filters,
+    dropping siblings) to only the kinds that actually trellis."""
+    k = str(kind)
+    if k in SUPPORTED_KINDS:
+        return "trellised"
+    fb = FALLBACKS.get(k)
+    if fb == "convert_to_donut":
+        return "fallback_donut"
+    if fb == "sibling_fanout":
+        return "needs_sibling_fanout"
+    if fb == "pivot_shelves":
+        return "needs_pivot_shelves"
+    return "flat"
+
+
+def trellises(kind):
+    """True when apply will set a native trellis (supported kind, or pie->donut).
+    (Ruby: TrellisEmit.trellises?)"""
+    d = disposition(kind)
+    return d == "trellised" or d == "fallback_donut"
+
+
+def apply(element, facet_column_id, orientation):
+    """Mutating. On a supported kind (or pie->donut) sets element['trellis'] and
+    returns "trellised" / "fallback_donut". On kpi/pivot/table leaves the element
+    untouched and returns the signal so the caller runs the documented fallback."""
+    kind = str(element.get("kind"))
+    if kind == "pie-chart":
+        element["kind"] = "donut-chart"  # donut trellises natively; pie strips the key
+        result = "fallback_donut"
+    elif kind in SUPPORTED_KINDS:
+        result = "trellised"
+    else:
+        return disposition(kind)  # no-op: needs_sibling_fanout / needs_pivot_shelves / flat
+    element["trellis"] = trellis_object(facet_column_id, orientation)
+    return result
+
+
+def trellis_object(facet_column_id, orientation):
+    """Build the `trellis` value for the given facet(s) + orientation.
+      'rows' -> { rowsBy: [ref] }                     vertical small-multiples
+      'cols' -> { columnsBy: [ref] }                  horizontal small-multiples
+      'grid' -> two facet ids  -> { rowsBy:[a], columnsBy:[b] }  a true 2-D grid
+                one facet id   -> { columnsBy: [ref] }  single field wraps into a tile grid
+    A single facet always faces ONE axis (rowsBy XOR columnsBy — emitting both on
+    the SAME column is degenerate)."""
+    ids = facet_column_id if isinstance(facet_column_id, (list, tuple)) else [facet_column_id]
+    o = str(orientation)
+    if o == "rows":
+        return {"rowsBy": [ref(ids[0])]}
+    if o == "grid":
+        if len(ids) >= 2:
+            return {"rowsBy": [ref(ids[0])], "columnsBy": [ref(ids[1])]}
+        return {"columnsBy": [ref(ids[0])]}
+    # 'cols' and any other single-axis default
+    return {"columnsBy": [ref(ids[0])]}
+
+
+def ref(column_id):
+    return {"columnId": column_id}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -144,6 +144,80 @@ def _reflines(refline):
     return {"x": conv(refline.get("refLinesX")), "y": conv(refline.get("refLines"))}
 
 
+def _trellis_field(d):
+    """Facet field from a Qlik trellis dimension def (string / qDef / libId)."""
+    if isinstance(d, str):
+        return d
+    qd = (d or {}).get("qDef") or {}
+    return (qd.get("qFieldDefs") or [None])[0] or (d or {}).get("qLibraryId") or (d or {}).get("field")
+
+
+def _trellis_sig(props):
+    """Best-effort: extract a NATIVE Qlik CHART-LEVEL trellis signal from an
+    object's engine properties -> the converter-neutral
+    {field, orientation, secondary?, label?}, or None when the object carries no
+    trellis. The build path (build-sigma-workbook.py: emit_trellis) turns this
+    into Sigma's native element `trellis` (rowsBy/columnsBy) via the shared
+    TrellisEmit. Keys checked are `trellis` / `trellising` (the chart's
+    Appearance>Trellis block). An enabled block names the facet dimension
+    (qFieldDefs / qLibraryId) and, optionally, a 2nd dim + a rows/columns config
+    -> a 2-D grid. Never raises; returns None on anything unrecognized so a
+    non-trellis app's charts.json is byte-identical."""
+    try:
+        t = props.get("trellis") or props.get("trellising")
+        if not isinstance(t, dict) or not t:
+            return None
+        if t.get("enabled") is False or t.get("show") is False:
+            return None
+        dims = t.get("dimensions") or t.get("qDimensions") or []
+        field = _trellis_field(dims[0]) if dims else (t.get("field") or t.get("dimensionField"))
+        if not field:
+            return None
+        sig = {"field": field}
+        if t.get("orientation") in ("rows", "cols", "grid"):
+            sig["orientation"] = t["orientation"]
+        elif t.get("rows") and not t.get("columns"):
+            sig["orientation"] = "rows"   # a fixed single column of stacked panels
+        else:
+            sig["orientation"] = "cols"   # Qlik wraps one trellis dim into a column grid
+        sec = _trellis_field(dims[1]) if len(dims) > 1 else t.get("secondaryField")
+        if sec:
+            sig["secondary"] = sec
+            sig["orientation"] = "grid"
+        if t.get("label"):
+            sig["label"] = t["label"]
+        return sig
+    except Exception:
+        return None
+
+
+def _trellis_container(props, hc):
+    """Best-effort: a native Qlik TRELLIS-CONTAINER ("trellis container"/"grid
+    container", qType sn-trellis-container) -> (child_ids, signal) so the build
+    path emits ONE faceted element from the container's base child chart. The
+    child chart id(s) come from `children` / `cells` / `qChildList`; the facet
+    dimension comes from the container's own first hypercube dimension (or a
+    `trellis`/`dimensions` block). Returns ([], None) when unrecognized."""
+    try:
+        kids = []
+        for k in (props.get("children") or props.get("cells") or []):
+            cid = k.get("name") if isinstance(k, dict) else k
+            if cid:
+                kids.append(cid)
+        if not kids:
+            cl = (props.get("qChildList") or {}).get("qItems") or []
+            kids = [it.get("qInfo", {}).get("qId") for it in cl if it.get("qInfo", {}).get("qId")]
+        sig = _trellis_sig(props)
+        if sig is None:
+            qdims = hc.get("qDimensions") or []
+            field = _trellis_field(qdims[0].get("qDef")) if qdims else None
+            if field:
+                sig = {"field": field, "orientation": "cols"}
+        return kids, sig
+    except Exception:
+        return [], None
+
+
 def awrite(path, obj):
     """Atomic JSON write — orchestrators poll for these files from a
     concurrent lane and must never observe a half-written artifact."""
@@ -584,6 +658,22 @@ def main():
         elif qtype == "filterpane":
             rec["children"] = fp_children.get(oid, [])
             rec["state"] = props.get("qStateName")
+        elif qtype in ("sn-trellis-container", "trellis-container", "grid-container"):
+            # Native trellis container: normalize to vizType "trellis-container"
+            # (the build path's emit_trellis faceting shape) + carry the base
+            # child chart id(s) and the facet signal.
+            kids, tsig = _trellis_container(props, hc)
+            rec["vizType"] = "trellis-container"
+            rec["children"] = kids
+            if tsig:
+                rec["trellis"] = tsig
+        else:
+            # Chart-level native trellis (Appearance>Trellis): faceting one chart
+            # into a panel grid. Only added when present -> byte-identical charts.json
+            # for the (overwhelmingly common) non-trellis object.
+            tsig = _trellis_sig(props)
+            if tsig:
+                rec["trellis"] = tsig
         charts.append(rec)
     # Pane children that `app object ls` did NOT list as standalone objects:
     # synthesize their listbox records from the evaluated layouts so the

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test_trellis_emit.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test_trellis_emit.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""test_trellis_emit.py — unit test for TrellisEmit (the shared native-trellis
+emitter), the Python side. Byte-for-byte behavioural mirror of the Ruby
+test-trellis-emit.rb: identical cases, identical expected shapes, results as the
+mirrored STRINGS (Ruby returns symbols). Converter-agnostic, pure, no network.
+Canonical in shared/scripts; edit there, run tools/sync-shared.rb.
+Run: python3 scripts/test_trellis_emit.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import trellis_emit as TE  # noqa: E402
+
+_fail = 0
+
+
+def ok(name, cond):
+    global _fail
+    print(("  ok  " if cond else "FAIL  ") + name)
+    if not cond:
+        _fail += 1
+
+
+def el(kind, cols=None):
+    return {"id": "el-1", "kind": kind, "columns": cols if cols is not None else [{"id": "c-cat"}]}
+
+
+# ---- supported kinds -> trellis set, right axis per orientation --------------
+for k in ("bar-chart", "line-chart", "area-chart", "combo-chart", "scatter-chart", "donut-chart"):
+    e = el(k)
+    r = TE.apply(e, "c-cat", "rows")
+    ok("%s: rows -> trellised + trellis.rowsBy" % k,
+       r == "trellised" and e["trellis"] == {"rowsBy": [{"columnId": "c-cat"}]})
+
+    e2 = el(k)
+    r2 = TE.apply(e2, "c-cat", "cols")
+    ok("%s: cols -> trellis.columnsBy (and NOT rowsBy)" % k,
+       r2 == "trellised" and e2["trellis"] == {"columnsBy": [{"columnId": "c-cat"}]})
+
+# ---- pie-chart -> donut + trellis (fallback) --------------------------------
+e = el("pie-chart")
+r = TE.apply(e, "c-cat", "cols")
+ok("pie-chart -> fallback_donut", r == "fallback_donut")
+ok("pie-chart kind flipped to donut-chart", e["kind"] == "donut-chart")
+ok("pie->donut carries the native trellis", e["trellis"] == {"columnsBy": [{"columnId": "c-cat"}]})
+ok("pie-chart trellises() is true (converts)", TE.trellises("pie-chart"))
+
+# ---- kpi-chart -> needs-sibling signal, element untouched -------------------
+e = el("kpi-chart")
+r = TE.apply(e, "c-cat", "cols")
+ok("kpi-chart -> needs_sibling_fanout", r == "needs_sibling_fanout")
+ok("kpi-chart left UNTOUCHED (no trellis, kind unchanged)",
+   "trellis" not in e and e["kind"] == "kpi-chart")
+ok("kpi-chart trellises() is false", not TE.trellises("kpi-chart"))
+
+# ---- pivot-table -> needs-shelves signal, untouched -------------------------
+e = el("pivot-table")
+r = TE.apply(e, "c-cat", "rows")
+ok("pivot-table -> needs_pivot_shelves", r == "needs_pivot_shelves")
+ok("pivot-table left UNTOUCHED", "trellis" not in e and e["kind"] == "pivot-table")
+
+# ---- table -> flat no-op ----------------------------------------------------
+e = el("table")
+r = TE.apply(e, "c-cat", "cols")
+ok("table -> flat", r == "flat")
+ok("table left UNTOUCHED", "trellis" not in e)
+
+# ---- unknown kind -> flat (default fallback) --------------------------------
+e = el("funnel-chart")
+ok("unknown kind -> flat disposition", TE.disposition("funnel-chart") == "flat")
+r = TE.apply(e, "c-cat", "cols")
+ok("unknown kind -> flat + untouched", r == "flat" and "trellis" not in e)
+
+# ---- 2-D grid -> BOTH keys, two different columns ---------------------------
+e = el("bar-chart", [{"id": "c-row"}, {"id": "c-col"}])
+r = TE.apply(e, ["c-row", "c-col"], "grid")
+ok("grid + two facet ids -> trellised", r == "trellised")
+ok("grid -> rowsBy AND columnsBy on the two distinct columns",
+   e["trellis"] == {"rowsBy": [{"columnId": "c-row"}], "columnsBy": [{"columnId": "c-col"}]})
+
+# A single-field grid wraps into a tile grid -> columnsBy only (tableau parity).
+e = el("bar-chart")
+TE.apply(e, "c-cat", "grid")
+ok("grid + single facet id -> columnsBy only (single-field tile grid)",
+   e["trellis"] == {"columnsBy": [{"columnId": "c-cat"}]})
+
+# ---- disposition is the single source of truth (non-mutating) ---------------
+ok("disposition(bar-chart) == trellised", TE.disposition("bar-chart") == "trellised")
+ok("disposition(pie-chart) == fallback_donut", TE.disposition("pie-chart") == "fallback_donut")
+ok("disposition(kpi-chart) == needs_sibling_fanout",
+   TE.disposition("kpi-chart") == "needs_sibling_fanout")
+ok("disposition(pivot-table) == needs_pivot_shelves",
+   TE.disposition("pivot-table") == "needs_pivot_shelves")
+ok("disposition(table) == flat", TE.disposition("table") == "flat")
+ok("SUPPORTED_KINDS is the documented readback-safe set",
+   list(TE.SUPPORTED_KINDS) == ["bar-chart", "line-chart", "area-chart",
+                                "combo-chart", "scatter-chart", "donut-chart"])
+
+print()
+if _fail == 0:
+    print("ALL PASS — TrellisEmit (supported->trellis by orientation; pie->donut; "
+          "kpi/pivot/table fallbacks; 2-D grid -> both keys)")
+    sys.exit(0)
+else:
+    print("%d FAILURE(S)" % _fail)
+    sys.exit(1)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_trellis.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_trellis.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""test_trellis.py — e2e for the Qlik native-trellis path in build-sigma-workbook.py.
+
+Builds a synthetic Qlik app (charts.json + denorm.json) that carries every
+trellis shape and asserts the ONE-faceted-element outcome, delegated to the
+shared TrellisEmit (supported-kind gate + fallbacks):
+
+  1. chart-level trellis (bar, cols)  -> ONE bar-chart + trellis.columnsBy
+  2. chart-level trellis (line, rows) -> ONE line-chart + trellis.rowsBy
+  3. faceted PIE                       -> flipped to donut-chart + trellis (pie strips it)
+  4. trellis-CONTAINER wrapping a bar  -> ONE bar-chart on the CONTAINER's id;
+                                          the base child is NOT emitted standalone
+  5. 2-D grid (primary + secondary)    -> trellis.rowsBy AND columnsBy, 2 columns
+  6. faceted KPI                       -> left FLAT (no native KPI trellis fallback)
+  7. NON-trellis bar                   -> no `trellis` key (byte-identical shape)
+Plus: the round-trip sidecar native-trellis-emitted.json lists exactly the
+emitted (supported) elements, and re-verifies GREEN against a faithful readback
+and FAILS against a stripped one (verify-trellis-survived.rb).
+
+Run: python3 tests/test_trellis.py   (exit 0 = pass)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCRIPTS = os.path.join(SKILL, "scripts")
+BUILDER = os.path.join(SCRIPTS, "build-sigma-workbook.py")
+# verify-trellis-survived.rb is the converter-neutral readback guard (canonical
+# lives in the tableau skill; it reads any tool's native-trellis-emitted.json).
+VERIFY = os.path.join(SKILL, "..", "..", "..", "tableau-to-sigma", "skills",
+                      "tableau-to-sigma", "scripts", "verify-trellis-survived.rb")
+
+DENORM = {"element": {"columns": [
+    {"name": "Region",   "formula": "[Custom SQL/REGION]"},
+    {"name": "Category", "formula": "[Custom SQL/CATEGORY]"},
+    {"name": "Month",    "formula": "[Custom SQL/MONTH]"},
+    {"name": "Revenue",  "formula": "[Custom SQL/REVENUE]"},
+]}}
+
+_SORT = {"interColumnSortOrder": [], "dimensions": [[]], "measures": [{}]}
+
+
+def _chart(cid, vt, dims, title, **extra):
+    c = {"id": cid, "vizType": vt, "title": title, "sheet": None,
+         "dimensions": [[d] for d in dims], "dimLabels": [None] * len(dims),
+         "dimNullSuppression": [False] * len(dims),
+         "measures": ["Sum(REVENUE)"], "measureLabels": ["Revenue"], "measureFmts": [None],
+         "sort": _SORT}
+    c.update(extra)
+    return c
+
+
+CHARTS = [
+    _chart("bar-tr", "barchart", ["CATEGORY"], "Rev by Category / Region",
+           trellis={"field": "REGION", "orientation": "cols", "label": "Region"}),
+    _chart("line-tr", "linechart", ["MONTH"], "Rev over Month / Region",
+           trellis={"field": "REGION", "orientation": "rows"}),
+    _chart("pie-tr", "piechart", ["CATEGORY"], "Rev share / Region",
+           trellis={"field": "REGION", "orientation": "cols"}),
+    # trellis container + its base child (child must NOT emit standalone)
+    _chart("cont-base", "barchart", ["CATEGORY"], "Base bar"),
+    {"id": "tc-1", "vizType": "trellis-container", "title": "Container by Region",
+     "children": ["cont-base"], "trellis": {"field": "REGION", "orientation": "cols"},
+     "dimensions": [], "measures": [], "sort": _SORT},
+    _chart("grid-tr", "barchart", ["CATEGORY"], "2-D grid",
+           trellis={"field": "REGION", "secondary": "MONTH", "orientation": "cols"}),
+    _chart("kpi-tr", "kpi", [], "KPI faceted",
+           trellis={"field": "REGION", "orientation": "cols"}),
+    _chart("plain-bar", "barchart", ["CATEGORY"], "Plain bar (no trellis)"),
+]
+
+_fail = 0
+
+
+def ok(name, cond):
+    global _fail
+    print(("  ok  " if cond else "FAIL  ") + name)
+    if not cond:
+        _fail += 1
+
+
+def build(charts):
+    d = tempfile.mkdtemp()
+    cp = os.path.join(d, "charts.json"); json.dump(charts, open(cp, "w"))
+    dp = os.path.join(d, "denorm.json"); json.dump(DENORM, open(dp, "w"))
+    sp = os.path.join(d, "spec.json")
+    r = subprocess.run(
+        [sys.executable, BUILDER, "--charts", cp, "--denorm", dp, "--dm-id", "dm-x",
+         "--denorm-element-id", "el-x", "--name", "TRELLIS", "--dry-run",
+         "--spec-out", sp, "--out", os.path.join(d, "res.json"),
+         "--element-map", os.path.join(d, "emap.json"), "--layout-out", os.path.join(d, "l.xml")],
+        capture_output=True, text=True)
+    assert r.returncode == 0, "builder failed:\n" + r.stderr
+    spec = json.load(open(sp))
+    els = {e["id"]: e for p in spec["pages"] for e in p["elements"]}
+    return els, d, (r.stdout + r.stderr)
+
+
+def main():
+    els, workdir, out = build(CHARTS)
+
+    def facet_formula(el, colid):
+        return next((c["formula"] for c in el["columns"] if c["id"] == colid), None)
+
+    # 1) chart-level bar, cols -> columnsBy on a Region facet column
+    e = els["el-bartr"]
+    ok("bar chart-level trellis -> bar-chart kind kept", e["kind"] == "bar-chart")
+    cb = e.get("trellis", {}).get("columnsBy")
+    ok("bar trellis.columnsBy set", bool(cb) and "rowsBy" not in e["trellis"])
+    ok("bar facet column is [Master/Region]",
+       cb and facet_formula(e, cb[0]["columnId"]) == "[Master/Region]")
+
+    # 2) line, rows -> rowsBy
+    e = els["el-linetr"]
+    ok("line trellis.rowsBy set (and not columnsBy)",
+       e.get("trellis", {}).get("rowsBy") and "columnsBy" not in e["trellis"] and e["kind"] == "line-chart")
+
+    # 3) pie -> donut fallback + trellis
+    e = els["el-pietr"]
+    ok("faceted pie flipped to donut-chart", e["kind"] == "donut-chart")
+    ok("pie->donut carries trellis.columnsBy", bool(e.get("trellis", {}).get("columnsBy")))
+
+    # 4) trellis container -> element on the CONTAINER id; child not standalone
+    ok("container emits ONE element on the container id el-tc1", "el-tc1" in els)
+    ok("container element is the base bar-chart + trellis",
+       els["el-tc1"]["kind"] == "bar-chart" and bool(els["el-tc1"].get("trellis")))
+    ok("base child NOT emitted standalone (el-contbase absent)", "el-contbase" not in els)
+
+    # 5) 2-D grid -> rowsBy AND columnsBy, two distinct columns
+    e = els["el-gridtr"]
+    tr = e.get("trellis", {})
+    ok("grid trellis has BOTH rowsBy and columnsBy", bool(tr.get("rowsBy")) and bool(tr.get("columnsBy")))
+    ok("grid facets are two distinct columns",
+       tr and tr["rowsBy"][0]["columnId"] != tr["columnsBy"][0]["columnId"])
+    ok("grid rowsBy=Region, columnsBy=Month",
+       tr and facet_formula(e, tr["rowsBy"][0]["columnId"]) == "[Master/Region]"
+       and facet_formula(e, tr["columnsBy"][0]["columnId"]) == "[Master/Month]")
+
+    # 6) kpi -> left flat (no native KPI trellis)
+    e = els["el-kpitr"]
+    ok("faceted KPI left FLAT (no trellis key, kind kpi-chart)",
+       "trellis" not in e and e["kind"] == "kpi-chart")
+    ok("KPI fallback warned", "does NOT support a native trellis" in out and "kpi-chart" in out)
+
+    # 7) non-trellis bar -> no trellis key
+    ok("plain bar has NO trellis key", "trellis" not in els["el-plainbar"])
+
+    # sidecar: exactly the emitted (supported) elements, correct axis
+    nt = json.load(open(os.path.join(workdir, "native-trellis-emitted.json")))
+    ids = {r["element_id"]: r["axis"] for r in nt["elements"]}
+    ok("sidecar lists the 5 emitted trellis elements (bar/line/pie->donut/container/grid)",
+       set(ids) == {"el-bartr", "el-linetr", "el-pietr", "el-tc1", "el-gridtr"})
+    ok("sidecar excludes the flat KPI + plain bar",
+       "el-kpitr" not in ids and "el-plainbar" not in ids)
+    ok("sidecar axis: line=rowsBy, bar=columnsBy", ids.get("el-linetr") == "rowsBy" and ids.get("el-bartr") == "columnsBy")
+
+    # readback guard: GREEN against a faithful readback, RED against a stripped one
+    if os.path.exists(VERIFY):
+        spec_ok = {"pages": [{"elements": [dict(els[i], id=i) for i in ids]}]}
+        rp = os.path.join(workdir, "readback-ok.json"); json.dump({"spec": spec_ok}, open(rp, "w"))
+        g = subprocess.run(["ruby", VERIFY, "--emitted", os.path.join(workdir, "native-trellis-emitted.json"),
+                            "--spec", rp], capture_output=True, text=True)
+        ok("verify-trellis-survived PASSES on a faithful readback", g.returncode == 0)
+        # strip every trellis on the readback -> must FAIL
+        spec_bad = {"pages": [{"elements": [{"id": i, "kind": els[i]["kind"]} for i in ids]}]}
+        bp = os.path.join(workdir, "readback-stripped.json"); json.dump({"spec": spec_bad}, open(bp, "w"))
+        b = subprocess.run(["ruby", VERIFY, "--emitted", os.path.join(workdir, "native-trellis-emitted.json"),
+                            "--spec", bp], capture_output=True, text=True)
+        ok("verify-trellis-survived FAILS when Sigma strips the trellis", b.returncode != 0)
+    else:
+        print("  --   verify-trellis-survived.rb not found; skipped readback guard assertions")
+
+    # byte-identical: a charts.json with EVERY trellis signal removed emits no
+    # trellis and no sidecar.
+    flat_charts = [dict(c) for c in CHARTS if c["vizType"] != "trellis-container"]
+    for c in flat_charts:
+        c.pop("trellis", None)
+    els2, wd2, _ = build(flat_charts)
+    ok("no-signal build emits ZERO trellis keys",
+       not any("trellis" in e for e in els2.values()))
+    ok("no-signal build writes NO sidecar",
+       not os.path.exists(os.path.join(wd2, "native-trellis-emitted.json")))
+
+    print()
+    if _fail == 0:
+        print("ALL PASS — Qlik native trellis (chart-level + container; supported-kind gate; "
+              "pie->donut; kpi flat; 2-D grid; readback guard; byte-identical no-op)")
+        sys.exit(0)
+    print("%d FAILURE(S)" % _fail)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared/lib/trellis_emit.py
+++ b/shared/lib/trellis_emit.py
@@ -1,0 +1,126 @@
+"""TrellisEmit — the converter-agnostic emitter for Sigma's NATIVE element
+`trellis` property (small multiples / faceting). ONE source of truth for
+  (a) which chart kinds actually support a spec-authored trellis, and
+  (b) what to do on the kinds that DON'T (the documented fallbacks).
+
+BYTE-COMPATIBLE PYTHON MIRROR of shared/lib/trellis_emit.rb — same supported set,
+same fallbacks, same disposition semantics, same results. The Ruby copy is used
+by the Ruby builders (tableau); the Qlik / Power-BI builders are Python, so they
+call this. The scout_gate.rb / scout_gate.py pair is the precedent for a shared
+cross-language lib: the two sides must agree exactly on the contract. Ruby's
+result SYMBOLS (:trellised, :fallback_donut, :needs_sibling_fanout,
+:needs_pivot_shelves, :flat) are mirrored here as the identical STRINGS.
+
+Empirical basis: docs/sigma-trellis-chart-support.md. Sigma accepts a POST with
+an element `trellis` key (200 OK) but SILENTLY STRIPS it on unsupported kinds —
+the key is simply gone on readback and the tile renders flat, no error. So the
+supported set below is a hard gate, and every caller that emits a native trellis
+MUST re-read the spec and assert the key survived (see verify-trellis-survived).
+
+The correct Sigma shape is ONE viz element with the facet dimension as a column
+and `trellis: { rowsBy | columnsBy: [{ columnId }] }` (a 2-D grid points rowsBy
+and columnsBy at two DIFFERENT columns). This is distinct from the pivot-table's
+own `rowsBy`/`columnsBy` cross-tab shelves (keyed on `id`, a separate mechanism).
+
+Interface (converter-agnostic; mutates the element dict in place):
+  apply(element, facet_column_id, orientation)
+    element          — the Sigma element spec dict (needs 'kind'; 'trellis' set here)
+    facet_column_id  — a columns[] id str, OR a 2-element [rowId, colId] list for
+                       a true 2-D grid
+    orientation      — 'rows' | 'cols' | 'grid'
+  -> returns one of RESULTS:
+    "trellised"             — supported kind; element['trellis'] set
+    "fallback_donut"        — kind was pie-chart -> converted to donut + trellis set
+    "needs_sibling_fanout"  — kpi-chart -> caller should fan out to N sibling KPIs
+    "needs_pivot_shelves"   — pivot-table -> caller should use its own rowsBy/columnsBy
+    "flat"                  — table / anything else -> leave flat (no-op)
+  On the three no-op results the element is left UNTOUCHED (no trellis key, no
+  kind change), so a caller can branch on the result and take the fallback path.
+
+Pure + stdlib-only + unit-tested (test_trellis_emit.py). Canonical lives in
+shared/lib; edit there, run tools/sync-shared.rb.
+"""
+
+# Kinds whose native `trellis` key round-trips (survives readback). Emit ONLY
+# for these; the rest silently strip it. (docs/sigma-trellis-chart-support.md)
+SUPPORTED_KINDS = (
+    "bar-chart", "line-chart", "area-chart", "combo-chart", "scatter-chart", "donut-chart",
+)
+
+# Fallback rule per unsupported kind -> the action the emitter takes / signals.
+#   convert_to_donut  pie has no native trellis but donut does -> convert, then trellis
+#   sibling_fanout    kpi has no native trellis -> fan out to N per-member KPI elements
+#   pivot_shelves     pivot-table faceting is its OWN rowsBy/columnsBy shelves
+#   flat              table (and any other kind) -> keep flat
+FALLBACKS = {
+    "pie-chart": "convert_to_donut",
+    "kpi-chart": "sibling_fanout",
+    "pivot-table": "pivot_shelves",
+    "table": "flat",
+}
+
+RESULTS = ("trellised", "fallback_donut", "needs_sibling_fanout", "needs_pivot_shelves", "flat")
+
+
+def disposition(kind):
+    """Non-mutating: what WILL apply do for this kind? Lets a caller gate the
+    element-specific work (adding the facet column, emptying member filters,
+    dropping siblings) to only the kinds that actually trellis."""
+    k = str(kind)
+    if k in SUPPORTED_KINDS:
+        return "trellised"
+    fb = FALLBACKS.get(k)
+    if fb == "convert_to_donut":
+        return "fallback_donut"
+    if fb == "sibling_fanout":
+        return "needs_sibling_fanout"
+    if fb == "pivot_shelves":
+        return "needs_pivot_shelves"
+    return "flat"
+
+
+def trellises(kind):
+    """True when apply will set a native trellis (supported kind, or pie->donut).
+    (Ruby: TrellisEmit.trellises?)"""
+    d = disposition(kind)
+    return d == "trellised" or d == "fallback_donut"
+
+
+def apply(element, facet_column_id, orientation):
+    """Mutating. On a supported kind (or pie->donut) sets element['trellis'] and
+    returns "trellised" / "fallback_donut". On kpi/pivot/table leaves the element
+    untouched and returns the signal so the caller runs the documented fallback."""
+    kind = str(element.get("kind"))
+    if kind == "pie-chart":
+        element["kind"] = "donut-chart"  # donut trellises natively; pie strips the key
+        result = "fallback_donut"
+    elif kind in SUPPORTED_KINDS:
+        result = "trellised"
+    else:
+        return disposition(kind)  # no-op: needs_sibling_fanout / needs_pivot_shelves / flat
+    element["trellis"] = trellis_object(facet_column_id, orientation)
+    return result
+
+
+def trellis_object(facet_column_id, orientation):
+    """Build the `trellis` value for the given facet(s) + orientation.
+      'rows' -> { rowsBy: [ref] }                     vertical small-multiples
+      'cols' -> { columnsBy: [ref] }                  horizontal small-multiples
+      'grid' -> two facet ids  -> { rowsBy:[a], columnsBy:[b] }  a true 2-D grid
+                one facet id   -> { columnsBy: [ref] }  single field wraps into a tile grid
+    A single facet always faces ONE axis (rowsBy XOR columnsBy — emitting both on
+    the SAME column is degenerate)."""
+    ids = facet_column_id if isinstance(facet_column_id, (list, tuple)) else [facet_column_id]
+    o = str(orientation)
+    if o == "rows":
+        return {"rowsBy": [ref(ids[0])]}
+    if o == "grid":
+        if len(ids) >= 2:
+            return {"rowsBy": [ref(ids[0])], "columnsBy": [ref(ids[1])]}
+        return {"columnsBy": [ref(ids[0])]}
+    # 'cols' and any other single-axis default
+    return {"columnsBy": [ref(ids[0])]}
+
+
+def ref(column_id):
+    return {"columnId": column_id}

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -425,9 +425,21 @@
    ]
   },
   {
+   "canonical": "shared/lib/trellis_emit.py",
+   "targets": [
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/trellis_emit.py"
+   ]
+  },
+  {
    "canonical": "shared/scripts/test-trellis-emit.rb",
    "targets": [
     "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-trellis-emit.rb"
+   ]
+  },
+  {
+   "canonical": "shared/scripts/test_trellis_emit.py",
+   "targets": [
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test_trellis_emit.py"
    ]
   },
   {

--- a/shared/scripts/test_trellis_emit.py
+++ b/shared/scripts/test_trellis_emit.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""test_trellis_emit.py — unit test for TrellisEmit (the shared native-trellis
+emitter), the Python side. Byte-for-byte behavioural mirror of the Ruby
+test-trellis-emit.rb: identical cases, identical expected shapes, results as the
+mirrored STRINGS (Ruby returns symbols). Converter-agnostic, pure, no network.
+Canonical in shared/scripts; edit there, run tools/sync-shared.rb.
+Run: python3 scripts/test_trellis_emit.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import trellis_emit as TE  # noqa: E402
+
+_fail = 0
+
+
+def ok(name, cond):
+    global _fail
+    print(("  ok  " if cond else "FAIL  ") + name)
+    if not cond:
+        _fail += 1
+
+
+def el(kind, cols=None):
+    return {"id": "el-1", "kind": kind, "columns": cols if cols is not None else [{"id": "c-cat"}]}
+
+
+# ---- supported kinds -> trellis set, right axis per orientation --------------
+for k in ("bar-chart", "line-chart", "area-chart", "combo-chart", "scatter-chart", "donut-chart"):
+    e = el(k)
+    r = TE.apply(e, "c-cat", "rows")
+    ok("%s: rows -> trellised + trellis.rowsBy" % k,
+       r == "trellised" and e["trellis"] == {"rowsBy": [{"columnId": "c-cat"}]})
+
+    e2 = el(k)
+    r2 = TE.apply(e2, "c-cat", "cols")
+    ok("%s: cols -> trellis.columnsBy (and NOT rowsBy)" % k,
+       r2 == "trellised" and e2["trellis"] == {"columnsBy": [{"columnId": "c-cat"}]})
+
+# ---- pie-chart -> donut + trellis (fallback) --------------------------------
+e = el("pie-chart")
+r = TE.apply(e, "c-cat", "cols")
+ok("pie-chart -> fallback_donut", r == "fallback_donut")
+ok("pie-chart kind flipped to donut-chart", e["kind"] == "donut-chart")
+ok("pie->donut carries the native trellis", e["trellis"] == {"columnsBy": [{"columnId": "c-cat"}]})
+ok("pie-chart trellises() is true (converts)", TE.trellises("pie-chart"))
+
+# ---- kpi-chart -> needs-sibling signal, element untouched -------------------
+e = el("kpi-chart")
+r = TE.apply(e, "c-cat", "cols")
+ok("kpi-chart -> needs_sibling_fanout", r == "needs_sibling_fanout")
+ok("kpi-chart left UNTOUCHED (no trellis, kind unchanged)",
+   "trellis" not in e and e["kind"] == "kpi-chart")
+ok("kpi-chart trellises() is false", not TE.trellises("kpi-chart"))
+
+# ---- pivot-table -> needs-shelves signal, untouched -------------------------
+e = el("pivot-table")
+r = TE.apply(e, "c-cat", "rows")
+ok("pivot-table -> needs_pivot_shelves", r == "needs_pivot_shelves")
+ok("pivot-table left UNTOUCHED", "trellis" not in e and e["kind"] == "pivot-table")
+
+# ---- table -> flat no-op ----------------------------------------------------
+e = el("table")
+r = TE.apply(e, "c-cat", "cols")
+ok("table -> flat", r == "flat")
+ok("table left UNTOUCHED", "trellis" not in e)
+
+# ---- unknown kind -> flat (default fallback) --------------------------------
+e = el("funnel-chart")
+ok("unknown kind -> flat disposition", TE.disposition("funnel-chart") == "flat")
+r = TE.apply(e, "c-cat", "cols")
+ok("unknown kind -> flat + untouched", r == "flat" and "trellis" not in e)
+
+# ---- 2-D grid -> BOTH keys, two different columns ---------------------------
+e = el("bar-chart", [{"id": "c-row"}, {"id": "c-col"}])
+r = TE.apply(e, ["c-row", "c-col"], "grid")
+ok("grid + two facet ids -> trellised", r == "trellised")
+ok("grid -> rowsBy AND columnsBy on the two distinct columns",
+   e["trellis"] == {"rowsBy": [{"columnId": "c-row"}], "columnsBy": [{"columnId": "c-col"}]})
+
+# A single-field grid wraps into a tile grid -> columnsBy only (tableau parity).
+e = el("bar-chart")
+TE.apply(e, "c-cat", "grid")
+ok("grid + single facet id -> columnsBy only (single-field tile grid)",
+   e["trellis"] == {"columnsBy": [{"columnId": "c-cat"}]})
+
+# ---- disposition is the single source of truth (non-mutating) ---------------
+ok("disposition(bar-chart) == trellised", TE.disposition("bar-chart") == "trellised")
+ok("disposition(pie-chart) == fallback_donut", TE.disposition("pie-chart") == "fallback_donut")
+ok("disposition(kpi-chart) == needs_sibling_fanout",
+   TE.disposition("kpi-chart") == "needs_sibling_fanout")
+ok("disposition(pivot-table) == needs_pivot_shelves",
+   TE.disposition("pivot-table") == "needs_pivot_shelves")
+ok("disposition(table) == flat", TE.disposition("table") == "flat")
+ok("SUPPORTED_KINDS is the documented readback-safe set",
+   list(TE.SUPPORTED_KINDS) == ["bar-chart", "line-chart", "area-chart",
+                                "combo-chart", "scatter-chart", "donut-chart"])
+
+print()
+if _fail == 0:
+    print("ALL PASS — TrellisEmit (supported->trellis by orientation; pie->donut; "
+          "kpi/pivot/table fallbacks; 2-D grid -> both keys)")
+    sys.exit(0)
+else:
+    print("%d FAILURE(S)" % _fail)
+    sys.exit(1)


### PR DESCRIPTION
## Native trellis in the qlik-to-sigma converter (rank-2 of the cross-converter plan)

Wires Qlik's native trellis into the qlik-to-sigma workbook builder. A **chart-level trellis** (Qlik Appearance>Trellis splits one chart into a panel grid by a dimension) and the native **trellis-container** object both collapse to Sigma's **native element `trellis`** — ONE viz element + `rowsBy`/`columnsBy` faceting, not N cloned charts — through the shared, converter-agnostic emitter. Per `docs/trellis-cross-converter-plan.md`, Qlik is **rank 2** ("Native Trellis + trellis-container"; detection site = `build-sigma-workbook.py`).

### Detection
- **Discovery** (`qlik-discover.py`): best-effort extraction of the neutral signal `chart["trellis"] = {field, orientation, secondary?, label?}` from the engine props (chart-level) and a trellis-container's `children` + facet dimension. Added **only when present** → `charts.json` byte-identical for non-trellis apps.
- **Build** (`build-sigma-workbook.py`, the plan's detection site): `trellis_base()` resolves a container to its base child chart (emitted on the container's element id; the child is **not** emitted standalone). `emit_trellis()` detects the signal on any built element.

### Emission (shared emitter)
- `emit_trellis()` adds the facet dimension as a column and calls **`TrellisEmit.apply`** — the single source of truth for the supported kinds (`bar/line/area/combo/scatter/donut`) and the fallbacks (**pie→donut**, kpi→N sibling KPIs, pivot→own shelves, table→flat). A secondary facet → a true 2-D grid (`rowsBy` × `columnsBy`).
- The Qlik builder is **Python**, so this adds **`shared/lib/trellis_emit.py`** — a byte-compatible mirror of the Ruby `shared/lib/trellis_emit.rb` (same supported set + fallbacks + disposition/result semantics, results as the mirrored strings). Registered in `shared/manifest.json` + synced (`check-shared` green); the `scout_gate.rb`/`scout_gate.py` pair is the precedent. `shared/scripts/test_trellis_emit.py` mirrors the Ruby unit test.

### Silent-stripping guard
Sigma returns `200` on a `trellis` POST but **silently strips** the key on unsupported kinds. This build path has **no post-POST readback**, so the guard is external: the build writes the neutral `native-trellis-emitted.json` sidecar (only when a trellis was emitted), and the converter-neutral `verify-trellis-survived.rb` asserts each `trellis.<axis>` survived `GET /v2/workbooks/{id}/spec`.

### Byte-identical
No signal → every trellis function is a no-op → **no sidecar, no id-counter drift**. The grounding golden (`tests/test_grounding.py`) is unchanged.

### Tests / evidence
- `tests/test_trellis.py` (new, 22 assertions): chart-level (bar cols / line rows) + container → one element; **supported-kind gate**; **pie→donut**; **kpi left flat**; **2-D grid**; sidecar contents/axes; **readback guard GREEN on a faithful readback and RED on a stripped one**; byte-identical no-op (no signal → no trellis, no sidecar).
- `tests/test_grounding.py` golden unchanged; `shared/scripts/test_trellis_emit.py` + the Ruby `test-trellis-emit.rb` both pass; `tools/check-shared.rb`, `corpus/run-corpus.sh --check` (17/17), and the full governance/hygiene sweep all green.
- **Live**: a real Qlik→Sigma migration needs Qlik source + Sigma API creds + a warehouse (unavailable here). Proof is a strong local e2e **plus a spec-readback survival proof** via `verify-trellis-survived.rb`; the empirical readback-survival of these kinds in a live org is already documented in `docs/sigma-trellis-chart-support.md`.

Refs: `docs/trellis-cross-converter-plan.md`, `docs/sigma-trellis-chart-support.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
