### PR TITLE
powerbi-to-sigma: native trellis from the "Small multiples" field well

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -247,6 +247,8 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-scout-ledger-integrity.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-trellis-emit.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-trellis.rb
             plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb

--- a/docs/trellis-cross-converter-plan.md
+++ b/docs/trellis-cross-converter-plan.md
@@ -22,9 +22,10 @@ they land in a later wave, one PR each.
   (`:needs_sibling_fanout` / `:needs_pivot_shelves` / `:flat`). A 2-D grid passes
   a two-element `[rowId, colId]` and `orientation: :grid`.
 - **Silent-stripping is the shared risk.** Every converter that emits `trellis`
-  must re-read the spec and assert the key survived (generalize
-  `verify-trellis-survived.rb`, which already reads a converter-neutral
-  `native-trellis-emitted.json` sidecar).
+  must re-read the spec and assert the key survived. `verify-trellis-survived.rb`
+  is now the shared, converter-neutral guard (canonical
+  `shared/scripts/verify-trellis-survived.rb`, synced into tableau + powerbi); it
+  reads the neutral `native-trellis-emitted.json` sidecar each converter writes.
 - **Several converters currently document trellis as "Sigma UI-only"** — a belief
   that predates the native `rowsBy`/`columnsBy` finding (#460/#462). Those notes
   (Looker `SKILL.md`, Power BI `measure-patterns.md`, Looker/QuickSight enhance
@@ -35,7 +36,7 @@ they land in a later wave, one PR each.
 
 | Rank | Converter | Source small-multiples concept | Detection site (parse path) | Difficulty | Emission |
 |------|-----------|--------------------------------|-----------------------------|------------|----------|
-| 1 | **Power BI** | **First-class "Small multiples"** field well on cartesian visuals (bar/column/line); category splits the visual into a panel grid. Also multi-page "by" duplication. | `build-workbook-from-pbir.rb` / `build-charts-from-signals.rb` — read the visual's `smallMultiples` / `SmallMultiples` well from the PBIR `visual.json` at chart-build. | **Low–Med** — explicit property, no geometry inference. | `TrellisEmit.apply` |
+| 1 | **Power BI** ✅ **DONE** | **First-class "Small multiples"** field well on cartesian visuals (bar/column/line); category splits the visual into a panel grid. Also multi-page "by" duplication. | `build-workbook-from-pbir.rb` (`apply_small_multiples!`) — reads the visual's `SmallMultiples` projection role (passed through by `extract-pbir.py` `_role_bindings`) at chart-build. | **Low–Med** — explicit property, no geometry inference. | `TrellisEmit.apply` (single PBI facet → `columnsBy` tile grid; pie→donut; kpi/pivot/table left flat). Round-trip guard: `native-trellis-emitted.json` + shared `verify-trellis-survived.rb`. Tested by `test-pbi-trellis.rb`. |
 | 2 | **Qlik** | **Native "Trellis"** — chart-level trellis (a dimension splits one chart into a grid) plus the **trellis-container** object. Strong, explicit concept. | `build-sigma-workbook.py` — read the chart's trellis dimension / trellis-container children from the app object model (QVF layout JSON). | **Low–Med** — explicit; container variant needs a member→panel mapping. | `TrellisEmit.apply` |
 | 3 | **Looker** | **`looker_donut_multiples`** (donut small multiples) and **row/column `pivots`** that render as repeated panels. | `parse_lookml_dashboard.py` → `build_looker_dashboard*.py` — read `type: looker_donut_multiples` and the `pivots` list on each dashboard element. | **Med** — donut-multiples maps cleanly (donut is supported); pivots-as-facet needs care not to collide with a real pivot table. | `TrellisEmit.apply` (donut path is the sweet spot) |
 | 4 | **QuickSight** | **"Small multiples"** field well (`SmallMultiplesOptions`) on bar/line/combo visuals. | `build-workbook-from-quicksight.rb` / `build-charts-from-signals.rb` — read the visual's small-multiples field from the analysis/definition JSON. | **Low–Med** — explicit property. | `TrellisEmit.apply` |

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/measure-patterns.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/measure-patterns.md
@@ -32,8 +32,16 @@ A chart splits into one series per category **iff** it carries a `color` block:
 "color": { "by": "category", "column": "<colId>" }
 ```
 
-- This is *persisted* in the workbook spec (unlike trellis/tooltip, which are
-  UI-only — see memory `feedback_sigma_trellis_ui_only` / `_tooltip_ui_only`).
+- This is *persisted* in the workbook spec (like the native `trellis` facet —
+  see below — but unlike tooltip, which stays UI-only: `_tooltip_ui_only`).
+- **Small multiples → native `trellis` (NOT UI-only).** The old
+  `feedback_sigma_trellis_ui_only` belief predates the `rowsBy`/`columnsBy` finding
+  (#460/#462): a spec-authored `element.trellis` DOES bind the facet on the
+  readback-safe kinds (bar/line/area/combo/scatter/donut). `build-workbook-from-pbir.rb`
+  detects a visual's PBI **"Small multiples"** field well (`SmallMultiples`
+  projection role) and calls the shared `TrellisEmit.apply` (pie→donut; kpi/pivot/
+  table stay flat). See `docs/sigma-trellis-chart-support.md` +
+  `docs/trellis-cross-converter-plan.md`.
 - Removing the `color` block collapses the chart to a **single series**.
 - **Line builder default = single series** (`beads-sigma-c07`): a line chart
   should NOT emit `color` unless the source PBI visual has a Legend/Series
@@ -369,7 +377,9 @@ verified via `/v2/workbooks/{id}/spec` PUT round-trip 2026-06-02.)
   (DM/workbook post fixups), `connection.md` (Phase 1–2 extract).
 - Memory: `feedback_sigma_cross_element_ref_form` (triple-segment refs),
   `feedback_sigma_window_functions` (window-fn silent failures in calc cols),
-  `feedback_sigma_trellis_ui_only` / `_tooltip_ui_only` (UI-only fields —
-  contrast with `color`, which IS persisted).
+  `_tooltip_ui_only` (UI-only field — contrast with `color` AND the native
+  `trellis` facet, both of which ARE persisted). NOTE
+  `feedback_sigma_trellis_ui_only` is STALE — the `rowsBy`/`columnsBy` trellis is
+  spec-authored now (small multiples → `TrellisEmit.apply`; see above).
 - Beads: `c07` (line default single series), `2tf` (UI-only-referenceable DM
   metric for the cross-element ratio), `tkd` (post fixups).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-model-gotchas.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-model-gotchas.md
@@ -70,7 +70,9 @@ M families (Excel/CSV/SharePoint/Web/Dataflows/Dataverse/Salesforce/OData/ODBC/K
 SAP) — handled by the sibling land-then-repoint project (`pbi-nonwarehouse-sources`).
 Report layer: field-well→encoding mapping, conditional formatting (MERGED per
 `pbi-conditional-formatting` — confirm), style `objects` (titles/labels/legend/format),
-themes, small multiples, matrix subtotals, buttons/drillthrough/page-nav actions,
+themes, small multiples (DONE — the "Small multiples" field well maps to Sigma's
+native `trellis`; `build-workbook-from-pbir.rb` → `TrellisEmit.apply`), matrix
+subtotals, buttons/drillthrough/page-nav actions,
 slicer mode (dropdown/relative-date/between), Deneb/Vega custom visuals, mobile layout.
 
 ## Public test corpus (real files; warehouse-connected where possible)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -54,6 +54,7 @@ require_relative 'lib/pbi_pivot_sort'
 require_relative 'lib/pbi_style'
 require_relative 'lib/pbi_conditional_formats'
 require_relative 'lib/coverage_catalog'
+require_relative 'lib/trellis_emit' # shared native-trellis emitter (supported-kind gate + fallbacks)
 include SigmaLayout
 
 # ---------------------------------------------------------------------------
@@ -991,6 +992,104 @@ def drop_unresolved_columns!(el, rec, kind)
                     action: "Map the PBI queryRef(s) for #{leaves} to a master column in master-map.json and re-run.")
 end
 
+# Power BI "Small multiples" field well -> Sigma NATIVE element `trellis`
+# (rowsBy / columnsBy), via the shared converter-agnostic emitter
+# (shared/lib/trellis_emit.rb). SUPERSEDES the stale "trellis is Sigma UI-only"
+# note (measure-patterns.md): the rowsBy/columnsBy form binds the facet from spec
+# on the readback-safe kinds (docs/sigma-trellis-chart-support.md).
+#
+# DETECTION: a PBIR visual carries its small-multiples facet as a `SmallMultiples`
+# projection role in visual.query.queryState; extract-pbir.py's _role_bindings
+# passes every role through verbatim, so it arrives here as
+# rec['bindings']['SmallMultiples'] -> the facet dimension's queryRef. No geometry
+# inference: it is an explicit source property. Detection-gated — a visual with NO
+# SmallMultiples role takes an early `return nil` and is built byte-identically to
+# origin/main.
+#
+# EMISSION: one Sigma element (the base viz) with the facet added as a column, then
+# TrellisEmit.apply sets element['trellis']. The emitter is the single source of
+# truth for (a) the readback-safe kinds (bar/line/area/combo/scatter/donut), which
+# it trellises, and (b) the fallbacks on the rest — pie->donut (flipped in place),
+# and kpi/pivot/table left flat (Sigma returns 200 then SILENTLY STRIPS the key on
+# those, so we must not emit it). Every emitted trellis is recorded in
+# $native_trellis_records -> the native-trellis-emitted.json round-trip sidecar,
+# which verify-trellis-survived.rb re-checks against the readback spec.
+#
+# ORIENTATION: a Power BI small multiple is a SINGLE dimension tiled into a grid
+# (the grid's row/column counts are a layout detail, not a second facet field).
+# Sigma wraps a single-facet `columnsBy` into exactly that tile grid, so columnsBy
+# is the faithful mapping. A true 2-D Sigma grid (rowsBy AND columnsBy) needs two
+# DISTINCT facet columns, which a PBI small multiple never supplies — so we never
+# emit both. (Deferred: honoring an explicit single-column PBI layout as rowsBy;
+# the grid default is correct for the common case.)
+def apply_small_multiples!(el, rec, fields, master, eid, qr_cids)
+  b = rec['bindings'] || {}
+  facet_qr = (b['SmallMultiples'] || b['smallMultiples'] || []).first
+  return nil unless facet_qr # detection-gated: no small-multiples role -> byte-identical build
+
+  kind = el['kind']
+  name = el['name'].is_a?(Hash) ? el['name']['text'] : el['name'].to_s
+
+  # Gate to the kinds whose native `trellis` survives readback. On kpi/pivot/table
+  # Sigma accepts the POST (200) then drops the key and renders flat — emitting it
+  # there would be a silent lie, so leave those flat and record the documented
+  # fallback (kpi -> N sibling KPIs, pivot -> its own shelves, table -> flat).
+  unless TrellisEmit.trellises?(kind)
+    disp = TrellisEmit.disposition(kind)
+    fallback = case disp
+               when :needs_sibling_fanout then 'fan out to N per-member KPI tiles (no native KPI trellis)'
+               when :needs_pivot_shelves  then "use the pivot's own rowsBy/columnsBy cross-tab shelves"
+               else 'model the facet as an extra grouping/row dimension, or build small multiples post-publish'
+               end
+    warn "[build-workbook] WARN visual '#{name}': PBI Small multiples facet '#{facet_qr}' on a #{kind} — " \
+         "Sigma has no native trellis for that kind (silently stripped on readback); facet left off."
+    record_unresolved(visual: name, pbi_type: rec['visual_type'], sigma_kind: kind,
+                      severity: 'degraded', recoverable: true,
+                      detail: "Small multiples facet '#{facet_qr}' dropped — #{kind} has no native Sigma trellis",
+                      action: "Sigma strips a #{kind} trellis on readback; #{fallback}.")
+    return nil
+  end
+
+  # The facet must resolve on the element's chosen master (a Sigma element sources
+  # exactly one master). If it can't, adding the column would leak an unresolved
+  # literal ref that drop_unresolved_columns! prunes, leaving a dangling trellis.
+  fs = field_spec(facet_qr, fields, master)
+  reachable = master && (fs['master'] == master ||
+                         Array(fs['alts']).any? { |a| a['master'] == master })
+  unless reachable
+    warn "[build-workbook] WARN visual '#{name}': Small multiples facet '#{facet_qr}' does not resolve on " \
+         "master '#{master.inspect}' — trellis NOT emitted (a Sigma element sources one master)."
+    record_unresolved(visual: name, pbi_type: rec['visual_type'], sigma_kind: kind,
+                      severity: 'degraded', recoverable: true,
+                      detail: "Small multiples facet '#{facet_qr}' not reachable on master '#{master}' — trellis dropped",
+                      action: "Add '#{facet_qr}' to master '#{master}' (or a single joined master) so the facet binds, then re-run.")
+    return nil
+  end
+
+  # Add the facet as a real column and face it via the shared emitter. A single
+  # PBI facet -> columnsBy (Sigma tile grid; see ORIENTATION above).
+  fcid = "#{eid}-sm"
+  (el['columns'] ||= []) << { 'id' => fcid, 'formula' => fs['ref'], 'name' => qr_leaf(facet_qr, 'Facet') }
+  qr_cids[facet_qr] = fcid
+  was_pie = (kind == 'pie-chart')
+  result  = TrellisEmit.apply(el, facet_column_id: fcid, orientation: :cols)
+  axis = el['trellis'].keys.first
+
+  # Round-trip guard record (Sigma silently strips an unsupported trellis; the
+  # post-publish verifier re-reads the spec and asserts each of these survived).
+  ($native_trellis_records ||= []) << {
+    'element_id' => el['id'], 'kind' => el['kind'], 'name' => name,
+    'axis' => axis, 'columnId' => fcid, 'visual_id' => rec['visual_id']
+  }
+  if was_pie
+    warn "[build-workbook] visual '#{name}': PBI small-multiples PIE -> Sigma DONUT + trellis.#{axis} " \
+         '(pie silently strips the trellis key on readback; donut supports it).'
+  end
+  warn "[build-workbook] visual '#{name}': PBI Small multiples '#{facet_qr}' -> ONE #{el['kind']} element " \
+       "'#{el['id']}' with trellis.#{axis} (facet column #{fcid})."
+  result
+end
+
 def build_element(rec, fields, masters, extra_data = [])
   # viz-kind resolution (grounded by refs/catalogs/viz-kind.json; SIGMA_KIND is
   # derived from it). An UNMAPPED/blank kind token used to SILENTLY become a
@@ -1683,6 +1782,11 @@ def build_element(rec, fields, masters, extra_data = [])
 
   # Controls reference a master column; they carry no columns array of their own.
   el['columns'] = cols unless el['kind'] == 'control'
+  # Power BI "Small multiples" field well -> Sigma native `trellis` (detection-
+  # gated: no SmallMultiples role -> no-op, byte-identical build). Runs after the
+  # columns are attached so the facet joins a real columns[] and before
+  # drop_unresolved_columns! so the (reachable) facet column is retained.
+  apply_small_multiples!(el, rec, fields, master, eid, qr_cids) unless el['kind'] == 'control'
   # Style fidelity (refs/style-fidelity.md §5-7) — applied AFTER columns are
   # attached so the measure-column formats exist to rewrite:
   #   §5 number abbreviation — KPI/chart measure columns render compact ("$126k")
@@ -2166,6 +2270,22 @@ spec['folderId'] = opts[:folder] if opts[:folder]
 File.write(opts[:out], JSON.pretty_generate(spec))
 warn "[build-workbook] wrote #{opts[:out]} (#{data_elements.size} master(s), " \
      "#{content_pages.sum { |p| p['elements'].size }} chart element(s); layout embedded)"
+
+# Native-trellis round-trip guard sidecar — written ONLY when a small-multiples
+# visual actually emitted a native trellis (a workbook with none stays byte-
+# identical: no sidecar). verify-trellis-survived.rb re-reads the readback spec
+# and asserts each element still carries its `trellis` key (Sigma silently strips
+# unsupported ones). Converter-neutral shape shared with the Tableau path.
+if ($native_trellis_records ||= []).any?
+  begin
+    nt_path = File.join(File.dirname(File.expand_path(opts[:out])), 'native-trellis-emitted.json')
+    File.write(nt_path, JSON.pretty_generate('version' => 1, 'elements' => $native_trellis_records))
+    warn "[build-workbook] wrote #{nt_path} (#{$native_trellis_records.size} native trellis element(s) — " \
+         'verify survives readback with verify-trellis-survived.rb)'
+  rescue => e
+    warn "[build-workbook] WARN native-trellis sidecar not written (round-trip coverage unrecorded): #{e.message}"
+  end
+end
 
 # coverage.json — the aggregated migration-coverage ledger (bead beads-sigma-cov).
 # Written AFTER the final spec so builtElements equals the shipped element count.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/trellis_emit.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/trellis_emit.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+#
+# TrellisEmit — the converter-agnostic emitter for Sigma's NATIVE element
+# `trellis` property (small multiples / faceting). ONE source of truth for
+#   (a) which chart kinds actually support a spec-authored trellis, and
+#   (b) what to do on the kinds that DON'T (the documented fallbacks).
+#
+# Empirical basis: docs/sigma-trellis-chart-support.md. Sigma accepts a POST with
+# an element `trellis` key (200 OK) but SILENTLY STRIPS it on unsupported kinds —
+# the key is simply gone on readback and the tile renders flat, no error. So the
+# supported set below is a hard gate, and every caller that emits a native trellis
+# MUST re-read the spec and assert the key survived (see verify-trellis-survived).
+#
+# The correct Sigma shape is ONE viz element with the facet dimension as a column
+# and `trellis: { rowsBy | columnsBy: [{ columnId }] }` (a 2-D grid points rowsBy
+# and columnsBy at two DIFFERENT columns). This is distinct from the pivot-table's
+# own `rowsBy`/`columnsBy` cross-tab shelves (keyed on `id`, a separate mechanism).
+#
+# Interface (converter-agnostic; mutates the element hash in place):
+#   TrellisEmit.apply(element, facet_column_id:, orientation:)
+#     element          — the Sigma element spec Hash (needs 'kind'; 'trellis' set here)
+#     facet_column_id  — a columns[] id String, OR a 2-element [rowId, colId] Array
+#                        for a true 2-D grid
+#     orientation      — :rows | :cols | :grid   (Strings 'rows'/'cols'/'grid' ok)
+#   → returns one of RESULTS:
+#     :trellised             — supported kind; element['trellis'] set
+#     :fallback_donut        — kind was pie-chart → converted to donut + trellis set
+#     :needs_sibling_fanout  — kpi-chart → caller should fan out to N sibling KPIs
+#     :needs_pivot_shelves   — pivot-table → caller should use its own rowsBy/columnsBy
+#     :flat                  — table / anything else → leave flat (no-op)
+#   On the three no-op results the element is left UNTOUCHED (no trellis key, no
+#   kind change), so a caller can branch on the result and take the fallback path.
+#
+# Pure + stdlib-only + unit-tested (test-trellis-emit.rb). Canonical lives in
+# shared/lib; edit there, run tools/sync-shared.rb.
+
+module TrellisEmit
+  module_function
+
+  # Kinds whose native `trellis` key round-trips (survives readback). Emit ONLY
+  # for these; the rest silently strip it. (docs/sigma-trellis-chart-support.md)
+  SUPPORTED_KINDS = %w[
+    bar-chart line-chart area-chart combo-chart scatter-chart donut-chart
+  ].freeze
+
+  # Fallback rule per unsupported kind → the action the emitter takes / signals.
+  #   :convert_to_donut  pie has no native trellis but donut does → convert, then trellis
+  #   :sibling_fanout    kpi has no native trellis → fan out to N per-member KPI elements
+  #   :pivot_shelves     pivot-table faceting is its OWN rowsBy/columnsBy shelves
+  #   :flat              table (and any other kind) → keep flat
+  FALLBACKS = {
+    'pie-chart'   => :convert_to_donut,
+    'kpi-chart'   => :sibling_fanout,
+    'pivot-table' => :pivot_shelves,
+    'table'       => :flat
+  }.freeze
+
+  RESULTS = %i[trellised fallback_donut needs_sibling_fanout needs_pivot_shelves flat].freeze
+
+  # Non-mutating: what WILL apply do for this kind? Lets a caller gate the
+  # element-specific work (adding the facet column, emptying member filters,
+  # dropping siblings) to only the kinds that actually trellis.
+  def disposition(kind)
+    k = kind.to_s
+    return :trellised if SUPPORTED_KINDS.include?(k)
+
+    case FALLBACKS[k]
+    when :convert_to_donut then :fallback_donut
+    when :sibling_fanout   then :needs_sibling_fanout
+    when :pivot_shelves    then :needs_pivot_shelves
+    else :flat
+    end
+  end
+
+  # True when apply will set a native trellis (supported kind, or pie→donut).
+  def trellises?(kind)
+    d = disposition(kind)
+    d == :trellised || d == :fallback_donut
+  end
+
+  # Mutating. On a supported kind (or pie→donut) sets element['trellis'] and
+  # returns :trellised / :fallback_donut. On kpi/pivot/table leaves the element
+  # untouched and returns the signal so the caller runs the documented fallback.
+  def apply(element, facet_column_id:, orientation:)
+    kind = element['kind'].to_s
+    result =
+      if kind == 'pie-chart'
+        element['kind'] = 'donut-chart' # donut trellises natively; pie strips the key
+        :fallback_donut
+      elsif SUPPORTED_KINDS.include?(kind)
+        :trellised
+      else
+        return disposition(kind) # no-op: needs_sibling_fanout / needs_pivot_shelves / flat
+      end
+    element['trellis'] = trellis_object(facet_column_id, orientation)
+    result
+  end
+
+  # Build the `trellis` value for the given facet(s) + orientation.
+  #   :rows → { rowsBy: [ref] }                     vertical small-multiples
+  #   :cols → { columnsBy: [ref] }                  horizontal small-multiples
+  #   :grid → two facet ids  → { rowsBy:[a], columnsBy:[b] }  a true 2-D grid
+  #           one facet id   → { columnsBy: [ref] }  single field wraps into a tile grid
+  # A single facet always faces ONE axis (rowsBy XOR columnsBy — emitting both on
+  # the SAME column is degenerate).
+  def trellis_object(facet_column_id, orientation)
+    ids = Array(facet_column_id)
+    case orientation.to_s
+    when 'rows'
+      { 'rowsBy' => [ref(ids.first)] }
+    when 'grid'
+      if ids.length >= 2
+        { 'rowsBy' => [ref(ids[0])], 'columnsBy' => [ref(ids[1])] }
+      else
+        { 'columnsBy' => [ref(ids.first)] }
+      end
+    else # 'cols' and any other single-axis default
+      { 'columnsBy' => [ref(ids.first)] }
+    end
+  end
+
+  def ref(column_id)
+    { 'columnId' => column_id }
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-trellis.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-trellis.rb
@@ -1,0 +1,205 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-pbi-trellis.rb — end-to-end regression for the Power BI "Small multiples"
+# field well -> Sigma native `trellis` wiring in build-workbook-from-pbir.rb
+# (shared TrellisEmit). Offline: no API, no creds. Runs the REAL builder as a
+# subprocess against synthesized signals + master-map fixtures and asserts on the
+# emitted workbook spec + the native-trellis-emitted.json round-trip sidecar.
+#
+# Covers:
+#   1. bar visual WITH SmallMultiples  -> ONE bar-chart element carrying
+#      trellis.columnsBy referencing the facet column (single PBI facet -> Sigma
+#      tile grid via columnsBy); the facet is added as a real column.
+#   2. bar visual WITHOUT SmallMultiples -> NO trellis key (detection-gated;
+#      built exactly as before).
+#   3. pie visual WITH SmallMultiples  -> flipped to donut-chart + trellis
+#      (pie silently strips the key on readback; donut supports it).
+#   4. kpi visual WITH SmallMultiples  -> NO trellis (Sigma strips it on a
+#      kpi-chart); recorded as a degraded fallback, not silently emitted.
+#   5. the round-trip sidecar lists exactly the trellised elements (bar + donut).
+#   6. a signals file with NO small-multiples visual writes NO sidecar and emits
+#      NO trellis anywhere (byte-identical-shape guarantee).
+#
+# Run: ruby scripts/test-pbi-trellis.rb
+require 'json'
+require 'tmpdir'
+require 'open3'
+
+HERE     = __dir__
+BUILDER  = File.join(HERE, 'build-workbook-from-pbir.rb')
+DM_ID    = 'dm-test-0001'
+
+$fail = 0
+def ok(name, cond)
+  puts((cond ? '  ok  ' : 'FAIL  ') + name)
+  $fail += 1 unless cond
+end
+
+# One master "OF" carrying every field the fixtures bind (Channel dim, Region
+# facet dim, Revenue measure). Region is the small-multiples facet.
+MASTER_MAP = {
+  'masters' => {
+    'OF' => {
+      'id' => 'master-of', 'element_id' => 'el-of', 'data_model' => DM_ID,
+      'columns' => [
+        { 'id' => 'mof-rev', 'name' => 'Net Revenue',  'formula' => '[Order Fact/Net Revenue]' },
+        { 'id' => 'mof-ch',  'name' => 'Order Channel', 'formula' => '[Order Fact/Order Channel]' },
+        { 'id' => 'mof-rg',  'name' => 'Region',        'formula' => '[Order Fact/Region]' }
+      ]
+    }
+  },
+  'fields' => {
+    'ORDER_FACT.Total Net Revenue' => { 'master' => 'OF', 'ref' => '[OF/Net Revenue]',   'agg' => 'Sum' },
+    'ORDER_FACT.Order Channel'      => { 'master' => 'OF', 'ref' => '[OF/Order Channel]', 'agg' => nil },
+    'ORDER_FACT.Region'             => { 'master' => 'OF', 'ref' => '[OF/Region]',        'agg' => nil }
+  }
+}.freeze
+
+def visual(id, type, kind, bindings, title)
+  { 'visual_id' => id, 'visual_type' => type, 'sigma_kind' => kind, 'title' => title,
+    'x' => 0, 'y' => 0, 'w' => 400, 'h' => 300, 'z' => 0, 'orientation' => nil,
+    'bindings' => bindings, 'formats' => {} }
+end
+
+# Run the real builder; return the parsed workbook spec + parsed sidecar (or nil).
+def build(signals)
+  Dir.mktmpdir do |dir|
+    sig  = File.join(dir, 'signals.json')
+    mmap = File.join(dir, 'master-map.json')
+    out  = File.join(dir, 'wb-spec.json')
+    File.write(sig,  JSON.generate(signals))
+    File.write(mmap, JSON.generate(MASTER_MAP))
+    _o, _e, st = Open3.capture3('ruby', BUILDER, '--signals', sig, '--master-map', mmap,
+                                '--data-model', DM_ID, '--out', out, '--name', 'Trellis Test')
+    unless st.success? && File.exist?(out)
+      warn "builder failed:\n#{_e}"
+      return [nil, nil]
+    end
+    spec = JSON.parse(File.read(out))
+    sidecar_path = File.join(dir, 'native-trellis-emitted.json')
+    sidecar = File.exist?(sidecar_path) ? JSON.parse(File.read(sidecar_path)) : nil
+    [spec, sidecar]
+  end
+end
+
+# Every content-page element (skip the Data page). Builder hashes visual ids into
+# element ids, so tests match on the (unique) visual title instead.
+def content_elements(spec)
+  Array(spec['pages']).reject { |pg| pg['id'] == 'page-data' }
+                      .flat_map { |pg| Array(pg['elements']) }
+                      .select { |e| e.is_a?(Hash) }
+end
+
+def el_name(el)
+  n = el['name']
+  n.is_a?(Hash) ? n['text'].to_s : n.to_s
+end
+
+def find_el(spec, needle)
+  content_elements(spec).find { |e| el_name(e).include?(needle) }
+end
+
+def facet_col(el)
+  Array(el['columns']).find { |c| c['name'].to_s.casecmp?('Region') }
+end
+
+# =============================================================================
+# CASE A — a mixed page: bar+SM, bar (no SM), pie+SM, kpi+SM.
+# =============================================================================
+signals = {
+  'source' => 'pbir', 'theme' => nil,
+  'pages' => [{
+    'page_id' => 'p1', 'page_title' => 'Trellis', 'page_w' => 1280, 'page_h' => 720,
+    'visuals' => [
+      visual('v-bar-sm', 'clusteredColumnChart', 'bar',
+             { 'Category' => ['ORDER_FACT.Order Channel'], 'Y' => ['ORDER_FACT.Total Net Revenue'],
+               'SmallMultiples' => ['ORDER_FACT.Region'] }, 'Revenue by Channel (small multiples)'),
+      visual('v-bar-plain', 'clusteredColumnChart', 'bar',
+             { 'Category' => ['ORDER_FACT.Order Channel'], 'Y' => ['ORDER_FACT.Total Net Revenue'] },
+             'Revenue by Channel'),
+      visual('v-pie-sm', 'pieChart', 'pie',
+             { 'Category' => ['ORDER_FACT.Order Channel'], 'Values' => ['ORDER_FACT.Total Net Revenue'],
+               'SmallMultiples' => ['ORDER_FACT.Region'] }, 'Revenue share (small multiples)'),
+      visual('v-kpi-sm', 'card', 'kpi',
+             { 'Values' => ['ORDER_FACT.Total Net Revenue'], 'SmallMultiples' => ['ORDER_FACT.Region'] },
+             'Total Revenue')
+    ],
+    'interactions' => []
+  }]
+}
+
+spec, sidecar = build(signals)
+ok('CASE A: builder produced a spec', !spec.nil?)
+if spec
+  # 1. bar + SmallMultiples -> single bar-chart with trellis.columnsBy on the facet.
+  bar = find_el(spec, 'Revenue by Channel (small multiples)')
+  ok('bar+SM element exists and stayed a bar-chart', bar && bar['kind'] == 'bar-chart')
+  fc = bar && facet_col(bar)
+  ok('bar+SM: facet dimension added as a column', !fc.nil?)
+  tr = bar && bar['trellis']
+  ok('bar+SM: has trellis.columnsBy (single facet -> tile grid)',
+     tr.is_a?(Hash) && tr.key?('columnsBy') && !tr.key?('rowsBy'))
+  ok('bar+SM: trellis references the facet column id',
+     fc && tr && tr['columnsBy'] == [{ 'columnId' => fc['id'] }])
+
+  # 2. bar WITHOUT SmallMultiples -> no trellis (detection-gated). Exact-match the
+  # title so the "(small multiples)" variant isn't picked up.
+  plain = content_elements(spec).find { |e| el_name(e) == 'Revenue by Channel' }
+  ok('bar (no SM) exists', !plain.nil?)
+  ok('bar (no SM): NO trellis key', plain && !plain.key?('trellis'))
+  ok('bar (no SM): NO Region facet column leaked', plain && facet_col(plain).nil?)
+
+  # 3. pie + SmallMultiples -> donut-chart + trellis (pie->donut fallback).
+  pie = find_el(spec, 'Revenue share (small multiples)')
+  ok('pie+SM: flipped to donut-chart', pie && pie['kind'] == 'donut-chart')
+  ok('pie+SM: has trellis.columnsBy', pie && pie['trellis'].is_a?(Hash) && pie['trellis'].key?('columnsBy'))
+
+  # 4. kpi + SmallMultiples -> NO trellis (Sigma strips it on a kpi-chart). A
+  # single-value card names itself after its measure leaf ("Total Net Revenue").
+  kpi = find_el(spec, 'Total Net Revenue')
+  ok('kpi+SM: exists as kpi-chart', kpi && kpi['kind'] == 'kpi-chart')
+  ok('kpi+SM: NO trellis emitted (would be silently stripped)', kpi && !kpi.key?('trellis'))
+
+  # 5. round-trip sidecar lists exactly the two trellised elements (bar + donut).
+  ok('sidecar written', !sidecar.nil?)
+  if sidecar && bar && pie
+    recs = Array(sidecar['elements'])
+    ids  = recs.map { |r| r['element_id'] }.sort
+    ok('sidecar lists exactly the bar + donut trellis element ids',
+       ids == [bar['id'], pie['id']].sort)
+    ok('sidecar records the correct kinds (bar-chart + donut-chart)',
+       recs.map { |r| r['kind'] }.sort == %w[bar-chart donut-chart])
+    ok('sidecar records the columnsBy axis',
+       recs.all? { |r| r['axis'] == 'columnsBy' })
+    ok('sidecar records the facet columnId',
+       recs.all? { |r| r['columnId'].to_s.end_with?('-sm') })
+  end
+end
+
+# =============================================================================
+# CASE B — no small-multiples anywhere: no sidecar, no trellis (byte-shape guard).
+# =============================================================================
+plain_signals = {
+  'source' => 'pbir', 'theme' => nil,
+  'pages' => [{
+    'page_id' => 'p1', 'page_title' => 'Plain', 'page_w' => 1280, 'page_h' => 720,
+    'visuals' => [
+      visual('v1', 'clusteredColumnChart', 'bar',
+             { 'Category' => ['ORDER_FACT.Order Channel'], 'Y' => ['ORDER_FACT.Total Net Revenue'] },
+             'Revenue by Channel'),
+      visual('v2', 'card', 'kpi', { 'Values' => ['ORDER_FACT.Total Net Revenue'] }, 'Total Revenue')
+    ],
+    'interactions' => []
+  }]
+}
+spec_b, sidecar_b = build(plain_signals)
+ok('CASE B: builder produced a spec', !spec_b.nil?)
+if spec_b
+  any_trellis = content_elements(spec_b).any? { |e| e.key?('trellis') }
+  ok('CASE B: NO element carries a trellis key', !any_trellis)
+  ok('CASE B: NO round-trip sidecar written (nothing trellised)', sidecar_b.nil?)
+end
+
+puts $fail.zero? ? "\nall pbi-trellis tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-trellis-emit.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-trellis-emit.rb
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-trellis-emit.rb — unit test for TrellisEmit (the shared native-trellis
+# emitter). Converter-agnostic, pure, no network. Canonical in shared/scripts;
+# edit there, run tools/sync-shared.rb.
+# Run: ruby scripts/test-trellis-emit.rb
+require_relative 'lib/trellis_emit'
+
+$fail = 0
+def ok(name, cond); puts((cond ? '  ok  ' : 'FAIL  ') + name); $fail += 1 unless cond; end
+
+def el(kind, cols = [{ 'id' => 'c-cat' }])
+  { 'id' => 'el-1', 'kind' => kind, 'columns' => cols }
+end
+
+# ---- supported kinds → trellis set, right axis per orientation --------------
+%w[bar-chart line-chart area-chart combo-chart scatter-chart donut-chart].each do |k|
+  e = el(k)
+  r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :rows)
+  ok("#{k}: rows → :trellised + trellis.rowsBy", r == :trellised &&
+     e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-cat' }] })
+
+  e2 = el(k)
+  r2 = TrellisEmit.apply(e2, facet_column_id: 'c-cat', orientation: :cols)
+  ok("#{k}: cols → trellis.columnsBy (and NOT rowsBy)", r2 == :trellised &&
+     e2['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+end
+
+# String orientation is accepted the same as the symbol.
+e = el('bar-chart')
+TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: 'rows')
+ok('orientation may be a String', e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-cat' }] })
+
+# ---- pie-chart → donut + trellis (fallback) ---------------------------------
+e = el('pie-chart')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('pie-chart → :fallback_donut', r == :fallback_donut)
+ok('pie-chart kind flipped to donut-chart', e['kind'] == 'donut-chart')
+ok('pie→donut carries the native trellis', e['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+ok('pie-chart trellises? is true (converts)', TrellisEmit.trellises?('pie-chart'))
+
+# ---- kpi-chart → needs-sibling signal, element untouched --------------------
+e = el('kpi-chart')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('kpi-chart → :needs_sibling_fanout', r == :needs_sibling_fanout)
+ok('kpi-chart left UNTOUCHED (no trellis, kind unchanged)',
+   !e.key?('trellis') && e['kind'] == 'kpi-chart')
+ok('kpi-chart trellises? is false', !TrellisEmit.trellises?('kpi-chart'))
+
+# ---- pivot-table → needs-shelves signal, untouched --------------------------
+e = el('pivot-table')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :rows)
+ok('pivot-table → :needs_pivot_shelves', r == :needs_pivot_shelves)
+ok('pivot-table left UNTOUCHED', !e.key?('trellis') && e['kind'] == 'pivot-table')
+
+# ---- table → flat no-op -----------------------------------------------------
+e = el('table')
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('table → :flat', r == :flat)
+ok('table left UNTOUCHED', !e.key?('trellis'))
+
+# ---- unknown kind → flat (default fallback) ---------------------------------
+e = el('funnel-chart')
+ok('unknown kind → :flat disposition', TrellisEmit.disposition('funnel-chart') == :flat)
+r = TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :cols)
+ok('unknown kind → :flat + untouched', r == :flat && !e.key?('trellis'))
+
+# ---- 2-D grid → BOTH keys, two different columns ----------------------------
+e = el('bar-chart', [{ 'id' => 'c-row' }, { 'id' => 'c-col' }])
+r = TrellisEmit.apply(e, facet_column_id: %w[c-row c-col], orientation: :grid)
+ok('grid + two facet ids → :trellised', r == :trellised)
+ok('grid → rowsBy AND columnsBy on the two distinct columns',
+   e['trellis'] == { 'rowsBy' => [{ 'columnId' => 'c-row' }],
+                     'columnsBy' => [{ 'columnId' => 'c-col' }] })
+
+# A single-field grid wraps into a tile grid → columnsBy only (tableau parity).
+e = el('bar-chart')
+TrellisEmit.apply(e, facet_column_id: 'c-cat', orientation: :grid)
+ok('grid + single facet id → columnsBy only (single-field tile grid)',
+   e['trellis'] == { 'columnsBy' => [{ 'columnId' => 'c-cat' }] })
+
+# ---- disposition is the single source of truth (non-mutating) ---------------
+ok('disposition(bar-chart) == :trellised', TrellisEmit.disposition('bar-chart') == :trellised)
+ok('disposition(pie-chart) == :fallback_donut', TrellisEmit.disposition('pie-chart') == :fallback_donut)
+ok('disposition(kpi-chart) == :needs_sibling_fanout',
+   TrellisEmit.disposition('kpi-chart') == :needs_sibling_fanout)
+ok('disposition(pivot-table) == :needs_pivot_shelves',
+   TrellisEmit.disposition('pivot-table') == :needs_pivot_shelves)
+ok('disposition(table) == :flat', TrellisEmit.disposition('table') == :flat)
+ok('SUPPORTED_KINDS is the documented readback-safe set',
+   TrellisEmit::SUPPORTED_KINDS == %w[bar-chart line-chart area-chart combo-chart scatter-chart donut-chart])
+
+puts
+if $fail.zero?
+  puts 'ALL PASS — TrellisEmit (supported→trellis by orientation; pie→donut; ' \
+       'kpi/pivot/table fallbacks; 2-D grid → both keys)'
+  exit 0
+else
+  puts "#{$fail} FAILURE(S)"
+  exit 1
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-trellis-survived.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-trellis-survived.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby
+# Round-trip guard for native trellis (SUPERSEDES #451 card-trellis).
+#
+# Sigma accepts a POST with an element `trellis` property (200 OK) but SILENTLY
+# STRIPS it on unsupported element kinds — the key is simply gone from the
+# readback spec and the tile renders flat, with no error. build-charts-from-
+# signals.rb records every trellis it emitted in native-trellis-emitted.json;
+# this asserts each one still carries its `trellis` key (with the same axis) on
+# the readback spec. A stripped trellis is a FAILURE to surface — never a silent
+# "flat but green".
+#
+# Usage:
+#   ruby verify-trellis-survived.rb --emitted <native-trellis-emitted.json> \
+#        --spec <readback wb-spec JSON (GET /v2/workbooks/{id}/spec .spec)>
+#
+# Exit 0 = every emitted trellis survived; exit 1 = one or more were stripped
+# (or the axis changed). Pure stdlib; no network.
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--emitted PATH', 'native-trellis-emitted.json from build-charts') { |v| opts[:emitted] = v }
+  p.on('--spec PATH', 'readback workbook spec JSON (the .spec object, or the full GET response)') { |v| opts[:spec] = v }
+end.parse!
+
+abort 'FATAL: --emitted and --spec are required' unless opts[:emitted] && opts[:spec]
+unless File.exist?(opts[:emitted])
+  # No sidecar = no trellis was emitted this run — nothing to verify (pass).
+  puts 'verify-trellis-survived: no native-trellis-emitted.json (no trellis emitted) — nothing to assert'
+  exit 0
+end
+
+emitted = JSON.parse(File.read(opts[:emitted]))
+records = Array(emitted['elements'])
+if records.empty?
+  puts 'verify-trellis-survived: 0 emitted trellis records — nothing to assert'
+  exit 0
+end
+
+raw  = JSON.parse(File.read(opts[:spec]))
+spec = raw['spec'].is_a?(Hash) ? raw['spec'] : raw # accept the full GET body or the bare spec
+
+# Index every element on every page by id.
+by_id = {}
+Array(spec['pages']).each do |pg|
+  Array(pg['elements']).each { |e| by_id[e['id']] = e if e.is_a?(Hash) && e['id'] }
+end
+
+fails = []
+oks = []
+records.each do |r|
+  eid  = r['element_id']
+  axis = r['axis'] # 'rowsBy' | 'columnsBy'
+  el = by_id[eid]
+  if el.nil?
+    fails << "element #{eid.inspect} (#{r['name'].inspect}) NOT FOUND on the readback spec"
+    next
+  end
+  tr = el['trellis']
+  if !tr.is_a?(Hash) || tr[axis].nil? || Array(tr[axis]).empty?
+    fails << "element #{eid.inspect} (#{r['name'].inspect}, kind #{el['kind'].inspect}) lost its trellis.#{axis} " \
+             'on readback — Sigma STRIPPED it (unsupported kind or malformed). Route to the documented fallback ' \
+             '(pie→donut / kpi→N siblings / pivot→own shelves / table→postpublish).'
+  else
+    oks << "#{eid} trellis.#{axis} survived (#{el['kind']})"
+  end
+end
+
+oks.each { |m| puts "  OK   #{m}" }
+if fails.empty?
+  puts "verify-trellis-survived: PASS — all #{records.size} native trellis element(s) survived readback"
+  exit 0
+else
+  warn "verify-trellis-survived: FAIL — #{fails.size}/#{records.size} trellis element(s) were STRIPPED:"
+  fails.each { |f| warn "  - #{f}" }
+  exit 1
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -421,13 +421,22 @@
   {
    "canonical": "shared/lib/trellis_emit.rb",
    "targets": [
-    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/trellis_emit.rb"
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/trellis_emit.rb",
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/trellis_emit.rb"
    ]
   },
   {
    "canonical": "shared/scripts/test-trellis-emit.rb",
    "targets": [
-    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-trellis-emit.rb"
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-trellis-emit.rb",
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-trellis-emit.rb"
+   ]
+  },
+  {
+   "canonical": "shared/scripts/verify-trellis-survived.rb",
+   "targets": [
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-trellis-survived.rb",
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-trellis-survived.rb"
    ]
   },
   {

--- a/shared/scripts/verify-trellis-survived.rb
+++ b/shared/scripts/verify-trellis-survived.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby
+# Round-trip guard for native trellis (SUPERSEDES #451 card-trellis).
+#
+# Sigma accepts a POST with an element `trellis` property (200 OK) but SILENTLY
+# STRIPS it on unsupported element kinds — the key is simply gone from the
+# readback spec and the tile renders flat, with no error. build-charts-from-
+# signals.rb records every trellis it emitted in native-trellis-emitted.json;
+# this asserts each one still carries its `trellis` key (with the same axis) on
+# the readback spec. A stripped trellis is a FAILURE to surface — never a silent
+# "flat but green".
+#
+# Usage:
+#   ruby verify-trellis-survived.rb --emitted <native-trellis-emitted.json> \
+#        --spec <readback wb-spec JSON (GET /v2/workbooks/{id}/spec .spec)>
+#
+# Exit 0 = every emitted trellis survived; exit 1 = one or more were stripped
+# (or the axis changed). Pure stdlib; no network.
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--emitted PATH', 'native-trellis-emitted.json from build-charts') { |v| opts[:emitted] = v }
+  p.on('--spec PATH', 'readback workbook spec JSON (the .spec object, or the full GET response)') { |v| opts[:spec] = v }
+end.parse!
+
+abort 'FATAL: --emitted and --spec are required' unless opts[:emitted] && opts[:spec]
+unless File.exist?(opts[:emitted])
+  # No sidecar = no trellis was emitted this run — nothing to verify (pass).
+  puts 'verify-trellis-survived: no native-trellis-emitted.json (no trellis emitted) — nothing to assert'
+  exit 0
+end
+
+emitted = JSON.parse(File.read(opts[:emitted]))
+records = Array(emitted['elements'])
+if records.empty?
+  puts 'verify-trellis-survived: 0 emitted trellis records — nothing to assert'
+  exit 0
+end
+
+raw  = JSON.parse(File.read(opts[:spec]))
+spec = raw['spec'].is_a?(Hash) ? raw['spec'] : raw # accept the full GET body or the bare spec
+
+# Index every element on every page by id.
+by_id = {}
+Array(spec['pages']).each do |pg|
+  Array(pg['elements']).each { |e| by_id[e['id']] = e if e.is_a?(Hash) && e['id'] }
+end
+
+fails = []
+oks = []
+records.each do |r|
+  eid  = r['element_id']
+  axis = r['axis'] # 'rowsBy' | 'columnsBy'
+  el = by_id[eid]
+  if el.nil?
+    fails << "element #{eid.inspect} (#{r['name'].inspect}) NOT FOUND on the readback spec"
+    next
+  end
+  tr = el['trellis']
+  if !tr.is_a?(Hash) || tr[axis].nil? || Array(tr[axis]).empty?
+    fails << "element #{eid.inspect} (#{r['name'].inspect}, kind #{el['kind'].inspect}) lost its trellis.#{axis} " \
+             'on readback — Sigma STRIPPED it (unsupported kind or malformed). Route to the documented fallback ' \
+             '(pie→donut / kpi→N siblings / pivot→own shelves / table→postpublish).'
+  else
+    oks << "#{eid} trellis.#{axis} survived (#{el['kind']})"
+  end
+end
+
+oks.each { |m| puts "  OK   #{m}" }
+if fails.empty?
+  puts "verify-trellis-survived: PASS — all #{records.size} native trellis element(s) survived readback"
+  exit 0
+else
+  warn "verify-trellis-survived: FAIL — #{fails.size}/#{records.size} trellis element(s) were STRIPPED:"
+  fails.each { |f| warn "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## What

Wires Power BI's first-class **"Small multiples"** field well to Sigma's **native `element.trellis`** (`rowsBy`/`columnsBy`) through the shared, converter-agnostic `TrellisEmit.apply` — the same emitter the Tableau converter uses. This is **rank-1** in `docs/trellis-cross-converter-plan.md`; coverage matrix in `docs/sigma-trellis-chart-support.md`.

## Detection

`build-workbook-from-pbir.rb` (`apply_small_multiples!`): a PBIR visual carries its facet as a `SmallMultiples` **projection role** in `visual.query.queryState`, already passed through verbatim by `extract-pbir.py`'s `_role_bindings` -> `rec['bindings']['SmallMultiples']`. Explicit source property, **no geometry inference**. The Power BI build path is Ruby, so it `require`s the shared Ruby lib directly — **no Python mirror needed**.

## Emission

One Sigma element (the base viz) with the facet added as a column, then `TrellisEmit.apply` sets `element['trellis']`. The shared emitter gates to the readback-safe kinds (bar/line/area/combo/scatter/donut) and applies the documented fallbacks: **pie->donut** (flipped in place), **kpi/pivot/table** left flat (Sigma returns `200` then **silently strips** the key on those). A single PBI facet -> `columnsBy`, which Sigma wraps into the tile grid PBI renders (a true 2-D Sigma grid needs two *distinct* facet columns, which a PBI small multiple never supplies — noted as deferred).

## Round-trip guard

The builder writes the neutral `native-trellis-emitted.json` sidecar **only when a trellis was actually emitted**. `verify-trellis-survived.rb` — promoted to `shared/scripts/` and synced into tableau + powerbi — re-reads the readback spec and fails loudly on a silently stripped key. Proven both directions: **PASS** on a faithful readback, **exit 1** on a stripped one.

## Byte-identical

A PBIR with no small-multiples visual is **detection-gated** and builds byte-for-byte identically to `origin/main` — verified by diffing the `orders-overview` fixture output against the `origin/main` builder (empty diff).

## Tests

- `test-pbi-trellis.rb` drives the **real builder** end-to-end: bar+SM -> one trellised `bar-chart` referencing the facet; plain bar -> unchanged (no trellis, no leaked column); pie+SM -> `donut-chart` + trellis; kpi+SM -> no trellis; sidecar contents; no-SM page -> no sidecar / no trellis anywhere.
- `test-trellis-emit.rb` (shared unit test) synced into powerbi.
- Both added to the offline CI suite. `corpus/run-corpus.sh --check` **17/17**, `tools/check-shared.rb` green (461 copies), hygiene clean.

## Docs

Corrected the stale **"trellis is Sigma UI-only"** notes (`refs/measure-patterns.md`, `refs/pbi-model-gotchas.md`) that predate the native `rowsBy`/`columnsBy` finding (#460/#462), and marked the Power BI row done in the cross-converter plan.

Generated with [Claude Code](https://claude.com/claude-code)
