### PR TITLE
shared: truststore TLS ladder + PEP-668-safe bootstrap + doctor Looker probe

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/bootstrap.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/bootstrap.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/bootstrap.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get_token.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/bootstrap.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/bootstrap.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/bootstrap.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get_token.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/bootstrap.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/bootstrap.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/bootstrap.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get_token.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/bootstrap.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/bootstrap.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/bootstrap.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get_token.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/bootstrap.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/bootstrap.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/bootstrap.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get_token.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/bootstrap.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/bootstrap.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/bootstrap.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get_token.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/bootstrap.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/bootstrap.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/bootstrap.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get_token.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/bootstrap.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/bootstrap.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get_token.py
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/bootstrap.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/bootstrap.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/bootstrap.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/bootstrap.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/bootstrap.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get_token.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/bootstrap.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/bootstrap.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/bootstrap.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get_token.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/bootstrap.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/bootstrap.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get_token.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/bootstrap.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/bootstrap.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get_token.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(

--- a/shared/scripts/bootstrap.ps1
+++ b/shared/scripts/bootstrap.ps1
@@ -139,6 +139,17 @@ if ($script:PyExe) {
   }
 }
 
+# pip --user install that survives PEP 668 ("externally-managed-environment"):
+# try plain --user, then retry with --break-system-packages. No admin.
+function Invoke-PipUserInstall {
+  param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Pkgs)
+  $a = @(); if ($script:PyPre) { $a += $script:PyPre }
+  & $script:PyExe @a -m pip install --user --quiet @Pkgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) { return $true }
+  & $script:PyExe @a -m pip install --user --break-system-packages --quiet @Pkgs 2>&1 | Out-Null
+  return ($LASTEXITCODE -eq 0)
+}
+
 # --- python deps (doctor's render/similarity checks) ------------------------
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
@@ -147,10 +158,22 @@ if ($script:PyExe) {
   else {
     Plan "python deps missing (Pillow/numpy/requests)" "$script:PyExe $script:PyPre -m pip install --user pillow numpy requests (no admin)"
     if (-not $Check) {
-      & $script:PyExe @pyArgs -m pip install --user --quiet pillow numpy requests 2>&1 | Out-Null
+      $ok = Invoke-PipUserInstall pillow numpy requests
       & $script:PyExe @pyArgs -c "import PIL, numpy, requests" 2>$null | Out-Null
-      if ($LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
-      else { $script:InstallFailed = $true; Note 'pip --user install FAILED (offline? proxy?) -- re-run bootstrap when the network allows' }
+      if ($ok -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user pillow numpy requests'; Okay 'python deps installed (pip --user)' }
+      else { $script:InstallFailed = $true; Note 'pip --user install FAILED -- if PEP 668 (externally-managed) the --break-system-packages retry also failed; otherwise check network/proxy' }
+    }
+  }
+  # truststore (best effort): OS trust store so OpenSSL 3.x verifies Looker/Tableau certs
+  & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { Okay 'python truststore (OS trust store for TLS)' }
+  else {
+    Plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" "$script:PyExe $script:PyPre -m pip install --user truststore"
+    if (-not $Check) {
+      $okt = Invoke-PipUserInstall truststore
+      & $script:PyExe @pyArgs -c "import truststore" 2>$null | Out-Null
+      if ($okt -and $LASTEXITCODE -eq 0) { $script:Actions += 'install: pip --user truststore'; Okay 'python truststore installed' }
+      else { Note 'pip --user install of truststore FAILED -- TLS falls back to certifi/default; install manually if a Looker/Tableau TLS error appears' }
     }
   }
 }

--- a/shared/scripts/bootstrap.sh
+++ b/shared/scripts/bootstrap.sh
@@ -181,6 +181,14 @@ else
   fi
 fi
 
+# pip --user install that survives PEP 668 ("externally-managed-environment",
+# e.g. Homebrew/Debian Python): try plain --user first, then retry allowing the
+# user-site override. Never sudos, never touches system dirs.
+pip_user_install() {
+  $PY_RUN -m pip install --user --quiet "$@" >/dev/null 2>&1 && return 0
+  $PY_RUN -m pip install --user --break-system-packages --quiet "$@" >/dev/null 2>&1
+}
+
 # ── python deps (doctor's render/similarity checks: Pillow + numpy + requests) ─
 if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
   if $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
@@ -189,13 +197,31 @@ if [ -n "$PY_RUN" ] || py_real py -3 || py_real python3 || py_real python; then
     plan "python deps missing (Pillow/numpy/requests — renders + the gate-14 visual floor)" \
          "$PY_RUN -m pip install --user pillow numpy requests (user site-packages; no admin)"
     if [ "$MODE" = full ]; then
-      if $PY_RUN -m pip install --user --quiet pillow numpy requests >/dev/null 2>&1 \
+      if pip_user_install pillow numpy requests \
          && $PY_RUN -c "import PIL, numpy, requests" >/dev/null 2>&1; then
         act "install: pip --user pillow numpy requests"
         okay "python deps installed (pip --user)"
       else
         INSTALL_FAILED=1
-        note "pip --user install of pillow/numpy/requests FAILED (offline? proxy?) — re-run bootstrap when the network allows"
+        note "pip --user install of pillow/numpy/requests FAILED — if the error was 'externally-managed-environment' (PEP 668) the retry with --break-system-packages also failed; otherwise check network/proxy. Re-run bootstrap when resolved"
+      fi
+    fi
+  fi
+  # truststore (best effort): makes Python's TLS use the OS trust store so
+  # OpenSSL 3.x verifies Looker/Tableau certs that curl/Ruby already accept.
+  # Not required — looker_api/tableau_rest fall back to certifi/default — so a
+  # failure here only warns.
+  if $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+    okay "python truststore (OS trust store for TLS)"
+  else
+    plan "python truststore missing (OpenSSL 3.x TLS vs Looker/Tableau Cloud)" \
+         "$PY_RUN -m pip install --user truststore"
+    if [ "$MODE" = full ]; then
+      if pip_user_install truststore && $PY_RUN -c "import truststore" >/dev/null 2>&1; then
+        act "install: pip --user truststore"
+        okay "python truststore installed"
+      else
+        note "pip --user install of truststore FAILED — TLS falls back to certifi/default; install manually if a Looker/Tableau TLS verification error appears"
       fi
     fi
   fi

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -71,7 +71,7 @@ if ($script:PyExe) {
   $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
   if ($probe -eq 'TRUSTWARN') {
     $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" `
          "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
@@ -181,6 +181,35 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   }
 }
 
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only where looker_api.py + ~/.looker/
+# looker.ini exist. Modern Google-hosted Looker serves the API on 443; the
+# legacy :19999 is often unreachable. looker_api self-heals to 443, but flag a
+# stale ini. Uses the UNAUTHENTICATED /api/4.0/versions via Invoke-WebRequest
+# (Windows cert store - isolates the PORT question from the TLS one above).
+$script:LookerProbe = "skipped"
+$lkIni = Join-Path $env:USERPROFILE ".looker\looker.ini"
+$lkApi = Join-Path $PSScriptRoot "looker_api.py"
+if ((Test-Path $lkApi) -and (Test-Path $lkIni)) {
+  $lkMatch = Select-String -Path $lkIni -Pattern '^\s*base_url\s*=\s*(.+?)\s*$' -ErrorAction SilentlyContinue | Select-Object -First 1
+  $lkBase = if ($lkMatch) { $lkMatch.Matches.Groups[1].Value.TrimEnd('/') } else { "" }
+  if ($lkBase) {
+    $lkNoPort = ($lkBase -replace '^(https?://[^/:]+)(:\d+)?.*$', '$1')
+    $reach = { param($u) try { Invoke-WebRequest -Uri "$u/api/4.0/versions" -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop | Out-Null; $true } catch { $false } }
+    if (& $reach $lkBase) {
+      Ok "Looker API reachable at $lkBase"; $script:LookerProbe = "pass"
+    } elseif (($lkNoPort -ne $lkBase) -and (& $reach $lkNoPort)) {
+      Warn "Looker base_url ($lkBase) is unreachable but $lkNoPort (443) answers - looker_api will self-heal to 443 at run time" `
+           "Update base_url in ~/.looker/looker.ini to '$lkNoPort' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      $script:LookerProbe = "fallback"
+    } else {
+      Warn "Looker API not reachable at $lkBase (network / VPN / instance URL?)" `
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      $script:LookerProbe = "fail"
+    }
+  }
+}
+
 # --- skill version drift (v3 §2.1) -----------------------------------------
 # A pinned plugin install never self-updates; a stale SHA silently ships
 # pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
@@ -243,7 +272,7 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
-  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau }
+  cred_smoke   = [ordered]@{ sigma = $script:SmokeSigma; tableau = $script:SmokeTableau; looker = $script:LookerProbe }
   hyperapi_present = $hyperapiPresent
   skill_sha    = "$skillSha"
   behind_count = $behindCount

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -123,7 +123,7 @@ fi
 if [ -n "$PY_ARGV" ]; then
   TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
   if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
-    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Looker or Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
@@ -245,6 +245,36 @@ if [ -f "$HERE/setup-tableau.rb" ] && [ -f "$HERE/lib/tableau_rest.rb" ]; then
       bad "Tableau credentials present but the live PAT signin FAILED twice (expired/revoked PAT, wrong site or server URL)" \
           "Re-run 'ruby scripts/setup-tableau.rb' with a fresh PAT. Genuinely offline? SIGMA_SKIP_CRED_SMOKE=1 skips this probe."
       SMOKE_TABLEAU="fail"
+    fi
+  fi
+fi
+
+# --- Looker API reachability (self-gated: looker skills only) ----------------
+# Plugin-aware like the Tableau checks: only speaks up where the sibling Looker
+# client exists (looker_api.py) and a ~/.looker/looker.ini is present. Modern
+# Google-hosted Looker serves the API on 443; the legacy :19999 port is often
+# unreachable. The client self-heals (looker_api falls back to 443), but flag a
+# stale ini so the user can fix it. Uses the UNAUTHENTICATED /api/4.0/versions
+# endpoint via curl (OS trust store — isolates the PORT question from the TLS
+# one above). Recorded in doctor.json {cred_smoke:{looker: pass|fallback|fail|skipped}}.
+LOOKER_PROBE="skipped"
+LK_INI="$HOME/.looker/looker.ini"
+if [ -f "$HERE/looker_api.py" ] && [ -f "$LK_INI" ] && command -v curl >/dev/null 2>&1; then
+  LK_BASE="$(sed -n 's/^[[:space:]]*base_url[[:space:]]*=[[:space:]]*//p' "$LK_INI" | head -1 | tr -d '\r')"
+  LK_BASE="${LK_BASE%/}"
+  if [ -n "$LK_BASE" ]; then
+    LK_NOPORT="$(printf '%s' "$LK_BASE" | sed -E 's#^(https?://[^/:]+)(:[0-9]+)?.*#\1#')"
+    if curl -sS -m 8 -o /dev/null "$LK_BASE/api/4.0/versions" 2>/dev/null; then
+      ok "Looker API reachable at $LK_BASE"
+      LOOKER_PROBE="pass"
+    elif [ "$LK_NOPORT" != "$LK_BASE" ] && curl -sS -m 8 -o /dev/null "$LK_NOPORT/api/4.0/versions" 2>/dev/null; then
+      warn "Looker base_url ($LK_BASE) is unreachable but $LK_NOPORT (443) answers — looker_api will self-heal to 443 at run time" \
+           "Update base_url in ~/.looker/looker.ini to '$LK_NOPORT' (drop the legacy :19999 API port), or set LOOKER_BASE_URL."
+      LOOKER_PROBE="fallback"
+    else
+      warn "Looker API not reachable at $LK_BASE (network / VPN / instance URL?)" \
+           "Confirm the Looker instance URL and that this host can reach its API 4.0 endpoint."
+      LOOKER_PROBE="fail"
     fi
   fi
 fi
@@ -384,7 +414,7 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
-    printf '"cred_smoke":{"sigma":"%s","tableau":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU"
+    printf '"cred_smoke":{"sigma":"%s","tableau":"%s","looker":"%s"},' "$SMOKE_SIGMA" "$SMOKE_TABLEAU" "$LOOKER_PROBE"
     printf '"hyperapi_present":%s,' "$HYPERAPI"
     printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
     printf '"behind_count":%s,' "$BEHIND_COUNT"

--- a/shared/scripts/get_token.py
+++ b/shared/scripts/get_token.py
@@ -35,6 +35,24 @@ import urllib.request
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
 
 
+def _ssl_ctx():
+    """Verified SSL context that tolerates OpenSSL 3.x strictness: prefer the OS
+    trust store via truststore (matches curl/Ruby, accepts chains the stock
+    bundle rejects), then certifi, then the stock verified context. Never
+    disables verification."""
+    import ssl
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
 def _load_neutral_env():
     """If Sigma creds aren't already in the environment, load them from the
     neutral cred file written by setup.rb. Existing env always wins — mirrors
@@ -96,7 +114,7 @@ def mint_token():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx()) as resp:
             payload = json.load(resp)
     except urllib.error.HTTPError as e:
         _die(


### PR DESCRIPTION
## What & why

Isolated shared-lib hardening, motivated by a live Looker run that hit three environment walls before anything ran: Python OpenSSL-3.x cert rejection, a PEP-668 pip wall, and a stale API port. Canonical copies edited under `shared/` and fanned to every plugin via `tools/sync-shared.rb`.

- **bootstrap.sh / bootstrap.ps1** — install `truststore` and survive PEP 668 (externally-managed Python) by retrying `pip --user` with `--break-system-packages`.
- **doctor.sh / doctor.ps1** — name Looker (not just Tableau) in the OpenSSL-3.x TLS-trust warning; add a self-gated Looker reachability probe (only when `~/.looker/looker.ini` + `looker_api.py` exist) that flags a stale legacy `:19999` base when 443 answers. Recorded in `doctor.json` `cred_smoke.looker`.
- **get_token.py** — verified `truststore → certifi → default` SSL ladder for Sigma token minting.

Benefits all 22 plugins (truststore + doctor) / 12 (get_token). Plugin-specific consumers (e.g. `looker_api.py`) land in their own plugin PRs.

## Scope

- Plugin(s) touched: none — **isolated shared-lib change** (canonical + 100-file fan-out)
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green (edited `shared/` + `tools/sync-shared.rb`, never a copy)
- [x] `ruby tools/lint-skills.rb` — green
- [ ] `./corpus/run-corpus.sh --check` — n/a (no converter/builder changed)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in

## If this changes a shared lib

- [x] Edited the canonical copy under `shared/` and ran `tools/sync-shared.rb`
- [x] This is a standalone PR (no feature work mixed in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
