### PR TITLE
looker: self-heal API connectivity (legacy port fallback + env override + truststore)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -278,6 +278,7 @@ jobs:
           python3 -m pip install --quiet pyyaml
           tests=(
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grid_fidelity.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_looker_client.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker_api.py
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker_api.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import threading
+import urllib.error
 import urllib.parse
 import urllib.request
 from configparser import ConfigParser
@@ -30,40 +31,110 @@ _token_lock = threading.Lock()
 _token_cache = {}  # base_url -> access_token
 
 
+def _api_base(base):
+    base = base.rstrip("/")
+    if not base.endswith("/api/4.0"):
+        base += "/api/4.0"
+    return base
+
+
+def _strip_port(base):
+    """`base` with an explicit port removed (→ default 443), or None if there is
+    no explicit port. Used to self-heal a stale Looker API port: modern
+    Google-hosted Looker serves the API on 443, not the legacy :19999."""
+    p = urllib.parse.urlsplit(base)
+    if not p.port:
+        return None
+    return urllib.parse.urlunsplit((p.scheme, p.hostname, p.path, p.query, p.fragment))
+
+
 def _cfg():
     c = ConfigParser()
     c.read(INI)
     s = c["Looker"]
-    base = s["base_url"].rstrip("/")
-    if not base.endswith("/api/4.0"):
-        base = base + "/api/4.0"
-    return base, s["client_id"], s["client_secret"], s.getboolean("verify_ssl", True)
+    # An env override wins over the ini (LOOKER_BASE_URL; also accept the Looker
+    # SDK's LOOKERSDK_BASE_URL) so a stale/bad ini port can be corrected without
+    # editing the shared config.
+    raw_base = (os.environ.get("LOOKER_BASE_URL")
+                or os.environ.get("LOOKERSDK_BASE_URL")
+                or s["base_url"])
+    return _api_base(raw_base), s["client_id"], s["client_secret"], s.getboolean("verify_ssl", True)
+
+
+_ctx_cache = {}
 
 
 def _ctx(verify):
+    """SSL context for Looker requests. When verify is on (the default), delegate
+    to the OS trust store via `truststore` — it accepts chains that Python's
+    stricter OpenSSL 3.x default bundle rejects (e.g. a CA cert whose Basic
+    Constraints aren't marked critical), matching curl/Ruby — then fall back to
+    certifi and finally the stock verified context. verify=False (ini
+    `verify_ssl=false`) DISABLES verification: opt-in only, and it warns once."""
     import ssl
-    if verify:
-        return None
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    if verify in _ctx_cache:
+        return _ctx_cache[verify]
+    if not verify:
+        print("looker_api: verify_ssl=false — TLS certificate verification is "
+              "DISABLED for Looker requests. Do not use in production.", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    else:
+        ctx = None
+        try:
+            import truststore
+            ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        except Exception:
+            ctx = None
+        if ctx is None:
+            try:
+                import certifi
+                ctx = ssl.create_default_context(cafile=certifi.where())
+            except Exception:
+                ctx = ssl.create_default_context()
+    _ctx_cache[verify] = ctx
     return ctx
+
+
+# configured api-base -> reachable api-base (memoizes a successful port fallback)
+_resolved_base = {}
+
+
+def _do_login(base, cid, csec, verify):
+    data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
+    req = urllib.request.Request(base + "/login", data=data, method="POST")
+    with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
+        return json.load(r)["access_token"]
 
 
 def login(force=False):
     """Return (base, token, verify), reusing the per-process cached token.
 
     force=True mints a fresh token (NEW Looker session — see the dev-workspace
-    caveat above). Thread-safe: parallel callers share one login.
+    caveat above). Thread-safe: parallel callers share one login. If the
+    configured API base is unreachable AND carries an explicit port (e.g. the
+    legacy :19999), retries once on the port-stripped (443) base and remembers it.
     """
-    base, cid, csec, verify = _cfg()
+    cfg_base, cid, csec, verify = _cfg()
+    base = _resolved_base.get(cfg_base, cfg_base)
     with _token_lock:
         if not force and base in _token_cache:
             return base, _token_cache[base], verify
-        data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
-        req = urllib.request.Request(base + "/login", data=data, method="POST")
-        with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
-            tok = json.load(r)["access_token"]
+        try:
+            tok = _do_login(base, cid, csec, verify)
+        except urllib.error.URLError as e:
+            if isinstance(e, urllib.error.HTTPError):
+                raise  # a real HTTP response (bad creds, etc.), not a connectivity problem
+            alt = _strip_port(base)
+            if not alt or alt == base:
+                raise
+            print(f"looker_api: {base} unreachable ({getattr(e, 'reason', e)}); "
+                  f"retrying on {alt}. Update base_url in ~/.looker/looker.ini to "
+                  f"drop the legacy API port.", file=sys.stderr)
+            tok = _do_login(alt, cid, csec, verify)
+            _resolved_base[cfg_base] = alt
+            base = alt
         _token_cache[base] = tok
     return base, tok, verify
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -215,13 +215,21 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
 
 ```ini
 [Looker]
-base_url=https://<your-instance>.cloud.looker.com:19999
+base_url=https://<your-instance>.cloud.looker.com
 client_id=<API3 client_id>
 client_secret=<API3 client_secret>
 verify_ssl=True
 ```
 
-- **API 4.0**, key-pair-free `client_credentials` (login on `:19999` returns a bearer).
+- **API 4.0**, key-pair-free `client_credentials`. Modern Google-hosted Looker serves the API on
+  the standard **443** at `https://<instance>.cloud.looker.com/api/4.0` — no port needed. Older
+  self-hosted instances used the legacy `:19999`; if your `base_url` still carries it and that
+  port is unreachable, the client **self-heals**: it retries on 443 and warns you to update the
+  ini. You can also override the base without editing the ini via `LOOKER_BASE_URL`
+  (or `LOOKERSDK_BASE_URL`).
+- **TLS:** requests use the OS trust store via `truststore` (installed by `bash scripts/bootstrap.sh`),
+  so Python's stricter OpenSSL 3.x accepts the same certs curl/Ruby do; it falls back to certifi
+  then the stock bundle. Leave `verify_ssl=True` (setting it false disables verification and warns).
 - The credential's user needs **Admin** (or at least: see models, dashboards, run queries, and
   — for the test-fixture builders or Git-deploy flow — develop + deploy).
 - Generate an API3 key in Looker: **Admin → Users → (your user) → Edit Keys → New API3 Key**.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
@@ -14,29 +14,26 @@ import re
 import sys
 import urllib.parse
 import urllib.request
-from configparser import ConfigParser
+
+import looker_api  # sibling: single source of truth for base resolution + SSL/truststore
 
 INI = os.path.expanduser("~/.looker/looker.ini")
 
 
 def _client():
-    c = ConfigParser(); c.read(INI); s = c["Looker"]
-    base = s["base_url"].rstrip("/")
-    if not base.endswith("/api/4.0"):
-        base += "/api/4.0"
-    data = urllib.parse.urlencode({"client_id": s["client_id"],
-                                   "client_secret": s["client_secret"]}).encode()
-    tok = json.load(urllib.request.urlopen(
-        urllib.request.Request(base + "/login", data=data, method="POST"), timeout=30))["access_token"]
-    return base, tok
+    # Delegate to looker_api so the port fallback (legacy :19999 → 443), the
+    # LOOKER_BASE_URL override, and the truststore SSL context all apply here too.
+    base, tok, verify = looker_api.login()
+    return base, tok, verify
 
 
 def get(path):
-    base, tok = get._cache if hasattr(get, "_cache") else (None, None)
-    if base is None:
-        base, tok = _client(); get._cache = (base, tok)
+    cache = getattr(get, "_cache", None)
+    if cache is None:
+        cache = get._cache = _client()
+    base, tok, verify = cache
     req = urllib.request.Request(base + path, headers={"Authorization": "Bearer " + tok})
-    with urllib.request.urlopen(req, timeout=60) as r:
+    with urllib.request.urlopen(req, context=looker_api._ctx(verify), timeout=60) as r:
         return json.load(r)
 
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker_api.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker_api.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import threading
+import urllib.error
 import urllib.parse
 import urllib.request
 from configparser import ConfigParser
@@ -30,40 +31,110 @@ _token_lock = threading.Lock()
 _token_cache = {}  # base_url -> access_token
 
 
+def _api_base(base):
+    base = base.rstrip("/")
+    if not base.endswith("/api/4.0"):
+        base += "/api/4.0"
+    return base
+
+
+def _strip_port(base):
+    """`base` with an explicit port removed (→ default 443), or None if there is
+    no explicit port. Used to self-heal a stale Looker API port: modern
+    Google-hosted Looker serves the API on 443, not the legacy :19999."""
+    p = urllib.parse.urlsplit(base)
+    if not p.port:
+        return None
+    return urllib.parse.urlunsplit((p.scheme, p.hostname, p.path, p.query, p.fragment))
+
+
 def _cfg():
     c = ConfigParser()
     c.read(INI)
     s = c["Looker"]
-    base = s["base_url"].rstrip("/")
-    if not base.endswith("/api/4.0"):
-        base = base + "/api/4.0"
-    return base, s["client_id"], s["client_secret"], s.getboolean("verify_ssl", True)
+    # An env override wins over the ini (LOOKER_BASE_URL; also accept the Looker
+    # SDK's LOOKERSDK_BASE_URL) so a stale/bad ini port can be corrected without
+    # editing the shared config.
+    raw_base = (os.environ.get("LOOKER_BASE_URL")
+                or os.environ.get("LOOKERSDK_BASE_URL")
+                or s["base_url"])
+    return _api_base(raw_base), s["client_id"], s["client_secret"], s.getboolean("verify_ssl", True)
+
+
+_ctx_cache = {}
 
 
 def _ctx(verify):
+    """SSL context for Looker requests. When verify is on (the default), delegate
+    to the OS trust store via `truststore` — it accepts chains that Python's
+    stricter OpenSSL 3.x default bundle rejects (e.g. a CA cert whose Basic
+    Constraints aren't marked critical), matching curl/Ruby — then fall back to
+    certifi and finally the stock verified context. verify=False (ini
+    `verify_ssl=false`) DISABLES verification: opt-in only, and it warns once."""
     import ssl
-    if verify:
-        return None
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    if verify in _ctx_cache:
+        return _ctx_cache[verify]
+    if not verify:
+        print("looker_api: verify_ssl=false — TLS certificate verification is "
+              "DISABLED for Looker requests. Do not use in production.", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    else:
+        ctx = None
+        try:
+            import truststore
+            ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        except Exception:
+            ctx = None
+        if ctx is None:
+            try:
+                import certifi
+                ctx = ssl.create_default_context(cafile=certifi.where())
+            except Exception:
+                ctx = ssl.create_default_context()
+    _ctx_cache[verify] = ctx
     return ctx
+
+
+# configured api-base -> reachable api-base (memoizes a successful port fallback)
+_resolved_base = {}
+
+
+def _do_login(base, cid, csec, verify):
+    data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
+    req = urllib.request.Request(base + "/login", data=data, method="POST")
+    with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
+        return json.load(r)["access_token"]
 
 
 def login(force=False):
     """Return (base, token, verify), reusing the per-process cached token.
 
     force=True mints a fresh token (NEW Looker session — see the dev-workspace
-    caveat above). Thread-safe: parallel callers share one login.
+    caveat above). Thread-safe: parallel callers share one login. If the
+    configured API base is unreachable AND carries an explicit port (e.g. the
+    legacy :19999), retries once on the port-stripped (443) base and remembers it.
     """
-    base, cid, csec, verify = _cfg()
+    cfg_base, cid, csec, verify = _cfg()
+    base = _resolved_base.get(cfg_base, cfg_base)
     with _token_lock:
         if not force and base in _token_cache:
             return base, _token_cache[base], verify
-        data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
-        req = urllib.request.Request(base + "/login", data=data, method="POST")
-        with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
-            tok = json.load(r)["access_token"]
+        try:
+            tok = _do_login(base, cid, csec, verify)
+        except urllib.error.URLError as e:
+            if isinstance(e, urllib.error.HTTPError):
+                raise  # a real HTTP response (bad creds, etc.), not a connectivity problem
+            alt = _strip_port(base)
+            if not alt or alt == base:
+                raise
+            print(f"looker_api: {base} unreachable ({getattr(e, 'reason', e)}); "
+                  f"retrying on {alt}. Update base_url in ~/.looker/looker.ini to "
+                  f"drop the legacy API port.", file=sys.stderr)
+            tok = _do_login(alt, cid, csec, verify)
+            _resolved_base[cfg_base] = alt
+            base = alt
         _token_cache[base] = tok
     return base, tok, verify
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_looker_client.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_looker_client.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""looker_api client hardening regression (offline, creds-free, no network).
+
+Guards the three connectivity/TLS fixes that a real Look-8 run needed by hand:
+
+  env override    → LOOKER_BASE_URL / LOOKERSDK_BASE_URL win over the ini base
+  port self-heal  → a login against a stale legacy :19999 base that times out
+                    retries once on the port-stripped 443 base and memoizes it
+  verified TLS    → _ctx(verify=True) returns a REAL verified context (the
+                    pre-fix bug returned None → plain OpenSSL 3.x → cert reject);
+                    _ctx(verify=False) is CERT_NONE (opt-in insecure)
+
+Run: python3 tests/test_looker_client.py   (exit 0 = pass)
+"""
+import os
+import ssl
+import sys
+import tempfile
+import urllib.error
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = os.path.join(os.path.dirname(HERE), "scripts")
+sys.path.insert(0, SCRIPTS)
+import looker_api  # noqa: E402
+
+
+def _write_ini(base_url):
+    f = tempfile.NamedTemporaryFile("w", suffix=".ini", delete=False)
+    f.write(f"[Looker]\nbase_url={base_url}\nclient_id=x\nclient_secret=y\nverify_ssl=True\n")
+    f.close()
+    looker_api.INI = f.name
+    return f.name
+
+
+def test_env_override():
+    _write_ini("https://ini.cloud.looker.com:19999")
+    for k in ("LOOKER_BASE_URL", "LOOKERSDK_BASE_URL"):
+        os.environ.pop(k, None)
+    base, cid, csec, verify = looker_api._cfg()
+    assert base == "https://ini.cloud.looker.com:19999/api/4.0", base
+    assert (cid, csec, verify) == ("x", "y", True), (cid, csec, verify)
+
+    os.environ["LOOKER_BASE_URL"] = "https://override.cloud.looker.com"
+    try:
+        assert looker_api._cfg()[0] == "https://override.cloud.looker.com/api/4.0"
+    finally:
+        os.environ.pop("LOOKER_BASE_URL", None)
+
+    os.environ["LOOKERSDK_BASE_URL"] = "https://sdkvar.cloud.looker.com"
+    try:
+        assert looker_api._cfg()[0] == "https://sdkvar.cloud.looker.com/api/4.0"
+    finally:
+        os.environ.pop("LOOKERSDK_BASE_URL", None)
+    print("PASS test_env_override")
+
+
+def test_strip_port():
+    assert looker_api._strip_port("https://h.cloud.looker.com:19999/api/4.0") == \
+        "https://h.cloud.looker.com/api/4.0"
+    assert looker_api._strip_port("https://h.cloud.looker.com/api/4.0") is None
+    print("PASS test_strip_port")
+
+
+def test_port_fallback():
+    _write_ini("https://demo.cloud.looker.com:19999")
+    looker_api._token_cache.clear()
+    looker_api._resolved_base.clear()
+    for k in ("LOOKER_BASE_URL", "LOOKERSDK_BASE_URL"):
+        os.environ.pop(k, None)
+
+    orig = looker_api._do_login
+    calls = []
+
+    def fake_do_login(base, cid, csec, verify):
+        calls.append(base)
+        if ":19999" in base:
+            raise urllib.error.URLError("timed out")
+        return "TOKEN_443"
+
+    looker_api._do_login = fake_do_login
+    try:
+        base, tok, verify = looker_api.login()
+        assert tok == "TOKEN_443", tok
+        assert base == "https://demo.cloud.looker.com/api/4.0", base
+        assert calls[0] == "https://demo.cloud.looker.com:19999/api/4.0", calls
+        assert calls[1] == "https://demo.cloud.looker.com/api/4.0", calls
+        # a second login is served from cache via the memoized 443 base — no retry
+        calls.clear()
+        _, tok2, _ = looker_api.login()
+        assert tok2 == "TOKEN_443"
+        assert calls == [], f"expected cache hit, got {calls}"
+    finally:
+        looker_api._do_login = orig
+        looker_api._token_cache.clear()
+        looker_api._resolved_base.clear()
+    print("PASS test_port_fallback")
+
+
+def test_http_error_not_treated_as_connectivity():
+    """A real HTTP response (e.g. 401 bad creds) must NOT trigger the 443 fallback."""
+    _write_ini("https://demo.cloud.looker.com:19999")
+    looker_api._token_cache.clear()
+    looker_api._resolved_base.clear()
+    orig = looker_api._do_login
+    calls = []
+
+    def fake_do_login(base, cid, csec, verify):
+        calls.append(base)
+        raise urllib.error.HTTPError(base, 401, "Unauthorized", {}, None)
+
+    looker_api._do_login = fake_do_login
+    try:
+        raised = False
+        try:
+            looker_api.login()
+        except urllib.error.HTTPError:
+            raised = True
+        assert raised, "HTTPError should propagate, not fall back"
+        assert calls == ["https://demo.cloud.looker.com:19999/api/4.0"], calls
+    finally:
+        looker_api._do_login = orig
+        looker_api._token_cache.clear()
+        looker_api._resolved_base.clear()
+    print("PASS test_http_error_not_treated_as_connectivity")
+
+
+def test_ctx():
+    looker_api._ctx_cache.clear()
+    verified = looker_api._ctx(True)
+    assert verified is not None, "verified context must not be None (the pre-fix reject bug)"
+    assert isinstance(verified, ssl.SSLContext)
+    assert verified.verify_mode != ssl.CERT_NONE, "verified context must actually verify"
+
+    looker_api._ctx_cache.clear()
+    insecure = looker_api._ctx(False)
+    assert insecure.verify_mode == ssl.CERT_NONE
+    assert insecure.check_hostname is False
+    print("PASS test_ctx")
+
+
+if __name__ == "__main__":
+    test_env_override()
+    test_strip_port()
+    test_port_fallback()
+    test_http_error_not_treated_as_connectivity()
+    test_ctx()
+    print("ALL PASS")


### PR DESCRIPTION
## What & why

A live Looker run stalled before anything ran: `~/.looker/looker.ini` pinned the legacy `:19999` API port (unreachable on modern Google-hosted Looker, which serves API 4.0 on 443), and Python OpenSSL 3.x rejected the cert (CA Basic Constraints not marked critical) where curl/Ruby succeed. This fixes the Looker client so customers self-heal both.

- `looker_api.py`: `_cfg` honors `LOOKER_BASE_URL` / `LOOKERSDK_BASE_URL`; `login` retries once on the port-stripped (443) base when the configured explicit port is unreachable and memoizes it; `_ctx` uses a `truststore → certifi → default` SSL ladder (`verify_ssl=false` stays an opt-in, loud, insecure path). **Proven end-to-end**: forcing `:19999`, `whoami` + a Look fetch both self-heal to 443 with no ini edit.
- `fetch_looker_dashboard.py`: single-sources base + SSL through `looker_api` (kills a duplicate base-derivation that had no SSL context); `fetch_looker_look` inherits.
- Mirrored the fix to the `looker-assessment` copy of `looker_api.py`.
- `tests/test_looker_client.py` — 5 offline cases (env override, port fallback, HTTPError-not-connectivity, verified/insecure contexts); registered in the corpus-check unit-tests allowlist.

Pairs with #477 (shared bootstrap/doctor: installs `truststore` + adds the Looker reachability probe). This client works standalone regardless — it falls back to certifi/default when `truststore` is absent.

## Scope

- Plugin(s) touched: **looker-to-sigma** (+ the `looker-assessment` copy of `looker_api.py`)
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green (no shared canonical edited here — see #477)
- [x] `ruby tools/lint-skills.rb` — green
- [ ] `./corpus/run-corpus.sh --check` — n/a (no converter/builder changed; offline client test added)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
