### PR TITLE
looker: detect expensive derived tables + opt-in Sigma materialization (perf)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -278,6 +278,7 @@ jobs:
           python3 -m pip install --quiet pyyaml
           tests=(
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grid_fidelity.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_derived_perf.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -130,6 +130,19 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
   adopt a DM missing a *column* the workbook needs → the workbook POST then 400s
   `Dependency not found`; that footgun is now opt-in via `--reuse-auto`.) Skip the
   scan entirely with `--skip-dm-reuse-check`. The folder is auto-resolved + printed.
+- **Performance scan (Phase 2b) — don't port slow SQL blind:** the converter turns every
+  `derived_table` into ONE Sigma Custom SQL element with the SQL carried through verbatim
+  (nested derived views inline as stacked CTEs into a single element), so a slow Looker derived
+  table stays slow in Sigma. `detect_derived_perf.py` runs after the RLS gate (scoped to the
+  migrated explore) and prints per-derived-table recommendations — `materialize` /
+  `rebuild-as-element` / `leave-inline` — to `derived-perf.json`. It is **informational, never
+  blocks** (unlike RLS), and is silent when there are no derived tables. `--materialize-derived
+  auto` then triggers a Sigma materialization for the flagged element(s) after the DM is built
+  (`all` = every Custom-SQL element); default `off` = recommend only. The recurring **schedule is
+  UI-only** (Element ⋮ → Materialization), so this triggers/monitors and, when an element isn't
+  materialization-configured yet, prints the exact UI handoff. Post-migration, rank which
+  materializations actually pay off by warehouse credit with the **`sigma-materialization-advisor`**
+  skill.
 - **Source repointing:** if the LookML `sql_table_name` points at a DB.SCHEMA the
   Sigma connection doesn't serve (e.g. dev `DEMO_DB.DEMO.*` vs the connection's
   `QUICKSTARTS.LOOKER_RETAIL_ANALYTICS.*`), pass
@@ -182,6 +195,7 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
 | `scripts/fetch_looker_look.py` | **Phase 1 (live — Looks):** `GET /looks/{id}` → the **same contract** as the dashboard fetch but with ONE tile, `filters:[]`, a full-width layout, and a `fieldMeta` map. Imports+reuses `fetch_looker_dashboard`'s helpers (single source of truth), so a Look tile normalizes identically to a dashboard tile. `python3 fetch_looker_look.py <look_id> [out.json]`. |
 | `scripts/parse_lookml_dashboard.py` | **Phase 1 (offline):** parse a `.dashboard.lookml` (YAML) → the SAME contract. Dev/test only; cannot see UDD dashboards. Requires PyYAML. |
 | `scripts/detect_rls.py` | **Phase 1 (RLS scan):** dependency-free regex scan of a LookML dir/file (and/or model JSON) for row-level-security constructs (`access_filter`, `sql_always_where`, `access_grant`, `user_attribute`). Prints a structured summary + recommended Sigma mapping per finding (or `--json`). **Prints nothing / exits 0 when there's no RLS** (zero-overhead). `python3 detect_rls.py <lookml_dir> [--json]` |
+| `scripts/detect_derived_perf.py` | **Phase 2b (performance scan):** dependency-free regex scan for EXPENSIVE `derived_table`s (nested-on-derived, un-persisted, persisted/incremental PDTs, NDTs, SQL complexity, warehouse hints). Scores each and recommends `materialize` / `rebuild-as-element` / `leave-inline` — the handoff for `--materialize-derived` and, post-migration, `sigma-materialization-advisor`. **Informational (never blocks); silent when there are no derived tables.** `python3 detect_derived_perf.py <lookml_dir> [--scope-explores e1,e2] [--json]` |
 | `scripts/apply_sigma_rls.py` | **Phase 1.5 (apply RLS):** scripted, API-driven RLS port. Reuse-first `GET /v2/user-attributes` (prints a match before creating); `--create` → `POST /v2/user-attributes`; `--assign` (+`--member-id`,`--value`) → `POST /v2/user-attributes/{id}/users`; `--field`/`--element-id` → print the verified RLS calc-col + element-filter snippet, `--apply --dm-id` → PATCH it into the DM element spec. **Read-only / plan-only by default — mutates only on an explicit `--create`/`--assign`/`--apply` flag.** Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN` like `post_dm.py`. |
 | `scripts/convert_dm.mjs` | **Phase 2:** run `convertLookMLToSigma` against a directory of `.lkml` files for one explore → a Sigma DM spec JSON + `…-warnings.json` sidecar. A `.model.lkml` is optional — with none it converts **view-only** (each view → standalone element; pass the WHOLE directory so cross-view `${view.SQL_TABLE_NAME}` refs resolve — see `refs/layered-lookml.md`). Bypasses the deployed MCP build (see the converter-build gotcha below). Env: `LOOKML_DIR`, `CONVERTER_SRC`; args `<exploreName> <out.json>`. |
 | `scripts/lookml-dm-signature.py` | **Phase 2.5:** LookML view files → DM-reuse signature (`{warehouse_tables, referenced_columns, measures}`) for `find-or-pick-dm.rb`. Pure, no network. |

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/demo.model.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/demo.model.lkml
@@ -1,0 +1,12 @@
+connection: "demo"
+
+include: "/views/*.view.lkml"
+
+explore: perf_explore {
+  from: perf_nested
+  join: perf_pdt {
+    type: left_outer
+    sql_on: ${perf_explore.region} = ${perf_pdt.region} ;;
+    relationship: many_to_one
+  }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_base.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_base.view.lkml
@@ -1,0 +1,12 @@
+# Fixture (synthetic demo data — no customer content). Exercises the
+# derived-table performance scanner (detect_derived_perf.py).
+
+# Simple ephemeral derived table, no persistence, trivial SQL → leave-inline.
+view: perf_base {
+  derived_table: {
+    sql: SELECT id, region, amount FROM demo.sales ;;
+  }
+  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }
+  dimension: region { sql: ${TABLE}.region ;; }
+  measure: total_amount { type: sum  sql: ${TABLE}.amount ;; }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_incremental.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_incremental.view.lkml
@@ -1,0 +1,15 @@
+# Incremental PDT → materialize (Sigma has no incremental derived table).
+view: perf_incremental {
+  derived_table: {
+    sql:
+      SELECT event_date, region, SUM(amount) AS revenue
+      FROM demo.events
+      WHERE {% incrementcondition %} event_date {% endincrementcondition %}
+      GROUP BY event_date, region ;;
+    datagroup_trigger: demo_default_datagroup
+    increment_key: "event_date"
+    increment_offset: 3
+  }
+  dimension: event_date { type: date  sql: ${TABLE}.event_date ;; }
+  measure: revenue { type: sum  sql: ${TABLE}.revenue ;; }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_nested.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_nested.view.lkml
@@ -1,0 +1,15 @@
+# Nested, un-persisted derived table: references another derived view's
+# SQL_TABLE_NAME (inlined as a stacked CTE) + joins + group by → materialize.
+view: perf_nested {
+  derived_table: {
+    sql:
+      SELECT b.region,
+             COUNT(*) AS order_count,
+             SUM(b.amount) AS revenue
+      FROM ${perf_base.SQL_TABLE_NAME} b
+      JOIN demo.customers c ON b.id = c.order_id
+      GROUP BY b.region ;;
+  }
+  dimension: region { sql: ${TABLE}.region ;; }
+  measure: revenue { type: sum  sql: ${TABLE}.revenue ;; }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_pdt.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_pdt.view.lkml
@@ -1,0 +1,10 @@
+# Persisted PDT (datagroup_trigger) → materialize (author deemed it expensive).
+view: perf_pdt {
+  derived_table: {
+    sql: SELECT region, SUM(amount) AS revenue FROM demo.sales GROUP BY region ;;
+    datagroup_trigger: demo_default_datagroup
+    cluster_keys: ["region"]
+  }
+  dimension: region { sql: ${TABLE}.region ;; }
+  measure: revenue { type: sum  sql: ${TABLE}.revenue ;; }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_plain.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-derived/views/perf_plain.view.lkml
@@ -1,0 +1,6 @@
+# Plain warehouse-table view (NO derived_table) → never a finding.
+view: perf_plain {
+  sql_table_name: DEMO.PUBLIC.PRODUCTS ;;
+  dimension: product_id { primary_key: yes  sql: ${TABLE}.product_id ;; }
+  dimension: category { sql: ${TABLE}.category ;; }
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/detect_derived_perf.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/detect_derived_perf.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Phase 2b (Performance scan): cheap regex scan of a LookML project for
+EXPENSIVE derived tables, so a migration doesn't blindly port slow SQL into
+Sigma. The converter turns every `derived_table` into ONE Sigma Custom SQL
+element with the SQL carried through verbatim (nested derived views inline as
+stacked CTEs into a single element) — so a slow Looker derived table stays slow
+in Sigma. This flags the ones worth MATERIALIZING (or rebuilding) instead.
+
+NEVER SILENT, but NEVER SLOW when there's nothing to decide: if the project has
+no derived tables, this prints NOTHING and exits 0. Findings are INFORMATIONAL —
+this never blocks a migration (unlike the RLS gate); it recommends. Exit 2 only
+on a usage/IO error.
+
+Signals per derived table (from refs/layered-lookml.md + the converter's own
+warning triggers in converter/lookml.mjs):
+  - no_persistence   ephemeral derived_table with no datagroup_trigger /
+                     persist_for / sql_trigger_value → re-runs every query
+  - persisted_pdt    has a persistence hint → author already deemed it expensive
+  - incremental_pdt  increment_key / {% incrementcondition %} → Sigma has no
+                     incremental equiv; the element recomputes its full SQL
+  - nested_dt        sql references ${other_view.SQL_TABLE_NAME} of ANOTHER
+                     derived view → inlined as stacked CTEs (depth = # refs)
+  - ndt              derived_table.explore_source (Native Derived Table)
+  - sql complexity   counts of JOIN / GROUP BY / window OVER( / CTE (WITH ... AS)
+  - cte_fragment     leading-comma CTE-continuation fragment (manual SQL layering)
+  - warehouse_hints  cluster_keys / sortkeys / distribution / partition_keys
+
+Recommendation ∈ {materialize, rebuild-as-element, leave-inline}. The
+`materialize` set is the handoff to `--materialize-derived` (migrate-looker) and,
+post-migration, to the `sigma-materialization-advisor` skill (credit ranking).
+
+Dependency-free (stdlib only). Mirrors the style of detect_rls.py.
+
+Usage:
+    python3 detect_derived_perf.py <lookml_dir_or_file> [<more> ...] [--json]
+        [--scope-explores e1,e2]   # only flag derived tables the explore(s) use
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+# --- regexes (loose, whitespace-tolerant — LookML style) -------------------
+_VIEW = re.compile(r"\bview\s*:\s*([A-Za-z0-9_]+)\s*\{")
+_DERIVED = re.compile(r"\bderived_table\s*:\s*\{")
+# derived_table's SQL: first `sql: ... ;;` after the derived_table opener
+_DT_SQL = re.compile(r"\bsql\s*:\s*(.*?);;", re.DOTALL)
+_SQL_TABLE_REF = re.compile(r"\$\{\s*([A-Za-z0-9_]+)\.SQL_TABLE_NAME\s*\}")
+_PERSIST = re.compile(r"\b(datagroup_trigger|persist_for|sql_trigger_value|materialized_view)\s*:")
+_INCREMENTAL = re.compile(r"\bincrement_key\s*:|\{%\s*incrementcondition")
+_EXPLORE_SOURCE = re.compile(r"\bexplore_source\s*:")
+_WH_HINTS = re.compile(r"\b(cluster_keys|sortkeys|distribution|partition_keys|indexes)\s*:")
+# explore → the views it references (from + join {from|view}), for scoping
+_EXPLORE = re.compile(r"\bexplore\s*:\s*([A-Za-z0-9_]+)\s*\{")
+_FROM = re.compile(r"\bfrom\s*:\s*([A-Za-z0-9_]+)")
+_JOIN = re.compile(r"\bjoin\s*:\s*([A-Za-z0-9_]+)")
+
+HIGH, MED = 10, 4
+
+
+def _view_slabs(text):
+    """Yield (view_name, slab_text). A slab is a view's text from its `view:`
+    opener to the next view opener (or EOF) — loose block scan like detect_rls,
+    robust to nested braces we don't need to balance."""
+    starts = [(m.group(1), m.start()) for m in _VIEW.finditer(text)]
+    for i, (name, s) in enumerate(starts):
+        e = starts[i + 1][1] if i + 1 < len(starts) else len(text)
+        yield name, text[s:e]
+
+
+def _derived_sql(slab):
+    """The derived_table's SQL text (first `sql: … ;;` after the opener), or ''."""
+    md = _DERIVED.search(slab)
+    if not md:
+        return ""
+    ms = _DT_SQL.search(slab, md.end())
+    return (ms.group(1).strip() if ms else "")
+
+
+def _count(pat, s):
+    return len(re.findall(pat, s, re.IGNORECASE))
+
+
+def _analyze_view(name, slab, derived_names):
+    """Return a finding dict for a derived-table view, or None."""
+    if not _DERIVED.search(slab):
+        return None
+    dsql = _derived_sql(slab)
+    signals, cost = [], 0
+
+    persisted = bool(_PERSIST.search(slab))
+    incremental = bool(_INCREMENTAL.search(slab))
+    ndt = bool(_EXPLORE_SOURCE.search(slab))
+    wh_hints = bool(_WH_HINTS.search(slab))
+    cte_fragment = dsql.lstrip().startswith(",")
+
+    refs = [v for v in _SQL_TABLE_REF.findall(dsql) if v != name]
+    nested_refs = [v for v in refs if v in derived_names]
+
+    joins = _count(r"\bjoin\b", dsql)
+    group_bys = _count(r"\bgroup\s+by\b", dsql)
+    windows = _count(r"\bover\s*\(", dsql)
+    ctes = _count(r"\bwith\b|\)\s*,\s*[A-Za-z0-9_]+\s+as\s*\(", dsql)
+
+    cost += joins * 2 + group_bys * 2 + windows * 3 + ctes * 2
+    if joins:
+        signals.append(f"joins:{joins}")
+    if group_bys:
+        signals.append(f"group_by:{group_bys}")
+    if windows:
+        signals.append(f"windows:{windows}")
+    if ctes:
+        signals.append(f"cte:{ctes}")
+    if nested_refs:
+        cost += 5
+        signals.append(f"nested_dt:{len(nested_refs)}")
+    if incremental:
+        cost += 4
+        signals.append("incremental_pdt")
+    if ndt:
+        cost += 3
+        signals.append("ndt")
+    if cte_fragment:
+        signals.append("cte_fragment")
+    if wh_hints:
+        signals.append("warehouse_hints")
+    if persisted:
+        signals.append("persisted_pdt")
+    else:
+        signals.append("no_persistence")
+        if cost >= MED:
+            cost += 3  # re-runs every query in Sigma (was persisted-worthy in Looker)
+
+    # recommendation
+    if ndt:
+        rec = "rebuild-as-element"
+        why = ("Native Derived Table (explore_source) → the converter pushes the aggregation "
+               "into one Custom SQL element; rebuilding it as a native Sigma data-model element "
+               "is cleaner and faster.")
+    elif persisted or incremental:
+        rec = "materialize"
+        why = ("Persisted/incremental PDT — the author already deemed it expensive enough to "
+               "persist, but Sigma has no incremental derived table, so the converted element "
+               "recomputes its full SQL. Materialize it on a schedule matching the datagroup cadence.")
+    elif cost >= HIGH or (nested_refs and not persisted):
+        rec = "materialize"
+        why = ("Heavy, un-persisted derived table" + (f" nested on {len(nested_refs)} other derived "
+               "view(s) (inlined as stacked CTEs into one element)" if nested_refs else "")
+               + " — slow in Looker, slow in Sigma. Materialize it so runtime queries hit a stored table."
+               + (" Very complex — a dbt model / warehouse view is another good home." if ctes >= 3 else ""))
+    elif cost >= MED:
+        rec = "materialize"
+        why = "Non-trivial un-persisted derived table — materializing avoids re-running the SQL per query."
+    else:
+        rec = "leave-inline"
+        why = "Simple derived table — cheap to inline as Custom SQL; no materialization needed."
+
+    severity = "high" if cost >= HIGH else "medium" if cost >= MED else "low"
+    return {
+        "view": name,
+        "signals": signals,
+        "nested_on": nested_refs,
+        "cost": cost,
+        "severity": severity,
+        "recommendation": rec,
+        "why": why,
+    }
+
+
+def scan(paths):
+    # pass 1: collect (view, slab, source) and the set of derived-table view names
+    views, derived_names = [], set()
+    for fp in _iter_files(paths):
+        try:
+            with open(fp, encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError as e:
+            print(f"detect_derived_perf: cannot read {fp}: {e}", file=sys.stderr)
+            continue
+        src = os.path.relpath(fp)
+        for name, slab in _view_slabs(text):
+            views.append((name, slab, src))
+            if _DERIVED.search(slab):
+                derived_names.add(name)
+    # pass 2: analyze each derived-table view (nested needs the full name set)
+    findings = []
+    for name, slab, src in views:
+        f = _analyze_view(name, slab, derived_names)
+        if f:
+            f["source"] = src
+            findings.append(f)
+    findings.sort(key=lambda f: -f["cost"])
+    return findings
+
+
+def _iter_files(paths):
+    for p in paths:
+        if os.path.isdir(p):
+            for root, _dirs, files in os.walk(p):
+                for fn in files:
+                    if fn.endswith((".lkml", ".lookml")):
+                        yield os.path.join(root, fn)
+        elif os.path.isfile(p):
+            yield p
+        else:
+            print(f"detect_derived_perf: no such path: {p}", file=sys.stderr)
+
+
+def _explore_views(paths, explores):
+    """Views referenced (from / join) by the given explores, across model files —
+    for scoping. Empty result (couldn't parse) means 'don't scope' (safe default)."""
+    want = set()
+    for fp in _iter_files(paths):
+        try:
+            with open(fp, encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        estarts = [(m.group(1), m.start()) for m in _EXPLORE.finditer(text)]
+        for i, (ename, s) in enumerate(estarts):
+            if ename not in explores:
+                continue
+            e = estarts[i + 1][1] if i + 1 < len(estarts) else len(text)
+            body = text[s:e]
+            want.add(ename)  # explore name defaults to a view when `from:` is absent
+            want.update(_FROM.findall(body))
+            want.update(_JOIN.findall(body))
+    return want
+
+
+def split_scope(findings, in_scope_views):
+    if not in_scope_views:
+        return findings, []
+    keep, info = [], []
+    for f in findings:
+        (keep if f["view"] in in_scope_views else info).append(f)
+    return keep, info
+
+
+def render(findings, informational):
+    lines = ["DERIVED-TABLE PERFORMANCE SCAN — the converter ports derived_table SQL verbatim,",
+             "so slow Looker SQL stays slow in Sigma. Consider materializing the flagged elements.",
+             f"  {len(findings)} derived table(s) in scope"
+             + (f", {len(informational)} out of scope" if informational else "") + "."]
+    by = {}
+    for f in findings:
+        by.setdefault(f["recommendation"], []).append(f)
+    for rec in ("materialize", "rebuild-as-element", "leave-inline"):
+        items = by.get(rec)
+        if not items:
+            continue
+        lines.append("")
+        lines.append(f"  {rec}  ({len(items)}):")
+        for it in items:
+            lines.append(f"    - {it['view']}  [{it['severity']}, cost={it['cost']}]  "
+                         f"({', '.join(it['signals'])})  — {it['source']}")
+            lines.append(f"        → {it['why']}")
+    if informational:
+        lines.append("")
+        lines.append(f"  INFORMATIONAL — {len(informational)} derived table(s) the migrated "
+                     "explore(s) don't use:")
+        for it in informational[:10]:
+            lines.append(f"    - {it['view']} [{it['severity']}] — {it['source']}")
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Scan LookML for expensive derived tables (silent if none).")
+    ap.add_argument("paths", nargs="+", help="LookML dir(s)/file(s)")
+    ap.add_argument("--json", action="store_true", help="emit findings as JSON")
+    ap.add_argument("--scope-explores", help="comma-separated explore name(s) the migration uses — "
+                    "derived tables NOT referenced by them become informational")
+    a = ap.parse_args()
+
+    findings = scan(a.paths)
+    explores = {e.strip() for e in (a.scope_explores or "").split(",") if e.strip()}
+    informational = []
+    if explores:
+        in_scope_views = _explore_views(a.paths, explores)
+        findings, informational = split_scope(findings, in_scope_views)
+
+    if not findings and not informational:
+        if a.json:
+            print(json.dumps({"findings": [], "informational": []}))
+        return 0
+    if a.json:
+        print(json.dumps({"findings": findings, "informational": informational}, indent=2))
+        return 0
+    print(render(findings, informational))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -498,6 +498,12 @@ def main():
                          "build-new (reuse only via explicit --reuse-dm).")
     ap.add_argument("--yes", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--materialize-derived", choices=["off", "auto", "all"], default="off",
+                    help="Phase 2b always SCANS for expensive derived tables (informational). "
+                         "'auto' also triggers a Sigma materialization for the DM elements the "
+                         "scan flagged `materialize`; 'all' for every Custom-SQL (derived) element. "
+                         "Default 'off' = recommend only. Creating the recurring schedule is "
+                         "UI-only, so this triggers/monitors and prints the exact UI handoff.")
     ap.add_argument("--print-converter", action="store_true",
                     help="Resolve the converter (CONVERTER_SRC -> CONVERTER_PATH -> "
                          "vendored bundle), print the resolved path + a one-line "
@@ -636,6 +642,36 @@ def main():
             return 10
         print("   --yes: proceeding WITHOUT porting RLS — the migrated model shows ALL rows")
         print("   to everyone until you run apply_sigma_rls.py (recorded in rls-findings.json)")
+
+    # ── Phase 2b — Performance scan (detect_derived_perf.py; informational) ───
+    # The converter ports every derived_table's SQL verbatim (nested derived
+    # views inline as stacked CTEs into ONE Custom SQL element), so slow Looker
+    # SQL stays slow in Sigma. Scan for expensive derived tables and recommend
+    # materializing them. NON-BLOCKING — recommend, never stop (unlike the RLS gate).
+    print("\n── Phase 2b · Performance scan (detect_derived_perf.py) ──")
+    perf_findings = []
+    pp = subprocess.run(
+        [sys.executable, os.path.join(HERE, "detect_derived_perf.py"), lookml_dir, "--json"]
+        + (["--scope-explores", ",".join(dash_explores)] if dash_explores else []),
+        capture_output=True, text=True)
+    try:
+        pparsed = json.loads(pp.stdout) if pp.stdout.strip() else {}
+        perf_findings = pparsed.get("findings", []) if isinstance(pparsed, dict) else []
+    except ValueError:
+        perf_findings = []
+    mat_views = [f for f in perf_findings if f.get("recommendation") == "materialize"]
+    if not perf_findings:
+        print("   no expensive derived tables in scope — nothing to optimize")
+    else:
+        print(f"   {len(perf_findings)} derived table(s) in scope; "
+              f"{len(mat_views)} recommended to MATERIALIZE:")
+        for f in perf_findings[:12]:
+            print(f"     - {f['view']} [{f['severity']}, cost={f['cost']}] → "
+                  f"{f['recommendation']} ({', '.join(f['signals'])})")
+        json.dump(perf_findings, open(os.path.join(wd, "derived-perf.json"), "w"), indent=2)
+        if a.materialize_derived == "off" and mat_views:
+            print("   ℹ pass --materialize-derived auto to materialize the flagged element(s) after "
+                  "the DM is built, or open each element's ⋮ → Materialization in the Sigma UI.")
 
     # ── Phase 3 — Convert (local build / patched source / MCP request) ────────
     hdr(3, TOTAL, "Convert")
@@ -842,6 +878,58 @@ console.error('stats:', JSON.stringify(res.stats));
         or ("Custom SQL" if src.get("kind") == "sql" else denorm["id"])
     print(f"   DM {dm} · denorm '{denorm_name}' ({denorm['id']}, "
           f"{len(denorm.get('columns') or [])} cols) · {len(els)} element(s)")
+
+    # ── Phase 4a.6 — Materialize expensive derived tables (opt-in) ────────────
+    # Custom-SQL elements ARE the ported derived tables. --materialize-derived
+    # triggers a Sigma materialization so runtime queries hit a stored table
+    # instead of re-running the (possibly nested-CTE) SQL. The recurring SCHEDULE
+    # is UI-only; the API only triggers/monitors — so a not-yet-configured element
+    # degrades to a precise UI handoff, never a silent failure. (perf_findings
+    # was gathered in Phase 2b, which runs before this on every path.)
+    if a.materialize_derived != "off":
+        sql_els = [e for e in els if (e.get("source") or {}).get("kind") == "sql"]
+        if a.materialize_derived == "auto" and perf_findings:
+            want = {re.sub(r"[^a-z0-9]", "", (f["view"] or "").lower())
+                    for f in perf_findings if f.get("recommendation") == "materialize"}
+            targets = [e for e in sql_els
+                       if re.sub(r"[^a-z0-9]", "", (e.get("name") or "").lower()) in want] or sql_els
+        else:  # "all"
+            targets = sql_els
+        if not targets:
+            print("   --materialize-derived: no Custom-SQL (derived-table) elements in this DM")
+        else:
+            # Sigma's API only TRIGGERS an already-configured materialization; the
+            # recurring schedule is created in the UI (verified: :materialize on an
+            # unscheduled element returns 400 "Scheduled materialization is not
+            # configured for this element"). So this triggers where a schedule
+            # exists and otherwise emits a precise, per-element UI handoff.
+            print(f"   --materialize-derived {a.materialize_derived}: {len(targets)} derived "
+                  "element(s). Sigma triggers a materialization only where a schedule already "
+                  "exists (schedule creation is UI-only):")
+            actions = []
+            for e in targets:
+                eid = e["id"]; ename = e.get("name") or eid
+                try:
+                    res = json.loads(sigma("POST", f"/v2/dataModels/{dm}:materialize",
+                                           {"sheetId": eid}) or "{}")
+                    mid = res.get("materializationId")
+                    print(f"     ✓ {ename}: triggered (materializationId={mid}) — runs async")
+                    actions.append({"element": ename, "id": eid, "status": "triggered",
+                                    "materializationId": mid})
+                except RuntimeError as ex:
+                    msg = str(ex)
+                    if "not configured" in msg or "not_permitted" in msg:
+                        print(f"     • {ename}: no schedule yet → in Sigma open this element's "
+                              "⋮ → Materialization and set a cadence matching the old Looker "
+                              "datagroup; it then materializes on that schedule.")
+                        status = "needs-ui-schedule"
+                    else:
+                        print(f"     ⚠ {ename}: trigger failed — {msg[:140]}")
+                        status = "error"
+                    actions.append({"element": ename, "id": eid, "status": status, "error": msg[:200]})
+            json.dump(actions, open(os.path.join(wd, "materialization-actions.json"), "w"), indent=2)
+            print("   ↪ then rank which materializations pay off by warehouse credit with the "
+                  "sigma-materialization-advisor skill (post-migration, credit-based).")
 
     # ── Phase 4a.5 — shape preflight (REUSE only) ────────────────────────────
     # Mechanical reuse gate for the failure modes a spec POST won't catch and that

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_derived_perf.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_derived_perf.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""detect_derived_perf.py regression (offline, creds-free, no network).
+
+Runs the scanner over fixtures/skilltest-derived (synthetic demo views) and
+asserts the classifications a migration relies on:
+
+  perf_base        simple ephemeral derived table            → leave-inline (low)
+  perf_nested      nested on perf_base + joins + group by     → materialize
+  perf_pdt         persisted PDT (datagroup_trigger)          → materialize
+  perf_incremental incremental PDT (increment_key/Liquid)     → materialize
+  perf_plain       plain sql_table_name view (no derived)     → NOT a finding
+
+Also: --scope-explores demotes out-of-scope tables; an all-plain dir is silent.
+
+Run: python3 tests/test_derived_perf.py   (exit 0 = pass)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCANNER = os.path.join(SKILL, "scripts", "detect_derived_perf.py")
+FIX = os.path.join(SKILL, "fixtures", "skilltest-derived")
+
+
+def _scan(*args):
+    r = subprocess.run([sys.executable, SCANNER, *args, "--json"],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+    return json.loads(r.stdout)
+
+
+def test_classification():
+    out = _scan(FIX)
+    byview = {f["view"]: f for f in out["findings"]}
+
+    assert "perf_plain" not in byview, "a plain sql_table_name view must not be flagged"
+
+    assert byview["perf_base"]["recommendation"] == "leave-inline", byview["perf_base"]
+    assert byview["perf_base"]["severity"] == "low"
+
+    n = byview["perf_nested"]
+    assert n["recommendation"] == "materialize", n
+    assert "perf_base" in n["nested_on"], n
+    assert any(s.startswith("nested_dt") for s in n["signals"]), n
+
+    assert byview["perf_pdt"]["recommendation"] == "materialize"
+    assert "persisted_pdt" in byview["perf_pdt"]["signals"]
+
+    inc = byview["perf_incremental"]
+    assert inc["recommendation"] == "materialize"
+    assert "incremental_pdt" in inc["signals"]
+
+    # cost ordering: a nested/complex table outranks the trivial one
+    assert n["cost"] > byview["perf_base"]["cost"], (n["cost"], byview["perf_base"]["cost"])
+    print("PASS test_classification")
+
+
+def test_scope_explores():
+    # perf_explore = from: perf_nested, join: perf_pdt → only those two in scope
+    out = _scan(FIX, "--scope-explores", "perf_explore")
+    in_scope = {f["view"] for f in out["findings"]}
+    info = {f["view"] for f in out["informational"]}
+    assert "perf_nested" in in_scope and "perf_pdt" in in_scope, in_scope
+    assert "perf_incremental" in info and "perf_base" in info, info
+    print("PASS test_scope_explores")
+
+
+def test_silent_when_no_derived_tables():
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "plain.view.lkml"), "w") as f:
+            f.write("view: only_plain {\n  sql_table_name: DEMO.PUBLIC.T ;;\n"
+                    "  dimension: id { sql: ${TABLE}.id ;; }\n}\n")
+        out = _scan(d)
+        assert out["findings"] == [], out
+        assert out["informational"] == [], out
+    print("PASS test_silent_when_no_derived_tables")
+
+
+if __name__ == "__main__":
+    test_classification()
+    test_scope_explores()
+    test_silent_when_no_derived_tables()
+    print("ALL PASS")


### PR DESCRIPTION
## What & why

The converter ports every Looker `derived_table` into ONE Sigma Custom SQL element with the SQL carried through verbatim — nested derived views inline as stacked CTEs into a single element — so a slow Looker derived table stays slow in Sigma. Multi-page dashboards backed by many (often un-persisted) derived tables reproduce that slowness. This adds detection + an opt-in optimization so we don't port bad SQL blind.

- **`scripts/detect_derived_perf.py`** — stdlib regex scanner (mirrors `detect_rls.py`). Per `derived_table` it scores signals — nested-on-derived (stacked CTEs), un-persisted ephemeral, persisted/incremental PDTs, NDTs, SQL complexity (joins/group-by/window/CTE), warehouse hints — and recommends `materialize` / `rebuild-as-element` / `leave-inline`. `--scope-explores` demotes derived tables the migrated explore doesn't use. Informational; silent when there are none. Validated on the real demo LookML (4 tables ranked correctly).
- **`migrate-looker.py`** — new **Phase 2b** runs the scan (scoped to the migrated explore), prints recommendations, writes `derived-perf.json` — **NON-blocking** (unlike the RLS gate). New **`--materialize-derived {off|auto|all}`** (default `off`): after the DM is built it triggers `POST /v2/dataModels/{id}:materialize` for the flagged Custom-SQL elements and records `materialization-actions.json`.
- **Verified live**: `:materialize` on an unscheduled element returns `400 "Scheduled materialization is not configured"` — the recurring schedule is UI-only. So the flag triggers where a schedule exists and otherwise emits a precise per-element UI handoff (never a silent failure). Post-migration credit-ranking is handed off to the `sigma-materialization-advisor` skill.
- Fixtures `fixtures/skilltest-derived` (synthetic demo views) + `tests/test_derived_perf.py` (classification, scoping, silent-when-none); registered in the corpus-check unit-tests allowlist. SKILL.md documents Phase 2b and the flag.

## Scope

- Plugin(s) touched: **looker-to-sigma**
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] `ruby tools/lint-skills.rb` — green (Phase 2b is informational, not a mandatory gate)
- [ ] `./corpus/run-corpus.sh --check` — n/a (goldens unchanged; new offline test added)
- [x] Phase numbers unchanged (2b is an informational sub-phase; the 6 numbered phases are intact)
- [x] No unrelated working-tree changes swept in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
