### PR TITLE
sigma-authoring: make the SYNC re-vendor procedure clobber-safe

### DIFF
--- a/plugins/sigma-authoring/SYNC.md
+++ b/plugins/sigma-authoring/SYNC.md
@@ -19,8 +19,20 @@ for s in sigma-workbooks sigma-data-models custom-sql-to-data-model; do
   rm -rf "plugins/sigma-authoring/skills/$s"
   cp -R "$SRC/$s" "plugins/sigma-authoring/skills/$s"
 done
+
+# CLOBBER-SAFETY (required): the vendored skill dirs ALSO carry manifest-fanned
+# shared files (scripts/doctor.{sh,ps1}, scripts/bootstrap.{sh,ps1},
+# refs/environment.md, the token scripts, …) that do NOT exist upstream — the
+# rm -rf above deletes them. Re-fan them from shared/manifest.json and verify,
+# or the shared-lib drift gate (tools/check-shared.rb in CI) fails:
+ruby tools/sync-shared.rb        # restore the fanned shared copies the cp -R dropped
+ruby tools/check-shared.rb       # MUST be green before committing
+
 # then update the "Vendored at" SHA above and commit
 ```
 
 Do NOT edit these copies directly — changes belong upstream in `sigma-skills`,
-then re-vendor here.
+then re-vendor here. (Native trellis shapes were back-ported upstream in
+`twells89/sigma-skills` #19; re-vendor `sigma-workbooks` from the SoT once that
+merges to pick them up — the marketplace copy already carries the identical
+recipe, so this is a consistency refresh, not a functional change.)


### PR DESCRIPTION
## What & why

beads-sigma-0q8e. Follow-up to the trellis back-port (`twells89/sigma-skills` #19). The documented re-vendor in `plugins/sigma-authoring/SYNC.md` (`rm -rf` + `cp -R` from a fresh `sigma-skills` clone) silently **deletes the manifest-fanned shared files** that live inside each vendored skill dir — `scripts/doctor.{sh,ps1}`, `scripts/bootstrap.{sh,ps1}`, `refs/environment.md`, the token scripts — because upstream `sigma-skills` doesn't carry them. The next re-vendor would then fail `tools/check-shared.rb` (the shared-lib drift gate) in CI. This makes the procedure clobber-safe: after the copy, re-run `ruby tools/sync-shared.rb` + `ruby tools/check-shared.rb` to restore/verify the fanned copies. Also notes the pending native-trellis back-port so a future re-vendor picks it up.

Docs-only (`SYNC.md`, a plugin-native governance doc — not a vendored copy).

## Scope

- Plugin(s) touched: **sigma-authoring** (SYNC.md governance doc only)
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green (no shared canonical or vendored copy edited)
- [x] `ruby tools/lint-skills.rb` — green
- [ ] `./corpus/run-corpus.sh --check` — n/a (docs-only)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
