### PR TITLE
looker: table columns follow the visualization (order, labels, hidden), not the data tab

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -278,6 +278,10 @@ jobs:
           python3 -m pip install --quiet pyyaml
           tests=(
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grid_fidelity.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_table_column_order.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_vis_column_order_capture.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_look_migration.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -662,6 +662,19 @@ Tile-type, filter-type, and layout maps are in `refs/dashboard-contract.md` and
 | `text` | `text` (markdown body) |
 | `looker_map` / geo / funnel / waterfall / boxplot / sankey / custom viz | none — approximate or drop + warn |
 
+**Table column order, labels & hidden columns.** A table's Sigma column order follows the Looker
+**visualization** order (`vis_config.column_order`, captured as contract `columnOrder`), NOT
+`query.fields` — the Data-tab order, which forces dimensions before measures. Fields not listed in
+`column_order` append in `fields` order (Looker appends newly-added fields at the end). Column
+**names** prefer the viz label (`vis_config.series_labels`, captured as `columnLabels`) over the
+humanized field name — a column renamed in the visualization can differ from the Data-tab name. Columns
+**hidden from the visualization** (`vis_config.hidden_fields`, captured as `hiddenFields`) get
+`hidden: true` on the Sigma column — but a hidden **dimension is KEPT in `groupings.groupBy`** so
+the aggregation grain (and therefore every measure value) is unchanged. Never *drop* a hidden
+dimension: Looker keeps it in the query ("Hide from Visualization" doesn't re-run the query), so
+dropping it would silently change the numbers. Both are additive contract keys — absent/empty →
+columns stay in `fields` order, byte-identical to before. Verified: `tests/test_table_column_order.py`.
+
 Newspaper layout math (a single arithmetic transform, no spatial heuristic):
 `gridColumn = (col+1) / (col+1+width)`, `gridRow = (row+1) / (row+1+height)`. `tile` / `static`
 / `grid` modes need a snap heuristic (lossy) — warn + stack; see `refs/looker-dashboard-layout.md` §3.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -20,6 +20,21 @@ def sid(p="el"): return p + "-" + "".join(secrets.choice(string.ascii_lowercase 
 def disp(seg):  return " ".join(w.capitalize() for w in str(seg).split("_"))
 def leaf(field): return field.split(".")[-1]            # users.traffic_source -> traffic_source
 
+
+def ordered_visible_fields(el):
+    """The DISPLAY order for a table/pivot tile's dimension+measure fields.
+
+    Looker's query.fields is the Data-tab order (dims forced before measures); the
+    tile's ACTUAL column order lives in vis_config.column_order (contract key
+    `columnOrder`), set by dragging columns in the viz. Honor columnOrder when present;
+    any query field not listed there is appended in fields order (Looker appends
+    newly-added fields at the end). Membership is UNCHANGED — hidden columns are handled
+    by the caller via a per-column `hidden` flag so the GROUP-BY grain is never altered.
+    Empty/absent columnOrder → fields order (non-reordered tiles stay byte-identical)."""
+    fields = el.get("fields") or []
+    order = [f for f in (el.get("columnOrder") or []) if f in fields]
+    return order + [f for f in fields if f not in order]
+
 # dimension_group timeframe expansion — MIRRORS the DM converter (lookml.ts
 # TIMEFRAME_MAP / DEFAULT_TIMEFRAMES): a `dimension_group: order_date` with >1
 # timeframes becomes DM columns "Order Date Raw" / "Order Date Date" /
@@ -1201,8 +1216,16 @@ def main():
             # (emit_native_trellis), faceted by the panel-splitting dimension.
         elif kind == "table":
             cols, gids, cids = [], [], []
-            for f in el["fields"] + (el.get("pivots") or []):
-                tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": disp(leaf(f))}
+            hidden = set(el.get("hiddenFields") or [])
+            labels = el.get("columnLabels") or {}
+            # Column order = the Looker VIZ order (columnOrder), not query.fields (the
+            # Data-tab order). Column NAMES prefer the viz series label (columnLabels) over
+            # the humanized field name. Hidden columns get a `hidden` flag, but a hidden
+            # DIMENSION still joins the group-by below so the aggregation grain is unchanged.
+            for f in ordered_visible_fields(el) + (el.get("pivots") or []):
+                tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": labels.get(f) or disp(leaf(f))}
+                if f in hidden:
+                    tcol["hidden"] = True
                 if is_measure(f):
                     apply_fmt(tcol, f); _warn_count(f, el); cids.append(tcol["id"])
                 else:
@@ -1217,6 +1240,12 @@ def main():
             # col ids]}].
             if gids and cids:
                 base["groupings"] = [{"id": sid("g"), "groupBy": gids, "calculations": cids}]
+            if hidden:
+                warnings.append(
+                    f"tile '{el['name']}': {len(hidden)} column(s) hidden in the Looker "
+                    f"viz ({', '.join(sorted(leaf(h) for h in hidden))}) → hidden in Sigma "
+                    "but KEPT in the group-by, so the aggregation grain (and every measure "
+                    "value) is preserved; confirm row counts in the visual-QA pass.")
             # Looker grid cell visualizations (vis_config.series_cell_visualizations) →
             # Sigma element-level conditionalFormats on the measure's calc column.
             # KEY (verified live 2026-06-24): Sigma `dataBars` are SIGN-colored — one fill
@@ -1258,8 +1287,12 @@ def main():
             # shelves replace `groupings`. Shape verified: sigma-workbooks tables.md.
             cols, row_ids, col_ids, val_ids = [], [], [], []
             pivset = set(el.get("pivots") or [])
-            for f in el["fields"] + (el.get("pivots") or []):
-                tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": disp(leaf(f))}
+            hidden = set(el.get("hiddenFields") or [])
+            labels = el.get("columnLabels") or {}
+            for f in ordered_visible_fields(el) + (el.get("pivots") or []):
+                tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": labels.get(f) or disp(leaf(f))}
+                if f in hidden:
+                    tcol["hidden"] = True
                 if is_measure(f):
                     apply_fmt(tcol, f); _warn_count(f, el); val_ids.append(tcol["id"])
                 elif f in pivset:
@@ -1269,6 +1302,11 @@ def main():
                 cols.append(tcol)
                 field2cid[f] = tcol["id"]
             base["columns"] = cols
+            if hidden:
+                warnings.append(
+                    f"tile '{el['name']}': hidden viz column(s) "
+                    f"({', '.join(sorted(leaf(h) for h in hidden))}) hidden in Sigma but "
+                    "KEPT in the query so the pivot grain is preserved.")
             base["values"] = val_ids
             base["rowsBy"] = [{"id": i} for i in row_ids]
             base["columnsBy"] = [{"id": i} for i in col_ids]

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
@@ -155,6 +155,46 @@ def _cell_viz(vc):
     return out
 
 
+def _column_order(vc):
+    """vis_config.column_order -> the VISUALIZATION column order (a list of Looker
+    "view.field" names). This is the order the user set by dragging columns in a table
+    viz; it differs from query.fields, which is the Data-tab order (Looker forces
+    dimensions before measures there). Empty list when absent -> build_workbook falls
+    back to the fields order, keeping non-reordered tiles byte-identical."""
+    co = vc.get("column_order")
+    return [f for f in co if isinstance(f, str)] if isinstance(co, list) else []
+
+
+def _hidden_fields(vc):
+    """Fields present in the query but HIDDEN from the visualization. Looker keeps a
+    hidden dimension IN the query (so it still sets the GROUP-BY grain) and only hides
+    the displayed column -> build_workbook keeps it in the group-by and marks the Sigma
+    column hidden (never drops it, which would change the grain). Primary key is
+    `hidden_fields` (list); tolerate a `hidden_columns` alias ({field: true} dict or a
+    list). Empty when absent."""
+    hf = vc.get("hidden_fields")
+    if not isinstance(hf, list):
+        hc = vc.get("hidden_columns")
+        if isinstance(hc, dict):
+            hf = [k for k, v in hc.items() if v]
+        elif isinstance(hc, list):
+            hf = hc
+        else:
+            hf = []
+    return [f for f in hf if isinstance(f, str)]
+
+
+def _series_labels(vc):
+    """vis_config.series_labels -> {field: custom column label}. Looker lets you rename a
+    table column in the VISUALIZATION (e.g. "Sales Region"), and that label differs from the
+    Data-tab column name. Only str→str entries kept. Empty when absent -> build_workbook falls
+    back to the humanized field name (byte-identical to before)."""
+    sl = vc.get("series_labels")
+    if not isinstance(sl, dict):
+        return {}
+    return {k: v for k, v in sl.items() if isinstance(k, str) and isinstance(v, str)}
+
+
 def _dyn(df):
     """Looker returns dashboard_element.query.dynamic_fields as a JSON string."""
     if isinstance(df, str):
@@ -231,6 +271,12 @@ def normalize_element(el, layout=None):
         "referenceLines": _reflines(vc),
         "color": _color(vc),
         "cellVisualizations": _cell_viz(vc),
+        # table column order + hidden columns (vis_config) → build_workbook reorders
+        # the displayed columns to the viz order and hides hidden ones (keeping hidden
+        # dims in the group-by). Empty when absent → fields order, byte-identical.
+        "columnOrder": _column_order(vc),
+        "hiddenFields": _hidden_fields(vc),
+        "columnLabels": _series_labels(vc),
         "layout": lay,
     }
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/parse_lookml_dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/parse_lookml_dashboard.py
@@ -141,6 +141,13 @@ def norm_element(el):
         "color": norm_color(el),
         # grid in-cell data bars (series_cell_visualizations) → Sigma conditionalFormats
         "cellVisualizations": norm_cell_viz(el),
+        # table column order + hidden columns (LookML `column_order:` / `hidden_fields:`),
+        # mirroring fetch_looker_dashboard.normalize_element so the contract is uniform.
+        # Usually absent in LookML dashboards → empty → build_workbook keeps fields order.
+        "columnOrder": [f for f in (el.get("column_order") or []) if isinstance(f, str)],
+        "hiddenFields": [f for f in (el.get("hidden_fields") or []) if isinstance(f, str)],
+        "columnLabels": {k: v for k, v in (el.get("series_labels") or {}).items()
+                         if isinstance(k, str) and isinstance(v, str)},
         # newspaper grid units (LookML uses `col`; API uses `column` — normalize to col)
         "layout": {
             "row": el.get("row", 0), "col": el.get("col", 0),

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_table_column_order.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_table_column_order.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Table column ORDER + HIDDEN-column fidelity (Looker viz order vs. data order).
+
+Looker exposes two column orders for a table: `query.fields` (the Data-tab order, which
+forces dimensions before measures) and `vis_config.column_order` (the Visualization
+order the user set by dragging columns). The migration must reproduce the VIZ order.
+
+Columns hidden from the visualization stay IN the query, so a hidden DIMENSION still
+sets the GROUP-BY grain (and therefore every measure value). They must be hidden in
+Sigma's presentation, NEVER dropped — dropping a hidden dimension would silently change
+the numbers.
+
+Drives the REAL build_workbook.py against the vendored skilltest-looks fixtures with
+in-memory-patched contracts (`columnOrder` / `hiddenFields` — exactly what
+fetch_looker_dashboard.normalize_element now emits). No live warehouse.
+
+Run: python3 tests/test_table_column_order.py   (exit 0 = pass)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCRIPTS = os.path.join(SKILL, "scripts")
+FIX = os.path.join(SKILL, "fixtures", "skilltest-looks")
+VIEWS = os.path.join(FIX, "views")
+
+# display names build_workbook derives via disp(leaf(field)) for the grouped_table fixture
+REGION, CATEGORY = "Region", "Category"
+TNR, DOC, AOV = "Total Net Revenue", "Distinct Order Count", "Average Order Value"
+
+
+def _load(name):
+    return json.load(open(os.path.join(FIX, f"look_{name}.contract.json")))
+
+
+def build(contract):
+    with tempfile.TemporaryDirectory() as d:
+        cp = os.path.join(d, "c.json")
+        op = os.path.join(d, "wb.json")
+        json.dump(contract, open(cp, "w"))
+        r = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS, "build_workbook.py"), cp,
+             "--views", VIEWS, "--dm-element-name", "Order Fact View", "--out", op],
+            capture_output=True, text=True)
+        assert r.returncode == 0, f"build_workbook failed:\n{r.stderr}"
+        return json.load(open(op)), (r.stdout + r.stderr)
+
+
+def _element(spec, kind):
+    els = []
+    for pg in spec.get("pages", []):
+        for e in pg.get("elements", []):
+            if e.get("kind") == kind and e.get("name") != "Data":
+                els.append(e)
+    assert len(els) == 1, f"expected one {kind}, got {[e.get('kind') for e in els]}"
+    return els[0]
+
+
+def _names(el):
+    return [c.get("name") for c in el.get("columns", [])]
+
+
+def _grouping(el):
+    g = (el.get("groupings") or [{}])[0]
+    idname = {c["id"]: c.get("name") for c in el.get("columns", [])}
+    return ([idname.get(i) for i in g.get("groupBy", [])],
+            [idname.get(i) for i in g.get("calculations", [])])
+
+
+def test_fallback_no_column_order():
+    """No columnOrder → columns stay in query.fields order (current behavior)."""
+    spec, _ = build(_load("grouped_table"))
+    t = _element(spec, "table")
+    assert _names(t) == [REGION, CATEGORY, TNR, DOC, AOV], _names(t)
+    print("[ok] fallback: fields order preserved when no columnOrder")
+
+
+def test_reorder_measure_first_interleaved():
+    """columnOrder wins: a measure can lead and dims/measures interleave freely."""
+    c = _load("grouped_table")
+    c["elements"][0]["columnOrder"] = [
+        "order_fact.total_net_revenue", "customer_dim.region",
+        "order_fact.average_order_value", "product_dim.category",
+        "order_fact.distinct_order_count"]
+    t = _element(build(c)[0], "table")
+    assert _names(t) == [TNR, REGION, AOV, CATEGORY, DOC], _names(t)
+    gb, calc = _grouping(t)
+    assert gb == [REGION, CATEGORY], gb          # both dims still grouped (in display order)
+    assert calc == [TNR, AOV, DOC], calc         # measures in display order
+    print("[ok] reorder: columns follow columnOrder; grouping membership intact")
+
+
+def test_partial_column_order_appends_rest():
+    """Fields absent from columnOrder append in fields order (Looker appends new fields)."""
+    c = _load("grouped_table")
+    c["elements"][0]["columnOrder"] = ["order_fact.average_order_value", "customer_dim.region"]
+    t = _element(build(c)[0], "table")
+    # listed first (AOV, Region), then the remainder in fields order (Category, TNR, DOC)
+    assert _names(t) == [AOV, REGION, CATEGORY, TNR, DOC], _names(t)
+    print("[ok] partial columnOrder: listed first, remainder in fields order")
+
+
+def test_hidden_dimension_preserves_grain():
+    """A hidden DIMENSION is hidden in Sigma but STAYS in groupBy (grain unchanged)."""
+    c = _load("grouped_table")
+    c["elements"][0]["hiddenFields"] = ["customer_dim.region"]
+    spec, log = build(c)
+    t = _element(spec, "table")
+    col = {c_["name"]: c_ for c_ in t["columns"]}
+    assert col[REGION].get("hidden") is True, "hidden dim column must carry hidden:true"
+    assert col[CATEGORY].get("hidden") in (None, False), "visible dim must not be hidden"
+    gb, _ = _grouping(t)
+    assert REGION in gb, "hidden dimension MUST remain in groupBy (grain preservation)"
+    assert "hidden" in log.lower() and "group-by" in log.lower(), \
+        "expected a grain-preservation warning mentioning the group-by"
+    print("[ok] hidden dim: hidden:true but kept in groupBy + warned")
+
+
+def test_hidden_measure_flagged_not_dropped():
+    """A hidden MEASURE is flagged hidden but still emitted as a calculation column."""
+    c = _load("grouped_table")
+    c["elements"][0]["hiddenFields"] = ["order_fact.average_order_value"]
+    t = _element(build(c)[0], "table")
+    col = {c_["name"]: c_ for c_ in t["columns"]}
+    assert col[AOV].get("hidden") is True, "hidden measure column must carry hidden:true"
+    _, calc = _grouping(t)
+    assert AOV in calc, "hidden measure still a calculation (present, just hidden)"
+    print("[ok] hidden measure: hidden:true, still a calculation")
+
+
+def test_custom_column_labels():
+    """Viz series_labels (contract columnLabels) override the default humanized name."""
+    c = _load("grouped_table")
+    c["elements"][0]["columnLabels"] = {
+        "customer_dim.region": "Sales Region",
+        "order_fact.total_net_revenue": "Revenue ($)"}
+    t = _element(build(c)[0], "table")
+    names = _names(t)
+    assert "Sales Region" in names, names             # relabeled dimension
+    assert "Revenue ($)" in names, names              # relabeled measure
+    assert REGION not in names and TNR not in names, names  # defaults replaced
+    assert CATEGORY in names, names                   # unlabeled column keeps its default
+    print("[ok] custom labels: viz series_labels override default column names")
+
+
+def test_pivot_reorder_rows():
+    """Pivot rowsBy order follows columnOrder; the pivot field stays on the column shelf."""
+    c = _load("pivot_table")
+    el = c["elements"][0]
+    # add a 2nd row dimension so row order is observable (fixture ships only one)
+    el["fields"] = ["customer_dim.region", "product_dim.category", "order_fact.total_net_revenue"]
+    c["fieldMeta"]["product_dim.category"] = {"category": "dimension"}
+    # viz order puts Category BEFORE Region
+    el["columnOrder"] = ["product_dim.category", "customer_dim.region", "order_fact.total_net_revenue"]
+    p = _element(build(c)[0], "pivot-table")
+    idname = {col["id"]: col.get("name") for col in p["columns"]}
+    rows = [idname.get(r["id"]) for r in p.get("rowsBy", [])]
+    vals = [idname.get(v) for v in p.get("values", [])]
+    cols_shelf = [idname.get(cb["id"]) for cb in p.get("columnsBy", [])]
+    assert rows == [CATEGORY, REGION], rows          # rowsBy follows columnOrder
+    assert vals == [TNR], vals                       # measure on the value shelf
+    assert cols_shelf == ["Order Channel"], cols_shelf  # pivot stays on the column shelf
+    print("[ok] pivot: rowsBy follows columnOrder; pivot stays on column shelf")
+
+
+if __name__ == "__main__":
+    test_fallback_no_column_order()
+    test_reorder_measure_first_interleaved()
+    test_partial_column_order_appends_rest()
+    test_hidden_dimension_preserves_grain()
+    test_hidden_measure_flagged_not_dropped()
+    test_custom_column_labels()
+    test_pivot_reorder_rows()
+    print("ALL PASS")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_vis_column_order_capture.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_vis_column_order_capture.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Capture-layer unit tests: the normalizers must lift the Looker visualization column
+order (vis_config.column_order) and hidden fields into the contract, WITHOUT reordering
+query.fields itself (build_workbook owns display ordering).
+
+Both source paths must agree:
+  - fetch_looker_dashboard.normalize_element  (live API + Looks, via fetch_looker_look)
+  - parse_lookml_dashboard.norm_element        (offline .dashboard.lookml)
+
+Pure functions — no network, no warehouse.
+
+Run: python3 tests/test_vis_column_order_capture.py   (exit 0 = pass)
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCRIPTS = os.path.join(SKILL, "scripts")
+sys.path.insert(0, SCRIPTS)
+
+import fetch_looker_dashboard as fd          # noqa: E402
+import parse_lookml_dashboard as pl          # noqa: E402
+
+A, B, C = "v.dim_a", "v.dim_b", "v.measure_c"
+
+
+def test_api_normalize_element_captures_order_and_hidden():
+    el = {"type": "vis", "query": {
+        "model": "m", "view": "v",
+        "fields": [A, B, C],
+        "vis_config": {"type": "looker_grid", "column_order": [C, A, B],
+                       "hidden_fields": [B],
+                       "series_labels": {A: "Alpha", C: "Charlie"}}}}
+    tile = fd.normalize_element(el, layout={"row": 0, "col": 0, "width": 24, "height": 8})
+    assert tile["columnOrder"] == [C, A, B], tile["columnOrder"]
+    assert tile["hiddenFields"] == [B], tile["hiddenFields"]
+    assert tile["columnLabels"] == {A: "Alpha", C: "Charlie"}, tile["columnLabels"]
+    assert tile["fields"] == [A, B, C], "fields (data order) must be preserved verbatim"
+    print("[ok] API normalize_element: columnOrder + hiddenFields + columnLabels captured; fields intact")
+
+
+def test_api_hidden_columns_alias():
+    """Tolerate the legacy `hidden_columns` dict alias ({field: true})."""
+    el = {"type": "vis", "query": {
+        "model": "m", "view": "v", "fields": [A, B, C],
+        "vis_config": {"type": "looker_grid", "hidden_columns": {B: True, C: False}}}}
+    tile = fd.normalize_element(el, layout={})
+    assert tile["hiddenFields"] == [B], tile["hiddenFields"]  # only truthy entries
+    print("[ok] API normalize_element: hidden_columns dict alias → hiddenFields")
+
+
+def test_api_absent_keys_default_empty():
+    """No column_order / hidden state → empty lists (build_workbook falls back to fields)."""
+    el = {"type": "vis", "query": {
+        "model": "m", "view": "v", "fields": [A, B, C],
+        "vis_config": {"type": "looker_grid"}}}
+    tile = fd.normalize_element(el, layout={})
+    assert tile["columnOrder"] == [] and tile["hiddenFields"] == [] and tile["columnLabels"] == {}, tile
+    print("[ok] API normalize_element: absent keys → empty (byte-identical fallback)")
+
+
+def test_lookml_norm_element_captures_order_and_hidden():
+    el = {"name": "t", "type": "looker_grid", "model": "m", "explore": "v",
+          "fields": [A, B, C], "column_order": [C, A, B], "hidden_fields": [B],
+          "series_labels": {A: "Alpha", C: "Charlie"}}
+    tile = pl.norm_element(el)
+    assert tile["columnOrder"] == [C, A, B], tile["columnOrder"]
+    assert tile["hiddenFields"] == [B], tile["hiddenFields"]
+    assert tile["columnLabels"] == {A: "Alpha", C: "Charlie"}, tile["columnLabels"]
+    assert tile["fields"] == [A, B, C]
+    print("[ok] LookML norm_element: columnOrder + hiddenFields + columnLabels captured; fields intact")
+
+
+def test_lookml_absent_keys_default_empty():
+    el = {"name": "t", "type": "looker_grid", "model": "m", "explore": "v", "fields": [A, B, C]}
+    tile = pl.norm_element(el)
+    assert tile["columnOrder"] == [] and tile["hiddenFields"] == [] and tile["columnLabels"] == {}, tile
+    print("[ok] LookML norm_element: absent keys → empty")
+
+
+if __name__ == "__main__":
+    test_api_normalize_element_captures_order_and_hidden()
+    test_api_hidden_columns_alias()
+    test_api_absent_keys_default_empty()
+    test_lookml_norm_element_captures_order_and_hidden()
+    test_lookml_absent_keys_default_empty()
+    print("ALL PASS")


### PR DESCRIPTION
## What & why

Migrated Looker **tables** reproduced columns in the wrong order, with default names, and still showed columns the user had hidden — because the converter captured only `query.fields` (Looker's Data-tab order, which forces dims before measures) and discarded the visualization's `vis_config`. This teaches both source paths to honor the visualization: column order, custom labels, and hidden columns.

## Scope

- Plugin(s) touched: **looker-to-sigma** (+ CI allowlist in `.github/workflows/corpus-check.yml`)
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

### Changes
- **Capture** — additive contract keys (absent/empty ⇒ byte-identical): `vis_config.column_order` → `columnOrder`, `series_labels` → `columnLabels`, `hidden_fields` → `hiddenFields`. In `fetch_looker_dashboard.normalize_element` (API path, inherited by Looks via `fetch_looker_look`) and `parse_lookml_dashboard.norm_element` (offline LookML).
- **Build** (`build_workbook.py`, table + pivot-table branches only): columns follow the viz order (unlisted fields append in `fields` order); names prefer the viz label over the humanized field name; hidden columns get `hidden: true` — but a **hidden dimension stays in `groupings.groupBy`** so the aggregation grain (and every measure value) is unchanged. Never dropped.
- **Tests**: new `test_table_column_order.py` (structural, through `build_workbook`) + `test_vis_column_order_capture.py` (pure-function capture), wired into `corpus-check.yml` along with the previously CI-invisible `test_look_migration.py` + `test_grounding.py`.

## Checklist
- [x] `ruby tools/check-shared.rb` — green (no shared files touched, 469/469)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (looker DM golden unaffected)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in

### Validation
- Offline: all 5 looker test suites pass; **`test_grounding` golden byte-identical (no drift)** — proves the no-`columnOrder` path is untouched.
- Live (hakkoda1 Look 9 — reordered + custom-labeled + hidden dimension): Sigma table came out `[Revenue ($), Sales Region, Distinct Order Count, Category(HIDDEN)]`, `groupBy=[Sales Region, Category]` — viz order, custom labels, and the hidden dimension all reproduced with grain preserved. Bonus finding: `apply_vis=true` honors `hidden_fields` but does **not** reorder columns, confirming `vis_config.column_order` is the right source to parse (not an `apply_vis` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
