### PR TITLE
looker: workbook tiles reference DM metrics ([Metrics/<name>]) instead of re-deriving inline

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -284,6 +284,7 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_vis_column_order_capture.py
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_look_migration.py
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_metric_reference.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -697,6 +697,18 @@ dimension: Looker keeps it in the query ("Hide from Visualization" doesn't re-ru
 dropping it would silently change the numbers. Both are additive contract keys — absent/empty →
 columns stay in `fields` order, byte-identical to before. Verified: `tests/test_table_column_order.py`.
 
+**DM metric references (leverage the semantic layer, don't duplicate it).** A table/pivot measure
+column prefers a governed **`[Metrics/<name>]`** reference over re-deriving the aggregation inline,
+when the measure's inline aggregate matches a metric defined on (or inherited by) the source DM
+element. Match is by FORMULA equivalence — strip the master prefix so `Sum([Data/Net Revenue])`
+equals a metric's `Sum([Net Revenue])` — so it's naming-independent and SAFE: ratios, filtered
+measures, custom/ad-hoc measures, and any non-match fall back to the inline formula. migrate-looker
+passes each element's referenceable metrics (name+formula) via `--dm-elements`, resolved through the
+`source.elementId` chain (a denorm "<X> View" element inherits its base fact's metrics — Sigma
+exposes them, and `[Metrics/<name>]` resolves on the denorm through the master→element chain,
+verified live). Absent metrics (the offline test/golden path) → inline, byte-identical. Verified:
+`tests/test_metric_reference.py`.
+
 Newspaper layout math (a single arithmetic transform, no spatial heuristic):
 `gridColumn = (col+1) / (col+1+width)`, `gridRow = (row+1) / (row+1+height)`. `tile` / `static`
 / `grid` modes need a snap heuristic (lossy) — warn + stack; see `refs/looker-dashboard-layout.md` §3.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -448,6 +448,9 @@ def main():
                 # FLAT ('<Field> (<view>)'); the base fact element only reaches
                 # them through a relationship traversal. master_ref keys off this.
                 "denorm": (dme.get("name") or "").endswith(" View"),
+                # DM metrics on this element (name+formula) → build_workbook prefers a
+                # governed [Metrics/<name>] ref over re-deriving the aggregate inline.
+                "metrics": dme.get("metrics") or [],
                 "needed": {},
             }
             if n == 1:
@@ -655,6 +658,28 @@ def main():
                             f"master column — emitted Count() as a degraded fallback; verify parity.")
             return "Count()"
         return f"[{master_of(explore)['name']}/{cd}]"
+    def metric_or_inline(f, explore):
+        """Prefer a governed DM-metric reference `[Metrics/<name>]` over re-deriving the
+        aggregation inline, when the measure's inline aggregate matches a metric defined on
+        the source element. Match is by FORMULA equivalence — strip the master prefix so
+        `Sum([Data/Net Revenue])` equals the metric's `Sum([Net Revenue])` — which is
+        naming-independent and SAFE: any mismatch (ratios, filtered measures, custom/ad-hoc
+        measures, or an absent metric list, e.g. the offline test path) falls back to the
+        inline formula. A metric on the DM element resolves as `[Metrics/<name>]` through the
+        master→DM-element source chain (verified live). Scoped to table/pivot calc columns."""
+        inline = formula_for(f, explore)
+        if not is_measure(f) or not isinstance(inline, str):
+            return inline
+        mst = master_of(explore)
+        mets = mst.get("metrics") or []
+        if not mets:
+            return inline
+        want = re.sub(r"\s+", "", inline.replace(f"[{mst['name']}/", "["))
+        for m in mets:
+            mf, mn = m.get("formula"), m.get("name")
+            if mf and mn and re.sub(r"\s+", "", mf) == want:
+                return f"[Metrics/{mn}]"
+        return inline
     def _warn_count(f, el):
         if measures.get(f, (None,))[0] == "count":
             v = f.split(".")[0]
@@ -1223,7 +1248,7 @@ def main():
             # the humanized field name. Hidden columns get a `hidden` flag, but a hidden
             # DIMENSION still joins the group-by below so the aggregation grain is unchanged.
             for f in ordered_visible_fields(el) + (el.get("pivots") or []):
-                tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": labels.get(f) or disp(leaf(f))}
+                tcol = {"id": sid("c"), "formula": metric_or_inline(f, ex), "name": labels.get(f) or disp(leaf(f))}
                 if f in hidden:
                     tcol["hidden"] = True
                 if is_measure(f):
@@ -1290,7 +1315,7 @@ def main():
             hidden = set(el.get("hiddenFields") or [])
             labels = el.get("columnLabels") or {}
             for f in ordered_visible_fields(el) + (el.get("pivots") or []):
-                tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": labels.get(f) or disp(leaf(f))}
+                tcol = {"id": sid("c"), "formula": metric_or_inline(f, ex), "name": labels.get(f) or disp(leaf(f))}
                 if f in hidden:
                     tcol["hidden"] = True
                 if is_measure(f):

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -963,8 +963,35 @@ console.error('stats:', JSON.stringify(res.stats));
     # Full element catalog (id+name) → one master per explore for multi-explore
     # dashboards (each explore matched to its DM element by normalized name).
     dm_els_path = os.path.join(wd, "dm-elements.json")
+    # Attach each element's REFERENCEABLE DM metrics (name + formula) so build_workbook can
+    # emit a governed [Metrics/<name>] reference instead of re-deriving the aggregation inline
+    # (matched by formula equivalence; falls back to inline when there's no match). Metrics
+    # are inherited through the `source.elementId` chain: a denorm "<X> View" element carries
+    # 0 own metrics but inherits its base fact's — Sigma exposes them and they resolve as
+    # [Metrics/<name>] on the denorm (verified live). So resolve the chain, deduped by name.
+    _by_id = {e["id"]: e for e in els}
+
+    def _avail_metrics(eid, seen=None):
+        seen = seen if seen is not None else set()
+        e = _by_id.get(eid)
+        if not e or eid in seen:
+            return []
+        seen.add(eid)
+        own = [{"name": m.get("name"), "formula": m.get("formula")}
+               for m in (e.get("metrics") or []) if m.get("name") and m.get("formula")]
+        return own + _avail_metrics((e.get("source") or {}).get("elementId"), seen)
+
+    def _dedup(ms):
+        seen, out = set(), []
+        for m in ms:
+            if m["name"] not in seen:
+                seen.add(m["name"])
+                out.append(m)
+        return out
+
     json.dump([{"id": e["id"], "name": e.get("name")
-                or ((e.get("source") or {}).get("path") or [None])[-1]}
+                or ((e.get("source") or {}).get("path") or [None])[-1],
+                "metrics": _dedup(_avail_metrics(e["id"]))}
                for e in els], open(dm_els_path, "w"))
     # Use --flag=value for ids: Sigma-reassigned element ids can start with '-'
     # (e.g. "-BGy34L4Yj"), which argparse otherwise mis-reads as a flag.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_metric_reference.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_metric_reference.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""DM-metric references (leverage the semantic layer instead of duplicating aggregations).
+
+build_workbook prefers a governed `[Metrics/<name>]` reference over re-deriving a measure's
+aggregation inline, when the measure's inline aggregate matches a metric defined on the source
+DM element. Match is by FORMULA equivalence (strip the master prefix so `Sum([Data/Net Revenue])`
+equals a metric's `Sum([Net Revenue])`) — naming-independent and SAFE: ratios, filtered measures,
+custom/ad-hoc measures, non-matching metrics, and the no-metrics path all fall back to inline.
+
+Metric names/formulas reach build_workbook via the `--dm-elements` payload (migrate-looker reads
+them from the posted/reused DM spec). With no metrics passed (this suite's control + all other
+offline suites + the golden) output is byte-identical to before. No live warehouse.
+
+Run: python3 tests/test_metric_reference.py   (exit 0 = pass)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCRIPTS = os.path.join(SKILL, "scripts")
+FIX = os.path.join(SKILL, "fixtures", "skilltest-looks")
+VIEWS = os.path.join(FIX, "views")
+
+# metrics whose formulas match the grouped_table fixture's Sum/CountDistinct measures
+# (master prefix stripped) — mirrors what migrate-looker reads off the DM spec.
+METRICS = [{"id": "el-x", "name": "Order Fact View", "metrics": [
+    {"name": "Net Revenue", "formula": "Sum([Net Revenue])"},
+    {"name": "Orders", "formula": "CountDistinct([Order Id])"}]}]
+
+
+def build(dm_elements=None):
+    with tempfile.TemporaryDirectory() as d:
+        op = os.path.join(d, "wb.json")
+        cmd = [sys.executable, os.path.join(SCRIPTS, "build_workbook.py"),
+               os.path.join(FIX, "look_grouped_table.contract.json"),
+               "--views", VIEWS, "--dm-element-name", "Order Fact View", "--out", op]
+        if dm_elements is not None:
+            dep = os.path.join(d, "dm-elements.json")
+            json.dump(dm_elements, open(dep, "w"))
+            cmd.append(f"--dm-elements={dep}")
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        assert r.returncode == 0, f"build_workbook failed:\n{r.stderr}"
+        spec = json.load(open(op))
+        t = [e for pg in spec["pages"] for e in pg["elements"]
+             if e.get("kind") == "table" and e.get("name") != "Data"][0]
+        return {c.get("name"): c["formula"] for c in t["columns"]}
+
+
+def test_fallback_without_metrics():
+    """No metrics passed → inline aggregates (byte-identical to prior behavior)."""
+    cols = build(None)
+    assert cols["Total Net Revenue"].startswith("Sum("), cols["Total Net Revenue"]
+    assert cols["Distinct Order Count"].startswith("CountDistinct("), cols["Distinct Order Count"]
+    assert not any(str(v).startswith("[Metrics/") for v in cols.values()), cols
+    print("[ok] no metrics passed → inline (byte-identical fallback)")
+
+
+def test_metric_ref_when_matched():
+    """A measure whose inline aggregate matches a DM metric → [Metrics/<name>]."""
+    cols = build(METRICS)
+    assert cols["Total Net Revenue"] == "[Metrics/Net Revenue]", cols["Total Net Revenue"]
+    assert cols["Distinct Order Count"] == "[Metrics/Orders]", cols["Distinct Order Count"]
+    print("[ok] matched aggregates → [Metrics/<name>] (governed, no re-derive)")
+
+
+def test_ratio_falls_back_to_inline():
+    """A ratio measure with no exact-formula metric match stays inline (safe)."""
+    aov = build(METRICS)["Average Order Value"]
+    assert aov.startswith("1.0 *") and "[Metrics/" not in aov, aov
+    print("[ok] ratio (no exact match) → inline fallback")
+
+
+def test_unmatched_metric_is_ignored():
+    """A metric that doesn't match any measure's formula must NOT be referenced."""
+    cols = build([{"id": "el-x", "name": "Order Fact View",
+                   "metrics": [{"name": "Unrelated", "formula": "Sum([Something Else])"}]}])
+    assert cols["Total Net Revenue"].startswith("Sum(") and "[Metrics/" not in cols["Total Net Revenue"], cols
+    print("[ok] non-matching metric → inline (no false positive)")
+
+
+if __name__ == "__main__":
+    test_fallback_without_metrics()
+    test_metric_ref_when_matched()
+    test_ratio_falls_back_to_inline()
+    test_unmatched_metric_is_ignored()
+    print("ALL PASS")


### PR DESCRIPTION
## What & why

The LookML→Sigma data model defines reusable **metrics** (`Net Revenue = Sum([Net Revenue])`, `Orders = CountDistinct([Order Id])`, …), but `build_workbook` re-derived every workbook measure as a fresh `Sum([Master/col])` / `CountDistinct(...)` **inline** — bypassing the governed metric and duplicating the aggregation (they can drift; analysts don't get the metric object). This teaches the looker workbook builder to **reference** the DM metric instead.

Reference implementation for the cross-converter "workbooks bypass DM metrics" epic (scoped across all 10 converters); **looker first**.

## Scope

- Plugin(s) touched: **looker-to-sigma** (+ CI allowlist in `.github/workflows/corpus-check.yml`)
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

### Changes
- **`build_workbook.py`** — a table/pivot measure column prefers a governed **`[Metrics/<name>]`** reference when the measure's inline aggregate matches a metric on (or inherited by) the tile's source DM element. Match is by **formula equivalence** (strip the master prefix so `Sum([Data/Net Revenue])` equals the metric's `Sum([Net Revenue])`) — naming-independent and **safe**: ratios, filtered/custom measures, and any non-match fall back to the inline formula. Scoped to the `table` + `pivot-table` branches.
- **`migrate-looker.py`** — passes each element's **referenceable** metrics (name+formula) via `--dm-elements`, resolved through the `source.elementId` chain: a denorm `"<X> View"` element carries 0 own metrics but **inherits** its base fact's, and Sigma exposes them so `[Metrics/<name>]` resolves on the denorm through the master→element chain.
- **Test** — `tests/test_metric_reference.py` (matched → `[Metrics/<name>]`; ratio/unmatched/no-metrics → inline), wired into CI.

## Checklist
- [x] `ruby tools/check-shared.rb` — green (no shared files touched, 469/469)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (looker DM golden unaffected)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in

### Validation
- Offline: all 6 looker suites pass; **`test_grounding` golden byte-identical** (the offline/golden path passes no metrics → inline fallback).
- **Live** (DM `257301db` "Looker Look 8", element "Order Fact View"): `build_workbook` emitted `[Metrics/Net Revenue]` + `[Metrics/Orders]`; the posted workbook renders **correct grouped values** through the master→denorm architecture (e.g. West/Electronics $16,707.94 / 74 orders; Midwest/Home $3,981.76 / 27) and matches the prior inline result. Empirically confirmed inherited metrics resolve as `[Metrics/<name>]` on the denorm element. The ratio (Avg Order Value) safely stays inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
