### PR TITLE
control_lint: hard-fail conflicting cross-page control defaults (#485)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -237,6 +237,8 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-preflight-lint.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-field-census.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-number-range-filter-emission.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-conflicting-page-defaults.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
@@ -249,6 +251,8 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-trellis-emit.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-trellis.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conflicting-page-defaults.rb
             plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/control-parity.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/control-parity.md
@@ -19,8 +19,9 @@ their default state.
 
 1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
    dead controls, ghost filter targets, source-closure reach vs same-page
-   queryable elements, and source-signal coverage via the
-   `control-scope.json` sidecar. Runs automatically in
+   queryable elements, source-signal coverage via the `control-scope.json`
+   sidecar, and **conflicting cross-page control defaults** (the severe D11
+   case below). Runs automatically in
    `post-and-readback.rb --type workbook` (exit 4) and as
    `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
 2. **control-scope.json contract** — emitted by the builder next to the
@@ -91,6 +92,37 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Severe D11 case: shared master + disjoint per-page control defaults = workbook-wide zero rows
+
+The documented D11 multi-page control-bind defect is cross-page *leakage*
+(flipping page A's control moves page B's numbers, because both bind the one
+shared hidden master). Its severe special case is a full, silent **data
+outage**: when two pages' controls default to non-empty, **disjoint** values on
+the same logical column, Sigma **AND-composes** every control that filters a
+shared source element — so the composed filter is `col IN [A] AND col IN [B]`
+with `A ∩ B = ∅` → the master matches **zero rows** → every chart/KPI/table on
+every page sourced from it reads EMPTY, with no error at build or POST.
+
+Sigma composes by the shared master **element** in the source chain, not by
+column identity, so duplicating the column under a second id (`m-website-type`
+vs `m-website-type-overview`, both formula `[Custom SQL/Website Type]`) does
+**not** dodge it. Control lint check (d) sees through that by grouping a target
+table's columns by normalized formula.
+
+Check (d) hard-fails this shape (blocks GREEN via gate 7). It fires only when
+two controls on **different** pages target the **same** element+column-alias
+with **non-empty, disjoint** defaults — the common default-all case
+(`values: []`) never trips it. Two fixes, both of which the lint recommends:
+
+- **Independent per-page masters** — give each audience/page its own
+  independently-sourced master element (a distinct filter-target elementId per
+  page), so the controls no longer compose against one source. (This is what
+  the archived pre-regression version of the workbook that surfaced #485 did:
+  `master-agent` / `master-leads` / `master-overview`.)
+- **Overlapping (or default-all) defaults** — make the per-page defaults share a
+  non-empty intersection, or leave them default-all, so the composed filter is
+  satisfiable.
 
 ## Gotcha: list-control targets on NUMERIC columns are silently stripped
 Same class as the datetime strip: a list control whose filter target column is

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb
@@ -14,7 +14,7 @@
 # three list controls bound to no element at all) or controls that silently
 # skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
 # escape, and the Qlik class: source full of listboxes, spec with zero
-# controls). Three checks:
+# controls). Four checks:
 #
 #   (a) dead control — every kind:control element must have >=1 `filters`
 #       target resolving to a REAL element id in the spec, OR be referenced
@@ -33,6 +33,17 @@
 #       zero controls, if an annotated control is missing from the spec,
 #       or if an annotated mustReach element is not in that control's
 #       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
 #
 # CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
 # to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
@@ -191,6 +202,93 @@ module ControlLint
     n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
   end
 
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+        by_formula = Hash.new { |h, k| h[k] = [] }
+        (el['columns'] || []).each do |c|
+          next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+          by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+        end
+        out[el['id']] = by_formula
+      end
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid, page: info[:page],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page] }.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if a[:page] == b[:page]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
   def lint(spec, scope: nil)
     violations = []
     elems = elements(spec)
@@ -283,6 +381,10 @@ module ControlLint
                       'scope:[...] — see header CONTRACT)'
       end
     end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
 
     # (c) annotated controls that never made it into the spec ------------------
     # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/control-parity.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/control-parity.md
@@ -19,8 +19,9 @@ their default state.
 
 1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
    dead controls, ghost filter targets, source-closure reach vs same-page
-   queryable elements, and source-signal coverage via the
-   `control-scope.json` sidecar. Runs automatically in
+   queryable elements, source-signal coverage via the `control-scope.json`
+   sidecar, and **conflicting cross-page control defaults** (the severe D11
+   case below). Runs automatically in
    `post-and-readback.rb --type workbook` (exit 4) and as
    `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
 2. **control-scope.json contract** — emitted by the builder next to the
@@ -91,6 +92,37 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Severe D11 case: shared master + disjoint per-page control defaults = workbook-wide zero rows
+
+The documented D11 multi-page control-bind defect is cross-page *leakage*
+(flipping page A's control moves page B's numbers, because both bind the one
+shared hidden master). Its severe special case is a full, silent **data
+outage**: when two pages' controls default to non-empty, **disjoint** values on
+the same logical column, Sigma **AND-composes** every control that filters a
+shared source element — so the composed filter is `col IN [A] AND col IN [B]`
+with `A ∩ B = ∅` → the master matches **zero rows** → every chart/KPI/table on
+every page sourced from it reads EMPTY, with no error at build or POST.
+
+Sigma composes by the shared master **element** in the source chain, not by
+column identity, so duplicating the column under a second id (`m-website-type`
+vs `m-website-type-overview`, both formula `[Custom SQL/Website Type]`) does
+**not** dodge it. Control lint check (d) sees through that by grouping a target
+table's columns by normalized formula.
+
+Check (d) hard-fails this shape (blocks GREEN via gate 7). It fires only when
+two controls on **different** pages target the **same** element+column-alias
+with **non-empty, disjoint** defaults — the common default-all case
+(`values: []`) never trips it. Two fixes, both of which the lint recommends:
+
+- **Independent per-page masters** — give each audience/page its own
+  independently-sourced master element (a distinct filter-target elementId per
+  page), so the controls no longer compose against one source. (This is what
+  the archived pre-regression version of the workbook that surfaced #485 did:
+  `master-agent` / `master-leads` / `master-overview`.)
+- **Overlapping (or default-all) defaults** — make the per-page defaults share a
+  non-empty intersection, or leave them default-all, so the composed filter is
+  satisfiable.
 
 ## Gotcha: list-control targets on NUMERIC columns are silently stripped
 Same class as the datetime strip: a list control whose filter target column is

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
@@ -14,7 +14,7 @@
 # three list controls bound to no element at all) or controls that silently
 # skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
 # escape, and the Qlik class: source full of listboxes, spec with zero
-# controls). Three checks:
+# controls). Four checks:
 #
 #   (a) dead control — every kind:control element must have >=1 `filters`
 #       target resolving to a REAL element id in the spec, OR be referenced
@@ -33,6 +33,17 @@
 #       zero controls, if an annotated control is missing from the spec,
 #       or if an annotated mustReach element is not in that control's
 #       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
 #
 # CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
 # to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
@@ -191,6 +202,93 @@ module ControlLint
     n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
   end
 
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+        by_formula = Hash.new { |h, k| h[k] = [] }
+        (el['columns'] || []).each do |c|
+          next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+          by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+        end
+        out[el['id']] = by_formula
+      end
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid, page: info[:page],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page] }.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if a[:page] == b[:page]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
   def lint(spec, scope: nil)
     violations = []
     elems = elements(spec)
@@ -283,6 +381,10 @@ module ControlLint
                       'scope:[...] — see header CONTRACT)'
       end
     end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
 
     # (c) annotated controls that never made it into the spec ------------------
     # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
@@ -19,8 +19,9 @@ their default state.
 
 1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
    dead controls, ghost filter targets, source-closure reach vs same-page
-   queryable elements, and source-signal coverage via the
-   `control-scope.json` sidecar. Runs automatically in
+   queryable elements, source-signal coverage via the `control-scope.json`
+   sidecar, and **conflicting cross-page control defaults** (the severe D11
+   case below). Runs automatically in
    `post-and-readback.rb --type workbook` (exit 4) and as
    `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
 2. **control-scope.json contract** — emitted by the builder next to the
@@ -91,6 +92,37 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Severe D11 case: shared master + disjoint per-page control defaults = workbook-wide zero rows
+
+The documented D11 multi-page control-bind defect is cross-page *leakage*
+(flipping page A's control moves page B's numbers, because both bind the one
+shared hidden master). Its severe special case is a full, silent **data
+outage**: when two pages' controls default to non-empty, **disjoint** values on
+the same logical column, Sigma **AND-composes** every control that filters a
+shared source element — so the composed filter is `col IN [A] AND col IN [B]`
+with `A ∩ B = ∅` → the master matches **zero rows** → every chart/KPI/table on
+every page sourced from it reads EMPTY, with no error at build or POST.
+
+Sigma composes by the shared master **element** in the source chain, not by
+column identity, so duplicating the column under a second id (`m-website-type`
+vs `m-website-type-overview`, both formula `[Custom SQL/Website Type]`) does
+**not** dodge it. Control lint check (d) sees through that by grouping a target
+table's columns by normalized formula.
+
+Check (d) hard-fails this shape (blocks GREEN via gate 7). It fires only when
+two controls on **different** pages target the **same** element+column-alias
+with **non-empty, disjoint** defaults — the common default-all case
+(`values: []`) never trips it. Two fixes, both of which the lint recommends:
+
+- **Independent per-page masters** — give each audience/page its own
+  independently-sourced master element (a distinct filter-target elementId per
+  page), so the controls no longer compose against one source. (This is what
+  the archived pre-regression version of the workbook that surfaced #485 did:
+  `master-agent` / `master-leads` / `master-overview`.)
+- **Overlapping (or default-all) defaults** — make the per-page defaults share a
+  non-empty intersection, or leave them default-all, so the composed filter is
+  satisfiable.
 
 ## Gotcha: list-control targets on NUMERIC columns are silently stripped
 Same class as the datetime strip: a list control whose filter target column is

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/control_lint.rb
@@ -14,7 +14,7 @@
 # three list controls bound to no element at all) or controls that silently
 # skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
 # escape, and the Qlik class: source full of listboxes, spec with zero
-# controls). Three checks:
+# controls). Four checks:
 #
 #   (a) dead control — every kind:control element must have >=1 `filters`
 #       target resolving to a REAL element id in the spec, OR be referenced
@@ -33,6 +33,17 @@
 #       zero controls, if an annotated control is missing from the spec,
 #       or if an annotated mustReach element is not in that control's
 #       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
 #
 # CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
 # to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
@@ -191,6 +202,93 @@ module ControlLint
     n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
   end
 
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+        by_formula = Hash.new { |h, k| h[k] = [] }
+        (el['columns'] || []).each do |c|
+          next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+          by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+        end
+        out[el['id']] = by_formula
+      end
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid, page: info[:page],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page] }.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if a[:page] == b[:page]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
   def lint(spec, scope: nil)
     violations = []
     elems = elements(spec)
@@ -283,6 +381,10 @@ module ControlLint
                       'scope:[...] — see header CONTRACT)'
       end
     end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
 
     # (c) annotated controls that never made it into the spec ------------------
     # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conflicting-page-defaults.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conflicting-page-defaults.rb
@@ -1,0 +1,109 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Regression test for control_lint check (d): conflicting cross-page control
+# defaults (issue #485 — the severe D11 special case).
+#
+# A single shared master (source:{kind:data-model}) with per-page list controls
+# that default to DISJOINT, non-empty values on the same logical column makes
+# Sigma AND-compose both filters against the one master -> impossible filter ->
+# ZERO rows for the master and therefore every element on every page, silently.
+# Check (d) must hard-fail that shape while NOT flagging any of the legitimate
+# arrangements (independent per-page masters, overlapping/default-all defaults,
+# a single page), and it must see through the id-duplication workaround (the
+# same logical column emitted under two ids with the same formula).
+#
+# Usage:  ruby scripts/test-conflicting-page-defaults.rb   (run from a vendored plugin copy)
+require 'json'
+require 'set'
+require_relative 'lib/control_lint'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# A list control whose `filters` target {source:{elementId:target}, columnId:col}
+# and whose own default selected values are `values`.
+def ctl(id, cid, values, target: 'm', col: 'c-type')
+  { 'id' => id, 'kind' => 'control', 'controlId' => cid, 'controlType' => 'list',
+    'mode' => 'include', 'selectionMode' => 'multiple', 'values' => values,
+    'source'  => { 'kind' => 'source', 'source' => { 'kind' => 'table', 'elementId' => target }, 'columnId' => col },
+    'filters' => [{ 'source' => { 'elementId' => target }, 'columnId' => col }] }
+end
+
+# A master TABLE element carrying two columnIds that share ONE formula — so the
+# alias grouping collapses the id-dup workaround (c-type / c-type-ovw) to one key.
+def master(id = 'm')
+  { 'id' => id, 'kind' => 'table', 'name' => 'Master', 'columns' => [
+    { 'id' => 'c-type',     'formula' => '[Custom SQL/Website Type]' },
+    { 'id' => 'c-type-ovw', 'formula' => '[Custom SQL/Website Type]' }
+  ] }
+end
+
+def spec_of(*pages)
+  { 'pages' => pages.map.with_index { |els, i| { 'name' => "P#{i + 1}", 'elements' => els } } }
+end
+
+fires = ->(vs) { vs.any? { |v| v.include?('conflicting cross-page control defaults') } }
+
+# 1. THE CONFLICT — two pages, one shared master, disjoint non-empty defaults.
+v1 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Brokerage Website'])]
+))
+check(fires.call(v1), "conflict fires: shared master + disjoint per-page defaults (got #{v1.grep(/conflicting/).inspect})", fails)
+
+# 2. id-duplication workaround — page B binds to a DIFFERENT columnId (c-type-ovw)
+#    that shares the same formula. Formula-alias grouping must still fire.
+v2 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Brokerage Website'], col: 'c-type-ovw')]
+))
+check(fires.call(v2), 'id-dup workaround still fires via formula-alias grouping', fails)
+
+# 3. Independent per-page masters (the real fix) — distinct target elements per
+#    page -> the controls no longer compose against one source -> NO conflict.
+v3 = ControlLint.lint(spec_of(
+  [master('m-a'), ctl('a', 'ctl-a', ['Agent Website'],    target: 'm-a')],
+  [master('m-b'), ctl('b', 'ctl-b', ['Brokerage Website'], target: 'm-b')]
+))
+check(!fires.call(v3), "independent per-page masters do NOT fire (got #{v3.grep(/conflicting/).inspect})", fails)
+
+# 4. Same master, identical defaults (the overlap fix) — satisfiable -> NO conflict.
+v4 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Agent Website'])]
+))
+check(!fires.call(v4), 'same master + identical defaults do NOT fire', fails)
+
+# 5. Partial (non-disjoint) overlap -> intersection non-empty -> NO conflict.
+v5 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', %w[A B])],
+  [ctl('b', 'ctl-b', %w[B C])]
+))
+check(!fires.call(v5), 'partial (non-disjoint) overlap does NOT fire', fails)
+
+# 6. Single page — both disjoint controls on ONE page (page uniq < 2) -> NO conflict.
+v6 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website']), ctl('b', 'ctl-b', ['Brokerage Website'])]
+))
+check(!fires.call(v6), 'single-page spec stays clean (page uniq < 2)', fails)
+
+# 7. Default-all both pages (values: []) — the common case, empty defaults -> NO conflict.
+v7 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', [])],
+  [ctl('b', 'ctl-b', [])]
+))
+check(!fires.call(v7), 'default-all (values: []) both pages do NOT fire (false-positive guard)', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — control_lint check (d) flags the impossible-filter shape and only that'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/control-parity.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/control-parity.md
@@ -19,8 +19,9 @@ their default state.
 
 1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
    dead controls, ghost filter targets, source-closure reach vs same-page
-   queryable elements, and source-signal coverage via the
-   `control-scope.json` sidecar. Runs automatically in
+   queryable elements, source-signal coverage via the `control-scope.json`
+   sidecar, and **conflicting cross-page control defaults** (the severe D11
+   case below). Runs automatically in
    `post-and-readback.rb --type workbook` (exit 4) and as
    `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
 2. **control-scope.json contract** — emitted by the builder next to the
@@ -91,6 +92,37 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Severe D11 case: shared master + disjoint per-page control defaults = workbook-wide zero rows
+
+The documented D11 multi-page control-bind defect is cross-page *leakage*
+(flipping page A's control moves page B's numbers, because both bind the one
+shared hidden master). Its severe special case is a full, silent **data
+outage**: when two pages' controls default to non-empty, **disjoint** values on
+the same logical column, Sigma **AND-composes** every control that filters a
+shared source element — so the composed filter is `col IN [A] AND col IN [B]`
+with `A ∩ B = ∅` → the master matches **zero rows** → every chart/KPI/table on
+every page sourced from it reads EMPTY, with no error at build or POST.
+
+Sigma composes by the shared master **element** in the source chain, not by
+column identity, so duplicating the column under a second id (`m-website-type`
+vs `m-website-type-overview`, both formula `[Custom SQL/Website Type]`) does
+**not** dodge it. Control lint check (d) sees through that by grouping a target
+table's columns by normalized formula.
+
+Check (d) hard-fails this shape (blocks GREEN via gate 7). It fires only when
+two controls on **different** pages target the **same** element+column-alias
+with **non-empty, disjoint** defaults — the common default-all case
+(`values: []`) never trips it. Two fixes, both of which the lint recommends:
+
+- **Independent per-page masters** — give each audience/page its own
+  independently-sourced master element (a distinct filter-target elementId per
+  page), so the controls no longer compose against one source. (This is what
+  the archived pre-regression version of the workbook that surfaced #485 did:
+  `master-agent` / `master-leads` / `master-overview`.)
+- **Overlapping (or default-all) defaults** — make the per-page defaults share a
+  non-empty intersection, or leave them default-all, so the composed filter is
+  satisfiable.
 
 ## Gotcha: list-control targets on NUMERIC columns are silently stripped
 Same class as the datetime strip: a list control whose filter target column is

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
@@ -14,7 +14,7 @@
 # three list controls bound to no element at all) or controls that silently
 # skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
 # escape, and the Qlik class: source full of listboxes, spec with zero
-# controls). Three checks:
+# controls). Four checks:
 #
 #   (a) dead control — every kind:control element must have >=1 `filters`
 #       target resolving to a REAL element id in the spec, OR be referenced
@@ -33,6 +33,17 @@
 #       zero controls, if an annotated control is missing from the spec,
 #       or if an annotated mustReach element is not in that control's
 #       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
 #
 # CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
 # to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
@@ -191,6 +202,93 @@ module ControlLint
     n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
   end
 
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+        by_formula = Hash.new { |h, k| h[k] = [] }
+        (el['columns'] || []).each do |c|
+          next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+          by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+        end
+        out[el['id']] = by_formula
+      end
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid, page: info[:page],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page] }.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if a[:page] == b[:page]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
   def lint(spec, scope: nil)
     violations = []
     elems = elements(spec)
@@ -283,6 +381,10 @@ module ControlLint
                       'scope:[...] — see header CONTRACT)'
       end
     end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
 
     # (c) annotated controls that never made it into the spec ------------------
     # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/control-parity.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/control-parity.md
@@ -19,8 +19,9 @@ their default state.
 
 1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
    dead controls, ghost filter targets, source-closure reach vs same-page
-   queryable elements, and source-signal coverage via the
-   `control-scope.json` sidecar. Runs automatically in
+   queryable elements, source-signal coverage via the `control-scope.json`
+   sidecar, and **conflicting cross-page control defaults** (the severe D11
+   case below). Runs automatically in
    `post-and-readback.rb --type workbook` (exit 4) and as
    `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
 2. **control-scope.json contract** — emitted by the builder next to the
@@ -91,6 +92,37 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Severe D11 case: shared master + disjoint per-page control defaults = workbook-wide zero rows
+
+The documented D11 multi-page control-bind defect is cross-page *leakage*
+(flipping page A's control moves page B's numbers, because both bind the one
+shared hidden master). Its severe special case is a full, silent **data
+outage**: when two pages' controls default to non-empty, **disjoint** values on
+the same logical column, Sigma **AND-composes** every control that filters a
+shared source element — so the composed filter is `col IN [A] AND col IN [B]`
+with `A ∩ B = ∅` → the master matches **zero rows** → every chart/KPI/table on
+every page sourced from it reads EMPTY, with no error at build or POST.
+
+Sigma composes by the shared master **element** in the source chain, not by
+column identity, so duplicating the column under a second id (`m-website-type`
+vs `m-website-type-overview`, both formula `[Custom SQL/Website Type]`) does
+**not** dodge it. Control lint check (d) sees through that by grouping a target
+table's columns by normalized formula.
+
+Check (d) hard-fails this shape (blocks GREEN via gate 7). It fires only when
+two controls on **different** pages target the **same** element+column-alias
+with **non-empty, disjoint** defaults — the common default-all case
+(`values: []`) never trips it. Two fixes, both of which the lint recommends:
+
+- **Independent per-page masters** — give each audience/page its own
+  independently-sourced master element (a distinct filter-target elementId per
+  page), so the controls no longer compose against one source. (This is what
+  the archived pre-regression version of the workbook that surfaced #485 did:
+  `master-agent` / `master-leads` / `master-overview`.)
+- **Overlapping (or default-all) defaults** — make the per-page defaults share a
+  non-empty intersection, or leave them default-all, so the composed filter is
+  satisfiable.
 
 ## Gotcha: list-control targets on NUMERIC columns are silently stripped
 Same class as the datetime strip: a list control whose filter target column is

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/control_lint.rb
@@ -14,7 +14,7 @@
 # three list controls bound to no element at all) or controls that silently
 # skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
 # escape, and the Qlik class: source full of listboxes, spec with zero
-# controls). Three checks:
+# controls). Four checks:
 #
 #   (a) dead control — every kind:control element must have >=1 `filters`
 #       target resolving to a REAL element id in the spec, OR be referenced
@@ -33,6 +33,17 @@
 #       zero controls, if an annotated control is missing from the spec,
 #       or if an annotated mustReach element is not in that control's
 #       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
 #
 # CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
 # to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
@@ -191,6 +202,93 @@ module ControlLint
     n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
   end
 
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+        by_formula = Hash.new { |h, k| h[k] = [] }
+        (el['columns'] || []).each do |c|
+          next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+          by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+        end
+        out[el['id']] = by_formula
+      end
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid, page: info[:page],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page] }.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if a[:page] == b[:page]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
   def lint(spec, scope: nil)
     violations = []
     elems = elements(spec)
@@ -283,6 +381,10 @@ module ControlLint
                       'scope:[...] — see header CONTRACT)'
       end
     end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
 
     # (c) annotated controls that never made it into the spec ------------------
     # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/control-parity.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/control-parity.md
@@ -19,8 +19,9 @@ their default state.
 
 1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
    dead controls, ghost filter targets, source-closure reach vs same-page
-   queryable elements, and source-signal coverage via the
-   `control-scope.json` sidecar. Runs automatically in
+   queryable elements, source-signal coverage via the `control-scope.json`
+   sidecar, and **conflicting cross-page control defaults** (the severe D11
+   case below). Runs automatically in
    `post-and-readback.rb --type workbook` (exit 4) and as
    `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
 2. **control-scope.json contract** — emitted by the builder next to the
@@ -91,6 +92,37 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Severe D11 case: shared master + disjoint per-page control defaults = workbook-wide zero rows
+
+The documented D11 multi-page control-bind defect is cross-page *leakage*
+(flipping page A's control moves page B's numbers, because both bind the one
+shared hidden master). Its severe special case is a full, silent **data
+outage**: when two pages' controls default to non-empty, **disjoint** values on
+the same logical column, Sigma **AND-composes** every control that filters a
+shared source element — so the composed filter is `col IN [A] AND col IN [B]`
+with `A ∩ B = ∅` → the master matches **zero rows** → every chart/KPI/table on
+every page sourced from it reads EMPTY, with no error at build or POST.
+
+Sigma composes by the shared master **element** in the source chain, not by
+column identity, so duplicating the column under a second id (`m-website-type`
+vs `m-website-type-overview`, both formula `[Custom SQL/Website Type]`) does
+**not** dodge it. Control lint check (d) sees through that by grouping a target
+table's columns by normalized formula.
+
+Check (d) hard-fails this shape (blocks GREEN via gate 7). It fires only when
+two controls on **different** pages target the **same** element+column-alias
+with **non-empty, disjoint** defaults — the common default-all case
+(`values: []`) never trips it. Two fixes, both of which the lint recommends:
+
+- **Independent per-page masters** — give each audience/page its own
+  independently-sourced master element (a distinct filter-target elementId per
+  page), so the controls no longer compose against one source. (This is what
+  the archived pre-regression version of the workbook that surfaced #485 did:
+  `master-agent` / `master-leads` / `master-overview`.)
+- **Overlapping (or default-all) defaults** — make the per-page defaults share a
+  non-empty intersection, or leave them default-all, so the composed filter is
+  satisfiable.
 
 ## Gotcha: list-control targets on NUMERIC columns are silently stripped
 Same class as the datetime strip: a list control whose filter target column is

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_lint.rb
@@ -14,7 +14,7 @@
 # three list controls bound to no element at all) or controls that silently
 # skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
 # escape, and the Qlik class: source full of listboxes, spec with zero
-# controls). Three checks:
+# controls). Four checks:
 #
 #   (a) dead control — every kind:control element must have >=1 `filters`
 #       target resolving to a REAL element id in the spec, OR be referenced
@@ -33,6 +33,17 @@
 #       zero controls, if an annotated control is missing from the spec,
 #       or if an annotated mustReach element is not in that control's
 #       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
 #
 # CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
 # to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
@@ -191,6 +202,93 @@ module ControlLint
     n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
   end
 
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+        by_formula = Hash.new { |h, k| h[k] = [] }
+        (el['columns'] || []).each do |c|
+          next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+          by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+        end
+        out[el['id']] = by_formula
+      end
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid, page: info[:page],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page] }.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if a[:page] == b[:page]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
   def lint(spec, scope: nil)
     violations = []
     elems = elements(spec)
@@ -283,6 +381,10 @@ module ControlLint
                       'scope:[...] — see header CONTRACT)'
       end
     end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
 
     # (c) annotated controls that never made it into the spec ------------------
     # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-conflicting-page-defaults.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-conflicting-page-defaults.rb
@@ -1,0 +1,109 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Regression test for control_lint check (d): conflicting cross-page control
+# defaults (issue #485 — the severe D11 special case).
+#
+# A single shared master (source:{kind:data-model}) with per-page list controls
+# that default to DISJOINT, non-empty values on the same logical column makes
+# Sigma AND-compose both filters against the one master -> impossible filter ->
+# ZERO rows for the master and therefore every element on every page, silently.
+# Check (d) must hard-fail that shape while NOT flagging any of the legitimate
+# arrangements (independent per-page masters, overlapping/default-all defaults,
+# a single page), and it must see through the id-duplication workaround (the
+# same logical column emitted under two ids with the same formula).
+#
+# Usage:  ruby scripts/test-conflicting-page-defaults.rb   (run from a vendored plugin copy)
+require 'json'
+require 'set'
+require_relative 'lib/control_lint'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# A list control whose `filters` target {source:{elementId:target}, columnId:col}
+# and whose own default selected values are `values`.
+def ctl(id, cid, values, target: 'm', col: 'c-type')
+  { 'id' => id, 'kind' => 'control', 'controlId' => cid, 'controlType' => 'list',
+    'mode' => 'include', 'selectionMode' => 'multiple', 'values' => values,
+    'source'  => { 'kind' => 'source', 'source' => { 'kind' => 'table', 'elementId' => target }, 'columnId' => col },
+    'filters' => [{ 'source' => { 'elementId' => target }, 'columnId' => col }] }
+end
+
+# A master TABLE element carrying two columnIds that share ONE formula — so the
+# alias grouping collapses the id-dup workaround (c-type / c-type-ovw) to one key.
+def master(id = 'm')
+  { 'id' => id, 'kind' => 'table', 'name' => 'Master', 'columns' => [
+    { 'id' => 'c-type',     'formula' => '[Custom SQL/Website Type]' },
+    { 'id' => 'c-type-ovw', 'formula' => '[Custom SQL/Website Type]' }
+  ] }
+end
+
+def spec_of(*pages)
+  { 'pages' => pages.map.with_index { |els, i| { 'name' => "P#{i + 1}", 'elements' => els } } }
+end
+
+fires = ->(vs) { vs.any? { |v| v.include?('conflicting cross-page control defaults') } }
+
+# 1. THE CONFLICT — two pages, one shared master, disjoint non-empty defaults.
+v1 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Brokerage Website'])]
+))
+check(fires.call(v1), "conflict fires: shared master + disjoint per-page defaults (got #{v1.grep(/conflicting/).inspect})", fails)
+
+# 2. id-duplication workaround — page B binds to a DIFFERENT columnId (c-type-ovw)
+#    that shares the same formula. Formula-alias grouping must still fire.
+v2 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Brokerage Website'], col: 'c-type-ovw')]
+))
+check(fires.call(v2), 'id-dup workaround still fires via formula-alias grouping', fails)
+
+# 3. Independent per-page masters (the real fix) — distinct target elements per
+#    page -> the controls no longer compose against one source -> NO conflict.
+v3 = ControlLint.lint(spec_of(
+  [master('m-a'), ctl('a', 'ctl-a', ['Agent Website'],    target: 'm-a')],
+  [master('m-b'), ctl('b', 'ctl-b', ['Brokerage Website'], target: 'm-b')]
+))
+check(!fires.call(v3), "independent per-page masters do NOT fire (got #{v3.grep(/conflicting/).inspect})", fails)
+
+# 4. Same master, identical defaults (the overlap fix) — satisfiable -> NO conflict.
+v4 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Agent Website'])]
+))
+check(!fires.call(v4), 'same master + identical defaults do NOT fire', fails)
+
+# 5. Partial (non-disjoint) overlap -> intersection non-empty -> NO conflict.
+v5 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', %w[A B])],
+  [ctl('b', 'ctl-b', %w[B C])]
+))
+check(!fires.call(v5), 'partial (non-disjoint) overlap does NOT fire', fails)
+
+# 6. Single page — both disjoint controls on ONE page (page uniq < 2) -> NO conflict.
+v6 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website']), ctl('b', 'ctl-b', ['Brokerage Website'])]
+))
+check(!fires.call(v6), 'single-page spec stays clean (page uniq < 2)', fails)
+
+# 7. Default-all both pages (values: []) — the common case, empty defaults -> NO conflict.
+v7 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', [])],
+  [ctl('b', 'ctl-b', [])]
+))
+check(!fires.call(v7), 'default-all (values: []) both pages do NOT fire (false-positive guard)', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — control_lint check (d) flags the impossible-filter shape and only that'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/control-parity.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/control-parity.md
@@ -19,8 +19,9 @@ their default state.
 
 1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
    dead controls, ghost filter targets, source-closure reach vs same-page
-   queryable elements, and source-signal coverage via the
-   `control-scope.json` sidecar. Runs automatically in
+   queryable elements, source-signal coverage via the `control-scope.json`
+   sidecar, and **conflicting cross-page control defaults** (the severe D11
+   case below). Runs automatically in
    `post-and-readback.rb --type workbook` (exit 4) and as
    `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
 2. **control-scope.json contract** — emitted by the builder next to the
@@ -91,6 +92,37 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Severe D11 case: shared master + disjoint per-page control defaults = workbook-wide zero rows
+
+The documented D11 multi-page control-bind defect is cross-page *leakage*
+(flipping page A's control moves page B's numbers, because both bind the one
+shared hidden master). Its severe special case is a full, silent **data
+outage**: when two pages' controls default to non-empty, **disjoint** values on
+the same logical column, Sigma **AND-composes** every control that filters a
+shared source element — so the composed filter is `col IN [A] AND col IN [B]`
+with `A ∩ B = ∅` → the master matches **zero rows** → every chart/KPI/table on
+every page sourced from it reads EMPTY, with no error at build or POST.
+
+Sigma composes by the shared master **element** in the source chain, not by
+column identity, so duplicating the column under a second id (`m-website-type`
+vs `m-website-type-overview`, both formula `[Custom SQL/Website Type]`) does
+**not** dodge it. Control lint check (d) sees through that by grouping a target
+table's columns by normalized formula.
+
+Check (d) hard-fails this shape (blocks GREEN via gate 7). It fires only when
+two controls on **different** pages target the **same** element+column-alias
+with **non-empty, disjoint** defaults — the common default-all case
+(`values: []`) never trips it. Two fixes, both of which the lint recommends:
+
+- **Independent per-page masters** — give each audience/page its own
+  independently-sourced master element (a distinct filter-target elementId per
+  page), so the controls no longer compose against one source. (This is what
+  the archived pre-regression version of the workbook that surfaced #485 did:
+  `master-agent` / `master-leads` / `master-overview`.)
+- **Overlapping (or default-all) defaults** — make the per-page defaults share a
+  non-empty intersection, or leave them default-all, so the composed filter is
+  satisfiable.
 
 ## Gotcha: list-control targets on NUMERIC columns are silently stripped
 Same class as the datetime strip: a list control whose filter target column is

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/control_lint.rb
@@ -14,7 +14,7 @@
 # three list controls bound to no element at all) or controls that silently
 # skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
 # escape, and the Qlik class: source full of listboxes, spec with zero
-# controls). Three checks:
+# controls). Four checks:
 #
 #   (a) dead control — every kind:control element must have >=1 `filters`
 #       target resolving to a REAL element id in the spec, OR be referenced
@@ -33,6 +33,17 @@
 #       zero controls, if an annotated control is missing from the spec,
 #       or if an annotated mustReach element is not in that control's
 #       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
 #
 # CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
 # to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
@@ -191,6 +202,93 @@ module ControlLint
     n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
   end
 
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+        by_formula = Hash.new { |h, k| h[k] = [] }
+        (el['columns'] || []).each do |c|
+          next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+          by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+        end
+        out[el['id']] = by_formula
+      end
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid, page: info[:page],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page] }.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if a[:page] == b[:page]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
   def lint(spec, scope: nil)
     violations = []
     elems = elements(spec)
@@ -283,6 +381,10 @@ module ControlLint
                       'scope:[...] — see header CONTRACT)'
       end
     end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
 
     # (c) annotated controls that never made it into the spec ------------------
     # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/

--- a/shared/lib/control_lint.rb
+++ b/shared/lib/control_lint.rb
@@ -14,7 +14,7 @@
 # three list controls bound to no element at all) or controls that silently
 # skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
 # escape, and the Qlik class: source full of listboxes, spec with zero
-# controls). Three checks:
+# controls). Four checks:
 #
 #   (a) dead control — every kind:control element must have >=1 `filters`
 #       target resolving to a REAL element id in the spec, OR be referenced
@@ -33,6 +33,17 @@
 #       zero controls, if an annotated control is missing from the spec,
 #       or if an annotated mustReach element is not in that control's
 #       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
 #
 # CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
 # to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
@@ -191,6 +202,93 @@ module ControlLint
     n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
   end
 
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+        by_formula = Hash.new { |h, k| h[k] = [] }
+        (el['columns'] || []).each do |c|
+          next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+          by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+        end
+        out[el['id']] = by_formula
+      end
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid, page: info[:page],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page] }.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if a[:page] == b[:page]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
   def lint(spec, scope: nil)
     violations = []
     elems = elements(spec)
@@ -283,6 +381,10 @@ module ControlLint
                       'scope:[...] — see header CONTRACT)'
       end
     end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
 
     # (c) annotated controls that never made it into the spec ------------------
     # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -472,6 +472,13 @@
    ]
   },
   {
+   "canonical": "shared/scripts/test-conflicting-page-defaults.rb",
+   "targets": [
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conflicting-page-defaults.rb",
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-conflicting-page-defaults.rb"
+   ]
+  },
+  {
    "canonical": "shared/scripts/test-telemetry-gate.rb",
    "targets": [
     "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb",

--- a/shared/scripts/test-conflicting-page-defaults.rb
+++ b/shared/scripts/test-conflicting-page-defaults.rb
@@ -1,0 +1,109 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Regression test for control_lint check (d): conflicting cross-page control
+# defaults (issue #485 — the severe D11 special case).
+#
+# A single shared master (source:{kind:data-model}) with per-page list controls
+# that default to DISJOINT, non-empty values on the same logical column makes
+# Sigma AND-compose both filters against the one master -> impossible filter ->
+# ZERO rows for the master and therefore every element on every page, silently.
+# Check (d) must hard-fail that shape while NOT flagging any of the legitimate
+# arrangements (independent per-page masters, overlapping/default-all defaults,
+# a single page), and it must see through the id-duplication workaround (the
+# same logical column emitted under two ids with the same formula).
+#
+# Usage:  ruby scripts/test-conflicting-page-defaults.rb   (run from a vendored plugin copy)
+require 'json'
+require 'set'
+require_relative 'lib/control_lint'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# A list control whose `filters` target {source:{elementId:target}, columnId:col}
+# and whose own default selected values are `values`.
+def ctl(id, cid, values, target: 'm', col: 'c-type')
+  { 'id' => id, 'kind' => 'control', 'controlId' => cid, 'controlType' => 'list',
+    'mode' => 'include', 'selectionMode' => 'multiple', 'values' => values,
+    'source'  => { 'kind' => 'source', 'source' => { 'kind' => 'table', 'elementId' => target }, 'columnId' => col },
+    'filters' => [{ 'source' => { 'elementId' => target }, 'columnId' => col }] }
+end
+
+# A master TABLE element carrying two columnIds that share ONE formula — so the
+# alias grouping collapses the id-dup workaround (c-type / c-type-ovw) to one key.
+def master(id = 'm')
+  { 'id' => id, 'kind' => 'table', 'name' => 'Master', 'columns' => [
+    { 'id' => 'c-type',     'formula' => '[Custom SQL/Website Type]' },
+    { 'id' => 'c-type-ovw', 'formula' => '[Custom SQL/Website Type]' }
+  ] }
+end
+
+def spec_of(*pages)
+  { 'pages' => pages.map.with_index { |els, i| { 'name' => "P#{i + 1}", 'elements' => els } } }
+end
+
+fires = ->(vs) { vs.any? { |v| v.include?('conflicting cross-page control defaults') } }
+
+# 1. THE CONFLICT — two pages, one shared master, disjoint non-empty defaults.
+v1 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Brokerage Website'])]
+))
+check(fires.call(v1), "conflict fires: shared master + disjoint per-page defaults (got #{v1.grep(/conflicting/).inspect})", fails)
+
+# 2. id-duplication workaround — page B binds to a DIFFERENT columnId (c-type-ovw)
+#    that shares the same formula. Formula-alias grouping must still fire.
+v2 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Brokerage Website'], col: 'c-type-ovw')]
+))
+check(fires.call(v2), 'id-dup workaround still fires via formula-alias grouping', fails)
+
+# 3. Independent per-page masters (the real fix) — distinct target elements per
+#    page -> the controls no longer compose against one source -> NO conflict.
+v3 = ControlLint.lint(spec_of(
+  [master('m-a'), ctl('a', 'ctl-a', ['Agent Website'],    target: 'm-a')],
+  [master('m-b'), ctl('b', 'ctl-b', ['Brokerage Website'], target: 'm-b')]
+))
+check(!fires.call(v3), "independent per-page masters do NOT fire (got #{v3.grep(/conflicting/).inspect})", fails)
+
+# 4. Same master, identical defaults (the overlap fix) — satisfiable -> NO conflict.
+v4 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website'])],
+  [ctl('b', 'ctl-b', ['Agent Website'])]
+))
+check(!fires.call(v4), 'same master + identical defaults do NOT fire', fails)
+
+# 5. Partial (non-disjoint) overlap -> intersection non-empty -> NO conflict.
+v5 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', %w[A B])],
+  [ctl('b', 'ctl-b', %w[B C])]
+))
+check(!fires.call(v5), 'partial (non-disjoint) overlap does NOT fire', fails)
+
+# 6. Single page — both disjoint controls on ONE page (page uniq < 2) -> NO conflict.
+v6 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', ['Agent Website']), ctl('b', 'ctl-b', ['Brokerage Website'])]
+))
+check(!fires.call(v6), 'single-page spec stays clean (page uniq < 2)', fails)
+
+# 7. Default-all both pages (values: []) — the common case, empty defaults -> NO conflict.
+v7 = ControlLint.lint(spec_of(
+  [master, ctl('a', 'ctl-a', [])],
+  [ctl('b', 'ctl-b', [])]
+))
+check(!fires.call(v7), 'default-all (values: []) both pages do NOT fire (false-positive guard)', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — control_lint check (d) flags the impossible-filter shape and only that'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end


### PR DESCRIPTION
## What & why

Fixes #485. A single shared hidden master (`source:{kind:data-model}`) with per-page list controls that default to non-empty, **disjoint** values on the same logical column makes Sigma **AND-compose** both filters against the one master → impossible filter → **zero rows** for the master and therefore every element on every page, silently (no error at build or POST). `control_lint.rb`'s existing three checks all pass — the wiring is correct; the data is empty.

Adds a fourth check `(d)` to the shared lib: detect ≥2 controls on **different pages** whose `filters` target the **same** source element on the **same column (or a textual formula-alias of it**, so the id-duplication workaround is caught) with **non-empty, disjoint** defaults, and hard-fail. It blocks GREEN via `assert-phase6-ran` gate 7 / `post-and-readback` across all 7 converters that vendor the lib. Conservative by construction — fires only on the impossible-filter shape; the common default-all (`values: []`) case is skipped, so near-zero false positives. The remediation message recommends only remedies that exist in this branch (independent per-page masters, or overlapping/default-all defaults — **not** a `--per-page-masters` flag, which doesn't exist here).

## Scope

- Plugin(s) touched: **shared lib** (`shared/lib/control_lint.rb`) fanned out to all 7 vendored copies (looker, microstrategy, powerbi, qlik, quicksight, tableau, thoughtspot) via `tools/sync-shared.rb`; new shared regression test; `refs/control-parity.md` D11 section (7 copies); CI allow-list.
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (17/17)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in

## If this changes a shared lib

- [x] Edited the canonical copy under `shared/` and ran `tools/sync-shared.rb`
- [x] This is a standalone PR (no feature work mixed in)

## e2e (offline, before PR)

- `ruby shared/lib/control_lint.rb <conflict-spec.json>` → exit 1 with the `conflicting cross-page control defaults` violation.
- New `test-conflicting-page-defaults.rb` (7 assertions: conflict fires; id-dup fires via formula-alias; independent masters / overlapping / partial-overlap / single-page / default-all all do NOT fire) → exit 0 from a vendored copy.
- Existing `test-control-lint.rb` → exit 0 (no regression). `tools/check-shared.rb` → exit 0.

⚠️ Note: this lands a new hard-fail on shared infra used by **every** `*-to-sigma` converter — flagged per #485. The logic is deliberately narrow (impossible disjoint per-page defaults against one shared source only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)