### PR TITLE
sigma-authoring: fix dead OpenAPI URL (ICE Bug 2) + worked multi-level grouping example (Suggestion 3)

### DIFF
--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/folders-groupings.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/folders-groupings.md
@@ -50,33 +50,50 @@ Groupings define default group-by behavior on the table element.
 
 **Grouping schema:** `id` (required), `groupBy`? (array of column or folder IDs), `calculations`? (array of calculation column IDs)
 
-### Multiple levels — list each level's OWN dimension only (incremental)
+### Multiple levels — each id appears at most ONCE across all levels
 
-Levels nest hierarchically by array order (outer → inner). **Each level's `groupBy`
-lists only the NEW dimension it adds — never repeat the parent level's dimensions.**
-Sigma collapses every level's `groupBy` into a single flat `GROUP BY` at the
-warehouse (it does not run a separate grouping step per level), so it assembles the
-full combined key from all levels automatically. Repeating a parent dimension in a
-child level references that column twice (once implicitly from the outer level, once
-explicitly here) and fails with **`Duplicate column or folder reference`**.
+Levels nest hierarchically by array order (outer → inner). Sigma collapses every
+level's `groupBy` into a single flat `GROUP BY` at the warehouse (it does not run a
+separate grouping step per level) and assembles the full combined key automatically.
 
-✅ **Correct (incremental — each level adds only its own dimension):**
+**The hard rule (POST-enforced, live-verified): no column or calculation id may
+appear more than once across the whole `groupings` array — in either `groupBy` OR
+`calculations`.** Repeating any id fails the POST with
+**`Duplicate column or folder reference: '<id>'`**. So:
+
+- Each level's `groupBy` lists only the NEW dimension it adds (never repeat a parent
+  level's dimension).
+- Each aggregate in `calculations` is listed on exactly ONE level — typically the
+  innermost — NOT repeated per level. Sigma still applies it across the collapsed
+  `GROUP BY`.
+
+✅ **Correct** — dimensions incremental, the calculation listed once (inner level):
+
+```json
+"groupings": [
+  { "id": "by-region", "groupBy": ["col-region"] },
+  { "id": "by-flag",   "groupBy": ["col-flag"], "calculations": ["col-total"] }
+]
+```
+
+(Listing `calculations` on the outer level instead, or omitting it, also POSTs clean —
+just don't list the same calc on more than one level.)
+
+❌ **Wrong — inner level repeats the outer dimension** → `Duplicate column or folder reference: 'col-region'`:
+
+```json
+"groupings": [
+  { "id": "by-region", "groupBy": ["col-region"] },
+  { "id": "by-flag",   "groupBy": ["col-region", "col-flag"] }
+]
+```
+
+❌ **Also wrong — the same calculation repeated on every level** → `Duplicate column or folder reference: 'col-total'`:
 
 ```json
 "groupings": [
   { "id": "by-region", "groupBy": ["col-region"], "calculations": ["col-total"] },
   { "id": "by-flag",   "groupBy": ["col-flag"],   "calculations": ["col-total"] }
-]
-```
-
-Produces a `region, flag` grouping (Sigma combines the levels).
-
-❌ **Wrong (cumulative — inner level repeats the outer dimension) → `Duplicate column or folder reference`:**
-
-```json
-"groupings": [
-  { "id": "by-region", "groupBy": ["col-region"],            "calculations": ["col-total"] },
-  { "id": "by-flag",   "groupBy": ["col-region", "col-flag"], "calculations": ["col-total"] }
 ]
 ```
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/folders-groupings.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/folders-groupings.md
@@ -50,6 +50,36 @@ Groupings define default group-by behavior on the table element.
 
 **Grouping schema:** `id` (required), `groupBy`? (array of column or folder IDs), `calculations`? (array of calculation column IDs)
 
+### Multiple levels — list each level's OWN dimension only (incremental)
+
+Levels nest hierarchically by array order (outer → inner). **Each level's `groupBy`
+lists only the NEW dimension it adds — never repeat the parent level's dimensions.**
+Sigma collapses every level's `groupBy` into a single flat `GROUP BY` at the
+warehouse (it does not run a separate grouping step per level), so it assembles the
+full combined key from all levels automatically. Repeating a parent dimension in a
+child level references that column twice (once implicitly from the outer level, once
+explicitly here) and fails with **`Duplicate column or folder reference`**.
+
+✅ **Correct (incremental — each level adds only its own dimension):**
+
+```json
+"groupings": [
+  { "id": "by-region", "groupBy": ["col-region"], "calculations": ["col-total"] },
+  { "id": "by-flag",   "groupBy": ["col-flag"],   "calculations": ["col-total"] }
+]
+```
+
+Produces a `region, flag` grouping (Sigma combines the levels).
+
+❌ **Wrong (cumulative — inner level repeats the outer dimension) → `Duplicate column or folder reference`:**
+
+```json
+"groupings": [
+  { "id": "by-region", "groupBy": ["col-region"],            "calculations": ["col-total"] },
+  { "id": "by-flag",   "groupBy": ["col-region", "col-flag"], "calculations": ["col-total"] }
+]
+```
+
 ## Column order
 
 The `order` array sets the display sequence of columns and folders. Items not listed appear after the listed ones. Summary columns are excluded from `order`.

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/validate.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/validate.md
@@ -21,7 +21,7 @@ Run through this before every `POST /v2/dataModels/spec` and `PUT /v2/dataModels
 
 | Error | Likely cause |
 |---|---|
-| `400 Invalid argument` / `unknown field` / `unexpected property` | Schema drift between this skill and the live API. Fetch the OpenAPI (`https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`) and diff field names. |
+| `400 Invalid argument` / `unknown field` / `unexpected property` | Schema drift between this skill and the live API. Fetch the data-model spec OpenAPI (`https://help.sigmacomputing.com/openapi/code-representation.json` — the `/v2/dataModels/spec` request body) and diff field names. (The `help.sigmacomputing.com/openapi.json` index lists this alongside `sigma-rest-api.json`; the old `sigma-computing-public-rest-api.json` path now 404s.) |
 | `400 Invalid column reference` | Bare `[col]` used where `[TABLE/col]` was needed, or the column name is misspelled. |
 | `400 Invalid element ID` (in relationships) | An UPDATE that mixes external and internal IDs. The existing element ID must come from `GET`. |
 | `403 Forbidden` | Credential lacks "Create, edit, and publish data models" permission, or "Can edit" on the destination folder. Ask your Sigma admin. |

--- a/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
@@ -30,9 +30,9 @@ Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi
 **Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
 - **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
-- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, served as a content-addressed Fern docs asset (the sanctioned reference for now):
   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+  Good for offline `jq` navigation. Caveats: it may **lag** the live API slightly (it's refreshed out-of-band — manually today, moving to an automated refresh + a dedicated reliably-hosted asset that will also back the CLI), and the hash pins a build so the path can change on a docs redeploy. So treat a **live workbook readback** (above) as the always-current source, and if this asset 404s, rediscover the current link from the Sigma API reference docs. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
 
 When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
@@ -23,8 +23,9 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 ## Sources of truth
 
 1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
 
 Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
 
@@ -33,7 +34,8 @@ Everything in this skill is commentary, style guidance, and recipes layered on t
 The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
 
 ```bash
-curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+# ^ content-addressed docs asset (see "Sources of truth"); if it 404s, use the current link from the Sigma API reference docs, or read a live workbook spec (GET /v2/workbooks/{id}/spec) and navigate pages[].elements[] by kind.
 
 # The entire workbook spec request body lives under one path (it is not split into named schemas):
 jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json

--- a/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
@@ -22,16 +22,23 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 
 ## Sources of truth
 
-1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
+Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi.json` that lists two **canonical split specs** (split from one large spec to fix compilation / out-of-memory errors — so the structure changed subtly):
 
-Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+1. **`https://help.sigmacomputing.com/openapi/openapi/sigma-rest-api.json`** — the REST API: endpoint request/response shapes (workbooks, data models, members, connections, exports, materialization, …). Use for API *calls*.
+2. **`https://help.sigmacomputing.com/openapi/openapi/code-representation.json`** — the "code representation" (as-code) spec. Today it documents the **data-model** spec (`/v2/dataModels/spec`); use it for data-model element shapes.
 
-## Consulting the OpenAPI
+**Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
-The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+- **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+  `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+
+When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
+
+## Consulting the shapes (compiled OpenAPI or a live readback)
+
+**The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the full compiled spec (the Fern asset in *Sources of truth*) or a live workbook readback. Fetch the compiled spec once per session and inspect with `jq`:
 
 ```bash
 curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
@@ -56,6 +63,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 ```
 
 `WebFetch` works for the JSON too. Either path is fine.
+
+**Or navigate a live workbook readback** (durable, when the compiled asset is unavailable) — same `kind` discriminator, just walk the elements directly:
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" "$SIGMA_BASE_URL/v2/workbooks/<id>/spec" > /tmp/wb.json
+# list the kinds a real workbook uses; inspect one element's full shape:
+jq -r '[.. | objects | select(.kind) | .kind] | unique[]' /tmp/wb.json
+jq 'first(.. | objects | select(.kind=="bar-chart"))' /tmp/wb.json
+```
+(`wb-rep.rb capabilities --workbook <id>` does the same enumeration in pure Ruby — no `jq` needed.)
 
 No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
 ships a `capabilities` subcommand that does the same three queries with

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -16,8 +16,9 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 ## Sources of truth
 
 1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
 
 Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
 
@@ -26,7 +27,8 @@ Everything in this skill is commentary, style guidance, and recipes layered on t
 The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
 
 ```bash
-curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+# ^ content-addressed docs asset (see "Sources of truth"); if it 404s, use the current link from the Sigma API reference docs, or read a live workbook spec (GET /v2/workbooks/{id}/spec) and navigate pages[].elements[] by kind.
 
 # The entire workbook spec request body lives under one path (it is not split into named schemas):
 jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -15,16 +15,23 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 
 ## Sources of truth
 
-1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
+Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi.json` that lists two **canonical split specs** (split from one large spec to fix compilation / out-of-memory errors — so the structure changed subtly):
 
-Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+1. **`https://help.sigmacomputing.com/openapi/openapi/sigma-rest-api.json`** — the REST API: endpoint request/response shapes (workbooks, data models, members, connections, exports, materialization, …). Use for API *calls*.
+2. **`https://help.sigmacomputing.com/openapi/openapi/code-representation.json`** — the "code representation" (as-code) spec. Today it documents the **data-model** spec (`/v2/dataModels/spec`); use it for data-model element shapes.
 
-## Consulting the OpenAPI
+**Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
-The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+- **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+  `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+
+When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
+
+## Consulting the shapes (compiled OpenAPI or a live readback)
+
+**The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the full compiled spec (the Fern asset in *Sources of truth*) or a live workbook readback. Fetch the compiled spec once per session and inspect with `jq`:
 
 ```bash
 curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
@@ -49,6 +56,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 ```
 
 `WebFetch` works for the JSON too. Either path is fine.
+
+**Or navigate a live workbook readback** (durable, when the compiled asset is unavailable) — same `kind` discriminator, just walk the elements directly:
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" "$SIGMA_BASE_URL/v2/workbooks/<id>/spec" > /tmp/wb.json
+# list the kinds a real workbook uses; inspect one element's full shape:
+jq -r '[.. | objects | select(.kind) | .kind] | unique[]' /tmp/wb.json
+jq 'first(.. | objects | select(.kind=="bar-chart"))' /tmp/wb.json
+```
+(`wb-rep.rb capabilities --workbook <id>` does the same enumeration in pure Ruby — no `jq` needed.)
 
 No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
 ships a `capabilities` subcommand that does the same three queries with

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -23,9 +23,9 @@ Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi
 **Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
 - **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
-- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, served as a content-addressed Fern docs asset (the sanctioned reference for now):
   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+  Good for offline `jq` navigation. Caveats: it may **lag** the live API slightly (it's refreshed out-of-band — manually today, moving to an automated refresh + a dedicated reliably-hosted asset that will also back the CLI), and the hash pins a build so the path can change on a docs redeploy. So treat a **live workbook readback** (above) as the always-current source, and if this asset 404s, rediscover the current link from the Sigma API reference docs. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
 
 When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
@@ -16,8 +16,9 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 ## Sources of truth
 
 1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
 
 Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
 
@@ -26,7 +27,8 @@ Everything in this skill is commentary, style guidance, and recipes layered on t
 The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
 
 ```bash
-curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+# ^ content-addressed docs asset (see "Sources of truth"); if it 404s, use the current link from the Sigma API reference docs, or read a live workbook spec (GET /v2/workbooks/{id}/spec) and navigate pages[].elements[] by kind.
 
 # The entire workbook spec request body lives under one path (it is not split into named schemas):
 jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
@@ -15,16 +15,23 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 
 ## Sources of truth
 
-1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
+Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi.json` that lists two **canonical split specs** (split from one large spec to fix compilation / out-of-memory errors — so the structure changed subtly):
 
-Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+1. **`https://help.sigmacomputing.com/openapi/openapi/sigma-rest-api.json`** — the REST API: endpoint request/response shapes (workbooks, data models, members, connections, exports, materialization, …). Use for API *calls*.
+2. **`https://help.sigmacomputing.com/openapi/openapi/code-representation.json`** — the "code representation" (as-code) spec. Today it documents the **data-model** spec (`/v2/dataModels/spec`); use it for data-model element shapes.
 
-## Consulting the OpenAPI
+**Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
-The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+- **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+  `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+
+When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
+
+## Consulting the shapes (compiled OpenAPI or a live readback)
+
+**The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the full compiled spec (the Fern asset in *Sources of truth*) or a live workbook readback. Fetch the compiled spec once per session and inspect with `jq`:
 
 ```bash
 curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
@@ -49,6 +56,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 ```
 
 `WebFetch` works for the JSON too. Either path is fine.
+
+**Or navigate a live workbook readback** (durable, when the compiled asset is unavailable) — same `kind` discriminator, just walk the elements directly:
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" "$SIGMA_BASE_URL/v2/workbooks/<id>/spec" > /tmp/wb.json
+# list the kinds a real workbook uses; inspect one element's full shape:
+jq -r '[.. | objects | select(.kind) | .kind] | unique[]' /tmp/wb.json
+jq 'first(.. | objects | select(.kind=="bar-chart"))' /tmp/wb.json
+```
+(`wb-rep.rb capabilities --workbook <id>` does the same enumeration in pure Ruby — no `jq` needed.)
 
 No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
 ships a `capabilities` subcommand that does the same three queries with

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
@@ -23,9 +23,9 @@ Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi
 **Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
 - **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
-- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, served as a content-addressed Fern docs asset (the sanctioned reference for now):
   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+  Good for offline `jq` navigation. Caveats: it may **lag** the live API slightly (it's refreshed out-of-band — manually today, moving to an automated refresh + a dedicated reliably-hosted asset that will also back the CLI), and the hash pins a build so the path can change on a docs redeploy. So treat a **live workbook readback** (above) as the always-current source, and if this asset 404s, rediscover the current link from the Sigma API reference docs. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
 
 When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -16,8 +16,9 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 ## Sources of truth
 
 1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
 
 Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
 
@@ -26,7 +27,8 @@ Everything in this skill is commentary, style guidance, and recipes layered on t
 The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
 
 ```bash
-curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+# ^ content-addressed docs asset (see "Sources of truth"); if it 404s, use the current link from the Sigma API reference docs, or read a live workbook spec (GET /v2/workbooks/{id}/spec) and navigate pages[].elements[] by kind.
 
 # The entire workbook spec request body lives under one path (it is not split into named schemas):
 jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -15,16 +15,23 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 
 ## Sources of truth
 
-1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
+Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi.json` that lists two **canonical split specs** (split from one large spec to fix compilation / out-of-memory errors — so the structure changed subtly):
 
-Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+1. **`https://help.sigmacomputing.com/openapi/openapi/sigma-rest-api.json`** — the REST API: endpoint request/response shapes (workbooks, data models, members, connections, exports, materialization, …). Use for API *calls*.
+2. **`https://help.sigmacomputing.com/openapi/openapi/code-representation.json`** — the "code representation" (as-code) spec. Today it documents the **data-model** spec (`/v2/dataModels/spec`); use it for data-model element shapes.
 
-## Consulting the OpenAPI
+**Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
-The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+- **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+  `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+
+When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
+
+## Consulting the shapes (compiled OpenAPI or a live readback)
+
+**The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the full compiled spec (the Fern asset in *Sources of truth*) or a live workbook readback. Fetch the compiled spec once per session and inspect with `jq`:
 
 ```bash
 curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
@@ -49,6 +56,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 ```
 
 `WebFetch` works for the JSON too. Either path is fine.
+
+**Or navigate a live workbook readback** (durable, when the compiled asset is unavailable) — same `kind` discriminator, just walk the elements directly:
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" "$SIGMA_BASE_URL/v2/workbooks/<id>/spec" > /tmp/wb.json
+# list the kinds a real workbook uses; inspect one element's full shape:
+jq -r '[.. | objects | select(.kind) | .kind] | unique[]' /tmp/wb.json
+jq 'first(.. | objects | select(.kind=="bar-chart"))' /tmp/wb.json
+```
+(`wb-rep.rb capabilities --workbook <id>` does the same enumeration in pure Ruby — no `jq` needed.)
 
 No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
 ships a `capabilities` subcommand that does the same three queries with

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -23,9 +23,9 @@ Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi
 **Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
 - **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
-- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, served as a content-addressed Fern docs asset (the sanctioned reference for now):
   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+  Good for offline `jq` navigation. Caveats: it may **lag** the live API slightly (it's refreshed out-of-band — manually today, moving to an automated refresh + a dedicated reliably-hosted asset that will also back the CLI), and the hash pins a build so the path can change on a docs redeploy. So treat a **live workbook readback** (above) as the always-current source, and if this asset 404s, rediscover the current link from the Sigma API reference docs. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
 
 When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -20,16 +20,23 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 
 ## Sources of truth
 
-1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
+Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi.json` that lists two **canonical split specs** (split from one large spec to fix compilation / out-of-memory errors — so the structure changed subtly):
 
-Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+1. **`https://help.sigmacomputing.com/openapi/openapi/sigma-rest-api.json`** — the REST API: endpoint request/response shapes (workbooks, data models, members, connections, exports, materialization, …). Use for API *calls*.
+2. **`https://help.sigmacomputing.com/openapi/openapi/code-representation.json`** — the "code representation" (as-code) spec. Today it documents the **data-model** spec (`/v2/dataModels/spec`); use it for data-model element shapes.
 
-## Consulting the OpenAPI
+**Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
-The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+- **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+  `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+
+When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
+
+## Consulting the shapes (compiled OpenAPI or a live readback)
+
+**The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the full compiled spec (the Fern asset in *Sources of truth*) or a live workbook readback. Fetch the compiled spec once per session and inspect with `jq`:
 
 ```bash
 curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
@@ -54,6 +61,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 ```
 
 `WebFetch` works for the JSON too. Either path is fine.
+
+**Or navigate a live workbook readback** (durable, when the compiled asset is unavailable) — same `kind` discriminator, just walk the elements directly:
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" "$SIGMA_BASE_URL/v2/workbooks/<id>/spec" > /tmp/wb.json
+# list the kinds a real workbook uses; inspect one element's full shape:
+jq -r '[.. | objects | select(.kind) | .kind] | unique[]' /tmp/wb.json
+jq 'first(.. | objects | select(.kind=="bar-chart"))' /tmp/wb.json
+```
+(`wb-rep.rb capabilities --workbook <id>` does the same enumeration in pure Ruby — no `jq` needed.)
 
 No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
 ships a `capabilities` subcommand that does the same three queries with

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -21,8 +21,9 @@ The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pag
 ## Sources of truth
 
 1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
-   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
-2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
+   This is the full REST spec including the `/v2/workbooks/spec` request body with every element/control/format shape inlined by `kind`. **It is a content-addressed docs asset** (the hash in the path pins one docs build), so it can rotate when Sigma redeploys docs. If it 404s: the `help.sigmacomputing.com/openapi.json` index now only lists `sigma-rest-api.json` (REST endpoints, NO workbook-spec shapes) and `code-representation.json` (`/v2/dataModels/spec` only) — neither carries the workbook element shapes — so grab the current full-spec asset link from the Sigma API reference docs, and until then use source 2 (a live workbook readback), which is always current for element shapes.
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`. This is the always-current source for element/control/format shapes; when the OpenAPI asset above is unreachable, read a real workbook and navigate its `pages[].elements[]` by `kind`.
 
 Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
 
@@ -31,7 +32,8 @@ Everything in this skill is commentary, style guidance, and recipes layered on t
 The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
 
 ```bash
-curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+curl -sf https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+# ^ content-addressed docs asset (see "Sources of truth"); if it 404s, use the current link from the Sigma API reference docs, or read a live workbook spec (GET /v2/workbooks/{id}/spec) and navigate pages[].elements[] by kind.
 
 # The entire workbook spec request body lives under one path (it is not split into named schemas):
 jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -28,9 +28,9 @@ Sigma's public API docs are an index at `https://help.sigmacomputing.com/openapi
 **Workbook element/control/format shapes** (the `bar-chart` / `kpi-chart` / `control` / format `kind`s that go under `/v2/workbooks/spec`) are **not inlined in either split spec** — get them from one of:
 
 - **A live workbook readback** — `GET /v2/workbooks/{id}/spec` on the user's org. The durable, always-current source: read a real workbook and navigate `pages[].elements[]` by `kind`. **Prefer this.**
-- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, currently served as a content-addressed Fern docs asset:
+- **The full compiled OpenAPI** — one spec that *does* inline every workbook `kind`, served as a content-addressed Fern docs asset (the sanctioned reference for now):
   `https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json`
-  Handy for offline `jq` navigation, but **transitional** — the hash pins one docs build (rotates on redeploy), and Sigma is moving this to a dedicated, reliably-hosted asset. If it 404s, rediscover the current link from the Sigma API reference docs or fall back to a live readback. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
+  Good for offline `jq` navigation. Caveats: it may **lag** the live API slightly (it's refreshed out-of-band — manually today, moving to an automated refresh + a dedicated reliably-hosted asset that will also back the CLI), and the hash pins a build so the path can change on a docs redeploy. So treat a **live workbook readback** (above) as the always-current source, and if this asset 404s, rediscover the current link from the Sigma API reference docs. (The retired `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` path now 404s.)
 
 When this skill and the spec (or a live readback) disagree, the spec wins. When a feature isn't covered here, consult the spec / a live workbook and use what it documents.
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
@@ -402,7 +402,14 @@ def cmd_summarize(args)
 end
 
 OPENAPI_CACHE = File.join(Dir.tmpdir, 'sigma-api.json').freeze
-OPENAPI_URL = 'https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json'.freeze
+# Full REST spec (incl. /v2/workbooks/spec element/control/format shapes inlined
+# by `kind`). Content-addressed docs asset — the hash pins one docs build and can
+# rotate on redeploy. If `capabilities` fails to fetch it, grab the current link
+# from the Sigma API reference docs (the public help.sigmacomputing.com/openapi.json
+# index no longer lists the workbook-spec shapes), or read a live workbook spec
+# (`wb-rep.rb pull` / GET /v2/workbooks/{id}/spec) and navigate pages[].elements[]
+# by `kind`. See sigma-workbooks SKILL.md "Sources of truth".
+OPENAPI_URL = 'https://files.buildwithfern.com/sigma.docs.buildwithfern.com/006ce360082503c7b849529b4c183cc4dc63360aff76038ca64669572c662b87/assets/openapi/sigma-computing-public-rest-api.json'.freeze
 
 # Depth-first walk mirroring jq's `.. | objects`: yields every Hash reachable
 # from `node` (including `node` itself), descending through both Hash values

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
@@ -462,9 +462,33 @@ def find_field_schema(kind_schema, field)
 end
 
 def cmd_capabilities(args)
-  kind = field = nil
+  kind = field = wb = nil
   if (i = args.index('--kind')) then kind = args[i + 1]; args.slice!(i, 2); end
   if (i = args.index('--field')) then field = args[i + 1]; args.slice!(i, 2); end
+  if (i = args.index('--workbook')) then wb = args[i + 1]; args.slice!(i, 2); end
+
+  # --workbook <id>: enumerate kinds/fields from a LIVE workbook readback — the
+  # durable source for workbook element/control/format shapes (the split public
+  # specs don't inline them; the compiled OpenAPI asset is transitional). Selects
+  # on each object's instance `kind`, not an OpenAPI properties.kind.enum schema.
+  if wb
+    spec = YAML.load(api(:get, "/v2/workbooks/#{wb}/spec"))
+    die "workbook #{wb} spec has no pages" unless spec.is_a?(Hash) && spec['pages']
+    if kind.nil?
+      walk_objects(spec).map { |o| o['kind'] }.select { |k| k.is_a?(String) && !k.empty? }.uniq.sort.each { |k| puts k }
+    else
+      matches = walk_objects(spec).select { |o| o['kind'] == kind }
+      die "no element/source/control with kind #{kind.inspect} in workbook #{wb}" if matches.empty?
+      if field.nil?
+        matches.flat_map(&:keys).uniq.sort.each { |k| puts k }
+      else
+        sample = matches.map { |m| m[field] }.compact.first
+        puts sample.nil? ? 'null' : JSON.pretty_generate(sample)
+      end
+    end
+    return
+  end
+
   unless File.exist?(OPENAPI_CACHE)
     uri = URI(OPENAPI_URL)
     res = Net::HTTP.get_response(uri)


### PR DESCRIPTION
## What & why

Two items from the ICE migration feedback (customer-anonymized), both in the `sigma-authoring` plugin.

### Bug 2 — documented OpenAPI fetch URL 404s (blocks the skill's step 1)

The hardcoded `help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json` returns **404**. Sigma split its public API docs (to fix compilation / OOM errors) into an index at `help.sigmacomputing.com/openapi.json` listing two canonical specs:
- `openapi/openapi/sigma-rest-api.json` — REST endpoints
- `openapi/openapi/code-representation.json` — as-code spec; today `/v2/dataModels/spec`

**Verified:** neither split spec inlines the workbook-spec element/control/format `kind` shapes (1,555 `kind`-enum objects in the old spec, **0** in both splits; `/v2/workbooks/spec` absent). The full all-in-one spec that *does* inline them remains available as a transitional content-addressed Fern asset (moving to a dedicated reliably-hosted CLI asset per web-infra).

Fix:
- **`sigma-workbooks/SKILL.md`** — rewrite "Sources of truth" to the split-spec model: the index + what each split covers; workbook element shapes come from a **live workbook readback** (durable, preferred) or the compiled Fern asset (transitional). jq examples work against either; added a live-readback navigation example.
- **`sigma-workbooks/scripts/wb-rep.rb`** — `OPENAPI_URL` → compiled asset (still has the kinds); **new `capabilities --workbook <id>`** enumerates kinds/fields from a live readback (durable, no jq, no dependence on the transitional asset). Both modes **live-verified**.
- **`sigma-data-models/reference/workflows/validate.md`** — DM schema-drift diffs → `code-representation.json` (the split DM spec).
- Regenerated `sigma-workbooks` agent variants.

### Suggestion 3 — no worked multi-level grouping example

`folders-groupings.md`: added a **multi-level** worked example — each level's `groupBy` lists only its own new dimension (incremental); Sigma collapses all levels into one flat warehouse `GROUP BY`; repeating a parent dimension in a child level fails with **`Duplicate column or folder reference`**. Both correct and failing shapes shown.

## Scope & verification

- One plugin (`sigma-authoring`); no shared-lib change. `check-shared` / `lint-skills` / `check-agent-variants` / `corpus --check` all green.
- Live: `wb-rep.rb capabilities` (compiled asset) and `capabilities --workbook <id>` (live readback) both fetch and enumerate kinds + per-kind fields.

## Note for Sigma web-infra

The split `code-representation.json` currently documents only `/v2/dataModels/spec` — the **workbook** spec shapes aren't in either split spec yet. This PR routes around that (live readback + transitional compiled asset); if/when workbooks-as-code lands in `code-representation.json`, the skill can point there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)