### PR TITLE
shared: metric-binding helper — bind workbook measures to governed DM metrics (7bun.1)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -260,6 +260,7 @@ jobs:
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-trellis-emit.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-qs-trellis.rb
+            shared/lib/test_metric_binding.rb
           )
           fail=0
           for t in "${tests[@]}"; do
@@ -291,6 +292,7 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_look_migration.py
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_metric_reference.py
+            shared/lib/test_metric_binding.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/metric_binding.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""metric_binding.py — bind a workbook measure to a governed DM metric.
+
+Every converter builds a Sigma data model whose elements carry reusable metrics
+(name + formula), but the workbook builder tends to re-derive each measure inline
+(``Sum([Master/Net Revenue])``, ``CountDistinct(...)``, ...), bypassing the
+governed metric: the aggregation logic is duplicated (and can drift) and the
+analyst never gets the metric object. This module is the thin, converter-agnostic
+binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
+is provably the same aggregation — and fall back to the inline formula otherwise.
+
+Two pure functions, stdlib only:
+
+- ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on
+  an element: its own metrics plus those it inherits through the ``source.elementId``
+  chain (a denorm "<X> View" element carries 0 own metrics but inherits its base
+  fact's; Sigma exposes them and they resolve as ``[Metrics/<name>]`` on the denorm
+  — verified live). Deduped by name, nearest element wins. Each metric is
+  ``{"name", "formula"}``; entries missing either field are skipped.
+
+- ``metric_ref_or_inline(inline, master_name, metrics)`` — returns
+  ``[Metrics/<name>]`` when ``inline`` matches a metric by FORMULA EQUIVALENCE
+  (strip the master prefix so ``Sum([Data/Net Revenue])`` equals a metric's
+  ``Sum([Net Revenue])``, then compare ignoring whitespace), else returns ``inline``
+  unchanged. Naming-independent and SAFE: ratios / filtered / custom / no-match /
+  empty-metrics all fall through to the inline formula, so passing no metrics is
+  byte-identical to the pre-binding behavior. Whether a given column is even a
+  measure (worth binding) is the caller's decision — only call this for measures.
+
+The reference form is the literal namespace ``[Metrics/<Metric Name>]`` — NOT
+``[Element/Name]`` (that errors). Extracted from the looker reference implementation
+(PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.rb — keep the
+two in lockstep.
+"""
+import re
+
+_WS = re.compile(r"\s+")
+
+
+def canon(formula):
+    """Whitespace-insensitive canonical form of a Sigma formula (or empty)."""
+    return _WS.sub("", formula or "")
+
+
+def available_metrics(element_id, elements_by_id):
+    """Metrics referenceable on ``element_id`` = its own metrics + those inherited
+    through the ``source.elementId`` chain, deduped by name (nearest element wins).
+
+    ``elements_by_id`` maps an element id to its dict (each with an optional
+    ``metrics`` list and ``source.elementId``). Returns a list of
+    ``{"name", "formula"}`` dicts; metrics missing a name or formula are dropped.
+    Cycle-safe."""
+    seen, chain = set(), []
+    eid = element_id
+    while eid and eid not in seen:
+        seen.add(eid)
+        el = elements_by_id.get(eid)
+        if not el:
+            break
+        for m in (el.get("metrics") or []):
+            name, formula = m.get("name"), m.get("formula")
+            if name and formula:
+                chain.append({"name": name, "formula": formula})
+        eid = (el.get("source") or {}).get("elementId")
+    return _dedup_by_name(chain)
+
+
+def _dedup_by_name(metrics):
+    seen, out = set(), []
+    for m in metrics:
+        if m["name"] not in seen:
+            seen.add(m["name"])
+            out.append(m)
+    return out
+
+
+def metric_ref_or_inline(inline, master_name, metrics):
+    """Prefer ``[Metrics/<name>]`` when ``inline`` matches a metric by formula
+    equivalence (master prefix stripped, whitespace ignored); otherwise return
+    ``inline`` unchanged. Safe no-op when ``metrics`` is empty or ``inline`` is not
+    a string. See the module docstring."""
+    if not isinstance(inline, str) or not metrics:
+        return inline
+    want = canon(inline.replace(f"[{master_name}/", "["))
+    for m in metrics:
+        name, formula = m.get("name"), m.get("formula")
+        if name and formula and canon(formula) == want:
+            return f"[Metrics/{name}]"
+    return inline

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/metric_binding.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""metric_binding.py — bind a workbook measure to a governed DM metric.
+
+Every converter builds a Sigma data model whose elements carry reusable metrics
+(name + formula), but the workbook builder tends to re-derive each measure inline
+(``Sum([Master/Net Revenue])``, ``CountDistinct(...)``, ...), bypassing the
+governed metric: the aggregation logic is duplicated (and can drift) and the
+analyst never gets the metric object. This module is the thin, converter-agnostic
+binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
+is provably the same aggregation — and fall back to the inline formula otherwise.
+
+Two pure functions, stdlib only:
+
+- ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on
+  an element: its own metrics plus those it inherits through the ``source.elementId``
+  chain (a denorm "<X> View" element carries 0 own metrics but inherits its base
+  fact's; Sigma exposes them and they resolve as ``[Metrics/<name>]`` on the denorm
+  — verified live). Deduped by name, nearest element wins. Each metric is
+  ``{"name", "formula"}``; entries missing either field are skipped.
+
+- ``metric_ref_or_inline(inline, master_name, metrics)`` — returns
+  ``[Metrics/<name>]`` when ``inline`` matches a metric by FORMULA EQUIVALENCE
+  (strip the master prefix so ``Sum([Data/Net Revenue])`` equals a metric's
+  ``Sum([Net Revenue])``, then compare ignoring whitespace), else returns ``inline``
+  unchanged. Naming-independent and SAFE: ratios / filtered / custom / no-match /
+  empty-metrics all fall through to the inline formula, so passing no metrics is
+  byte-identical to the pre-binding behavior. Whether a given column is even a
+  measure (worth binding) is the caller's decision — only call this for measures.
+
+The reference form is the literal namespace ``[Metrics/<Metric Name>]`` — NOT
+``[Element/Name]`` (that errors). Extracted from the looker reference implementation
+(PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.rb — keep the
+two in lockstep.
+"""
+import re
+
+_WS = re.compile(r"\s+")
+
+
+def canon(formula):
+    """Whitespace-insensitive canonical form of a Sigma formula (or empty)."""
+    return _WS.sub("", formula or "")
+
+
+def available_metrics(element_id, elements_by_id):
+    """Metrics referenceable on ``element_id`` = its own metrics + those inherited
+    through the ``source.elementId`` chain, deduped by name (nearest element wins).
+
+    ``elements_by_id`` maps an element id to its dict (each with an optional
+    ``metrics`` list and ``source.elementId``). Returns a list of
+    ``{"name", "formula"}`` dicts; metrics missing a name or formula are dropped.
+    Cycle-safe."""
+    seen, chain = set(), []
+    eid = element_id
+    while eid and eid not in seen:
+        seen.add(eid)
+        el = elements_by_id.get(eid)
+        if not el:
+            break
+        for m in (el.get("metrics") or []):
+            name, formula = m.get("name"), m.get("formula")
+            if name and formula:
+                chain.append({"name": name, "formula": formula})
+        eid = (el.get("source") or {}).get("elementId")
+    return _dedup_by_name(chain)
+
+
+def _dedup_by_name(metrics):
+    seen, out = set(), []
+    for m in metrics:
+        if m["name"] not in seen:
+            seen.add(m["name"])
+            out.append(m)
+    return out
+
+
+def metric_ref_or_inline(inline, master_name, metrics):
+    """Prefer ``[Metrics/<name>]`` when ``inline`` matches a metric by formula
+    equivalence (master prefix stripped, whitespace ignored); otherwise return
+    ``inline`` unchanged. Safe no-op when ``metrics`` is empty or ``inline`` is not
+    a string. See the module docstring."""
+    if not isinstance(inline, str) or not metrics:
+        return inline
+    want = canon(inline.replace(f"[{master_name}/", "["))
+    for m in metrics:
+        name, formula = m.get("name"), m.get("formula")
+        if name and formula and canon(formula) == want:
+            return f"[Metrics/{name}]"
+    return inline

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/metric_binding.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""metric_binding.py — bind a workbook measure to a governed DM metric.
+
+Every converter builds a Sigma data model whose elements carry reusable metrics
+(name + formula), but the workbook builder tends to re-derive each measure inline
+(``Sum([Master/Net Revenue])``, ``CountDistinct(...)``, ...), bypassing the
+governed metric: the aggregation logic is duplicated (and can drift) and the
+analyst never gets the metric object. This module is the thin, converter-agnostic
+binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
+is provably the same aggregation — and fall back to the inline formula otherwise.
+
+Two pure functions, stdlib only:
+
+- ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on
+  an element: its own metrics plus those it inherits through the ``source.elementId``
+  chain (a denorm "<X> View" element carries 0 own metrics but inherits its base
+  fact's; Sigma exposes them and they resolve as ``[Metrics/<name>]`` on the denorm
+  — verified live). Deduped by name, nearest element wins. Each metric is
+  ``{"name", "formula"}``; entries missing either field are skipped.
+
+- ``metric_ref_or_inline(inline, master_name, metrics)`` — returns
+  ``[Metrics/<name>]`` when ``inline`` matches a metric by FORMULA EQUIVALENCE
+  (strip the master prefix so ``Sum([Data/Net Revenue])`` equals a metric's
+  ``Sum([Net Revenue])``, then compare ignoring whitespace), else returns ``inline``
+  unchanged. Naming-independent and SAFE: ratios / filtered / custom / no-match /
+  empty-metrics all fall through to the inline formula, so passing no metrics is
+  byte-identical to the pre-binding behavior. Whether a given column is even a
+  measure (worth binding) is the caller's decision — only call this for measures.
+
+The reference form is the literal namespace ``[Metrics/<Metric Name>]`` — NOT
+``[Element/Name]`` (that errors). Extracted from the looker reference implementation
+(PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.rb — keep the
+two in lockstep.
+"""
+import re
+
+_WS = re.compile(r"\s+")
+
+
+def canon(formula):
+    """Whitespace-insensitive canonical form of a Sigma formula (or empty)."""
+    return _WS.sub("", formula or "")
+
+
+def available_metrics(element_id, elements_by_id):
+    """Metrics referenceable on ``element_id`` = its own metrics + those inherited
+    through the ``source.elementId`` chain, deduped by name (nearest element wins).
+
+    ``elements_by_id`` maps an element id to its dict (each with an optional
+    ``metrics`` list and ``source.elementId``). Returns a list of
+    ``{"name", "formula"}`` dicts; metrics missing a name or formula are dropped.
+    Cycle-safe."""
+    seen, chain = set(), []
+    eid = element_id
+    while eid and eid not in seen:
+        seen.add(eid)
+        el = elements_by_id.get(eid)
+        if not el:
+            break
+        for m in (el.get("metrics") or []):
+            name, formula = m.get("name"), m.get("formula")
+            if name and formula:
+                chain.append({"name": name, "formula": formula})
+        eid = (el.get("source") or {}).get("elementId")
+    return _dedup_by_name(chain)
+
+
+def _dedup_by_name(metrics):
+    seen, out = set(), []
+    for m in metrics:
+        if m["name"] not in seen:
+            seen.add(m["name"])
+            out.append(m)
+    return out
+
+
+def metric_ref_or_inline(inline, master_name, metrics):
+    """Prefer ``[Metrics/<name>]`` when ``inline`` matches a metric by formula
+    equivalence (master prefix stripped, whitespace ignored); otherwise return
+    ``inline`` unchanged. Safe no-op when ``metrics`` is empty or ``inline`` is not
+    a string. See the module docstring."""
+    if not isinstance(inline, str) or not metrics:
+        return inline
+    want = canon(inline.replace(f"[{master_name}/", "["))
+    for m in metrics:
+        name, formula = m.get("name"), m.get("formula")
+        if name and formula and canon(formula) == want:
+            return f"[Metrics/{name}]"
+    return inline

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/metric_binding.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/metric_binding.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+#
+# metric_binding.rb — bind a workbook measure to a governed DM metric.
+#
+# Every converter builds a Sigma data model whose elements carry reusable metrics
+# (name + formula), but the workbook builder tends to re-derive each measure inline
+# (Sum([Master/Net Revenue]), CountDistinct(...), ...), bypassing the governed
+# metric: the aggregation logic is duplicated (and can drift) and the analyst never
+# gets the metric object. This is the thin, converter-agnostic binder that lets a
+# builder prefer a governed [Metrics/<name>] reference when it is provably the same
+# aggregation — and fall back to the inline formula otherwise.
+#
+# Two pure functions:
+#
+# - available_metrics(element_id, elements_by_id) — the metrics REFERENCEABLE on an
+#   element: its own metrics plus those inherited through the source.elementId chain
+#   (a denorm "<X> View" element carries 0 own metrics but inherits its base fact's;
+#   Sigma exposes them and they resolve as [Metrics/<name>] on the denorm — verified
+#   live). Deduped by name, nearest element wins. Each metric is {"name","formula"};
+#   entries missing either field are skipped.
+#
+# - metric_ref_or_inline(inline, master_name, metrics) — returns "[Metrics/<name>]"
+#   when `inline` matches a metric by FORMULA EQUIVALENCE (strip the master prefix so
+#   Sum([Data/Net Revenue]) equals a metric's Sum([Net Revenue]), then compare
+#   ignoring whitespace), else returns `inline` unchanged. Naming-independent and
+#   SAFE: ratios / filtered / custom / no-match / empty-metrics all fall through to
+#   inline, so passing no metrics is byte-identical to the pre-binding behavior.
+#   Whether a column is even a measure (worth binding) is the caller's decision.
+#
+# The reference form is the literal namespace [Metrics/<Metric Name>] — NOT
+# [Element/Name] (that errors). Extracted from the looker reference implementation
+# (PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.py — keep the
+# two in lockstep.
+
+module MetricBinding
+  module_function
+
+  # Whitespace-insensitive canonical form of a Sigma formula (or empty).
+  def canon(formula)
+    (formula || '').gsub(/\s+/, '')
+  end
+
+  # Metrics referenceable on element_id = own + inherited via source.elementId,
+  # deduped by name (nearest element wins). elements_by_id maps id => element hash
+  # (string keys, as JSON.parse produces). Returns an array of
+  # {"name"=>, "formula"=>}; metrics missing a name or formula are dropped.
+  # Cycle-safe.
+  def available_metrics(element_id, elements_by_id)
+    seen = {}
+    chain = []
+    eid = element_id
+    while eid && !seen[eid]
+      seen[eid] = true
+      el = elements_by_id[eid]
+      break unless el
+
+      (el['metrics'] || []).each do |m|
+        name = m['name']
+        formula = m['formula']
+        chain << { 'name' => name, 'formula' => formula } if name && formula
+      end
+      eid = (el['source'] || {})['elementId']
+    end
+    dedup_by_name(chain)
+  end
+
+  def dedup_by_name(metrics)
+    seen = {}
+    metrics.each_with_object([]) do |m, out|
+      next if seen[m['name']]
+
+      seen[m['name']] = true
+      out << m
+    end
+  end
+
+  # Prefer "[Metrics/<name>]" when `inline` matches a metric by formula equivalence
+  # (master prefix stripped, whitespace ignored); otherwise return `inline`
+  # unchanged. Safe no-op when `metrics` is empty/nil or `inline` is not a String.
+  def metric_ref_or_inline(inline, master_name, metrics)
+    return inline unless inline.is_a?(String) && metrics && !metrics.empty?
+
+    # gsub with a String pattern strips EVERY master prefix literally (matches the
+    # Python mirror's str.replace); Sum([M/a])/Sum([M/b]) → Sum([a])/Sum([b]).
+    want = canon(inline.gsub("[#{master_name}/", '['))
+    metrics.each do |m|
+      name = m['name']
+      formula = m['formula']
+      return "[Metrics/#{name}]" if name && formula && canon(formula) == want
+    end
+    inline
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/metric_binding.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""metric_binding.py — bind a workbook measure to a governed DM metric.
+
+Every converter builds a Sigma data model whose elements carry reusable metrics
+(name + formula), but the workbook builder tends to re-derive each measure inline
+(``Sum([Master/Net Revenue])``, ``CountDistinct(...)``, ...), bypassing the
+governed metric: the aggregation logic is duplicated (and can drift) and the
+analyst never gets the metric object. This module is the thin, converter-agnostic
+binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
+is provably the same aggregation — and fall back to the inline formula otherwise.
+
+Two pure functions, stdlib only:
+
+- ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on
+  an element: its own metrics plus those it inherits through the ``source.elementId``
+  chain (a denorm "<X> View" element carries 0 own metrics but inherits its base
+  fact's; Sigma exposes them and they resolve as ``[Metrics/<name>]`` on the denorm
+  — verified live). Deduped by name, nearest element wins. Each metric is
+  ``{"name", "formula"}``; entries missing either field are skipped.
+
+- ``metric_ref_or_inline(inline, master_name, metrics)`` — returns
+  ``[Metrics/<name>]`` when ``inline`` matches a metric by FORMULA EQUIVALENCE
+  (strip the master prefix so ``Sum([Data/Net Revenue])`` equals a metric's
+  ``Sum([Net Revenue])``, then compare ignoring whitespace), else returns ``inline``
+  unchanged. Naming-independent and SAFE: ratios / filtered / custom / no-match /
+  empty-metrics all fall through to the inline formula, so passing no metrics is
+  byte-identical to the pre-binding behavior. Whether a given column is even a
+  measure (worth binding) is the caller's decision — only call this for measures.
+
+The reference form is the literal namespace ``[Metrics/<Metric Name>]`` — NOT
+``[Element/Name]`` (that errors). Extracted from the looker reference implementation
+(PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.rb — keep the
+two in lockstep.
+"""
+import re
+
+_WS = re.compile(r"\s+")
+
+
+def canon(formula):
+    """Whitespace-insensitive canonical form of a Sigma formula (or empty)."""
+    return _WS.sub("", formula or "")
+
+
+def available_metrics(element_id, elements_by_id):
+    """Metrics referenceable on ``element_id`` = its own metrics + those inherited
+    through the ``source.elementId`` chain, deduped by name (nearest element wins).
+
+    ``elements_by_id`` maps an element id to its dict (each with an optional
+    ``metrics`` list and ``source.elementId``). Returns a list of
+    ``{"name", "formula"}`` dicts; metrics missing a name or formula are dropped.
+    Cycle-safe."""
+    seen, chain = set(), []
+    eid = element_id
+    while eid and eid not in seen:
+        seen.add(eid)
+        el = elements_by_id.get(eid)
+        if not el:
+            break
+        for m in (el.get("metrics") or []):
+            name, formula = m.get("name"), m.get("formula")
+            if name and formula:
+                chain.append({"name": name, "formula": formula})
+        eid = (el.get("source") or {}).get("elementId")
+    return _dedup_by_name(chain)
+
+
+def _dedup_by_name(metrics):
+    seen, out = set(), []
+    for m in metrics:
+        if m["name"] not in seen:
+            seen.add(m["name"])
+            out.append(m)
+    return out
+
+
+def metric_ref_or_inline(inline, master_name, metrics):
+    """Prefer ``[Metrics/<name>]`` when ``inline`` matches a metric by formula
+    equivalence (master prefix stripped, whitespace ignored); otherwise return
+    ``inline`` unchanged. Safe no-op when ``metrics`` is empty or ``inline`` is not
+    a string. See the module docstring."""
+    if not isinstance(inline, str) or not metrics:
+        return inline
+    want = canon(inline.replace(f"[{master_name}/", "["))
+    for m in metrics:
+        name, formula = m.get("name"), m.get("formula")
+        if name and formula and canon(formula) == want:
+            return f"[Metrics/{name}]"
+    return inline

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/metric_binding.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/metric_binding.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+#
+# metric_binding.rb — bind a workbook measure to a governed DM metric.
+#
+# Every converter builds a Sigma data model whose elements carry reusable metrics
+# (name + formula), but the workbook builder tends to re-derive each measure inline
+# (Sum([Master/Net Revenue]), CountDistinct(...), ...), bypassing the governed
+# metric: the aggregation logic is duplicated (and can drift) and the analyst never
+# gets the metric object. This is the thin, converter-agnostic binder that lets a
+# builder prefer a governed [Metrics/<name>] reference when it is provably the same
+# aggregation — and fall back to the inline formula otherwise.
+#
+# Two pure functions:
+#
+# - available_metrics(element_id, elements_by_id) — the metrics REFERENCEABLE on an
+#   element: its own metrics plus those inherited through the source.elementId chain
+#   (a denorm "<X> View" element carries 0 own metrics but inherits its base fact's;
+#   Sigma exposes them and they resolve as [Metrics/<name>] on the denorm — verified
+#   live). Deduped by name, nearest element wins. Each metric is {"name","formula"};
+#   entries missing either field are skipped.
+#
+# - metric_ref_or_inline(inline, master_name, metrics) — returns "[Metrics/<name>]"
+#   when `inline` matches a metric by FORMULA EQUIVALENCE (strip the master prefix so
+#   Sum([Data/Net Revenue]) equals a metric's Sum([Net Revenue]), then compare
+#   ignoring whitespace), else returns `inline` unchanged. Naming-independent and
+#   SAFE: ratios / filtered / custom / no-match / empty-metrics all fall through to
+#   inline, so passing no metrics is byte-identical to the pre-binding behavior.
+#   Whether a column is even a measure (worth binding) is the caller's decision.
+#
+# The reference form is the literal namespace [Metrics/<Metric Name>] — NOT
+# [Element/Name] (that errors). Extracted from the looker reference implementation
+# (PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.py — keep the
+# two in lockstep.
+
+module MetricBinding
+  module_function
+
+  # Whitespace-insensitive canonical form of a Sigma formula (or empty).
+  def canon(formula)
+    (formula || '').gsub(/\s+/, '')
+  end
+
+  # Metrics referenceable on element_id = own + inherited via source.elementId,
+  # deduped by name (nearest element wins). elements_by_id maps id => element hash
+  # (string keys, as JSON.parse produces). Returns an array of
+  # {"name"=>, "formula"=>}; metrics missing a name or formula are dropped.
+  # Cycle-safe.
+  def available_metrics(element_id, elements_by_id)
+    seen = {}
+    chain = []
+    eid = element_id
+    while eid && !seen[eid]
+      seen[eid] = true
+      el = elements_by_id[eid]
+      break unless el
+
+      (el['metrics'] || []).each do |m|
+        name = m['name']
+        formula = m['formula']
+        chain << { 'name' => name, 'formula' => formula } if name && formula
+      end
+      eid = (el['source'] || {})['elementId']
+    end
+    dedup_by_name(chain)
+  end
+
+  def dedup_by_name(metrics)
+    seen = {}
+    metrics.each_with_object([]) do |m, out|
+      next if seen[m['name']]
+
+      seen[m['name']] = true
+      out << m
+    end
+  end
+
+  # Prefer "[Metrics/<name>]" when `inline` matches a metric by formula equivalence
+  # (master prefix stripped, whitespace ignored); otherwise return `inline`
+  # unchanged. Safe no-op when `metrics` is empty/nil or `inline` is not a String.
+  def metric_ref_or_inline(inline, master_name, metrics)
+    return inline unless inline.is_a?(String) && metrics && !metrics.empty?
+
+    # gsub with a String pattern strips EVERY master prefix literally (matches the
+    # Python mirror's str.replace); Sum([M/a])/Sum([M/b]) → Sum([a])/Sum([b]).
+    want = canon(inline.gsub("[#{master_name}/", '['))
+    metrics.each do |m|
+      name = m['name']
+      formula = m['formula']
+      return "[Metrics/#{name}]" if name && formula && canon(formula) == want
+    end
+    inline
+  end
+end

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/metric_binding.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""metric_binding.py — bind a workbook measure to a governed DM metric.
+
+Every converter builds a Sigma data model whose elements carry reusable metrics
+(name + formula), but the workbook builder tends to re-derive each measure inline
+(``Sum([Master/Net Revenue])``, ``CountDistinct(...)``, ...), bypassing the
+governed metric: the aggregation logic is duplicated (and can drift) and the
+analyst never gets the metric object. This module is the thin, converter-agnostic
+binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
+is provably the same aggregation — and fall back to the inline formula otherwise.
+
+Two pure functions, stdlib only:
+
+- ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on
+  an element: its own metrics plus those it inherits through the ``source.elementId``
+  chain (a denorm "<X> View" element carries 0 own metrics but inherits its base
+  fact's; Sigma exposes them and they resolve as ``[Metrics/<name>]`` on the denorm
+  — verified live). Deduped by name, nearest element wins. Each metric is
+  ``{"name", "formula"}``; entries missing either field are skipped.
+
+- ``metric_ref_or_inline(inline, master_name, metrics)`` — returns
+  ``[Metrics/<name>]`` when ``inline`` matches a metric by FORMULA EQUIVALENCE
+  (strip the master prefix so ``Sum([Data/Net Revenue])`` equals a metric's
+  ``Sum([Net Revenue])``, then compare ignoring whitespace), else returns ``inline``
+  unchanged. Naming-independent and SAFE: ratios / filtered / custom / no-match /
+  empty-metrics all fall through to the inline formula, so passing no metrics is
+  byte-identical to the pre-binding behavior. Whether a given column is even a
+  measure (worth binding) is the caller's decision — only call this for measures.
+
+The reference form is the literal namespace ``[Metrics/<Metric Name>]`` — NOT
+``[Element/Name]`` (that errors). Extracted from the looker reference implementation
+(PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.rb — keep the
+two in lockstep.
+"""
+import re
+
+_WS = re.compile(r"\s+")
+
+
+def canon(formula):
+    """Whitespace-insensitive canonical form of a Sigma formula (or empty)."""
+    return _WS.sub("", formula or "")
+
+
+def available_metrics(element_id, elements_by_id):
+    """Metrics referenceable on ``element_id`` = its own metrics + those inherited
+    through the ``source.elementId`` chain, deduped by name (nearest element wins).
+
+    ``elements_by_id`` maps an element id to its dict (each with an optional
+    ``metrics`` list and ``source.elementId``). Returns a list of
+    ``{"name", "formula"}`` dicts; metrics missing a name or formula are dropped.
+    Cycle-safe."""
+    seen, chain = set(), []
+    eid = element_id
+    while eid and eid not in seen:
+        seen.add(eid)
+        el = elements_by_id.get(eid)
+        if not el:
+            break
+        for m in (el.get("metrics") or []):
+            name, formula = m.get("name"), m.get("formula")
+            if name and formula:
+                chain.append({"name": name, "formula": formula})
+        eid = (el.get("source") or {}).get("elementId")
+    return _dedup_by_name(chain)
+
+
+def _dedup_by_name(metrics):
+    seen, out = set(), []
+    for m in metrics:
+        if m["name"] not in seen:
+            seen.add(m["name"])
+            out.append(m)
+    return out
+
+
+def metric_ref_or_inline(inline, master_name, metrics):
+    """Prefer ``[Metrics/<name>]`` when ``inline`` matches a metric by formula
+    equivalence (master prefix stripped, whitespace ignored); otherwise return
+    ``inline`` unchanged. Safe no-op when ``metrics`` is empty or ``inline`` is not
+    a string. See the module docstring."""
+    if not isinstance(inline, str) or not metrics:
+        return inline
+    want = canon(inline.replace(f"[{master_name}/", "["))
+    for m in metrics:
+        name, formula = m.get("name"), m.get("formula")
+        if name and formula and canon(formula) == want:
+            return f"[Metrics/{name}]"
+    return inline

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/metric_binding.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/metric_binding.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+#
+# metric_binding.rb — bind a workbook measure to a governed DM metric.
+#
+# Every converter builds a Sigma data model whose elements carry reusable metrics
+# (name + formula), but the workbook builder tends to re-derive each measure inline
+# (Sum([Master/Net Revenue]), CountDistinct(...), ...), bypassing the governed
+# metric: the aggregation logic is duplicated (and can drift) and the analyst never
+# gets the metric object. This is the thin, converter-agnostic binder that lets a
+# builder prefer a governed [Metrics/<name>] reference when it is provably the same
+# aggregation — and fall back to the inline formula otherwise.
+#
+# Two pure functions:
+#
+# - available_metrics(element_id, elements_by_id) — the metrics REFERENCEABLE on an
+#   element: its own metrics plus those inherited through the source.elementId chain
+#   (a denorm "<X> View" element carries 0 own metrics but inherits its base fact's;
+#   Sigma exposes them and they resolve as [Metrics/<name>] on the denorm — verified
+#   live). Deduped by name, nearest element wins. Each metric is {"name","formula"};
+#   entries missing either field are skipped.
+#
+# - metric_ref_or_inline(inline, master_name, metrics) — returns "[Metrics/<name>]"
+#   when `inline` matches a metric by FORMULA EQUIVALENCE (strip the master prefix so
+#   Sum([Data/Net Revenue]) equals a metric's Sum([Net Revenue]), then compare
+#   ignoring whitespace), else returns `inline` unchanged. Naming-independent and
+#   SAFE: ratios / filtered / custom / no-match / empty-metrics all fall through to
+#   inline, so passing no metrics is byte-identical to the pre-binding behavior.
+#   Whether a column is even a measure (worth binding) is the caller's decision.
+#
+# The reference form is the literal namespace [Metrics/<Metric Name>] — NOT
+# [Element/Name] (that errors). Extracted from the looker reference implementation
+# (PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.py — keep the
+# two in lockstep.
+
+module MetricBinding
+  module_function
+
+  # Whitespace-insensitive canonical form of a Sigma formula (or empty).
+  def canon(formula)
+    (formula || '').gsub(/\s+/, '')
+  end
+
+  # Metrics referenceable on element_id = own + inherited via source.elementId,
+  # deduped by name (nearest element wins). elements_by_id maps id => element hash
+  # (string keys, as JSON.parse produces). Returns an array of
+  # {"name"=>, "formula"=>}; metrics missing a name or formula are dropped.
+  # Cycle-safe.
+  def available_metrics(element_id, elements_by_id)
+    seen = {}
+    chain = []
+    eid = element_id
+    while eid && !seen[eid]
+      seen[eid] = true
+      el = elements_by_id[eid]
+      break unless el
+
+      (el['metrics'] || []).each do |m|
+        name = m['name']
+        formula = m['formula']
+        chain << { 'name' => name, 'formula' => formula } if name && formula
+      end
+      eid = (el['source'] || {})['elementId']
+    end
+    dedup_by_name(chain)
+  end
+
+  def dedup_by_name(metrics)
+    seen = {}
+    metrics.each_with_object([]) do |m, out|
+      next if seen[m['name']]
+
+      seen[m['name']] = true
+      out << m
+    end
+  end
+
+  # Prefer "[Metrics/<name>]" when `inline` matches a metric by formula equivalence
+  # (master prefix stripped, whitespace ignored); otherwise return `inline`
+  # unchanged. Safe no-op when `metrics` is empty/nil or `inline` is not a String.
+  def metric_ref_or_inline(inline, master_name, metrics)
+    return inline unless inline.is_a?(String) && metrics && !metrics.empty?
+
+    # gsub with a String pattern strips EVERY master prefix literally (matches the
+    # Python mirror's str.replace); Sum([M/a])/Sum([M/b]) → Sum([a])/Sum([b]).
+    want = canon(inline.gsub("[#{master_name}/", '['))
+    metrics.each do |m|
+      name = m['name']
+      formula = m['formula']
+      return "[Metrics/#{name}]" if name && formula && canon(formula) == want
+    end
+    inline
+  end
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/metric_binding.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""metric_binding.py — bind a workbook measure to a governed DM metric.
+
+Every converter builds a Sigma data model whose elements carry reusable metrics
+(name + formula), but the workbook builder tends to re-derive each measure inline
+(``Sum([Master/Net Revenue])``, ``CountDistinct(...)``, ...), bypassing the
+governed metric: the aggregation logic is duplicated (and can drift) and the
+analyst never gets the metric object. This module is the thin, converter-agnostic
+binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
+is provably the same aggregation — and fall back to the inline formula otherwise.
+
+Two pure functions, stdlib only:
+
+- ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on
+  an element: its own metrics plus those it inherits through the ``source.elementId``
+  chain (a denorm "<X> View" element carries 0 own metrics but inherits its base
+  fact's; Sigma exposes them and they resolve as ``[Metrics/<name>]`` on the denorm
+  — verified live). Deduped by name, nearest element wins. Each metric is
+  ``{"name", "formula"}``; entries missing either field are skipped.
+
+- ``metric_ref_or_inline(inline, master_name, metrics)`` — returns
+  ``[Metrics/<name>]`` when ``inline`` matches a metric by FORMULA EQUIVALENCE
+  (strip the master prefix so ``Sum([Data/Net Revenue])`` equals a metric's
+  ``Sum([Net Revenue])``, then compare ignoring whitespace), else returns ``inline``
+  unchanged. Naming-independent and SAFE: ratios / filtered / custom / no-match /
+  empty-metrics all fall through to the inline formula, so passing no metrics is
+  byte-identical to the pre-binding behavior. Whether a given column is even a
+  measure (worth binding) is the caller's decision — only call this for measures.
+
+The reference form is the literal namespace ``[Metrics/<Metric Name>]`` — NOT
+``[Element/Name]`` (that errors). Extracted from the looker reference implementation
+(PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.rb — keep the
+two in lockstep.
+"""
+import re
+
+_WS = re.compile(r"\s+")
+
+
+def canon(formula):
+    """Whitespace-insensitive canonical form of a Sigma formula (or empty)."""
+    return _WS.sub("", formula or "")
+
+
+def available_metrics(element_id, elements_by_id):
+    """Metrics referenceable on ``element_id`` = its own metrics + those inherited
+    through the ``source.elementId`` chain, deduped by name (nearest element wins).
+
+    ``elements_by_id`` maps an element id to its dict (each with an optional
+    ``metrics`` list and ``source.elementId``). Returns a list of
+    ``{"name", "formula"}`` dicts; metrics missing a name or formula are dropped.
+    Cycle-safe."""
+    seen, chain = set(), []
+    eid = element_id
+    while eid and eid not in seen:
+        seen.add(eid)
+        el = elements_by_id.get(eid)
+        if not el:
+            break
+        for m in (el.get("metrics") or []):
+            name, formula = m.get("name"), m.get("formula")
+            if name and formula:
+                chain.append({"name": name, "formula": formula})
+        eid = (el.get("source") or {}).get("elementId")
+    return _dedup_by_name(chain)
+
+
+def _dedup_by_name(metrics):
+    seen, out = set(), []
+    for m in metrics:
+        if m["name"] not in seen:
+            seen.add(m["name"])
+            out.append(m)
+    return out
+
+
+def metric_ref_or_inline(inline, master_name, metrics):
+    """Prefer ``[Metrics/<name>]`` when ``inline`` matches a metric by formula
+    equivalence (master prefix stripped, whitespace ignored); otherwise return
+    ``inline`` unchanged. Safe no-op when ``metrics`` is empty or ``inline`` is not
+    a string. See the module docstring."""
+    if not isinstance(inline, str) or not metrics:
+        return inline
+    want = canon(inline.replace(f"[{master_name}/", "["))
+    for m in metrics:
+        name, formula = m.get("name"), m.get("formula")
+        if name and formula and canon(formula) == want:
+            return f"[Metrics/{name}]"
+    return inline

--- a/shared/lib/metric_binding.py
+++ b/shared/lib/metric_binding.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""metric_binding.py — bind a workbook measure to a governed DM metric.
+
+Every converter builds a Sigma data model whose elements carry reusable metrics
+(name + formula), but the workbook builder tends to re-derive each measure inline
+(``Sum([Master/Net Revenue])``, ``CountDistinct(...)``, ...), bypassing the
+governed metric: the aggregation logic is duplicated (and can drift) and the
+analyst never gets the metric object. This module is the thin, converter-agnostic
+binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
+is provably the same aggregation — and fall back to the inline formula otherwise.
+
+Two pure functions, stdlib only:
+
+- ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on
+  an element: its own metrics plus those it inherits through the ``source.elementId``
+  chain (a denorm "<X> View" element carries 0 own metrics but inherits its base
+  fact's; Sigma exposes them and they resolve as ``[Metrics/<name>]`` on the denorm
+  — verified live). Deduped by name, nearest element wins. Each metric is
+  ``{"name", "formula"}``; entries missing either field are skipped.
+
+- ``metric_ref_or_inline(inline, master_name, metrics)`` — returns
+  ``[Metrics/<name>]`` when ``inline`` matches a metric by FORMULA EQUIVALENCE
+  (strip the master prefix so ``Sum([Data/Net Revenue])`` equals a metric's
+  ``Sum([Net Revenue])``, then compare ignoring whitespace), else returns ``inline``
+  unchanged. Naming-independent and SAFE: ratios / filtered / custom / no-match /
+  empty-metrics all fall through to the inline formula, so passing no metrics is
+  byte-identical to the pre-binding behavior. Whether a given column is even a
+  measure (worth binding) is the caller's decision — only call this for measures.
+
+The reference form is the literal namespace ``[Metrics/<Metric Name>]`` — NOT
+``[Element/Name]`` (that errors). Extracted from the looker reference implementation
+(PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.rb — keep the
+two in lockstep.
+"""
+import re
+
+_WS = re.compile(r"\s+")
+
+
+def canon(formula):
+    """Whitespace-insensitive canonical form of a Sigma formula (or empty)."""
+    return _WS.sub("", formula or "")
+
+
+def available_metrics(element_id, elements_by_id):
+    """Metrics referenceable on ``element_id`` = its own metrics + those inherited
+    through the ``source.elementId`` chain, deduped by name (nearest element wins).
+
+    ``elements_by_id`` maps an element id to its dict (each with an optional
+    ``metrics`` list and ``source.elementId``). Returns a list of
+    ``{"name", "formula"}`` dicts; metrics missing a name or formula are dropped.
+    Cycle-safe."""
+    seen, chain = set(), []
+    eid = element_id
+    while eid and eid not in seen:
+        seen.add(eid)
+        el = elements_by_id.get(eid)
+        if not el:
+            break
+        for m in (el.get("metrics") or []):
+            name, formula = m.get("name"), m.get("formula")
+            if name and formula:
+                chain.append({"name": name, "formula": formula})
+        eid = (el.get("source") or {}).get("elementId")
+    return _dedup_by_name(chain)
+
+
+def _dedup_by_name(metrics):
+    seen, out = set(), []
+    for m in metrics:
+        if m["name"] not in seen:
+            seen.add(m["name"])
+            out.append(m)
+    return out
+
+
+def metric_ref_or_inline(inline, master_name, metrics):
+    """Prefer ``[Metrics/<name>]`` when ``inline`` matches a metric by formula
+    equivalence (master prefix stripped, whitespace ignored); otherwise return
+    ``inline`` unchanged. Safe no-op when ``metrics`` is empty or ``inline`` is not
+    a string. See the module docstring."""
+    if not isinstance(inline, str) or not metrics:
+        return inline
+    want = canon(inline.replace(f"[{master_name}/", "["))
+    for m in metrics:
+        name, formula = m.get("name"), m.get("formula")
+        if name and formula and canon(formula) == want:
+            return f"[Metrics/{name}]"
+    return inline

--- a/shared/lib/metric_binding.rb
+++ b/shared/lib/metric_binding.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+#
+# metric_binding.rb — bind a workbook measure to a governed DM metric.
+#
+# Every converter builds a Sigma data model whose elements carry reusable metrics
+# (name + formula), but the workbook builder tends to re-derive each measure inline
+# (Sum([Master/Net Revenue]), CountDistinct(...), ...), bypassing the governed
+# metric: the aggregation logic is duplicated (and can drift) and the analyst never
+# gets the metric object. This is the thin, converter-agnostic binder that lets a
+# builder prefer a governed [Metrics/<name>] reference when it is provably the same
+# aggregation — and fall back to the inline formula otherwise.
+#
+# Two pure functions:
+#
+# - available_metrics(element_id, elements_by_id) — the metrics REFERENCEABLE on an
+#   element: its own metrics plus those inherited through the source.elementId chain
+#   (a denorm "<X> View" element carries 0 own metrics but inherits its base fact's;
+#   Sigma exposes them and they resolve as [Metrics/<name>] on the denorm — verified
+#   live). Deduped by name, nearest element wins. Each metric is {"name","formula"};
+#   entries missing either field are skipped.
+#
+# - metric_ref_or_inline(inline, master_name, metrics) — returns "[Metrics/<name>]"
+#   when `inline` matches a metric by FORMULA EQUIVALENCE (strip the master prefix so
+#   Sum([Data/Net Revenue]) equals a metric's Sum([Net Revenue]), then compare
+#   ignoring whitespace), else returns `inline` unchanged. Naming-independent and
+#   SAFE: ratios / filtered / custom / no-match / empty-metrics all fall through to
+#   inline, so passing no metrics is byte-identical to the pre-binding behavior.
+#   Whether a column is even a measure (worth binding) is the caller's decision.
+#
+# The reference form is the literal namespace [Metrics/<Metric Name>] — NOT
+# [Element/Name] (that errors). Extracted from the looker reference implementation
+# (PR #484); see beads-sigma-7bun. Mirror: shared/lib/metric_binding.py — keep the
+# two in lockstep.
+
+module MetricBinding
+  module_function
+
+  # Whitespace-insensitive canonical form of a Sigma formula (or empty).
+  def canon(formula)
+    (formula || '').gsub(/\s+/, '')
+  end
+
+  # Metrics referenceable on element_id = own + inherited via source.elementId,
+  # deduped by name (nearest element wins). elements_by_id maps id => element hash
+  # (string keys, as JSON.parse produces). Returns an array of
+  # {"name"=>, "formula"=>}; metrics missing a name or formula are dropped.
+  # Cycle-safe.
+  def available_metrics(element_id, elements_by_id)
+    seen = {}
+    chain = []
+    eid = element_id
+    while eid && !seen[eid]
+      seen[eid] = true
+      el = elements_by_id[eid]
+      break unless el
+
+      (el['metrics'] || []).each do |m|
+        name = m['name']
+        formula = m['formula']
+        chain << { 'name' => name, 'formula' => formula } if name && formula
+      end
+      eid = (el['source'] || {})['elementId']
+    end
+    dedup_by_name(chain)
+  end
+
+  def dedup_by_name(metrics)
+    seen = {}
+    metrics.each_with_object([]) do |m, out|
+      next if seen[m['name']]
+
+      seen[m['name']] = true
+      out << m
+    end
+  end
+
+  # Prefer "[Metrics/<name>]" when `inline` matches a metric by formula equivalence
+  # (master prefix stripped, whitespace ignored); otherwise return `inline`
+  # unchanged. Safe no-op when `metrics` is empty/nil or `inline` is not a String.
+  def metric_ref_or_inline(inline, master_name, metrics)
+    return inline unless inline.is_a?(String) && metrics && !metrics.empty?
+
+    # gsub with a String pattern strips EVERY master prefix literally (matches the
+    # Python mirror's str.replace); Sum([M/a])/Sum([M/b]) → Sum([a])/Sum([b]).
+    want = canon(inline.gsub("[#{master_name}/", '['))
+    metrics.each do |m|
+      name = m['name']
+      formula = m['formula']
+      return "[Metrics/#{name}]" if name && formula && canon(formula) == want
+    end
+    inline
+  end
+end

--- a/shared/lib/test_metric_binding.py
+++ b/shared/lib/test_metric_binding.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Unit test for metric_binding.py — the shared workbook↔DM-metric binder.
+Stdlib only; run directly:  python3 shared/lib/test_metric_binding.py
+
+Semantics mirror the looker reference (PR #484) that this helper was extracted
+from: a measure whose inline aggregate matches a metric on (or inherited by) the
+source element binds to [Metrics/<name>]; everything else — ratios, filtered,
+custom, no match, empty metrics, non-string input — falls back to inline.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import metric_binding as mb  # noqa: E402
+
+
+class MetricRefOrInlineTest(unittest.TestCase):
+    METRICS = [
+        {"name": "Net Revenue", "formula": "Sum([Net Revenue])"},
+        {"name": "Orders", "formula": "CountDistinct([Order Id])"},
+    ]
+
+    def test_matched_aggregate_binds_to_metric(self):
+        self.assertEqual(
+            mb.metric_ref_or_inline("Sum([Data/Net Revenue])", "Data", self.METRICS),
+            "[Metrics/Net Revenue]")
+        self.assertEqual(
+            mb.metric_ref_or_inline("CountDistinct([Data/Order Id])", "Data", self.METRICS),
+            "[Metrics/Orders]")
+
+    def test_whitespace_insensitive_match(self):
+        # extra whitespace on either side must not defeat the match
+        self.assertEqual(
+            mb.metric_ref_or_inline("Sum( [Data/Net Revenue] )", "Data", self.METRICS),
+            "[Metrics/Net Revenue]")
+
+    def test_strips_every_master_prefix(self):
+        # a ratio of two master refs, matched against a metric with no prefix
+        mets = [{"name": "AOV", "formula": "Sum([Net Revenue]) / Sum([Order Id])"}]
+        self.assertEqual(
+            mb.metric_ref_or_inline("Sum([Data/Net Revenue]) / Sum([Data/Order Id])", "Data", mets),
+            "[Metrics/AOV]")
+
+    def test_ratio_without_metric_falls_back(self):
+        got = mb.metric_ref_or_inline("1.0 * Sum([Data/Net Revenue]) / Count([Data/Order Id])",
+                                      "Data", self.METRICS)
+        self.assertEqual(got, "1.0 * Sum([Data/Net Revenue]) / Count([Data/Order Id])")
+
+    def test_nonmatching_metric_ignored(self):
+        mets = [{"name": "Unrelated", "formula": "Sum([Something Else])"}]
+        self.assertEqual(
+            mb.metric_ref_or_inline("Sum([Data/Net Revenue])", "Data", mets),
+            "Sum([Data/Net Revenue])")
+
+    def test_empty_metrics_is_noop(self):
+        self.assertEqual(mb.metric_ref_or_inline("Sum([Data/x])", "Data", []),
+                         "Sum([Data/x])")
+        self.assertEqual(mb.metric_ref_or_inline("Sum([Data/x])", "Data", None),
+                         "Sum([Data/x])")
+
+    def test_non_string_inline_passthrough(self):
+        self.assertIsNone(mb.metric_ref_or_inline(None, "Data", self.METRICS))
+        self.assertEqual(mb.metric_ref_or_inline(42, "Data", self.METRICS), 42)
+
+    def test_metric_missing_formula_or_name_skipped(self):
+        mets = [{"name": "NoFormula"}, {"formula": "Sum([Data/x])"},
+                {"name": "Good", "formula": "Sum([x])"}]
+        self.assertEqual(mb.metric_ref_or_inline("Sum([Data/x])", "Data", mets),
+                         "[Metrics/Good]")
+
+
+class AvailableMetricsTest(unittest.TestCase):
+    def test_own_metrics(self):
+        els = {"a": {"metrics": [{"name": "M1", "formula": "Sum([x])"}]}}
+        got = mb.available_metrics("a", els)
+        self.assertEqual(got, [{"name": "M1", "formula": "Sum([x])"}])
+
+    def test_inherited_via_source_chain(self):
+        # denorm 'View' element carries 0 own metrics but inherits its base fact's
+        els = {
+            "view": {"metrics": [], "source": {"elementId": "fact"}},
+            "fact": {"metrics": [{"name": "Net Revenue", "formula": "Sum([Net Revenue])"}]},
+        }
+        got = mb.available_metrics("view", els)
+        self.assertEqual(got, [{"name": "Net Revenue", "formula": "Sum([Net Revenue])"}])
+
+    def test_nearest_wins_on_name_collision(self):
+        els = {
+            "view": {"metrics": [{"name": "M", "formula": "OWN"}], "source": {"elementId": "fact"}},
+            "fact": {"metrics": [{"name": "M", "formula": "INHERITED"}]},
+        }
+        got = mb.available_metrics("view", els)
+        self.assertEqual(got, [{"name": "M", "formula": "OWN"}])
+
+    def test_skips_metrics_missing_fields(self):
+        els = {"a": {"metrics": [{"name": "OnlyName"}, {"formula": "OnlyFormula"},
+                                 {"name": "Ok", "formula": "Sum([x])"}]}}
+        self.assertEqual(mb.available_metrics("a", els),
+                         [{"name": "Ok", "formula": "Sum([x])"}])
+
+    def test_cycle_safe(self):
+        els = {"a": {"metrics": [{"name": "A", "formula": "f"}], "source": {"elementId": "b"}},
+               "b": {"metrics": [{"name": "B", "formula": "g"}], "source": {"elementId": "a"}}}
+        got = mb.available_metrics("a", els)
+        self.assertEqual([m["name"] for m in got], ["A", "B"])
+
+    def test_missing_element_and_none(self):
+        self.assertEqual(mb.available_metrics("nope", {"a": {}}), [])
+        self.assertEqual(mb.available_metrics(None, {"a": {}}), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/shared/lib/test_metric_binding.rb
+++ b/shared/lib/test_metric_binding.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Unit test for metric_binding.rb. Run: ruby shared/lib/test_metric_binding.rb
+#
+# Kept in lockstep with shared/lib/test_metric_binding.py — same cases, same
+# semantics (this is the Ruby mirror of the shared binder).
+
+require_relative 'metric_binding'
+
+$failures = 0
+def check(desc)
+  ok = yield
+  puts(ok ? "  [ok] #{desc}" : "  [FAIL] #{desc}")
+  $failures += 1 unless ok
+end
+
+METRICS = [
+  { 'name' => 'Net Revenue', 'formula' => 'Sum([Net Revenue])' },
+  { 'name' => 'Orders', 'formula' => 'CountDistinct([Order Id])' }
+].freeze
+
+# --- metric_ref_or_inline ---------------------------------------------------
+check('matched aggregate binds to metric') do
+  MetricBinding.metric_ref_or_inline('Sum([Data/Net Revenue])', 'Data', METRICS) == '[Metrics/Net Revenue]' &&
+    MetricBinding.metric_ref_or_inline('CountDistinct([Data/Order Id])', 'Data', METRICS) == '[Metrics/Orders]'
+end
+
+check('whitespace-insensitive match') do
+  MetricBinding.metric_ref_or_inline('Sum( [Data/Net Revenue] )', 'Data', METRICS) == '[Metrics/Net Revenue]'
+end
+
+check('strips EVERY master prefix (gsub, not sub)') do
+  mets = [{ 'name' => 'AOV', 'formula' => 'Sum([Net Revenue]) / Sum([Order Id])' }]
+  MetricBinding.metric_ref_or_inline('Sum([Data/Net Revenue]) / Sum([Data/Order Id])', 'Data', mets) == '[Metrics/AOV]'
+end
+
+check('ratio without a matching metric falls back to inline') do
+  inline = '1.0 * Sum([Data/Net Revenue]) / Count([Data/Order Id])'
+  MetricBinding.metric_ref_or_inline(inline, 'Data', METRICS) == inline
+end
+
+check('non-matching metric ignored (no false positive)') do
+  mets = [{ 'name' => 'Unrelated', 'formula' => 'Sum([Something Else])' }]
+  MetricBinding.metric_ref_or_inline('Sum([Data/Net Revenue])', 'Data', mets) == 'Sum([Data/Net Revenue])'
+end
+
+check('empty / nil metrics is a no-op') do
+  MetricBinding.metric_ref_or_inline('Sum([Data/x])', 'Data', []) == 'Sum([Data/x])' &&
+    MetricBinding.metric_ref_or_inline('Sum([Data/x])', 'Data', nil) == 'Sum([Data/x])'
+end
+
+check('non-string inline passes through') do
+  MetricBinding.metric_ref_or_inline(nil, 'Data', METRICS).nil? &&
+    MetricBinding.metric_ref_or_inline(42, 'Data', METRICS) == 42
+end
+
+check('metric missing name/formula is skipped') do
+  mets = [{ 'name' => 'NoFormula' }, { 'formula' => 'Sum([Data/x])' },
+          { 'name' => 'Good', 'formula' => 'Sum([x])' }]
+  MetricBinding.metric_ref_or_inline('Sum([Data/x])', 'Data', mets) == '[Metrics/Good]'
+end
+
+# --- available_metrics ------------------------------------------------------
+check('own metrics') do
+  els = { 'a' => { 'metrics' => [{ 'name' => 'M1', 'formula' => 'Sum([x])' }] } }
+  MetricBinding.available_metrics('a', els) == [{ 'name' => 'M1', 'formula' => 'Sum([x])' }]
+end
+
+check('inherited via source.elementId chain') do
+  els = {
+    'view' => { 'metrics' => [], 'source' => { 'elementId' => 'fact' } },
+    'fact' => { 'metrics' => [{ 'name' => 'Net Revenue', 'formula' => 'Sum([Net Revenue])' }] }
+  }
+  MetricBinding.available_metrics('view', els) == [{ 'name' => 'Net Revenue', 'formula' => 'Sum([Net Revenue])' }]
+end
+
+check('nearest wins on name collision') do
+  els = {
+    'view' => { 'metrics' => [{ 'name' => 'M', 'formula' => 'OWN' }], 'source' => { 'elementId' => 'fact' } },
+    'fact' => { 'metrics' => [{ 'name' => 'M', 'formula' => 'INHERITED' }] }
+  }
+  MetricBinding.available_metrics('view', els) == [{ 'name' => 'M', 'formula' => 'OWN' }]
+end
+
+check('skips metrics missing fields') do
+  els = { 'a' => { 'metrics' => [{ 'name' => 'OnlyName' }, { 'formula' => 'OnlyFormula' },
+                                  { 'name' => 'Ok', 'formula' => 'Sum([x])' }] } }
+  MetricBinding.available_metrics('a', els) == [{ 'name' => 'Ok', 'formula' => 'Sum([x])' }]
+end
+
+check('cycle-safe') do
+  els = { 'a' => { 'metrics' => [{ 'name' => 'A', 'formula' => 'f' }], 'source' => { 'elementId' => 'b' } },
+          'b' => { 'metrics' => [{ 'name' => 'B', 'formula' => 'g' }], 'source' => { 'elementId' => 'a' } } }
+  MetricBinding.available_metrics('a', els).map { |m| m['name'] } == %w[A B]
+end
+
+check('missing element and nil id return empty') do
+  MetricBinding.available_metrics('nope', { 'a' => {} }) == [] &&
+    MetricBinding.available_metrics(nil, { 'a' => {} }) == []
+end
+
+puts($failures.zero? ? 'ALL PASS' : "#{$failures} FAILURE(S)")
+exit($failures.zero? ? 0 : 1)

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -13,6 +13,25 @@
    ]
   },
   {
+   "canonical": "shared/lib/metric_binding.py",
+   "targets": [
+    "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/metric_binding.py",
+    "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/metric_binding.py",
+    "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/metric_binding.py",
+    "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/metric_binding.py",
+    "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/metric_binding.py",
+    "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/metric_binding.py"
+   ]
+  },
+  {
+   "canonical": "shared/lib/metric_binding.rb",
+   "targets": [
+    "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/metric_binding.rb",
+    "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/metric_binding.rb",
+    "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/metric_binding.rb"
+   ]
+  },
+  {
    "canonical": "shared/lib/coverage_catalog.rb",
    "targets": [
     "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_catalog.rb",


### PR DESCRIPTION
## What

Extracts the looker reference implementation (PR #484, merged) into a **converter-agnostic shared helper** so every workbook builder can prefer a governed `[Metrics/<name>]` reference over re-deriving a measure's aggregation inline — instead of each of the 9 remaining converters re-porting the same logic.

This is **beads-sigma-7bun.1** (the "build first" item of epic `7bun`). No consumer is wired yet — that's one plugin PR per converter (7bun.3–7bun.11).

## The helper (`shared/lib/metric_binding.{py,rb}`, kept in lockstep)

- **`available_metrics(element_id, elements_by_id)`** — metrics *referenceable* on an element = its own + those inherited through the `source.elementId` chain (a denorm `"<X> View"` carries 0 own metrics but inherits its base fact's; Sigma resolves them as `[Metrics/<name>]` on the denorm — verified live in #484). Deduped by name, nearest element wins. Cycle-safe.
- **`metric_ref_or_inline(inline, master_name, metrics)`** — returns `[Metrics/<name>]` when `inline` matches a metric by **formula equivalence** (strip the master prefix so `Sum([Data/Net Revenue])` == a metric's `Sum([Net Revenue])`, compare ignoring whitespace); otherwise returns `inline` unchanged.

**Safe by construction:** ratios / filtered / custom / no-match / empty-metrics all fall back to the inline formula, so passing no metrics is **byte-identical** to the pre-binding behavior. Whether a column is even a measure worth binding stays the caller's decision.

## Fan-out (`tools/sync-shared.rb`)

Vendored into the 9 consumer plugins:
- **Python** (`metric_binding.py`): looker, qlik, thoughtspot, gooddata, sisense, microstrategy
- **Ruby** (`metric_binding.rb`): tableau, powerbi, quicksight

cognos (TypeScript) will land its own variant with bead 7bun.7.

## Tests

Canonical unit tests `shared/lib/test_metric_binding.{py,rb}` — 14 cases each (match / whitespace / multi-prefix strip / ratio fallback / non-matching-metric / empty / non-string / missing-field; own + inherited + nearest-wins + cycle-safe + missing-element resolution). Registered in the `corpus-check` offline allow-lists (Python + Ruby), alongside the looker `test_metric_reference.py`.

## Checks
- `tools/check-shared.rb` — 500 vendored copies match canonical ✅
- full local governance hook (skills / hygiene / ESM / twb-encoding / agent-variants) ✅
- both shared test suites pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)