### PR TITLE
qlik: workbook measures reference DM metrics ([Metrics/<name>]) instead of re-deriving inline (7bun.3)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -299,6 +299,7 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_scout_ledger_integrity.py
+            plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_metric_reference.py
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -282,6 +282,18 @@ The Qlik cell grid maps 1:1 onto the 24-col Sigma grid. Element shapes + the
 `source.dataModelId` requirement in `refs/sigma-build-gotchas.md`.
 POST `/v2/workbooks/spec`, then `scripts/vendor/put-layout.rb` applies the layout XML.
 
+**DM metric references (leverage the semantic layer, don't duplicate it).** A measure
+column prefers a governed **`[Metrics/<name>]`** reference over re-deriving the aggregation
+inline, when the measure's translated inline aggregate matches a metric hosted on the denorm
+element the master sources. Match is by FORMULA equivalence — strip the master prefix so
+`Sum([Master/Net Revenue])` equals a metric's `Sum([Net Revenue])` — so it's naming-independent
+and SAFE: ratios with no exact-metric match, measures in a different representation (e.g. the
+inline `CountDistinct(...)` vs a Qlik-form `Count(DISTINCT ...)` metric), and any non-match all
+fall back to inline. `migrate-qlik.rb` hands the freshly-built DM spec to the builder via
+`--dm-spec`; the shared binder (`scripts/lib/metric_binding.py`, resolving own + inherited
+metrics through the `source.elementId` chain) does the matching. No `--dm-spec` / the DM-reuse
+path → inline, byte-identical to before. Verified: `tests/test_metric_reference.py`.
+
 **Filterpanes/listboxes → controls (NOT skipped).** Each filterpane child
 listbox (discovered via `qChildList` + per-listbox layout) and standalone
 listbox becomes a Sigma **list control** — or a **date-range control** when the

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -60,6 +60,7 @@ TEMPORAL = re.compile(r"DATE|MONTH|YEAR|QUARTER|WEEK|DAY", re.I)
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import coverage_catalog as _cc  # noqa: E402
 import trellis_emit as _te      # noqa: E402  shared native-trellis emitter (supported-kind gate + fallbacks)
+import metric_binding as _mb    # noqa: E402  shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 
 # Native-trellis round-trip sidecar records (element_id/kind/name/axis/columnId).
 # Populated by emit_trellis; written to native-trellis-emitted.json ONLY when a
@@ -461,8 +462,10 @@ def emit_trellis(el, c, resolve, warnings):
     warnings.append(f"native trellis: '{el.get('name')}' -> ONE {el['kind']} element with "
                     f"trellis.{axis_key} (orientation={orientation}, facet column {facet_col['id']})")
 
-def build_element(c, resolve, warnings):
-    """One Qlik chart object -> one Sigma element (or None + warning)."""
+def build_element(c, resolve, warnings, metrics=None):
+    """One Qlik chart object -> one Sigma element (or None + warning). `metrics`
+    (DM metrics referenceable on the master) lets a measure bind to a governed
+    [Metrics/<name>] reference; None/empty keeps every measure inline."""
     title = c.get("title") or c.get("vizType")
     dims_raw = [(d[0] if isinstance(d, list) else d) for d in (c.get("dimensions") or [])]
     dim_disp = [resolve(d) for d in dims_raw]
@@ -496,6 +499,9 @@ def build_element(c, resolve, warnings):
         if f is None:
             warnings.append(f"'{title}': measure not translated: {mexpr}")
             continue
+        # Prefer a governed [Metrics/<name>] ref when this inline aggregate matches a
+        # DM metric by formula equivalence; safe no-op (inline) otherwise.
+        f = _mb.metric_ref_or_inline(f, MASTER, metrics)
         mname = mlabels[i] or (title if kind == "kpi-chart" else f"Measure {i+1}")
         cid = nid("y")
         _mcol = {"id": cid, "formula": f, "name": mname}
@@ -767,6 +773,11 @@ def main():
     ap.add_argument("--denorm", required=True)
     ap.add_argument("--dm-id", required=True)
     ap.add_argument("--denorm-element-id", required=True)
+    ap.add_argument("--dm-spec", default=None,
+                    help="DM spec JSON (build-sigma-dm.py --spec-out). When present, a measure "
+                         "whose inline aggregate matches a metric on the denorm element binds to "
+                         "a governed [Metrics/<name>] reference instead of re-deriving it inline. "
+                         "Absent (or on the DM-reuse path) → inline, byte-identical to before.")
     ap.add_argument("--name", required=True)
     ap.add_argument("--folder")
     ap.add_argument("--dry-run", action="store_true")
@@ -813,6 +824,21 @@ def main():
     denorm_cols = [(c["name"], (re.search(r"\[Custom SQL/(.+)\]", c["formula"]) or [None, c["name"]])[1])
                    for c in denorm["columns"]]
     resolve = Resolver(denorm_cols)
+
+    # DM metrics referenceable on the master (it sources the denorm element): a
+    # measure whose translated inline aggregate matches one binds to [Metrics/<name>]
+    # (governed) instead of re-deriving it. No dm-spec / DM-reuse path → empty list
+    # → every measure stays inline (byte-identical). Resolution + formula-equivalence
+    # matching live in the shared binder (shared/lib/metric_binding.py).
+    metrics = []
+    if a.dm_spec and os.path.exists(a.dm_spec):
+        try:
+            _dm = json.load(open(a.dm_spec))
+            _by_id = {e.get("id"): e for pg in _dm.get("pages", []) for e in (pg.get("elements") or [])}
+            metrics = _mb.available_metrics(a.denorm_element_id, _by_id)
+        except (ValueError, OSError) as e:
+            warnings_dm_spec = f"--dm-spec unreadable ({e}); measures stay inline"
+            print(warnings_dm_spec, file=sys.stderr)
 
     master = {"id": MASTER_ID, "name": MASTER, "kind": "table",
               "source": {"dataModelId": a.dm_id, "elementId": a.denorm_element_id, "kind": "data-model"},
@@ -876,7 +902,7 @@ def main():
                 if c is None: continue
                 if c["vizType"] not in CHARTY and not (c.get("measures") or c.get("dimensions")):
                     warnings.append(f"skip '{cell['objectId']}' ({c['vizType']}): not a chart"); continue
-                el = build_element(c, resolve, warnings)
+                el = build_element(c, resolve, warnings, metrics)
                 if el is None: continue
                 emit_trellis(el, c, resolve, warnings)   # native trellis (no-op if no signal)
                 elems.append(el); placed.append((cell, el))
@@ -908,7 +934,7 @@ def main():
             c = trellis_base(c, charts, warnings)   # container -> its base child chart
             if c is None: continue
             if not (c.get("measures")): continue
-            el = build_element(c, resolve, warnings)
+            el = build_element(c, resolve, warnings, metrics)
             if el is None: continue
             emit_trellis(el, c, resolve, warnings)   # native trellis (no-op if no signal)
             elems.append(el)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -689,6 +689,11 @@ wb_cmd = [*PyResolve.argv, File.join(HERE, 'build-sigma-workbook.py'),
           '--out', File.join(WORK, 'wb-result.json'), '--spec-out', File.join(WORK, 'wb-spec.json'),
           '--layout-out', File.join(WORK, 'layout.xml'),
           '--element-map', File.join(WORK, 'element-map.json')]
+# Freshly-built DM only: hand the workbook builder the DM spec so measures whose
+# inline aggregate matches a metric on the denorm element bind to [Metrics/<name>]
+# (governed) instead of re-deriving inline. The reuse path writes no dm-spec.json,
+# so measures stay inline there (unchanged) until a live metric-fetch exists.
+wb_cmd += ['--dm-spec', File.join(WORK, 'dm-spec.json')] unless opts[:reuse_dm]
 wb_cmd += ['--folder', (opts[:folder] || dm_res['folderId'] || prep[:folder_id])] if opts[:folder] || dm_res['folderId'] || prep[:folder_id]
 wb_cmd << '--dry-run' if opts[:dry_run]
 run!(wb_cmd)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_metric_reference.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_metric_reference.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""DM-metric references in the qlik workbook builder (leverage the semantic layer
+instead of duplicating aggregations). Offline, creds-free.
+
+build-sigma-workbook.py prefers a governed `[Metrics/<name>]` reference over
+re-deriving a measure's aggregation inline, when the measure's translated inline
+aggregate matches a metric on the denorm element the master sources. Match is by
+FORMULA equivalence (strip the master prefix so `Sum([Master/Net Revenue])` equals
+a metric's `Sum([Net Revenue])`) — via the shared binder (shared/lib/metric_binding.py).
+SAFE: no `--dm-spec`, no match, or a metric in a different formula representation
+(e.g. Qlik-form `Count(DISTINCT ...)` vs the inline's `CountDistinct(...)`) all fall
+back to inline. Without `--dm-spec` the output is byte-identical to before.
+
+Run: python3 tests/test_metric_reference.py   (exit 0 = pass)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+BUILDER = os.path.join(SKILL, "scripts", "build-sigma-workbook.py")
+
+DENORM = {"element": {"id": "el-x", "columns": [
+    {"name": "Region",      "formula": "[Custom SQL/REGION]"},
+    {"name": "Net Revenue", "formula": "[Custom SQL/NET_REVENUE]"},
+    {"name": "Order Id",    "formula": "[Custom SQL/ORDER_ID]"},
+]}}
+
+_SORT = {"interColumnSortOrder": [], "dimensions": [[]], "measures": [{}]}
+
+# a table with two measures: a plain Sum (will match a metric) and a
+# Count(DISTINCT) (translates to CountDistinct — the DM metric is Qlik-form, so it
+# must NOT match and must stay inline).
+CHARTS = [{
+    "id": "tbl", "vizType": "table", "title": "Rev by Region", "sheet": None,
+    "dimensions": [["REGION"]], "dimLabels": [None], "dimNullSuppression": [False],
+    "measures": ["Sum(NET_REVENUE)", "Count(DISTINCT ORDER_ID)"],
+    "measureLabels": ["Total Net Revenue", "Distinct Orders"],
+    "measureFmts": [None, None], "sort": _SORT,
+}]
+
+# metrics as build-sigma-dm.py would host them on the denorm element
+METRICS = [
+    {"name": "Net Revenue", "formula": "Sum([Net Revenue])"},          # matches Sum(NET_REVENUE)
+    {"name": "Order Count", "formula": "Count(DISTINCT [Order Id])"},  # Qlik-form → no match
+    {"name": "Unrelated",   "formula": "Sum([Nonexistent Col])"},      # matches nothing
+]
+
+
+def build(with_metrics):
+    with tempfile.TemporaryDirectory() as d:
+        cp = os.path.join(d, "charts.json"); json.dump(CHARTS, open(cp, "w"))
+        dp = os.path.join(d, "denorm.json"); json.dump(DENORM, open(dp, "w"))
+        sp = os.path.join(d, "wb.json")
+        cmd = [sys.executable, BUILDER, "--charts", cp, "--denorm", dp,
+               "--dm-id", "dm-x", "--denorm-element-id", "el-x", "--name", "QT",
+               "--dry-run", "--spec-out", sp, "--out", os.path.join(d, "r.json"),
+               "--layout-out", os.path.join(d, "l.xml"),
+               "--element-map", os.path.join(d, "em.json")]
+        if with_metrics:
+            dm = {"name": "t", "schemaVersion": 1, "pages": [{"id": "pg", "name": "P",
+                  "elements": [{"id": "el-x", "name": "Custom SQL", "metrics": METRICS}]}]}
+            dmp = os.path.join(d, "dm-spec.json"); json.dump(dm, open(dmp, "w"))
+            cmd += ["--dm-spec", dmp]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        assert r.returncode == 0, f"builder failed:\n{r.stderr}"
+        spec = json.load(open(sp))
+        # every measure/dim column formula keyed by column name, across data pages
+        cols = {}
+        for pg in spec["pages"]:
+            for el in pg["elements"]:
+                for c in el.get("columns", []):
+                    cols[c.get("name")] = c["formula"]
+        return cols
+
+
+def test_fallback_without_dm_spec():
+    cols = build(with_metrics=False)
+    assert cols["Total Net Revenue"].startswith("Sum("), cols["Total Net Revenue"]
+    assert not any(str(v).startswith("[Metrics/") for v in cols.values()), cols
+    print("[ok] no --dm-spec → inline (byte-identical fallback)")
+
+
+def test_matched_measure_binds_to_metric():
+    cols = build(with_metrics=True)
+    assert cols["Total Net Revenue"] == "[Metrics/Net Revenue]", cols["Total Net Revenue"]
+    print("[ok] matched aggregate → [Metrics/Net Revenue] (governed, no re-derive)")
+
+
+def test_countdistinct_form_mismatch_falls_back():
+    cols = build(with_metrics=True)
+    # metric is Qlik-form Count(DISTINCT ...); inline is CountDistinct(...) → no match
+    assert cols["Distinct Orders"].startswith("CountDistinct("), cols["Distinct Orders"]
+    assert "[Metrics/" not in cols["Distinct Orders"], cols["Distinct Orders"]
+    print("[ok] Count(DISTINCT) metric vs CountDistinct inline → inline fallback (safe)")
+
+
+def test_unmatched_metric_never_referenced():
+    cols = build(with_metrics=True)
+    assert not any(v == "[Metrics/Unrelated]" for v in cols.values()), cols
+    print("[ok] non-matching metric → never referenced (no false positive)")
+
+
+if __name__ == "__main__":
+    test_fallback_without_dm_spec()
+    test_matched_measure_binds_to_metric()
+    test_countdistinct_form_mismatch_falls_back()
+    test_unmatched_metric_never_referenced()
+    print("ALL PASS")


### PR DESCRIPTION
## What

First consumer of the shared metric binder (PR #496). The qlik workbook builder prefers a governed **`[Metrics/<name>]`** reference for a measure column when its translated inline aggregate matches a metric hosted on the denorm element the master sources — instead of re-deriving the aggregation inline.

**beads-sigma-7bun.3** (epic `7bun`); follows the looker reference (#484).

## How

- **`migrate-qlik.rb`** hands the freshly-built DM spec to the builder via a new `--dm-spec` flag (fresh-build path only — the DM-reuse path writes no `dm-spec.json`, so it stays inline).
- **`build-sigma-workbook.py`** resolves the referenceable metrics for the denorm element via the shared binder (`scripts/lib/metric_binding.py` → `available_metrics`), then wraps each translated measure formula with `metric_ref_or_inline(f, "Master", metrics)`.

## Safe by construction

Ratios with no exact match, empty metrics, no `--dm-spec`, and metrics in a *different representation* (the inline `CountDistinct(...)` vs a Qlik-form `Count(DISTINCT ...)` metric) all fall back to the inline formula. The helper's exact-match also means it will never bind to a malformed/Qlik-form metric.

## Verification (offline, `retail-orders` fixture)

- **Byte-identical fallback:** the edited builder with **no** `--dm-spec` produces output **identical** to `origin/main`'s builder (`diff` clean).
- **Real bindings:** with the fixture's actual DM metrics, **30 measure columns** bind to `[Metrics/<name>]` (0 before) — Net Revenue ×23, Units Sold, Discount Amount, Net Profit, Net Margin %, Return Rate %, Avg Days to Ship. `Count(DISTINCT)`-based metrics (Order Count, Avg Order Value) correctly stay inline.
- New offline test `tests/test_metric_reference.py` (4 cases: fallback / matched-bind / count-distinct-form falls back / unmatched-metric ignored) — added to the `corpus-check` Python allow-list.
- qlik golden + trellis + grounding tests still pass (no regression); full local governance hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)