### PR TITLE
gooddata: workbook measures reference DM metrics ([Metrics/<name>]) instead of re-deriving inline (7bun.9)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -300,6 +300,7 @@ jobs:
             plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_metric_reference.py
+            plugins/gooddata-to-sigma/skills/gooddata-to-sigma/tests/test_metric_reference.py
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
@@ -113,8 +113,20 @@ and resolves a related-dataset `view` attribute to a cross-element reference
 ```
 python3 scripts/build_workbook.py --workspace gd_workspace.json \
   --data-model-id <dm-uuid> --fact-element <elId> --fact-name <TABLE> \
-  --rel-name <REL_NAME> --fact-dataset <ds-id> --folder-id <folder> --out wb_spec.json
+  --rel-name <REL_NAME> --fact-dataset <ds-id> --folder-id <folder> \
+  --dm-spec dm_spec.json --out wb_spec.json
 ```
+**DM metric references (leverage the semantic layer, don't duplicate it).** Pass
+`--dm-spec dm_spec.json` (the Phase-2 `convert.py` output) and a measure column
+prefers a governed **`[Metrics/<name>]`** reference over re-deriving the aggregation
+inline, when its translated inline aggregate matches a metric on the fact element
+(formula-equivalence match via the shared binder `scripts/lib/metric_binding.py` —
+strip the `Data` master prefix so `Sum([Data/Net Revenue])` equals a metric's
+`Sum([Net Revenue])`). SAFE: `BY ALL`/`FOR` context measures (already flagged),
+metric-of-metric ratios (workbook expands them; the DM keeps `[MetricName]` refs),
+and any non-match fall back to inline. `--fact-element` must be the DM element id
+`convert.py` assigned (CREATE preserves ids), so it keys into the spec's elements.
+No `--dm-spec` → inline, byte-identical. Verified: `tests/test_metric_reference.py`.
 Apply the dashboard grid **layout as the LAST write** (after all elements exist;
 a bare spec PUT wipes layout) — match GoodData's section/widget arrangement.
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build_workbook.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build_workbook.py
@@ -33,6 +33,7 @@ import argparse, json, re, sys, os
 # BY ALL/WITHIN/FOR hard-MAQL flagging — STAYS as cited code (see each site).
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import coverage_catalog as _cc  # noqa: E402
+import metric_binding as _mb    # noqa: E402  shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 _CAT_DIR = _cc.default_catalog_dir(__file__)
 VIZ_CAT  = _cc.load(_CAT_DIR, "viz-kind")        # GoodData visualizationUrl -> Sigma element kind
 AGG_CAT  = _cc.load(_CAT_DIR, "aggregation")     # MAQL scalar aggregate fn  -> Sigma aggregate fn
@@ -68,9 +69,29 @@ def main():
     ap.add_argument("--fact-dataset", required=True)
     ap.add_argument("--folder-id", required=True)
     ap.add_argument("--dashboard", default=None, help="migrate only this dashboard id (+ its filterContext)")
+    ap.add_argument("--dm-spec", default=None,
+                    help="DM spec JSON (convert.py --out). When present, a measure whose inline "
+                         "aggregate matches a metric on the fact element binds to a governed "
+                         "[Metrics/<name>] reference instead of re-deriving it inline. Absent → "
+                         "inline, byte-identical to before.")
     ap.add_argument("--out", default="wb_spec.json")
     a = ap.parse_args()
     P = a.fact_name  # element-name prefix for the master's own (DM-sourced) formulas
+
+    # DM metrics referenceable on the master (it sources the fact element): a measure
+    # whose translated inline aggregate matches one binds to [Metrics/<name>] (governed)
+    # instead of re-deriving it. No --dm-spec → empty list → every measure stays inline
+    # (byte-identical). Resolution + formula-equivalence matching live in the shared
+    # binder (scripts/lib/metric_binding.py). --fact-element must be the DM element id
+    # convert.py assigned (CREATE preserves ids), so it keys into the spec's elements.
+    metrics = []
+    if a.dm_spec and os.path.exists(a.dm_spec):
+        try:
+            _dm = json.load(open(a.dm_spec))
+            _by_id = {e.get("id"): e for pg in _dm.get("pages", []) for e in (pg.get("elements") or [])}
+            metrics = _mb.available_metrics(a.fact_element, _by_id)
+        except (ValueError, OSError) as e:
+            print(f"--dm-spec unreadable ({e}); measures stay inline", file=sys.stderr)
 
     layout = json.load(open(a.workspace)); ldm = layout["ldm"]; an = layout["analytics"]
     # symbol tables
@@ -209,7 +230,9 @@ def main():
             flags.append({"insight": iid, "reason": "measure uses workbook-level MAQL (BY ALL / FOR)"}); continue
         mcols = []
         for m, t, f in meas:
-            c = {"id": cid(t) or m, "formula": to_master(f), "name": t}
+            # Prefer a governed [Metrics/<name>] ref when this inline aggregate matches a
+            # DM metric by formula equivalence; safe no-op (inline) otherwise.
+            c = {"id": cid(t) or m, "formula": _mb.metric_ref_or_inline(to_master(f), MASTER_NAME, metrics), "name": t}
             fmt = gd_fmt(metric_fmt.get(m))
             if fmt: c["format"] = fmt
             mcols.append(c)

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/tests/test_metric_reference.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/tests/test_metric_reference.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""DM-metric references in the gooddata workbook builder (leverage the semantic
+layer instead of duplicating aggregations). Offline, creds-free.
+
+build_workbook.py prefers a governed `[Metrics/<name>]` reference over re-deriving
+a measure's aggregation inline, when the measure's translated inline aggregate
+matches a metric on the fact element the master sources — via the shared binder
+(scripts/lib/metric_binding.py; formula-equivalence match, master prefix "Data").
+SAFE: no `--dm-spec`, no match, and MAQL-context/ratio measures fall back to inline.
+
+The matched-case metric formula is DERIVED from the no-`--dm-spec` build's own inline
+output (stripping the "[Data/" master prefix), so the test exercises the real MAQL
+translate path rather than hardcoding a fact title.
+
+Run: python3 tests/test_metric_reference.py   (exit 0 = pass)
+"""
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+BUILDER = os.path.join(SKILL, "scripts", "build_workbook.py")
+FIXTURE = os.path.join(SKILL, "fixtures", "test_workspace_orders.json")
+
+# a bar chart over one plain-Sum measure (m_gross_revenue = SELECT SUM({fact/gross_revenue}))
+# and one category dim, injected into the (otherwise viz-empty) fixture.
+INSIGHT = {
+    "id": "ins_rev_by_channel", "title": "Rev by Channel",
+    "content": {"visualizationUrl": "local:column", "buckets": [
+        {"localIdentifier": "measures", "items": [
+            {"measure": {"localIdentifier": "m1", "title": "Gross Revenue",
+                         "definition": {"measureDefinition": {
+                             "item": {"identifier": {"id": "m_gross_revenue"}}}}}}]},
+        {"localIdentifier": "view", "items": [
+            {"attribute": {"localIdentifier": "a1",
+                           "displayForm": {"identifier": {"id": "acquisition_channel.name"}}}}]},
+    ]},
+}
+
+
+def build(dm_spec=None):
+    ws = copy.deepcopy(json.load(open(FIXTURE)))
+    ws["analytics"]["visualizationObjects"] = [INSIGHT]
+    with tempfile.TemporaryDirectory() as d:
+        wp = os.path.join(d, "ws.json"); json.dump(ws, open(wp, "w"))
+        out = os.path.join(d, "wb.json")
+        cmd = [sys.executable, BUILDER, "--workspace", wp,
+               "--data-model-id", "dm-x", "--fact-element", "el-x",
+               "--fact-name", "ORDER_FACT", "--rel-name", "EL_CUSTOMER",
+               "--fact-dataset", "order", "--folder-id", "fld-x", "--out", out]
+        if dm_spec is not None:
+            sp = os.path.join(d, "dm-spec.json"); json.dump(dm_spec, open(sp, "w"))
+            cmd += ["--dm-spec", sp]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        assert r.returncode == 0, "build_workbook failed:\n" + r.stderr
+        spec = json.load(open(out))
+        # the injected chart element (NOT the Data-page master detail table, which
+        # also carries a "Gross Revenue" column)
+        for pg in spec["pages"]:
+            for el in pg["elements"]:
+                if el.get("id") != INSIGHT["id"]:
+                    continue
+                for c in el.get("columns", []):
+                    if c.get("name") == "Gross Revenue":
+                        return c["formula"]
+        raise AssertionError("Gross Revenue measure column not found: " + json.dumps(spec))
+
+
+def _dm_spec(metrics):
+    return {"name": "t", "schemaVersion": 1, "pages": [{"id": "pg", "name": "P",
+            "elements": [{"id": "el-x", "name": "Data", "metrics": metrics}]}]}
+
+
+def test_fallback_without_dm_spec():
+    f = build(None)
+    assert f.startswith("Sum(") and "[Metrics/" not in f, f
+    print("[ok] no --dm-spec → inline (byte-identical fallback):", f)
+
+
+def test_matched_measure_binds_to_metric():
+    inline = build(None)                              # real translate-path output
+    metric_formula = inline.replace("[Data/", "[")    # element-relative form a DM metric uses
+    f = build(_dm_spec([{"name": "Gross Revenue Metric", "formula": metric_formula}]))
+    assert f == "[Metrics/Gross Revenue Metric]", f
+    print("[ok] matched aggregate → [Metrics/Gross Revenue Metric] (governed, no re-derive)")
+
+
+def test_unmatched_metric_never_referenced():
+    f = build(_dm_spec([{"name": "Unrelated", "formula": "Sum([Nonexistent Col])"}]))
+    assert f.startswith("Sum(") and "[Metrics/" not in f, f
+    print("[ok] non-matching metric → inline (no false positive)")
+
+
+if __name__ == "__main__":
+    test_fallback_without_dm_spec()
+    test_matched_measure_binds_to_metric()
+    test_unmatched_metric_never_referenced()
+    print("ALL PASS")


### PR DESCRIPTION
## What
Wires the shared metric binder (PR #496) into the gooddata workbook builder. A measure column prefers a governed **`[Metrics/<name>]`** reference when its translated inline aggregate matches a metric on the fact element the master sources — instead of re-deriving the aggregation inline. **beads-sigma-7bun.9**; follows looker (#484) / qlik (#497).

## How
- **`build_workbook.py`**: new `--dm-spec` flag (the Phase-2 `convert.py` output). Loads it, resolves the fact element's referenceable metrics via `metric_binding.available_metrics`, and wraps each measure formula with `metric_ref_or_inline(to_master(f), "Data", metrics)`.
- **SKILL.md Phase 3**: documents `--dm-spec` + the behavior. `--fact-element` keys into the spec's elements (CREATE preserves ids).

## Safe by construction
`BY ALL`/`FOR` context measures (already flagged), metric-of-metric ratios (build_workbook recursively expands them while the DM keeps `[MetricName]` refs → no match), and any non-match fall back to inline. No `--dm-spec` → byte-identical.

## Verification (offline, no creds)
- New `tests/test_metric_reference.py` (3 cases): derives the matched-case metric formula from the **real no-`--dm-spec` inline output** (so it's naming/title-independent and exercises the actual MAQL translate path), then asserts the `[Metrics/…]` flip, the no-`--dm-spec` inline fallback, and that a non-matching metric is never referenced. Added to the `corpus-check` Python allow-list.
- gooddata `test_grounding.py` (catalogs / no-inline-map / loud-viz / coverage-matrix) still passes; full local governance hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)