### PR TITLE
microstrategy: workbook measures reference DM metrics ([Metrics/<name>]) instead of re-deriving inline (7bun.8)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -301,6 +301,7 @@ jobs:
             plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_metric_reference.py
             plugins/gooddata-to-sigma/skills/gooddata-to-sigma/tests/test_metric_reference.py
+            plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_metric_reference.py
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -241,6 +241,17 @@ attribute's KEY form and label with `Max([DESC])`; dim-keyed groupings get an
 `exclude [null]` filter to mirror MSTR's inner joins; metrics referencing
 metrics are inlined in workbook context, `[Name]`-referenced in DM context.
 
+**DM metric references (leverage the semantic layer, don't duplicate it).** A metric
+column prefers a governed **`[Metrics/<name>]`** reference over re-deriving the
+aggregation inline, when its expanded inline aggregate matches a metric on the join
+element (formula-equivalence match via the shared binder `scripts/lib/metric_binding.py`
+— strip the `--join-element-name` prefix so `Sum([Orders/Net Revenue])` equals a
+metric's `Sum([Net Revenue])`). `build_workbook_spec` receives the just-built DM's
+elements in-process (own metrics live on the join element). SAFE: composite/ratio
+metrics stay inline (the workbook expands them with `expand_metrics=True`, while the DM
+keeps `[MetricName]` refs, so they never match) and any non-match falls back to inline.
+Empty metrics → byte-identical. Verified: `tests/test_metric_reference.py`.
+
 ## Phase 2.5 — AE row-collapse resolution (only when flagged)
 
 If any report has an attribute whose DESC form differs from its key (the

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
@@ -49,6 +49,7 @@ import sys
 # the beads-sigma-kvza / -93ps contract: catalog = data, code = thin resolver.
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import coverage_catalog as _cc  # noqa: E402
+import metric_binding as _mb    # noqa: E402  shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 _CAT_DIR = _cc.default_catalog_dir(__file__)
 AGG_CAT = _cc.load(_CAT_DIR, "aggregation")     # MSTR group function -> Sigma/SQL aggregate
 FMT_CAT = _cc.load(_CAT_DIR, "number-format")   # MSTR format category -> Sigma number format
@@ -1039,10 +1040,20 @@ def build_ae_page(b: Bundle, args, ch_name, report, cfg, dm_id, el_ref,
     }
 
 
-def build_workbook_spec(b: Bundle, args, ae_winners=None, dm_element_ids=None):
+def build_workbook_spec(b: Bundle, args, ae_winners=None, dm_element_ids=None, dm_elements=None):
     dm_id = args.data_model_id or "{{DATA_MODEL_ID}}"
     dm_element_ids = dm_element_ids or {}
     join_name = args.join_element_name
+
+    # DM metrics referenceable on the join element (which the workbook measures source):
+    # a measure whose expanded inline aggregate matches one binds to [Metrics/<name>]
+    # (governed) instead of re-deriving it. Own metrics live on the join element; the
+    # shared binder (scripts/lib/metric_binding.py) does the formula-equivalence match.
+    # No dm_elements → empty list → every measure stays inline (byte-identical).
+    _els = dm_elements or []
+    _by_id = {e.get("id"): e for e in _els}
+    _join_el = next((e for e in _els if e.get("name") == join_name), None)
+    metrics = _mb.available_metrics(_join_el["id"], _by_id) if _join_el else []
 
     def el_ref(name):
         if name == join_name and args.orders_element_id:
@@ -1134,11 +1145,14 @@ def build_workbook_spec(b: Bundle, args, ae_winners=None, dm_element_ids=None):
                     mid = el["id"]
                     mname = b.metrics[mid]["information"]["name"]
                     cid = f"c-{slug(ch_name)}-{slug(mname)}"
+                    # Prefer a governed [Metrics/<name>] ref when this expanded inline
+                    # aggregate matches a DM metric by formula equivalence; safe no-op
+                    # (inline) otherwise (ratios/composites expand and won't match).
+                    _inline = b.metric_formula(mid, wb_ref, expand_metrics=True)
                     col = {
                         "id": cid,
                         "name": mname,
-                        "formula": b.metric_formula(mid, wb_ref,
-                                                    expand_metrics=True),
+                        "formula": _mb.metric_ref_or_inline(_inline, join_name, metrics),
                     }
                     fmt = b.metric_display_format(mid)
                     if fmt:
@@ -1267,8 +1281,11 @@ def main():
                       if args.dm_element_ids else None)
 
     dm = build_dm_spec(b, args, inode_map, ae_winners)
+    # thread the built DM's elements so workbook measures can bind to governed
+    # [Metrics/<name>] refs (own metrics live on the join element)
+    _dm_elements = [e for pg in dm.get("pages", []) for e in (pg.get("elements") or [])]
     wb, report_keys, layout_xml, control_scope, warnings = \
-        build_workbook_spec(b, args, ae_winners, dm_element_ids)
+        build_workbook_spec(b, args, ae_winners, dm_element_ids, _dm_elements)
     json.dump(dm, open(args.out_dm, "w"), indent=1)
     json.dump(wb, open(args.out_wb, "w"), indent=1)
     json.dump(report_keys, open("parity_keys.json", "w"), indent=1)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_metric_reference.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_metric_reference.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""DM-metric references in the microstrategy workbook builder (leverage the
+semantic layer instead of duplicating aggregations). Offline, creds-free.
+
+convert.py builds the DM (metrics on the join element) then the workbook in one
+process; a metric column prefers a governed `[Metrics/<name>]` reference over
+re-deriving the aggregation inline, when its expanded inline aggregate matches a
+metric on the join element — via the shared binder (scripts/lib/metric_binding.py;
+formula-equivalence match, master prefix = --join-element-name, default "Orders").
+SAFE: composite/ratio metrics (which the workbook expands inline while the DM keeps
+[MetricName] refs) and any non-match fall back to inline; empty metrics are a no-op.
+
+Run: python3 tests/test_metric_reference.py   (exit 0 = pass)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+CONV = os.path.join(SKILL, "scripts", "convert.py")
+BUNDLE = os.path.join(SKILL, "fixtures", "bundle.json")
+AE_WINNERS = os.path.join(SKILL, "fixtures", "ae_winners.json")
+
+
+def _convert():
+    with tempfile.TemporaryDirectory() as d:
+        wb = os.path.join(d, "wb.json"); dm = os.path.join(d, "dm.json")
+        r = subprocess.run(
+            [sys.executable, CONV, "--bundle", BUNDLE, "--connection-id", "conn-x",
+             "--database", "DEMO_DB", "--folder-id", "fld-x", "--ae-winners", AE_WINNERS,
+             "--out-dm", dm, "--out-wb", wb, "--out-layout", os.path.join(d, "l.xml"),
+             "--control-scope-out", os.path.join(d, "cs.json")],
+            capture_output=True, text=True, cwd=d)
+        assert r.returncode == 0, "convert.py failed:\n" + r.stderr
+        return json.load(open(wb)), json.load(open(dm))
+
+
+def _cols(wb):
+    return [c for pg in wb["pages"] for el in pg["elements"] for c in el.get("columns", [])]
+
+
+def _dm_metric_names(dm):
+    return {m["name"] for pg in dm["pages"] for el in pg["elements"] for m in (el.get("metrics") or [])}
+
+
+def test_matched_measures_bind_to_metrics():
+    """Simple-aggregate metric columns (Sum/CountDistinct) → [Metrics/<name>]."""
+    wb, dm = _convert()
+    refs = {c["formula"] for c in _cols(wb) if str(c["formula"]).startswith("[Metrics/")}
+    assert "[Metrics/Total Net Revenue]" in refs, refs
+    assert "[Metrics/Order Count]" in refs, refs      # CountDistinct binds (same repr both sides)
+    # every emitted [Metrics/<name>] must name a metric that actually exists on the DM
+    names = _dm_metric_names(dm)
+    for r in refs:
+        nm = r[len("[Metrics/"):-1]
+        assert nm in names, f"referenced non-existent metric {nm!r}; DM has {sorted(names)}"
+    print("[ok] matched aggregates → governed [Metrics/<name>] refs:", sorted(refs))
+
+
+def test_ratio_metric_stays_inline():
+    """A composite/ratio metric (Profit Margin Pct) is expanded inline in the workbook
+    and must NOT bind to itself (representations differ → safe fallback)."""
+    wb, _ = _convert()
+    for c in _cols(wb):
+        if c.get("name") == "Profit Margin Pct":
+            assert not str(c["formula"]).startswith("[Metrics/"), c["formula"]
+            print("[ok] ratio 'Profit Margin Pct' → inline fallback:", c["formula"])
+            return
+    # ratio may not appear on any report in the fixture — that's fine, nothing to assert
+    print("[ok] ratio not present on a report (nothing to bind)")
+
+
+def test_no_false_positive():
+    """No column references a metric name absent from the DM (formula match, not name)."""
+    wb, dm = _convert()
+    names = _dm_metric_names(dm)
+    bad = [c["formula"] for c in _cols(wb)
+           if str(c["formula"]).startswith("[Metrics/") and c["formula"][len("[Metrics/"):-1] not in names]
+    assert not bad, bad
+    print("[ok] no [Metrics/<name>] ref points at a non-existent metric")
+
+
+if __name__ == "__main__":
+    test_matched_measures_bind_to_metrics()
+    test_ratio_metric_stays_inline()
+    test_no_false_positive()
+    print("ALL PASS")


### PR DESCRIPTION
## What
Wires the shared metric binder (PR #496) into the microstrategy converter. A metric column prefers a governed **`[Metrics/<name>]`** reference over re-deriving the aggregation inline, when its expanded inline aggregate matches a metric on the join element. **beads-sigma-7bun.8**; follows looker (#484) / qlik (#497) / gooddata (#498).

## How
`convert.py` builds the DM then the workbook **in one process**, so `build_workbook_spec` now receives the just-built DM's elements directly (no new CLI flag). It resolves the join element's own metrics via `metric_binding.available_metrics` and wraps each metric column's `metric_formula(..., expand_metrics=True)` with `metric_ref_or_inline(inline, join_name, metrics)` (`join_name` = `--join-element-name`, default `Orders`).

## Safe by construction
Composite/ratio metrics stay inline — the workbook expands them (`expand_metrics=True`) while the DM keeps `[MetricName]` refs, so they never match — and any non-match falls back to inline. Empty metrics → byte-identical.

## Verification (offline, `fixtures/bundle.json`)
- **5 measure columns bind**: Total Net Revenue ×2, Total Gross Profit, Units Sold, Order Count (`CountDistinct` binds — same representation both sides).
- **DM spec byte-identical** to origin/main; the workbook diff vs origin/main is **exactly those 5 formula lines** and nothing else.
- **`Profit Margin Pct`** (ratio) correctly stays inline: `(Sum([Orders/Gross Profit])) / (Sum([Orders/Net Revenue]))`.
- New `tests/test_metric_reference.py` (matched-bind / ratio-inline / no-false-positive) added to the `corpus-check` Python allow-list. `test_grounding.py` (chart-emission, coverage-matrix, e2e) still passes; full local governance hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)