### PR TITLE
thoughtspot: workbook measures reference DM metrics ([Metrics/<name>]) instead of re-deriving inline (7bun.6)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -302,6 +302,7 @@ jobs:
             plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_metric_reference.py
             plugins/gooddata-to-sigma/skills/gooddata-to-sigma/tests/test_metric_reference.py
             plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_metric_reference.py
+            plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/tests/test_metric_reference.py
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -228,6 +228,17 @@ python3 scripts/migrate.py --model-tml fixtures/retail-analytics-model.tml \
    `{"columnId": c}`; donut `value`/`color` use `{"id": c}`; grouped tables need
    `groupings:[{groupBy, calculations}]`. Full spec shapes:
    **`refs/liveboard-to-workbook.md`** (charts) + **`refs/model-conversion-rules.md`** (DM).
+   **DM metric references (leverage the semantic layer, don't duplicate it):** a
+   measure column prefers a governed **`[Metrics/<name>]`** reference over re-deriving
+   the aggregate inline, when its inline aggregate matches a metric referenceable on
+   the master (formula-equivalence match via the shared binder
+   `scripts/lib/metric_binding.py` — strip the `OFV` prefix so `Sum([OFV/Net Revenue])`
+   equals a metric's `Sum([Net Revenue])`). `migrate.py` resolves the metrics off the
+   denorm "<root> View" element (0 own metrics; it inherits the base fact's via
+   `source.elementId`) and stashes them on the resolver. SAFE: synthesized
+   timeshift/growth/window measures, dim-grain KPIs, ratios, and any non-match fall
+   back to inline; the DM-reuse path (no conv) stays inline, byte-identical. Verified:
+   `tests/test_metric_reference.py`.
 5. **Layout** — `apply_layouts.py` maps the Liveboard's OWN `layout.tiles`
    geometry (x/y/w/h on ThoughtSpot's 12-col grid) onto Sigma's 24-col grid
    (cols ×2, rows ×ROW_SCALE min 2 so axis/KPI labels render), as the **LAST**

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -38,6 +38,7 @@ import argparse, json, os, re, ssl, subprocess, sys, time, urllib.request, urlli
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import yaml, ts_common, apply_layouts, scout_gate
+import metric_binding as _mb    # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -483,6 +484,7 @@ def main():
             r = (match or {}).get("rationale") or "no candidate"
             print(f"  DM-reuse scan: no safe match ({r}) — building a new DM")
 
+    dm_metrics = []
     if a.reuse_dm:
         dm = a.reuse_dm
         denorm_id, denorm_name = find_denorm(dm)
@@ -490,10 +492,20 @@ def main():
     else:
         conv = convert_model(model_tml, wd, a.converted)
         dm, denorm_id, denorm_name = build_dm(conv, f"{prefix}{model_name} (from ThoughtSpot)", folder)
+        # DM metrics referenceable on the denorm "<X> View" element (own + inherited
+        # base-fact metrics via source.elementId) → a workbook measure whose inline
+        # aggregate matches one binds to a governed [Metrics/<name>] ref. Reuse-DM
+        # path keeps metrics empty (no conv) → inline, byte-identical.
+        try:
+            _els = conv["model"]["pages"][0]["elements"]
+            dm_metrics = _mb.available_metrics(denorm_id, {e["id"]: e for e in _els})
+        except (KeyError, TypeError, IndexError):
+            dm_metrics = []
 
     # chasm-trap guard inputs: the DM's raw table elements, for dimension-grain
     # measures that must NOT be aggregated over the fanned-out denorm view
     resolver["__dm_id__"] = dm
+    resolver["__metrics__"] = dm_metrics
     try:
         resolver["__dim_elements__"] = find_table_elements(dm)
     except Exception as ex:

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -24,6 +24,7 @@ import os, sys
 # code = thin resolver + cited compositional predicates.
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import coverage_catalog as _cc  # noqa: E402
+import metric_binding as _mb    # noqa: E402  shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 _CAT_DIR = _cc.default_catalog_dir(__file__)
 VIZ_CAT  = _cc.load(_CAT_DIR, "viz-kind")        # TS chart_type   -> Sigma element kind
 FMT_CAT  = _cc.load(_CAT_DIR, "number-format")   # currency ISO    -> Unicode symbol
@@ -870,6 +871,13 @@ def _element_core(spec, resolver, master="OFV"):
     mtypes = spec.get("mtypes") or {}
     dref = lambda b: f"[{master}/{_bucket_friendly(b) or _resolve(resolver, b)['friendly']}]"
 
+    # DM metrics referenceable on the master (m-ofv sources the denorm "<X> View"
+    # element, which inherits the base fact's metrics via source.elementId). A plain
+    # or aggregate-formula measure whose inline aggregate matches one binds to a
+    # governed [Metrics/<name>] ref (shared binder); the synthesized timeshift/growth/
+    # window measures stay inline. Empty (or reuse-DM path) → inline, byte-identical.
+    _mets = resolver.get("__metrics__") or []
+
     def mref(b):
         mt = mtypes.get(b)
         if mt and mt.get("kind") == "timeshift":      # sales(this year) / sales(last year)
@@ -881,12 +889,12 @@ def _element_core(spec, resolver, master="OFV"):
         if mt and mt.get("kind") == "growth":         # period-over-period (flagged): show base agg
             return f"Sum([{master}/{_resolve(resolver, mt['base'])['friendly']}])"
         if mt and mt.get("kind") == "aggregate":      # answer/model aggregate formula
-            return ts_expr_to_sigma(mt["expr"], lambda n: dref(n))
+            return _mb.metric_ref_or_inline(ts_expr_to_sigma(mt["expr"], lambda n: dref(n)), master, _mets)
         if mt and mt.get("kind") == "window":         # FLAGGED: inner raw aggregate fallback
             inner = window_inner_ref(mt.get("expr")) or b
             return f"Sum([{master}/{_resolve(resolver, inner)['friendly']}])"
         agg = _resolve_agg((mt or {}).get("agg"), context=b)
-        return f"{agg}([{master}/{_resolve(resolver, b)['friendly']}])"
+        return _mb.metric_ref_or_inline(f"{agg}([{master}/{_resolve(resolver, b)['friendly']}])", master, _mets)
 
     def mfmt(b):
         # Format follows the underlying measure: a period-shifted/growth measure

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/tests/test_metric_reference.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/tests/test_metric_reference.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""DM-metric references in the thoughtspot workbook builder (leverage the semantic
+layer instead of duplicating aggregations). Offline, creds-free.
+
+ts_common._element_core's `mref` prefers a governed `[Metrics/<name>]` reference
+over re-deriving a measure's aggregate inline, when the measure's inline aggregate
+matches a metric referenceable on the master (the `resolver["__metrics__"]` list
+migrate.py resolves via metric_binding.available_metrics over the denorm view's
+source.elementId chain). Match is by FORMULA equivalence (strip the "OFV" master
+prefix). SAFE: no metrics / no match / synthesized timeshift-growth-window measures
+fall back to inline; empty is byte-identical (the existing test_grounding suite runs
+with resolver={} and is unaffected).
+
+Run: python3 tests/test_metric_reference.py   (exit 0 = pass)
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = os.path.join(os.path.dirname(HERE), "scripts")
+sys.path.insert(0, SCRIPTS)
+sys.path.insert(0, os.path.join(SCRIPTS, "lib"))
+import ts_common as t  # noqa: E402
+import metric_binding as mb  # noqa: E402
+
+KPI = {"name": "Rev", "chart": "KPI", "dims": [], "measures": ["Revenue"],
+       "mtypes": {"Revenue": {"agg": "SUM"}}}
+
+
+def _formula(resolver):
+    el = t.sigma_element(dict(KPI), resolver)
+    return el["columns"][0]["formula"]
+
+
+def test_fallback_without_metrics():
+    """resolver has no __metrics__ (the state every existing test runs in) → inline."""
+    f = _formula({})
+    assert f.startswith("Sum(") and "[Metrics/" not in f, f
+    print("[ok] no __metrics__ → inline (byte-identical fallback):", f)
+
+
+def test_matched_measure_binds_to_metric():
+    f = _formula({"__metrics__": [{"name": "Total Revenue", "formula": "Sum([Revenue])"}]})
+    assert f == "[Metrics/Total Revenue]", f
+    print("[ok] matched aggregate → [Metrics/Total Revenue] (governed, no re-derive)")
+
+
+def test_nonmatching_metric_ignored():
+    f = _formula({"__metrics__": [{"name": "Other", "formula": "Sum([Something Else])"}]})
+    assert f.startswith("Sum(") and "[Metrics/" not in f, f
+    print("[ok] non-matching metric → inline (no false positive)")
+
+
+def test_available_metrics_walks_view_chain():
+    """The migrate.py resolution half: a denorm '<X> View' element (0 own metrics)
+    inherits its base fact's metrics via source.elementId — exactly what migrate.py
+    feeds into resolver["__metrics__"]."""
+    els = {
+        "view": {"id": "view", "name": "Order Fact View", "metrics": [],
+                 "source": {"elementId": "fact"}},
+        "fact": {"id": "fact", "name": "Order Fact",
+                 "metrics": [{"name": "Net Revenue", "formula": "Sum([Net Revenue])"}]},
+    }
+    got = mb.available_metrics("view", els)
+    assert got == [{"name": "Net Revenue", "formula": "Sum([Net Revenue])"}], got
+    print("[ok] available_metrics walks the denorm-view → base-fact source.elementId chain")
+
+
+if __name__ == "__main__":
+    test_fallback_without_metrics()
+    test_matched_measure_binds_to_metric()
+    test_nonmatching_metric_ignored()
+    test_available_metrics_walks_view_chain()
+    print("ALL PASS")


### PR DESCRIPTION
## What
Wires the shared metric binder (PR #496) into the thoughtspot workbook builder. A measure column prefers a governed **`[Metrics/<name>]`** reference over re-deriving the aggregate inline, when its inline aggregate matches a metric referenceable on the master. **beads-sigma-7bun.6**; follows looker (#484) / qlik (#497) / gooddata (#498) / microstrategy (#499).

## How
- **`ts_common.py`** `_element_core.mref`: wraps the plain-aggregate and aggregate-formula returns with `metric_ref_or_inline(inline, "OFV", metrics)`. The synthesized timeshift/growth/window returns stay inline.
- **`migrate.py`**: resolves the referenceable metrics off the denorm `"<root> View"` element — which carries **0 own metrics but inherits the base fact's via `source.elementId`** (`available_metrics` walks the chain) — and stashes them on `resolver["__metrics__"]` (the same dict already carrying `__dm_id__`/`__dim_elements__`).

## Safe by construction
Synthesized timeshift/growth/window measures, the dim-grain (chasm-trap) KPI path, ratios, and any non-match stay inline. The DM-reuse path (no `conv`) keeps metrics empty → inline. The entire existing `test_grounding` suite runs with `resolver={}` and is unaffected (byte-identical).

## Verification (offline, no creds)
- **Resolution half:** on `fixtures/retail-analytics-model.tml`, the node converter emits a denorm `"Order Fact View"` (0 own metrics) that `available_metrics` resolves to **8 inherited base-fact metrics** via `source.elementId` (`Sum([Net Revenue])`, …).
- **Binding half:** `sigma_element` with `resolver["__metrics__"]=[{"Total Revenue","Sum([Revenue])"}]` turns a `Sum([OFV/Revenue])` KPI into `[Metrics/Total Revenue]`; empty/non-match → inline.
- New `tests/test_metric_reference.py` (4 cases) added to the `corpus-check` Python allow-list; `test_grounding.py` still passes; full local governance hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)