### PR TITLE
tableau: workbook measures reference DM metrics ([Metrics/<name>]) instead of re-deriving inline (7bun.4)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -241,6 +241,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-datasource-filter-gate.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-conflicting-page-defaults.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-metric-reference.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -278,7 +278,7 @@ it when a STOP routes you to a script.
 | `escalate-gap.py` | Opt-in issue filer (dry-run by default; `--yes` to file) |
 | `learned-rules.rb` | Merges `learned/starter-rules.yaml` + `~/.tableau-to-sigma/learned-rules.yaml` |
 | `parse-twb-layout.rb` | `.twb` → per-dashboard zone list + `*-meta.json` (+ `story-plan.json` for stories) |
-| `build-charts-from-signals.rb` | Zones + CSVs + master map → Sigma chart specs; writes `coverage.json`; 🚧 requires `png-read.json` |
+| `build-charts-from-signals.rb` | Zones + CSVs + master map → Sigma chart specs; writes `coverage.json`; 🚧 requires `png-read.json`. `--metrics` (from `migrate-tableau.rb`, resolved off the fact element's own + `source.elementId`-inherited metrics) makes a measure prefer a governed **`[Metrics/<name>]`** ref over its inline aggregate when they match by formula equivalence (strip the `Master` prefix); ratios/LODs/table-calcs/no-match stay inline — no `--metrics` is byte-identical. Verified: `test-metric-reference.rb` |
 | `extract-custom-sql.rb` / `resolve-published-ds.rb` / `hydrate-custom-sql.rb` | Custom-SQL + published-DS (sqlproxy) resolution/hydration — never a phantom table |
 | `lib/tableau_rest.rb` | Tableau REST wrapper |
 | `estimate-cost.rb` | Phase 0c scope + token-cost estimate → `cost-estimate.json` + run-state ack |

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -278,7 +278,7 @@ it when a STOP routes you to a script.
 | `escalate-gap.py` | Opt-in issue filer (dry-run by default; `--yes` to file) |
 | `learned-rules.rb` | Merges `learned/starter-rules.yaml` + `~/.tableau-to-sigma/learned-rules.yaml` |
 | `parse-twb-layout.rb` | `.twb` → per-dashboard zone list + `*-meta.json` (+ `story-plan.json` for stories) |
-| `build-charts-from-signals.rb` | Zones + CSVs + master map → Sigma chart specs; writes `coverage.json`; 🚧 requires `png-read.json`. `--metrics` (from `migrate-tableau.rb`, resolved off the fact element's own + `source.elementId`-inherited metrics) makes a measure prefer a governed **`[Metrics/<name>]`** ref over its inline aggregate when they match by formula equivalence (strip the `Master` prefix); ratios/LODs/table-calcs/no-match stay inline — no `--metrics` is byte-identical. Verified: `test-metric-reference.rb` |
+| `build-charts-from-signals.rb` | Zones + CSVs + master map → Sigma chart specs; writes `coverage.json`; 🚧 requires `png-read.json` |
 | `extract-custom-sql.rb` / `resolve-published-ds.rb` / `hydrate-custom-sql.rb` | Custom-SQL + published-DS (sqlproxy) resolution/hydration — never a phantom table |
 | `lib/tableau_rest.rb` | Tableau REST wrapper |
 | `estimate-cost.rb` | Phase 0c scope + token-cost estimate → `cost-estimate.json` + run-state ack |

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -67,6 +67,7 @@ require_relative 'lib/series_colors'  # PR-12: ordered per-series color schemes
 require_relative 'lib/threshold_halo'  # C2: threshold-halo (computed-boolean color) detection
 require_relative 'lib/integer_dim'    # PR-18: integer-coded dimension decode-to-text routing
 require_relative 'lib/trellis_emit'   # shared native-trellis emitter (supported-kind gate + fallbacks)
+require_relative 'lib/metric_binding' # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 require 'erb'
 
 opts = { master_id: 'master' }
@@ -100,8 +101,18 @@ OptionParser.new do |p|
   # 🚧 GATE escape hatch — waive the Phase 1d dashboard-read requirement. Use ONLY
   # when the source dashboard PNG genuinely cannot be read; name the reason in your report.
   p.on('--skip-dashboard-read REASON', 'waive the Phase 1d dashboard-read gate (REQUIRED reason; name it in your report)') { |v| opts[:skip_dashboard_read] = v }
+  # DM metrics referenceable on the master (name+formula, own + inherited via
+  # source.elementId) — a measure whose inline aggregate matches one binds to a
+  # governed [Metrics/<name>] ref instead of re-deriving inline. Absent → inline.
+  p.on('--metrics PATH', 'JSON array of DM metrics {name,formula} referenceable on the master element') { |v| opts[:metrics_file] = v }
 end.parse!
 %i[tab layout mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+# Load the referenceable DM metrics once; every measure-emission site prefers a
+# governed [Metrics/<name>] ref over its inline aggregate when they match by formula
+# equivalence (strip the literal 'Master' prefix). Empty/absent → inline, byte-identical.
+opts[:metrics] = (opts[:metrics_file] && File.exist?(opts[:metrics_file]) ?
+                  JSON.parse(File.read(opts[:metrics_file], encoding: 'UTF-8')) : [])
 
 # 🚧 GATE (Phase 1d) — refuse to build charts until the SOURCE dashboard PNG has
 # been read and enumerated. png-read.json is the artifact of that read; without it
@@ -3987,6 +3998,9 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   end
 
   measure_col_id = "k-#{el_id}"
+  # Prefer a governed [Metrics/<name>] ref when this KPI aggregate matches a DM
+  # metric by formula equivalence; safe no-op (inline) otherwise.
+  formula = MetricBinding.metric_ref_or_inline(formula, 'Master', opts[:metrics])
   measure_col = {
     'id'      => measure_col_id,
     'name'    => master['name'].to_s.strip,
@@ -4406,6 +4420,7 @@ layout.each do |dash|
                 { 'kind' => 'number', 'formatString' => ',.0f' }
         # Column NAME = the Tableau measure-name label verbatim — the parity
         # plan pivots the long CSV and matches Sigma columns by display name.
+        formula = MetricBinding.metric_ref_or_inline(formula, 'Master', opts[:metrics])
         y_cols << { 'id' => "y#{i}-#{el_id}", 'name' => label, 'formula' => formula, 'format' => fmt }
       end
       if y_cols.any?
@@ -4772,6 +4787,9 @@ layout.each do |dash|
                       else
                         render_agg(sigma_agg, "[Master/#{meas['name']}]")
                       end
+    # Prefer a governed [Metrics/<name>] ref when this inline aggregate matches a
+    # DM metric by formula equivalence; safe no-op (inline) otherwise.
+    measure_formula = MetricBinding.metric_ref_or_inline(measure_formula, 'Master', opts[:metrics])
     # v5.4: NUMERIC aggregates over a TEXT column compile to type=error on the
     # live workbook (Sum/Avg/Median are numeric-only). Tableau's CSV header
     # order can hand a string column to the measure slot (the scatter
@@ -5204,6 +5222,7 @@ layout.each do |dash|
       meas2 = map_column(meas2_hdr, mmap) ||
               { 'id' => "m-#{meas2_hdr.downcase.gsub(/\W+/,'-')}", 'name' => meas2_hdr }
       meas2_formula = meas2['formula'] || render_agg(sigma_agg, "[Master/#{meas2['name']}]")
+      meas2_formula = MetricBinding.metric_ref_or_inline(meas2_formula, 'Master', opts[:metrics])
       extra_meas_col = {
         'id'      => "y2-#{el_id}",
         'name'    => meas2['name'],

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -134,6 +134,7 @@ require_relative 'lib/offramp' # structured "where did this run leave the golden
 require_relative 'lib/fast_path' # FAST-PATH routing + BOM-tolerant JSON reads
 require_relative 'lib/phase_cache' # sha-stamped phase-output reuse on re-entry (refs/performance.md)
 require_relative 'lib/sigma_rest' # in-process Sigma token minting (no bash/eval)
+require_relative 'lib/metric_binding' # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 require_relative 'lib/tableau_rest' # in-process Tableau token minting (Windows-safe; no bash/eval)
 require_relative 'hydrate-custom-sql'
 
@@ -3439,6 +3440,21 @@ if mechanical
   File.write(mmap_path, JSON.pretty_generate(mmap))
   line "master-map: #{master_columns.size} master column(s) (fact element '#{fact['name']}', #{real_labels ? real_labels.size : 0} readback labels)"
 
+  # DM metrics referenceable on the master (own on the fact element + inherited via
+  # source.elementId): a chart/KPI measure whose inline aggregate matches one binds
+  # to a governed [Metrics/<name>] ref instead of re-deriving inline (formula
+  # equivalence; ratios/LODs/table-calcs/no-match stay inline — byte-identical).
+  metrics_path = File.join(WORK, 'metrics.json')
+  begin
+    els_by_id = MechanicalSpecs.all_elements(conv['model']).each_with_object({}) { |e, h| h[e['id']] = e }
+    wb_metrics = MetricBinding.available_metrics(conv_fact['id'], els_by_id)
+  rescue StandardError => e
+    line "metric-binding: could not resolve DM metrics (#{e.class}: #{e.message}) — measures stay inline"
+    wb_metrics = []
+  end
+  File.write(metrics_path, JSON.pretty_generate(wb_metrics))
+  line "metric-binding: #{wb_metrics.size} referenceable DM metric(s) for [Metrics/<name>] refs" if wb_metrics.any?
+
   # 2) Build the chart-element specs from the parsed zones + view CSVs + map.
   #    ONE SIGMA PAGE PER TABLEAU DASHBOARD (bead ptrt) — a fat workbook's 4
   #    dashboards become 4 laid-out pages, each with its own banded layout.
@@ -3446,6 +3462,7 @@ if mechanical
   build_cmd = ['ruby', File.join(HERE, 'build-charts-from-signals.rb'),
                '--tableau-dir', WORK, '--layout', layout_json,
                '--master-map', mmap_path, '--master-element-id', 'master',
+               '--metrics', metrics_path,
                '--page-per-dashboard',
                '--out', charts_path,
                '--coverage-out', File.join(WORK, 'coverage.json')]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-metric-reference.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-metric-reference.rb
@@ -1,0 +1,131 @@
+#!/usr/bin/env ruby
+# Regression test for DM-metric references in the workbook builder (bead 7bun.4).
+#
+# A chart/KPI measure prefers a governed [Metrics/<name>] reference over
+# re-deriving the aggregation inline, when its inline aggregate matches a metric
+# referenceable on the master (formula-equivalence match via the shared binder,
+# lib/metric_binding.rb; strip the literal 'Master' prefix). migrate-tableau.rb
+# resolves those metrics off the fact element (own + inherited via source.elementId)
+# and passes them with --metrics. SAFE: no --metrics / no match → inline,
+# byte-identical to before.
+#
+# Deterministic + offline: synthesizes a minimal .twb (a line chart of
+# Month(Order Date) x SUM(Gross Revenue)), runs the ACTUAL parse-twb-layout.rb +
+# build-charts-from-signals.rb with and without --metrics, and asserts the y-axis
+# measure formula flips from Sum([Master/Gross Revenue]) to [Metrics/Gross Revenue].
+#
+# Usage:  ruby scripts/test-metric-reference.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='ORDER_FACT' name='federated.fact'>
+        <connection class='federated'>
+          <named-connections>
+            <named-connection name='snow'><connection class='snowflake' dbname='DEMO_DB' schema='DEMO' /></named-connection>
+          </named-connections>
+          <relation connection='snow' name='ORDER_FACT' table='[DEMO].[ORDER_FACT]' type='table' />
+        </connection>
+        <column caption='Gross Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+        <column caption='Order Date ' name='[c2ec6b07-897e-39ab-9422-aa895d35a627]' datatype='date' role='dimension' type='ordinal' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Monthly Revenue Trend'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Gross Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+              <column caption='Order Date ' name='[c2ec6b07-897e-39ab-9422-aa895d35a627]' datatype='date' role='dimension' type='ordinal' />
+              <column-instance column='[c2ec6b07-897e-39ab-9422-aa895d35a627]' derivation='Month-Trunc' name='[tmn:c2ec6b07-897e-39ab-9422-aa895d35a627:qk]' pivot='key' type='quantitative' />
+              <column-instance column='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' derivation='Sum' name='[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' pivot='key' type='quantitative' />
+            </datasource-dependencies>
+          </view>
+          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
+          <cols>[federated.fact].[tmn:c2ec6b07-897e-39ab-9422-aa895d35a627:qk]</cols>
+          <pane><mark class='Line' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Dash'>
+        <zones><zone id='1' name='Monthly Revenue Trend' x='0' y='0' w='100000' h='100000' /></zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Gross Revenue$' => { 'id' => 'm-gr', 'name' => 'Gross Revenue' },
+  '(?i)^Order Date $'   => { 'id' => 'm-od', 'name' => 'Order Date ' },
+  '(?i)^Order Date$'    => { 'id' => 'm-od', 'name' => 'Order Date ' }
+}
+
+# emit the same view CSV both runs; only --metrics differs
+def build_ycol(metrics)
+  ycol = nil
+  Dir.mktmpdir do |d|
+    twb = File.join(d, 'wb.twb'); lay = File.join(d, 'layout.json'); mm = File.join(d, 'master-map.json')
+    File.write(twb, TWB)
+    File.write(mm, JSON.dump(MASTER_MAP))
+    File.write(File.join(d, 'get-workbook.json'),
+               JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Monthly Revenue Trend' }] }))
+    Dir.mkdir(File.join(d, 'views'))
+    File.write(File.join(d, 'views', 'v1.csv'), "Month of Order Date,Gross Revenue\n2024-01,100\n")
+    File.write(File.join(d, 'png-read.json'),
+               JSON.dump('source_png' => 'views/v1.png',
+                         'tiles' => [{ 'title' => 'Monthly Revenue Trend', 'kind' => 'line-chart' }],
+                         'text_elements' => [], 'filter_shelf' => []))
+    system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL) or abort 'parse-twb-layout failed'
+    out = File.join(d, 'specs.json')
+    cmd = ['ruby', BUILD, '--tableau-dir', d, '--layout', lay, '--master-map', mm,
+           '--master-element-id', 'master', '--title', 'Dash', '--out', out]
+    if metrics
+      mp = File.join(d, 'metrics.json'); File.write(mp, JSON.dump(metrics)); cmd += ['--metrics', mp]
+    end
+    system(*cmd, out: File::NULL, err: File::NULL) or abort 'build-charts failed'
+    spec = JSON.parse(File.read(out))
+    els = spec.is_a?(Array) ? spec : (spec['elements'] || (spec['pages'] || []).flat_map { |p| p['elements'] || [] })
+    trend = els.find { |e| e['name'].to_s.casecmp?('Monthly Revenue Trend') }
+    cols = trend ? (trend['columns'] || []) : []
+    ycol = trend && cols.find { |c| trend.dig('yAxis', 'columnIds')&.include?(c['id']) }
+  end
+  ycol && ycol['formula'].to_s
+end
+
+# 1) no --metrics → inline Sum (byte-identical fallback)
+f0 = build_ycol(nil)
+check(f0 =~ /\ASum\(/i && !f0.include?('[Metrics/'),
+      "no --metrics: y-axis stays inline Sum(...) (got #{f0.inspect})", fails)
+
+# 2) with a matching DM metric → governed [Metrics/<name>] reference
+f1 = build_ycol([{ 'name' => 'Gross Revenue', 'formula' => 'Sum([Gross Revenue])' }])
+check(f1 == '[Metrics/Gross Revenue]',
+      "matching metric: y-axis binds to [Metrics/Gross Revenue] (got #{f1.inspect})", fails)
+
+# 3) non-matching metric → inline (no false positive)
+f2 = build_ycol([{ 'name' => 'Unrelated', 'formula' => 'Sum([Something Else])' }])
+check(f2 =~ /\ASum\(/i && !f2.include?('[Metrics/'),
+      "non-matching metric: y-axis stays inline (got #{f2.inspect})", fails)
+
+if fails.empty?
+  puts 'ALL PASS — tableau workbook measures bind to [Metrics/<name>] (byte-identical fallback)'
+  exit 0
+else
+  puts "FAILURES:\n  - #{fails.join("\n  - ")}"
+  exit 1
+end


### PR DESCRIPTION
## What
Wires the shared metric binder (PR #496) into the tableau workbook builder. A chart/KPI measure prefers a governed **`[Metrics/<name>]`** reference over re-deriving the aggregation inline, when its inline aggregate matches a metric referenceable on the master. **beads-sigma-7bun.4**; follows looker (#484) / qlik (#497) / gooddata (#498) / microstrategy (#499) / thoughtspot (#500).

## How
- **`build-charts-from-signals.rb`**: new `--metrics` flag; wrapped at **all four** measure-emission sites (standard chart measure, KPI value, Measure Names/Values, dual-axis `meas2`) with `MetricBinding.metric_ref_or_inline(formula, 'Master', opts[:metrics])`. The master prefix stripped is the literal `Master` (the `[Master/…]` inline form), not the lowercase `master` element id.
- **`migrate-tableau.rb`**: resolves the referenceable metrics off the converter's fact element (own + inherited via `source.elementId`) with `MetricBinding.available_metrics`, writes `metrics.json`, and passes `--metrics`.

## Safe by construction
Ratios, FIXED/INCLUDE/EXCLUDE LODs (helper-element refs), table calcs / window functions (no DM metric exists), custom/no-match, and empty metrics all fall back to inline. No `--metrics` → byte-identical.

## Verification (offline, no creds)
- On the deterministic build-from-signals harness (a `Sum(Gross Revenue)` line chart): **no `--metrics`** → `Sum([Master/Gross Revenue])`; **matching metric** `Sum([Gross Revenue])` → `[Metrics/Gross Revenue]`; **non-matching** → inline.
- New `scripts/test-metric-reference.rb` added to the `corpus-check` Ruby allow-list.
- Existing build-charts regressions still pass: `test-empty-csv-build-from-signals`, `test-recipe-multimetric`, `test-aggregate-dimension`, `test-bar-orientation-kpi-dedup`. Full local governance hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)