### PR TITLE
quicksight: EMIT DM metrics from field-well aggregations, then reference them ([Metrics/<name>]) (7bun.10)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -262,6 +262,7 @@ jobs:
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-trellis-emit.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-qs-trellis.rb
+            plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-metric-reference.rb
             shared/lib/test_metric_binding.rb
           )
           fail=0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -210,6 +210,8 @@ ruby scripts/post-and-readback.rb --type datamodel --spec dm-spec.json --out dm-
 
 `--fixup` forces `schemaVersion: 1`, names every element + its passthrough columns (so workbook masters can reference them), rewrites sql refs to `[Custom SQL/<ALIAS>]` form, and injects `folderId`. `post-and-readback.rb` confirms every column resolved to a concrete type — **no `error` columns**.
 
+**DM metric references (emit-first — leverage the semantic layer, don't duplicate it).** QuickSight has no source-side metrics, so `--fixup` also **EMITS** a governed metric per field-well aggregation (reads `analysis.json`, resolves the aggregation via the same `aggregation.json` catalog the builder uses, and attaches `{name, formula:"<Agg>([<Col>])"}` to the element(s) that carry the column). Then `build-workbook-from-quicksight.rb` prefers a **`[Metrics/<name>]`** reference over its inline aggregate when they match by formula equivalence (strip the master prefix so `Sum([Master/Net Revenue])` equals the metric's `Sum([Net Revenue])`) — via the shared binder `scripts/lib/metric_binding.rb`. SAFE: an unmapped aggregation is skipped (the builder loudly neutralizes it), window/calc/no-match measures fall back to inline, and no emitted metrics is byte-identical. Verified: `scripts/test-metric-reference.rb`.
+
 ## Phase 5 — Build the workbook
 
 ```bash

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -31,6 +31,7 @@ require 'securerandom'
 require 'set'
 require_relative 'lib/coverage_catalog'
 require_relative 'lib/trellis_emit' # shared native-trellis emitter (supported-kind gate + fallbacks)
+require_relative 'lib/metric_binding' # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 
 opts = {}
 OptionParser.new do |o|
@@ -187,6 +188,13 @@ DMEL = dm_el_obj['name'] || 'Custom SQL'   # DM element name — master refs col
 # own name — not the fixture leftover 'Orders', which is wrong for any non-Orders
 # dashboard and confused an early customer migration (RCA #10, bead 3goo.13).
 M = opts[:mname] || DMEL
+# DM metrics referenceable on the master (own on the host element + inherited via
+# source.elementId): a measure whose inline aggregate matches one binds to a governed
+# [Metrics/<name>] ref instead of re-deriving inline (bead 7bun.10 — emitted from the
+# field-well aggregations by convert-model.rb --fixup). Global so the top-level
+# meas_col / qs_reference_lines defs can read it; empty (or reuse-DM) → inline.
+$QS_METRICS = MetricBinding.available_metrics(dm_el, rb_els.each_with_object({}) { |e, h| h[e['id']] = e })
+STDERR.puts "metric-binding: #{$QS_METRICS.size} referenceable DM metric(s) for [Metrics/<name>] refs" if $QS_METRICS.any?
 
 def nid(p = 'el'); "#{p}-" + SecureRandom.hex(5); end
 NUM = ->(fs) { { 'kind' => 'number', 'formatString' => fs } }
@@ -475,7 +483,7 @@ def qs_reference_lines(inner, calc, master_cols, dmel, m, title, warnings)
                         'reason' => "dynamic reference-line aggregation '#{aggk}' has no documented Sigma mapping — line skipped (was silently defaulting to Avg); add a cited row to refs/catalogs/aggregation.json if it should map" }
           next
         end
-        formula = "#{sig_agg}([#{m}/#{ref['name']}])"
+        formula = MetricBinding.metric_ref_or_inline("#{sig_agg}([#{m}/#{ref['name']}])", m, $QS_METRICS || [])
       end
     end
     if formula.nil? || formula.empty?
@@ -811,7 +819,8 @@ def meas_col(role, calc, mc, dmel, m)
       # aggregate itself as the measure (refs resolve to the master via the `m` prefix).
       calc[col].scan(/\{([^}]+)\}/).flatten.each { |bc| master_ref(bc.strip, calc, mc, dmel) }
       id = nid('m')
-      col_h = { 'id' => id, 'formula' => expr, 'name' => col }
+      # governed [Metrics/<name>] ref when this aggregate calc matches a DM metric
+      col_h = { 'id' => id, 'formula' => MetricBinding.metric_ref_or_inline(expr, m, $QS_METRICS || []), 'name' => col }
       (fs = fmt_for(col)) && (col_h['format'] = NUM.(fs))
       return [col_h, id]
     end
@@ -832,7 +841,9 @@ def meas_col(role, calc, mc, dmel, m)
     return [{ 'id' => id, 'formula' => 'Null', 'name' => ref['name'],
               'description' => "unmapped QuickSight aggregation '#{agg}' — re-author in Sigma" }, id]
   end
-  col_h = { 'id' => id, 'formula' => "#{sig_agg}([#{m}/#{ref['name']}])", 'name' => ref['name'] }
+  col_h = { 'id' => id,
+            'formula' => MetricBinding.metric_ref_or_inline("#{sig_agg}([#{m}/#{ref['name']}])", m, $QS_METRICS || []),
+            'name' => ref['name'] }
   (fs = fmt_for(ref['name'])) && (col_h['format'] = NUM.(fs))
   [col_h, id]
 end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
@@ -33,6 +33,27 @@
 require 'json'
 require 'optparse'
 require 'set'
+require_relative 'lib/coverage_catalog' # aggregation catalog (same source the workbook builder uses)
+
+# Every field-well MEASURE across an analysis (recursive: any NumericalMeasureField /
+# CategoricalMeasureField, whatever the visual type) → [rawColumnName, AGG_TOKEN].
+# Mirrors build-workbook-from-quicksight.rb's field_role measure branches so the
+# emitted DM metric matches the workbook's inline aggregate. (bead 7bun.10)
+def field_well_measures(node, out = [])
+  if node.is_a?(Hash)
+    if (mf = node['NumericalMeasureField'])
+      col = mf.dig('Column', 'ColumnName')
+      out << [col, (mf.dig('AggregationFunction', 'SimpleNumericalAggregation') || 'SUM').to_s.upcase] if col
+    elsif (mf = node['CategoricalMeasureField'])
+      col = mf.dig('Column', 'ColumnName')
+      out << [col, (mf['AggregationFunction'] || 'COUNT').to_s.upcase] if col
+    end
+    node.each_value { |v| field_well_measures(v, out) }
+  elsif node.is_a?(Array)
+    node.each { |v| field_well_measures(v, out) }
+  end
+  out
+end
 
 opts = {}
 OptionParser.new do |o|
@@ -357,6 +378,42 @@ if opts[:fixup]
   if dir && !filter_exprs.empty?
     File.write(File.join(dir, 'dm-filters.json'), JSON.pretty_generate('filters' => filter_exprs.uniq))
     STDERR.puts "fixup: surfaced #{filter_exprs.uniq.size} dataset filter(s) -> dm-filters.json (#{filter_exprs.uniq.join('; ')})"
+  end
+
+  # --- EMIT DM metrics from field-well aggregations (bead 7bun.10) ------------
+  # The workbook builder re-derives each measure inline (Sum([Master/Col])); emit the
+  # matching governed metric on the element(s) that carry the column so the builder can
+  # bind [Metrics/<name>] instead. AGG is catalog-resolved (same source the builder
+  # uses) — an unmapped aggregation is skipped (the builder loudly neutralizes it).
+  # The metric formula references the column by titleize(rawCol), which equals the
+  # builder's disp() and the element's column name (sans sanitize_name paren-stripping),
+  # so the strip-prefix formula-equivalence match fires. No analysis / no match → no
+  # metrics emitted → builder inline, byte-identical.
+  analysis_path = dir && File.join(dir, 'analysis.json')
+  analysis = (analysis_path && File.exist?(analysis_path)) ? (JSON.parse(File.read(analysis_path)) rescue nil) : nil
+  if analysis
+    agg_map = Coverage.load_all(Coverage.default_catalog_dir(__FILE__)).fetch('aggregation')
+                      .rows.each_with_object({}) { |r, h| h[r['source']] = r['sigma'] if r['sigma'] }
+    metric_defs = {} # "sig|dispName" => {name, formula}
+    field_well_measures(analysis).each do |rawcol, agg|
+      sig = agg_map[agg] or next
+      dn = titleize(rawcol)
+      metric_defs["#{sig}|#{dn}"] ||= { 'name' => "#{sig} of #{dn}", 'formula' => "#{sig}([#{dn}])" }
+    end
+    emitted = 0
+    unless metric_defs.empty?
+      (model['pages'] || []).each do |pg|
+        (pg['elements'] || []).each do |el|
+          colnames = (el['columns'] || []).map { |c| c['name'] }.compact.to_set
+          add = metric_defs.values.select { |m| colnames.include?(m['formula'][/\[([^\]]+)\]/, 1]) }
+          next if add.empty?
+          existing = (el['metrics'] ||= [])
+          have = existing.map { |m| m['name'] }.to_set
+          add.each { |m| (existing << m; have << m['name']; emitted += 1) unless have.include?(m['name']) }
+        end
+      end
+    end
+    STDERR.puts "fixup: emitted #{emitted} DM metric(s) from #{metric_defs.size} field-well aggregation(s) for [Metrics/<name>] refs" if emitted.positive?
   end
 
   out = opts[:out] || 'dm-spec.json'

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-metric-reference.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-metric-reference.rb
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+# Regression test for DM-metric EMIT + reference (bead 7bun.10 — emit-first).
+#
+# QuickSight doesn't emit DM metrics from the source; convert-model.rb --fixup now
+# EMITS a governed metric per field-well aggregation onto the element(s) that carry
+# the column, and build-workbook-from-quicksight.rb REFERENCES it: a measure whose
+# inline aggregate matches binds to [Metrics/<name>] (formula-equivalence via the
+# shared binder lib/metric_binding.rb; strip the master prefix). SAFE: no metrics /
+# no match → inline, byte-identical.
+#
+# Deterministic + offline: runs the ACTUAL convert-model.rb --fixup (EMIT) then feeds
+# its dm-spec as the workbook builder's --dm-readback (REFERENCE) — a true
+# emit→reference round-trip — and asserts the SUM measure flips to [Metrics/<name>].
+#
+# Usage: ruby scripts/test-metric-reference.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+HERE = __dir__
+CONVERT = File.join(HERE, 'convert-model.rb')
+BUILDER = File.join(HERE, 'build-workbook-from-quicksight.rb')
+RUBY = RbConfig.ruby
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# one field-well SUM(NET_REVENUE) by REGION — the aggregation the DM metric is emitted from
+ANALYSIS = { 'Definition' => { 'Sheets' => [{ 'SheetId' => 's1', 'Name' => 'S1', 'Visuals' => [
+  { 'BarChartVisual' => { 'VisualId' => 'v1', 'Title' => { 'FormatText' => { 'PlainText' => 'Rev by Region' } },
+    'ChartConfiguration' => { 'FieldWells' => { 'BarChartAggregatedFieldWells' => {
+      'Category' => [{ 'CategoricalDimensionField' => { 'FieldId' => 'd1', 'Column' => { 'ColumnName' => 'REGION' } } }],
+      'Values' => [{ 'NumericalMeasureField' => { 'FieldId' => 'f1', 'Column' => { 'ColumnName' => 'NET_REVENUE' },
+        'AggregationFunction' => { 'SimpleNumericalAggregation' => 'SUM' } } }] } } } } }
+] }] } }.freeze
+
+# a converter-out model with one passthrough element carrying the columns
+MODEL = { 'name' => 'QS', 'schemaVersion' => 1, 'pages' => [{ 'id' => 'pg', 'elements' => [
+  { 'id' => 'el-1', 'name' => 'Orders', 'kind' => 'table',
+    'source' => { 'connectionId' => 'conn', 'kind' => 'sql', 'statement' => 'select 1' },
+    'columns' => [{ 'id' => 'c1', 'name' => 'Net Revenue', 'formula' => '[Custom SQL/NET_REVENUE]' },
+                  { 'id' => 'c2', 'name' => 'Region', 'formula' => '[Custom SQL/REGION]' }] } ] }] }.freeze
+
+# ---- EMIT: convert-model.rb --fixup reads analysis.json → metrics on the element ----
+def emit_dm
+  Dir.mktmpdir do |d|
+    Dir.mkdir(File.join(d, 'datasets'))
+    File.write(File.join(d, 'analysis.json'), JSON.generate(ANALYSIS))
+    inp = File.join(d, 'model.json'); File.write(inp, JSON.generate(MODEL))
+    out = File.join(d, 'dm-spec.json')
+    system(RUBY, CONVERT, '--fixup', '--in', inp, '--discover-dir', d, '--folder-id', 'fld-x', '--out', out,
+           out: File::NULL, err: File::NULL) or abort 'convert-model --fixup failed'
+    return JSON.parse(File.read(out))
+  end
+end
+
+# ---- REFERENCE: build the workbook against a readback, return the measure formula ----
+def measure_formula(readback)
+  Dir.mktmpdir do |d|
+    an = File.join(d, 'an.json'); rb = File.join(d, 'rb.json'); out = File.join(d, 'wb.json')
+    File.write(an, JSON.generate(ANALYSIS)); File.write(rb, JSON.generate(readback))
+    system(RUBY, BUILDER, '--analysis', an, '--dm-readback', rb, '--out', out,
+           out: File::NULL, err: File::NULL) or abort 'build-workbook failed'
+    spec = JSON.parse(File.read(out))
+    el = spec['pages'].flat_map { |p| p['elements'] }.find { |e| e['name'] == 'Rev by Region' }
+    (el['columns'] || []).map { |c| c['formula'] }.find { |f| f.to_s =~ /Net Revenue|Metrics/ }
+  end
+end
+
+# 1) EMIT: the field-well SUM(NET_REVENUE) becomes a metric on the "Orders" element
+dm = emit_dm
+orders = dm['pages'].flat_map { |p| p['elements'] }.find { |e| e['name'] == 'Orders' }
+mets = (orders && orders['metrics']) || []
+check(mets.any? { |m| m['formula'] == 'Sum([Net Revenue])' },
+      "EMIT: convert-model emitted Sum([Net Revenue]) metric on the element (got #{mets.inspect})", fails)
+metric_name = (mets.find { |m| m['formula'] == 'Sum([Net Revenue])' } || {})['name']
+
+# 2) REFERENCE (round-trip): feed the emitted dm-spec back as the readback → measure binds
+f_bound = measure_formula(dm)
+check(f_bound == "[Metrics/#{metric_name}]",
+      "REFERENCE: SUM measure binds to [Metrics/#{metric_name}] (got #{f_bound.inspect})", fails)
+
+# 3) fallback: a readback with NO metrics → inline (byte-identical)
+no_metrics = JSON.parse(JSON.generate(dm))
+no_metrics['pages'].flat_map { |p| p['elements'] }.each { |e| e.delete('metrics') }
+f_inline = measure_formula(no_metrics)
+check(f_inline == 'Sum([Orders/Net Revenue])',
+      "fallback: no metrics → inline Sum([Orders/Net Revenue]) (got #{f_inline.inspect})", fails)
+
+# 4) non-match: a metric with a different formula must NOT be referenced
+other = JSON.parse(JSON.generate(dm))
+other['pages'].flat_map { |p| p['elements'] }.each { |e| e['metrics'] = [{ 'name' => 'Unrelated', 'formula' => 'Sum([Something Else])' }] if e['name'] == 'Orders' }
+f_other = measure_formula(other)
+check(f_other == 'Sum([Orders/Net Revenue])',
+      "non-match: unrelated metric → inline (got #{f_other.inspect})", fails)
+
+if fails.empty?
+  puts 'ALL PASS — quicksight EMITs DM metrics from field-wells + binds workbook measures to [Metrics/<name>]'
+  exit 0
+else
+  puts "FAILURES:\n  - #{fails.join("\n  - ")}"
+  exit 1
+end


### PR DESCRIPTION
## What
QuickSight has **no source-side metrics**, so this is **emit-first**: `convert-model.rb --fixup` now emits a governed metric per field-well aggregation, and `build-workbook-from-quicksight.rb` references it (`[Metrics/<name>]`) instead of re-deriving the aggregate inline. **beads-sigma-7bun.10** (first of the P3 pair); follows the P2 batch (#497–#503).

## How
- **EMIT (`convert-model.rb --fixup`)**: reads `analysis.json` (recursive `field_well_measures` over every `NumericalMeasureField`/`CategoricalMeasureField`), resolves each aggregation via the **same `aggregation.json` catalog** the builder uses, and attaches `{name: "<Agg> of <Col>", formula: "<Agg>([<Col>])"}` to every element that carries the column. Unmapped aggregations are skipped (the builder loudly neutralizes those).
- **REFERENCE (`build-workbook-from-quicksight.rb`)**: `available_metrics(dm_el)` → a `$QS_METRICS` global (the top-level `meas_col`/`qs_reference_lines` defs read it); each measure formula is wrapped with `MetricBinding.metric_ref_or_inline(inline, M, metrics)`.

## Safe by construction
`titleize` (convert-model) == `disp` (builder), so the emitted metric formula lines up with the builder's stripped inline. Window/calc/unmapped/no-match measures fall back to inline; **no emitted metrics → byte-identical**.

## Verification (offline, no creds)
- New `scripts/test-metric-reference.rb` runs the **real `convert-model --fixup` (EMIT)** then feeds its dm-spec as the builder's `--dm-readback` (**REFERENCE**) — a true emit→reference round-trip: `Sum(NET_REVENUE)` → metric `Sum([Net Revenue])` → measure binds to `[Metrics/Sum of Net Revenue]`; a no-metrics readback and an unrelated metric both stay inline `Sum([Orders/Net Revenue])`. Added to the `corpus-check` Ruby allow-list.
- `test-grounding`, `test-window-native`, `test-qs-trellis`, `test-scout-ledger-integrity`, `test-trellis-emit` still pass; full local governance hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)