### PR TITLE
sisense: EMIT DM metrics from JAQL measures, then reference them ([Metrics/<name>]) (7bun.11)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -306,6 +306,7 @@ jobs:
             plugins/gooddata-to-sigma/skills/gooddata-to-sigma/tests/test_metric_reference.py
             plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_metric_reference.py
             plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/tests/test_metric_reference.py
+            plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_metric_reference.py
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
@@ -145,6 +145,18 @@ ids — the workbook's Master element sources the fact element by its read-back
 id, never the client-side one (DM POST reassigns ids; workbook CREATE preserves
 them).
 
+**DM metric references (emit-first — leverage the semantic layer, don't duplicate it).**
+Sisense has no source-side metrics, so pass `convert.py model … --dashboards dashboards.json`
+and the model step **EMITs** a governed metric per JAQL measure (`harvest_metrics` →
+`{name, formula:"<Agg>([<Col>])"}`) onto the DM element(s) that carry the columns. Then
+`convert.py dashboard … --dm-spec sigma_dm_spec.json` prefers a **`[Metrics/<name>]`**
+reference over the inline aggregate when they match by formula equivalence (strip the
+`Master` prefix so `Sum([Master/Revenue])` equals a metric's `Sum([Revenue])`) — via the
+shared binder `scripts/lib/metric_binding.py`. The reference binds only to the DM's ACTUAL
+metrics (from `--dm-spec`), so a workbook never points at an absent metric. SAFE:
+`J.Unsupported` measures are skipped; no `--dashboards`/`--dm-spec` → inline, byte-identical.
+Verified: `tests/test_metric_reference.py`.
+
 ## Phase 3 — Convert dashboards  ✅ live-validated
 `convert.py dashboard` → workbook spec: widget `type` → element
 (`pivot2`→pivot-table, `indicator`→KPI, `chart/*`→chart, `tablewidget`→table),

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/convert.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/convert.py
@@ -25,6 +25,7 @@ import jaql_expr as J
 # map is loaded the same way inside jaql_expr.py.
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import coverage_catalog as _cc  # noqa: E402
+import metric_binding as _mb    # noqa: E402  shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 _CAT_DIR = _cc.default_catalog_dir(__file__)
 VIZ_CAT  = _cc.load(_CAT_DIR, "viz-kind")        # Sisense widget type -> Sigma element kind
 FMT_CAT  = _cc.load(_CAT_DIR, "number-format")   # JAQL format mask    -> Sigma number format
@@ -142,8 +143,42 @@ def probe_directions(model, schema, database, snow_conn):
             directions[frozenset({a, b})] = a[0]
     return directions
 
+def harvest_metrics(dashboards):
+    """Governed DM metrics harvested from the dashboards' JAQL measure panels
+    (bead 7bun.11). Sisense has no source-side metrics, so a measure's aggregation
+    only exists in a widget's JAQL. Each measure item → {name: jaql.title, formula:
+    <J.classify output, NOT masterized>} — the bare DM-column form (e.g. Sum([Revenue]))
+    that matches the workbook's inline once the [Master/…] prefix is stripped. Deduped
+    by name; J.Unsupported items are skipped (they never become a metric)."""
+    out, seen = [], set()
+    for d in dashboards or []:
+        for w in d.get("widgets", []):
+            for p in w.get("metadata", {}).get("panels", []):
+                for it in p.get("items", []):
+                    jaql = it.get("jaql", {})
+                    if not jaql:
+                        continue
+                    try:
+                        k, formula = J.classify(jaql)
+                    except J.Unsupported:
+                        continue
+                    if k != "measure":
+                        continue
+                    name = jaql.get("title") or "measure"
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    out.append({"name": name, "formula": formula})
+    return out
+
+
+def _metric_ref_cols(formula):
+    """The bare [Col] refs a metric formula depends on (for host-element matching)."""
+    return {m for m in re.findall(r"\[([^/\]]+)\]", formula or "")}
+
+
 def convert_model(model, connection_id, schema="SISENSE_ECOMMERCE",
-                  database="DEMO_DB", name=None, directions=None):
+                  database="DEMO_DB", name=None, directions=None, metrics=None):
     """Sisense Live/ElastiCube model export -> (Sigma DM spec, flags).
     Plain tables -> warehouse-table elements (source = connectionId + path).
     Tables with an `expression` (ElastiCube custom SQL) -> custom-SQL ('sql')
@@ -217,6 +252,20 @@ def convert_model(model, connection_id, schema="SISENSE_ECOMMERCE",
                               "targetColumnId": col_id[(tt, tc)]}],
                     "name": tt.upper()})  # clean workbook cross-refs: [Fact/DIM/Col]
     elements.sort(key=lambda e: 1 if e.get("relationships") else 0)  # dims before fact
+    # EMIT governed DM metrics harvested from the dashboards' JAQL (bead 7bun.11) onto
+    # every element that carries their referenced columns — so the fact element (which
+    # the workbook master sources) gets them and the workbook can bind [Metrics/<name>]
+    # instead of re-deriving the aggregate inline. No metrics → no change (byte-identical).
+    for m in (metrics or []):
+        cols_needed = _metric_ref_cols(m["formula"])
+        if not cols_needed:
+            continue
+        for el in elements:
+            names = {c["name"] for c in el.get("columns", [])}
+            if cols_needed <= names:
+                bag = el.setdefault("metrics", [])
+                if m["name"] not in {x["name"] for x in bag}:
+                    bag.append({"name": m["name"], "formula": m["formula"]})
     spec = {"name": name or f"{model.get('title', 'Model')} (from Sisense)",
             "pages": [{"id": "p1", "name": "Model", "elements": elements}]}
     return spec, flags
@@ -447,7 +496,7 @@ def build_layout(dashboards, control_ids, wid2elem):
     return '<?xml version="1.0" encoding="utf-8"?>\n' + data_page + "\n" + main_page
 
 
-def convert_dashboard(dashboards, model, dm_info):
+def convert_dashboard(dashboards, model, dm_info, dm_metrics=None):
     """Emit a Sigma workbook spec from Sisense dashboards.
     dm_info = {dataModelId, factElementId, factName}. Builds a Master data
     element on the fact DM element (own cols + cross-ref dim cols) and one viz
@@ -509,7 +558,13 @@ def convert_dashboard(dashboards, model, dm_info):
                     for m in re.finditer(r"\[([^.\]/]+)\.([^\]]+)\]", J.raw_dims(jaql)):
                         master_ref(m.group(1), m.group(2))
                     vid = "c_" + cid()
-                    spec = {"id": vid, "formula": _masterize(formula),
+                    _f = _masterize(formula)
+                    if k == "measure":
+                        # governed [Metrics/<name>] ref when this inline aggregate matches
+                        # a metric on the fact element (strip the "Master" prefix); safe
+                        # no-op (inline) otherwise or when no --dm-spec metrics passed.
+                        _f = _mb.metric_ref_or_inline(_f, "Master", dm_metrics)
+                    spec = {"id": vid, "formula": _f,
                             "name": jaql.get("title") or k}
                     if k == "measure":
                         _fmt_warns = []
@@ -631,7 +686,13 @@ if __name__ == "__main__":
             conn = sys.argv[sys.argv.index("--verify-card") + 1]
             directions = probe_directions(model, schema, database, conn)
             print(f"cardinality-resolved {len(directions)} relationship directions")
-        spec, flags = convert_model(model, connection_id, schema, database, directions=directions)
+        # --dashboards <file>: harvest governed metrics from the dashboards' JAQL and
+        # EMIT them onto the DM elements, so the workbook can reference [Metrics/<name>]
+        # (bead 7bun.11). Absent → no metrics emitted (byte-identical).
+        metrics = None
+        if "--dashboards" in sys.argv:
+            metrics = harvest_metrics(json.load(open(sys.argv[sys.argv.index("--dashboards") + 1])))
+        spec, flags = convert_model(model, connection_id, schema, database, directions=directions, metrics=metrics)
         json.dump(spec, open("sigma_dm_spec.json", "w"), indent=2)
         print(f"wrote sigma_dm_spec.json ({len(spec['pages'][0]['elements'])} elements)")
         if flags:
@@ -655,7 +716,15 @@ if __name__ == "__main__":
             only = sys.argv[sys.argv.index("--only") + 1]
             dashboards = [{**d, "widgets": [w for w in d.get("widgets", []) if d.get("title") == only or True]}
                           for d in dashboards if d.get("title") == only]
-        spec, flags = convert_dashboard(dashboards, model, dm_info)
+        # --dm-spec <sigma_dm_spec.json>: bind workbook measures to the posted DM's
+        # ACTUAL metrics (emitted by the `model --dashboards` step) — never references a
+        # metric that isn't on the DM. Absent → measures stay inline (byte-identical).
+        dm_metrics = None
+        if "--dm-spec" in sys.argv:
+            _dm = json.load(open(sys.argv[sys.argv.index("--dm-spec") + 1]))
+            _by_id = {e.get("id"): e for pg in _dm.get("pages", []) for e in (pg.get("elements") or [])}
+            dm_metrics = _mb.available_metrics(dm_info["factElementId"], _by_id)
+        spec, flags = convert_dashboard(dashboards, model, dm_info, dm_metrics=dm_metrics)
         json.dump(spec, open("sigma_workbook_spec.json", "w"), indent=2)
         print(f"wrote sigma_workbook_spec.json ({len(spec['pages'][1]['elements'])} viz elements, "
               f"{len(spec['pages'][0]['elements'][0]['columns'])} master cols)")

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_metric_reference.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_metric_reference.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""DM-metric EMIT + reference for sisense (bead 7bun.11 — emit-first). Offline, creds-free.
+
+Sisense has no source-side metrics, so `harvest_metrics` pulls a governed metric per
+dashboard JAQL measure, `convert_model(..., metrics=…)` EMITs them onto the DM
+element(s) that carry the columns, and `convert_dashboard(..., dm_metrics=…)` prefers a
+`[Metrics/<name>]` reference over the inline aggregate (formula-equivalence via the
+shared binder scripts/lib/metric_binding.py; strip the "Master" prefix). Reference is
+gated on the DM's ACTUAL metrics so a workbook never points at an absent metric. SAFE:
+no metrics → inline, byte-identical.
+
+This is a true emit→reference round-trip, in-process (mirrors tests/test_convert.py).
+Run: python3 tests/test_metric_reference.py   (exit 0 = pass)
+"""
+import sys, os, json
+
+HERE = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts", "lib"))
+import convert as C  # noqa: E402
+import metric_binding as mb  # noqa: E402
+
+FIX = os.path.join(HERE, "..", "fixtures")
+CONN = "00000000-0000-0000-0000-000000000000"
+MODEL = json.load(open(os.path.join(FIX, "model_ecommerce.json")))
+DASHBOARDS = json.load(open(os.path.join(FIX, "dashboards.json")))
+
+fails = []
+def ok(label, cond):
+    print(f"  {'PASS' if cond else 'FAIL'}  {label}")
+    if not cond:
+        fails.append(label)
+
+
+def fact_of(spec):
+    els = spec["pages"][0]["elements"]
+    return max(els, key=lambda e: len(e.get("columns", [])))
+
+
+def measure_formulas(dm_metrics):
+    dm_info = {"dataModelId": "dm-x", "factElementId": FACT_ID, "factName": "Commerce"}
+    wb, _ = C.convert_dashboard(LIVE, MODEL, dm_info, dm_metrics=dm_metrics)
+    cols = [c for pg in wb["pages"] for el in pg["elements"] for c in el.get("columns", [])]
+    return [str(c["formula"]) for c in cols]
+
+
+LIVE = [d for d in DASHBOARDS if "Live" in (d.get("title") or "")][:1] or DASHBOARDS[:1]
+
+# ---- EMIT: harvest_metrics + convert_model(metrics=…) puts metrics on the fact -----
+harvested = C.harvest_metrics(LIVE)
+ok("EMIT: harvest_metrics found dashboard measures", len(harvested) > 0)
+spec, _ = C.convert_model(MODEL, CONN, "SISENSE_ECOMMERCE", "DEMO_DB", metrics=harvested)
+fact = fact_of(spec)
+FACT_ID = fact["id"]
+fact_mets = fact.get("metrics") or []
+ok("EMIT: metrics attached to the fact element", len(fact_mets) > 0)
+# every emitted metric references only columns that exist on the element (no broken metric)
+fact_cols = {c["name"] for c in fact["columns"]}
+ok("EMIT: each emitted metric references only real fact columns",
+   all(C._metric_ref_cols(m["formula"]) <= fact_cols for m in fact_mets))
+
+# a plain Sum(Revenue) measure should have produced a metric with formula Sum([Revenue])
+rev_metric = next((m for m in fact_mets if m["formula"] == "Sum([Revenue])"), None)
+ok("EMIT: Sum([Revenue]) metric emitted", rev_metric is not None)
+
+# ---- REFERENCE: bind workbook measures to the DM's actual metrics -------------------
+by_id = {e["id"]: e for e in spec["pages"][0]["elements"]}
+dm_metrics = mb.available_metrics(FACT_ID, by_id)
+
+bound = measure_formulas(dm_metrics)
+inline = measure_formulas(None)
+
+if rev_metric:
+    want = f"[Metrics/{rev_metric['name']}]"
+    ok(f"REFERENCE: a Sum([Master/Revenue]) measure binds to {want}", want in bound)
+ok("REFERENCE: with metrics, at least one measure became a [Metrics/<name>] ref",
+   any(f.startswith("[Metrics/") for f in bound))
+
+# ---- fallback: no dm_metrics → inline, no metric refs (byte-identical) --------------
+ok("fallback: no dm_metrics → Sum([Master/Revenue]) stays inline",
+   any(f == "Sum([Master/Revenue])" for f in inline))
+ok("fallback: no dm_metrics → no [Metrics/<name>] refs",
+   not any(f.startswith("[Metrics/") for f in inline))
+
+if fails:
+    print("FAILURES:\n  - " + "\n  - ".join(fails))
+    sys.exit(1)
+print("ALL PASS — sisense EMITs DM metrics from JAQL + binds workbook measures to [Metrics/<name>]")


### PR DESCRIPTION
## What
Sisense has **no source-side metrics**, so this is **emit-first** (all in `convert.py`): the model step emits a governed metric per JAQL measure, and the dashboard step references it (`[Metrics/<name>]`) instead of re-deriving the aggregate inline. **beads-sigma-7bun.11 — the final converter**, completing epic `7bun` (follows #497–#504).

## How
- **`harvest_metrics(dashboards)`**: each JAQL measure item (`J.classify` → `k=="measure"`) → `{name: jaql.title, formula}` — the **bare** `Sum([Col])` form (not masterized), deduped.
- **EMIT — `convert_model(..., metrics=)`**: attaches them onto every element that carries the referenced columns (so the fact element the master sources gets them). Driven by `convert.py model … --dashboards dashboards.json`.
- **REFERENCE — `convert_dashboard(..., dm_metrics=)`**: a measure prefers `[Metrics/<name>]` over the inline `_masterize(formula)` when they match by formula equivalence (strip `"Master"`). Driven by `convert.py dashboard … --dm-spec sigma_dm_spec.json`, which binds to the DM's **actual** metrics via `available_metrics(factElementId)` — so a workbook **never references a metric absent from the posted DM**.

## Safe by construction
Both sides run the **same `J.classify`**, so the emitted metric formula lines up with the workbook's stripped inline. `J.Unsupported` measures are skipped; no `--dashboards`/`--dm-spec` → inline, byte-identical.

## Verification (offline, no creds)
- New `tests/test_metric_reference.py`: a true emit→reference round-trip on the ecommerce fixtures — `Sum(Revenue)` JAQL → metric `Sum([Revenue])` emitted on the fact element (asserted to reference **only real columns** — no broken metric) → workbook measure binds to `[Metrics/Total Revenue]`; a no-metrics run stays inline `Sum([Master/Revenue])`. Added to the `corpus-check` Python allow-list.
- `test_convert.py` (28), `test_jaql.py` (19), `test_grounding.py` still pass; full local governance hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)