### PR TITLE
tools: gate cognos vendored bundle freshness (cli.mjs vs converter/*.ts)

### DIFF
--- a/.githooks/run-governance-checks.sh
+++ b/.githooks/run-governance-checks.sh
@@ -24,6 +24,7 @@ ruby tools/lint-skills.rb   || fail=1
 [ -f tools/lint-esm-imports.rb ] && { ruby tools/lint-esm-imports.rb || fail=1; }
 [ -f tools/lint-twb-encoding.rb ] && { ruby tools/lint-twb-encoding.rb || fail=1; }
 [ -f tools/check-agent-variants.rb ] && { ruby tools/check-agent-variants.rb || fail=1; }
+[ -f tools/check-cognos-bundle.rb ] && { ruby tools/check-cognos-bundle.rb || fail=1; }
 if [ "$fail" -ne 0 ]; then
   echo "" >&2
   echo "governance checks failed — fix above, or bypass with --no-verify (CI will still gate)." >&2

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -174,6 +174,12 @@ jobs:
         # each skill's SKILL.md by tools/gen-agent-variants.rb. Fail if a
         # committed variant drifted, so EVERY coding agent reads the same steps.
         run: ruby tools/check-agent-variants.rb
+      - name: Cognos vendored bundle is fresh vs converter/*.ts
+        # cognos ships its converter as in-skill TS bundled into converter/cli.mjs
+        # (production runs the bundle). Fail if a converter/*.ts edit shipped without
+        # re-running tools/vendor-converters.sh — a stale bundle silently ships the OLD
+        # behavior. Source-hash gate (not a flaky byte compare); mirrors check-shared.
+        run: ruby tools/check-cognos-bundle.rb
 
   unit-tests:
     name: offline unit/regression tests (creds-free)

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -258,7 +258,8 @@ display name) to the converter via `--metrics`. SAFE: KPI/crosstab measures are 
 `Sum(…)`-wrapped, so a non-Sum metric won't match (stays inline); composite/param-switch
 measures and any non-match fall back to inline; no `--metrics` is byte-identical.
 **Re-vendor after editing `converter/*.ts`:** `tools/vendor-converters.sh <mcp> cognos`
-rebuilds `converter/cli.mjs`. Verified: `scripts/test-metric-reference.mjs`. Then post-and-readback POSTs
+rebuilds `converter/cli.mjs` (production runs the bundle). This is **enforced** — `tools/check-cognos-bundle.rb`
+(governance hook + CI) fails if a `converter/*.ts` edit ships without re-bundling. Verified: `scripts/test-metric-reference.mjs`. Then post-and-readback POSTs
 the workbook and re-runs the error-column gate. **`apply-layout.mjs` then gives the page a
 clean 24-col grid** (controls on top, content stacked full-width with per-kind heights) —
 Sigma auto-arrange otherwise squishes every element to the same height. It writes the

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/PROVENANCE.json
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/PROVENANCE.json
@@ -1,6 +1,14 @@
 {
-  "source": "in-skill converter/cli.ts (cognos.ts + cognos-report.ts + sigma-ids.ts)",
+  "source": "in-skill converter/cli.ts (cli.ts + cognos-report.ts + cognos.ts + metric-binding.ts + sigma-ids.ts)",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "cli.mjs",
-  "note": "Self-contained bundle of the skill's own pinned Cognos converter. Refresh with tools/vendor-converters.sh after editing converter/*.ts."
+  "source_sha256": "26cb0f41485300760aa8ba2b52a167280bfa988955a47663898f8ffaa191b434",
+  "sources": [
+    "cli.ts",
+    "cognos-report.ts",
+    "cognos.ts",
+    "metric-binding.ts",
+    "sigma-ids.ts"
+  ],
+  "note": "cli.mjs is GENERATED from converter/*.ts — do not hand-edit. After editing any converter/*.ts, re-run tools/vendor-converters.sh <sigma-data-model-mcp> cognos (rebuilds cli.mjs + refreshes source_sha256). CI gate: tools/check-cognos-bundle.rb."
 }

--- a/tools/check-cognos-bundle.rb
+++ b/tools/check-cognos-bundle.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# check-cognos-bundle.rb — freshness gate for the cognos vendored converter bundle.
+#
+# Unlike the other converters (which vendor from sigma-data-model-mcp), cognos vendors
+# its OWN TypeScript converter IN the skill: converter/cli.ts (+ cognos.ts /
+# cognos-report.ts / sigma-ids.ts / metric-binding.ts) is bundled by esbuild into the
+# committed, self-contained converter/cli.mjs — and PRODUCTION runs that bundle (plain
+# `node`, no tsx). So a converter/*.ts edit that ships WITHOUT re-bundling cli.mjs
+# silently ships the OLD behavior — the migrate run keeps using the stale bundle. That
+# is exactly the "edited .ts, forgot to re-vendor" footgun.
+#
+# This gate closes it the same way tools/check-shared.rb closes shared-file drift: it
+# records a SHA-256 over the BUNDLED converter sources in PROVENANCE.json (written by
+# tools/vendor-converters.sh right after it bundles) and re-verifies it here. A byte
+# compare of cli.mjs would be flaky — esbuild output varies by version — so we hash the
+# source of truth, not the generated artifact.
+#
+#   ruby tools/check-cognos-bundle.rb            # CI/hook gate: fail if stale
+#   ruby tools/check-cognos-bundle.rb --write    # (re)write PROVENANCE.json's source_sha256
+#                                                #  — called by tools/vendor-converters.sh
+#
+# Scope note: hashes converter/*.ts EXCEPT the test file (test.ts / *.test.ts), which is
+# not part of the bundle. A fast-xml-parser (node_modules) bump is out of scope — that
+# dep is pinned in package.json; this gate targets the .ts-edit footgun the SKILL warns
+# about.
+require 'json'
+require 'digest'
+
+ROOT = File.expand_path('..', __dir__)
+CONV = File.join(ROOT, 'plugins/cognos-to-sigma/skills/cognos-to-sigma/converter')
+PROV = File.join(CONV, 'PROVENANCE.json')
+BUNDLE = File.join(CONV, 'cli.mjs')
+
+REVENDOR = 'tools/vendor-converters.sh <sigma-data-model-mcp> cognos'
+
+def bundled_sources
+  Dir[File.join(CONV, '*.ts')]
+    .reject { |f| File.basename(f) == 'test.ts' || File.basename(f).end_with?('.test.ts') }
+    .sort_by { |f| File.basename(f) }
+end
+
+# A stable manifest — "<basename>  <sha256(content)>" per bundled source, sorted — then
+# a single SHA over that. Reproducible in one place (here); vendor-converters.sh invokes
+# `--write` rather than re-implementing it, so bash/ruby can never drift.
+def source_manifest
+  bundled_sources.map { |f| "#{File.basename(f)}  #{Digest::SHA256.hexdigest(File.read(f))}" }
+end
+
+def source_sha
+  Digest::SHA256.hexdigest(source_manifest.join("\n"))
+end
+
+def write_provenance
+  prov = {
+    'source' => "in-skill converter/cli.ts (#{bundled_sources.map { |f| File.basename(f) }.join(' + ')})",
+    'bundler' => 'esbuild --bundle --format=esm --platform=node',
+    'vendored_modules' => 'cli.mjs',
+    'source_sha256' => source_sha,
+    'sources' => bundled_sources.map { |f| File.basename(f) },
+    'note' => 'cli.mjs is GENERATED from converter/*.ts — do not hand-edit. After editing ' \
+              "any converter/*.ts, re-run #{REVENDOR} (rebuilds cli.mjs + refreshes " \
+              'source_sha256). CI gate: tools/check-cognos-bundle.rb.'
+  }
+  File.write(PROV, "#{JSON.pretty_generate(prov)}\n")
+  warn "wrote #{File.basename(PROV)} — source_sha256 #{prov['source_sha256'][0, 12]} over #{bundled_sources.size} TS source(s)"
+end
+
+def check
+  abort "FATAL: #{BUNDLE} missing — the cognos converter bundle is not vendored. Run #{REVENDOR}." unless File.exist?(BUNDLE)
+  abort "FATAL: #{PROV} missing — run #{REVENDOR} to generate it." unless File.exist?(PROV)
+  want = (JSON.parse(File.read(PROV)) rescue {})['source_sha256']
+  have = source_sha
+  if want.nil? || want.empty?
+    abort "cognos PROVENANCE.json has no source_sha256 (stale format) — run #{REVENDOR}."
+  elsif want != have
+    abort "cognos converter/cli.mjs is STALE vs converter/*.ts " \
+          "(recorded source_sha256 #{want[0, 12]} != current #{have[0, 12]}).\n" \
+          "  A converter/*.ts edit shipped without re-bundling cli.mjs — production runs the\n" \
+          "  vendored bundle, so the change would NOT take effect. Fix:\n    #{REVENDOR}"
+  end
+  puts "OK: cognos cli.mjs is fresh vs converter/*.ts (#{bundled_sources.size} bundled TS source(s), source_sha256 #{have[0, 12]})"
+end
+
+if ARGV.include?('--write')
+  write_provenance
+else
+  check
+end

--- a/tools/vendor-converters.sh
+++ b/tools/vendor-converters.sh
@@ -71,15 +71,10 @@ for mod in "${WANT[@]}"; do
     [ -d "$dest/node_modules/fast-xml-parser" ] || ( cd "$dest" && npm install --silent )
     "$ESBUILD" "$entry" --bundle --format=esm --platform=node --outfile="$out" >/dev/null
     echo "✓ $skill/converter/cli.mjs  ($(du -h "$out" | cut -f1))  [bundled from in-skill cli.ts]"
-    # cognos provenance tracks the in-repo TS source, not the mcp commit.
-    cat > "$dest/PROVENANCE.json" <<EOF
-{
-  "source": "in-skill converter/cli.ts (cognos.ts + cognos-report.ts + sigma-ids.ts)",
-  "bundler": "esbuild --bundle --format=esm --platform=node",
-  "vendored_modules": "cli.mjs",
-  "note": "Self-contained bundle of the skill's own pinned Cognos converter. Refresh with tools/vendor-converters.sh after editing converter/*.ts."
-}
-EOF
+    # cognos provenance tracks the in-repo TS source, not the mcp commit. Writing the
+    # source_sha256 here (single owner: tools/check-cognos-bundle.rb) is what lets the
+    # freshness gate detect a converter/*.ts edit that skipped this re-bundle.
+    ruby "$ROOT/tools/check-cognos-bundle.rb" --write
     continue
   fi
 


### PR DESCRIPTION
## Why
cognos is the one converter that vendors its own TypeScript **in the skill** — `converter/cli.ts` (+ `cognos.ts` / `cognos-report.ts` / `sigma-ids.ts` / `metric-binding.ts`) is bundled by esbuild into the committed, self-contained `converter/cli.mjs`, and **production runs that bundle**. So editing a `converter/*.ts` without re-running `tools/vendor-converters.sh` silently ships the **old** behavior. That was only a prose caveat in the SKILL (added with #503) — this makes it an **enforced gate**.

## How
- **`tools/check-cognos-bundle.rb`** — records a SHA-256 over the *bundled* converter sources (`converter/*.ts` minus `test.ts`) in `PROVENANCE.json` and re-verifies it. A byte-compare of `cli.mjs` would be flaky (esbuild output varies by version — that's why re-vendoring in #503 changed the size), so it hashes the **source of truth**, mirroring `tools/check-shared.rb`. `--write` (re)stamps the hash and is the single owner of that logic; the default mode fails loudly with the exact re-vendor command.
- **`tools/vendor-converters.sh`** — after bundling cognos, calls `check-cognos-bundle.rb --write` (replaces the hand-written `PROVENANCE` heredoc), so the stamp can't drift from the bundle it just built.
- Wired into **`.githooks/run-governance-checks.sh`** (local pre-commit/push) and the **`corpus-check` "skill conformance"** CI job.
- cognos `SKILL.md` — the re-vendor note now states it's enforced.

## Verified
- Gate **passes** on the fresh tree.
- **Fails** on a `converter/*.ts` edit with a clear message (`… STALE vs converter/*.ts … Fix: tools/vendor-converters.sh <mcp> cognos`).
- **Passes** again after revert.
- A `test.ts` edit does **not** trip it (test.ts isn't part of the bundle — 5 bundled sources, not 6).
- Full local governance hook green (including the new gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)