### PR TITLE
Wave 0: calc-translation hotfixes, exhaustive pagination + token TTL, full CI suite + macOS smoke

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -444,7 +444,7 @@ jobs:
         run: |
           set -uo pipefail
           fail=0
-          for h in tools/test-hygiene-sweep.sh tools/test-commit-msg-guard.sh tools/test-converter-provenance.sh tools/test-tree-litter.sh; do
+          for h in tools/test-hygiene-sweep.sh tools/test-commit-msg-guard.sh tools/test-converter-provenance.sh tools/test-tree-litter.sh plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-doctor-json.sh; do
             echo "::group::$h"
             if timeout 300 bash "$h"; then echo "OK $h"; else echo "::error file=$h::harness failed"; fail=1; fi
             echo "::endgroup::"

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -209,7 +209,9 @@ jobs:
       - name: Run offline test-*.rb suites
         # EXPLICIT allow-list — only tests that need NO Tableau/Sigma creds or
         # network. Do NOT add test-calc-discovery.rb (needs a Tableau token);
-        # keep this workflow creds-free. New offline test-*.rb → add its path here.
+        # keep this workflow creds-free. New offline test-*.rb → add its path
+        # here (tableau-to-sigma scripts/test-*.rb need no entry — the
+        # ruby-full-suite job below globs them all).
         run: |
           set -uo pipefail
           tests=(
@@ -354,6 +356,163 @@ jobs:
           for t in "${tests[@]}"; do
             echo "::group::$t"
             if node "$t"; then echo "OK $t"; else echo "::error file=$t::test failed"; fail=1; fi
+            echo "::endgroup::"
+          done
+          exit $fail
+
+  ruby-full-suite:
+    name: full ruby suite (every tableau-to-sigma scripts/test-*.rb, globbed)
+    # E8.4: the unit-tests allow-list above has drifted behind the scripts/
+    # directory — well over a hundred committed test-*.rb files were in no CI
+    # job at all. This job GLOBS the directory so a new test is in CI the
+    # moment it is committed; the allow-list stays as the curated cross-plugin
+    # picks (the overlap double-runs in ~1 min and buys zero-drift coverage).
+    # Whole suite measured: ~114 s serial, slowest single file ~17 s.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      # UTF-8-heavy fixtures (.twb XML with em-dashes, curly quotes) crash
+      # under a US-ASCII default external encoding (the F5 crash class), so
+      # pin the locale rather than inherit the runner default.
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run EVERY offline test-*.rb (glob, per-file timeout)
+        run: |
+          set -uo pipefail
+          # Several tests shell out to the vendored node converter — fail
+          # loudly up front if a runner-image change drops node from PATH,
+          # not as N obscure downstream test failures.
+          node --version || { echo "::error::node is not on PATH — converter-backed tests need it"; exit 1; }
+          shopt -s nullglob
+          tests=(plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-*.rb)
+          # A moved/renamed scripts dir must FAIL here, never vacuously pass.
+          [ "${#tests[@]}" -gt 0 ] || { echo "::error::glob matched no tableau-to-sigma test files"; exit 1; }
+          # Plugin-unique suites that run in NO other job ride along (none are
+          # in the unit-tests allow-list either) — each verified offline and
+          # creds-free. The test-verify-complete.rb twins deliberately DIVERGE
+          # per plugin (each checks its own skill's phase completeness), so
+          # unlike the identical twins they need their own runs. After these,
+          # the only tracked test-*.rb not run by any job are byte-identical
+          # twins — enforced by the shared-libs drift gate — of files already
+          # run above.
+          tests+=(
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conditional-formats.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-gate.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-style.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-filter-apply.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-pivot-sort.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-oracle-sql.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-coverage-gate.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-complete.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/tests/test-grounding.rb
+            plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-flip-gate.rb
+            plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-verify-complete.rb
+            plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test-verify-guards.rb
+            plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-complete.rb
+            plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-verify-complete.rb
+            plugins/quicksight-to-sigma/skills/quicksight-to-sigma/tests/test-grounding.rb
+            plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test-verify-complete.rb
+          )
+          fail=0; ran=0
+          for t in "${tests[@]}"; do
+            case "$(basename "$t")" in
+              # The ONLY exclusion. Do NOT add test-calc-discovery.rb (needs
+              # a Tableau token); keep this workflow creds-free.
+              test-calc-discovery.rb) echo "SKIP $t (needs a Tableau token)"; continue ;;
+            esac
+            echo "::group::$t"
+            # Per-file cap so one hung test cannot eat the whole job budget.
+            if timeout 120 ruby "$t"; then
+              echo "OK $t"
+            else
+              rc=$?
+              msg="test failed (exit $rc)"
+              [ "$rc" -eq 124 ] && msg="test TIMED OUT (per-file 120 s cap)"
+              echo "::error file=$t::$msg"; fail=1
+            fi
+            echo "::endgroup::"
+            ran=$((ran+1))
+          done
+          echo "ran $ran ruby test file(s)"
+          exit $fail
+      - name: Run the tools/*.sh guard harnesses
+        # Self-tests of the repo-level guards (hygiene sweep, commit-msg
+        # guard, converter provenance, tree litter). Hermetic — each builds
+        # its own fixture repo; creds-free, network-free.
+        run: |
+          set -uo pipefail
+          fail=0
+          for h in tools/test-hygiene-sweep.sh tools/test-commit-msg-guard.sh tools/test-converter-provenance.sh tools/test-tree-litter.sh; do
+            echo "::group::$h"
+            if timeout 300 bash "$h"; then echo "OK $h"; else echo "::error file=$h::harness failed"; fail=1; fi
+            echo "::endgroup::"
+          done
+          exit $fail
+
+  macos-smoke:
+    name: BSD userland smoke (macOS — grep/sed/iconv/strings divergence)
+    # The ubuntu jobs run GNU coreutils and CANNOT observe BSD divergence;
+    # windows-smoke runs Git Bash, which is MSYS2/GNU userland. This job
+    # exists because tools/hygiene-sweep.sh ships a BSD-grep-specific
+    # identifier-LEAK fix (newline-separated iconv layers): reverting it
+    # fails test-hygiene-sweep.sh on Darwin and passes on every GNU runner.
+    # Creds-free, network-free, ~30 s of steps.
+    runs-on: macos-latest
+    timeout-minutes: 10
+    env:
+      # NOT optional. Under LC_ALL=C, LC_ALL=UTF-8, or unset, BSD grep does
+      # not exhibit the invalid-UTF-8 line-skip at all and this job would
+      # pass green against a reverted fix (verified: en_US.UTF-8 and C.UTF-8
+      # detect; C, UTF-8 and unset do not). test-bootstrap.rb also crashes
+      # outright under a US-ASCII default external encoding.
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the live sweep + litter lint read git state beyond a shallow head
+          fetch-depth: 0
+      - name: Confirm this runner is actually BSD userland
+        # A silent runner-image change to GNU tools would make every
+        # assertion below vacuous. Fail loudly instead.
+        run: |
+          set -e
+          [ "$(uname -s)" = "Darwin" ] || { echo "::error::not Darwin"; exit 1; }
+          /usr/bin/grep --version 2>&1 | head -1 | grep -qi bsd \
+            || { echo "::error::/usr/bin/grep is not BSD grep — this job's premise is gone"; exit 1; }
+          /usr/bin/sed --version >/dev/null 2>&1 \
+            && { echo "::error::/usr/bin/sed accepts --version — that is GNU sed, not BSD"; exit 1; } || true
+          echo "BSD userland confirmed: $(/usr/bin/grep --version 2>&1 | head -1)"
+      - name: hygiene sweep self-test (BSD grep/iconv/strings — THE reason this job exists)
+        run: bash tools/test-hygiene-sweep.sh
+      - name: sweep the checkout itself under BSD grep
+        run: bash tools/hygiene-sweep.sh   # committed patterns only in CI (the local file is gitignored)
+      - name: commit-message guard self-test
+        run: bash tools/test-commit-msg-guard.sh
+      - name: converter-provenance guard self-test
+        run: bash tools/test-converter-provenance.sh
+      - name: tracked-litter lint self-test
+        run: bash tools/test-tree-litter.sh
+      - name: bootstrap/doctor lockstep self-test
+        run: bash plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bootstrap-lockstep.sh
+      - name: bootstrap harness under /bin/bash 3.2 (hermetic shims)
+        # The only place bash-3.2 `set -u` + array semantics are EXECUTED
+        # rather than parse-checked — every user-facing .sh must stay
+        # macOS-default-bash safe.
+        run: ruby shared/scripts/test-bootstrap.rb
+      - name: encoding-sensitive ruby subset (BSD + UTF-8 locale)
+        # Small on purpose — the FULL ruby suite runs on ubuntu above. These
+        # are the byte/encoding-shaped tests most likely to diverge on
+        # Darwin: binary zip members, and UTF-8-heavy .twb styled-text
+        # extraction.
+        run: |
+          set -uo pipefail
+          fail=0
+          for t in plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zip-extract.rb plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-extraction.rb; do
+            echo "::group::$t"
+            if ruby "$t"; then echo "OK $t"; else echo "::error file=$t::test failed"; fail=1; fi
             echo "::endgroup::"
           done
           exit $fail

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-bootstrap.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-bootstrap.rb
@@ -67,7 +67,9 @@ def run_bootstrap(home, path_dirs, *args)
   env = { 'HOME' => home, 'USERPROFILE' => home, 'PATH' => path_dirs.join(':'),
           # keep the doctor's networked probes off — offline test
           'SIGMA_SKIP_CRED_SMOKE' => '1', 'SIGMA_SKIP_VERSION_CHECK' => '1' }
-  out, st = Open3.capture2e(env, '/bin/bash', BOOTSTRAP, *args)
+  # unsetenv_others: the parent's env (SIGMA_* creds on a dev machine) must
+  # not leak into the child — the hash above IS the whole child environment.
+  out, st = Open3.capture2e(env, '/bin/bash', BOOTSTRAP, *args, unsetenv_others: true)
   [st.exitstatus, out]
 end
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
@@ -19,6 +19,18 @@
         "comment-only hygiene neutralization of a workbook name in the multi-datasource comment (no behavior change)"
       ],
       "upstream_pr": null
+    },
+    {
+      "commit": "worktree (uncommitted at patch time — becomes the landing commit of PR #507 calc hotfixes)",
+      "summary": "Calc-translation hotfixes (PR #507 field-audit batch, live-verified bugs) applied to the vendored bundle in place AND to the local vendor source tree (scripts/vendor/sigma-data-model-mcp src/formulas.ts + rebuilt build/ + updated src tests), pending upstreaming. Fallback path used deliberately: the local upstream clone does not contain source_commit d769bec (divergent history, dirty src/tableau.ts) and re-bundling from any source tree would drop the unlanded d8a049a bundle-only patches above.",
+      "changes": [
+        "ZN → native Sigma Zn() via TABLEAU_FUNC_MAP name-map; removed the single-paren Coalesce($1, 0) regex that emitted malformed Coalesce(Sum([x], 0)) for ZN(AGG(...)) — the dominant field null-guard idiom",
+        "removed Coalesce from _TEXT_FN_RE: its type follows its args, and counting it as text-producing turned numeric ZN(a)+ZN(b) addition into silent string concat (&); _isTextOperand instead recurses into Coalesce's top-level args, so string-literal guard chains (Coalesce([a], \"x\") + …) still convert + to & while numeric or unknown-type guards keep +",
+        "start-of-week literal handling: DATETRUNC 3rd arg / 4-arg DATEDIFF 'monday' is still dropped (Sigma has no start-of-week slot) but now emits a verify warning instead of silent week-boundary drift; the drop is scoped to DateTrunc/DateDiff via a balanced-paren walk so other calls keeping a weekday string as a real last argument (e.g. CONTAINS(x, 'monday')) are no longer mangled",
+        "stopped emitting non-existent Sigma functions: DATETIME → Date (was Datetime), DATEPART('weekday'/'dayofweek') → Weekday(date) with a numbering-verify warning (was DayOfWeek), DATENAME('week') → Text(DatePart(\"week\", …)) at the source branch (was Text(Week(…)))",
+        "un-staled the window-untranslatable list: WINDOW_CORR/WINDOW_VAR/WINDOW_COUNT now map to MovingCorr/MovingVariance/MovingCount (offset forms spanning the current row; all three present in the Sigma function index, verified 2026-07-25); population variants WINDOW_VARP/COVARP/STDEVP stay untranslatable; SIGMA_CHART_ONLY_WINDOW_RE extended with MovingVariance/MovingCorr so the DM router keeps refusing them"
+      ],
+      "upstream_pr": null
     }
   ],
   "_upstream_and_revendor_tasks": [

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
@@ -21,8 +21,8 @@
       "upstream_pr": null
     },
     {
-      "commit": "worktree (uncommitted at patch time — becomes the landing commit of PR #507 calc hotfixes)",
-      "summary": "Calc-translation hotfixes (PR #507 field-audit batch, live-verified bugs) applied to the vendored bundle in place AND to the local vendor source tree (scripts/vendor/sigma-data-model-mcp src/formulas.ts + rebuilt build/ + updated src tests), pending upstreaming. Fallback path used deliberately: the local upstream clone does not contain source_commit d769bec (divergent history, dirty src/tableau.ts) and re-bundling from any source tree would drop the unlanded d8a049a bundle-only patches above.",
+      "commit": "worktree (uncommitted at patch time — becomes the landing commit of the PR #508 calc-hotfix batch)",
+      "summary": "Calc-translation hotfixes (PR #508 speed-program batch, live-verified bugs) applied to the vendored bundle in place AND to the local vendor source tree (scripts/vendor/sigma-data-model-mcp src/formulas.ts + rebuilt build/ + updated src tests), pending upstreaming. Fallback path used deliberately: the local upstream clone does not contain source_commit d769bec (divergent history, dirty src/tableau.ts) and re-bundling from any source tree would drop the unlanded d8a049a bundle-only patches above.",
       "changes": [
         "ZN → native Sigma Zn() via TABLEAU_FUNC_MAP name-map; removed the single-paren Coalesce($1, 0) regex that emitted malformed Coalesce(Sum([x], 0)) for ZN(AGG(...)) — the dominant field null-guard idiom",
         "removed Coalesce from _TEXT_FN_RE: its type follows its args, and counting it as text-producing turned numeric ZN(a)+ZN(b) addition into silent string concat (&); _isTextOperand instead recurses into Coalesce's top-level args, so string-literal guard chains (Coalesce([a], \"x\") + …) still convert + to & while numeric or unknown-type guards keep +",
@@ -30,7 +30,7 @@
         "stopped emitting non-existent Sigma functions: DATETIME → Date (was Datetime), DATEPART('weekday'/'dayofweek') → Weekday(date) with a numbering-verify warning (was DayOfWeek), DATENAME('week') → Text(DatePart(\"week\", …)) at the source branch (was Text(Week(…)))",
         "un-staled the window-untranslatable list: WINDOW_CORR/WINDOW_VAR/WINDOW_COUNT now map to MovingCorr/MovingVariance/MovingCount (offset forms spanning the current row; all three present in the Sigma function index, verified 2026-07-25); population variants WINDOW_VARP/COVARP/STDEVP stay untranslatable; SIGMA_CHART_ONLY_WINDOW_RE extended with MovingVariance/MovingCorr so the DM router keeps refusing them"
       ],
-      "upstream_pr": null
+      "upstream_pr": "twells89/sigma-data-model-mcp#111 (upstream commit 60a0355)"
     }
   ],
   "_upstream_and_revendor_tasks": [

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
@@ -2495,7 +2495,44 @@ function tableauInToSigma(formula) {
   }
   return f;
 }
-var _TEXT_FN_RE = /(?:Coalesce|Concat|Text|Left|Right|Mid|Substring|Substr|Upper|Lower|Trim|Replace|MonthName|WeekdayName|DateName|Proper)$/i;
+// Coalesce is deliberately NOT in the text set: its type follows its args, and
+// the null-guard idiom Coalesce(x, 0) is numeric — counting it as text turned
+// ZN(a)+ZN(b) addition into silent string concat (live-verified field bug).
+// Instead _isTextOperand recurses into Coalesce's args, so string-guard chains
+// (Coalesce([first], "x") + …) still convert + → & while numeric guards keep +.
+var _TEXT_FN_RE = /(?:Concat|Text|Left|Right|Mid|Substring|Substr|Upper|Lower|Trim|Replace|MonthName|WeekdayName|DateName|Proper)$/i;
+function _splitTopLevelArgs(s) {
+  const args = [];
+  let depth = 0, quote = null, buf = "";
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (quote) {
+      buf += ch;
+      if (ch === quote && s[i - 1] !== "\\")
+        quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'")
+      quote = ch;
+    else if (ch === "(" || ch === "[")
+      depth++;
+    else if (ch === ")" || ch === "]") {
+      depth--;
+      // Depth going negative means s is not a single call's arg list (e.g. an
+      // unwrapped compound like `Coalesce(a, 0) = X`) — report no args.
+      if (depth < 0)
+        return [];
+    } else if (ch === "," && depth === 0) {
+      args.push(buf.trim());
+      buf = "";
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf.trim())
+    args.push(buf.trim());
+  return args;
+}
 function _isTextOperand(op, isTextRef) {
   let s = op.trim();
   while (/^\(.*\)$/s.test(s)) {
@@ -2525,6 +2562,10 @@ function _isTextOperand(op, isTextRef) {
   const fn = s.match(/^([A-Za-z_]+)\s*\(.*\)$/s);
   if (fn && _TEXT_FN_RE.test(fn[1]))
     return true;
+  if (fn && /^Coalesce$/i.test(fn[1])) {
+    const args = _splitTopLevelArgs(s.slice(s.indexOf("(") + 1, -1));
+    return args.some((a) => _isTextOperand(a, isTextRef));
+  }
   return false;
 }
 function tableauTextConcatToSigma(formula, isTextRef) {
@@ -2680,7 +2721,9 @@ var TABLEAU_FUNC_MAP = {
   // to DatePart("week", date) below (verified via docs + live query 2026-07-10).
   "QUARTER": "Quarter",
   "DATE": "Date",
-  "DATETIME": "Datetime",
+  // DATETIME(x) → Date(x): Sigma has no Datetime() (absent from the function
+  // index) — Date() is the documented cast to the datetime type.
+  "DATETIME": "Date",
   "MAKEDATE": "MakeDate",
   // regex (same arg order as Tableau)
   "REGEXP_EXTRACT": "RegexpExtract",
@@ -2693,9 +2736,13 @@ var TABLEAU_FUNC_MAP = {
   "PERCENTILE": "PercentileCont",
   "CORR": "Corr",
   // string split — both 1-indexed, negatives count from the right
-  "SPLIT": "SplitPart"
+  "SPLIT": "SplitPart",
+  // null-guard — native Sigma Zn (docs/zn). Name-map, not an arg regex: the old
+  // single-paren Coalesce($1, 0) rewrite emitted malformed Coalesce(Sum([x], 0))
+  // for the dominant field idiom ZN(AGG(...)).
+  "ZN": "Zn"
 };
-var SIGMA_CHART_ONLY_WINDOW_RE = /\b(?:Cumulative(?:Sum|Avg|Min|Max|Count)|Moving(?:Sum|Avg|Min|Max|Count|StdDev)|RankDense|RankPercentile|Rank|PercentOfTotal|RowNumber|Lag|Lead)\s*\(/;
+var SIGMA_CHART_ONLY_WINDOW_RE = /\b(?:Cumulative(?:Sum|Avg|Min|Max|Count)|Moving(?:Sum|Avg|Min|Max|Count|StdDev|Variance|Corr)|RankDense|RankPercentile|Rank|PercentOfTotal|RowNumber|Lag|Lead)\s*\(/;
 var TABLEAU_TABLE_CALC_TOKEN_RE = /\b(?:WINDOW_[A-Z]+|RUNNING_[A-Z]+|LOOKUP|PREVIOUS_VALUE|RANK(?:_[A-Z]+)?|INDEX|SIZE|TOTAL|FIRST|LAST)\s*\(/;
 var TABLEAU_TABLE_CALC_TOKEN_CI_RE = /\b(?:WINDOW_[A-Za-z]+|RUNNING_[A-Za-z]+|PREVIOUS_VALUE)\s*\(/i;
 var TABLEAU_LOD_LEFTOVER_RE = /\{\s*(?:FIXED|INCLUDE|EXCLUDE)\b/i;
@@ -2735,8 +2782,11 @@ function _tcSameRef(a, b) {
   const norm = (s) => s.replace(/^\[|\]$/g, "").replace(/[^A-Za-z0-9_]/g, "_").toUpperCase();
   return norm(a) === norm(b);
 }
+// WINDOW_CORR / WINDOW_VAR / WINDOW_COUNT are NOT listed — Sigma ships
+// MovingCorr/MovingVariance/MovingCount (function index, verified 2026-07-25),
+// mapped below. The population variants (VARP/COVARP/STDEVP) stay: no Moving*Pop.
 function tableauWindowUntranslatable(formula) {
-  const m = (formula || "").match(/\b(WINDOW_MEDIAN|WINDOW_PERCENTILE|WINDOW_CORR|WINDOW_COVARP?|WINDOW_VARP?|WINDOW_STDEVP|PREVIOUS_VALUE|SIZE)\s*\(/i);
+  const m = (formula || "").match(/\b(WINDOW_MEDIAN|WINDOW_PERCENTILE|WINDOW_COVARP?|WINDOW_VARP|WINDOW_STDEVP|PREVIOUS_VALUE|SIZE)\s*\(/i);
   return m ? m[1].toUpperCase() : null;
 }
 function tableauWindowToSigmaChart(formula) {
@@ -2762,21 +2812,39 @@ function tableauWindowToSigmaChart(formula) {
     const fn = "Cumulative" + m[1].charAt(0).toUpperCase() + m[1].slice(1).toLowerCase();
     return { formula: `${fn}(${_tcAgg(m[1], m[2])})`, kind: "cumulative" };
   }
-  m = f.match(new RegExp(`^WINDOW_(SUM|AVG|MIN|MAX|STDEV)\\s*\\(\\s*${_TC_AGG_EXPR}\\s*,\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*\\)$`, "i"));
+  m = f.match(new RegExp(`^WINDOW_(SUM|AVG|MIN|MAX|STDEV|COUNT|VAR)\\s*\\(\\s*${_TC_AGG_EXPR}\\s*,\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*\\)$`, "i"));
   if (m) {
     const back = parseInt(m[4], 10);
     const fwd = parseInt(m[5], 10);
     if (back <= 0 && fwd >= 0) {
+      // COUNT/VAR → MovingCount/MovingVariance: present in the Sigma function
+      // index (verified 2026-07-25); previously mis-listed as untranslatable.
       const movMap = {
         SUM: "MovingSum",
         AVG: "MovingAvg",
         MIN: "MovingMin",
         MAX: "MovingMax",
-        STDEV: "MovingStdDev"
+        STDEV: "MovingStdDev",
+        COUNT: "MovingCount",
+        VAR: "MovingVariance"
       };
       const fn = movMap[m[1].toUpperCase()];
       const args = fwd === 0 ? `${-back}` : `${-back}, ${fwd}`;
       return { formula: `${fn}(${_tcAgg(m[2], m[3])}, ${args})`, kind: "moving" };
+    }
+    return null;
+  }
+  // WINDOW_CORR(AGG([x]), AGG([y]), -n, m) → MovingCorr(Agg([x]), Agg([y]), n[, m])
+  // (two-expression form; offsets must span the current row, like the other
+  // Moving* mappings). Offset-less WINDOW_CORR is a whole-partition corr with
+  // no validated Sigma window shape — it falls to the loud not-converted flag.
+  m = f.match(new RegExp(`^WINDOW_CORR\\s*\\(\\s*${_TC_AGG_EXPR}\\s*,\\s*${_TC_AGG_EXPR}\\s*,\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*\\)$`, "i"));
+  if (m) {
+    const back = parseInt(m[5], 10);
+    const fwd = parseInt(m[6], 10);
+    if (back <= 0 && fwd >= 0) {
+      const args = fwd === 0 ? `${-back}` : `${-back}, ${fwd}`;
+      return { formula: `MovingCorr(${_tcAgg(m[1], m[2])}, ${_tcAgg(m[3], m[4])}, ${args})`, kind: "moving" };
     }
     return null;
   }
@@ -2891,7 +2959,7 @@ function tableauFormulaToSigma(formula, warnings) {
       warnings.push(`\u26A0 COVAR/COVARP has no Sigma equivalent \u2014 not converted. Fragment: ${f.slice(0, 120)}`);
     return "/* no Sigma equivalent: " + f.replace(/\/\*/g, "").replace(/\*\//g, "") + " */";
   }
-  f = f.replace(/\bZN\s*\(([^)]+)\)/gi, "Coalesce($1, 0)");
+  // (ZN → Zn happens in the TABLEAU_FUNC_MAP pass — nesting-safe name rename.)
   f = f.replace(/\bIFNULL\s*\(/gi, "Coalesce(").replace(/\bIFERROR\s*\(/gi, "Coalesce(");
   f = f.replace(/\bISNULL\s*\(/gi, "IsNull(");
   f = f.replace(/\bCOUNT\s*\(([^)]+)\)/gi, (m, arg) => "CountIf(IsNotNull(" + arg.trim() + "))");
@@ -2902,8 +2970,17 @@ function tableauFormulaToSigma(formula, warnings) {
   f = f.replace(/\bIIF\s*\(/gi, "If(");
   f = tableauCaseToSigma(f);
   f = f.replace(/\bDATEPART\s*\(\s*'(\w+)'\s*,\s*([^)]+)\)/gi, (m, part, dateArg) => {
-    if (part.toLowerCase() === "week")
+    const p = part.toLowerCase();
+    if (p === "week")
       return 'DatePart("week", ' + dateArg.trim() + ")";
+    // 'weekday'/'dayofweek' → Weekday(date) — Sigma has no DayOfWeek() (absent
+    // from the function index). Sigma Weekday anchors Sunday=1..7; Tableau
+    // numbering follows the datasource start-of-week — flag to verify.
+    if (p === "weekday" || p === "dayofweek") {
+      if (warnings)
+        warnings.push(`⚠ DATEPART('${p}') → Weekday() — verify numbering: Sigma anchors Sunday=1..7; Tableau follows the datasource start-of-week.`);
+      return "Weekday(" + dateArg.trim() + ")";
+    }
     const partMap = {
       year: "Year",
       month: "Month",
@@ -2911,11 +2988,9 @@ function tableauFormulaToSigma(formula, warnings) {
       hour: "Hour",
       minute: "Minute",
       second: "Second",
-      quarter: "Quarter",
-      dayofweek: "DayOfWeek",
-      weekday: "DayOfWeek"
+      quarter: "Quarter"
     };
-    const fn = partMap[part.toLowerCase()];
+    const fn = partMap[p];
     return fn ? fn + "(" + dateArg.trim() + ")" : m;
   });
   f = f.replace(/\bDATENAME\s*\(\s*'(\w+)'\s*,\s*([^,)]+)(?:,[^)]*)?\)/gi, (m, part, dateArg) => {
@@ -2933,7 +3008,8 @@ function tableauFormulaToSigma(formula, warnings) {
       case "day":
         return "Text(Day(" + arg + "))";
       case "week":
-        return "Text(Week(" + arg + "))";
+        // via DatePart("week", …) — Sigma has no Week() (see the WEEK note above)
+        return 'Text(DatePart("week", ' + arg + "))";
       case "hour":
         return "Text(Hour(" + arg + "))";
       case "minute":
@@ -2945,7 +3021,33 @@ function tableauFormulaToSigma(formula, warnings) {
     }
   });
   f = f.replace(/\bDATETRUNC\s*\(\s*'([^']+)'\s*,/gi, 'DateTrunc("$1",');
-  f = f.replace(/,\s*["'](?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)["']\s*\)/gi, ")");
+  // Start-of-week literal — DATETRUNC('week', d, 'monday') 3rd arg / 4-arg
+  // DATEDIFF('week', a, b, 'monday'): Sigma DateTrunc/DateDiff have no
+  // start-of-week slot, so the literal is dropped — but never silently (week
+  // boundaries then follow the warehouse week start; silent drift shipped in
+  // the field). Scoped to those two callers via a balanced-paren walk back to
+  // the enclosing call, so e.g. Contains([Day], 'monday') keeps its argument.
+  f = f.replace(/,\s*["'](monday|tuesday|wednesday|thursday|friday|saturday|sunday)["']\s*\)/gi, (m, day, off, whole) => {
+    let fn = "", depth = 0;
+    for (let i = off; i >= 0; i--) {
+      const c = whole[i];
+      if (c === ")")
+        depth++;
+      else if (c === "(") {
+        if (depth === 0) {
+          const h = whole.slice(0, i).match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/);
+          fn = h ? h[1] : "";
+          break;
+        }
+        depth--;
+      }
+    }
+    if (!/^(?:datetrunc|datediff)$/i.test(fn))
+      return m;
+    if (warnings)
+      warnings.push(`⚠ ${fn.toUpperCase()} start-of-week '${day}' dropped — Sigma ${/^datetrunc$/i.test(fn) ? "DateTrunc" : "DateDiff"} has no start-of-week argument; week boundaries follow the warehouse week start. Verify week-grain results.`);
+    return ")";
+  });
   f = f.replace(/\bDATEADD\s*\(\s*'([^']+)'\s*,/gi, 'DateAdd("$1",');
   f = f.replace(/\bDATEDIFF\s*\(\s*'([^']+)'\s*,/gi, 'DateDiff("$1",');
   f = f.replace(/\bWEEK\s*\(\s*([^()]*(?:\([^()]*\)[^()]*)*)\)/gi, 'DatePart("week", $1)');

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/coverage-manifest.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/coverage-manifest.json
@@ -364,7 +364,7 @@
   {
    "fn": "DATETIME",
    "category": "typeconv",
-   "sigma": "Datetime",
+   "sigma": "Date",
    "status": "spec",
    "probe": "DATETIME(\"2024-01-15 10:30:00\")"
   },
@@ -427,7 +427,7 @@
   {
    "fn": "WEEK",
    "category": "date",
-   "sigma": "Week",
+   "sigma": "DatePart(\"week\", d)",
    "status": "spec",
    "probe": "WEEK(MAKEDATE(2024, 1, 15))"
   },
@@ -581,7 +581,7 @@
   {
    "fn": "ZN",
    "category": "logical",
-   "sigma": "Coalesce(x,0)",
+   "sigma": "Zn",
    "status": "spec",
    "probe": "ZN([DISCOUNT_AMOUNT])"
   },

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/coverage-matrix.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/coverage-matrix.md
@@ -43,7 +43,7 @@ Sourced from the translator code, not aspiration. Last reconciled 2026-07-10.
 | `IF/THEN/ELSEIF/ELSE/END` | nested `If(...)` | ✅ | missing ELSE → `null` arm |
 | `IIF(c,t,f)` | `If(c,t,f)` | ✅ | |
 | `CASE WHEN` | nested `If(field = v, r, …)` | ✅ | |
-| `ZN(x)` | `Coalesce(x, 0)` | ✅ | |
+| `ZN(x)` | `Zn(x)` | ✅ | native null-guard, name-mapped 2026-07-25 (nesting-safe for `ZN(SUM(…))`); the chart-path table-calc translator still emits `Coalesce(x, 0)` — same semantics |
 | `IFNULL(x,y)` / `IFERROR(x,y)` | `Coalesce(x, y)` | ✅ | |
 | `ISNULL(x)` | `IsNull(x)` | ✅ | distinct from `= ''` |
 | `ATTR(x)` | `x` (unwrapped) | ✅ | |
@@ -78,9 +78,10 @@ All via the function map (rename only — **no argument transformation**).
 | `DATENAME('month',d)` | `MonthName(d)` | ✅ | weekday→`WeekdayName`; numeric units → `Text(Year(d))` etc. |
 | `DATETRUNC` `DATEADD` `DATEDIFF` | `DateTrunc` `DateAdd` `DateDiff` | ✅ | unit single→double-quoted; arg order preserved |
 | `DATEPARSE('fmt',str)` | `DateParse(str,"%Y…")` | ✅ | resolves to datetime (verified 2026-06-15); **arg order reversed** + Java tokens→strftime — a verify warning is emitted |
-| `MAKEDATE` `DATE` `DATETIME` | `MakeDate` `Date` `Datetime` | ✅ | |
+| `MAKEDATE` `DATE` `DATETIME` | `MakeDate` `Date` `Date` | ✅ | `DATETIME`→`Date` (fixed 2026-07-25): Sigma has no `Datetime()` — `Date()` is the cast to the datetime type |
 | `TODAY` `NOW` | `Today` `Now` | ✅ | |
-| `YEAR/MONTH/DAY/HOUR/MINUTE/SECOND/WEEK/QUARTER` | same-named | ✅ | |
+| `YEAR/MONTH/DAY/HOUR/MINUTE/SECOND/QUARTER` | same-named | ✅ | |
+| `WEEK(d)` | `DatePart("week", d)` | ✅ | Sigma has no `Week()` — rewritten, not same-named (see header note; live-probe verified) |
 
 ## 6. Aggregates
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/extract-landing.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/extract-landing.md
@@ -24,11 +24,14 @@ unpinned `pip install pandas` grabs 3.x and the landing fails on
 
 ## The command
 
-Discovery now **auto-detects** an extract-backed workbook (an `<extract>` block
-or `hyper`/`textscan` connection class in the .twb) and re-downloads
-`workbook-content.twbx` **with** the payload (`includeExtract=true`) — check the
-discovery log for "extract payload landed". If the payload is missing anyway
-(older discovery output, or the re-fetch WARNed), verify with
+Discovery **auto-detects** an extract-backed workbook (an `<extract>` block
+or `hyper`/`textscan` connection class in the .twb), but the payload
+re-download is **opt-in**: pass `--extract-refetch` to `tableau-discover.rb`
+on extract-landing runs to re-download `workbook-content.twbx` **with** the
+payload (`includeExtract=true`) — check the discovery log for "extract payload
+landed". Without the flag, discovery logs "extract re-fetch SKIPPED" and the
+.twbx stays thin (no `.hyper` inside). If the payload is missing (a
+default-skip discovery run, or the re-fetch WARNed), verify with
 `unzip -l <workdir>/workbook-content.twbx | grep -c '\.hyper'` and re-download
 via `Tableau.download_workbook_content(<wb-luid>, include_extract: true)` before
 landing — a 0-hyper .twbx makes `land-extracts.py` a silent no-op. Then:

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/calc_coverage.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/calc_coverage.rb
@@ -186,13 +186,13 @@ module CalcCoverage
 
   # --------------------------------------------------------------- coverage
 
-  # Lazy-loaded catalog wrapper: {"provenance", "functions" => [185 entries],
+  # Lazy-loaded catalog wrapper: {"provenance", "functions" => [187 entries],
   # "keywords" => {"logicals", "lod"}}.
   def catalog
     @catalog ||= JSON.parse(File.read(CATALOG_PATH))
   end
 
-  # {name => entry} over the 185-entry catalog, keyed by uppercase name.
+  # {name => entry} over the 187-entry catalog, keyed by uppercase name.
   def catalog_index
     @catalog_index ||= begin
       idx = {}
@@ -211,7 +211,7 @@ module CalcCoverage
   #
   #   covered    — sorted names seen in formulas AND in `translated`.
   #   uncovered  — [{name:, count:, formulas_sample: [...]}] for names in the
-  #                185-entry catalog but NOT in `translated` (named residue —
+  #                187-entry catalog but NOT in `translated` (named residue —
   #                the whole point of classifying before building). Sorted by
   #                count desc, then name.
   #   unknown    — sorted names not in the catalog at all (typos, extensions,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/formula_normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/formula_normalize.rb
@@ -32,15 +32,18 @@ require_relative 'sigma_functions'
 module FormulaNormalize
   # Sigma functions named across the skill's refs that are missing from the
   # canonical whitelist in sigma_functions.rb:
-  #   - Week, Datetime — refs/coverage-matrix.md (`WEEK` -> `Week`,
-  #     `DATETIME` -> `Datetime`, both marked verified).
   #   - Ltrim, Rtrim — the spelling refs/coverage-matrix.md documents and
   #     converter/tableau.mjs emits (`LTRIM` -> `Ltrim`). sigma_functions.rb
   #     lists `LTrim`/`RTrim`; both spellings are treated as KNOWN (neither is
   #     ever rewritten), but pure case-variants (`LTRIM(`, `ltrim(`) normalize
   #     to the converter's spelling so normalized output matches what the
   #     converter path has posted successfully.
-  EXTRA_FUNCTIONS = %w[Week Datetime Ltrim Rtrim].freeze
+  # Week and Datetime were REMOVED (2026-07-25): neither exists in Sigma (absent
+  # from the live function index; converter probe logged "Unknown function:
+  # Week") — the stale coverage-matrix rows that blessed them defeated the
+  # validator. The converter now emits DatePart("week", …) / Date(…) instead;
+  # a WEEK(/DATETIME( leak must surface as unknown, not get case-normalized.
+  EXTRA_FUNCTIONS = %w[Ltrim Rtrim].freeze
 
   KNOWN_FUNCTIONS = (SigmaFunctions::ALL + EXTRA_FUNCTIONS).uniq.freeze
   KNOWN_EXACT = KNOWN_FUNCTIONS.to_set.freeze

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_functions.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_functions.json
@@ -535,7 +535,7 @@
       "maxArgs": 1,
       "category": "user",
       "sigmaEquivalent": null,
-      "notes": "Sigma: CurrentUserAttribute"
+      "notes": "Sigma: CurrentUserAttributeText (the live function name — no bare CurrentUserAttribute exists; the converter emits CurrentUserAttributeText)"
     },
     {
       "name": "USERATTRIBUTEINCLUDES",
@@ -602,6 +602,14 @@
       "notes": "External model call; not portable"
     },
     {
+      "name": "MODEL_EXTENSION_STR",
+      "minArgs": 2,
+      "maxArgs": null,
+      "category": "table_calc",
+      "sigmaEquivalent": null,
+      "notes": "External model call; not portable. Current Tableau docs spelling — kept alongside legacy MODEL_EXTENSION_STRING so modern .twb files don't bucket as unknown-function (added 2026-07-25 beyond the tflex set)"
+    },
+    {
       "name": "MODEL_EXTENSION_STRING",
       "minArgs": 2,
       "maxArgs": null,
@@ -638,8 +646,8 @@
       "minArgs": 1,
       "maxArgs": 2,
       "category": "table_calc",
-      "sigmaEquivalent": "Rank()",
-      "notes": "tflex window-serialization handler ExpressionToSql.js:224-227/255-258 emits RANK() OVER (...)"
+      "sigmaEquivalent": "Rank({0}, \"desc\")",
+      "notes": "tflex window-serialization handler ExpressionToSql.js:224-227/255-258 emits RANK() OVER (...). Direction is REQUIRED in the template: Sigma Rank([column],[direction]) defaults to \"asc\" while Tableau RANK defaults descending — a bare Rank() inverts every rank (matches the converter's Rank(agg, \"desc\") emission)"
     },
     {
       "name": "RANK_DENSE",
@@ -654,8 +662,8 @@
       "minArgs": 1,
       "maxArgs": 2,
       "category": "table_calc",
-      "sigmaEquivalent": "Rank()",
-      "notes": "tflex ExpressionToSql.js:228-230/259-261 approximates with plain RANK()"
+      "sigmaEquivalent": "Rank({0}, \"desc\")",
+      "notes": "tflex ExpressionToSql.js:228-230/259-261 approximates with plain RANK(). Direction required (Sigma default asc, Tableau default desc). VERIFY tie behavior: modified-competition ranking gives ties the LAST position in the tie block; Sigma Rank gives the first — an approximation, not an equivalent"
     },
     {
       "name": "RANK_PERCENTILE",
@@ -968,6 +976,14 @@
       "category": "additional_passthrough",
       "sigmaEquivalent": null,
       "notes": null
+    },
+    {
+      "name": "REGEXP_REPLACE",
+      "minArgs": 3,
+      "maxArgs": 3,
+      "category": "additional_passthrough",
+      "sigmaEquivalent": "RegexpReplace({0}, {1}, {2})",
+      "notes": "Sigma RegexpReplace, same arg order (string, pattern, replacement); converter maps it. Added 2026-07-25 beyond the tflex set — absence made scan-workbook-gaps bucket a real Tableau function as unknown/typo"
     },
     {
       "name": "GET_JSON_OBJECT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
@@ -500,7 +500,7 @@ def analyze_fields(doc, content)
   # 4b. Calc-coverage census (v5.0, tflex-derived): tokenize every calc formula
   #     with the MASKING tokenizer (comments/strings/field-refs masked first, so
   #     'IF(' inside a string literal never false-hits) and extract the function
-  #     names actually used. Functions absent from the 185-entry official
+  #     names actually used. Functions absent from the 187-entry official
   #     catalog are named up front — a typo'd or extension function becomes a
   #     scoping fact here instead of a silent formula error after the build.
   fn_census = Hash.new(0)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
@@ -80,8 +80,12 @@ OptionParser.new do |o|
   o.on('--skip-images')           { opts[:fetch_view_images] = 'none' }
   o.on('--all-view-images')       { opts[:fetch_view_images] = 'all' }
   o.on('--skip-content')          { opts[:skip_content] = true }
-  o.on('--no-extract-refetch', 'skip the includeExtract=true re-download when extract markers are found — ' \
-                               'for routes that never consume the frozen extract bytes (e.g. a live repoint)') { opts[:no_extract_refetch] = true }
+  # --[no-]: existing callers (migrate-tableau.rb's live-repoint route) still
+  # pass the old opt-out spelling; it must stay accepted even though skip is
+  # now the default.
+  o.on('--[no-]extract-refetch', 'opt IN to the includeExtract=true re-download when extract markers are found — ' \
+                                 'default is to SKIP it (most routes never consume the frozen extract bytes); ' \
+                                 'pass --extract-refetch on extract-landing runs') { |v| opts[:extract_refetch] = v }
   o.on('--pool N', Integer, 'Fetch-pool size (default 5 — measured sweet spot)') { |v| opts[:pool] = v }
 end.parse!
 
@@ -252,19 +256,17 @@ unless opts[:skip_content]
       twb_xml, had_hypers = persist.call(bytes)
       # EXTRACT-BACKED workbook, thin download: the default REST download
       # excludes the extract payload (includeExtract=false), so the .twbx has
-      # NO Data/**/*.hyper inside — directly contradicting what the landing
-      # step needs (three independent field runs each hand-rewrote this
-      # re-fetch; refs/extract-landing.md wrongly claimed discovery already
-      # had it). Detect extract markers in the ACTUAL XML and re-download WITH
-      # the payload; non-extract workbooks never pay the big download.
+      # NO Data/**/*.hyper inside — the extract-landing step needs it (three
+      # independent field runs each hand-rewrote this re-fetch;
+      # refs/extract-landing.md wrongly claimed discovery already had it).
+      # Detect extract markers in the ACTUAL XML; the re-download WITH the
+      # payload is OPT-IN (--extract-refetch) — it is the heaviest task in
+      # discovery and only extract-landing routes consume the frozen bytes.
+      # Non-extract workbooks never reach this branch at all.
       if twb_xml && !had_hypers &&
          (twb_xml.include?('<extract') || twb_xml =~ /class='(?:hyper|textscan)'/)
-        if opts[:no_extract_refetch]
-          # One clear line, then move on: this route never consumes the frozen
-          # extract bytes, so the heavy includeExtract=true download is waste.
-          log 'embedded extract detected — extract re-fetch SKIPPED (--no-extract-refetch: this route needs no extract bytes)'
-        else
-          log 'embedded extract detected but no .hyper payload in the download — re-fetching WITH includeExtract=true'
+        if opts[:extract_refetch]
+          log 'embedded extract detected but no .hyper payload in the download — re-fetching WITH includeExtract=true (--extract-refetch)'
           with_extract = run_task('twb-download-extract', max_attempts: 2) { Tableau.download_workbook_content(wb['id'], include_extract: true) }
           if with_extract && with_extract.bytesize > bytes.bytesize
             twb_xml2, had2 = persist.call(with_extract)
@@ -274,6 +276,11 @@ unless opts[:skip_content]
           else
             log 'WARN: includeExtract=true re-fetch returned nothing larger — proceeding with the thin .twb'
           end
+        else
+          # One clear line, then move on. This is the breadcrumb for a landing
+          # run that forgot the flag: without it, "land-extracts.py found no
+          # .hyper" is undebuggable from the discovery log.
+          log 'embedded extract detected — extract re-fetch SKIPPED (default; pass --extract-refetch when the frozen extract bytes must land, e.g. for land-extracts.py)'
         end
       end
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bootstrap.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bootstrap.rb
@@ -67,7 +67,9 @@ def run_bootstrap(home, path_dirs, *args)
   env = { 'HOME' => home, 'USERPROFILE' => home, 'PATH' => path_dirs.join(':'),
           # keep the doctor's networked probes off — offline test
           'SIGMA_SKIP_CRED_SMOKE' => '1', 'SIGMA_SKIP_VERSION_CHECK' => '1' }
-  out, st = Open3.capture2e(env, '/bin/bash', BOOTSTRAP, *args)
+  # unsetenv_others: the parent's env (SIGMA_* creds on a dev machine) must
+  # not leak into the child — the hash above IS the whole child environment.
+  out, st = Open3.capture2e(env, '/bin/bash', BOOTSTRAP, *args, unsetenv_others: true)
   [st.exitstatus, out]
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-coverage.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-coverage.rb
@@ -51,10 +51,12 @@ puts 'Part 0 — catalog integrity (lib/tableau_functions.json)'
 cat = CalcCoverage.catalog
 check(cat.is_a?(Hash) && cat['provenance'].to_s.include?('tflex'),
       'catalog wrapper carries tflex provenance', fails)
-check(cat['functions'].is_a?(Array) && cat['functions'].size == 185,
-      "catalog has 185 function entries (got #{cat['functions'] ? cat['functions'].size : 'none'})", fails)
+# 187 = tflex's 185 + REGEXP_REPLACE + MODEL_EXTENSION_STR (added 2026-07-25 —
+# real Tableau functions whose absence bucketed field workbooks as unknown/typo).
+check(cat['functions'].is_a?(Array) && cat['functions'].size == 187,
+      "catalog has 187 function entries (got #{cat['functions'] ? cat['functions'].size : 'none'})", fails)
 names = cat['functions'].map { |e| e['name'] }
-check(names.uniq.size == 185, 'catalog names are unique', fails)
+check(names.uniq.size == 187, 'catalog names are unique', fails)
 check(cat['functions'].all? { |e| e.key?('minArgs') && e.key?('maxArgs') && e.key?('category') && e.key?('sigmaEquivalent') },
       'every entry carries minArgs/maxArgs/category/sigmaEquivalent', fails)
 check(cat['keywords'] == { 'logicals' => CalcCoverage::KEYWORDS, 'lod' => CalcCoverage::LOD_KEYWORDS },
@@ -203,7 +205,7 @@ cov = CalcCoverage.coverage(formulas, translated: translated)
 check(cov[:covered] == %w[DATEDIFF IFNULL],
       "covered = translated-set hits, sorted (got #{cov[:covered].inspect})", fails)
 check(cov[:unknown] == ['FOOBAR'],
-      "unknown = names absent from the 185-entry catalog (got #{cov[:unknown].inspect})", fails)
+      "unknown = names absent from the catalog (got #{cov[:unknown].inspect})", fails)
 check(cov[:uncovered].map { |u| u[:name] } == ['UPPER'],
       'uncovered = in-catalog but untranslated (UPPER, spec F19)', fails)
 upper = cov[:uncovered][0]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-census.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-census.rb
@@ -44,7 +44,7 @@ end
 puts 'Part A — clean readback: no problems'
 posted = posted_spec('Order Fact' => %w[Sales Profit Region])
 rb = readback_spec(['Order Fact'])
-problems = ColumnCensus.census(posted, rb, entries_for('srv-el-0' => %w[Sales Profit Region]))
+problems = ColumnCensus.census(posted, rb, entries_for({ 'srv-el-0' => %w[Sales Profit Region] }))
 check(problems.empty?, "all columns resolved -> [] (got #{problems.inspect})", fails)
 check(ColumnCensus.posted_column_count(posted) == 3, 'posted_column_count sums columns', fails)
 
@@ -53,7 +53,7 @@ puts 'Part B — the silent-drop catastrophe: most posted columns missing'
 many = (1..30).map { |i| "Col #{format('%02d', i)}" }
 posted = posted_spec('Order Fact' => many)
 rb = readback_spec(['Order Fact'])
-problems = ColumnCensus.census(posted, rb, entries_for('srv-el-0' => many.first(4)))
+problems = ColumnCensus.census(posted, rb, entries_for({ 'srv-el-0' => many.first(4) }))
 check(problems.size == 1, 'one problem element reported', fails)
 p1 = problems.first
 check(p1['posted'] == 30 && p1['resolved'] == 4, "posted 30 / resolved 4 counted (got #{p1['posted']}/#{p1['resolved']})", fails)
@@ -67,7 +67,7 @@ puts
 puts 'Part C — element entirely absent from readback'
 posted = posted_spec('Order Fact' => %w[Sales], 'Ghost Element' => %w[A B])
 rb = readback_spec(['Order Fact'])
-problems = ColumnCensus.census(posted, rb, entries_for('srv-el-0' => %w[Sales]))
+problems = ColumnCensus.census(posted, rb, entries_for({ 'srv-el-0' => %w[Sales] }))
 check(problems.size == 1 && problems.first['element'] == 'Ghost Element', 'dropped element reported', fails)
 check(problems.first['resolved'] == 0 && problems.first['missing'] == %w[A B], 'all its columns missing', fails)
 check(problems.first['note'].to_s.include?('missing from readback'), 'note explains the element-level drop', fails)
@@ -85,7 +85,7 @@ puts
 puts 'Part E — suffixed-label tolerance (Sigma joined-dim relabeling)'
 posted = posted_spec('Order Fact' => ['Customer Id', 'Sales'])
 rb = readback_spec(['Order Fact'])
-problems = ColumnCensus.census(posted, rb, entries_for('srv-el-0' => ['Customer Id (CUSTOMER_DIM)', 'Sales']))
+problems = ColumnCensus.census(posted, rb, entries_for({ 'srv-el-0' => ['Customer Id (CUSTOMER_DIM)', 'Sales'] }))
 check(problems.empty?, "posted 'Customer Id' resolved by suffixed label (got #{problems.inspect})", fails)
 
 puts
@@ -93,7 +93,7 @@ puts 'Part F — id fallback when names are blank but ids survive'
 posted = { 'pages' => [{ 'elements' => [{ 'id' => 'kept-id', 'kind' => 'table',
                                           'columns' => [{ 'id' => 'c1', 'name' => 'Sales' }] }] }] }
 rb = { 'pages' => [{ 'elements' => [{ 'id' => 'kept-id', 'kind' => 'table' }] }] }
-problems = ColumnCensus.census(posted, rb, entries_for('kept-id' => %w[Sales]))
+problems = ColumnCensus.census(posted, rb, entries_for({ 'kept-id' => %w[Sales] }))
 check(problems.empty?, 'nameless element matched by surviving id', fails)
 
 puts
@@ -102,7 +102,7 @@ posted = { 'pages' => [{ 'elements' => [{ 'id' => 'e1', 'name' => 'Fact', 'kind'
                                           'columns' => [{ 'id' => 'c1', 'name' => 'Sales' }],
                                           'metrics' => [{ 'id' => 'm1', 'name' => 'Total Sales' }] }] }] }
 rb = readback_spec(['Fact'])
-problems = ColumnCensus.census(posted, rb, entries_for('srv-el-0' => ['Sales']))
+problems = ColumnCensus.census(posted, rb, entries_for({ 'srv-el-0' => ['Sales'] }))
 check(problems.size == 1 && problems.first['missing'] == ['Total Sales'], 'missing metric caught', fails)
 
 puts

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-converter-fixtures.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-converter-fixtures.rb
@@ -16,7 +16,9 @@
 #
 #   Part A: vendored converter/tableau.mjs internal tableauFormulaToSigma
 #           (export-appended tmp copy — the bundle only exports
-#           convertTableauToSigma) — 29 asserted fixtures + 1 PENDING (N-X2).
+#           convertTableauToSigma) — 44 asserted fixtures, 0 PENDING (N-X2 was
+#           promoted 2026-07-25 when the vendored ZN → native Zn fix landed;
+#           the N-Z*/N-D*/N-W* rows lock the same calc-hotfix batch).
 #           Needs `node` on PATH; when node itself is absent Part A is
 #           SKIPPED with a warning (CI runners may lack node) — but a
 #           re-vendor that renames/splits tableauFormulaToSigma still
@@ -52,13 +54,17 @@ end
 
 # ---------------------------------------------------------------------------
 # Part A fixture table — measured 2026-07-11 against converter/tableau.mjs
-# @ c33e5bd (see converter/PROVENANCE.json). :warn => substring that must
-# appear in the warnings array; no :warn => warnings must be EMPTY.
+# @ c33e5bd (see converter/PROVENANCE.json); ZN/date/window rows re-measured
+# 2026-07-25 against the calc-hotfix local patches (PROVENANCE local_patches).
+# :warn => substring that must appear in the warnings array; no :warn =>
+# warnings must be EMPTY.
 # ---------------------------------------------------------------------------
 NODE_FIXTURES = [
   { id: 'N-F1',  input: 'IFNULL([Sales], 0)',                    expect: 'Coalesce([Sales], 0)' },
   { id: 'N-F2',  input: 'ISNULL([Discount])',                    expect: 'IsNull([Discount])' },
-  { id: 'N-F3',  input: 'ZN([Profit])',                          expect: 'Coalesce([Profit], 0)' },
+  # ZN → native Sigma Zn (docs/zn) — name-map, robust for any nesting; the old
+  # Coalesce($1, 0) regex broke ZN(AGG(...)) (see N-X2).
+  { id: 'N-F3',  input: 'ZN([Profit])',                          expect: 'Zn([Profit])' },
   # tflex F4: DATEDIFF arg swap + pass-count parity chaos. Absent here — the
   # skill preserves Tableau (part, start, end) order, which is exactly Sigma's
   # DateDiff(part, start, end); single-pass regex, no double-swap.
@@ -103,17 +109,49 @@ NODE_FIXTURES = [
   # CASE → If-chain form (semantically = Switch).
   { id: 'N-X1',  input: 'CASE [Region] WHEN "West" THEN 1 ELSE 0 END',
     expect: 'If([Region] = "West", 1, 0)' },
-  # PENDING — the suite's one known-wrong row. The ZN rewrite
-  # /\bZN\s*\(([^)]+)\)/gi (tableau.mjs :2853) is not nesting-aware: [^)]+
-  # stops at the first ')', so the ', 0' lands INSIDE Sum(...). Current
-  # (malformed) output: Coalesce(Sum([Profit], 0)). The Ruby agg path (R-X2)
-  # gets the same input RIGHT — that pair is the cross-path divergence lock.
-  # Fix belongs UPSTREAM (twells89/sigma-data-model-mcp), then re-vendor via
-  # tools/vendor-converters.sh and promote this to a hard assertion. Never
-  # assert the wrong output as if it were desired.
-  { id: 'N-X2',  input: 'ZN(SUM([Profit]))',
-    pending: { expected: 'Coalesce(Sum([Profit]), 0)',
-               reason: 'ZN rewrite [^)]+ not nesting-aware (tableau.mjs :2853); fix upstream + re-vendor' } },
+  # PROMOTED 2026-07-25 (was the suite's one PENDING row): the single-paren
+  # Coalesce ZN rewrite emitted malformed Coalesce(Sum([Profit], 0)); the fix
+  # maps ZN → native Sigma Zn() by NAME, so any nesting survives. Landed as a
+  # vendored local patch (converter/PROVENANCE.json local_patches — upstream
+  # clone divergent), not the re-vendor the old note asked for.
+  { id: 'N-X2',  input: 'ZN(SUM([Profit]))',                     expect: 'Zn(Sum([Profit]))' },
+  # Locks the _TEXT_FN_RE fix: Coalesce/Zn are NOT text-producing, so numeric
+  # `+` between null-guards must stay `+` (was silently corrupted to `&`).
+  { id: 'N-Z1',  input: 'ZN([Sales]) + ZN([Profit])',            expect: 'Zn([Sales]) + Zn([Profit])' },
+  { id: 'N-Z2',  input: 'ZN(SUM([Sales])) - ZN(SUM([Profit]))',  expect: 'Zn(Sum([Sales])) - Zn(Sum([Profit]))' },
+  # …while the OTHER side of the same fix holds: _isTextOperand recurses into
+  # Coalesce's args, so a string-literal null-guard chain still converts + → &
+  # (was silently left as numeric +, which errors the column at render), and a
+  # ref-only Coalesce with no type info conservatively keeps +.
+  { id: 'N-Z3',  input: 'IFNULL([a], "x") + IFNULL([b], "y")',
+    expect: 'Coalesce([a], "x") & Coalesce([b], "y")' },
+  { id: 'N-Z4',  input: 'IFNULL([c], [e]) + IFNULL([d], [f])',
+    expect: 'Coalesce([c], [e]) + Coalesce([d], [f])' },
+  # Start-of-week arg has no Sigma slot — dropped LOUDLY (was silent drift)…
+  { id: 'N-D1',  input: "DATEDIFF('week', [Start], [Finish], 'monday')",
+    expect: 'DateDiff("week", [Start], [Finish])',  warn: "start-of-week 'monday' dropped" },
+  { id: 'N-D2',  input: "DATETRUNC('week', [Order Date], 'monday')",
+    expect: 'DateTrunc("week", [Order Date])',      warn: "start-of-week 'monday' dropped" },
+  # …and ONLY DateTrunc/DateDiff drop it — a weekday string that is a real last
+  # argument elsewhere survives (the old strip ate it: Contains([D], 'monday')
+  # became Contains([D])).
+  { id: 'N-D3',  input: "CONTAINS([Day Name], 'monday')",        expect: 'Contains([Day Name], "monday")' },
+  # Non-existent Sigma names purged from emission (function-index verified):
+  { id: 'N-D4',  input: 'DATETIME([Ship Date])',                 expect: 'Date([Ship Date])' },
+  { id: 'N-D5',  input: "DATEPART('weekday', [Order Date])",     expect: 'Weekday([Order Date])',
+    warn: 'verify numbering' },
+  { id: 'N-D6',  input: "DATENAME('week', [Order Date])",        expect: 'Text(DatePart("week", [Order Date]))' },
+  # Un-staled window mappings — MovingCorr/MovingVariance/MovingCount exist:
+  { id: 'N-W1',  input: 'WINDOW_CORR(SUM([Sales]), SUM([Profit]), -2, 0)',
+    expect: 'MovingCorr(Sum([Sales]), Sum([Profit]), 2)', warn: 'CHART/grouped-element context ONLY' },
+  { id: 'N-W2',  input: 'WINDOW_VAR(SUM([Sales]), -4, 0)',
+    expect: 'MovingVariance(Sum([Sales]), 4)',            warn: 'CHART/grouped-element context ONLY' },
+  { id: 'N-W3',  input: 'WINDOW_COUNT(COUNT([Sales]), -2, 0)',
+    expect: 'MovingCount(Count([Sales]), 2)',             warn: 'CHART/grouped-element context ONLY' },
+  # Population variant stays untranslatable (no Moving*Pop in Sigma):
+  { id: 'N-W4',  input: 'WINDOW_VARP(SUM([Sales]), -2, 0)',
+    expect: '/* table calc: WINDOW_VARP(SUM([Sales]), -2, 0) */',
+    warn: 'has no Sigma equivalent' },
   { id: 'N-X3',  input: 'COUNTD([Customer ID])',                 expect: 'CountDistinct([Customer ID])' },
   # Fail-open WITH warning is the B1 contract for unmapped functions.
   { id: 'N-X4',  input: 'FINDNTH([Path], "-", 2)',               expect: 'FINDNTH([Path], "-", 2)',
@@ -204,8 +242,10 @@ RUBY_FIXTURES = [
     expect: 'Sum([Master/PROFIT_RATIO]) * 100' },
   { id: 'R-X3',  entry: :kpi, input: 'COUNTD([Customer ID])',
     expect: 'CountDistinct([Master/CUSTOMER_ID])' },
-  # The paren-aware ZN loop gets right what node N-X2 gets wrong — this pair
-  # is the cross-path divergence lock (see the N-X2 PENDING row).
+  # Cross-path lock with node N-X2: both paths now translate ZN(AGG(...))
+  # correctly but through different idioms — node emits native Zn(...), the
+  # paren-aware Ruby agg loop emits Coalesce(..., 0). Semantically identical
+  # (Zn(x) ≡ Coalesce(x, 0)); each path's own shape is asserted exactly.
   { id: 'R-X2',  entry: :agg, input: 'ZN(SUM([Profit]))',
     expect: 'Coalesce(Sum([Master/PROFIT]), 0)' },
   { id: 'R-F16', entry: :win, input: 'RANK(SUM([Sales]))',

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-discover-extract-skip.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-discover-extract-skip.rb
@@ -1,17 +1,19 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-# Regression test for discovery's conditional extract re-fetch (PR-2 field-ops).
+# Regression test for discovery's OPT-IN extract re-fetch (B6 default flip).
 #
-# tableau-discover.rb re-downloads workbook content WITH includeExtract=true
+# tableau-discover.rb can re-download workbook content WITH includeExtract=true
 # when extract markers are present but the thin download carried no .hyper —
-# a 120s-timeout task that used to burn up to 4 attempts even on routes that
-# never consume the extract bytes. Now: --no-extract-refetch skips it with one
-# clear line (migrate-tableau.rb passes it on the --skip-extract-landing live
-# repoint), and the re-fetch task is capped at 2 attempts. Proven with a
-# STUBBED Tableau lib (the script + its real zip/fcp libs are copied to a
-# tmpdir whose lib/ carries a stub tableau_rest.rb, so no network is possible):
-# the stub serves a thin .twb with extract markers and fails the extract
-# re-fetch retryably, logging every fetch. Offline.
+# a 120s-timeout task that is the heaviest in discovery, and whose payload only
+# extract-landing routes ever consume. Contract under test: the re-fetch is
+# SKIPPED by default with one clear breadcrumb naming the opt-in flag;
+# --extract-refetch opts in (attempts still capped at 2); the old opt-out
+# spelling --no-extract-refetch stays accepted (migrate-tableau.rb passes it on
+# the --skip-extract-landing live repoint). Proven with a STUBBED Tableau lib
+# (the script + its real zip/fcp libs are copied to a tmpdir whose lib/ carries
+# a stub tableau_rest.rb, so no network is possible): the stub serves a thin
+# .twb with extract markers and fails the extract re-fetch retryably, logging
+# every fetch. Offline.
 #
 # Usage: ruby scripts/test-discover-extract-skip.rb
 
@@ -76,32 +78,52 @@ Dir.mktmpdir do |tmp|
   end
   File.write(File.join(tmp, 'lib', 'tableau_rest.rb'), STUB)
 
-  # (1) default + extract route: re-fetch attempted, capped at 2 attempts.
+  # (1) DEFAULT + extract route: NO re-fetch, one skip line naming the opt-in.
   log1 = File.join(tmp, 'fetch1.log')
   File.write(log1, '')
   code, out = run_discover(script, File.join(tmp, 'out1'), log1)
   fetches = File.readlines(log1).map(&:strip)
   check(code == 0, "default run completes (exit #{code})", fails)
-  check(fetches.count('download include_extract=false') == 1, 'thin download fetched once', fails)
+  check(fetches.count('download include_extract=false') == 1, 'thin download fetched once by default', fails)
   n_extract = fetches.count('download include_extract=true')
-  check(n_extract == 2, "extract re-fetch attempted and CAPPED at 2 attempts (got #{n_extract})", fails)
-  check(out.include?('re-fetching WITH includeExtract=true'), 'default route announces the re-fetch', fails)
+  check(n_extract.zero?, "NO extract re-fetch by default (got #{n_extract} includeExtract=true fetches)", fails)
+  skip_lines = out.lines.grep(/extract re-fetch SKIPPED/)
+  check(skip_lines.size == 1, "exactly one clear skip line by default (got #{skip_lines.size})", fails)
+  check(out.include?('--extract-refetch'), 'default skip line names the opt-in flag', fails)
 
-  # (2) --no-extract-refetch: NO extract fetch, one clear skip line.
+  # (2) --extract-refetch: re-fetch attempted, still CAPPED at 2 attempts.
   log2 = File.join(tmp, 'fetch2.log')
   File.write(log2, '')
-  code, out = run_discover(script, File.join(tmp, 'out2'), log2, '--no-extract-refetch')
+  code, out = run_discover(script, File.join(tmp, 'out2'), log2, '--extract-refetch')
   fetches = File.readlines(log2).map(&:strip)
-  check(code == 0, "--no-extract-refetch run completes (exit #{code})", fails)
-  check(fetches.count('download include_extract=true').zero?, 'no extract fetch under --no-extract-refetch', fails)
-  skip_lines = out.lines.grep(/extract re-fetch SKIPPED/)
-  check(skip_lines.size == 1, "exactly one clear skip line logged (got #{skip_lines.size})", fails)
-  check(out.include?('--no-extract-refetch'), 'skip line names the flag', fails)
+  check(code == 0, "--extract-refetch run completes (exit #{code})", fails)
+  n_extract = fetches.count('download include_extract=true')
+  check(n_extract == 2, "--extract-refetch attempts the re-fetch, CAPPED at 2 (got #{n_extract})", fails)
+  check(out.include?('re-fetching WITH includeExtract=true'), '--extract-refetch announces the re-fetch', fails)
 
-  # (3) migrate-tableau.rb wires the flag on the live-repoint route.
+  # (3) --no-extract-refetch (old opt-out spelling) stays accepted: no fetch,
+  # skip line still logged.
+  log3 = File.join(tmp, 'fetch3.log')
+  File.write(log3, '')
+  code, out = run_discover(script, File.join(tmp, 'out3'), log3, '--no-extract-refetch')
+  fetches = File.readlines(log3).map(&:strip)
+  check(code == 0, "--no-extract-refetch still accepted (exit #{code})", fails)
+  check(fetches.count('download include_extract=true').zero?, 'no extract fetch under --no-extract-refetch', fails)
+  check(out.lines.grep(/extract re-fetch SKIPPED/).size == 1, 'skip line still logged under --no-extract-refetch', fails)
+
+  # (4) migrate-tableau.rb keeps the --skip-extract-landing live repoint on the
+  # skip path. TWO spellings are correct under the opt-in default and both are
+  # accepted, so this check survives the coordinated orchestrator flip that
+  # restores auto-land (extract-refetch on landing routes):
+  #   old: '--no-extract-refetch' if opts[:skip_extract_landing]   (explicit skip)
+  #   new: '--extract-refetch' unless opts[:skip_extract_landing]  (landing routes opt in)
+  # The backwards combos (refetch ON the live repoint, or opt-out on landing
+  # routes only) match neither string and keep failing here.
   wiring = File.read(File.join(DIR, 'migrate-tableau.rb'))
-  check(wiring.include?("'--no-extract-refetch' if opts[:skip_extract_landing]"),
-        'orchestrator passes --no-extract-refetch on --skip-extract-landing (live repoint)', fails)
+  wired_old = wiring.include?("'--no-extract-refetch' if opts[:skip_extract_landing]")
+  wired_new = wiring.include?("'--extract-refetch' unless opts[:skip_extract_landing]")
+  check(wired_old || wired_new,
+        'orchestrator wires extract-refetch against :skip_extract_landing (either correct spelling)', fails)
 end
 
 puts

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-doctor-json.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-doctor-json.sh
@@ -59,8 +59,8 @@ assert isinstance(d["agent_vision"], bool), \
     "agent_vision is caller-asserted via SIGMA_AGENT_VISION (default false)"
 assert isinstance(d["model_hint"], str)
 assert isinstance(d["sandbox_hint"], str)
-assert set(d["cred_smoke"]) == {"sigma", "tableau"}, d["cred_smoke"]
-assert all(v in ("pass", "fail", "skipped") for v in d["cred_smoke"].values()), d["cred_smoke"]
+assert set(d["cred_smoke"]) == {"sigma", "tableau", "looker"}, d["cred_smoke"]
+assert all(v in ("pass", "fallback", "fail", "skipped") for v in d["cred_smoke"].values()), d["cred_smoke"]
 assert isinstance(d["pass"], bool) and isinstance(d["failures"], list)
 assert all(isinstance(f, str) for f in d["failures"])
 assert d["pass"] == (rc == 0), f"pass={d['pass']} but doctor exited {rc}"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-formula-normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-formula-normalize.rb
@@ -47,8 +47,8 @@ check(norm.call(nil).nil?, 'nil formula passes through', fails)
 puts
 puts 'Part C — known-list coverage (contract list + refs additions)'
 contract = %w[If Switch Sum Avg Min Max Median Count CountIf CountDistinct Coalesce IsNull IsNotNull
-              Lookup DateTrunc DateAdd DateDiff DatePart Year Month Day Hour Minute Second Week Quarter
-              MonthName WeekdayName Weekday MakeDate Date Datetime DateParse Today Now Text Left Right
+              Lookup DateTrunc DateAdd DateDiff DatePart Year Month Day Hour Minute Second Quarter
+              MonthName WeekdayName Weekday MakeDate Date DateParse Today Now Text Left Right
               Mid Len Find Contains StartsWith EndsWith Replace Trim Ltrim Rtrim Upper Lower SplitPart
               Concat Abs Round Ceiling Floor Power Sqrt Int Number Ln Log Exp Mod Sign Pi StdDev
               Variance VariancePop PercentileCont Rank RankDense RankPercentile RowNumber Lag Lead
@@ -59,8 +59,11 @@ contract = %w[If Switch Sum Avg Min Max Median Count CountIf CountDistinct Coale
               First Last Zn]
 unknown_to_map = contract.reject { |n| FormulaNormalize::CANONICAL_BY_DOWNCASE.key?(n.downcase) }
 check(unknown_to_map.empty?, "every contract-named function is known case-insensitively (missing: #{unknown_to_map.inspect})", fails)
-check(norm.call('WEEK([d])') == 'Week([d])', 'WEEK( -> Week( (refs addition beyond sigma_functions.rb)', fails)
-check(norm.call('datetime([d])') == 'Datetime([d])', 'datetime( -> Datetime( (refs addition)', fails)
+# Week()/Datetime() do NOT exist in Sigma (live probe: "Unknown function:
+# Week") — they must stay UNKNOWN so validate-spec rejects a leak instead of
+# the normalizer blessing it with a case-fix.
+check(norm.call('WEEK([d])') == 'WEEK([d])', 'WEEK( left untouched — no Sigma Week(); validator must catch it', fails)
+check(norm.call('datetime([d])') == 'datetime([d])', 'datetime( left untouched — no Sigma Datetime()', fails)
 check(norm.call('LTRIM([s])') == 'Ltrim([s])', 'LTRIM( -> Ltrim( (converter spelling wins the collision)', fails)
 check(norm.call('LTrim([s])') == 'LTrim([s])', 'LTrim( (whitelist spelling) treated as known — never rewritten', fails)
 check(norm.call('Ltrim([s])') == 'Ltrim([s])', 'Ltrim( (converter spelling) treated as known — never rewritten', fails)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sigma-rest-pagination.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sigma-rest-pagination.rb
@@ -1,0 +1,160 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Offline contract test for the repo-speed pass over the Sigma REST surface
+# (PR-507): Sigma.list_entries pagination + the orchestrator's mint-once-per-
+# TTL child-spawn wiring. Conventions of test-sigma-rest.rb: creds-free,
+# network-free — the token exchange is stubbed and requests go through the
+# `http:` injection seam.
+#
+# Covers:
+#   - list_entries: a multi-page list is FULLY consumed (limit=1000 + nextPage
+#     loop). Unpaginated single-page responses reached END OF SUPPORT
+#     2026-06-02, so a bare first-page GET silently truncates at the server
+#     default (50) — the field case is a 599-column workbook.
+#   - list_entries: query-string composition + defensive termination.
+#   - migrate-tableau.rb wiring pins: sigma_token! reuses a fresh-stamped
+#     token instead of minting per child; both Sigma spawn wrappers forward
+#     the mint stamp; tableau_env reuses its signin within a TTL; all four
+#     orchestrator list reads paginate via Sigma.list_entries.
+#
+# Usage: ruby scripts/test-sigma-rest-pagination.rb
+
+require 'json'
+require 'net/http'
+require_relative 'lib/sigma_rest'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# --- test harness (test-sigma-rest.rb conventions) --------------------------
+
+ENV_KEYS = %w[SIGMA_BASE_URL SIGMA_CLIENT_ID SIGMA_CLIENT_SECRET
+              SIGMA_API_TOKEN SIGMA_TOKEN_MINTED_AT SIGMA_WORKDIR].freeze
+
+# The library's load-time bootstrap may have pulled real creds from
+# ~/.sigma-migration/env or ./auth.json — scrub them so every case starts clean
+# and nothing here can reach a live API.
+def reset_state!
+  ENV_KEYS.each { |k| ENV.delete(k) }
+  Sigma.instance_variable_set(:@token_override, nil)
+  Sigma.instance_variable_set(:@minted_at, nil)
+  Sigma.instance_variable_set(:@refresh_inflight, false)
+end
+
+# Stub the mint: no network, deterministic tokens.
+$mints = 0
+module Sigma
+  def self.refresh_token!
+    $mints += 1
+    tok = "minted-#{$mints}"
+    now = Time.now
+    @token_mutex.synchronize do
+      @token_override = tok
+      @minted_at = now
+    end
+    ENV['SIGMA_API_TOKEN'] = tok
+    ENV['SIGMA_TOKEN_MINTED_AT'] = now.utc.iso8601
+    tok
+  end
+end
+
+def http_res(klass, code, body)
+  res = klass.new('1.1', code.to_s, 'msg')
+  res.instance_variable_set(:@body, body)
+  res.instance_variable_set(:@read, true)
+  res
+end
+
+# Injectable fake for Sigma.request(..., http:) — records requests, replays a
+# queued response per call.
+class FakeHttp
+  attr_reader :reqs
+  def initialize(responses)
+    @queue = responses
+    @reqs = []
+  end
+
+  def request(req)
+    @reqs << req
+    @queue.shift
+  end
+end
+
+puts 'test-sigma-rest-pagination.rb — list_entries pagination + mint-once-per-TTL wiring'
+
+# 1. A 2-page stubbed response is FULLY consumed, with limit=1000 on every
+#    request and the opaque nextPage token echoed back URL-encoded.
+reset_state!
+ENV['SIGMA_BASE_URL'] = 'https://sigma.example'
+ENV['SIGMA_API_TOKEN'] = 'tok'
+http = FakeHttp.new([
+  http_res(Net::HTTPOK, 200, JSON.generate('entries' => [{ 'label' => 'A' }, { 'label' => 'B' }],
+                                           'nextPage' => 'tok 2/x')),
+  http_res(Net::HTTPOK, 200, JSON.generate('entries' => [{ 'label' => 'C' }]))
+])
+out = Sigma.list_entries('/v2/workbooks/wb-1/columns', http: http)
+check(out.map { |e| e['label'] } == %w[A B C],
+      'list_entries consumes BOTH pages of a 2-page response (no silent truncation)', fails)
+check(http.reqs.length == 2 &&
+        http.reqs[0].path == '/v2/workbooks/wb-1/columns?limit=1000' &&
+        http.reqs[1].path == '/v2/workbooks/wb-1/columns?limit=1000&page=tok+2%2Fx',
+      'every page request carries limit=1000; the nextPage token rides back URL-encoded', fails)
+
+# 2. A path that already has a query string gets & (not a second ?).
+reset_state!
+ENV['SIGMA_BASE_URL'] = 'https://sigma.example'
+ENV['SIGMA_API_TOKEN'] = 'tok'
+http = FakeHttp.new([http_res(Net::HTTPOK, 200, JSON.generate('entries' => []))])
+Sigma.list_entries('/v2/files?typeFilters=folder', http: http)
+check(http.reqs.first.path == '/v2/files?typeFilters=folder&limit=1000',
+      'an existing query string is extended with &limit=1000', fails)
+
+# 3. A server that repeats the same nextPage token cannot loop us forever.
+reset_state!
+ENV['SIGMA_BASE_URL'] = 'https://sigma.example'
+ENV['SIGMA_API_TOKEN'] = 'tok'
+http = FakeHttp.new([
+  http_res(Net::HTTPOK, 200, JSON.generate('entries' => [{ 'id' => 1 }], 'nextPage' => 'same')),
+  http_res(Net::HTTPOK, 200, JSON.generate('entries' => [{ 'id' => 2 }], 'nextPage' => 'same'))
+])
+out = Sigma.list_entries('/v2/teams', http: http)
+check(out.length == 2 && http.reqs.length == 2,
+      'a repeated nextPage token ends the loop defensively (no spin)', fails)
+
+# 4. An empty-string nextPage (some endpoints) ends the loop like nil.
+reset_state!
+ENV['SIGMA_BASE_URL'] = 'https://sigma.example'
+ENV['SIGMA_API_TOKEN'] = 'tok'
+http = FakeHttp.new([
+  http_res(Net::HTTPOK, 200, JSON.generate('entries' => [{ 'id' => 1 }], 'nextPage' => ''))
+])
+out = Sigma.list_entries('/v2/teams', http: http)
+check(out.length == 1 && http.reqs.length == 1,
+      'an empty nextPage ends the loop (single page)', fails)
+
+# --- orchestrator wiring pins (migrate-tableau.rb): mint-once-per-TTL +
+#     paginated list reads through the shared lib ----------------------------
+src = File.read(File.expand_path('migrate-tableau.rb', __dir__), encoding: 'UTF-8')
+check(src =~ /def sigma_token!.*?Sigma\.token_minted_at\.nil\? \|\| Sigma\.token_stale\?.*?Sigma\.refresh_token!/m,
+      'sigma_token! reuses a fresh-stamped token and mints only when stale/unknown (once per TTL, not per child)', fails)
+check(src.scan("'SIGMA_TOKEN_MINTED_AT' => ENV['SIGMA_TOKEN_MINTED_AT']").size == 2,
+      'both Sigma child-spawn wrappers pass the mint stamp so children age the token correctly', fails)
+check(src.include?('TABLEAU_ENV_TTL_SECONDS') && src.include?('$tableau_env_cache'),
+      'tableau_env reuses the signin within a TTL window instead of re-signing per child', fails)
+check(src.scan('Sigma.list_entries(').size == 4 &&
+        !src.match?(%r{Sigma\.request\(:get, "/v2/(?:workbooks|dataModels)/[^"]*/columns"\)}),
+      'all four orchestrator list reads (members/files, files, DM /columns, WB /columns) paginate via Sigma.list_entries', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — list_entries pagination + mint-once-per-TTL wiring behave correctly'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-spec-guards.rb
@@ -112,11 +112,21 @@ check(out =~ /WARN: .*FluxCapacitor/, 'WARN names the function', fails)
 check(out.include?('--- 1 warnings (non-fatal)'), 'warning count summarized', fails)
 
 puts
-puts 'Part D — refs-documented spellings beyond sigma_functions.rb are clean'
+puts 'Part D — refs-documented spellings beyond sigma_functions.rb'
+# Ltrim/Rtrim (the converter's spellings) stay accepted via EXTRA_FUNCTIONS.
+spec = { 'pages' => [{ 'name' => 'P1', 'elements' => [el('t1', 'T', formula: 'Ltrim(Rtrim([Order Date]))')] }] }
+spec['pages'][0]['elements'][0]['columns'] << { 'id' => 'c-sib', 'name' => 'Order Date', 'formula' => nil }
+out, code = validate(spec)
+check(code == 0 && !out.include?('WARN:'), "Ltrim/Rtrim accepted, no warn (got #{code})", fails)
+# Week/Datetime were dropped from EXTRA_FUNCTIONS (2026-07-25): neither exists
+# in Sigma (live probe "Unknown function: Week"; both absent from the function
+# index) — the stale blessing defeated this validator. They must now surface
+# as unknown-function WARNs, no longer sail through clean.
 spec = { 'pages' => [{ 'name' => 'P1', 'elements' => [el('t1', 'T', formula: 'Week([Order Date]) + Datetime([Order Date])')] }] }
 spec['pages'][0]['elements'][0]['columns'] << { 'id' => 'c-sib', 'name' => 'Order Date', 'formula' => nil }
 out, code = validate(spec)
-check(code == 0 && !out.include?('WARN:'), "Week/Datetime accepted, no warn (got #{code})", fails)
+check(code == 0 && out =~ /WARN: .*Week/ && out =~ /WARN: .*Datetime/,
+      "Week/Datetime no longer blessed — flagged as unknown functions (got #{code})", fails)
 
 puts
 puts 'Part E — Tableau leaks stay hard ERRORS (unchanged behavior)'

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/shared/lib/sigma_rest.rb
+++ b/shared/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0

--- a/shared/scripts/test-bootstrap.rb
+++ b/shared/scripts/test-bootstrap.rb
@@ -67,7 +67,9 @@ def run_bootstrap(home, path_dirs, *args)
   env = { 'HOME' => home, 'USERPROFILE' => home, 'PATH' => path_dirs.join(':'),
           # keep the doctor's networked probes off — offline test
           'SIGMA_SKIP_CRED_SMOKE' => '1', 'SIGMA_SKIP_VERSION_CHECK' => '1' }
-  out, st = Open3.capture2e(env, '/bin/bash', BOOTSTRAP, *args)
+  # unsetenv_others: the parent's env (SIGMA_* creds on a dev machine) must
+  # not leak into the child — the hash above IS the whole child environment.
+  out, st = Open3.capture2e(env, '/bin/bash', BOOTSTRAP, *args, unsetenv_others: true)
   [st.exitstatus, out]
 end
 


### PR DESCRIPTION
Wave 0 of the speed & success program, stacked on #507 (merge that first — this PR's base is its branch).

Three commits:
- **Calc-translation hotfixes** — nine live-verified bugs in the dominant field idioms: the `ZN(AGG(...))` malformed-emission (30 of 97 corpus calcs), silent numeric→string concat via `Coalesce` in the text-operand list, 4-arg DATEDIFF drift, four non-existent-Sigma-function emissions (+ the validator whitelist that blessed two of them), stale window-function untranslatables, catalog gaps (REGEXP_REPLACE, MODEL_EXTENSION_STR), Rank direction, USERATTRIBUTE note. Upstream-patched and re-bundled with PROVENANCE pairing; converter fixtures green with zero new failures vs baseline.
- **Pagination + token TTL** — list endpoints follow `nextPage` with `limit=1000` (unpaginated responses hit end-of-support 2026-06-02; a bare first-page GET silently truncates at 50 — the field case is a 599-column workbook whose error audit saw one page). Sigma tokens mint once per ~50-min TTL instead of once per child process (~15–25 mints/run). Twins synced fleet-wide.
- **CI: full offline suite + macOS smoke** — the complete offline `test-*.rb` suite plus shell harnesses now run in CI (previously an allow-list subset), and a `macos-latest` job covers the BSD-vs-GNU surface the repo's portability premise depends on.

Verification: full tableau suite 186/187 (the one red is the documented creds-gated live smoke), hygiene harness 99/99 in both C and UTF-8 locales, all guard suites green, 513 shared twins byte-verified, converter fixture suite byte-identical to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
