### PR TITLE
Bump plugin.json version on release, enforced by CI (#486)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@
 - [ ] `./corpus/run-corpus.sh --check` — green; affected case reconverted if a converter/builder changed
 - [ ] Phase numbers unchanged (or new skill added to `docs/phase-schema.md`)
 - [ ] No unrelated working-tree changes swept in (`git status` is clean of other sessions' WIP)
+- [ ] Bumped the touched plugin's `plugin.json` version (strict semver ↑), or added a `Skip-Version-Bump: <reason>` commit trailer for a non-user-facing change (#486)
 
 ## If this changes a shared lib
 

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -165,6 +165,18 @@ jobs:
         run: |
           if [ -z "${RANGE_BASE:-}" ]; then echo "no diff range to check — skipping"; exit 0; fi
           bash tools/check-converter-provenance.sh "$RANGE_BASE" "$RANGE_HEAD"
+      - name: Plugin-version-bump guard (release-hygiene diff gate)
+        # #486: a change under plugins/<name>/** must move that plugin's
+        # plugin.json "version" (strict semver) so `claude plugin update` sees a
+        # newer version — else fixes ship with no update signal. Escape hatch:
+        # a `Skip-Version-Bump: <reason>` commit trailer. Range comes from the
+        # shared "Resolve push/PR diff range" step; guard logic +
+        # marketplace-listed-but-unversioned check live in
+        # tools/check-plugin-version-bump.sh (offline-tested by
+        # tools/test-plugin-version-bump.sh).
+        run: |
+          if [ -z "${RANGE_BASE:-}" ]; then echo "no diff range to check — skipping"; exit 0; fi
+          bash tools/check-plugin-version-bump.sh "$RANGE_BASE" "$RANGE_HEAD"
       - name: Sweep self-test (fixture repos, creds-free)
         # Proves the sweep tool itself still warns/fails/passes correctly
         # against throwaway fixture git repos — synthetic patterns only, no
@@ -184,6 +196,13 @@ jobs:
         # string-pin on the real tableau PROVENANCE.json (synthetic fixture
         # names only).
         run: bash tools/test-converter-provenance.sh
+      - name: Plugin-version-bump guard self-test (fixture repos, creds-free)
+        # Proves the version-bump gate fails an unbumped plugin change, passes a
+        # bumped one, honors the Skip-Version-Bump trailer, and fails a
+        # marketplace-listed plugin with no versionable manifest — plus a
+        # string-pin that every listed plugin in this repo carries a semver
+        # plugin.json (synthetic fixture names only).
+        run: bash tools/test-plugin-version-bump.sh
       - name: Bootstrap/doctor lockstep self-test (creds-free)
         # bootstrap.sh duplicates doctor.sh's probes (py_real, the vm-node
         # candidate globs, Test-RealPython) under KEEP-IN-LOCKSTEP comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,3 +209,6 @@ Skip-Version-Bump: <one-line reason>
 ```
 
 The reason is required and is visible in history and review — use it honestly.
+The trailer is global to the PR's whole diff range: a single `Skip-Version-Bump`
+commit anywhere in the range exempts every otherwise-failing plugin in that PR,
+not just the plugin its own commit touched.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,3 +187,25 @@ Sessions can't talk live, so coordinate through shared state:
 
 `ruby tools/check-shared.rb && ruby tools/lint-skills.rb && bash tools/hygiene-sweep.sh && ./corpus/run-corpus.sh --check`
 — all green. The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) lists the rest.
+
+## Versioning & releases
+
+Each plugin declares its release version in
+`plugins/<name>/.claude-plugin/plugin.json` (`"version"`). Claude Code's
+`claude plugin update` compares that string, so **if it doesn't move, consumers
+never see your fix** — the update reports "already at the latest version" and
+ships nothing (issue #486).
+
+**Rule:** any change under `plugins/<name>/**` must bump that plugin's
+`plugin.json` `version` — a strict [semver](https://semver.org/) increase
+(patch for fixes, minor for features, major for breaking changes). The
+`plugin-version-bump` CI gate enforces this over the PR's diff range.
+
+**Escape hatch:** for a genuinely non-user-facing change (a comment, an internal
+test, a typo that ships no behavior), add a commit trailer:
+
+```
+Skip-Version-Bump: <one-line reason>
+```
+
+The reason is required and is visible in history and review — use it honestly.

--- a/docs/superpowers/plans/2026-07-28-plugin-version-bump-gate.md
+++ b/docs/superpowers/plans/2026-07-28-plugin-version-bump-gate.md
@@ -1,0 +1,590 @@
+# Plugin `version` Bump Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every plugin's `plugin.json` `version` move whenever its shipped content changes — enforced by a CI diff-gate, with the currently-stale versions re-baselined — so `claude plugin update` stops reporting "already at latest" while shipping nothing (issue #486).
+
+**Architecture:** A range-parameterized bash guard (`tools/check-plugin-version-bump.sh <BASE> <HEAD>`) diffs the CI event's range, and for every touched `plugins/<name>/**` requires that plugin's `plugin.json` `version` strictly-increase (semver) unless a `Skip-Version-Bump: <reason>` commit trailer is present; it also fails a marketplace-listed plugin that has no versionable manifest. An offline fixture-repo self-test drives the guard; both are wired into `.github/workflows/hygiene.yml` reusing the workflow's existing `RANGE_BASE`/`RANGE_HEAD`. The stale versions are backfilled and the discipline documented — all in one release-hygiene PR.
+
+**Tech Stack:** bash + python3 (matching `tools/check-converter-provenance.sh`), GitHub Actions YAML, JSON manifests.
+
+**Design doc:** `docs/superpowers/specs/2026-07-28-plugin-version-bump-gate-design.md`
+
+## Global Constraints
+
+- Model this guard on `tools/check-converter-provenance.sh` and its self-test `tools/test-converter-provenance.sh` (same style, exit-code discipline, `::error file=…::` annotations, fixture-repo self-test). Read both before starting.
+- **Fail-closed:** unresolvable range, failed `git diff`, missing `python3`, unparseable JSON, or non-semver version must **fail** the guard — never read as green.
+- **No customer/field-derived identifiers** anywhere (commits, code, fixtures). Fixture plugin names are synthetic: `toolx-to-sigma`.
+- Semver = `MAJOR.MINOR.PATCH` (plain, as used repo-wide); only the numeric core is compared; strictly-greater required.
+- Escape-hatch trailer: `Skip-Version-Bump: <reason>` — key case-tolerant, **reason required** (non-empty), scanned over the full commit messages (`%B`) in the range; global to the range.
+- Backfill = **minor** bump for every plugin whose content moved past its initial version; `domo-to-sigma` untouched; `sisense-to-sigma` gets a new manifest at `1.0.0`.
+- Work happens in worktree `~/wt-plugin-version-gate` on branch `fix/plugin-version-bump-gate` (already created off `origin/main`). One PR.
+- Commit trailer on every commit: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File Structure
+
+- **Create** `plugins/sisense-to-sigma/.claude-plugin/plugin.json` — sisense's missing manifest (Task 1).
+- **Modify** 10 × `plugins/<name>/.claude-plugin/plugin.json` — version bumps (Task 1).
+- **Create** `tools/check-plugin-version-bump.sh` — the guard (Task 2).
+- **Create** `tools/test-plugin-version-bump.sh` — the offline self-test (Task 2).
+- **Modify** `.github/workflows/hygiene.yml` — two new steps (Task 3).
+- **Modify** `CONTRIBUTING.md` — "Versioning & releases" section (Task 4).
+- **Modify** `.github/PULL_REQUEST_TEMPLATE.md` — one checklist item (Task 4).
+
+Task order puts the backfill **first** so the guard's real-repo self-test pin (every listed plugin carries a semver manifest) is already satisfiable when the guard is built.
+
+---
+
+### Task 1: Backfill stale versions + author sisense's manifest
+
+**Files:**
+- Create: `plugins/sisense-to-sigma/.claude-plugin/plugin.json`
+- Modify: `plugins/cognos-to-sigma/.claude-plugin/plugin.json:5`
+- Modify: `plugins/gooddata-to-sigma/.claude-plugin/plugin.json:5`
+- Modify: `plugins/looker-to-sigma/.claude-plugin/plugin.json:5`
+- Modify: `plugins/microstrategy-to-sigma/.claude-plugin/plugin.json:5`
+- Modify: `plugins/powerbi-to-sigma/.claude-plugin/plugin.json:5`
+- Modify: `plugins/qlik-to-sigma/.claude-plugin/plugin.json:5`
+- Modify: `plugins/quicksight-to-sigma/.claude-plugin/plugin.json:5`
+- Modify: `plugins/sigma-authoring/.claude-plugin/plugin.json:5`
+- Modify: `plugins/tableau-to-sigma/.claude-plugin/plugin.json:5`
+- Modify: `plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json:5`
+
+**Interfaces:**
+- Produces: every plugin listed in `.claude-plugin/marketplace.json` has a `plugin.json` with a valid semver `version`. Consumed by Task 2's self-test Part E and by the guard's self-consistency check over the PR range.
+
+- [ ] **Step 1: Create sisense's manifest**
+
+Create `plugins/sisense-to-sigma/.claude-plugin/plugin.json` (shape mirrors `plugins/gooddata-to-sigma/.claude-plugin/plugin.json`; description/keywords taken from sisense's `marketplace.json` entry):
+
+```json
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sisense-to-sigma",
+  "displayName": "Sisense → Sigma",
+  "version": "1.0.0",
+  "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma — data model + workbook (indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; columnar layout→24-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
+  "author": { "name": "Thomas Wells" },
+  "license": "MIT",
+  "keywords": ["sisense", "elasticube", "jaql", "sigma", "migration", "bi", "converter", "assessment"],
+  "skills": "./skills/"
+}
+```
+
+- [ ] **Step 2: Bump the ten stale versions**
+
+For each file, replace the single version line. Old line is exactly `  "version": "1.0.0",` (2-space indent, trailing comma) except microstrategy which is `  "version": "0.1.0",`.
+
+- `plugins/cognos-to-sigma/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+- `plugins/gooddata-to-sigma/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+- `plugins/looker-to-sigma/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+- `plugins/microstrategy-to-sigma/.claude-plugin/plugin.json`: `0.1.0` → `0.2.0`
+- `plugins/powerbi-to-sigma/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+- `plugins/qlik-to-sigma/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+- `plugins/quicksight-to-sigma/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+- `plugins/sigma-authoring/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+- `plugins/tableau-to-sigma/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+- `plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0`
+
+Do **not** touch `plugins/domo-to-sigma/.claude-plugin/plugin.json` (stays `0.1.0`).
+
+- [ ] **Step 3: Verify every listed plugin carries a semver manifest**
+
+Run:
+```bash
+cd /Users/tjwells/wt-plugin-version-gate
+python3 - <<'PY'
+import json, re, pathlib
+root = pathlib.Path(".")
+mp = json.loads((root/".claude-plugin/marketplace.json").read_text())
+bad = []
+for p in mp["plugins"]:
+    name = p["name"]
+    f = root/"plugins"/name/".claude-plugin"/"plugin.json"
+    if not f.exists():
+        bad.append(f"{name}: NO manifest"); continue
+    v = json.loads(f.read_text()).get("version","")
+    if not re.match(r"^\d+\.\d+\.\d+$", v or ""):
+        bad.append(f"{name}: bad version {v!r}")
+print("FAIL:", bad) if bad else print("OK: all", len(mp["plugins"]), "listed plugins carry a semver manifest")
+PY
+```
+Expected: `OK: all 12 listed plugins carry a semver manifest`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/tjwells/wt-plugin-version-gate
+git add plugins/*/.claude-plugin/plugin.json
+git commit -m "chore(release): backfill plugin.json versions; add sisense manifest (#486)
+
+Re-baseline every plugin whose shipped content moved past its initial
+version (minor bump), and give sisense-to-sigma the plugin.json it was
+missing, so consumers get an update signal for fixes already shipped.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: The guard + its offline self-test
+
+**Files:**
+- Create: `tools/check-plugin-version-bump.sh`
+- Create (test): `tools/test-plugin-version-bump.sh`
+
+**Interfaces:**
+- Consumes: repo state from Task 1 (all listed plugins carry a semver manifest) for self-test Part E.
+- Produces: `bash tools/check-plugin-version-bump.sh <BASE> <HEAD>` — exit 0 when every touched plugin bumped (or trailer-exempted / new / removed), exit 1 otherwise. `bash tools/test-plugin-version-bump.sh` — exit 0 when all assertions pass. Both consumed by Task 3's CI wiring.
+
+- [ ] **Step 1: Write the self-test first (it will fail — guard absent)**
+
+Create `tools/test-plugin-version-bump.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Offline test for tools/check-plugin-version-bump.sh (plugin version-bump gate,
+# #486). test-converter-provenance.sh style: throwaway fixture git repos with
+# synthetic plugin names (toolx) only — no field-derived identifiers.
+#
+#   Part A — bump discipline: unbumped plugin change fails; same change + strict
+#            bump passes; a version DECREASE fails; a no-plugin-touched range
+#            passes trivially
+#   Part B — validity: a non-semver version fails; unparseable plugin.json fails
+#   Part C — escape hatch: a Skip-Version-Bump:<reason> trailer exempts an
+#            unbumped change; an empty-reason trailer does NOT
+#   Part D — manifest lifecycle: a new plugin (no manifest at BASE) passes; a
+#            marketplace-listed plugin with no manifest at HEAD fails; deleting
+#            a manifest while the plugin stays listed fails
+#   Part E — string-pin the real repo: every plugin listed in marketplace.json
+#            carries a semver plugin.json (satisfied by the Task 1 backfill)
+#
+# Runs standalone:  bash tools/test-plugin-version-bump.sh
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+GUARD="$HERE/check-plugin-version-bump.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+check() { # expect-rc actual-rc message   (expect: 0=pass wanted, 1=fail wanted)
+  if [ "$1" -eq "$2" ]; then printf '  PASS  %s\n' "$3"; else printf '  FAIL  %s (rc=%s)\n' "$3" "$2"; fails=$((fails+1)); fi
+}
+
+RC=0
+run_guard() { bash "$GUARD" "$1" "$2" >"$TMP/out" 2>&1; RC=$?; }
+passed() { [ "$RC" -eq 0 ] && echo 0 || echo 1; }   # 0 when guard passed
+failed() { [ "$RC" -ne 0 ] && echo 0 || echo 1; }   # 0 when guard failed
+
+new_repo() { rm -rf "$1"; mkdir -p "$1" && cd "$1" || exit 1; git init -q; git config user.email pvb@example.invalid; git config user.name pvb; git config commit.gpgsign false; }
+commit_msg() { git add -A && git commit -q --no-verify -m "$1" >/dev/null && git rev-parse HEAD; }
+manifest() { mkdir -p "$1/.claude-plugin"; printf '{ "name": "%s", "version": "%s", "skills": "./skills/" }\n' "$(basename "$1")" "$2" > "$1/.claude-plugin/plugin.json"; }
+skill_file() { mkdir -p "plugins/$1/skills/$1"; echo "$2" > "plugins/$1/skills/$1/SKILL.md"; }
+
+echo "Part A — bump discipline"
+new_repo "$TMP/a"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2
+H1="$(commit_msg 'edit skill, no bump')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "unbumped plugin change fails"
+grep -q "did not increase" "$TMP/out"; check 0 "$?" "failure names the missing bump"
+manifest "plugins/toolx-to-sigma" "1.0.1"
+H2="$(commit_msg 'bump to 1.0.1')"
+run_guard "$BASE" "$H2"; check 0 "$(passed)" "same change + strict bump passes"
+
+new_repo "$TMP/a_dec"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2; manifest "plugins/toolx-to-sigma" "0.9.0"
+H1="$(commit_msg 'edit + decrease')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "version decrease fails"
+
+new_repo "$TMP/a_none"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1; echo root > README.md
+BASE="$(commit_msg base)"
+echo root2 > README.md
+H1="$(commit_msg 'root-only change')"
+run_guard "$BASE" "$H1"; check 0 "$(passed)" "range touching no plugin dir passes"
+
+echo "Part B — validity"
+new_repo "$TMP/b_semver"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2; manifest "plugins/toolx-to-sigma" "1.0"
+H1="$(commit_msg 'non-semver version')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "non-semver version fails"
+
+new_repo "$TMP/b_json"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2; echo '{ not json' > plugins/toolx-to-sigma/.claude-plugin/plugin.json
+H1="$(commit_msg 'broken json')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "unparseable plugin.json fails"
+
+echo "Part C — escape hatch"
+new_repo "$TMP/c_ok"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2
+H1="$(commit_msg 'fix typo in a comment
+
+Skip-Version-Bump: comment-only, no shipped behavior change')"
+run_guard "$BASE" "$H1"; check 0 "$(passed)" "Skip-Version-Bump trailer with reason exempts"
+
+new_repo "$TMP/c_empty"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2
+H1="$(commit_msg 'edit skill
+
+Skip-Version-Bump:')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "empty-reason trailer does NOT exempt"
+
+echo "Part D — manifest lifecycle"
+new_repo "$TMP/d_new"
+echo root > README.md
+BASE="$(commit_msg base)"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+H1="$(commit_msg 'add new plugin')"
+run_guard "$BASE" "$H1"; check 0 "$(passed)" "new plugin (no manifest at BASE) passes"
+
+new_repo "$TMP/d_missing"
+mkdir -p .claude-plugin
+printf '{ "plugins": [ { "name": "toolx-to-sigma" } ] }\n' > .claude-plugin/marketplace.json
+skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2
+H1="$(commit_msg 'edit listed plugin with no manifest')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "marketplace-listed plugin with no manifest fails"
+
+new_repo "$TMP/d_delete"
+mkdir -p .claude-plugin
+printf '{ "plugins": [ { "name": "toolx-to-sigma" } ] }\n' > .claude-plugin/marketplace.json
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+rm plugins/toolx-to-sigma/.claude-plugin/plugin.json
+H1="$(commit_msg 'delete manifest, still listed')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "deleting a manifest while still listed fails"
+
+echo "Part E — string-pin the real repo"
+python3 - "$ROOT" <<'PY'
+import json, re, sys, pathlib
+root = pathlib.Path(sys.argv[1])
+mp = json.loads((root/".claude-plugin/marketplace.json").read_text())
+bad = [p["name"] for p in mp["plugins"]
+       if not re.match(r"^\d+\.\d+\.\d+$",
+           (json.loads((root/"plugins"/p["name"]/".claude-plugin"/"plugin.json").read_text()).get("version","")
+            if (root/"plugins"/p["name"]/".claude-plugin"/"plugin.json").exists() else ""))]
+sys.exit(1 if bad else 0)
+PY
+check 0 "$?" "every marketplace-listed plugin carries a semver plugin.json"
+
+echo ""
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; else echo "$fails FAILED"; exit 1; fi
+```
+
+- [ ] **Step 2: Run the self-test to verify it fails (guard missing)**
+
+Run: `cd /Users/tjwells/wt-plugin-version-gate && bash tools/test-plugin-version-bump.sh`
+Expected: FAIL — assertions error because `tools/check-plugin-version-bump.sh` does not exist yet.
+
+- [ ] **Step 3: Implement the guard**
+
+Create `tools/check-plugin-version-bump.sh`:
+
+```bash
+#!/usr/bin/env bash
+# tools/check-plugin-version-bump.sh — plugin version-bump diff gate (#486).
+#
+#   bash tools/check-plugin-version-bump.sh <BASE> <HEAD>
+#
+# Fails (exit 1) when the BASE..HEAD range changes anything under
+# plugins/<name>/** without that plugin's
+# plugins/<name>/.claude-plugin/plugin.json "version" strictly increasing
+# (semver) — UNLESS a `Skip-Version-Bump: <reason>` commit trailer (reason
+# required) appears anywhere in the range (a genuinely non-user-facing change).
+#
+# Also fails when a plugin listed in .claude-plugin/marketplace.json has no
+# versionable plugin.json at HEAD (a shipped plugin the update path can never
+# refresh — e.g. a missing or deleted manifest), and when a plugin.json's
+# version is not valid semver or the file is not valid JSON.
+#
+# A brand-new plugin (no plugin.json at BASE, one at HEAD) passes: its initial
+# version is fine. A removed plugin (gone from marketplace.json at HEAD) passes.
+#
+# Callers resolve the range (hygiene.yml derives it from the CI event); the
+# check is range-parameterized so tools/test-plugin-version-bump.sh can drive
+# it against throwaway fixture repos offline.
+set -uo pipefail
+
+BASE="${1:?usage: check-plugin-version-bump.sh <BASE> <HEAD>}"
+HEAD="${2:?usage: check-plugin-version-bump.sh <BASE> <HEAD>}"
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 missing — plugin-version-bump gate cannot run"; exit 1; }
+
+changed="$(git diff --name-only "$BASE" "$HEAD")" || { echo "git diff $BASE..$HEAD failed — cannot check plugin versions"; exit 1; }
+
+touched="$(printf '%s\n' "$changed" | sed -nE 's#^plugins/([^/]+)/.*#\1#p' | sort -u)"
+if [ -z "$touched" ]; then echo "plugin-version-bump gate OK ($BASE..$HEAD): no plugin directories changed"; exit 0; fi
+
+# Escape hatch: a Skip-Version-Bump: <reason> trailer (reason required) in any
+# commit's full message across the range.
+skip_reason=""; skip_commit=""
+while IFS= read -r sha; do
+  [ -n "$sha" ] || continue
+  reason="$(git log -1 --format=%B "$sha" | sed -nE 's/^[Ss]kip-[Vv]ersion-[Bb]ump:[[:space:]]*(.+[^[:space:]])[[:space:]]*$/\1/p' | head -1)"
+  if [ -n "$reason" ]; then skip_reason="$reason"; skip_commit="$sha"; break; fi
+done < <(git rev-list "$BASE..$HEAD" 2>/dev/null)
+
+# Print a plugin.json "version" from a ref; empty if the file is absent;
+# __BADJSON__ if unparseable; __NOVER__ if no non-empty string version.
+read_version() { # ref name
+  git show "$1:plugins/$2/.claude-plugin/plugin.json" 2>/dev/null | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+if raw == "": sys.exit(0)
+try: d = json.loads(raw)
+except Exception: print("__BADJSON__"); sys.exit(0)
+v = d.get("version")
+print(v if isinstance(v, str) and v else "__NOVER__")
+'
+}
+
+# strict semver-greater: exit 0 if head>base on (major,minor,patch); 1 if not;
+# 2 if either side is not semver.
+semver_gt() { # base head
+  python3 -c '
+import sys, re
+def core(v):
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)", v or "")
+    return tuple(int(x) for x in m.groups()) if m else None
+b, h = core(sys.argv[1]), core(sys.argv[2])
+if b is None or h is None: sys.exit(2)
+sys.exit(0 if h > b else 1)
+' "$1" "$2"
+}
+
+listed_at_head() { # name — is it in marketplace.json at HEAD?
+  git show "$HEAD:.claude-plugin/marketplace.json" 2>/dev/null | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception: sys.exit(1)
+sys.exit(0 if sys.argv[1] in [p.get("name") for p in d.get("plugins", [])] else 1)
+' "$1"
+}
+
+fail=0
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  base_v="$(read_version "$BASE" "$name")"
+  head_v="$(read_version "$HEAD" "$name")"
+
+  if [ -z "$head_v" ]; then
+    if listed_at_head "$name"; then
+      echo "::error file=plugins/$name/.claude-plugin/plugin.json::plugin '$name' is listed in marketplace.json but has no plugin.json version at HEAD — it can never be updated; add a versioned manifest"
+      fail=1
+    fi
+    continue
+  fi
+  if [ "$head_v" = "__BADJSON__" ]; then
+    echo "::error file=plugins/$name/.claude-plugin/plugin.json::plugin.json is not valid JSON"; fail=1; continue
+  fi
+  if [ "$head_v" = "__NOVER__" ]; then
+    echo "::error file=plugins/$name/.claude-plugin/plugin.json::plugin.json has no non-empty string \"version\" field"; fail=1; continue
+  fi
+  if [ -z "$base_v" ] || [ "$base_v" = "__BADJSON__" ] || [ "$base_v" = "__NOVER__" ]; then
+    echo "plugin-version-bump: '$name' — new/first versioned manifest ($head_v), OK"; continue
+  fi
+  semver_gt "$base_v" "$head_v"; rc=$?
+  if [ "$rc" -eq 0 ]; then echo "plugin-version-bump: '$name' $base_v -> $head_v, OK"; continue; fi
+  if [ "$rc" -eq 2 ]; then
+    echo "::error file=plugins/$name/.claude-plugin/plugin.json::version '$head_v' (or base '$base_v') is not valid semver (MAJOR.MINOR.PATCH)"; fail=1; continue
+  fi
+  if [ -n "$skip_reason" ]; then
+    echo "plugin-version-bump: '$name' version unchanged ($head_v) but exempted by Skip-Version-Bump in $skip_commit: $skip_reason"; continue
+  fi
+  echo "::error file=plugins/$name/.claude-plugin/plugin.json::'$name' changed under plugins/$name/** but version did not increase ($base_v -> $head_v). Bump it (strict semver), or add a 'Skip-Version-Bump: <reason>' commit trailer for a genuinely non-user-facing change."
+  fail=1
+done < <(printf '%s\n' "$touched")
+
+if [ "$fail" -ne 0 ]; then
+  echo "plugin-version-bump gate FAILED — see ::error annotations above (#486 release hygiene)."
+  exit 1
+fi
+echo "plugin-version-bump gate OK ($BASE..$HEAD)"
+```
+
+- [ ] **Step 4: Run the self-test to verify it passes**
+
+Run: `cd /Users/tjwells/wt-plugin-version-gate && bash tools/test-plugin-version-bump.sh`
+Expected: ends with `ALL PASS`.
+
+- [ ] **Step 5: Self-consistency — run the guard over the PR's own range**
+
+Run: `cd /Users/tjwells/wt-plugin-version-gate && bash tools/check-plugin-version-bump.sh origin/main HEAD`
+Expected: `plugin-version-bump gate OK` — every plugin touched by the Task 1 backfill shows `X -> Y, OK` (or, for sisense, `new/first versioned manifest (1.0.0), OK`); no `::error`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/tjwells/wt-plugin-version-gate
+chmod +x tools/check-plugin-version-bump.sh tools/test-plugin-version-bump.sh
+git add tools/check-plugin-version-bump.sh tools/test-plugin-version-bump.sh
+git commit -m "tools: add plugin.json version-bump diff gate + offline self-test (#486)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Wire the guard + self-test into CI
+
+**Files:**
+- Modify: `.github/workflows/hygiene.yml`
+
+**Interfaces:**
+- Consumes: `RANGE_BASE`/`RANGE_HEAD` set by the existing "Resolve push/PR diff range" step; the two scripts from Task 2.
+
+- [ ] **Step 1: Add the guard step after the converter-provenance guard**
+
+In `.github/workflows/hygiene.yml`, find the line (end of the converter-provenance guard step):
+```yaml
+          bash tools/check-converter-provenance.sh "$RANGE_BASE" "$RANGE_HEAD"
+```
+Immediately after it, insert:
+```yaml
+      - name: Plugin-version-bump guard (release-hygiene diff gate)
+        # #486: a change under plugins/<name>/** must move that plugin's
+        # plugin.json "version" (strict semver) so `claude plugin update` sees a
+        # newer version — else fixes ship with no update signal. Escape hatch:
+        # a `Skip-Version-Bump: <reason>` commit trailer. Range comes from the
+        # shared "Resolve push/PR diff range" step; guard logic +
+        # marketplace-listed-but-unversioned check live in
+        # tools/check-plugin-version-bump.sh (offline-tested by
+        # tools/test-plugin-version-bump.sh).
+        run: |
+          if [ -z "${RANGE_BASE:-}" ]; then echo "no diff range to check — skipping"; exit 0; fi
+          bash tools/check-plugin-version-bump.sh "$RANGE_BASE" "$RANGE_HEAD"
+```
+
+- [ ] **Step 2: Add the self-test step after the converter-provenance self-test**
+
+Find the line:
+```yaml
+        run: bash tools/test-converter-provenance.sh
+```
+Immediately after it, insert:
+```yaml
+      - name: Plugin-version-bump guard self-test (fixture repos, creds-free)
+        # Proves the version-bump gate fails an unbumped plugin change, passes a
+        # bumped one, honors the Skip-Version-Bump trailer, and fails a
+        # marketplace-listed plugin with no versionable manifest — plus a
+        # string-pin that every listed plugin in this repo carries a semver
+        # plugin.json (synthetic fixture names only).
+        run: bash tools/test-plugin-version-bump.sh
+```
+
+- [ ] **Step 3: Verify the two steps are present and the referenced scripts run**
+
+Run:
+```bash
+cd /Users/tjwells/wt-plugin-version-gate
+grep -n "check-plugin-version-bump.sh\|test-plugin-version-bump.sh" .github/workflows/hygiene.yml
+bash tools/test-plugin-version-bump.sh >/dev/null && echo "self-test OK"
+bash tools/check-plugin-version-bump.sh origin/main HEAD >/dev/null && echo "guard OK over PR range"
+```
+Expected: two grep hits (guard + self-test), then `self-test OK` and `guard OK over PR range`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/tjwells/wt-plugin-version-gate
+git add .github/workflows/hygiene.yml
+git commit -m "ci: run the plugin.json version-bump gate + self-test in hygiene (#486)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Document the discipline
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+- Modify: `.github/PULL_REQUEST_TEMPLATE.md`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Add a "Versioning & releases" section to `CONTRIBUTING.md`**
+
+Append this section at the end of `CONTRIBUTING.md` (or adjacent to the existing "Hygiene sweep" / governance material if such a heading exists — match the file's heading style):
+
+```markdown
+## Versioning & releases
+
+Each plugin declares its release version in
+`plugins/<name>/.claude-plugin/plugin.json` (`"version"`). Claude Code's
+`claude plugin update` compares that string, so **if it doesn't move, consumers
+never see your fix** — the update reports "already at the latest version" and
+ships nothing (issue #486).
+
+**Rule:** any change under `plugins/<name>/**` must bump that plugin's
+`plugin.json` `version` — a strict [semver](https://semver.org/) increase
+(patch for fixes, minor for features, major for breaking changes). The
+`plugin-version-bump` CI gate enforces this over the PR's diff range.
+
+**Escape hatch:** for a genuinely non-user-facing change (a comment, an internal
+test, a typo that ships no behavior), add a commit trailer:
+
+```
+Skip-Version-Bump: <one-line reason>
+```
+
+The reason is required and is visible in history and review — use it honestly.
+```
+
+- [ ] **Step 2: Add a checklist item to `.github/PULL_REQUEST_TEMPLATE.md`**
+
+Under the `## Checklist` section, add:
+```markdown
+- [ ] Bumped the touched plugin's `plugin.json` version (strict semver ↑), or added a `Skip-Version-Bump: <reason>` commit trailer for a non-user-facing change (#486)
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cd /Users/tjwells/wt-plugin-version-gate
+grep -q "Versioning & releases" CONTRIBUTING.md && echo "CONTRIBUTING OK"
+grep -q "Skip-Version-Bump" .github/PULL_REQUEST_TEMPLATE.md && echo "PR template OK"
+```
+Expected: `CONTRIBUTING OK` and `PR template OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/tjwells/wt-plugin-version-gate
+git add CONTRIBUTING.md .github/PULL_REQUEST_TEMPLATE.md
+git commit -m "docs: document the plugin version-bump discipline + escape hatch (#486)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (before opening the PR)
+
+- [ ] `bash tools/test-plugin-version-bump.sh` → `ALL PASS`
+- [ ] `bash tools/check-plugin-version-bump.sh origin/main HEAD` → `plugin-version-bump gate OK`
+- [ ] `bash .githooks/run-governance-checks.sh` → green (no regression in the existing gate)
+- [ ] `git log --oneline origin/main..HEAD` shows the design-doc, plan, backfill, guard, CI, and docs commits — no unrelated WIP swept in.
+- [ ] Open the PR against `main`, body noting this is a cross-cutting release-hygiene change (intentionally spans all plugins) that closes #486, and referencing the companion `anthropics/claude-code` issue for the update-check fallback.
+
+## Notes for the implementer
+
+- BSD (macOS) and GNU (Linux CI) both support `sed -nE` and `[[:space:]]`; the guard is tested on both via the self-test.
+- If any self-test assertion fails, read `"$TMP/out"` for that scenario (the self-test writes the guard's output there) before changing the guard — debug the raw output first.
+- Do not add this guard to `.githooks/run-governance-checks.sh`: it is range-based and CI-only, exactly like `check-converter-provenance.sh`.

--- a/docs/superpowers/specs/2026-07-28-plugin-version-bump-gate-design.md
+++ b/docs/superpowers/specs/2026-07-28-plugin-version-bump-gate-design.md
@@ -1,0 +1,206 @@
+# Plugin `version` bump gate — design
+
+**Issue:** [#486](https://github.com/twells89/sigma-migration-skills/issues/486) — *plugin.json version is never bumped on release — real fixes ship with no signal that an update exists*
+**Date:** 2026-07-28
+**Status:** approved (design)
+
+## Problem
+
+Every plugin's `plugins/<name>/.claude-plugin/plugin.json` declares a `version`
+string, but nothing moves it when fixes merge. Claude Code's plugin-update
+check compares that string, so `claude plugin update <plugin>` (and the
+`/plugin marketplace update` + `/reload-plugins` flow) reports "already at the
+latest version" and ships nothing — even though real bug-fix commits landed
+underneath. The only recovery is a full uninstall + reinstall.
+
+Observed: `tableau-to-sigma` sat at `1.0.0` through 333 commits and 5 merged
+bug-fix PRs. It is not unique — on `origin/main` at design time, **every**
+plugin except the just-added `domo-to-sigma` has dozens-to-hundreds of commits
+under its directory with no version movement, and **`sisense-to-sigma` has no
+`plugin.json` manifest at all** (the same defect in its most extreme form: a
+marketplace-listed plugin that cannot carry a version).
+
+This is the repo's own "does GREEN mean anything" concern applied to the
+release process: an update reports success while shipping nothing.
+
+## Goal
+
+Make a plugin's declared `version` move whenever its shipped content changes,
+enforced mechanically in CI so the signal cannot silently rot again. Re-baseline
+the versions that are already stale, and document the discipline.
+
+Out of scope: the Claude Code-side update-check fallback (different repo,
+`anthropics/claude-code`, already filed as a companion issue). Each repo fixes
+its own half.
+
+## Decisions (locked)
+
+1. **Escape hatch = explicit commit trailer.** Any change under
+   `plugins/<name>/**` requires a version bump by default; a
+   `Skip-Version-Bump: <reason>` commit trailer in the range exempts it. Honest,
+   auditable human assertion over a brittle path heuristic.
+2. **Bump rule = strict semver increase.** The `version` at HEAD must parse as
+   semver and be strictly greater than at BASE. Only "newer" is meaningful to
+   the update check.
+3. **Backfill owed + install guard**, in **one PR**, framed as a release-hygiene
+   change (cross-cutting by nature, like an isolated shared-lib change).
+4. **Per-plugin scope.** The guard concerns each plugin's own `plugin.json`
+   version — what `claude plugin update` reads. The top-level
+   `marketplace.json` version is out of scope.
+
+## Approach
+
+Mirror the existing range-diff guard family (`tools/check-converter-provenance.sh`):
+a range-parameterized bash guard + an offline fixture-repo self-test, wired into
+`.github/workflows/hygiene.yml` reusing the workflow's already-resolved
+`RANGE_BASE`/`RANGE_HEAD`. Rejected alternatives: a GitHub-Action-native
+changed-files + JS semver check (non-idiomatic here, not offline-testable), and
+a separate release-PR / `claude plugin tag` gate (heavier, and still lets fixes
+merge without moving the version).
+
+## Components
+
+### 1. `tools/check-plugin-version-bump.sh <BASE> <HEAD>`
+
+Range-parameterized so the self-test can drive it over throwaway fixture repos.
+Contract:
+
+1. `changed = git diff --name-only BASE HEAD`. An unresolvable range / failed
+   diff → **fail** (never read an empty change list as green). Missing `python3`
+   → **fail** (a missing runtime must fail loudly, mirroring the provenance
+   guard).
+2. Derive the set of touched plugin names: every changed path matching
+   `^plugins/([^/]+)/`.
+3. Scan `git log BASE..HEAD` full messages (`%B`) once for a
+   `Skip-Version-Bump:` trailer (key match case-insensitive) with a non-empty
+   reason. Record whether present and which commit carried it.
+4. For each touched plugin `<name>`, read `.version` from
+   `plugins/<name>/.claude-plugin/plugin.json` at BASE (`git show BASE:…`) and at
+   HEAD:
+   - **Present at HEAD, strictly-greater semver than BASE** → OK.
+   - **Present at HEAD, not strictly-greater (or unchanged)** → OK **iff** the
+     Skip-Version-Bump trailer was found (echo the exempting commit + reason for
+     audit); otherwise `::error file=plugins/<name>/.claude-plugin/plugin.json::`
+     and fail.
+   - **Absent at BASE, present at HEAD** (new plugin introduced in range) → OK;
+     its initial version is fine.
+   - **Absent at HEAD but `<name>` is listed in
+     `.claude-plugin/marketplace.json`** → **fail** (a shipped, listed plugin
+     with no versionable manifest — the sisense case; also catches deleting a
+     manifest while the plugin remains).
+   - **Absent at HEAD and not listed at HEAD** (plugin removed) → OK.
+   - **Version string at HEAD not valid semver**, or `plugin.json` unparseable
+     JSON → **fail** (must be semver / valid JSON).
+5. Exit non-zero if any plugin failed; else print an OK line naming the range.
+
+**Semver comparison:** a small `python3` helper parses `MAJOR.MINOR.PATCH`
+(optional `-prerelease`/`+build` tolerated but the numeric core is what's
+compared) and returns strictly-greater on the `(major, minor, patch)` tuple.
+A version whose core is not three non-negative integers is rejected as
+non-semver.
+
+**Trailer scope:** global to the range (a single trailer exempts every
+otherwise-failing touched plugin). The repo's "one PR = one plugin" rule makes
+this unambiguous in practice; not plugin-qualified, by YAGNI.
+
+**No circularity:** bumping the version is itself a change under the plugin
+directory, and it *is* the thing the guard requires — so a bump satisfies the
+guard for its own plugin with no special-casing.
+
+### 2. `tools/test-plugin-version-bump.sh` (offline self-test)
+
+Mirrors `tools/test-converter-provenance.sh`: throwaway `git init` fixture repos,
+synthetic `toolx-to-sigma` names only (no field-derived identifiers), drives the
+guard over real BASE..HEAD ranges and asserts:
+
+- A change under a plugin **without** a version bump **fails**; the same change
+  **with** a strict bump **passes**.
+- A version **decrease** fails; a **non-semver** version fails; **unparseable
+  JSON** fails.
+- A `Skip-Version-Bump: <reason>` trailer in the range **exempts** an otherwise
+  failing change (and an empty-reason trailer does **not**).
+- A **new plugin** introduced in the range (no manifest at BASE) **passes**.
+- A plugin **listed in a fixture marketplace.json but with no manifest** at HEAD
+  **fails**; **deleting** a manifest while the plugin remains listed **fails**.
+- A range touching **no** plugin directory **passes** trivially.
+- **String-pin** on the real repo: the guard is wired into `hygiene.yml`, and
+  every plugin listed in `marketplace.json` has a `plugin.json` carrying a
+  semver `version` (this pin fails today for `sisense-to-sigma` and turns green
+  with the backfill).
+
+Runs standalone (`bash tools/test-plugin-version-bump.sh`) and creds-free.
+
+### 3. CI wiring — `.github/workflows/hygiene.yml`
+
+Add two steps after the converter-provenance steps, reusing the workflow's
+`RANGE_BASE`/`RANGE_HEAD` (set by the existing "Resolve push/PR diff range"
+step):
+
+- **Plugin-version-bump guard:** skip if `RANGE_BASE` empty (push-only
+  no-range case, matching the sibling guards); else
+  `bash tools/check-plugin-version-bump.sh "$RANGE_BASE" "$RANGE_HEAD"`.
+- **Plugin-version-bump guard self-test:** `bash tools/test-plugin-version-bump.sh`.
+
+**Not** added to `.githooks/run-governance-checks.sh` — that gate is range-less
+(local pre-commit/pre-push) and this guard is inherently range-based, exactly
+like `check-converter-provenance.sh`, which also lives only in `hygiene.yml`.
+
+### 4. Backfill + docs (same PR)
+
+**Create `plugins/sisense-to-sigma/.claude-plugin/plugin.json`** — author a
+manifest matching its siblings' shape (`$schema`, `name`, `displayName`,
+`version`, `description`, `author`, `license`, `keywords`, `skills: "./skills/"`),
+`version` `1.0.0` as its true first release.
+
+**Re-baseline every plugin whose shipped content has moved past its initial
+version** — a **minor** bump. `domo-to-sigma` is untouched (added at the branch
+base, zero commits since). Concrete set:
+
+| plugin | from | to |
+|---|---|---|
+| cognos-to-sigma | 1.0.0 | 1.1.0 |
+| gooddata-to-sigma | 1.0.0 | 1.1.0 |
+| looker-to-sigma | 1.0.0 | 1.1.0 |
+| microstrategy-to-sigma | 0.1.0 | 0.2.0 |
+| powerbi-to-sigma | 1.0.0 | 1.1.0 |
+| qlik-to-sigma | 1.0.0 | 1.1.0 |
+| quicksight-to-sigma | 1.0.0 | 1.1.0 |
+| sigma-authoring | 1.0.0 | 1.1.0 |
+| tableau-to-sigma | 1.0.0 | 1.1.0 |
+| thoughtspot-to-sigma | 1.0.0 | 1.1.0 |
+| sisense-to-sigma | *(none)* | 1.0.0 *(new manifest)* |
+| domo-to-sigma | 0.1.0 | *(untouched)* |
+
+**Docs:**
+- `CONTRIBUTING.md` — a short "Versioning & releases" section: bump the touched
+  plugin's `plugin.json` `version` (strict semver increase) with any user-facing
+  change; use `Skip-Version-Bump: <reason>` in a commit for a genuinely
+  non-user-facing change; note the CI gate enforces it.
+- `.github/PULL_REQUEST_TEMPLATE.md` — one checklist item: *Bumped the touched
+  plugin's `plugin.json` version (semver ↑), or added `Skip-Version-Bump:
+  <reason>` for a non-user-facing change.*
+
+## Self-consistency of the one PR
+
+The backfill bumps every touched plugin's version, so when CI runs the new guard
+over this PR's own range, each changed plugin directory also carries a strict
+version increase and passes. The guard/CI/docs files live outside `plugins/**`
+and never trigger it.
+
+## Testing / verification
+
+- `bash tools/test-plugin-version-bump.sh` — all assertions pass (creds-free,
+  offline).
+- The full `hygiene.yml` gate is green on the PR (new guard + existing checks).
+- Manual: after merge + tag, `claude plugin update <plugin>` reports the new
+  version rather than "already at latest."
+
+## Risks / notes
+
+- **False "no bump needed" via the trailer.** Accepted: the trailer requires a
+  written reason and is visible in history and PR review — an explicit, auditable
+  human call, which is the point.
+- **Semver edge cases** (prerelease/build metadata) are tolerated but only the
+  numeric core is compared; the repo uses plain `X.Y.Z`, so this is sufficient.
+- **One-PR-per-plugin rule.** This PR intentionally spans all plugins; it is a
+  release-hygiene meta-change and is called out as such in the PR body.

--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData → Sigma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction, DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sisense-to-sigma",
+  "displayName": "Sisense → Sigma",
+  "version": "1.0.0",
+  "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma — data model + workbook (indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; columnar layout→24-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
+  "author": { "name": "Thomas Wells" },
+  "license": "MIT",
+  "keywords": ["sisense", "elasticube", "jaql", "sigma", "migration", "bi", "converter", "assessment"],
+  "skills": "./skills/"
+}

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/tools/check-plugin-version-bump.sh
+++ b/tools/check-plugin-version-bump.sh
@@ -42,17 +42,20 @@ while IFS= read -r sha; do
 done < <(git rev-list "$BASE..$HEAD" 2>/dev/null)
 
 # Print a plugin.json "version" from a ref; empty if the file is absent;
-# __BADJSON__ if unparseable; __NOVER__ if no non-empty string version.
+# __BADJSON__ if unparseable, OR valid JSON that is not an object (a dict is
+# required for .get("version") to be safe — [1,2,3]/null/a bare string must
+# never reach it); __NOVER__ if no non-empty string version.
 read_version() { # ref name
   git show "$1:plugins/$2/.claude-plugin/plugin.json" 2>/dev/null | python3 -c '
 import json, sys
 raw = sys.stdin.read()
 if raw == "": sys.exit(0)
 try: d = json.loads(raw)
-except Exception: print("__BADJSON__"); sys.exit(0)
+except Exception: d = None
+if not isinstance(d, dict): print("__BADJSON__"); sys.exit(0)
 v = d.get("version")
 print(v if isinstance(v, str) and v else "__NOVER__")
-'
+' 2>/dev/null
 }
 
 # strict semver-greater: exit 0 if head>base on (major,minor,patch); 1 if not;
@@ -73,9 +76,10 @@ listed_at_head() { # name — is it in marketplace.json at HEAD?
   git show "$HEAD:.claude-plugin/marketplace.json" 2>/dev/null | python3 -c '
 import json, sys
 try: d = json.load(sys.stdin)
-except Exception: sys.exit(1)
+except Exception: d = None
+if not isinstance(d, dict): sys.exit(1)
 sys.exit(0 if sys.argv[1] in [p.get("name") for p in d.get("plugins", [])] else 1)
-' "$1"
+' "$1" 2>/dev/null
 }
 
 fail=0

--- a/tools/check-plugin-version-bump.sh
+++ b/tools/check-plugin-version-bump.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tools/check-plugin-version-bump.sh — plugin version-bump diff gate (#486).
+#
+#   bash tools/check-plugin-version-bump.sh <BASE> <HEAD>
+#
+# Fails (exit 1) when the BASE..HEAD range changes anything under
+# plugins/<name>/** without that plugin's
+# plugins/<name>/.claude-plugin/plugin.json "version" strictly increasing
+# (semver) — UNLESS a `Skip-Version-Bump: <reason>` commit trailer (reason
+# required) appears anywhere in the range (a genuinely non-user-facing change).
+#
+# Also fails when a plugin listed in .claude-plugin/marketplace.json has no
+# versionable plugin.json at HEAD (a shipped plugin the update path can never
+# refresh — e.g. a missing or deleted manifest), and when a plugin.json's
+# version is not valid semver or the file is not valid JSON.
+#
+# A brand-new plugin (no plugin.json at BASE, one at HEAD) passes: its initial
+# version is fine. A removed plugin (gone from marketplace.json at HEAD) passes.
+#
+# Callers resolve the range (hygiene.yml derives it from the CI event); the
+# check is range-parameterized so tools/test-plugin-version-bump.sh can drive
+# it against throwaway fixture repos offline.
+set -uo pipefail
+
+BASE="${1:?usage: check-plugin-version-bump.sh <BASE> <HEAD>}"
+HEAD="${2:?usage: check-plugin-version-bump.sh <BASE> <HEAD>}"
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 missing — plugin-version-bump gate cannot run"; exit 1; }
+
+changed="$(git diff --name-only "$BASE" "$HEAD")" || { echo "git diff $BASE..$HEAD failed — cannot check plugin versions"; exit 1; }
+
+touched="$(printf '%s\n' "$changed" | sed -nE 's#^plugins/([^/]+)/.*#\1#p' | sort -u)"
+if [ -z "$touched" ]; then echo "plugin-version-bump gate OK ($BASE..$HEAD): no plugin directories changed"; exit 0; fi
+
+# Escape hatch: a Skip-Version-Bump: <reason> trailer (reason required) in any
+# commit's full message across the range.
+skip_reason=""; skip_commit=""
+while IFS= read -r sha; do
+  [ -n "$sha" ] || continue
+  reason="$(git log -1 --format=%B "$sha" | sed -nE 's/^[Ss]kip-[Vv]ersion-[Bb]ump:[[:space:]]*(.+[^[:space:]])[[:space:]]*$/\1/p' | head -1)"
+  if [ -n "$reason" ]; then skip_reason="$reason"; skip_commit="$sha"; break; fi
+done < <(git rev-list "$BASE..$HEAD" 2>/dev/null)
+
+# Print a plugin.json "version" from a ref; empty if the file is absent;
+# __BADJSON__ if unparseable; __NOVER__ if no non-empty string version.
+read_version() { # ref name
+  git show "$1:plugins/$2/.claude-plugin/plugin.json" 2>/dev/null | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+if raw == "": sys.exit(0)
+try: d = json.loads(raw)
+except Exception: print("__BADJSON__"); sys.exit(0)
+v = d.get("version")
+print(v if isinstance(v, str) and v else "__NOVER__")
+'
+}
+
+# strict semver-greater: exit 0 if head>base on (major,minor,patch); 1 if not;
+# 2 if either side is not semver.
+semver_gt() { # base head
+  python3 -c '
+import sys, re
+def core(v):
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)", v or "")
+    return tuple(int(x) for x in m.groups()) if m else None
+b, h = core(sys.argv[1]), core(sys.argv[2])
+if b is None or h is None: sys.exit(2)
+sys.exit(0 if h > b else 1)
+' "$1" "$2"
+}
+
+listed_at_head() { # name — is it in marketplace.json at HEAD?
+  git show "$HEAD:.claude-plugin/marketplace.json" 2>/dev/null | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception: sys.exit(1)
+sys.exit(0 if sys.argv[1] in [p.get("name") for p in d.get("plugins", [])] else 1)
+' "$1"
+}
+
+fail=0
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  base_v="$(read_version "$BASE" "$name")"
+  head_v="$(read_version "$HEAD" "$name")"
+
+  if [ -z "$head_v" ]; then
+    if listed_at_head "$name"; then
+      echo "::error file=plugins/$name/.claude-plugin/plugin.json::plugin '$name' is listed in marketplace.json but has no plugin.json version at HEAD — it can never be updated; add a versioned manifest"
+      fail=1
+    fi
+    continue
+  fi
+  if [ "$head_v" = "__BADJSON__" ]; then
+    echo "::error file=plugins/$name/.claude-plugin/plugin.json::plugin.json is not valid JSON"; fail=1; continue
+  fi
+  if [ "$head_v" = "__NOVER__" ]; then
+    echo "::error file=plugins/$name/.claude-plugin/plugin.json::plugin.json has no non-empty string \"version\" field"; fail=1; continue
+  fi
+  if [ -z "$base_v" ] || [ "$base_v" = "__BADJSON__" ] || [ "$base_v" = "__NOVER__" ]; then
+    echo "plugin-version-bump: '$name' — new/first versioned manifest ($head_v), OK"; continue
+  fi
+  semver_gt "$base_v" "$head_v"; rc=$?
+  if [ "$rc" -eq 0 ]; then echo "plugin-version-bump: '$name' $base_v -> $head_v, OK"; continue; fi
+  if [ "$rc" -eq 2 ]; then
+    echo "::error file=plugins/$name/.claude-plugin/plugin.json::version '$head_v' (or base '$base_v') is not valid semver (MAJOR.MINOR.PATCH)"; fail=1; continue
+  fi
+  if [ -n "$skip_reason" ]; then
+    echo "plugin-version-bump: '$name' version unchanged ($head_v) but exempted by Skip-Version-Bump in $skip_commit: $skip_reason"; continue
+  fi
+  echo "::error file=plugins/$name/.claude-plugin/plugin.json::'$name' changed under plugins/$name/** but version did not increase ($base_v -> $head_v). Bump it (strict semver), or add a 'Skip-Version-Bump: <reason>' commit trailer for a genuinely non-user-facing change."
+  fail=1
+done < <(printf '%s\n' "$touched")
+
+if [ "$fail" -ne 0 ]; then
+  echo "plugin-version-bump gate FAILED — see ::error annotations above (#486 release hygiene)."
+  exit 1
+fi
+echo "plugin-version-bump gate OK ($BASE..$HEAD)"

--- a/tools/check-plugin-version-bump.sh
+++ b/tools/check-plugin-version-bump.sh
@@ -73,6 +73,10 @@ sys.exit(0 if h > b else 1)
 }
 
 listed_at_head() { # name — is it in marketplace.json at HEAD?
+  # An unparseable or non-object marketplace.json is treated as "not listed"
+  # (fail-open by design here — marketplace.json's own integrity is outside
+  # this gate's remit; it only decides whether the missing-manifest check
+  # below applies).
   git show "$HEAD:.claude-plugin/marketplace.json" 2>/dev/null | python3 -c '
 import json, sys
 try: d = json.load(sys.stdin)
@@ -102,6 +106,14 @@ while IFS= read -r name; do
     echo "::error file=plugins/$name/.claude-plugin/plugin.json::plugin.json has no non-empty string \"version\" field"; fail=1; continue
   fi
   if [ -z "$base_v" ] || [ "$base_v" = "__BADJSON__" ] || [ "$base_v" = "__NOVER__" ]; then
+    # New/first manifest: nothing to compare against, but head_v still has to
+    # be valid semver — reuse semver_gt's own regex/idiom (a fixed, always-
+    # parseable "0.0.0" base means rc=2 can only mean head_v itself doesn't
+    # parse) rather than duplicating the semver check.
+    semver_gt "0.0.0" "$head_v"; new_rc=$?
+    if [ "$new_rc" -eq 2 ]; then
+      echo "::error file=plugins/$name/.claude-plugin/plugin.json::version '$head_v' is not valid semver (MAJOR.MINOR.PATCH)"; fail=1; continue
+    fi
     echo "plugin-version-bump: '$name' — new/first versioned manifest ($head_v), OK"; continue
   fi
   semver_gt "$base_v" "$head_v"; rc=$?

--- a/tools/test-plugin-version-bump.sh
+++ b/tools/test-plugin-version-bump.sh
@@ -116,6 +116,14 @@ manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
 H1="$(commit_msg 'add new plugin')"
 run_guard "$BASE" "$H1"; check 0 "$(passed)" "new plugin (no manifest at BASE) passes"
 
+new_repo "$TMP/d_new_badver"
+echo root > README.md
+BASE="$(commit_msg base)"
+manifest "plugins/toolx-to-sigma" "banana"; skill_file toolx-to-sigma v1
+H1="$(commit_msg 'add new plugin with non-semver version')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "new plugin with non-semver version fails"
+grep -q "not valid semver" "$TMP/out"; check 0 "$?" "failure names the non-semver version on a new manifest"
+
 new_repo "$TMP/d_missing"
 mkdir -p .claude-plugin
 printf '{ "plugins": [ { "name": "toolx-to-sigma" } ] }\n' > .claude-plugin/marketplace.json

--- a/tools/test-plugin-version-bump.sh
+++ b/tools/test-plugin-version-bump.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Offline test for tools/check-plugin-version-bump.sh (plugin version-bump gate,
+# #486). test-converter-provenance.sh style: throwaway fixture git repos with
+# synthetic plugin names (toolx) only — no field-derived identifiers.
+#
+#   Part A — bump discipline: unbumped plugin change fails; same change + strict
+#            bump passes; a version DECREASE fails; a no-plugin-touched range
+#            passes trivially
+#   Part B — validity: a non-semver version fails; unparseable plugin.json fails
+#   Part C — escape hatch: a Skip-Version-Bump:<reason> trailer exempts an
+#            unbumped change; an empty-reason trailer does NOT
+#   Part D — manifest lifecycle: a new plugin (no manifest at BASE) passes; a
+#            marketplace-listed plugin with no manifest at HEAD fails; deleting
+#            a manifest while the plugin stays listed fails
+#   Part E — string-pin the real repo: every plugin listed in marketplace.json
+#            carries a semver plugin.json (satisfied by the Task 1 backfill)
+#
+# Runs standalone:  bash tools/test-plugin-version-bump.sh
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+GUARD="$HERE/check-plugin-version-bump.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+check() { # expect-rc actual-rc message   (expect: 0=pass wanted, 1=fail wanted)
+  if [ "$1" -eq "$2" ]; then printf '  PASS  %s\n' "$3"; else printf '  FAIL  %s (rc=%s)\n' "$3" "$2"; fails=$((fails+1)); fi
+}
+
+RC=0
+run_guard() { bash "$GUARD" "$1" "$2" >"$TMP/out" 2>&1; RC=$?; }
+passed() { [ "$RC" -eq 0 ] && echo 0 || echo 1; }   # 0 when guard passed
+failed() { [ "$RC" -ne 0 ] && echo 0 || echo 1; }   # 0 when guard failed
+
+new_repo() { rm -rf "$1"; mkdir -p "$1" && cd "$1" || exit 1; git init -q; git config user.email pvb@example.invalid; git config user.name pvb; git config commit.gpgsign false; }
+commit_msg() { git add -A && git commit -q --no-verify -m "$1" >/dev/null && git rev-parse HEAD; }
+manifest() { mkdir -p "$1/.claude-plugin"; printf '{ "name": "%s", "version": "%s", "skills": "./skills/" }\n' "$(basename "$1")" "$2" > "$1/.claude-plugin/plugin.json"; }
+skill_file() { mkdir -p "plugins/$1/skills/$1"; echo "$2" > "plugins/$1/skills/$1/SKILL.md"; }
+
+echo "Part A — bump discipline"
+new_repo "$TMP/a"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2
+H1="$(commit_msg 'edit skill, no bump')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "unbumped plugin change fails"
+grep -q "did not increase" "$TMP/out"; check 0 "$?" "failure names the missing bump"
+manifest "plugins/toolx-to-sigma" "1.0.1"
+H2="$(commit_msg 'bump to 1.0.1')"
+run_guard "$BASE" "$H2"; check 0 "$(passed)" "same change + strict bump passes"
+
+new_repo "$TMP/a_dec"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2; manifest "plugins/toolx-to-sigma" "0.9.0"
+H1="$(commit_msg 'edit + decrease')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "version decrease fails"
+
+new_repo "$TMP/a_none"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1; echo root > README.md
+BASE="$(commit_msg base)"
+echo root2 > README.md
+H1="$(commit_msg 'root-only change')"
+run_guard "$BASE" "$H1"; check 0 "$(passed)" "range touching no plugin dir passes"
+
+echo "Part B — validity"
+new_repo "$TMP/b_semver"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2; manifest "plugins/toolx-to-sigma" "1.0"
+H1="$(commit_msg 'non-semver version')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "non-semver version fails"
+
+new_repo "$TMP/b_json"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2; echo '{ not json' > plugins/toolx-to-sigma/.claude-plugin/plugin.json
+H1="$(commit_msg 'broken json')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "unparseable plugin.json fails"
+
+echo "Part C — escape hatch"
+new_repo "$TMP/c_ok"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2
+H1="$(commit_msg 'fix typo in a comment
+
+Skip-Version-Bump: comment-only, no shipped behavior change')"
+run_guard "$BASE" "$H1"; check 0 "$(passed)" "Skip-Version-Bump trailer with reason exempts"
+
+new_repo "$TMP/c_empty"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2
+H1="$(commit_msg 'edit skill
+
+Skip-Version-Bump:')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "empty-reason trailer does NOT exempt"
+
+echo "Part D — manifest lifecycle"
+new_repo "$TMP/d_new"
+echo root > README.md
+BASE="$(commit_msg base)"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+H1="$(commit_msg 'add new plugin')"
+run_guard "$BASE" "$H1"; check 0 "$(passed)" "new plugin (no manifest at BASE) passes"
+
+new_repo "$TMP/d_missing"
+mkdir -p .claude-plugin
+printf '{ "plugins": [ { "name": "toolx-to-sigma" } ] }\n' > .claude-plugin/marketplace.json
+skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2
+H1="$(commit_msg 'edit listed plugin with no manifest')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "marketplace-listed plugin with no manifest fails"
+
+new_repo "$TMP/d_delete"
+mkdir -p .claude-plugin
+printf '{ "plugins": [ { "name": "toolx-to-sigma" } ] }\n' > .claude-plugin/marketplace.json
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+rm plugins/toolx-to-sigma/.claude-plugin/plugin.json
+H1="$(commit_msg 'delete manifest, still listed')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "deleting a manifest while still listed fails"
+
+echo "Part E — string-pin the real repo"
+python3 - "$ROOT" <<'PY'
+import json, re, sys, pathlib
+root = pathlib.Path(sys.argv[1])
+mp = json.loads((root/".claude-plugin/marketplace.json").read_text())
+bad = [p["name"] for p in mp["plugins"]
+       if not re.match(r"^\d+\.\d+\.\d+$",
+           (json.loads((root/"plugins"/p["name"]/".claude-plugin"/"plugin.json").read_text()).get("version","")
+            if (root/"plugins"/p["name"]/".claude-plugin"/"plugin.json").exists() else ""))]
+sys.exit(1 if bad else 0)
+PY
+check 0 "$?" "every marketplace-listed plugin carries a semver plugin.json"
+
+echo ""
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; else echo "$fails FAILED"; exit 1; fi

--- a/tools/test-plugin-version-bump.sh
+++ b/tools/test-plugin-version-bump.sh
@@ -80,6 +80,15 @@ skill_file toolx-to-sigma v2; echo '{ not json' > plugins/toolx-to-sigma/.claude
 H1="$(commit_msg 'broken json')"
 run_guard "$BASE" "$H1"; check 0 "$(failed)" "unparseable plugin.json fails"
 
+new_repo "$TMP/b_nonobject"
+manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1
+BASE="$(commit_msg base)"
+skill_file toolx-to-sigma v2; printf '[1,2,3]\n' > plugins/toolx-to-sigma/.claude-plugin/plugin.json
+H1="$(commit_msg 'valid json, not an object')"
+run_guard "$BASE" "$H1"; check 0 "$(failed)" "valid-but-non-object plugin.json fails"
+grep -q "not valid JSON" "$TMP/out"; check 0 "$?" "non-object failure reports not-valid-JSON"
+! grep -q "Traceback" "$TMP/out"; check 0 "$?" "non-object JSON does not leak a Python traceback"
+
 echo "Part C — escape hatch"
 new_repo "$TMP/c_ok"
 manifest "plugins/toolx-to-sigma" "1.0.0"; skill_file toolx-to-sigma v1


### PR DESCRIPTION
## What & why

Plugin `plugin.json` `version` fields never get bumped as fixes merge, so Claude Code's plugin-update check compares an unchanged version string and reports **"already at the latest version" — shipping nothing**. Observed on `tableau-to-sigma` (installed at `1.0.0`, then 333 commits / 5 bug-fix PRs with no bump); in the extreme, `sisense-to-sigma` had **no manifest at all**. The only recovery was a full uninstall + reinstall.

This makes the version signal honest: a CI diff-gate fails any PR that changes `plugins/<name>/**` without a strict-semver bump of that plugin's `version` (escape hatch: a `Skip-Version-Bump: <reason>` commit trailer), the already-stale versions are re-baselined, and the discipline is documented.

Fixes #486. Tracker: GitHub issue #486 (no bead).

## Scope

- Plugin(s) touched: **all** (version re-baseline) — see note below.
- [ ] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)
  - ⚠️ **Intentionally not one-plugin.** This is a cross-cutting release-hygiene change (a new `tools/` gate + CI wiring + docs + a one-line version bump to every plugin's `plugin.json`), analogous to the "isolated infra change" exception. It is self-consistent: each bumped plugin satisfies the new gate over this PR's own range.

## What changed

- `tools/check-plugin-version-bump.sh` — range-diff gate (strict semver increase; `Skip-Version-Bump: <reason>` trailer escape hatch; a marketplace-listed plugin with no versionable manifest fails; fail-closed on bad range / JSON / semver / missing `python3`). Modeled on the sibling `tools/check-converter-provenance.sh`.
- `tools/test-plugin-version-bump.sh` — offline fixture-repo self-test (18 assertions, synthetic `toolx` names only).
- `.github/workflows/hygiene.yml` — two steps (guard + self-test), reusing the workflow's `RANGE_BASE`/`RANGE_HEAD`. Deliberately **not** added to `.githooks/run-governance-checks.sh` (range-based → CI-only, like the provenance guard).
- Backfill: 10 plugins minor-bumped (`1.0.0 → 1.1.0`; `microstrategy-to-sigma` `0.1.0 → 0.2.0`); `sisense-to-sigma` given a new `1.0.0` manifest; `domo-to-sigma` left at `0.1.0` (just added upstream, unchanged since).
- `CONTRIBUTING.md` + `.github/PULL_REQUEST_TEMPLATE.md` — document the bump rule + escape hatch.
- `docs/superpowers/` — design spec + implementation plan (included as rationale; happy to drop before merge if you'd rather not ship them).

## Checklist

- [x] `ruby tools/check-shared.rb` — green (via `.githooks/run-governance-checks.sh`, rc=0)
- [x] `ruby tools/lint-skills.rb` — green (same)
- [ ] `./corpus/run-corpus.sh --check` — not run; no converter/builder changed
- [x] Phase numbers unchanged (no skill added / phase-schema untouched)
- [x] No unrelated working-tree changes swept in (`git status` clean)
- [x] New gate self-test green: `bash tools/test-plugin-version-bump.sh` → `ALL PASS`
- [x] Every touched plugin's `plugin.json` version bumped (the whole point) — guard passes over this PR's merge-base range

## Companion issue

The other half — Claude Code's update check having no fallback when a marketplace's version string doesn't move — is filed separately on `anthropics/claude-code`. Each repo can only fix its own half.

## Environment

Agent-assisted: Claude Code (Opus 4.8, 1M context) via the superpowers workflow (brainstorming → writing-plans → subagent-driven-development, with a Haiku/Sonnet implementer + reviewer per task and an Opus whole-branch review). The human partner directed the design decisions and reviewed the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
