### PR TITLE
chore(shared): re-sync domo sigma_rest.rb after #508 (restore list_entries)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. A read-only domo-assessment skill is scaffolded and ships in a later release. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/sigma_rest.rb
@@ -175,6 +175,32 @@ module Sigma
     end
   end
 
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    page = nil
+    seen = {}
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      entries.concat(data['entries'] || [])
+      page = data['nextPage']
+      break if page.nil? || page.to_s.empty? || seen[page]
+      seen[page] = true
+    end
+    entries
+  end
+
   def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
     uri = URI("#{base_url}#{path}")
     attempts = 0


### PR DESCRIPTION
## What
Re-syncs the `domo-to-sigma` vendored copy of `sigma_rest.rb` to canonical `shared/lib/sigma_rest.rb`.

## Why
#508 added the exhaustive-pagination helper `list_entries` to canonical `shared/lib/sigma_rest.rb` but did not re-sync the `domo-to-sigma` vendored copy (last synced in #513 / SP1a). That left a `check-shared` drift on `main` — every branch off `main` fails the pre-commit governance gate and the `check-shared` CI job, unrelated to their own changes.

## How
`ruby tools/sync-shared.rb` — one file changed, byte-restored from canonical, no domo-specific edits. `--dry-run` confirmed it touches only this target (the tableau `environment.md` fork stays allowlisted).

## Verification (offline)
- `ruby tools/check-shared.rb` → `OK: 534 shared-file copies all match canonical (1 allowlisted exceptions)`
- Full pre-commit governance suite green (hygiene-sweep, lint-skills, tree-litter, ESM/XML lints, agent-variant sync).
- No behavior change beyond the domo converter gaining the shared pagination helper.

One-concern PR (shared lib only). Unblocks the in-flight `feat/domo-assessment` (SP1b) branch, whose CI would otherwise fail on this inherited drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)