### PR TITLE
feat(shared): plugin_embed emitter + register-plugin helper + coverage_catalog plugin_archetype

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -291,6 +291,8 @@ jobs:
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-qs-trellis.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-metric-reference.rb
             shared/lib/test_metric_binding.rb
+            shared/lib/test_plugin_embed.rb
+            shared/lib/test_coverage_catalog.rb
             shared/lib/test_kpi_card.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-comparison-wiring.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-comparison-emit.rb
@@ -336,6 +338,8 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_metric_reference.py
             shared/lib/test_metric_binding.py
+            shared/lib/test_plugin_embed.py
+            shared/lib/test_coverage_catalog.py
             shared/lib/test_kpi_card.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py

--- a/docs/superpowers/plans/2026-07-28-ws2-plugin-recreation-gauge.md
+++ b/docs/superpowers/plans/2026-07-28-ws2-plugin-recreation-gauge.md
@@ -1,0 +1,234 @@
+# WS2 v1 — Plugin-recreation (radial gauge) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the migration converters can recreate a non-native gauge viz as a working, data-bound Sigma plugin — de-risking the greenfield `@sigmacomputing/plugin` lifecycle (build → register → host → embed → bind → render → parity) on one archetype before generalizing.
+
+**Architecture:** A clean-room single-file gauge plugin + a stdlib-only `shared/lib/plugin_embed` twin emitter (produces the verified `{kind:"plugin",pluginId,config:{...}}` element block) + a non-breaking `plugin_archetype` recognizer in `coverage_catalog` + a `plugin_archetype:"gauge"` annotation on QuickSight's `GaugeChartVisual` row + a registration helper. Proven E2E-first against live Sigma.
+
+**Tech Stack:** Ruby 2.6 (stdlib), Python 3 (stdlib), JS/HTML (`@sigmacomputing/plugin` via CDN), Sigma REST (`/v2/plugins`, `/v2/workbooks/spec`, `/v2/workbooks/{id}/export`, `/v2/query/{id}/download`), `shared/lib/sigma_rest` + `export_pool`, manifest-driven `sync-shared`/`check-shared`.
+
+## Global Constraints
+
+- **Ruby 2.6-compatible**, **stdlib only** for `shared/lib` (Ruby `require 'json'`; Python `import json`). Twins emit **sorted-key-identical** output (golden-fixture locked).
+- **No customer data / clean-room.** The gauge plugin + all fixtures use generic demo data; no customer names in code/commits.
+- **Verified plugin lifecycle gotchas** (bake in, do not rediscover): register via `POST /v2/plugins {name,description,url,type:"element"}` → `pluginId`; a **masked HTTP 404 can accompany a successful register** → confirm via `GET /v2/plugins` (by name); registration may be **403 permission-gated** (org-admin) → fall back to handoff, report honestly; the plugin `url` is **set-once** (re-register to change); embed shape `{kind:"plugin",pluginId,config:{source:{kind:"element",elementId}, <var>:"<columnId>"}}` with **every `config` value a bare string** (object/`{kind:"column"}` form is rejected, masked as `Invalid kind:"plugin"`); **`ResizeObserver` mandatory** (redraw on resize); **synthetic fallback** so the plugin previews standalone; the plugin's backing data element on a **separate hidden page** (`visibleAsSource:false` does not hide from layout).
+- **Hosting/render:** a **localhost**-hosted plugin renders only in a human browser that can reach it — Sigma's **server-side PNG export cannot reach localhost**. So: **data-parity on the bound element is the hard gate** (works with any host); the **headless plugin screenshot is best-effort and needs a public static host** (or a human-browser check).
+- **Shared governance:** a new `shared/lib` file is invisible until added to `shared/manifest.json`; after adding run `ruby tools/sync-shared.rb` then `ruby tools/check-shared.rb` (stays green). New `shared/lib` **unit tests are NOT manifested** but MUST be appended to the `unit-tests` allow-list arrays in `.github/workflows/corpus-check.yml`.
+- **After any SKILL.md edit**, run `ruby tools/gen-agent-variants.rb <skill-dir>`; verify with `ruby tools/check-agent-variants.rb`.
+- **Creds:** Sigma via env + `~/.sigma-migration/env` (Ruby libs self-mint). Branch: `feat/ws2-plugin-recreation` (worktree `/Users/tjwells/wt-ws2`). Commit per task.
+
+---
+
+### Task 1: Live GO/NO-GO E2E — the plugin lifecycle (GATE)
+
+Prove, against live Sigma, that a gauge plugin can be **registered, embedded, bound, and its bound data verified** — before building the machinery. **Gates every later task.** If registration is 403-permission-gated org-wide, or the embed shape is rejected, STOP and report (the premise needs the handoff path or an admin).
+
+**Files:**
+- Create: `shared/scripts/verify-plugin-gauge-e2e.rb` (creds-gated; NOT in the offline CI allow-list)
+- Consumes: `shared/lib/sigma_rest.rb`, `shared/lib/export_pool.rb`, a minimal gauge plugin (a temporary stub is fine for this task — the real one lands in Task 2), a `SIGMA_TEST_CONNECTION_ID` (Snowflake, e.g. `362d859b-f432-4657-8e58-efc8535aa354`)
+
+**Interfaces:**
+- Produces: exit 0 = lifecycle proven (registered + embedded + bound + data-parity); exit 1 = a NO-GO with the raw evidence.
+
+- [ ] **Step 1: Host a minimal gauge plugin reachable by Sigma's render server**
+
+Prefer a public static host so the render is headlessly screenshot-able. If a static-host CLI (e.g. `netlify`) is authenticated, deploy a one-file `gauge/index.html` stub (value+target bindings, an SVG arc, `ResizeObserver`, synthetic fallback) and record the public URL. If no public host is available, serve locally (`cd <dir> && python3 -m http.server 8080`) and record `http://localhost:8080/gauge/` — data-parity will still be provable; the headless screenshot will be skipped with a note.
+
+- [ ] **Step 2: Register the plugin (handle the masked 404 + 403)**
+
+```ruby
+resp = Sigma.request(:post, '/v2/plugins',
+  body: JSON.generate(name: 'WS2 gauge (e2e)', description: 'recreate-as-plugin gauge proof',
+                      url: PLUGIN_URL, type: 'element'))
+# A masked 404 can accompany a successful register — confirm by name.
+list = Sigma.request(:get, '/v2/plugins'); list = JSON.parse(list) if list.is_a?(String)
+plugin = (list['entries'] || list['plugins'] || []).find { |p| p['name'] == 'WS2 gauge (e2e)' }
+abort "NO-GO: registration 403/permission-gated or not found — needs an org admin (handoff path)" unless plugin
+plugin_id = plugin['pluginId'] || plugin['id']
+```
+
+- [ ] **Step 3: POST a minimal workbook: a table (value+target over real data) + the gauge plugin bound to it**
+
+Table element via custom SQL on `SIGMA_TEST_CONNECTION_ID` with known literals, e.g. `SELECT 82 AS actual, 100 AS target`. Plugin element (bare-string config values):
+```ruby
+{ 'id' => 'gauge-el', 'kind' => 'plugin', 'pluginId' => plugin_id,
+  'config' => { 'source' => { 'kind' => 'element', 'elementId' => 'tbl-src' },
+                'value' => 'actual', 'target' => 'target' } }
+```
+POST `/v2/workbooks/spec` (response is YAML — scrape `workbookId`; do not treat non-JSON as failure; no spec key may contain the substring `field`).
+
+- [ ] **Step 4: Data-parity (HARD) — export the bound element, assert the numbers**
+
+`ExportPool.start_json_export(wb, 'tbl-src', nil)` → `poll_json_download` → assert `actual==82` & `target==100` (matched case-insensitively by column display name). **No faked green.**
+
+- [ ] **Step 5: Visual (best-effort) — screenshot only if public-hosted**
+
+If `PLUGIN_URL` is public: `python3 <a sigma-export-png.py> --workbook <id> --out /tmp/gauge-e2e.png` and note whether the arc renders. If localhost: print `SKIP visual (localhost not reachable by render server)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/scripts/verify-plugin-gauge-e2e.rb
+git commit -m "test: live E2E proof of the Sigma plugin lifecycle (gauge)"
+```
+Report GO (data-parity passed, plugin registered+embedded) or NO-GO (with the blocker: 403 / rejected embed / host).
+
+---
+
+### Task 2: The clean-room gauge plugin
+
+**Files:**
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/index.html`
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/README.md`
+- Create: `plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-gauge-plugin-static.rb` *(static lint — see below; place with sibling ruby tests, or under the new skill)*
+
+**Interfaces:**
+- Editor-panel variables the emitter/embeds bind: `element` (source), `value` (column), `target` (column), optional `min`/`max`/`format` (text). These names are the contract `plugin_embed` (Task 3) emits.
+
+- [ ] **Step 1: Write the failing static-lint test**
+
+```ruby
+# test-gauge-plugin-static.rb — the plugin file must satisfy the lifecycle contract
+require 'json'
+HTML = File.read(File.expand_path('../../sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/index.html', __dir__)) rescue ''
+$f=0; def chk(c,m); puts(c ? "[ok] #{m}" : "[FAIL] #{m}"); $f+=1 unless c; end
+chk(HTML.include?('@sigmacomputing/plugin'), 'loads the @sigmacomputing/plugin SDK')
+chk(HTML.include?('configureEditorPanel'),   'configures an editor panel')
+chk(HTML =~ /['"]value['"]/ && HTML =~ /['"]target['"]/, 'declares value + target bindings')
+chk(HTML.include?('ResizeObserver'),         'attaches a ResizeObserver (redraw-on-resize)')
+chk(HTML.downcase.include?('synth') || HTML.include?('fallback'), 'has a synthetic fallback')
+exit($f.zero? ? 0 : 1)
+```
+
+- [ ] **Step 2: Run it — RED** (`ruby .../test-gauge-plugin-static.rb` → FAIL, file missing).
+
+- [ ] **Step 3: Write `gauge/index.html`** — single file, vanilla JS, `<script src="https://unpkg.com/@sigmacomputing/plugin">`; `client.config.configureEditorPanel([{name:'source',type:'element'},{name:'value',type:'column',source:'source',allowMultiple:false},{name:'target',type:'column',source:'source',allowMultiple:false},{name:'format',type:'text'}])`; subscribe to element data; render an SVG radial arc (value/target → fraction → arc + RAG color) with the value + target labels; **`ResizeObserver` on the container → redraw**; a `synth()` generator (e.g. value 82 / target 100) rendered when `client` is null or data incomplete. Clean-room, generic, no customer data.
+
+- [ ] **Step 4: Run the static lint — GREEN.** Also open the file in a browser at 2 widths to confirm the arc + resize (manual, note in report).
+
+- [ ] **Step 5: Commit** (`feat: add clean-room gauge plugin (@sigmacomputing/plugin)`), and add the test path to the Ruby `test-*.rb` array in `.github/workflows/corpus-check.yml`.
+
+---
+
+### Task 3: `plugin_embed` emitter twins + golden tests (TDD)
+
+**Files:**
+- Create: `shared/lib/plugin_embed.rb`, `shared/lib/plugin_embed.py`, `shared/lib/test_plugin_embed.rb`, `shared/lib/test_plugin_embed.py`, `shared/lib/testdata/plugin_embed_golden.json`
+
+**Interfaces:**
+- Ruby: `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {}) -> Hash`
+- Python: `plugin_embed.build(id, plugin_id, source_element_id, bindings, extra_config=None) -> dict`
+- `bindings` = `{ 'value' => 'colId', 'target' => 'colId' }` (var → columnId); `extra_config` = non-binding config (e.g. `{'format'=>'$.3~s'}`). **All config values coerced to strings**; bindings are bare columnId strings.
+
+- [ ] **Step 1: Golden fixture** `shared/lib/testdata/plugin_embed_golden.json` (sorted keys) for `build(id:'gauge-el', plugin_id:'pl-1', source_element_id:'tbl-1', bindings:{'value'=>'actual','target'=>'target'}, extra_config:{'format'=>'$.3~s'})`:
+```json
+{"config":{"format":"$.3~s","source":{"elementId":"tbl-1","kind":"element"},"target":"target","value":"actual"},"id":"gauge-el","kind":"plugin","pluginId":"pl-1"}
+```
+
+- [ ] **Step 2: Failing Ruby test** `test_plugin_embed.rb` (hand-rolled `check()` harness, mirrors `test_kpi_card.rb`): asserts `PluginEmbed.build(...)` deep-sorted == golden; a numeric `extra_config` value (e.g. `2`) is emitted as the string `"2"`; empty `plugin_id`/`source_element_id` raises. Run → RED (`cannot load ... plugin_embed`).
+
+- [ ] **Step 3: Write `plugin_embed.rb`**
+```ruby
+# frozen_string_literal: true
+# plugin_embed.rb — Ruby twin of shared/lib/plugin_embed.py. Emits the VERIFIED
+# Sigma {kind:"plugin"} element block. ALL config values are bare strings
+# (object form is rejected, masked "Invalid kind:\"plugin\""). Twin emits
+# sorted-key-identical output (shared/lib/testdata/plugin_embed_golden.json).
+# Stdlib only (json); Ruby 2.6-compatible.
+require 'json'
+module PluginEmbed
+  def self.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'plugin_id required' if plugin_id.to_s.empty?
+    raise ArgumentError, 'source_element_id required' if source_element_id.to_s.empty?
+    config = { 'source' => { 'kind' => 'element', 'elementId' => source_element_id } }
+    (bindings || {}).each { |k, v| config[k.to_s] = v.to_s }        # bare string columnId
+    (extra_config || {}).each { |k, v| config[k.to_s] = v.to_s }    # ALL config values -> string
+    { 'id' => id, 'kind' => 'plugin', 'pluginId' => plugin_id, 'config' => config }
+  end
+end
+```
+
+- [ ] **Step 4: Ruby test GREEN** (`ruby shared/lib/test_plugin_embed.rb`).
+
+- [ ] **Step 5–7: Python twin + test** — mirror (`def build(id, plugin_id, source_element_id, bindings, extra_config=None)`, `str(v)` coercion, `ValueError` on empty). RED → write `plugin_embed.py` → GREEN (`python3 shared/lib/test_plugin_embed.py`).
+
+- [ ] **Step 8: Commit** (`feat: add plugin_embed emitter (Ruby+Python twins, golden-tested)`).
+
+---
+
+### Task 4: Governance + registration helper + CI wiring
+
+**Files:**
+- Modify: `shared/manifest.json` (canonical `shared/lib/plugin_embed.rb` — fan later when a builder consumes it; for v1 keep canonical-only, like `kpi_card.py` was, OR fan to `quicksight-to-sigma` if Task 6 wires it there — decide when wiring)
+- Modify: `.github/workflows/corpus-check.yml` (add `shared/lib/test_plugin_embed.rb` to the Ruby array, `shared/lib/test_plugin_embed.py` to the Python array)
+- Create: `shared/scripts/register-plugin.rb`
+
+- [ ] **Step 1: Registration helper** `register-plugin.rb` — `register_or_get(name:, description:, url:)`: GET `/v2/plugins`, return existing `pluginId` by name if present (idempotent); else POST, then re-GET by name (masked-404 tolerant); raise a clear "permission-gated (403) — needs an org admin" on a real auth failure. Reuse in Task 1's E2E.
+
+- [ ] **Step 2: Wire the unit tests into CI** (both `test_plugin_embed.*` paths) and confirm they run: `ruby shared/lib/test_plugin_embed.rb && python3 shared/lib/test_plugin_embed.py`.
+
+- [ ] **Step 3: `ruby tools/check-shared.rb`** stays green (report the count). Commit (`chore: register-plugin helper + wire plugin_embed tests into CI`).
+
+---
+
+### Task 5: `coverage_catalog` `plugin_archetype` recognition + QuickSight gauge annotation (non-breaking, TDD)
+
+**Files:**
+- Modify: `shared/lib/coverage_catalog.rb`, `shared/lib/coverage_catalog.py`
+- Modify: `shared/lib/test_coverage_catalog.rb`, `shared/lib/test_coverage_catalog.py`
+- Modify: `plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/catalogs/viz-kind.json` (add `"plugin_archetype": "gauge"` to the `GaugeChartVisual` row — keep `"sigma": "kpi-chart"` so the live builder dispatch is UNCHANGED)
+
+**Interfaces:**
+- New (both twins): `plugin_archetype(source_key)` → the archetype string if the resolved row carries `plugin_archetype` (or its `sigma` starts with `"plugin:"`), else nil. Existing `resolve`/`target`/`resolve_or_warn` unchanged.
+
+- [ ] **Step 1: Failing test** — extend `test_coverage_catalog.{rb,py}`: a catalog row `{"source":"GaugeChartVisual","sigma":"kpi-chart","plugin_archetype":"gauge"}` → `plugin_archetype("GaugeChartVisual") == "gauge"`; a plain native row → nil; `target`/`resolve` for that row still return `"kpi-chart"` (non-breaking). RED (`undefined ... plugin_archetype`).
+
+- [ ] **Step 2: Implement** in both twins — add to the `Catalog` class:
+```ruby
+def plugin_archetype(source_key)
+  r = resolve(source_key); return nil unless r
+  a = r['plugin_archetype']; return a unless a.to_s.empty?
+  s = r['sigma'].to_s; s.start_with?('plugin:') ? s.sub('plugin:', '') : nil
+end
+```
+(Python mirror.) Add `"plugin_archetype": "gauge"` to the QS `GaugeChartVisual` row.
+
+- [ ] **Step 3: GREEN** (`ruby shared/lib/test_coverage_catalog.rb && python3 shared/lib/test_coverage_catalog.py`). `check-shared` clean (canonical edited + synced). Commit (`feat: coverage_catalog recognizes plugin:<archetype> (recreate-as-plugin); QS gauge annotated`).
+
+---
+
+### Task 6: `sigma-plugin-authoring` skill + reference + gauge exemplar
+
+**Files:**
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/SKILL.md`
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/plugin-lifecycle.md`
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/examples/gauge-embed.json` (a `plugin_embed.build` output exemplar)
+- (the gauge plugin from Task 2 lives under this skill's `plugins/gauge/`)
+- Modify: `plugins/sigma-authoring/.claude-plugin/plugin.json` if it enumerates skills; regenerate `generated/` variants
+
+- [ ] **Step 1: SKILL.md** — frontmatter (sharp `description:` — "use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin") + the build→register→host→embed→bind recipe, deferring the verified gotchas to `reference/plugin-lifecycle.md`.
+- [ ] **Step 2: `reference/plugin-lifecycle.md`** — the Global-Constraints gotchas as the canonical reference (register/masked-404/403; url set-once; bare-string config; `ResizeObserver`; synthetic fallback; hidden-page backing element; localhost-not-headless-renderable; `PluginEmbed.build`/`plugin_embed.build` as the emitter).
+- [ ] **Step 3: `examples/gauge-embed.json`** — the emitter output for the gauge (matches the golden shape).
+- [ ] **Step 4: Regenerate variants** — `ruby tools/gen-agent-variants.rb plugins/sigma-authoring/skills/sigma-plugin-authoring` → `ruby tools/check-agent-variants.rb` (in sync). Commit (`docs(sigma-authoring): sigma-plugin-authoring skill + gauge exemplar`).
+
+---
+
+### Task 7: Full verification + acceptance
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Offline gauntlet** — `ruby tools/check-shared.rb`, `ruby tools/check-agent-variants.rb`, `ruby shared/lib/test_plugin_embed.rb`, `python3 shared/lib/test_plugin_embed.py`, `ruby shared/lib/test_coverage_catalog.rb`, `python3 shared/lib/test_coverage_catalog.py`, `ruby .../test-gauge-plugin-static.rb`. All green.
+- [ ] **Step 2: Live acceptance** — re-run `ruby shared/scripts/verify-plugin-gauge-e2e.rb` (now using the real Task-2 gauge + the Task-4 helper + `plugin_embed`): registered + embedded + bound + **data-parity passes**; screenshot if public-hosted. Report the real numbers + the host/boundary.
+- [ ] **Step 3: Hand off** — use `superpowers:finishing-a-development-branch`. Note the split-PR structure (shared: `plugin_embed` + `coverage_catalog` + `register-plugin`; sigma-authoring: the skill + gauge plugin; quicksight: the one catalog row) per the one-plugin-or-shared convention. Flag the **fast-follow**: the per-tool builder auto-emit (source gauge tile → `plugin_embed` element) — v1 proves the lifecycle + machinery + catalog recognition; the automatic emit in a live migration is the next slice.
+
+---
+
+## Self-Review
+
+**Spec coverage:** `sigma-plugin-authoring` skill → Task 6 ✅; `plugin_embed` twins → Task 3 ✅; gauge plugin → Task 2 ✅; `recreate-as-plugin` disposition → Task 5 ✅; registration helper → Task 4 ✅; hosting handoff/turnkey → Task 1 + reference ✅; data-parity-hard + screenshot-soft → Tasks 1/7 ✅; E2E-first → Task 1 gate ✅. The full per-tool builder auto-emit is explicitly scoped as fast-follow (Task 7 hand-off) — consistent with the spec's v1 scope.
+
+**Placeholder scan:** No TBD/TODO. The two spec open-questions are resolved: tool = **QuickSight `GaugeChartVisual`** (Task 5); hosting = public static host when available for the headless screenshot, else localhost + data-parity (Task 1, Global Constraints). The one genuinely-conditional step (public vs localhost host) is called out explicitly, not hidden.
+
+**Type consistency:** `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config:)` identical across Tasks 3/4/6; `plugin_archetype(source_key)` signature matches between Task 5's test and impl; the gauge editor-panel var names (`value`/`target`) match the `plugin_embed` bindings and the golden fixture.

--- a/docs/superpowers/specs/2026-07-28-ws2-plugin-recreation-gauge-design.md
+++ b/docs/superpowers/specs/2026-07-28-ws2-plugin-recreation-gauge-design.md
@@ -1,0 +1,161 @@
+# Design — WS2 v1: Plugin-recreation (radial gauge, end-to-end)
+
+Status: **proposed** · Date: 2026-07-28 · Branch: `feat/ws2-plugin-recreation`
+
+## Provenance / why
+
+Reviewing `cmiller-coder/millersigma` surfaced Sigma custom plugins
+(`@sigmacomputing/plugin`) as a way to recreate a source-tool custom viz that
+Sigma has **no native equivalent** for — turning a "scoped-to-native /
+`warn+skip` / dropped" migration gap into a parity win. WS1 (comparative KPI
+cards) is shipped; this is WS2's first slice: prove the **greenfield plugin
+lifecycle** end-to-end on ONE archetype (a **radial gauge / progress-to-target**),
+then generalize.
+
+Techniques/patterns from millersigma only — no code lifted (its `LICENSE` is
+empty → effectively all-rights-reserved). The archetype is clean-room, generic
+demo data, **no customer names**.
+
+## Scope decision (v1)
+
+One archetype (radial gauge), end-to-end, to de-risk the unproven plugin
+lifecycle before investing in an archetype library. (User's choice.)
+
+Scout finding that motivates the gauge pick: on the live Tableau site, genuinely
+non-native viz are either **license-gated** (the "Viz Extensions Edition"
+dashboard's LaDataViz gauge / RFM score-meters render as "Get a license"
+placeholders — nothing to parity against) or the dashboards are fully
+native-representable (the "Call Center" dashboard is KPI+sparkline+WoW = WS1
+territory). The gauge / "% to target" is the non-native pattern actually present,
+is the most common exec/ops form, and is simple enough that v1 effort goes into
+the **lifecycle**, not viz complexity. Because the one real instance is
+license-gated, v1 anchors its end-to-end on a **real warehouse metric-vs-target**
+(the WS1 approach), not that specific dashboard.
+
+## Goal (v1)
+
+Prove the migration converters can turn a non-native gauge viz into a working
+Sigma plugin: a gauge source-kind resolves via the coverage catalog to
+`plugin:gauge` instead of `warn+skip`, and the pipeline emits a **registered,
+hosted, data-bound** Sigma plugin element whose value-vs-target renders correctly
+on real warehouse data. **Success = a live Sigma workbook with a gauge plugin
+bound to a real metric + target, data-parity-verified.**
+
+## Approach (chosen)
+
+Mirror WS1: a **shared emitter + a tool-agnostic authoring skill**, proven
+E2E-first, then a minimal migration hook. Rejected alternatives: docs-only (the
+verified plugin shapes drift), and full-library-first (invests before the
+lifecycle is proven).
+
+## Components (v1)
+
+1. **`sigma-plugin-authoring` skill** — new, tool-agnostic, in
+   `plugins/sigma-authoring/skills/sigma-plugin-authoring`. The
+   build → register → host → embed → bind recipe, encoding the verified
+   lifecycle gotchas: single-file `@sigmacomputing/plugin`; **`ResizeObserver`
+   mandatory** (redraw on resize — the #1 "wonky plugin" cause); a **synthetic
+   fallback** so it previews standalone; register via
+   `POST /v2/plugins {name,description,url,type:"element"}` → `pluginId`
+   (a **masked HTTP 404 can accompany a successful register** → confirm via
+   `GET /v2/plugins` by name, idempotent); `url` is **set-once** (re-register to
+   change); embed shape
+   `{kind:"plugin", pluginId, config:{source:{kind:"element",elementId}, <binding>:"<columnId>"}}`
+   with **every `config` value a bare string** (object/column-object form is
+   rejected, masked as `Invalid kind:"plugin"`); the plugin's backing data
+   element on a **separate hidden page** (`visibleAsSource:false` does not hide
+   it from layout). Ships a `reference/` of these gotchas + the gauge as an
+   `examples/` exemplar.
+2. **`shared/lib/plugin_embed.{rb,py}`** — twin emitter (stdlib-only, Ruby 2.6,
+   golden-fixture tested — the WS1 `kpi_card` pattern) that produces the verified
+   plugin element block. Coerces **all `config` values to strings**; bindings are
+   bare `columnId` strings; `source:{kind:"element",elementId}`.
+3. **One clean-room gauge plugin** — a single-file `index.html`
+   (`@sigmacomputing/plugin` via CDN) under the skill's `plugins/gauge/`. Editor
+   panel: an `element` data source + `value` + `target` column bindings
+   (+ optional `min`/`max`/`format`). Renders a radial arc with a RAG color and
+   the value + target; `ResizeObserver` redraw; synthetic fallback. Generic data.
+4. **`recreate-as-plugin` coverage-catalog disposition** — extend the
+   `coverage_catalog` resolver (`shared/lib/coverage_catalog.{rb,py}`) so a row
+   whose `sigma` is `plugin:<archetype>` (e.g. `plugin:gauge`) is recognized as a
+   *recreate-as-plugin* target — distinct from a native-kind target and from a
+   `warn+skip` miss. Wire ONE source tool's `viz-kind.json` with a
+   gauge→`plugin:gauge` row (candidate: `powerbi` `gauge` or `quicksight`
+   `GaugeChartVisual` — decide in planning). The gap-scan then surfaces "recreate
+   as plugin: gauge" instead of dropping it.
+5. **Registration helper** — a small script (in the skill or `shared/scripts`)
+   wrapping `POST /v2/plugins` + the masked-404 confirm-via-`GET`, returning a
+   `pluginId`; idempotent (GET-by-name first).
+6. **Hosting** — **handoff by default** (emit the plugin bundle + the exact
+   host + register steps; localhost for local preview), **turnkey opt-in**
+   (automate a static deploy + register) as a fast-follow. v1 proves the
+   lifecycle with a hosted (localhost or static) gauge.
+7. **Parity** — **data-parity HARD** on the gauge's bound element (export the
+   value + target columns, compare to the source/warehouse) + **visual soft**
+   (screenshot the rendered gauge). Reuses the WS1 export-verify loop.
+
+## Data flow (migration)
+
+```
+source gauge viz (non-native)
+  → viz-kind catalog resolves `plugin:gauge`  (not warn+skip)
+  → gap-scan surfaces "recreate as plugin: gauge"
+  → converter binds a data element (value + target columns from the DM)
+  → plugin_embed emits {kind:"plugin", pluginId, config:{source, value, target}}
+  → workbook spec → the registered+hosted gauge plugin renders value-vs-target
+  → C8: export the bound element (value/target correct vs warehouse) + screenshot
+```
+
+## Testing — E2E-first
+
+**Task 1 = a live GO/NO-GO proof, before wiring the catalog broadly** (the plugin
+lifecycle is greenfield — prove it end-to-end first):
+
+1. Build the gauge plugin (single-file), host it (localhost or a static host),
+   register it (`POST /v2/plugins` → `pluginId`, confirm via `GET`).
+2. POST a minimal Sigma workbook: a table over real warehouse data with a value
+   column + a target (column or constant), plus a plugin element bound to it via
+   `plugin_embed`.
+3. Export the bound element → assert the value + target are correct
+   (data-parity). **No faked green.**
+4. Screenshot → confirm the gauge renders the value-vs-target arc (visual soft).
+
+Only on GO: codify the emitter (golden-tested twins), the skill docs, and the
+`recreate-as-plugin` catalog wiring for one tool.
+
+**Unit tests:** `plugin_embed` twins emit sorted-key-identical JSON matching a
+golden fixture (incl. all-config-values-are-strings); the `coverage_catalog`
+resolver recognizes a `plugin:<archetype>` row as a recreate-as-plugin target
+(both twins). Wire the new lib tests into the CI `unit-tests` allow-list.
+
+## Error handling / guardrails
+
+- Registration masked-404 → confirm via `GET /v2/plugins` by name; never treat a
+  non-200 as a hard failure without the GET; idempotent.
+- All plugin `config` values emitted as **strings**; bindings bare `columnId`
+  strings (object form → masked `Invalid kind:"plugin"`).
+- Backing data element on a **separate hidden page**.
+- If registration is permission-gated (403) or no host is available, **fall back
+  to handoff** (emit bundle + exact steps) with a loud, honest note — never
+  silently drop the viz.
+- Conservative catalog: only source-kinds with a clear gauge semantic map to
+  `plugin:gauge`; ambiguous → `warn+skip` (unchanged).
+
+## Scope / YAGNI (v1)
+
+**In:** the `sigma-plugin-authoring` skill + reference; `plugin_embed` emitter
+(twins, golden-tested); ONE clean-room gauge plugin; the `recreate-as-plugin`
+disposition + ONE tool's `viz-kind` gauge row; the registration helper; the live
+E2E + unit tests; data-parity-hard + screenshot-soft.
+
+**Out (fast-follow):** more archetypes (heatmap, chord/sankey, gantt, rings,
+scatter-lasso); wiring the disposition across all source tools; turnkey static
+deploy automation; plugin→control interactivity binding (select-to-filter); the
+Netlify embed-portal.
+
+## Open questions (resolve in planning, non-blocking)
+
+- Which source tool + gauge source-kind to wire first (v1 picks one; `powerbi`
+  `gauge` or `quicksight` `GaugeChartVisual` are clean candidates).
+- Hosting for the v1 live proof: localhost (dev) is simplest and sufficient to
+  prove the lifecycle; a shareable static host is a turnkey fast-follow.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_catalog.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_catalog.rb
@@ -51,6 +51,19 @@ module Coverage
       r && r['sigma']
     end
 
+    # Return the recreate-as-plugin archetype for source_key, or nil. Honors an
+    # explicit `plugin_archetype` field on the row, or a `sigma` value of the
+    # form "plugin:<archetype>" (returns the part after the prefix). Additive —
+    # does not change resolve/target/resolve_or_warn's existing dispatch.
+    def plugin_archetype(source_key)
+      r = resolve(source_key)
+      return nil unless r
+      a = r['plugin_archetype']
+      return a unless a.to_s.empty?
+      s = r['sigma'].to_s
+      s.start_with?('plugin:') ? s.sub('plugin:', '') : nil
+    end
+
     # Resolve; on a miss append a standardized LOUD warning to `warnings` and
     # return nil. The caller MUST then skip/placeholder — makes the loud
     # fallback mandatory and uniform.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/coverage_catalog.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/coverage_catalog.rb
@@ -51,6 +51,19 @@ module Coverage
       r && r['sigma']
     end
 
+    # Return the recreate-as-plugin archetype for source_key, or nil. Honors an
+    # explicit `plugin_archetype` field on the row, or a `sigma` value of the
+    # form "plugin:<archetype>" (returns the part after the prefix). Additive —
+    # does not change resolve/target/resolve_or_warn's existing dispatch.
+    def plugin_archetype(source_key)
+      r = resolve(source_key)
+      return nil unless r
+      a = r['plugin_archetype']
+      return a unless a.to_s.empty?
+      s = r['sigma'].to_s
+      s.start_with?('plugin:') ? s.sub('plugin:', '') : nil
+    end
+
     # Resolve; on a miss append a standardized LOUD warning to `warnings` and
     # return nil. The caller MUST then skip/placeholder — makes the loud
     # fallback mandatory and uniform.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/shared/lib/coverage_catalog.py
+++ b/shared/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/shared/lib/coverage_catalog.rb
+++ b/shared/lib/coverage_catalog.rb
@@ -51,6 +51,19 @@ module Coverage
       r && r['sigma']
     end
 
+    # Return the recreate-as-plugin archetype for source_key, or nil. Honors an
+    # explicit `plugin_archetype` field on the row, or a `sigma` value of the
+    # form "plugin:<archetype>" (returns the part after the prefix). Additive —
+    # does not change resolve/target/resolve_or_warn's existing dispatch.
+    def plugin_archetype(source_key)
+      r = resolve(source_key)
+      return nil unless r
+      a = r['plugin_archetype']
+      return a unless a.to_s.empty?
+      s = r['sigma'].to_s
+      s.start_with?('plugin:') ? s.sub('plugin:', '') : nil
+    end
+
     # Resolve; on a miss append a standardized LOUD warning to `warnings` and
     # return nil. The caller MUST then skip/placeholder — makes the loud
     # fallback mandatory and uniform.

--- a/shared/lib/plugin_embed.py
+++ b/shared/lib/plugin_embed.py
@@ -1,0 +1,23 @@
+# plugin_embed.py — Python twin of shared/lib/plugin_embed.rb. Emits the
+# VERIFIED Sigma {kind:"plugin"} element block. ALL config values are bare
+# strings (object form is rejected, masked "Invalid kind:\"plugin\""). Twin
+# emits sorted-key-identical output (shared/lib/testdata/plugin_embed_golden.json).
+# Stdlib only (json); Windows-safe.
+import json
+
+
+def build(id, plugin_id, source_element_id, bindings, extra_config=None):
+    if not id:
+        raise ValueError("id required")
+    if not plugin_id:
+        raise ValueError("plugin_id required")
+    if not source_element_id:
+        raise ValueError("source_element_id required")
+
+    config = {"source": {"kind": "element", "elementId": source_element_id}}
+    for k, v in (bindings or {}).items():
+        config[str(k)] = str(v)  # bare string columnId
+    for k, v in (extra_config or {}).items():
+        config[str(k)] = str(v)  # ALL config values -> string
+
+    return {"id": id, "kind": "plugin", "pluginId": plugin_id, "config": config}

--- a/shared/lib/plugin_embed.rb
+++ b/shared/lib/plugin_embed.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# plugin_embed.rb — Ruby twin of shared/lib/plugin_embed.py. Emits the VERIFIED
+# Sigma {kind:"plugin"} element block. ALL config values are bare strings
+# (object form is rejected, masked "Invalid kind:\"plugin\""). Twin emits
+# sorted-key-identical output (shared/lib/testdata/plugin_embed_golden.json).
+# Stdlib only (json); Ruby 2.6-compatible.
+require 'json'
+module PluginEmbed
+  def self.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'plugin_id required' if plugin_id.to_s.empty?
+    raise ArgumentError, 'source_element_id required' if source_element_id.to_s.empty?
+    config = { 'source' => { 'kind' => 'element', 'elementId' => source_element_id } }
+    (bindings || {}).each { |k, v| config[k.to_s] = v.to_s }        # bare string columnId
+    (extra_config || {}).each { |k, v| config[k.to_s] = v.to_s }    # ALL config values -> string
+    { 'id' => id, 'kind' => 'plugin', 'pluginId' => plugin_id, 'config' => config }
+  end
+end

--- a/shared/lib/test_coverage_catalog.py
+++ b/shared/lib/test_coverage_catalog.py
@@ -95,6 +95,29 @@ class CoverageCatalogTest(unittest.TestCase):
         got = cc.default_catalog_dir(fake)
         self.assertTrue(got.endswith(os.path.join("skills", "x", "refs", "catalogs")))
 
+    def test_plugin_archetype(self):
+        _write_catalog(
+            self.dir, "viz-kind-plugin",
+            [
+                {"source": "GaugeChartVisual", "sigma": "kpi-chart", "plugin_archetype": "gauge"},
+                {"source": "HeatMapVisual", "sigma": "plugin:heatmap"},
+                {"source": "BarChartVisual", "sigma": "bar-chart"},
+            ],
+            dimension="viz-kind", source_tool="quicksight",
+        )
+        cat = cc.load(self.dir, "viz-kind-plugin")
+        # explicit plugin_archetype field wins
+        self.assertEqual(cat.plugin_archetype("GaugeChartVisual"), "gauge")
+        # sigma "plugin:<x>" prefix -> archetype
+        self.assertEqual(cat.plugin_archetype("HeatMapVisual"), "heatmap")
+        # plain native row -> None
+        self.assertIsNone(cat.plugin_archetype("BarChartVisual"))
+        # miss -> None
+        self.assertIsNone(cat.plugin_archetype("NopeVisual"))
+        # non-breaking: target/resolve for the gauge row still return "kpi-chart"
+        self.assertEqual(cat.target("GaugeChartVisual"), "kpi-chart")
+        self.assertEqual(cat.resolve("GaugeChartVisual")["sigma"], "kpi-chart")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/shared/lib/test_coverage_catalog.rb
+++ b/shared/lib/test_coverage_catalog.rb
@@ -59,6 +59,24 @@ Dir.mktmpdir('cc-rb-test-') do |dir|
   check('default_catalog_dir') do
     Coverage.default_catalog_dir('/a/b/skills/x/scripts/build.rb').end_with?(File.join('skills', 'x', 'refs', 'catalogs'))
   end
+
+  File.write(File.join(dir, 'viz-kind-plugin.json'), JSON.dump(
+    'dimension' => 'viz-kind', 'source_tool' => 'quicksight',
+    'rows' => [
+      { 'source' => 'GaugeChartVisual', 'sigma' => 'kpi-chart', 'plugin_archetype' => 'gauge' },
+      { 'source' => 'HeatMapVisual', 'sigma' => 'plugin:heatmap' },
+      { 'source' => 'BarChartVisual', 'sigma' => 'bar-chart' }
+    ]
+  ))
+  pcat = Coverage.load(dir, 'viz-kind-plugin')
+
+  check('plugin_archetype: explicit field wins') { pcat.plugin_archetype('GaugeChartVisual') == 'gauge' }
+  check('plugin_archetype: sigma "plugin:<x>" prefix') { pcat.plugin_archetype('HeatMapVisual') == 'heatmap' }
+  check('plugin_archetype: plain native row -> nil') { pcat.plugin_archetype('BarChartVisual').nil? }
+  check('plugin_archetype: miss -> nil') { pcat.plugin_archetype('NopeVisual').nil? }
+  check('non-breaking: target/resolve for gauge row still "kpi-chart"') do
+    pcat.target('GaugeChartVisual') == 'kpi-chart' && pcat.resolve('GaugeChartVisual')['sigma'] == 'kpi-chart'
+  end
 end
 
 if $failures.zero?

--- a/shared/lib/test_plugin_embed.py
+++ b/shared/lib/test_plugin_embed.py
@@ -1,0 +1,43 @@
+import json, os, sys, unittest
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import plugin_embed
+
+def _sort(o):
+    if isinstance(o, dict):
+        return {k: _sort(o[k]) for k in sorted(o)}
+    if isinstance(o, list):
+        return [_sort(e) for e in o]
+    return o
+
+class PluginEmbedTest(unittest.TestCase):
+    def setUp(self):
+        with open(os.path.join(os.path.dirname(__file__), "testdata", "plugin_embed_golden.json")) as f:
+            self.golden = json.load(f)
+
+    def test_gauge_matches_golden(self):
+        el = plugin_embed.build(id="gauge-el", plugin_id="pl-1", source_element_id="tbl-1",
+                                 bindings={"value": "actual", "target": "target"},
+                                 extra_config={"format": "$.3~s"})
+        self.assertEqual(json.dumps(_sort(el)), json.dumps(_sort(self.golden)))
+
+    def test_numeric_extra_config_coerced_to_string(self):
+        el = plugin_embed.build(id="gauge-el", plugin_id="pl-1", source_element_id="tbl-1",
+                                 bindings={"value": "actual"},
+                                 extra_config={"decimals": 2})
+        self.assertEqual(el["config"]["decimals"], "2")
+        self.assertIsInstance(el["config"]["decimals"], str)
+
+    def test_empty_id_raises(self):
+        with self.assertRaises(ValueError):
+            plugin_embed.build(id="", plugin_id="pl-1", source_element_id="tbl-1", bindings={})
+
+    def test_empty_plugin_id_raises(self):
+        with self.assertRaises(ValueError):
+            plugin_embed.build(id="gauge-el", plugin_id="", source_element_id="tbl-1", bindings={})
+
+    def test_empty_source_element_id_raises(self):
+        with self.assertRaises(ValueError):
+            plugin_embed.build(id="gauge-el", plugin_id="pl-1", source_element_id="", bindings={})
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/shared/lib/test_plugin_embed.rb
+++ b/shared/lib/test_plugin_embed.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+# test_plugin_embed.rb — run directly: ruby shared/lib/test_plugin_embed.rb
+require 'json'
+require_relative 'plugin_embed'
+
+$failures = 0
+def check(desc)
+  ok = yield
+  puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}")
+  $failures += 1 unless ok
+end
+
+# Deep-sort hashes/arrays so twin/golden comparison is key-order-independent.
+def sort_deep(o)
+  case o
+  when Hash then o.keys.sort.each_with_object({}) { |k, h| h[k] = sort_deep(o[k]) }
+  when Array then o.map { |e| sort_deep(e) }
+  else o
+  end
+end
+
+golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'plugin_embed_golden.json')))
+
+check('gauge plugin embed matches golden (sorted-key identical)') do
+  el = PluginEmbed.build(id: 'gauge-el', plugin_id: 'pl-1', source_element_id: 'tbl-1',
+                          bindings: { 'value' => 'actual', 'target' => 'target' },
+                          extra_config: { 'format' => '$.3~s' })
+  JSON.generate(sort_deep(el)) == JSON.generate(sort_deep(golden))
+end
+
+check('numeric extra_config value is coerced to a string') do
+  el = PluginEmbed.build(id: 'gauge-el', plugin_id: 'pl-1', source_element_id: 'tbl-1',
+                          bindings: { 'value' => 'actual' },
+                          extra_config: { 'decimals' => 2 })
+  el['config']['decimals'] == '2' && el['config']['decimals'].is_a?(String)
+end
+
+check('empty id raises ArgumentError') do
+  begin
+    PluginEmbed.build(id: '', plugin_id: 'pl-1', source_element_id: 'tbl-1', bindings: {})
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+check('empty plugin_id raises ArgumentError') do
+  begin
+    PluginEmbed.build(id: 'gauge-el', plugin_id: '', source_element_id: 'tbl-1', bindings: {})
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+check('empty source_element_id raises ArgumentError') do
+  begin
+    PluginEmbed.build(id: 'gauge-el', plugin_id: 'pl-1', source_element_id: '', bindings: {})
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+exit($failures.zero? ? 0 : 1)

--- a/shared/lib/testdata/plugin_embed_golden.json
+++ b/shared/lib/testdata/plugin_embed_golden.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "format": "$.3~s",
+    "source": {
+      "elementId": "tbl-1",
+      "kind": "element"
+    },
+    "target": "target",
+    "value": "actual"
+  },
+  "id": "gauge-el",
+  "kind": "plugin",
+  "pluginId": "pl-1"
+}

--- a/shared/scripts/register-plugin.rb
+++ b/shared/scripts/register-plugin.rb
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# register-plugin.rb — idempotent Sigma custom-plugin registration helper
+# (WS2 "plugin-recreation" Task 4).
+#
+# Extracts the inline register/confirm dance already proven live in
+# `verify-plugin-gauge-e2e.rb` (Task 1 — see `plugins_by_name` /
+# `register_plugin` there) into a reusable module + CLI, so other
+# scripts/skills that need to register a Sigma plugin don't have to
+# re-derive the masked-404-tolerant confirmation logic.
+#
+# PluginRegister.register_or_get(name:, description:, url:) is IDEMPOTENT:
+#   1. GET /v2/plugins first — if a plugin with this exact `name` already
+#      exists, return its pluginId. Never creates a duplicate.
+#   2. Else POST /v2/plugins {name,description,url,type:"element"}, then
+#      re-GET /v2/plugins and find by name. A non-2xx POST is NEVER treated
+#      as a hard failure by itself — Sigma is documented to sometimes return
+#      a masked 404 (or other error) on an otherwise-successful register, so
+#      the confirming GET is always attempted before deciding.
+#   3. Only if, after POST+GET, the plugin still isn't found AND the POST
+#      response clearly indicated an auth/permission failure (401/403) does
+#      this raise PluginRegister::PermissionError: "plugin registration is
+#      permission-gated (org-admin) — <detail>". Any other unresolved case
+#      raises a plain error (never a faked pluginId).
+#
+# Usage (library):
+#   $LOAD_PATH.unshift File.expand_path('../scripts', __dir__)  # adjust as needed
+#   require 'register-plugin'
+#   plugin_id = PluginRegister.register_or_get(
+#     name: "My Plugin", description: "...", url: "https://example.com/plugin/"
+#   )
+#
+# Usage (CLI):
+#   ruby shared/scripts/register-plugin.rb "<name>" "<url>" ["<description>"]
+#   -> prints the pluginId to stdout on success (exit 0); on failure, prints
+#      an error to stderr and exits non-zero.
+#
+# Env: SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET (or
+#      ~/.sigma-migration/env — sigma_rest.rb self-bootstraps).
+#
+# Cross-reference: shared/scripts/verify-plugin-gauge-e2e.rb (WS2 Task 1) is
+# the origin of this logic and the live-proven reference implementation;
+# consumers should prefer this helper over re-inlining the same dance.
+
+require 'json'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'sigma_rest'
+
+module PluginRegister
+  # Raised only when a POST /v2/plugins failure is unambiguously an auth/
+  # permission problem (401/403) AND the confirming GET also came up empty.
+  class PermissionError < StandardError; end
+
+  module_function
+
+  # Look up a plugin by exact `name` via GET /v2/plugins. Returns the plugin
+  # Hash (with at least a 'pluginId' or 'id' key) or nil if none matches.
+  def find_by_name(name)
+    list = Sigma.request(:get, '/v2/plugins?pageSize=1000')
+    list = (JSON.parse(list) rescue nil) if list.is_a?(String)
+    entries = (list.is_a?(Hash) && (list['entries'] || list['plugins'])) || []
+    entries.find { |p| p['name'] == name }
+  end
+
+  # Idempotent register-or-get. Returns the pluginId (String). Raises
+  # PermissionError on a confirmed 401/403 with no plugin found afterward, or
+  # a plain RuntimeError for any other unresolved failure.
+  def register_or_get(name:, description:, url:)
+    existing = find_by_name(name)
+    existing_id = existing && (existing['pluginId'] || existing['id'])
+    return existing_id if existing_id
+
+    post_error = nil
+    begin
+      Sigma.request(:post, '/v2/plugins',
+                    body: JSON.generate(name: name, description: description, url: url, type: 'element'))
+    rescue Sigma::Error => e
+      # Never trust the POST's own status — the masked-404 quirk means even a
+      # successful register can raise here. Always fall through to the
+      # confirming GET below before deciding anything.
+      post_error = e
+    end
+
+    plugin = find_by_name(name)
+    plugin_id = plugin && (plugin['pluginId'] || plugin['id'])
+    return plugin_id if plugin_id
+
+    if post_error && post_error.message =~ /-> (401|403)\b/
+      raise PermissionError,
+            "plugin registration is permission-gated (org-admin) — #{post_error.message[0, 300]}"
+    end
+
+    raise "plugin registration failed: could not confirm pluginId for #{name.inspect} via " \
+          "GET /v2/plugins after POST#{post_error ? " (POST raised: #{post_error.message[0, 300]})" : ' (POST returned 2xx)'}"
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  name        = ARGV[0]
+  url         = ARGV[1]
+  description = ARGV[2] || ''
+
+  if name.nil? || url.nil?
+    warn 'Usage: ruby register-plugin.rb "<name>" "<url>" ["<description>"]'
+    exit 2
+  end
+
+  begin
+    plugin_id = PluginRegister.register_or_get(name: name, description: description, url: url)
+    puts plugin_id
+  rescue PluginRegister::PermissionError => e
+    warn e.message
+    exit 1
+  rescue StandardError => e
+    warn "register-plugin failed: #{e.message}"
+    exit 1
+  end
+end

--- a/shared/scripts/verify-plugin-gauge-e2e.rb
+++ b/shared/scripts/verify-plugin-gauge-e2e.rb
@@ -1,0 +1,519 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-plugin-gauge-e2e.rb — LIVE GO/NO-GO E2E proof of the Sigma custom
+# plugin lifecycle (WS2 "plugin-recreation" Task 1 — the gate for the whole
+# workstream). Creds-gated: needs live Sigma + a warehouse connection, so it
+# is NOT part of the offline CI corpus.
+#
+# Proves, against a live Sigma org, that a bespoke `@sigmacomputing/plugin`
+# can be:
+#   1. HOSTED somewhere Sigma can be told a URL for.
+#   2. REGISTERED — POST /v2/plugins -> pluginId (tolerating the documented
+#      "masked HTTP 404 on a successful register" quirk; a real 403 means
+#      registration is org-admin-gated — reported as a hard NO-GO).
+#   3. EMBEDDED in a workbook, bound to a real data element (bare-string
+#      `config` values only — the object form is silently rejected).
+#   4. DATA-PARITY VERIFIED (HARD GATE) — the bound element is exported and
+#      its actual/target values are compared against the known literals.
+#      This is the gate that must pass for GO; it does NOT depend on the
+#      plugin's host being reachable (it only exports the backing table).
+#   5. Screenshotted (BEST-EFFORT, soft) — only when the plugin's host is
+#      genuinely public, since Sigma's server-side PNG renderer cannot reach
+#      localhost.
+#
+# HOST NOTES (why this run picked what it picked):
+#   `netlify`/`vercel`/`surge` were not installed/authenticated in this
+#   environment. `ngrok` WAS authenticated, so it was evaluated as a public
+#   tunnel — but a live check (GET through the tunnel with a real browser
+#   User-Agent) showed ngrok's free-tier interstitial "visit site" warning
+#   page instead of the plugin content. Sigma's render server can't send the
+#   `ngrok-skip-browser-warning` header a human browser would, so a free
+#   ngrok tunnel does NOT count as a genuinely public host here — this
+#   script verifies that live (see `genuinely_public?`) rather than assuming
+#   it, and falls back to localhost when the tunnel fails the check.
+#
+# Usage:  ruby shared/scripts/verify-plugin-gauge-e2e.rb
+# Env:    SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET (or
+#         ~/.sigma-migration/env — sigma_rest.rb self-bootstraps);
+#         SIGMA_TEST_CONNECTION_ID (Snowflake; defaults to the shared demo
+#         test connection).
+# Exit:   0 = lifecycle proven (registered + embedded + bound +
+#         data-parity passed). 1 = NO-GO, raw evidence printed above the
+#         verdict — never a faked green.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+require 'tmpdir'
+require 'socket'
+require 'time'
+require 'shellwords'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'sigma_rest'
+require 'export_pool'
+require_relative 'register-plugin'
+
+RUN_TAG        = Time.now.utc.strftime('%Y%m%dT%H%M%SZ')
+PLUGIN_NAME    = "WS2 gauge (e2e) #{RUN_TAG}"
+CONNECTION_ID  = ENV.fetch('SIGMA_TEST_CONNECTION_ID', '362d859b-f432-4657-8e58-efc8535aa354')
+SRC_ELEMENT_ID = 'tbl-src'
+GAUGE_EL_ID    = 'gauge-el'
+PAGE_ID        = 'pg-1'
+
+def log(msg)
+  $stderr.puts("[verify-plugin-gauge-e2e] #{msg}")
+end
+
+GAUGE_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <head>
+  <meta charset="utf-8">
+  <title>WS2 gauge (e2e stub)</title>
+  <style>
+    html,body{margin:0;padding:0;width:100%;height:100%;background:#fff;font-family:sans-serif;overflow:hidden}
+    #wrap{width:100%;height:100%;display:flex;align-items:center;justify-content:center}
+    #lbl{position:absolute;bottom:8px;left:0;right:0;text-align:center;font-size:12px;color:#555}
+  </style>
+  </head>
+  <body>
+  <div id="wrap"><svg id="gauge" viewBox="0 0 200 120"></svg></div>
+  <div id="lbl"></div>
+  <!-- React MUST load before the SDK: @sigmacomputing/plugin's UMD build has
+       React as a hard peer dep and throws at load without it, leaving
+       window.SigmaPlugin with no `client` (plugin then always synths). -->
+  <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+  <script>
+  // Temporary Task-1 stub — a minimal but real gauge, just enough to prove
+  // the lifecycle. The clean-room production plugin lands in Task 2.
+  function synth() { return { value: 82, target: 100 }; }
+
+  function polar(cx, cy, r, deg) {
+    var rad = (deg - 180) * Math.PI / 180;
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+  }
+  function arcPath(cx, cy, r, startDeg, endDeg) {
+    var s = polar(cx, cy, r, endDeg), e = polar(cx, cy, r, startDeg);
+    var large = (endDeg - startDeg) <= 180 ? 0 : 1;
+    return ['M', s.x, s.y, 'A', r, r, 0, large, 0, e.x, e.y].join(' ');
+  }
+
+  function render(value, target) {
+    var svg = document.getElementById('gauge');
+    var frac = target > 0 ? Math.max(0, Math.min(1, value / target)) : 0;
+    var color = frac >= 1 ? '#22c55e' : (frac >= 0.6 ? '#eab308' : '#ef4444');
+    svg.innerHTML =
+      '<path d="' + arcPath(100, 100, 80, 0, 180) + '" stroke="#e5e7eb" stroke-width="16" fill="none"/>' +
+      '<path d="' + arcPath(100, 100, 80, 0, 180 * frac) + '" stroke="' + color + '" stroke-width="16" fill="none"/>' +
+      '<text x="100" y="90" text-anchor="middle" font-size="28" fill="#111">' + value + '</text>' +
+      '<text x="100" y="112" text-anchor="middle" font-size="12" fill="#666">of ' + target + '</text>';
+    document.getElementById('lbl').textContent = 'value=' + value + ' target=' + target;
+  }
+
+  var s0 = synth(); render(s0.value, s0.target);   // immediate paint (standalone / pre-data)
+  var client = (window.SigmaPlugin && window.SigmaPlugin.client) ||
+               (window.Sigma && window.Sigma.client) || null;
+
+  if (client) {
+    client.config.configureEditorPanel([
+      { name: 'source', type: 'element' },
+      { name: 'value', type: 'column', source: 'source', allowMultiple: false },
+      { name: 'target', type: 'column', source: 'source', allowMultiple: false }
+    ]);
+    client.config.subscribe(function (cfg) {
+      if (!cfg || !cfg.source) { var s = synth(); render(s.value, s.target); return; }
+      client.elements.subscribeToElementData(cfg.source, function (data) {
+        try {
+          var vc = cfg.value, tc = cfg.target;
+          if (data && vc && tc && data[vc] && data[tc] && data[vc].length) {
+            render(Number(data[vc][0]), Number(data[tc][0]));
+          } else { var s = synth(); render(s.value, s.target); }
+        } catch (e) { var s = synth(); render(s.value, s.target); }
+      });
+    });
+  }
+
+  new ResizeObserver(function () {
+    var el = document.getElementById('lbl');
+    var last = el.textContent.match(/value=(-?\\d+(\\.\\d+)?) target=(-?\\d+(\\.\\d+)?)/);
+    if (last) render(Number(last[1]), Number(last[3]));
+  }).observe(document.body);
+  </script>
+  </body>
+  </html>
+HTML
+
+# ---------------------------------------------------------------------------
+# Step 1: host the stub somewhere Sigma can be told a URL for.
+# ---------------------------------------------------------------------------
+
+def free_port
+  s = TCPServer.new('127.0.0.1', 0)
+  port = s.addr[1]
+  s.close
+  port
+end
+
+def wait_for(url, tries: 20, sleep_s: 0.25)
+  tries.times do
+    begin
+      res = Net::HTTP.get_response(URI(url))
+      return true if res.code.to_i == 200
+    rescue StandardError
+      # not up yet
+    end
+    sleep sleep_s
+  end
+  false
+end
+
+# Real (not assumed) check that a URL serves OUR content to a browser-like
+# client, rather than e.g. an ngrok free-tier interstitial warning page.
+def genuinely_public?(url)
+  uri = URI(url)
+  req = Net::HTTP::Get.new(uri)
+  req['User-Agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' \
+                      '(KHTML, like Gecko) Chrome/124.0 Safari/537.36'
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 15) do |h|
+    h.request(req)
+  end
+  res.code.to_i == 200 && res.body.to_s.include?('WS2 gauge (e2e stub)')
+rescue StandardError => e
+  log "genuinely_public? check raised: #{e.message}"
+  false
+end
+
+def netlify_authed?
+  return false if `which netlify 2>/dev/null`.strip.empty?
+  out = `netlify status 2>&1`
+  $?.success? && out !~ /not logged in/i
+rescue StandardError
+  false
+end
+
+def ngrok_authed?
+  return false if `which ngrok 2>/dev/null`.strip.empty?
+  `ngrok config check 2>&1` =~ /Valid configuration/i ? true : false
+rescue StandardError
+  false
+end
+
+def start_ngrok(port)
+  pid = spawn('ngrok', 'http', port.to_s, '--log=stdout',
+              out: File::NULL, err: File::NULL)
+  public_url = nil
+  30.times do
+    begin
+      res = Net::HTTP.get_response(URI('http://127.0.0.1:4040/api/tunnels'))
+      if res.code.to_i == 200
+        data = JSON.parse(res.body)
+        t = (data['tunnels'] || []).find { |x| x['proto'] == 'https' } ||
+            (data['tunnels'] || []).first
+        public_url = t && t['public_url']
+      end
+    rescue StandardError
+      nil
+    end
+    break if public_url
+    sleep 0.5
+  end
+  [pid, public_url]
+end
+
+def host_stub
+  dir = Dir.mktmpdir('ws2-gauge-')
+  FileUtils.mkdir_p(File.join(dir, 'gauge'))
+  File.write(File.join(dir, 'gauge', 'index.html'), GAUGE_HTML)
+  port = free_port
+  http_pid = spawn('python3', '-m', 'http.server', port.to_s, chdir: dir,
+                    out: File::NULL, err: File::NULL)
+  local_url = "http://localhost:#{port}/gauge/"
+  raise "local http.server on port #{port} never came up" unless wait_for(local_url)
+  log "local stub serving at #{local_url}"
+
+  pids = [http_pid]
+
+  # netlify/vercel/surge preferred if authenticated — none available here.
+  if netlify_authed?
+    log 'netlify CLI authenticated — turnkey deploy not implemented in this ' \
+        'script; falling back to localhost (see report).'
+  end
+
+  if ngrok_authed?
+    log 'ngrok is authenticated — attempting a public tunnel...'
+    ngrok_pid, tunnel_url = start_ngrok(port)
+    if tunnel_url
+      pids << ngrok_pid
+      if genuinely_public?("#{tunnel_url}/gauge/")
+        log "ngrok tunnel #{tunnel_url} verified genuinely public (serves our content to a browser UA)."
+        return { url: "#{tunnel_url}/gauge/", public: true, pids: pids, note: 'ngrok public tunnel' }
+      else
+        log 'ngrok tunnel did NOT serve our content to a browser User-Agent ' \
+            '(free-tier interstitial confirmed live) — not counted as public. ' \
+            'Falling back to localhost.'
+      end
+    else
+      log 'ngrok did not produce a tunnel URL in time — falling back to localhost.'
+    end
+  else
+    log 'no public static-host CLI authenticated (netlify/vercel/surge/ngrok) — using localhost.'
+  end
+
+  { url: local_url, public: false, pids: pids,
+    note: 'localhost only — data-parity still provable; visual step will SKIP' }
+end
+
+# ---------------------------------------------------------------------------
+# Step 2: register the plugin (tolerate the masked-404-on-success quirk; a
+# real 403 is a hard NO-GO — registration is org-admin-gated).
+# ---------------------------------------------------------------------------
+
+# Thin wrapper around the shared PluginRegister.register_or_get helper
+# (register-plugin.rb), which is the live-proven origin of this exact
+# register/confirm dance — reusing it instead of re-inlining keeps the
+# masked-404-tolerant confirmation logic in one place. Maps register_or_get's
+# return/raise shape back onto the {forbidden:, plugin:} shape this script's
+# caller (below) already expects, so downstream behavior is unchanged.
+def register_plugin(name, description, url)
+  plugin_id = PluginRegister.register_or_get(name: name, description: description, url: url)
+  { forbidden: false, plugin: { 'pluginId' => plugin_id, 'name' => name } }
+rescue PluginRegister::PermissionError => e
+  { forbidden: true, detail: e.message }
+rescue StandardError => e
+  # Any other unresolved failure (register_or_get already retried the
+  # confirming GET internally) — surface as "not found", same as the old
+  # inline version's `{ forbidden: false, plugin: nil }` fallthrough.
+  log "register_or_get raised (not a permission error): #{e.message[0, 300]}"
+  { forbidden: false, plugin: nil }
+end
+
+# ---------------------------------------------------------------------------
+# Step 3: POST a minimal workbook — custom-SQL table (known literals) + the
+# plugin element bound to it. POST/PUT /v2/workbooks/spec is documented to
+# return YAML — never JSON.parse it directly; scrape workbookId instead.
+# ---------------------------------------------------------------------------
+
+def home_folder_id
+  me = Sigma.request(:get, '/v2/whoami')
+  uid = me && me['userId']
+  raise 'could not resolve userId from /v2/whoami' unless uid
+  mem = Sigma.request(:get, "/v2/members/#{uid}")
+  home = mem && mem['homeFolderId']
+  raise 'could not resolve homeFolderId' unless home
+  home
+end
+
+def reference_schema_version
+  wbs = Sigma.request(:get, '/v2/workbooks?limit=10')
+  entries = (wbs && (wbs['entries'] || wbs['workbooks'])) || []
+  entries.each do |w|
+    wid = w['workbookId'] || w['id']
+    next unless wid
+    spec = (Sigma.request(:get, "/v2/workbooks/#{wid}/spec", accept: 'application/json') rescue nil)
+    return spec['schemaVersion'] if spec.is_a?(Hash) && spec['schemaVersion']
+  end
+  raise 'could not discover schemaVersion from any existing workbook'
+end
+
+# POST/PUT /v2/workbooks/spec: response is documented as YAML. Never rely on
+# Sigma.request's accept:'application/json' auto-parse here (it would raise
+# on a YAML body) — request a non-JSON accept so the raw string always comes
+# back, then self-parse (JSON first in case the org actually returns JSON,
+# else scrape `workbookId:` out of the YAML text). A non-JSON response body
+# is NOT treated as a failure.
+def post_or_put_workbook_spec(method, path, spec_hash)
+  raw = Sigma.request(method, path, body: JSON.generate(spec_hash),
+                                     content_type: 'application/json', accept: 'application/yaml')
+  parsed = (JSON.parse(raw) rescue nil)
+  return parsed if parsed.is_a?(Hash) && parsed['workbookId']
+  m = raw.to_s.match(/^\s*workbookId:\s*"?'?([\w-]+)"?'?\s*$/)
+  raise "no workbookId in #{method.upcase} response: #{raw.to_s[0, 500]}" unless m
+  { 'workbookId' => m[1], 'raw' => raw }
+end
+
+# NOTE — the 82/100 test literals below are the SAME numbers GAUGE_HTML's
+# synth() fallback renders (see above). That coincidence is exactly what let
+# the original silent-synth bug hide in plain sight: a screenshot of the
+# broken plugin (client undefined, always synthing) looked identical to a
+# screenshot of a working one bound to this source. A screenshot — even a
+# genuinely live one — cannot distinguish "reading real data" from "showing
+# the synthetic fallback" here; export_and_check's element-level data-parity
+# assertion below is the actual gate.
+def build_spec(home, schema_version, plugin_id, actual_formula, target_formula)
+  {
+    'name' => "WS2 gauge plugin lifecycle — E2E proof (#{RUN_TAG})",
+    'folderId' => home,
+    'schemaVersion' => schema_version,
+    'description' => 'Live proof: register/embed/bind/data-parity a custom Sigma plugin. Throwaway test artifact.',
+    'pages' => [
+      {
+        'id' => PAGE_ID,
+        'name' => 'WS2 Gauge E2E',
+        'elements' => [
+          {
+            'id' => SRC_ELEMENT_ID, 'kind' => 'table', 'name' => 'Gauge source (e2e)',
+            'source' => {
+              'kind' => 'sql', 'connectionId' => CONNECTION_ID,
+              'statement' => 'SELECT 82 AS actual, 100 AS target',
+            },
+            'columns' => [
+              { 'id' => 'actual', 'name' => 'Actual', 'formula' => actual_formula },
+              { 'id' => 'target', 'name' => 'Target', 'formula' => target_formula },
+            ],
+          },
+          {
+            'id' => GAUGE_EL_ID, 'kind' => 'plugin', 'pluginId' => plugin_id, 'name' => 'Gauge (e2e)',
+            'config' => {
+              'source' => { 'kind' => 'element', 'elementId' => SRC_ELEMENT_ID },
+              'value' => 'actual',
+              'target' => 'target',
+            },
+          },
+        ],
+      },
+    ],
+  }
+end
+
+# ---------------------------------------------------------------------------
+# Step 4: data-parity (HARD) — export the bound element, assert the numbers.
+# ---------------------------------------------------------------------------
+
+def export_and_check(wb, element_id, deadline_s: 60)
+  qid = ExportPool.start_json_export(wb, element_id, nil)
+  return { ok: false, reason: 'export POST did not return a queryId' } unless qid
+  deadline = ExportPool::Deadline.new(deadline_s)
+  status, body = ExportPool.poll_json_download(qid, deadline)
+  return { ok: false, reason: "poll status=#{status}", status: status } unless status == :ok
+  rows = ExportPool.parse_json_rows(body)
+  row = rows.first
+  return { ok: false, reason: 'export returned zero rows', rows: rows } unless row
+
+  actual_key = row.keys.find { |k| k.to_s.strip.casecmp('actual').zero? }
+  target_key = row.keys.find { |k| k.to_s.strip.casecmp('target').zero? }
+  actual_val = actual_key && row[actual_key]
+  target_val = target_key && row[target_key]
+  ok = actual_val.to_s.strip.to_f == 82.0 && target_val.to_s.strip.to_f == 100.0 &&
+       !actual_key.nil? && !target_key.nil?
+  { ok: ok, row: row, actual: actual_val, target: target_val, reason: ok ? nil : 'value mismatch or missing column' }
+end
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+verdict = { go: false }
+pids_to_kill = []
+
+begin
+  # --- Step 1: host -----------------------------------------------------
+  host = host_stub
+  pids_to_kill = host[:pids]
+  log "PLUGIN_URL = #{host[:url]} (public=#{host[:public]}) — #{host[:note]}"
+
+  # --- Step 2: register --------------------------------------------------
+  reg = register_plugin(PLUGIN_NAME, 'recreate-as-plugin gauge proof (WS2 Task 1 live E2E)', host[:url])
+  if reg[:forbidden]
+    verdict = { go: false, blocker: '403 registration permission-gated (org-admin only)', detail: reg[:detail],
+                host: host }
+    log "NO-GO: #{verdict[:blocker]} — #{reg[:detail]}"
+  elsif reg[:plugin].nil?
+    verdict = { go: false, blocker: 'plugin registration not found via GET /v2/plugins after POST (not a 403 — ' \
+                                     'unexplained)', host: host }
+    log "NO-GO: #{verdict[:blocker]}"
+  else
+    plugin = reg[:plugin]
+    plugin_id = plugin['pluginId'] || plugin['id']
+    log "plugin registered: pluginId=#{plugin_id} name=#{plugin['name'].inspect}"
+
+    # --- Step 3: workbook (with a small live-verified formula-prefix retry) --
+    home = home_folder_id
+    schema_version = reference_schema_version
+    log "home folder=#{home} schemaVersion=#{schema_version}"
+
+    candidates = [
+      ['[Custom SQL/Actual]', '[Custom SQL/Target]'],
+      ['[Custom SQL/ACTUAL]', '[Custom SQL/TARGET]'],
+      ['[Custom SQL/actual]', '[Custom SQL/target]'],
+      ['[actual]', '[target]'],
+    ]
+
+    wb = nil
+    parity = nil
+    tried = []
+    candidates.each_with_index do |(af, tf), i|
+      spec = build_spec(home, schema_version, plugin_id, af, tf)
+      method = wb.nil? ? :post : :put
+      path = wb.nil? ? '/v2/workbooks/spec' : "/v2/workbooks/#{wb}/spec"
+      begin
+        resp = post_or_put_workbook_spec(method, path, spec)
+      rescue StandardError => e
+        tried << { formulas: [af, tf], error: e.message[0, 400] }
+        log "#{method.upcase} attempt #{i + 1} (#{af}/#{tf}) raised: #{e.message[0, 300]}"
+        next
+      end
+      wb ||= resp['workbookId']
+      unless wb
+        tried << { formulas: [af, tf], error: "no workbookId in response: #{resp.inspect[0, 300]}" }
+        next
+      end
+      log "workbook #{wb} — attempt #{i + 1} formulas=#{af}/#{tf}"
+      result = (export_and_check(wb, SRC_ELEMENT_ID) rescue { ok: false, reason: $!.message })
+      tried << { formulas: [af, tf], result: result }
+      if result[:ok]
+        parity = result
+        log "data-parity PASSED with formulas #{af}/#{tf}: actual=#{result[:actual]} target=#{result[:target]}"
+        break
+      else
+        log "attempt #{i + 1} formulas=#{af}/#{tf} did not pass: #{result[:reason]} (row=#{result[:row].inspect})"
+      end
+    end
+
+    if parity.nil?
+      verdict = { go: false, blocker: 'data-parity FAILED for every candidate formula prefix — no faked green',
+                  workbook_id: wb, plugin_id: plugin_id, host: host, tried: tried }
+      log 'NO-GO: data-parity never passed (see attempts above).'
+    else
+      # --- Step 5: visual (best-effort) ------------------------------------
+      visual = { attempted: false }
+      if host[:public]
+        png_script = File.expand_path('sigma-export-png.py', __dir__)
+        out_png = File.join(Dir.tmpdir, "gauge-e2e-#{RUN_TAG}.png")
+        cmd = ['python3', png_script, '--workbook', wb, '--page', PAGE_ID, '--out', out_png]
+        log "public host — attempting screenshot: #{cmd.join(' ')}"
+        png_out = `#{cmd.map { |c| Shellwords.escape(c) }.join(' ')} 2>&1` rescue nil
+        ok_png = $?.success? && File.exist?(out_png)
+        visual = { attempted: true, ok: ok_png, path: (ok_png ? out_png : nil), log: png_out.to_s[0, 500] }
+        log(ok_png ? "screenshot saved to #{out_png}" : "screenshot attempt output: #{png_out}")
+      else
+        log 'SKIP visual (localhost not reachable by render server)'
+        visual = { attempted: false, skip_reason: 'localhost not reachable by render server' }
+      end
+
+      verdict = {
+        go: true, workbook_id: wb, plugin_id: plugin_id, host: host, parity: parity, visual: visual,
+        formulas_used: tried.last && tried.last[:formulas],
+      }
+    end
+  end
+ensure
+  pids_to_kill.each do |pid|
+    begin
+      Process.kill('TERM', pid)
+      Process.wait(pid)
+    rescue StandardError
+      nil
+    end
+  end
+end
+
+puts
+puts '=' * 78
+puts verdict[:go] ? 'GO' : 'NO-GO'
+puts '=' * 78
+puts JSON.pretty_generate(verdict)
+exit(verdict[:go] ? 0 : 1)


### PR DESCRIPTION
## What & why

Shared building blocks for the "recreate a viz as a plugin" capability: a `PluginEmbed.build`
emitter (Ruby + Python twins, bare-string config, golden-tested against a shared fixture), an
idempotent `register-plugin` helper that tolerates a masked 404 from the plugin-registration
endpoint, and a `coverage_catalog.plugin_archetype` recognizer that lets a catalog row opt in to
a higher-fidelity plugin-based recreation path. The recognizer is purely additive — it does not
change any existing `resolve`/`target`/`resolve_or_warn` dispatch — and the 8 vendored
`coverage_catalog` copies are re-synced to canonical to pick it up. Also included: the live E2E
lifecycle proof script and the design/plan docs for this workstream.

## Merge order

This is PR 1 of 3. PR 2 (sigma-authoring's `sigma-plugin-authoring` skill) stacks directly on
this branch. PR 3 (QuickSight gauge annotation) is independent of this one but its
`plugin_archetype: gauge` annotation is inert until this PR's recognizer lands.

## Scope

- Plugin(s) touched: none directly — shared-lib change, plus a re-sync of the 8 plugins that
  vendor `coverage_catalog` (gooddata-to-sigma, looker-to-sigma, microstrategy-to-sigma,
  powerbi-to-sigma, qlik-to-sigma, quicksight-to-sigma, sisense-to-sigma, thoughtspot-to-sigma).
- [x] This PR is an isolated shared-lib change (no feature work mixed in)

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] `ruby tools/lint-skills.rb` — green
- [x] `ruby shared/lib/test_plugin_embed.rb` / `.py`, `test_coverage_catalog.rb` / `.py` — all green
- [x] `bash tools/check-plugin-version-bump.sh <merge-base> HEAD` — green; the 8 re-synced
  plugins are unchanged in version but exempted via a `Skip-Version-Bump:` commit trailer
  (additive shared-lib method, no per-plugin behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)