### PR TITLE
feat(sigma-authoring): sigma-plugin-authoring skill (recreate-as-plugin) + gauge + SDK/pattern refs

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -291,6 +291,8 @@ jobs:
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-qs-trellis.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-metric-reference.rb
             shared/lib/test_metric_binding.rb
+            shared/lib/test_plugin_embed.rb
+            shared/lib/test_coverage_catalog.rb
             shared/lib/test_kpi_card.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-comparison-wiring.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-comparison-emit.rb
@@ -336,6 +338,8 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_metric_reference.py
             shared/lib/test_metric_binding.py
+            shared/lib/test_plugin_embed.py
+            shared/lib/test_coverage_catalog.py
             shared/lib/test_kpi_card.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -269,6 +269,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-conflicting-page-defaults.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-metric-reference.rb
+            plugins/sigma-authoring/skills/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb

--- a/docs/superpowers/plans/2026-07-28-ws2-plugin-recreation-gauge.md
+++ b/docs/superpowers/plans/2026-07-28-ws2-plugin-recreation-gauge.md
@@ -1,0 +1,234 @@
+# WS2 v1 — Plugin-recreation (radial gauge) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the migration converters can recreate a non-native gauge viz as a working, data-bound Sigma plugin — de-risking the greenfield `@sigmacomputing/plugin` lifecycle (build → register → host → embed → bind → render → parity) on one archetype before generalizing.
+
+**Architecture:** A clean-room single-file gauge plugin + a stdlib-only `shared/lib/plugin_embed` twin emitter (produces the verified `{kind:"plugin",pluginId,config:{...}}` element block) + a non-breaking `plugin_archetype` recognizer in `coverage_catalog` + a `plugin_archetype:"gauge"` annotation on QuickSight's `GaugeChartVisual` row + a registration helper. Proven E2E-first against live Sigma.
+
+**Tech Stack:** Ruby 2.6 (stdlib), Python 3 (stdlib), JS/HTML (`@sigmacomputing/plugin` via CDN), Sigma REST (`/v2/plugins`, `/v2/workbooks/spec`, `/v2/workbooks/{id}/export`, `/v2/query/{id}/download`), `shared/lib/sigma_rest` + `export_pool`, manifest-driven `sync-shared`/`check-shared`.
+
+## Global Constraints
+
+- **Ruby 2.6-compatible**, **stdlib only** for `shared/lib` (Ruby `require 'json'`; Python `import json`). Twins emit **sorted-key-identical** output (golden-fixture locked).
+- **No customer data / clean-room.** The gauge plugin + all fixtures use generic demo data; no customer names in code/commits.
+- **Verified plugin lifecycle gotchas** (bake in, do not rediscover): register via `POST /v2/plugins {name,description,url,type:"element"}` → `pluginId`; a **masked HTTP 404 can accompany a successful register** → confirm via `GET /v2/plugins` (by name); registration may be **403 permission-gated** (org-admin) → fall back to handoff, report honestly; the plugin `url` is **set-once** (re-register to change); embed shape `{kind:"plugin",pluginId,config:{source:{kind:"element",elementId}, <var>:"<columnId>"}}` with **every `config` value a bare string** (object/`{kind:"column"}` form is rejected, masked as `Invalid kind:"plugin"`); **`ResizeObserver` mandatory** (redraw on resize); **synthetic fallback** so the plugin previews standalone; the plugin's backing data element on a **separate hidden page** (`visibleAsSource:false` does not hide from layout).
+- **Hosting/render:** a **localhost**-hosted plugin renders only in a human browser that can reach it — Sigma's **server-side PNG export cannot reach localhost**. So: **data-parity on the bound element is the hard gate** (works with any host); the **headless plugin screenshot is best-effort and needs a public static host** (or a human-browser check).
+- **Shared governance:** a new `shared/lib` file is invisible until added to `shared/manifest.json`; after adding run `ruby tools/sync-shared.rb` then `ruby tools/check-shared.rb` (stays green). New `shared/lib` **unit tests are NOT manifested** but MUST be appended to the `unit-tests` allow-list arrays in `.github/workflows/corpus-check.yml`.
+- **After any SKILL.md edit**, run `ruby tools/gen-agent-variants.rb <skill-dir>`; verify with `ruby tools/check-agent-variants.rb`.
+- **Creds:** Sigma via env + `~/.sigma-migration/env` (Ruby libs self-mint). Branch: `feat/ws2-plugin-recreation` (worktree `/Users/tjwells/wt-ws2`). Commit per task.
+
+---
+
+### Task 1: Live GO/NO-GO E2E — the plugin lifecycle (GATE)
+
+Prove, against live Sigma, that a gauge plugin can be **registered, embedded, bound, and its bound data verified** — before building the machinery. **Gates every later task.** If registration is 403-permission-gated org-wide, or the embed shape is rejected, STOP and report (the premise needs the handoff path or an admin).
+
+**Files:**
+- Create: `shared/scripts/verify-plugin-gauge-e2e.rb` (creds-gated; NOT in the offline CI allow-list)
+- Consumes: `shared/lib/sigma_rest.rb`, `shared/lib/export_pool.rb`, a minimal gauge plugin (a temporary stub is fine for this task — the real one lands in Task 2), a `SIGMA_TEST_CONNECTION_ID` (Snowflake, e.g. `362d859b-f432-4657-8e58-efc8535aa354`)
+
+**Interfaces:**
+- Produces: exit 0 = lifecycle proven (registered + embedded + bound + data-parity); exit 1 = a NO-GO with the raw evidence.
+
+- [ ] **Step 1: Host a minimal gauge plugin reachable by Sigma's render server**
+
+Prefer a public static host so the render is headlessly screenshot-able. If a static-host CLI (e.g. `netlify`) is authenticated, deploy a one-file `gauge/index.html` stub (value+target bindings, an SVG arc, `ResizeObserver`, synthetic fallback) and record the public URL. If no public host is available, serve locally (`cd <dir> && python3 -m http.server 8080`) and record `http://localhost:8080/gauge/` — data-parity will still be provable; the headless screenshot will be skipped with a note.
+
+- [ ] **Step 2: Register the plugin (handle the masked 404 + 403)**
+
+```ruby
+resp = Sigma.request(:post, '/v2/plugins',
+  body: JSON.generate(name: 'WS2 gauge (e2e)', description: 'recreate-as-plugin gauge proof',
+                      url: PLUGIN_URL, type: 'element'))
+# A masked 404 can accompany a successful register — confirm by name.
+list = Sigma.request(:get, '/v2/plugins'); list = JSON.parse(list) if list.is_a?(String)
+plugin = (list['entries'] || list['plugins'] || []).find { |p| p['name'] == 'WS2 gauge (e2e)' }
+abort "NO-GO: registration 403/permission-gated or not found — needs an org admin (handoff path)" unless plugin
+plugin_id = plugin['pluginId'] || plugin['id']
+```
+
+- [ ] **Step 3: POST a minimal workbook: a table (value+target over real data) + the gauge plugin bound to it**
+
+Table element via custom SQL on `SIGMA_TEST_CONNECTION_ID` with known literals, e.g. `SELECT 82 AS actual, 100 AS target`. Plugin element (bare-string config values):
+```ruby
+{ 'id' => 'gauge-el', 'kind' => 'plugin', 'pluginId' => plugin_id,
+  'config' => { 'source' => { 'kind' => 'element', 'elementId' => 'tbl-src' },
+                'value' => 'actual', 'target' => 'target' } }
+```
+POST `/v2/workbooks/spec` (response is YAML — scrape `workbookId`; do not treat non-JSON as failure; no spec key may contain the substring `field`).
+
+- [ ] **Step 4: Data-parity (HARD) — export the bound element, assert the numbers**
+
+`ExportPool.start_json_export(wb, 'tbl-src', nil)` → `poll_json_download` → assert `actual==82` & `target==100` (matched case-insensitively by column display name). **No faked green.**
+
+- [ ] **Step 5: Visual (best-effort) — screenshot only if public-hosted**
+
+If `PLUGIN_URL` is public: `python3 <a sigma-export-png.py> --workbook <id> --out /tmp/gauge-e2e.png` and note whether the arc renders. If localhost: print `SKIP visual (localhost not reachable by render server)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/scripts/verify-plugin-gauge-e2e.rb
+git commit -m "test: live E2E proof of the Sigma plugin lifecycle (gauge)"
+```
+Report GO (data-parity passed, plugin registered+embedded) or NO-GO (with the blocker: 403 / rejected embed / host).
+
+---
+
+### Task 2: The clean-room gauge plugin
+
+**Files:**
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/index.html`
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/README.md`
+- Create: `plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-gauge-plugin-static.rb` *(static lint — see below; place with sibling ruby tests, or under the new skill)*
+
+**Interfaces:**
+- Editor-panel variables the emitter/embeds bind: `element` (source), `value` (column), `target` (column), optional `min`/`max`/`format` (text). These names are the contract `plugin_embed` (Task 3) emits.
+
+- [ ] **Step 1: Write the failing static-lint test**
+
+```ruby
+# test-gauge-plugin-static.rb — the plugin file must satisfy the lifecycle contract
+require 'json'
+HTML = File.read(File.expand_path('../../sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/index.html', __dir__)) rescue ''
+$f=0; def chk(c,m); puts(c ? "[ok] #{m}" : "[FAIL] #{m}"); $f+=1 unless c; end
+chk(HTML.include?('@sigmacomputing/plugin'), 'loads the @sigmacomputing/plugin SDK')
+chk(HTML.include?('configureEditorPanel'),   'configures an editor panel')
+chk(HTML =~ /['"]value['"]/ && HTML =~ /['"]target['"]/, 'declares value + target bindings')
+chk(HTML.include?('ResizeObserver'),         'attaches a ResizeObserver (redraw-on-resize)')
+chk(HTML.downcase.include?('synth') || HTML.include?('fallback'), 'has a synthetic fallback')
+exit($f.zero? ? 0 : 1)
+```
+
+- [ ] **Step 2: Run it — RED** (`ruby .../test-gauge-plugin-static.rb` → FAIL, file missing).
+
+- [ ] **Step 3: Write `gauge/index.html`** — single file, vanilla JS, `<script src="https://unpkg.com/@sigmacomputing/plugin">`; `client.config.configureEditorPanel([{name:'source',type:'element'},{name:'value',type:'column',source:'source',allowMultiple:false},{name:'target',type:'column',source:'source',allowMultiple:false},{name:'format',type:'text'}])`; subscribe to element data; render an SVG radial arc (value/target → fraction → arc + RAG color) with the value + target labels; **`ResizeObserver` on the container → redraw**; a `synth()` generator (e.g. value 82 / target 100) rendered when `client` is null or data incomplete. Clean-room, generic, no customer data.
+
+- [ ] **Step 4: Run the static lint — GREEN.** Also open the file in a browser at 2 widths to confirm the arc + resize (manual, note in report).
+
+- [ ] **Step 5: Commit** (`feat: add clean-room gauge plugin (@sigmacomputing/plugin)`), and add the test path to the Ruby `test-*.rb` array in `.github/workflows/corpus-check.yml`.
+
+---
+
+### Task 3: `plugin_embed` emitter twins + golden tests (TDD)
+
+**Files:**
+- Create: `shared/lib/plugin_embed.rb`, `shared/lib/plugin_embed.py`, `shared/lib/test_plugin_embed.rb`, `shared/lib/test_plugin_embed.py`, `shared/lib/testdata/plugin_embed_golden.json`
+
+**Interfaces:**
+- Ruby: `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {}) -> Hash`
+- Python: `plugin_embed.build(id, plugin_id, source_element_id, bindings, extra_config=None) -> dict`
+- `bindings` = `{ 'value' => 'colId', 'target' => 'colId' }` (var → columnId); `extra_config` = non-binding config (e.g. `{'format'=>'$.3~s'}`). **All config values coerced to strings**; bindings are bare columnId strings.
+
+- [ ] **Step 1: Golden fixture** `shared/lib/testdata/plugin_embed_golden.json` (sorted keys) for `build(id:'gauge-el', plugin_id:'pl-1', source_element_id:'tbl-1', bindings:{'value'=>'actual','target'=>'target'}, extra_config:{'format'=>'$.3~s'})`:
+```json
+{"config":{"format":"$.3~s","source":{"elementId":"tbl-1","kind":"element"},"target":"target","value":"actual"},"id":"gauge-el","kind":"plugin","pluginId":"pl-1"}
+```
+
+- [ ] **Step 2: Failing Ruby test** `test_plugin_embed.rb` (hand-rolled `check()` harness, mirrors `test_kpi_card.rb`): asserts `PluginEmbed.build(...)` deep-sorted == golden; a numeric `extra_config` value (e.g. `2`) is emitted as the string `"2"`; empty `plugin_id`/`source_element_id` raises. Run → RED (`cannot load ... plugin_embed`).
+
+- [ ] **Step 3: Write `plugin_embed.rb`**
+```ruby
+# frozen_string_literal: true
+# plugin_embed.rb — Ruby twin of shared/lib/plugin_embed.py. Emits the VERIFIED
+# Sigma {kind:"plugin"} element block. ALL config values are bare strings
+# (object form is rejected, masked "Invalid kind:\"plugin\""). Twin emits
+# sorted-key-identical output (shared/lib/testdata/plugin_embed_golden.json).
+# Stdlib only (json); Ruby 2.6-compatible.
+require 'json'
+module PluginEmbed
+  def self.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'plugin_id required' if plugin_id.to_s.empty?
+    raise ArgumentError, 'source_element_id required' if source_element_id.to_s.empty?
+    config = { 'source' => { 'kind' => 'element', 'elementId' => source_element_id } }
+    (bindings || {}).each { |k, v| config[k.to_s] = v.to_s }        # bare string columnId
+    (extra_config || {}).each { |k, v| config[k.to_s] = v.to_s }    # ALL config values -> string
+    { 'id' => id, 'kind' => 'plugin', 'pluginId' => plugin_id, 'config' => config }
+  end
+end
+```
+
+- [ ] **Step 4: Ruby test GREEN** (`ruby shared/lib/test_plugin_embed.rb`).
+
+- [ ] **Step 5–7: Python twin + test** — mirror (`def build(id, plugin_id, source_element_id, bindings, extra_config=None)`, `str(v)` coercion, `ValueError` on empty). RED → write `plugin_embed.py` → GREEN (`python3 shared/lib/test_plugin_embed.py`).
+
+- [ ] **Step 8: Commit** (`feat: add plugin_embed emitter (Ruby+Python twins, golden-tested)`).
+
+---
+
+### Task 4: Governance + registration helper + CI wiring
+
+**Files:**
+- Modify: `shared/manifest.json` (canonical `shared/lib/plugin_embed.rb` — fan later when a builder consumes it; for v1 keep canonical-only, like `kpi_card.py` was, OR fan to `quicksight-to-sigma` if Task 6 wires it there — decide when wiring)
+- Modify: `.github/workflows/corpus-check.yml` (add `shared/lib/test_plugin_embed.rb` to the Ruby array, `shared/lib/test_plugin_embed.py` to the Python array)
+- Create: `shared/scripts/register-plugin.rb`
+
+- [ ] **Step 1: Registration helper** `register-plugin.rb` — `register_or_get(name:, description:, url:)`: GET `/v2/plugins`, return existing `pluginId` by name if present (idempotent); else POST, then re-GET by name (masked-404 tolerant); raise a clear "permission-gated (403) — needs an org admin" on a real auth failure. Reuse in Task 1's E2E.
+
+- [ ] **Step 2: Wire the unit tests into CI** (both `test_plugin_embed.*` paths) and confirm they run: `ruby shared/lib/test_plugin_embed.rb && python3 shared/lib/test_plugin_embed.py`.
+
+- [ ] **Step 3: `ruby tools/check-shared.rb`** stays green (report the count). Commit (`chore: register-plugin helper + wire plugin_embed tests into CI`).
+
+---
+
+### Task 5: `coverage_catalog` `plugin_archetype` recognition + QuickSight gauge annotation (non-breaking, TDD)
+
+**Files:**
+- Modify: `shared/lib/coverage_catalog.rb`, `shared/lib/coverage_catalog.py`
+- Modify: `shared/lib/test_coverage_catalog.rb`, `shared/lib/test_coverage_catalog.py`
+- Modify: `plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/catalogs/viz-kind.json` (add `"plugin_archetype": "gauge"` to the `GaugeChartVisual` row — keep `"sigma": "kpi-chart"` so the live builder dispatch is UNCHANGED)
+
+**Interfaces:**
+- New (both twins): `plugin_archetype(source_key)` → the archetype string if the resolved row carries `plugin_archetype` (or its `sigma` starts with `"plugin:"`), else nil. Existing `resolve`/`target`/`resolve_or_warn` unchanged.
+
+- [ ] **Step 1: Failing test** — extend `test_coverage_catalog.{rb,py}`: a catalog row `{"source":"GaugeChartVisual","sigma":"kpi-chart","plugin_archetype":"gauge"}` → `plugin_archetype("GaugeChartVisual") == "gauge"`; a plain native row → nil; `target`/`resolve` for that row still return `"kpi-chart"` (non-breaking). RED (`undefined ... plugin_archetype`).
+
+- [ ] **Step 2: Implement** in both twins — add to the `Catalog` class:
+```ruby
+def plugin_archetype(source_key)
+  r = resolve(source_key); return nil unless r
+  a = r['plugin_archetype']; return a unless a.to_s.empty?
+  s = r['sigma'].to_s; s.start_with?('plugin:') ? s.sub('plugin:', '') : nil
+end
+```
+(Python mirror.) Add `"plugin_archetype": "gauge"` to the QS `GaugeChartVisual` row.
+
+- [ ] **Step 3: GREEN** (`ruby shared/lib/test_coverage_catalog.rb && python3 shared/lib/test_coverage_catalog.py`). `check-shared` clean (canonical edited + synced). Commit (`feat: coverage_catalog recognizes plugin:<archetype> (recreate-as-plugin); QS gauge annotated`).
+
+---
+
+### Task 6: `sigma-plugin-authoring` skill + reference + gauge exemplar
+
+**Files:**
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/SKILL.md`
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/plugin-lifecycle.md`
+- Create: `plugins/sigma-authoring/skills/sigma-plugin-authoring/examples/gauge-embed.json` (a `plugin_embed.build` output exemplar)
+- (the gauge plugin from Task 2 lives under this skill's `plugins/gauge/`)
+- Modify: `plugins/sigma-authoring/.claude-plugin/plugin.json` if it enumerates skills; regenerate `generated/` variants
+
+- [ ] **Step 1: SKILL.md** — frontmatter (sharp `description:` — "use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin") + the build→register→host→embed→bind recipe, deferring the verified gotchas to `reference/plugin-lifecycle.md`.
+- [ ] **Step 2: `reference/plugin-lifecycle.md`** — the Global-Constraints gotchas as the canonical reference (register/masked-404/403; url set-once; bare-string config; `ResizeObserver`; synthetic fallback; hidden-page backing element; localhost-not-headless-renderable; `PluginEmbed.build`/`plugin_embed.build` as the emitter).
+- [ ] **Step 3: `examples/gauge-embed.json`** — the emitter output for the gauge (matches the golden shape).
+- [ ] **Step 4: Regenerate variants** — `ruby tools/gen-agent-variants.rb plugins/sigma-authoring/skills/sigma-plugin-authoring` → `ruby tools/check-agent-variants.rb` (in sync). Commit (`docs(sigma-authoring): sigma-plugin-authoring skill + gauge exemplar`).
+
+---
+
+### Task 7: Full verification + acceptance
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Offline gauntlet** — `ruby tools/check-shared.rb`, `ruby tools/check-agent-variants.rb`, `ruby shared/lib/test_plugin_embed.rb`, `python3 shared/lib/test_plugin_embed.py`, `ruby shared/lib/test_coverage_catalog.rb`, `python3 shared/lib/test_coverage_catalog.py`, `ruby .../test-gauge-plugin-static.rb`. All green.
+- [ ] **Step 2: Live acceptance** — re-run `ruby shared/scripts/verify-plugin-gauge-e2e.rb` (now using the real Task-2 gauge + the Task-4 helper + `plugin_embed`): registered + embedded + bound + **data-parity passes**; screenshot if public-hosted. Report the real numbers + the host/boundary.
+- [ ] **Step 3: Hand off** — use `superpowers:finishing-a-development-branch`. Note the split-PR structure (shared: `plugin_embed` + `coverage_catalog` + `register-plugin`; sigma-authoring: the skill + gauge plugin; quicksight: the one catalog row) per the one-plugin-or-shared convention. Flag the **fast-follow**: the per-tool builder auto-emit (source gauge tile → `plugin_embed` element) — v1 proves the lifecycle + machinery + catalog recognition; the automatic emit in a live migration is the next slice.
+
+---
+
+## Self-Review
+
+**Spec coverage:** `sigma-plugin-authoring` skill → Task 6 ✅; `plugin_embed` twins → Task 3 ✅; gauge plugin → Task 2 ✅; `recreate-as-plugin` disposition → Task 5 ✅; registration helper → Task 4 ✅; hosting handoff/turnkey → Task 1 + reference ✅; data-parity-hard + screenshot-soft → Tasks 1/7 ✅; E2E-first → Task 1 gate ✅. The full per-tool builder auto-emit is explicitly scoped as fast-follow (Task 7 hand-off) — consistent with the spec's v1 scope.
+
+**Placeholder scan:** No TBD/TODO. The two spec open-questions are resolved: tool = **QuickSight `GaugeChartVisual`** (Task 5); hosting = public static host when available for the headless screenshot, else localhost + data-parity (Task 1, Global Constraints). The one genuinely-conditional step (public vs localhost host) is called out explicitly, not hidden.
+
+**Type consistency:** `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config:)` identical across Tasks 3/4/6; `plugin_archetype(source_key)` signature matches between Task 5's test and impl; the gauge editor-panel var names (`value`/`target`) match the `plugin_embed` bindings and the golden fixture.

--- a/docs/superpowers/specs/2026-07-28-ws2-plugin-recreation-gauge-design.md
+++ b/docs/superpowers/specs/2026-07-28-ws2-plugin-recreation-gauge-design.md
@@ -1,0 +1,161 @@
+# Design — WS2 v1: Plugin-recreation (radial gauge, end-to-end)
+
+Status: **proposed** · Date: 2026-07-28 · Branch: `feat/ws2-plugin-recreation`
+
+## Provenance / why
+
+Reviewing `cmiller-coder/millersigma` surfaced Sigma custom plugins
+(`@sigmacomputing/plugin`) as a way to recreate a source-tool custom viz that
+Sigma has **no native equivalent** for — turning a "scoped-to-native /
+`warn+skip` / dropped" migration gap into a parity win. WS1 (comparative KPI
+cards) is shipped; this is WS2's first slice: prove the **greenfield plugin
+lifecycle** end-to-end on ONE archetype (a **radial gauge / progress-to-target**),
+then generalize.
+
+Techniques/patterns from millersigma only — no code lifted (its `LICENSE` is
+empty → effectively all-rights-reserved). The archetype is clean-room, generic
+demo data, **no customer names**.
+
+## Scope decision (v1)
+
+One archetype (radial gauge), end-to-end, to de-risk the unproven plugin
+lifecycle before investing in an archetype library. (User's choice.)
+
+Scout finding that motivates the gauge pick: on the live Tableau site, genuinely
+non-native viz are either **license-gated** (the "Viz Extensions Edition"
+dashboard's LaDataViz gauge / RFM score-meters render as "Get a license"
+placeholders — nothing to parity against) or the dashboards are fully
+native-representable (the "Call Center" dashboard is KPI+sparkline+WoW = WS1
+territory). The gauge / "% to target" is the non-native pattern actually present,
+is the most common exec/ops form, and is simple enough that v1 effort goes into
+the **lifecycle**, not viz complexity. Because the one real instance is
+license-gated, v1 anchors its end-to-end on a **real warehouse metric-vs-target**
+(the WS1 approach), not that specific dashboard.
+
+## Goal (v1)
+
+Prove the migration converters can turn a non-native gauge viz into a working
+Sigma plugin: a gauge source-kind resolves via the coverage catalog to
+`plugin:gauge` instead of `warn+skip`, and the pipeline emits a **registered,
+hosted, data-bound** Sigma plugin element whose value-vs-target renders correctly
+on real warehouse data. **Success = a live Sigma workbook with a gauge plugin
+bound to a real metric + target, data-parity-verified.**
+
+## Approach (chosen)
+
+Mirror WS1: a **shared emitter + a tool-agnostic authoring skill**, proven
+E2E-first, then a minimal migration hook. Rejected alternatives: docs-only (the
+verified plugin shapes drift), and full-library-first (invests before the
+lifecycle is proven).
+
+## Components (v1)
+
+1. **`sigma-plugin-authoring` skill** — new, tool-agnostic, in
+   `plugins/sigma-authoring/skills/sigma-plugin-authoring`. The
+   build → register → host → embed → bind recipe, encoding the verified
+   lifecycle gotchas: single-file `@sigmacomputing/plugin`; **`ResizeObserver`
+   mandatory** (redraw on resize — the #1 "wonky plugin" cause); a **synthetic
+   fallback** so it previews standalone; register via
+   `POST /v2/plugins {name,description,url,type:"element"}` → `pluginId`
+   (a **masked HTTP 404 can accompany a successful register** → confirm via
+   `GET /v2/plugins` by name, idempotent); `url` is **set-once** (re-register to
+   change); embed shape
+   `{kind:"plugin", pluginId, config:{source:{kind:"element",elementId}, <binding>:"<columnId>"}}`
+   with **every `config` value a bare string** (object/column-object form is
+   rejected, masked as `Invalid kind:"plugin"`); the plugin's backing data
+   element on a **separate hidden page** (`visibleAsSource:false` does not hide
+   it from layout). Ships a `reference/` of these gotchas + the gauge as an
+   `examples/` exemplar.
+2. **`shared/lib/plugin_embed.{rb,py}`** — twin emitter (stdlib-only, Ruby 2.6,
+   golden-fixture tested — the WS1 `kpi_card` pattern) that produces the verified
+   plugin element block. Coerces **all `config` values to strings**; bindings are
+   bare `columnId` strings; `source:{kind:"element",elementId}`.
+3. **One clean-room gauge plugin** — a single-file `index.html`
+   (`@sigmacomputing/plugin` via CDN) under the skill's `plugins/gauge/`. Editor
+   panel: an `element` data source + `value` + `target` column bindings
+   (+ optional `min`/`max`/`format`). Renders a radial arc with a RAG color and
+   the value + target; `ResizeObserver` redraw; synthetic fallback. Generic data.
+4. **`recreate-as-plugin` coverage-catalog disposition** — extend the
+   `coverage_catalog` resolver (`shared/lib/coverage_catalog.{rb,py}`) so a row
+   whose `sigma` is `plugin:<archetype>` (e.g. `plugin:gauge`) is recognized as a
+   *recreate-as-plugin* target — distinct from a native-kind target and from a
+   `warn+skip` miss. Wire ONE source tool's `viz-kind.json` with a
+   gauge→`plugin:gauge` row (candidate: `powerbi` `gauge` or `quicksight`
+   `GaugeChartVisual` — decide in planning). The gap-scan then surfaces "recreate
+   as plugin: gauge" instead of dropping it.
+5. **Registration helper** — a small script (in the skill or `shared/scripts`)
+   wrapping `POST /v2/plugins` + the masked-404 confirm-via-`GET`, returning a
+   `pluginId`; idempotent (GET-by-name first).
+6. **Hosting** — **handoff by default** (emit the plugin bundle + the exact
+   host + register steps; localhost for local preview), **turnkey opt-in**
+   (automate a static deploy + register) as a fast-follow. v1 proves the
+   lifecycle with a hosted (localhost or static) gauge.
+7. **Parity** — **data-parity HARD** on the gauge's bound element (export the
+   value + target columns, compare to the source/warehouse) + **visual soft**
+   (screenshot the rendered gauge). Reuses the WS1 export-verify loop.
+
+## Data flow (migration)
+
+```
+source gauge viz (non-native)
+  → viz-kind catalog resolves `plugin:gauge`  (not warn+skip)
+  → gap-scan surfaces "recreate as plugin: gauge"
+  → converter binds a data element (value + target columns from the DM)
+  → plugin_embed emits {kind:"plugin", pluginId, config:{source, value, target}}
+  → workbook spec → the registered+hosted gauge plugin renders value-vs-target
+  → C8: export the bound element (value/target correct vs warehouse) + screenshot
+```
+
+## Testing — E2E-first
+
+**Task 1 = a live GO/NO-GO proof, before wiring the catalog broadly** (the plugin
+lifecycle is greenfield — prove it end-to-end first):
+
+1. Build the gauge plugin (single-file), host it (localhost or a static host),
+   register it (`POST /v2/plugins` → `pluginId`, confirm via `GET`).
+2. POST a minimal Sigma workbook: a table over real warehouse data with a value
+   column + a target (column or constant), plus a plugin element bound to it via
+   `plugin_embed`.
+3. Export the bound element → assert the value + target are correct
+   (data-parity). **No faked green.**
+4. Screenshot → confirm the gauge renders the value-vs-target arc (visual soft).
+
+Only on GO: codify the emitter (golden-tested twins), the skill docs, and the
+`recreate-as-plugin` catalog wiring for one tool.
+
+**Unit tests:** `plugin_embed` twins emit sorted-key-identical JSON matching a
+golden fixture (incl. all-config-values-are-strings); the `coverage_catalog`
+resolver recognizes a `plugin:<archetype>` row as a recreate-as-plugin target
+(both twins). Wire the new lib tests into the CI `unit-tests` allow-list.
+
+## Error handling / guardrails
+
+- Registration masked-404 → confirm via `GET /v2/plugins` by name; never treat a
+  non-200 as a hard failure without the GET; idempotent.
+- All plugin `config` values emitted as **strings**; bindings bare `columnId`
+  strings (object form → masked `Invalid kind:"plugin"`).
+- Backing data element on a **separate hidden page**.
+- If registration is permission-gated (403) or no host is available, **fall back
+  to handoff** (emit bundle + exact steps) with a loud, honest note — never
+  silently drop the viz.
+- Conservative catalog: only source-kinds with a clear gauge semantic map to
+  `plugin:gauge`; ambiguous → `warn+skip` (unchanged).
+
+## Scope / YAGNI (v1)
+
+**In:** the `sigma-plugin-authoring` skill + reference; `plugin_embed` emitter
+(twins, golden-tested); ONE clean-room gauge plugin; the `recreate-as-plugin`
+disposition + ONE tool's `viz-kind` gauge row; the registration helper; the live
+E2E + unit tests; data-parity-hard + screenshot-soft.
+
+**Out (fast-follow):** more archetypes (heatmap, chord/sankey, gantt, rings,
+scatter-lasso); wiring the disposition across all source tools; turnkey static
+deploy automation; plugin→control interactivity binding (select-to-filter); the
+Netlify embed-portal.
+
+## Open questions (resolve in planning, non-blocking)
+
+- Which source tool + gauge source-kind to wire first (v1 picks one; `powerbi`
+  `gauge` or `quicksight` `GaugeChartVisual` are clean candidates).
+- Hosting for the v1 live proof: localhost (dev) is simplest and sufficient to
+  prove the lifecycle; a shareable static host is a turnkey fast-follow.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_catalog.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_catalog.rb
@@ -51,6 +51,19 @@ module Coverage
       r && r['sigma']
     end
 
+    # Return the recreate-as-plugin archetype for source_key, or nil. Honors an
+    # explicit `plugin_archetype` field on the row, or a `sigma` value of the
+    # form "plugin:<archetype>" (returns the part after the prefix). Additive —
+    # does not change resolve/target/resolve_or_warn's existing dispatch.
+    def plugin_archetype(source_key)
+      r = resolve(source_key)
+      return nil unless r
+      a = r['plugin_archetype']
+      return a unless a.to_s.empty?
+      s = r['sigma'].to_s
+      s.start_with?('plugin:') ? s.sub('plugin:', '') : nil
+    end
+
     # Resolve; on a miss append a standardized LOUD warning to `warnings` and
     # return nil. The caller MUST then skip/placeholder — makes the loud
     # fallback mandatory and uniform.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/coverage_catalog.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/coverage_catalog.rb
@@ -51,6 +51,19 @@ module Coverage
       r && r['sigma']
     end
 
+    # Return the recreate-as-plugin archetype for source_key, or nil. Honors an
+    # explicit `plugin_archetype` field on the row, or a `sigma` value of the
+    # form "plugin:<archetype>" (returns the part after the prefix). Additive —
+    # does not change resolve/target/resolve_or_warn's existing dispatch.
+    def plugin_archetype(source_key)
+      r = resolve(source_key)
+      return nil unless r
+      a = r['plugin_archetype']
+      return a unless a.to_s.empty?
+      s = r['sigma'].to_s
+      s.start_with?('plugin:') ? s.sub('plugin:', '') : nil
+    end
+
     # Resolve; on a miss append a standardized LOUD warning to `warnings` and
     # return nil. The caller MUST then skip/placeholder — makes the loud
     # fallback mandatory and uniform.

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: sigma-plugin-authoring
+description: >-
+  Build, register, host, embed, and data-bind a bespoke Sigma custom plugin
+  (@sigmacomputing/plugin) to recreate a source visualization for which
+  Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom
+  heatmap, a sankey, or any bespoke viz kind outside Sigma's native element
+  set. **Use when a source viz has no native Sigma equivalent and should be
+  recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or
+  table kind already covers it (that's the `sigma-workbooks` skill). Covers
+  the full lifecycle: writing the single-file plugin, registering it via
+  `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to
+  real data, and verifying value parity. Ships a worked example (a radial
+  gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires
+  an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+---
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+shapes" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby shared/scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+- Ruby: `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`shared/lib/plugin_embed.rb`)
+- Python: `plugin_embed.build(id, plugin_id, source_element_id, bindings, extra_config=None)` (`shared/lib/plugin_embed.py`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). Both twins coerce every
+value to a bare string and emit the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` / `plugin_embed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Recognizing a source viz as recreate-as-plugin during a migration
+  gap-scan** → `coverage_catalog.plugin_archetype(source_key)` in
+  `shared/lib/coverage_catalog.{rb,py}` — returns the archetype string
+  (e.g. `"gauge"`) for a catalog row whose `plugin_archetype` field is set or
+  whose `sigma` value is `plugin:<archetype>`, distinct from a native-kind
+  target and from a `warn+skip` miss.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build`/`plugin_embed.build` rather
+than hand-editing. See `reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/examples/gauge-embed.json
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/examples/gauge-embed.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "format": ".0%",
+    "source": {
+      "elementId": "tbl-gauge-data",
+      "kind": "element"
+    },
+    "target": "target",
+    "value": "actual"
+  },
+  "id": "gauge-el",
+  "kind": "plugin",
+  "pluginId": "00000000-0000-4000-8000-000000000000"
+}

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/generated/cline/sigma-plugin-authoring.md
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/generated/cline/sigma-plugin-authoring.md
@@ -1,0 +1,185 @@
+<!--
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
+-->
+
+> Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+shapes" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby shared/scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+- Ruby: `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`shared/lib/plugin_embed.rb`)
+- Python: `plugin_embed.build(id, plugin_id, source_element_id, bindings, extra_config=None)` (`shared/lib/plugin_embed.py`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). Both twins coerce every
+value to a bare string and emit the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` / `plugin_embed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Recognizing a source viz as recreate-as-plugin during a migration
+  gap-scan** → `coverage_catalog.plugin_archetype(source_key)` in
+  `shared/lib/coverage_catalog.{rb,py}` — returns the archetype string
+  (e.g. `"gauge"`) for a catalog row whose `plugin_archetype` field is set or
+  whose `sigma` value is `plugin:<archetype>`, distinct from a native-kind
+  target and from a `warn+skip` miss.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build`/`plugin_embed.build` rather
+than hand-editing. See `reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/generated/codex/AGENTS.md
@@ -1,0 +1,185 @@
+<!--
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
+-->
+
+> Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+shapes" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby shared/scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+- Ruby: `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`shared/lib/plugin_embed.rb`)
+- Python: `plugin_embed.build(id, plugin_id, source_element_id, bindings, extra_config=None)` (`shared/lib/plugin_embed.py`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). Both twins coerce every
+value to a bare string and emit the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` / `plugin_embed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Recognizing a source viz as recreate-as-plugin during a migration
+  gap-scan** → `coverage_catalog.plugin_archetype(source_key)` in
+  `shared/lib/coverage_catalog.{rb,py}` — returns the archetype string
+  (e.g. `"gauge"`) for a catalog row whose `plugin_archetype` field is set or
+  whose `sigma` value is `plugin:<archetype>`, distinct from a native-kind
+  target and from a `warn+skip` miss.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build`/`plugin_embed.build` rather
+than hand-editing. See `reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/generated/continue/sigma-plugin-authoring.md
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/generated/continue/sigma-plugin-authoring.md
@@ -1,0 +1,185 @@
+<!--
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
+-->
+
+> Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+shapes" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby shared/scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+- Ruby: `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`shared/lib/plugin_embed.rb`)
+- Python: `plugin_embed.build(id, plugin_id, source_element_id, bindings, extra_config=None)` (`shared/lib/plugin_embed.py`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). Both twins coerce every
+value to a bare string and emit the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` / `plugin_embed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Recognizing a source viz as recreate-as-plugin during a migration
+  gap-scan** → `coverage_catalog.plugin_archetype(source_key)` in
+  `shared/lib/coverage_catalog.{rb,py}` — returns the archetype string
+  (e.g. `"gauge"`) for a catalog row whose `plugin_archetype` field is set or
+  whose `sigma` value is `plugin:<archetype>`, distinct from a native-kind
+  target and from a `warn+skip` miss.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build`/`plugin_embed.build` rather
+than hand-editing. See `reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/generated/cursor/rules/sigma-plugin-authoring.mdc
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/generated/cursor/rules/sigma-plugin-authoring.mdc
@@ -1,0 +1,190 @@
+---
+description: "Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / \"value vs. target\" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first."
+alwaysApply: false
+---
+
+<!--
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
+-->
+
+> Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+shapes" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby shared/scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+- Ruby: `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`shared/lib/plugin_embed.rb`)
+- Python: `plugin_embed.build(id, plugin_id, source_element_id, bindings, extra_config=None)` (`shared/lib/plugin_embed.py`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). Both twins coerce every
+value to a bare string and emit the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` / `plugin_embed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Recognizing a source viz as recreate-as-plugin during a migration
+  gap-scan** → `coverage_catalog.plugin_archetype(source_key)` in
+  `shared/lib/coverage_catalog.{rb,py}` — returns the archetype string
+  (e.g. `"gauge"`) for a catalog row whose `plugin_archetype` field is set or
+  whose `sigma` value is `plugin:<archetype>`, distinct from a native-kind
+  target and from a `warn+skip` miss.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build`/`plugin_embed.build` rather
+than hand-editing. See `reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/README.md
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/README.md
@@ -1,0 +1,85 @@
+# Gauge plugin (value vs. target)
+
+A single-file, vanilla-JS Sigma custom plugin (`@sigmacomputing/plugin`) that
+renders a radial (semicircle) gauge — a value swept against a target, colored
+red/amber/green (RAG) by how close it is. It exists to recreate source vizzes
+(a QuickSight/Power BI-style gauge, a "% to target" indicator, …) for which
+Sigma has no native chart kind, as part of WS2's `recreate-as-plugin`
+disposition.
+
+Clean-room, generic data only — the file has no customer names or data. When
+there's no Sigma host (opened directly in a browser) or the bound data is
+incomplete, it falls back to a synthetic `value: 82, target: 100` so it always
+previews standalone.
+
+## Editor-panel bindings
+
+This is the contract other WS2 machinery (`shared/lib/plugin_embed`, the
+gap-scan/emitter) binds to — **do not rename these fields**:
+
+| name     | type                          | meaning                              |
+|----------|-------------------------------|---------------------------------------|
+| `source` | `element`                     | the bound data element                |
+| `value`  | `column` (source: `source`)   | the current value                     |
+| `target` | `column` (source: `source`)   | the target/goal                       |
+| `format` | `text`                        | optional number-format hint for labels|
+
+`format` supports a lightweight subset: a string containing `%` renders a
+percentage (`.1%` → 1 decimal place); a string like `.2f` fixes 2 decimals;
+`d`/`int` rounds to an integer; anything else (including blank) falls back to
+a locale-grouped number.
+
+## Design notes
+
+- **`ResizeObserver` on the render container → full redraw.** This is the
+  fix for the #1 "wonky plugin" failure mode: a plugin that only lets
+  CSS/viewBox scaling handle resize ends up with illegible text or a clipped
+  arc at small panel widths. Every resize here recomputes stroke width, font
+  size, and arc geometry from the container's actual box and re-renders from
+  scratch (not an incremental patch).
+- **Synthetic fallback (`synth()`)** renders whenever `client` is unavailable
+  or the bound `value`/`target` columns don't resolve to a non-empty row, so
+  the plugin is always previewable outside a workbook.
+- Single file, single responsibility: read `{value, target}`, draw the arc.
+  No dependencies beyond the Sigma plugin SDK (loaded via
+  `<script src="https://unpkg.com/@sigmacomputing/plugin">`).
+
+## Register + embed
+
+1. **Host** the file somewhere Sigma's render server can reach — a public
+   static host (for headless PNG export to work) or `localhost` for local
+   preview/dev (data-parity still works either way; only the headless
+   screenshot needs a public host).
+2. **Register** the plugin:
+   ```ruby
+   Sigma.request(:post, '/v2/plugins',
+     body: JSON.generate(name: 'Gauge (value vs. target)',
+                          description: 'Recreate-as-plugin radial gauge',
+                          url: PLUGIN_URL, type: 'element'))
+   # A masked HTTP 404 can accompany a SUCCESSFUL register — always confirm
+   # by name via GET /v2/plugins, never trust the POST status alone.
+   ```
+   The `url` is set-once per registration; re-register (or use the update
+   path, if available in your org) to change it. A 403 means registration is
+   org-admin-gated in that org.
+3. **Embed** the registered plugin in a workbook spec element, bound to a
+   data element. Every `config` value must be a **bare string** — the
+   object/`{kind:"column"}` form is silently rejected (masked as
+   `Invalid kind:"plugin"`):
+   ```json
+   {
+     "id": "gauge-el",
+     "kind": "plugin",
+     "pluginId": "<the registered pluginId>",
+     "config": {
+       "source": { "kind": "element", "elementId": "tbl-src" },
+       "value": "actual",
+       "target": "target"
+     }
+   }
+   ```
+   `shared/lib/plugin_embed.{rb,py}` emits exactly this shape from
+   `{value: colId, target: colId}` bindings.
+4. **Bind** `tbl-src` to a data element carrying the value + target columns
+   (put it on a separate hidden page — `visibleAsSource:false` alone does
+   not remove it from layout).

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/index.html
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/index.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<!--
+  gauge/index.html — clean-room WS2 "recreate-as-plugin" radial gauge.
+
+  A single-file, vanilla-JS Sigma custom plugin (@sigmacomputing/plugin) that
+  renders a value-vs-target radial (semicircle) gauge with RAG color, for
+  source vizzes (e.g. a QuickSight/Power BI gauge) that have no native Sigma
+  equivalent. Single responsibility: read {value, target} off a bound
+  element, draw the arc. No customer data anywhere in this file — the
+  standalone/synthetic preview uses generic literals (82 of 100).
+
+  Editor-panel contract (do not rename — this is what shared/lib/plugin_embed
+  binds and what the emitter/gap-scan machinery keys off of):
+    source  (type: element) — the bound data element
+    value   (type: column, source: 'source') — the current value
+    target  (type: column, source: 'source') — the target/goal
+    format  (type: text)    — optional number-format hint for the labels
+
+  Verified Sigma plugin-lifecycle gotchas encoded here (see
+  plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/ once that
+  lands in a later task):
+    - ResizeObserver on the render container -> FULL redraw. This is the #1
+      cause of a "wonky" plugin: a plugin that only lets CSS/viewBox scaling
+      handle resize ends up with illegible text or a clipped arc at small
+      panel widths. Here every resize recomputes stroke-width/font-size from
+      the container's actual box and re-renders from scratch.
+    - A synthetic fallback (synth()) renders whenever `client` is unavailable
+      (no Sigma host — e.g. opening this file directly in a browser) or the
+      bound data is incomplete, so the plugin always previews standalone.
+-->
+<html>
+<head>
+<meta charset="utf-8">
+<title>Gauge (value vs. target)</title>
+<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: #ffffff;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  #gauge-root {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+  }
+  #gauge-svg {
+    display: block;
+  }
+  #gauge-caption {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 6%;
+    text-align: center;
+    color: #6b7280;
+    pointer-events: none;
+  }
+</style>
+</head>
+<body>
+<div id="gauge-root">
+  <svg id="gauge-svg" xmlns="http://www.w3.org/2000/svg"></svg>
+  <div id="gauge-caption"></div>
+</div>
+
+<!--
+  REQUIRED: load React BEFORE the SDK. @sigmacomputing/plugin's UMD build has
+  React as a hard peer dependency — its factory dereferences React at load and,
+  if React is absent, THROWS before assigning `client`, leaving
+  window.SigmaPlugin with NO `client`. The plugin then can never read bound data
+  and silently falls back to synth() (looks like it works, shows demo numbers).
+  Sigma does NOT inject React into the plugin iframe, so the plugin must load it
+  itself. ReactDOM is NOT needed for the vanilla client API. Verified against
+  @sigmacomputing/plugin v1.2.0 (see reference/plugin-lifecycle.md).
+-->
+<script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+<script>
+(function () {
+  'use strict';
+
+  // ---------------------------------------------------------------------
+  // Synthetic fallback — generic demo literals only, never customer data.
+  // Rendered whenever there is no Sigma client, or the bound data can't be
+  // read as a complete {value, target} pair.
+  // ---------------------------------------------------------------------
+  function synth() {
+    return { value: 82, target: 100 };
+  }
+
+  // ---------------------------------------------------------------------
+  // Small format helper for the value/target labels. Supports a lightweight
+  // subset of common hint strings via the optional `format` editor-panel
+  // field; anything unrecognized falls back to a plain grouped number.
+  // ---------------------------------------------------------------------
+  function formatNumber(n, fmt) {
+    var num = Number(n);
+    if (!isFinite(num)) return String(n);
+    var f = (fmt || '').trim();
+    if (f === '') return num.toLocaleString();
+    if (f.indexOf('%') !== -1) {
+      var pctMatch = f.match(/\.(\d+)/);
+      var pctDigits = pctMatch ? Number(pctMatch[1]) : 0;
+      return (num * 100).toFixed(pctDigits) + '%';
+    }
+    var fixedMatch = f.match(/\.(\d+)f/);
+    if (fixedMatch) return num.toFixed(Number(fixedMatch[1]));
+    if (f === 'd' || f === 'int') return Math.round(num).toLocaleString();
+    return num.toLocaleString();
+  }
+
+  // ---------------------------------------------------------------------
+  // Geometry: a 180-degree (semicircle) gauge swept left-to-right.
+  // ---------------------------------------------------------------------
+  function polarPoint(cx, cy, r, deg) {
+    var rad = ((deg - 180) * Math.PI) / 180;
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+  }
+
+  function arcPath(cx, cy, r, startDeg, endDeg) {
+    var start = polarPoint(cx, cy, r, endDeg);
+    var end = polarPoint(cx, cy, r, startDeg);
+    var large = (endDeg - startDeg) <= 180 ? 0 : 1;
+    return ['M', start.x, start.y, 'A', r, r, 0, large, 0, end.x, end.y].join(' ');
+  }
+
+  // RAG color from the value/target fraction.
+  function ragColor(frac) {
+    if (frac >= 1) return '#22c55e';   // green — at/above target
+    if (frac >= 0.6) return '#eab308'; // amber — approaching target
+    return '#ef4444';                  // red — well below target
+  }
+
+  // ---------------------------------------------------------------------
+  // Render: draws the full gauge into #gauge-svg at the CURRENT container
+  // size. Called on every data update AND on every resize (full redraw,
+  // not incremental) so text/stroke stay legible at any panel size.
+  // ---------------------------------------------------------------------
+  var lastValue = null;
+  var lastTarget = null;
+  var lastFormat = '';
+
+  function render(value, target, fmt) {
+    lastValue = value;
+    lastTarget = target;
+    lastFormat = fmt || '';
+
+    var root = document.getElementById('gauge-root');
+    var svg = document.getElementById('gauge-svg');
+    var caption = document.getElementById('gauge-caption');
+
+    var box = root.getBoundingClientRect();
+    var w = Math.max(60, box.width);
+    var h = Math.max(40, box.height);
+    svg.setAttribute('width', w);
+    svg.setAttribute('height', h);
+    svg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+
+    var frac = target > 0 ? Math.max(0, Math.min(1, value / target)) : 0;
+    var color = ragColor(frac);
+
+    // Fit the FULL semicircle inside the box. The dome rises from the baseline
+    // (cy) by the radius (r), so r must not exceed the vertical room ABOVE cy or
+    // the dome top clips off-canvas (the wide-short-panel bug). Constrain r by
+    // BOTH the half-width and (cy - pad); center horizontally.
+    var cx = w / 2;
+    var strokeWidth = Math.max(4, Math.min(w, h * 1.6) * 0.09);
+    var pad = strokeWidth / 2 + 4;              // keep the rounded stroke cap inside the box
+    var cy = Math.min(h - pad, h * 0.80);        // arc baseline, low in the box
+    var r = Math.max(10, Math.min(w / 2 - pad, cy - pad)); // full dome fits above cy AND within width
+    var valueFontSize = Math.max(10, Math.min(w * 0.16, h * 0.34));
+    var targetFontSize = Math.max(8, valueFontSize * 0.42);
+
+    var track = arcPath(cx, cy, r, 0, 180);
+    var fill = arcPath(cx, cy, r, 0, 180 * frac);
+
+    var valueLabel = formatNumber(value, fmt);
+    var targetLabel = formatNumber(target, fmt);
+
+    svg.innerHTML =
+      '<path d="' + track + '" stroke="#e5e7eb" stroke-width="' + strokeWidth +
+        '" fill="none" stroke-linecap="round"/>' +
+      '<path d="' + fill + '" stroke="' + color + '" stroke-width="' + strokeWidth +
+        '" fill="none" stroke-linecap="round"/>' +
+      '<text x="' + cx + '" y="' + (cy - r * 0.15) + '" text-anchor="middle" ' +
+        'font-size="' + valueFontSize + '" font-weight="600" fill="#111827">' + valueLabel + '</text>' +
+      '<text x="' + cx + '" y="' + (cy - r * 0.15 + targetFontSize + 4) + '" text-anchor="middle" ' +
+        'font-size="' + targetFontSize + '" fill="#6b7280">of ' + targetLabel + '</text>';
+
+    caption.textContent = '';
+  }
+
+  function redrawFromLastKnown() {
+    var v = lastValue === null ? synth().value : lastValue;
+    var t = lastTarget === null ? synth().target : lastTarget;
+    render(v, t, lastFormat);
+  }
+
+  // ---------------------------------------------------------------------
+  // Sigma client wiring. Verified against @sigmacomputing/plugin v1.2.0
+  // (dist/umd + dist/esm/index.d.ts):
+  //   - The UMD build exposes its API as `window.SigmaPlugin` (not
+  //     `window.Sigma`). `.client` is the vanilla-JS bridge.
+  //   - Data subscription lives under `client.elements.subscribeToElementData
+  //     (sourceElementId, cb)` — it REQUIRES the source element id.
+  //   - We read bound column ids off the `client.config.subscribe(config => …)`
+  //     object (config.source / config.value / config.target are bare
+  //     ids/strings) so we also get re-notified when the binding changes.
+  //     (`client.config.getKey(k)` also returns the bare value at runtime —
+  //     despite its misleading `Pick<T,K>` type in the .d.ts — but doesn't
+  //     notify on change, so subscribe is the better fit here.)
+  // The `client` object exists even with no Sigma parent (opened standalone),
+  // so we paint the synthetic preview immediately and let real bound data
+  // overwrite it once the element-data subscription delivers.
+  // ---------------------------------------------------------------------
+  var s0 = synth();
+  render(s0.value, s0.target, '');   // immediate paint: standalone preview + pre-data placeholder
+
+  var client =
+    (window.SigmaPlugin && window.SigmaPlugin.client) ||   // real global (v1.2.0 UMD)
+    (window.Sigma && window.Sigma.client) ||               // legacy/alt global, just in case
+    null;
+
+  if (client) {
+    client.config.configureEditorPanel([
+      { name: 'source', type: 'element' },
+      { name: 'value', type: 'column', source: 'source', allowMultiple: false },
+      { name: 'target', type: 'column', source: 'source', allowMultiple: false },
+      { name: 'format', type: 'text' }
+    ]);
+
+    var unsubData = null;
+    client.config.subscribe(function (config) {
+      var sourceId = config && config.source;
+      if (unsubData) { unsubData(); unsubData = null; }   // re-subscribe if the source changes
+      if (!sourceId) {
+        var s = synth();
+        render(s.value, s.target, (config && config.format) || '');
+        return;
+      }
+      unsubData = client.elements.subscribeToElementData(sourceId, function (data) {
+        try {
+          var valueCol = config.value;
+          var targetCol = config.target;
+          var fmt = config.format;
+          var hasValue = data && valueCol && targetCol && data[valueCol] && data[targetCol] &&
+            data[valueCol].length && data[targetCol].length;
+          if (hasValue) {
+            render(Number(data[valueCol][0]), Number(data[targetCol][0]), fmt);
+          } else {
+            var s = synth();
+            render(s.value, s.target, fmt);
+          }
+        } catch (e) {
+          var fb = synth();
+          render(fb.value, fb.target, '');
+        }
+      });
+    });
+  }
+
+  // ResizeObserver on the render container -> full redraw. Mandatory: this
+  // is what keeps the gauge legible as the panel is resized in the Sigma
+  // workbook editor, rather than just letting the SVG stretch.
+  new ResizeObserver(function () {
+    redrawFromLastKnown();
+  }).observe(document.getElementById('gauge-root'));
+})();
+</script>
+</body>
+</html>

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/patterns.md
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/patterns.md
@@ -1,0 +1,345 @@
+# Interactivity & Settings Patterns
+
+Recipes for a plugin that does more than passively display one value —
+assumes you've read `reference/sdk-api.md` for the underlying config/data/
+variable/action vocabulary. Like that file, this one does not repeat
+`reference/plugin-lifecycle.md`'s registration/hosting/embedding gotchas.
+
+## Graceful loading / partial config
+
+A plugin renders the moment it's dropped onto a canvas, before the author
+has configured anything. Guide them through setup instead of showing an
+error or a blank box — check state in the order the author actually fills
+it in:
+```js
+function view(config, data) {
+  if (!config.dataSource) return renderMessage('Choose a data source.');
+  if (!config.metricColumn) return renderMessage('Choose a metric column.');
+  const values = data[config.metricColumn];
+  if (!values || values.length === 0) return renderMessage('No rows yet for this selection.');
+  return renderReady(values);
+}
+```
+No source → no column → no data → ready. Treat "ready" as the last branch
+you reach, never the first thing you assume.
+
+## JSON-settings pattern
+
+The built-in editor-panel field types cover simple config, but not a rich,
+bespoke settings UI (several color pickers, nested layout options, a form
+the plugin renders itself). Route that through a single `text` field
+holding a JSON blob instead of trying to model it as editor-panel fields:
+```js
+client.config.configureEditorPanel([
+  { name: 'dataSource', type: 'element' },
+  { name: 'settingsJson', type: 'text', label: 'Settings (internal — do not hand-edit)', defaultValue: '{}', multiline: true },
+  { name: 'editMode', type: 'toggle', label: 'Edit Mode' }
+]);
+
+const DEFAULT_SETTINGS = {
+  title: 'Untitled',
+  theme: 'light',
+  cardStyle: { radius: 8, shadow: true }
+};
+
+function loadSettings(raw) {
+  if (!raw || !raw.trim()) return { ...DEFAULT_SETTINGS };
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      ...DEFAULT_SETTINGS,
+      ...parsed,
+      // one level of deep merge — a flat spread alone only merges the TOP level
+      cardStyle: { ...DEFAULT_SETTINGS.cardStyle, ...(parsed.cardStyle || {}) }
+    };
+  } catch {
+    return { ...DEFAULT_SETTINGS }; // malformed JSON in the field — never throw, fall back
+  }
+}
+
+function saveSettings(settings) {
+  client.config.set({ settingsJson: JSON.stringify(settings) }); // persists with the workbook
+}
+```
+Always parse in a `try/catch`, and always overlay the parsed object onto
+the defaults rather than trusting it alone — that's what lets a later
+plugin version add a new settings key without breaking every workbook that
+saved the old shape. Settings saved this way persist with the workbook:
+they survive refresh and are shared with anyone viewing it.
+
+## Edit-mode gating
+
+Pair an `editMode` toggle (declared above) with — or in place of — reading
+`client.sigmaEnv`, to decide whether to show builder-only chrome:
+```js
+const showBuilderUI = config.editMode || client.sigmaEnv === 'author';
+```
+`editMode` is an explicit author opt-in (works even for an author who wants
+viewers to see it too); `sigmaEnv` reflects the actual session
+(`'author' | 'viewer' | 'explorer'`) regardless of any toggle. Gate a
+settings-gear icon, inline rename handles, or debug output (row counts, raw
+column IDs) behind whichever — or both — fits the plugin.
+
+## Variable + action-trigger writeback (the headline pattern)
+
+This is how a plugin stops passively displaying data and starts driving the
+workbook. Two editor-panel fields, always declared as a pair:
+```js
+client.config.configureEditorPanel([
+  { name: 'dataSource', type: 'element' },
+  { name: 'categoryColumn', type: 'column', source: 'dataSource', label: 'Category' },
+  { name: 'selected', type: 'variable', label: 'Selected Category', allowedTypes: ['text'] },
+  { name: 'onSelect', type: 'action-trigger', label: 'On Select' }
+]);
+```
+```js
+const [, setSelected] = useVariable(config.selected || '');   // write-only: discard the getter
+const fireOnSelect = useActionTrigger(config.onSelect || '');
+
+function choose(rowValue) {
+  setSelected(String(rowValue));  // 1. the WHAT — text variables want explicit String() coercion
+  fireOnSelect?.();               // 2. the REACT-NOW — tell the workbook something changed
+}
+
+function clear() {
+  setSelected('');   // clear with '' — not null
+  fireOnSelect?.();
+}
+```
+The variable carries the value; the trigger tells the workbook to notice
+it. The workbook builder is the one who wires the variable into a
+filter/control and the trigger into a refresh/navigate elsewhere in
+Sigma — declaring both fields here is what makes that wiring possible.
+
+**Multiple variables in one writeback** — set every value, then fire the
+trigger once:
+```js
+const [, setId] = useVariable(config.selectedId || '');
+const [, setLabel] = useVariable(config.selectedLabel || '');  // the "dual" value+label variant
+const fireOnSelect = useActionTrigger(config.onSelect || '');
+
+function choose(row) {
+  setId(String(row.id));
+  setLabel(String(row.name));
+  fireOnSelect?.();
+}
+```
+The dual (value + label) shape is handy whenever the consuming control
+needs a human-readable label alongside the raw value it filters on.
+
+## Dynamic editor-panel reconfiguration
+
+Keep the panel from cluttering itself with fields the author hasn't opted
+into. Recompute the config array from current config and re-call
+`configureEditorPanel`:
+```js
+function buildPanel(writebackEnabled) {
+  const base = [
+    { name: 'dataSource', type: 'element' },
+    { name: 'categoryColumn', type: 'column', source: 'dataSource', label: 'Category' },
+    { name: 'enableWriteback', type: 'toggle', label: 'Enable Writeback' }
+  ];
+  if (writebackEnabled) {
+    base.push(
+      { name: 'selected', type: 'variable', label: 'Selected Category' },
+      { name: 'onSelect', type: 'action-trigger', label: 'On Select' }
+    );
+  }
+  return base;
+}
+
+client.config.configureEditorPanel(buildPanel(false)); // initial
+
+client.config.subscribe((cfg) => {
+  client.config.configureEditorPanel(buildPanel(!!cfg.enableWriteback)); // reconfigure on change
+});
+```
+(React: the equivalent inside a `useEffect` keyed on `config.enableWriteback`.)
+The `variable`/`action-trigger` fields don't exist in the panel at all
+until the author flips `enableWriteback` on.
+
+## Variable-value unwrapping (footgun)
+
+The current SDK types `getVariable`/`useVariable`'s value as a fixed shape —
+`{ name: string, defaultValue: { type: string, value: any } }` — so the
+value itself lives at `variable.defaultValue.value`, never at the top
+level. Unwrap defensively anyway: some bindings and older SDK versions have
+been observed handing back a flatter `{ value }` shape, and `undefined`
+shows up whenever nothing is bound yet:
+```js
+function unwrapVariable(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object') return raw;                      // already a plain value
+  if (raw.defaultValue?.value !== undefined) return raw.defaultValue.value; // current shape
+  if (raw.value !== undefined) return raw.value;                 // flatter shape, seen elsewhere
+  return null;
+}
+```
+Date-typed variables have additionally been observed to carry one more
+nesting level around a millisecond timestamp:
+```js
+function unwrapDateVariable(raw) {
+  const inner = unwrapVariable(raw);
+  if (inner && typeof inner === 'object' && 'date' in inner) return new Date(inner.date);
+  return inner ? new Date(inner) : null;
+}
+```
+Run every variable read through one of these before using it. This is a
+footgun specifically because the documented shape works fine in quick
+testing, and only some bindings surface the flatter or extra-nested cases.
+
+## Action-effect (workbook → plugin)
+
+The inverse of a trigger: the workbook calls into the plugin.
+```js
+client.config.configureEditorPanel([
+  { name: 'onReset', type: 'action-effect', label: 'Reset Plugin' }
+]);
+```
+```js
+useActionEffect(config.onReset || '', () => {
+  clearSelection();
+  resetToDefaults();
+});
+```
+Typical uses: a workbook-level "reset all filters" control also resets this
+plugin's internal state, or a scheduled/triggered workbook action tells the
+plugin to refresh.
+
+## Multi-column roles
+
+A plugin needing several distinct roles from the same element (an x-axis,
+a y-axis, a label, a set of tooltip fields) declares one `column` entry per
+role, all pointing at the same `source`:
+```js
+client.config.configureEditorPanel([
+  { name: 'dataSource', type: 'element' },
+  { name: 'xAxis', type: 'column', source: 'dataSource', label: 'X Axis' },
+  { name: 'yAxis', type: 'column', source: 'dataSource', label: 'Y Axis' },
+  { name: 'seriesLabel', type: 'column', source: 'dataSource', label: 'Series Label' },
+  { name: 'tooltipFields', type: 'column', source: 'dataSource', allowMultiple: true, label: 'Tooltip Fields' }
+]);
+```
+`allowMultiple: true` can hand back a single string OR an array depending
+on how many columns are currently picked — always normalize before use:
+```js
+const tooltipIds = Array.isArray(config.tooltipFields)
+  ? config.tooltipFields
+  : [config.tooltipFields].filter(Boolean);
+```
+
+## Worked writeback example — click-to-filter list (documented recipe, not yet live-verified)
+
+The rest of this file has been individual recipes; this ties graceful
+loading, a single-column read, and variable + action-trigger writeback
+together into one small vanilla-JS plugin. It renders a category column as
+a clickable list; clicking a row writes a `selected` variable and fires an
+`onSelect` action-trigger so the workbook can filter something else off the
+choice.
+
+**Honesty note:** unlike the gauge plugin shipped with this skill — which
+has been registered, embedded, and value-verified against a live
+workbook — this recipe has **not** been rendered end-to-end against a live
+Sigma org. Doing that needs a workbook with a control and an action already
+wired to `selected`/`onSelect`, which is a live-workbook setup step outside
+a reference document. Treat this as a documented, SDK-correct starting
+point to adapt and verify yourself — not as a pre-verified artifact.
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Click-to-filter list (recipe)</title>
+<style>
+  body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  #list-root { padding: 8px; }
+  .list-row { padding: 6px 10px; cursor: pointer; border-radius: 4px; }
+  .list-row:hover { background: #f3f4f6; }
+  .list-row.is-active { background: #e0e7ff; font-weight: 600; }
+  .list-empty { color: #6b7280; padding: 8px; }
+</style>
+</head>
+<body>
+<div id="list-root"><div class="list-empty">Loading…</div></div>
+
+<script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+<script>
+(function () {
+  'use strict';
+
+  // Loaded via the CDN <script> tag, the SDK's UMD build exposes its named
+  // exports (client, useConfig, ...) on a `window.SigmaPlugin` global rather
+  // than through an import statement. React must load first — it's a hard
+  // peer dependency of the UMD build, which dereferences it at load and,
+  // if absent, throws before assigning `client`, leaving no client at all
+  // (not just a null one). No client (e.g. this file opened directly in a
+  // browser, or React missing) -> render a static demo list, no writeback
+  // wired.
+  var client = (typeof window.SigmaPlugin !== 'undefined') ? window.SigmaPlugin.client : null;
+  var root = document.getElementById('list-root');
+
+  function showMessage(text) {
+    root.innerHTML = '';
+    var msg = document.createElement('div');
+    msg.className = 'list-empty';
+    msg.textContent = text;
+    root.appendChild(msg);
+  }
+
+  function paintList(labels, activeLabel, onPick) {
+    if (!labels.length) return showMessage('No rows for this selection.');
+    root.innerHTML = '';
+    labels.forEach(function (label) {
+      var row = document.createElement('div');
+      row.className = 'list-row' + (label === activeLabel ? ' is-active' : '');
+      row.textContent = label;
+      row.addEventListener('click', function () { onPick(label); });
+      root.appendChild(row);
+    });
+  }
+
+  if (!client) {
+    paintList(['North', 'South', 'East', 'West'], null, function () {});
+    return;
+  }
+
+  client.config.configureEditorPanel([
+    { name: 'source', type: 'element' },
+    { name: 'categoryColumn', type: 'column', source: 'source', allowMultiple: false, label: 'Category Column' },
+    { name: 'selected', type: 'variable', label: 'Selected Category', allowedTypes: ['text'] },
+    { name: 'onSelect', type: 'action-trigger', label: 'On Select' }
+  ]);
+
+  var unsubData = null;
+  var activeLabel = null;
+
+  function handlePick(config, labels, label) {
+    activeLabel = label;
+    // 1. the WHAT — set the variable (text variables want String() coercion).
+    client.config.setVariable(config.selected, String(label));
+    // 2. the REACT-NOW — tell the workbook to notice it.
+    client.config.triggerAction(config.onSelect);
+    paintList(labels, activeLabel, function (nextLabel) { handlePick(config, labels, nextLabel); });
+  }
+
+  client.config.subscribe(function (config) {
+    if (unsubData) { unsubData(); unsubData = null; }
+
+    if (!config.source) return showMessage('Choose a data source.');
+    if (!config.categoryColumn) return showMessage('Choose a category column.');
+
+    unsubData = client.elements.subscribeToElementData(config.source, function (data) {
+      var values = data[config.categoryColumn];
+      if (!values || !values.length) return showMessage('No rows for this selection.');
+
+      var labels = Array.from(new Set(values.filter(function (v) { return v !== null; })));
+      paintList(labels, activeLabel, function (label) { handlePick(config, labels, label); });
+    });
+  });
+})();
+</script>
+</body>
+</html>
+```

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/plugin-lifecycle.md
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/plugin-lifecycle.md
@@ -1,0 +1,245 @@
+# Plugin Lifecycle — Verified Gotchas
+
+This is the canonical reference for the `@sigmacomputing/plugin` lifecycle:
+**build → register → host → embed → bind → verify.** Every gotcha below was
+proven against a live Sigma org (WS2 v1, gauge archetype) before being written
+down here — read this before registering or embedding a plugin, not after
+hitting the failure.
+
+The worked example throughout is the gauge plugin shipped with this skill:
+`plugins/gauge/index.html` (+ `plugins/gauge/README.md`), whose emitter output
+is `examples/gauge-embed.json`.
+
+## 1. Registration: `POST /v2/plugins`
+
+```
+POST /v2/plugins
+{ "name": "<unique plugin name>", "description": "<what it does>",
+  "url": "<hosted index.html URL>", "type": "element" }
+```
+
+A successful register returns a `pluginId`. **Always call
+`shared/scripts/register-plugin.rb` (`PluginRegister.register_or_get`)** rather
+than hand-rolling this — it already encodes the two gotchas below and is
+idempotent (safe to call repeatedly for the same `name`).
+
+### Masked 404 can accompany a *successful* register
+
+Sigma has been observed to return a non-2xx (masked 404-shaped) response on a
+`POST /v2/plugins` call that actually registered the plugin. **Never treat a
+non-2xx POST response as a hard failure by itself.** Always follow up with
+`GET /v2/plugins` and search the `entries` for a plugin matching the `name` you
+just sent — if it's there, the register succeeded regardless of what the POST
+response said. `register_or_get` does this automatically: GET-by-name first
+(idempotent short-circuit), POST if not found, then re-GET-by-name before
+deciding pass/fail.
+
+### Registration may be 403 org-admin-gated
+
+In some orgs, plugin registration requires org-admin credentials — a
+non-admin token gets a real 401/403 (not the masked-404 case above; this one
+is a genuine permission denial, confirmed by the follow-up GET *also* coming
+up empty). **Fall back to handoff**: hand the user the built plugin bundle,
+the exact hosting steps, and the exact `curl`/`register-plugin.rb` invocation
+to run once they have an org-admin token. Never silently drop the viz or fake
+a `pluginId`. `register_or_get` raises `PluginRegister::PermissionError` with
+this message shape so callers can catch it and switch to handoff.
+
+### `url` is set-once per registration
+
+Once registered, a plugin's `url` cannot be edited via the same registration
+call — if the hosted bundle moves (e.g. from localhost to a public host, or a
+new static-deploy URL), **re-register** (a new `POST /v2/plugins`, which
+mints a new `pluginId`) rather than expecting an in-place update. Downstream
+workbook specs that embedded the old `pluginId` will need to be repointed to
+the new one.
+
+## 2. Hosting: localhost is dev-iteration only; a PERSISTENT public host is required for anyone else to see it render
+
+A plugin hosted on `localhost` renders correctly in any **human's browser**
+that has it open — so building, previewing, and even binding real workbook
+data against it all work fine on localhost. What does **not** work on
+localhost: Sigma's **server-side rendering** (headless PNG export, scheduled
+PDF/email sends, any path that doesn't route through a human's browser)
+cannot reach it — it needs a **publicly reachable URL**. Nor does any
+*other* human — a teammate, a reviewer, an end user — who doesn't have that
+same localhost open. Treat localhost as dev-iteration only: fine for the
+person actively building the plugin, never sufficient for a shared or
+headlessly-rendered result.
+
+An **ephemeral tunnel** (a free-tier `ngrok`/`cloudflared` process, etc.) is
+not a fix either — it dies with the process, and some free tiers inject an
+interstitial page that a headless render server can't click through (no
+human to send the bypass header). The requirement is **persistence**, not
+just "has a public DNS name."
+
+**This is a hosting-platform decision the customer/user owns — this skill
+does not prescribe a vendor.** Ask (or use context to infer) which persistent
+public static host they prefer, then register the plugin at *that* host's
+URL. Common options, none of them a default:
+
+- The customer's own static-hosting setup (an existing S3+CloudFront /
+  internal CDN / corporate web server they already use for internal tools).
+- GitHub Pages, Netlify, Vercel, Cloudflare Pages, or any comparable static
+  host, on whichever account/org the customer controls.
+
+The registration and embed mechanics are **entirely host-neutral** — neither
+`register-plugin.rb` (`PluginRegister.register_or_get`) nor
+`PluginEmbed.build`/`plugin_embed.build` care which host served the bundle,
+only that its URL is persistent and reachable. Once you have *a* persistent
+public URL from *any* host, the steps in §1/§3 are identical.
+
+Practical consequence for verification: treat **data-parity** (export the
+plugin's bound element and compare the numbers) as the hard, always-provable
+gate — it works regardless of host. Treat the **visual screenshot** as
+depending on the host being persistent and public; on localhost or a dead/
+ephemeral tunnel, skip it with an honest note rather than faking a render.
+
+**Handoff is the default; turnkey is opt-in.** Emit the plugin bundle plus
+the exact host + register steps and let the user (or their CI) host it on
+their platform of choice — that's always correct and requires no new
+infrastructure trust from this skill. Automating a static deploy end-to-end
+is a fast-follow, not built into this skill; if the user already has an
+authenticated static-host CLI available, using it to get a persistent public
+URL up front makes the visual gate provable too, but never assume a
+particular one is present or preferred.
+
+*Worked example (illustrative only — not the standard):* WS2's own live
+acceptance test hosts the gauge plugin at
+`https://<your-org>.github.io/<repo>/gauge/`, a GitHub Pages site on a
+dedicated public repo (`main` branch, `/` root), used purely to prove the
+render lifecycle end-to-end during this skill's development. Substitute
+the customer's actual preferred host for production use — this URL is a
+demonstration, not a dependency.
+
+## 3. Embed shape: every *binding* value is a bare string
+
+The Sigma workbook-spec plugin element looks like:
+
+```json
+{
+  "id": "<element id>",
+  "kind": "plugin",
+  "pluginId": "<from registration>",
+  "config": {
+    "source": { "kind": "element", "elementId": "<bound data element id>" },
+    "<editor-panel var>": "<columnId or literal, as a STRING>"
+  }
+}
+```
+
+`config.source` is the **one** structured field — a fixed
+`{"kind":"element","elementId":...}` object naming the data element the
+plugin reads from. **Every other key in `config`** — every editor-panel
+binding (`value`, `target`, or whatever variables the plugin's
+`configureEditorPanel` declared) and any extra config (e.g. `format`) — **must
+be a bare string**, even when the underlying value is a `columnId` or a
+number. Sending a binding as a nested object (e.g. the
+`{"kind":"column","columnId":"..."}` shape used elsewhere in workbook specs)
+is **silently rejected**: the API does not name the offending field, it masks
+the failure as a generic `Invalid kind:"plugin"` error on the whole element.
+If you hit that error, the first thing to check is whether a config value
+that should be a string got emitted as an object or a number.
+
+**Don't hand-write this JSON — call the emitter:**
+
+- Ruby: `PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` — `shared/lib/plugin_embed.rb`
+- Python: `plugin_embed.build(id, plugin_id, source_element_id, bindings, extra_config=None)` — `shared/lib/plugin_embed.py`
+
+Both twins coerce every `bindings`/`extra_config` value to a string (so a
+numeric `2` becomes `"2"`) and always emit the correct `config.source` shape.
+`bindings` maps editor-panel var name → `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is anything
+else non-binding (e.g. `{"format" => ".0%"}`). See
+`examples/gauge-embed.json` for a full worked output.
+
+## 4. The plugin's backing data element needs its own hidden page
+
+The `source.elementId` a plugin binds to is a normal table/element in the
+workbook — but if you don't want it visible to end users, **put it on a
+separate hidden page**. Setting `visibleAsSource:false` on the element alone
+does **not** remove it from layout / visibility — pages are the actual
+visibility boundary. See the `sigma-workbooks` skill's layout reference for
+how to mark a page hidden.
+
+## 5. `ResizeObserver` is mandatory — the #1 "wonky plugin" cause
+
+A plugin that only relies on CSS or SVG `viewBox` scaling to handle resize
+ends up with illegible text or a clipped/distorted drawing at small panel
+widths — this is the single most common way a hand-built plugin looks broken
+in a real dashboard (where panels get resized constantly). The fix: attach a
+`ResizeObserver` to the render container and, on every resize event, **fully
+recompute** geometry (stroke width, font size, arc/shape dimensions) from the
+container's actual current box and re-render from scratch — not an
+incremental CSS-only patch. The gauge plugin
+(`plugins/gauge/index.html`) does exactly this: its `ResizeObserver` callback
+calls the same size-driven `render()` function used for the initial paint, so
+the same code path is exercised whether the panel first loads at 1100px or
+gets dragged down to 550px.
+
+## 6. Synthetic fallback — preview standalone, without a Sigma host
+
+Every plugin should render *something* sensible when opened directly in a
+browser (no Sigma `client`) or when the bound `value`/`target` columns don't
+resolve to a complete row — a `synth()` path that fabricates plausible demo
+data (the gauge uses `value: 82, target: 100`). This makes the plugin file
+independently previewable (open it in a browser, or screenshot it at multiple
+widths) before it's ever registered or embedded, which is the fastest way to
+iterate on layout/rendering without round-tripping through Sigma.
+
+## 7. The SDK's UMD build needs React loaded BEFORE it (silent-synth trap)
+
+`@sigmacomputing/plugin`'s UMD/CDN build — what
+`<script src="https://unpkg.com/@sigmacomputing/plugin">` gives you — has
+**React as a hard peer dependency**. Its factory dereferences React at load; if
+React isn't already on the page it **throws before assigning `client`**, leaving
+`window.SigmaPlugin` an empty object with no `client`. The plugin then has no way
+to read bound data and silently falls through to its `synth()` fallback (§6) —
+so it *looks* like it works (shows demo numbers) while never touching real data.
+Sigma does **not** inject React into the plugin iframe, so a vanilla single-file
+plugin must load React itself, **first**:
+
+```html
+<script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+```
+
+`ReactDOM` is **not** required for the vanilla `client` API — only `React`. Pin
+the version. For a plugin that must render in restrictive/offline contexts, host
+React and the SDK on the plugin's **own origin** instead of a CDN. This is the
+single most likely reason a freshly built plugin "renders fine" but shows demo
+numbers instead of your data. Verified against `@sigmacomputing/plugin` v1.2.0;
+see `reference/sdk-api.md` for the full `client` shape.
+
+## 8. Sigma's server-side PNG export does NOT hydrate plugin data
+
+The workbook **PNG export / screenshot** API renders a plugin's page,
+initializes its `client`, and fires `config.subscribe` with the correct
+bindings — but it does **not** deliver the plugin's asynchronous element data
+before it snapshots (the `subscribeToElementData` callback never fires in that
+environment, even with the source element on the exported page). So a
+server-rendered screenshot of a plugin shows its **`synth()` fallback, not live
+data** — a limitation of PNG export for plugins, not a plugin bug. For
+verification:
+
+- **Do not** treat a plugin's PNG-export screenshot as proof it reads real data
+  — it structurally cannot show that.
+- Verify **data-parity at the element level**: export the bound
+  `source.elementId` and assert its values (headless, independent of the
+  plugin). This is what `verify-plugin-gauge-e2e.rb` gates on.
+- Confirm the plugin's **live rendering** of that data only in a **live browser
+  session** (interactive workbook or a signed embed), where Sigma pushes element
+  data to the subscription normally.
+- Watch for coincidental literals: the gauge's `synth()` fallback and
+  `verify-plugin-gauge-e2e.rb`'s test data both happen to use `82`/`100`, so a
+  screenshot showing "82 of 100" proves nothing either way — it's exactly the
+  coincidence that let the original silent-synth bug hide behind a
+  correct-looking render; element-level data-parity is the real gate.
+
+## 9. Emitter recap
+
+| Concern | Tool |
+|---|---|
+| Register (idempotent, masked-404/403-aware) | `shared/scripts/register-plugin.rb` (`PluginRegister.register_or_get`) |
+| Emit the embed JSON (bare-string config, correct `source` shape) | `shared/lib/plugin_embed.{rb,py}` (`PluginEmbed.build` / `plugin_embed.build`) |
+| Worked example (plugin + emitter output) | `plugins/gauge/` + `examples/gauge-embed.json` |

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/sdk-api.md
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/sdk-api.md
@@ -1,0 +1,339 @@
+# SDK API Reference — Editor Panel, Client, and Hooks
+
+Lookup-oriented reference for the `@sigmacomputing/plugin` surface a plugin
+uses to declare its data contract (the editor panel) and read/write
+config, element data, variables, and actions once embedded. It does **not**
+cover getting a plugin registered, hosted, or embedded — that's
+`reference/plugin-lifecycle.md` (masked 404/403 on registration, `url`
+set-once, the localhost/hosting boundary, the bare-string `config` shape,
+the hidden backing page, `ResizeObserver`, the synthetic-fallback
+convention). Read that first if you haven't shipped a plugin before; this
+file assumes it and only adds the authoring surface.
+
+Every fact below is checked against the SDK's own published type
+declarations (`@sigmacomputing/plugin`, npm/GitHub — `sigmacomputing/plugin`,
+MIT — a different, unrestricted source from the clean-room secondary
+material this reference otherwise drew guidance from). Where the two
+disagreed, this file follows the published types and says so.
+
+## 1. Editor-panel config types
+
+`client.config.configureEditorPanel([...])` (or the `useEditorPanelConfig`
+hook, called once per render inside a component) declares the fields a
+workbook author fills in from Sigma's side panel for this plugin element.
+Every entry needs a unique `name` — the key you read its value back under —
+and a `type`. One of each type, with the properties specific to it:
+
+**`element`** — the one data-source picker every data-driven plugin needs.
+```js
+{ name: 'dataSource', type: 'element' }
+```
+Every `column`/`variable`-adjacent entry that needs to scope to it names it
+via `source: 'dataSource'`.
+
+**`column`** — pick a column out of an `element` entry.
+```js
+{
+  name: 'metricColumn',
+  type: 'column',
+  source: 'dataSource',                  // required — the element entry to pick from
+  allowMultiple: false,                  // true -> string[]; false -> string
+  allowedTypes: ['number', 'integer'],   // restrict to specific ValueType(s)
+  label: 'Metric'
+}
+```
+
+**`text`** — free-form string input; the backbone of the JSON-settings
+pattern (`patterns.md`) when paired with `multiline: true`.
+```js
+{
+  name: 'title', type: 'text', label: 'Panel Title',
+  defaultValue: '', placeholder: 'Untitled panel',
+  multiline: false,   // true renders a textarea
+  secure: false         // true masks input and omits it from pre-hydrated/URL config
+}
+```
+
+**`toggle`** / **`checkbox`** — both resolve to a `boolean`; pick whichever
+label style reads better in the panel. Both accept an optional
+`defaultValue: boolean`.
+```js
+{ name: 'showLegend', type: 'toggle', label: 'Show Legend', defaultValue: true }
+```
+
+**`radio`** — small fixed choice set.
+```js
+{
+  name: 'orientation', type: 'radio',
+  values: ['vertical', 'horizontal'],
+  singleLine: true,       // render inline instead of stacked — good for 2-3 options
+  defaultValue: 'vertical',
+  label: 'Orientation'
+}
+```
+
+**`dropdown`** — larger fixed choice set.
+```js
+{
+  name: 'aggregation', type: 'dropdown',
+  values: ['sum', 'avg', 'min', 'max'],
+  width: '160',            // pixel width — the SDK types this as a string, not a number
+  defaultValue: 'sum',
+  label: 'Aggregation'
+}
+```
+
+**`color`** — a color-picker input; value is a color string.
+```js
+{ name: 'accentColor', type: 'color', label: 'Accent Color' }
+```
+
+**`variable`** — bind to a workbook control variable; the read/write half
+of interactivity (see the writeback pattern in `patterns.md`).
+```js
+{
+  name: 'activeCategory', type: 'variable', label: 'Active Category',
+  allowedTypes: ['text']   // restrict to a ControlType — see enum below
+}
+```
+
+**`interaction`** — bind to cross-element selection state.
+**Deprecated as of the current published SDK — "Use Action API instead."**
+The type still exists and the `client.config.getInteraction`/`setInteraction`
+methods still work, but new plugins should reach for `action-trigger` +
+`action-effect` (below) instead of `interaction` for cross-element behavior.
+```js
+{ name: 'crossSelect', type: 'interaction', label: 'Selection Binding' } // legacy
+```
+
+**`action-trigger`** — the plugin fires a workbook action.
+```js
+{ name: 'onSelect', type: 'action-trigger', label: 'On Select' }
+```
+Paired with a `variable` for the headline writeback pattern: set the
+variable (the *what*), then fire the trigger (the *react now*).
+
+**`action-effect`** — the workbook invokes a callback inside the plugin;
+the inverse direction of `action-trigger`.
+```js
+{ name: 'onReset', type: 'action-effect', label: 'Reset Plugin' }
+```
+
+**`url-parameter`** — sync a value to the page URL for deep-linking. Note:
+this type's own declared shape omits `label` — it has no display label.
+```js
+{ name: 'deepLinkFilter', type: 'url-parameter' }
+```
+
+**`group`** — a purely visual grouping of related entries in the panel; no
+`source` property (unlike `column`/`dropdown`) and no runtime config value
+of its own.
+```js
+{ name: 'advanced', type: 'group', label: 'Advanced' }
+```
+
+### Config-value-by-type
+
+What `client.config.getKey(name)` / `useConfig()` hands back for each type:
+
+| Config `type` | Runtime value |
+|---|---|
+| `element` | `string` (element ID) or `undefined` until chosen |
+| `column`, `allowMultiple: false` | `string` (column ID) or `undefined` |
+| `column`, `allowMultiple: true` | `string[]` |
+| `text` | `string` |
+| `toggle` / `checkbox` | `boolean` |
+| `radio` / `dropdown` | one member of `values` |
+| `color` | `string` |
+| `variable` | `string` — a config ID; pass it to `getVariable`/`useVariable`, it is not the variable's value |
+| `interaction` (deprecated) | `string` — a config ID; pass to `getInteraction`/`setInteraction` |
+| `action-trigger` | `string` — a config ID; pass to `triggerAction`/`useActionTrigger` |
+| `action-effect` | `string` — a config ID; pass to `registerEffect`/`useActionEffect` |
+| `url-parameter` | `string` — a config ID; pass to the URL-parameter methods |
+| `group` | no runtime value — structural only |
+
+### ControlType (valid `allowedTypes` for a `variable` entry)
+`'boolean' | 'date' | 'number' | 'text' | 'text-list' | 'number-list' | 'date-list' | 'number-range' | 'date-range'`
+
+### ValueType (valid `allowedTypes` for a `column` entry)
+`'boolean' | 'datetime' | 'number' | 'integer' | 'text' | 'variant' | 'link' | 'error'`
+
+## 2. Reading config & data — two idioms
+
+> ⚠️ **Load React before the SDK.** The UMD build
+> (`<script src="https://unpkg.com/@sigmacomputing/plugin">`) has React as a
+> hard peer dependency and **throws at load if React is absent**, leaving
+> `window.SigmaPlugin` with no `client` — so *none* of the calls below work and
+> the plugin silently synths. Put a React `<script>` (React alone; ReactDOM not
+> needed for `client`) before the SDK. Full detail + the fix snippet:
+> `reference/plugin-lifecycle.md` §7.
+
+Every read/write has a vanilla `client.*` form and, in a React plugin, a
+hook form; both talk to the same underlying channel. Pick one idiom per
+file — don't mix them for the same value.
+
+**Namespace note:** several of these live under `client.config.*` in the
+current published SDK even though they aren't strictly about "config" —
+`getVariable`/`setVariable`, `getInteraction`/`setInteraction`,
+`triggerAction`, `registerEffect`, `setLoadingState`, and the
+URL-parameter methods are all `client.config.X`, not top-level `client.X`.
+Only `client.elements.*`, `client.style.*`, `client.sigmaEnv`, and
+`client.destroy()` sit outside `config`.
+
+### Side-by-side
+
+| Concern | Vanilla client API | React hook |
+|---|---|---|
+| Define the editor panel | `client.config.configureEditorPanel(entries)` | `useEditorPanelConfig(entries)` |
+| Read all config | `client.config.get()` / `client.config.subscribe(cb)` | `useConfig()` |
+| Read one config value | `client.config.getKey(name)` | `useConfig(name)` or destructure from `useConfig()` |
+| Write config | `client.config.set(partial)` / `client.config.setKey(name, value)` | same calls — there's no separate writer hook |
+| Element data | `client.elements.subscribeToElementData(sourceId, cb)` | `useElementData(sourceId)` |
+| Column metadata | `client.elements.subscribeToElementColumns(sourceId, cb)` | `useElementColumns(sourceId)` |
+| Variable read/write | `client.config.getVariable(id)` / `client.config.setVariable(id, ...values)` / `client.config.subscribeToWorkbookVariable(id, cb)` | `const [variable, setVariable] = useVariable(id)` |
+| Fire an action | `client.config.triggerAction(id)` | `const fire = useActionTrigger(id); fire()` |
+| Receive an action | `client.config.registerEffect(id, cb)` — returns an unsubscribe fn | `useActionEffect(id, cb)` |
+| Interaction (selection) — **deprecated**, prefer action-trigger/-effect | `client.config.getInteraction(id)` / `client.config.setInteraction(id, elementId, selection)` | `useInteraction(id, elementId)` — also deprecated |
+| URL parameter | `client.config.getUrlParameter(name)` / `client.config.setUrlParameter(name, value)` / `client.config.subscribeToUrlParameter(name, cb)` | `useUrlParameter(name)` |
+| Style | `client.style.get()` / `client.style.subscribe(cb)` | `usePluginStyle()` |
+| Environment | `client.sigmaEnv` | same — a plain property, no hook needed |
+| Loading indicator | `client.config.setLoadingState(bool)` | `useLoadingState(initialBool)` returns `[isLoading, setIsLoading]` |
+| Teardown | `client.destroy()` | handled by component unmount in practice |
+
+The SDK also ships `usePlugin()` (the whole `PluginInstance`) and
+`usePaginatedElementData`/`elements.fetchMoreElementData` (data beyond the
+default page size) — real, but out of scope for this reference; see the
+package's own README for those.
+
+### Vanilla client API surface
+```js
+import { client } from '@sigmacomputing/plugin';
+
+client.config.configureEditorPanel(entries);
+client.config.get();                        // full config object, once
+client.config.getKey('metricColumn');        // one value, once
+client.config.set({ title: 'New Title' });   // shallow merge into current config
+client.config.setKey('title', 'New Title');  // write a single key
+const stopConfig = client.config.subscribe((cfg) => { /* runs on every change */ });
+
+client.elements.subscribeToElementData(sourceId, (data) => { /* column-oriented rows */ });
+client.elements.subscribeToElementColumns(sourceId, (cols) => { /* metadata */ });
+
+client.config.getVariable(varId);                        // { name, defaultValue: { type, value } }
+client.config.setVariable(varId, newValue);               // range variables take 2 args
+const stopVar = client.config.subscribeToWorkbookVariable(varId, (v) => {});
+
+client.config.triggerAction(actionId);
+const stopEffect = client.config.registerEffect(effectId, () => { /* workbook triggered this */ });
+
+client.config.getUrlParameter('deepLinkFilter');           // { value: string }
+client.config.setUrlParameter('deepLinkFilter', 'east-region');
+const stopUrl = client.config.subscribeToUrlParameter('deepLinkFilter', (v) => {});
+
+client.style.get();               // Promise<{ backgroundColor: string }> — workbook theme
+client.style.subscribe((style) => {});
+
+client.sigmaEnv;                  // 'author' | 'viewer' | 'explorer'
+client.config.setLoadingState(true);  // show/hide Sigma's own loading indicator for this element
+client.destroy();                 // tear down every subscription this client created
+```
+`setVariable`/`setKey`/`set`/`triggerAction` are declared to return `void`
+(they post a message to the host and don't hand back a result to await).
+Some example code still wraps them in `await` anyway — harmless on a
+non-`Promise` return, and it defers the next statement to a microtask,
+which is a cheap way to make sure a variable write has a moment to
+propagate before a dependent trigger fires.
+
+### React hooks
+```js
+import {
+  useConfig, useEditorPanelConfig,
+  useElementData, useElementColumns,
+  useVariable, useActionTrigger, useActionEffect
+} from '@sigmacomputing/plugin';
+
+useEditorPanelConfig(entries);                    // define the panel from inside a component
+const config = useConfig();                       // all config values, re-renders on change
+const rows = useElementData(config.dataSource || '');
+const cols = useElementColumns(config.dataSource || '');
+const [variable, setVariable] = useVariable(config.activeCategory || '');
+const fireOnSelect = useActionTrigger(config.onSelect || '');
+useActionEffect(config.onReset || '', () => { /* workbook told the plugin to reset */ });
+```
+Guard every hook call with `|| ''` when the underlying config key might
+still be `undefined` — the plugin renders before the author finishes
+configuring it (see the graceful-loading pattern in `patterns.md`).
+
+## 3. Element data shape
+
+Data from `useElementData`/`subscribeToElementData` is **column-oriented**:
+```ts
+{ [columnId: string]: any[] }   // the SDK types values loosely; in practice
+                                 // each entry is a string, number, boolean, or null
+```
+Every column array is the same length (one entry per row).
+
+**Column IDs are not display names.** A key like `col-3f8a1c` says nothing
+about what the column *is* — resolve the human-readable name from the
+parallel column-metadata object (`useElementColumns`/`subscribeToElementColumns`):
+```ts
+{
+  [columnId: string]: {
+    id: string;
+    name: string;         // display name, e.g. "Order Total"
+    columnType: string;   // ValueType — 'text' | 'number' | 'integer' | 'datetime' | 'boolean' | ...
+    // Commonly also carries a `format` object at runtime — { type: string, format: string } —
+    // with a d3-format string for numeric types (e.g. "$,.2f") or a d3-time-format string for
+    // date/datetime types (e.g. "%Y-%m-%d"). This isn't part of the published column-metadata
+    // type as of SDK v1.2.0, so read it defensively: `columnMeta?.format?.format`.
+  }
+}
+```
+
+### Column → row transform
+Most rendering libraries want rows, not columns:
+```js
+function toRows(columnData, columnIds, columnMeta) {
+  const length = columnData[columnIds[0]]?.length ?? 0;
+  const rows = [];
+  for (let i = 0; i < length; i++) {
+    const row = {};
+    for (const id of columnIds) {
+      const key = columnMeta?.[id]?.name ?? id;
+      row[key] = columnData[id][i];
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+```
+
+## 4. Defensive date handling
+
+Dates can arrive as an ISO string, a numeric timestamp (epoch seconds *or*
+milliseconds — inconsistent across sources), or an already-constructed
+`Date`. Never assume one shape:
+```js
+function parseDate(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (raw instanceof Date) return isNaN(raw.getTime()) ? null : raw;
+  if (typeof raw === 'number') {
+    // Below ~10 billion, treat as epoch seconds; otherwise it's already milliseconds.
+    const ms = raw < 1e10 ? raw * 1000 : raw;
+    const d = new Date(ms);
+    return isNaN(d.getTime()) ? null : d;
+  }
+  if (typeof raw === 'string') {
+    const d = new Date(raw);
+    return isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+```
+Use the column-metadata `format.format` (a d3-time-format string, when
+present — see the hedge above) if you need to render a date the way Sigma
+would, rather than hard-coding a display format.
+
+This is a **column-value** parsing concern. A *variable's* date value has
+its own, different wrapping problem (an extra object layer, not a type
+ambiguity) — see the unwrap recipe in `patterns.md`.

--- a/plugins/sigma-authoring/skills/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
+++ b/plugins/sigma-authoring/skills/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-gauge-plugin-static.rb — static-lint gate for the WS2 clean-room gauge
+# plugin (plugins/sigma-authoring/skills/sigma-plugin-authoring/plugins/gauge/
+# index.html). Does NOT execute the plugin (no browser/JS runtime here) — it
+# asserts the file satisfies the verified Sigma plugin-lifecycle contract by
+# source inspection: loads the @sigmacomputing/plugin SDK, configures an
+# editor panel, declares value+target bindings (the plugin_embed contract),
+# attaches a ResizeObserver (redraw-on-resize — the #1 "wonky plugin" cause),
+# and ships a synthetic fallback so it previews standalone.
+#
+# Usage:  ruby plugins/sigma-authoring/skills/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
+#
+# Lives alongside the gauge plugin it lints (both under the
+# sigma-plugin-authoring skill) so this has no cross-plugin dependency —
+# previously it lived under tableau-to-sigma and reached across into
+# sigma-authoring, which meant installing tableau-to-sigma without
+# sigma-authoring made HTML read '' (ENOENT swallowed below) and every
+# check FAIL.
+require 'json'
+HTML = begin
+  File.read(File.expand_path('../plugins/gauge/index.html', __dir__))
+rescue Errno::ENOENT
+  ''
+end
+$f = 0
+def chk(c, m)
+  puts(c ? "[ok] #{m}" : "[FAIL] #{m}")
+  $f += 1 unless c
+end
+chk(HTML.include?('@sigmacomputing/plugin'), 'loads the @sigmacomputing/plugin SDK')
+chk(HTML.include?('configureEditorPanel'),   'configures an editor panel')
+chk(HTML =~ /['"]value['"]/ && HTML =~ /['"]target['"]/, 'declares value + target bindings')
+chk(HTML.include?('ResizeObserver'),         'attaches a ResizeObserver (redraw-on-resize)')
+chk(HTML.downcase.include?('synth') || HTML.include?('fallback'), 'has a synthetic fallback')
+# Data-binding contract (verified against @sigmacomputing/plugin v1.2.0 UMD +
+# dist/esm/index.d.ts). These guard the bug class that let the plugin silently
+# render synthetic data forever: the wrong SDK global, and the wrong data-
+# subscription path/arity.
+chk(HTML.include?('SigmaPlugin'),
+    'references the real SDK global window.SigmaPlugin (not the nonexistent window.Sigma)')
+chk(HTML =~ /elements\s*\.\s*subscribeToElementData/,
+    'reads bound data via client.elements.subscribeToElementData(sourceId, cb)')
+# React peer-dep: @sigmacomputing/plugin's UMD build THROWS at load if React is
+# absent, leaving window.SigmaPlugin with no `client` -> the plugin can never
+# read data and silently synths. React MUST be loaded BEFORE the SDK script.
+# Anchor on the actual <script src=…> tags (the SDK name also appears in prose
+# comments, so a plain string index would match the wrong position).
+react_idx = HTML =~ %r{<script[^>]*\bsrc=["'][^"']*react[@./][^"']*\.js}
+sdk_idx   = HTML =~ %r{<script[^>]*\bsrc=["'][^"']*@sigmacomputing/plugin}
+chk(react_idx && sdk_idx && react_idx < sdk_idx,
+    'loads React BEFORE the @sigmacomputing/plugin SDK (UMD peer dependency)')
+exit($f.zero? ? 0 : 1)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/shared/lib/coverage_catalog.py
+++ b/shared/lib/coverage_catalog.py
@@ -72,6 +72,21 @@ class Catalog:
         row = self.resolve(source_key)
         return row.get("sigma") if row else None
 
+    def plugin_archetype(self, source_key):
+        """Return the recreate-as-plugin archetype for ``source_key``, or
+        ``None``. Honors an explicit ``plugin_archetype`` field on the row, or
+        a ``sigma`` value of the form ``"plugin:<archetype>"`` (returns the
+        part after the prefix). Additive — does not change resolve/target/
+        resolve_or_warn's existing dispatch."""
+        row = self.resolve(source_key)
+        if not row:
+            return None
+        a = row.get("plugin_archetype")
+        if a is not None and str(a) != "":
+            return a
+        s = str(row.get("sigma") or "")
+        return s[len("plugin:"):] if s.startswith("plugin:") else None
+
     def resolve_or_warn(self, source_key, warnings, *, context=""):
         """Resolve ``source_key``; on a miss append a standardized LOUD warning to
         ``warnings`` and return ``None``. The caller must then skip/placeholder —

--- a/shared/lib/coverage_catalog.rb
+++ b/shared/lib/coverage_catalog.rb
@@ -51,6 +51,19 @@ module Coverage
       r && r['sigma']
     end
 
+    # Return the recreate-as-plugin archetype for source_key, or nil. Honors an
+    # explicit `plugin_archetype` field on the row, or a `sigma` value of the
+    # form "plugin:<archetype>" (returns the part after the prefix). Additive —
+    # does not change resolve/target/resolve_or_warn's existing dispatch.
+    def plugin_archetype(source_key)
+      r = resolve(source_key)
+      return nil unless r
+      a = r['plugin_archetype']
+      return a unless a.to_s.empty?
+      s = r['sigma'].to_s
+      s.start_with?('plugin:') ? s.sub('plugin:', '') : nil
+    end
+
     # Resolve; on a miss append a standardized LOUD warning to `warnings` and
     # return nil. The caller MUST then skip/placeholder — makes the loud
     # fallback mandatory and uniform.

--- a/shared/lib/plugin_embed.py
+++ b/shared/lib/plugin_embed.py
@@ -1,0 +1,23 @@
+# plugin_embed.py — Python twin of shared/lib/plugin_embed.rb. Emits the
+# VERIFIED Sigma {kind:"plugin"} element block. ALL config values are bare
+# strings (object form is rejected, masked "Invalid kind:\"plugin\""). Twin
+# emits sorted-key-identical output (shared/lib/testdata/plugin_embed_golden.json).
+# Stdlib only (json); Windows-safe.
+import json
+
+
+def build(id, plugin_id, source_element_id, bindings, extra_config=None):
+    if not id:
+        raise ValueError("id required")
+    if not plugin_id:
+        raise ValueError("plugin_id required")
+    if not source_element_id:
+        raise ValueError("source_element_id required")
+
+    config = {"source": {"kind": "element", "elementId": source_element_id}}
+    for k, v in (bindings or {}).items():
+        config[str(k)] = str(v)  # bare string columnId
+    for k, v in (extra_config or {}).items():
+        config[str(k)] = str(v)  # ALL config values -> string
+
+    return {"id": id, "kind": "plugin", "pluginId": plugin_id, "config": config}

--- a/shared/lib/plugin_embed.rb
+++ b/shared/lib/plugin_embed.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# plugin_embed.rb — Ruby twin of shared/lib/plugin_embed.py. Emits the VERIFIED
+# Sigma {kind:"plugin"} element block. ALL config values are bare strings
+# (object form is rejected, masked "Invalid kind:\"plugin\""). Twin emits
+# sorted-key-identical output (shared/lib/testdata/plugin_embed_golden.json).
+# Stdlib only (json); Ruby 2.6-compatible.
+require 'json'
+module PluginEmbed
+  def self.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'plugin_id required' if plugin_id.to_s.empty?
+    raise ArgumentError, 'source_element_id required' if source_element_id.to_s.empty?
+    config = { 'source' => { 'kind' => 'element', 'elementId' => source_element_id } }
+    (bindings || {}).each { |k, v| config[k.to_s] = v.to_s }        # bare string columnId
+    (extra_config || {}).each { |k, v| config[k.to_s] = v.to_s }    # ALL config values -> string
+    { 'id' => id, 'kind' => 'plugin', 'pluginId' => plugin_id, 'config' => config }
+  end
+end

--- a/shared/lib/test_coverage_catalog.py
+++ b/shared/lib/test_coverage_catalog.py
@@ -95,6 +95,29 @@ class CoverageCatalogTest(unittest.TestCase):
         got = cc.default_catalog_dir(fake)
         self.assertTrue(got.endswith(os.path.join("skills", "x", "refs", "catalogs")))
 
+    def test_plugin_archetype(self):
+        _write_catalog(
+            self.dir, "viz-kind-plugin",
+            [
+                {"source": "GaugeChartVisual", "sigma": "kpi-chart", "plugin_archetype": "gauge"},
+                {"source": "HeatMapVisual", "sigma": "plugin:heatmap"},
+                {"source": "BarChartVisual", "sigma": "bar-chart"},
+            ],
+            dimension="viz-kind", source_tool="quicksight",
+        )
+        cat = cc.load(self.dir, "viz-kind-plugin")
+        # explicit plugin_archetype field wins
+        self.assertEqual(cat.plugin_archetype("GaugeChartVisual"), "gauge")
+        # sigma "plugin:<x>" prefix -> archetype
+        self.assertEqual(cat.plugin_archetype("HeatMapVisual"), "heatmap")
+        # plain native row -> None
+        self.assertIsNone(cat.plugin_archetype("BarChartVisual"))
+        # miss -> None
+        self.assertIsNone(cat.plugin_archetype("NopeVisual"))
+        # non-breaking: target/resolve for the gauge row still return "kpi-chart"
+        self.assertEqual(cat.target("GaugeChartVisual"), "kpi-chart")
+        self.assertEqual(cat.resolve("GaugeChartVisual")["sigma"], "kpi-chart")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/shared/lib/test_coverage_catalog.rb
+++ b/shared/lib/test_coverage_catalog.rb
@@ -59,6 +59,24 @@ Dir.mktmpdir('cc-rb-test-') do |dir|
   check('default_catalog_dir') do
     Coverage.default_catalog_dir('/a/b/skills/x/scripts/build.rb').end_with?(File.join('skills', 'x', 'refs', 'catalogs'))
   end
+
+  File.write(File.join(dir, 'viz-kind-plugin.json'), JSON.dump(
+    'dimension' => 'viz-kind', 'source_tool' => 'quicksight',
+    'rows' => [
+      { 'source' => 'GaugeChartVisual', 'sigma' => 'kpi-chart', 'plugin_archetype' => 'gauge' },
+      { 'source' => 'HeatMapVisual', 'sigma' => 'plugin:heatmap' },
+      { 'source' => 'BarChartVisual', 'sigma' => 'bar-chart' }
+    ]
+  ))
+  pcat = Coverage.load(dir, 'viz-kind-plugin')
+
+  check('plugin_archetype: explicit field wins') { pcat.plugin_archetype('GaugeChartVisual') == 'gauge' }
+  check('plugin_archetype: sigma "plugin:<x>" prefix') { pcat.plugin_archetype('HeatMapVisual') == 'heatmap' }
+  check('plugin_archetype: plain native row -> nil') { pcat.plugin_archetype('BarChartVisual').nil? }
+  check('plugin_archetype: miss -> nil') { pcat.plugin_archetype('NopeVisual').nil? }
+  check('non-breaking: target/resolve for gauge row still "kpi-chart"') do
+    pcat.target('GaugeChartVisual') == 'kpi-chart' && pcat.resolve('GaugeChartVisual')['sigma'] == 'kpi-chart'
+  end
 end
 
 if $failures.zero?

--- a/shared/lib/test_plugin_embed.py
+++ b/shared/lib/test_plugin_embed.py
@@ -1,0 +1,43 @@
+import json, os, sys, unittest
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import plugin_embed
+
+def _sort(o):
+    if isinstance(o, dict):
+        return {k: _sort(o[k]) for k in sorted(o)}
+    if isinstance(o, list):
+        return [_sort(e) for e in o]
+    return o
+
+class PluginEmbedTest(unittest.TestCase):
+    def setUp(self):
+        with open(os.path.join(os.path.dirname(__file__), "testdata", "plugin_embed_golden.json")) as f:
+            self.golden = json.load(f)
+
+    def test_gauge_matches_golden(self):
+        el = plugin_embed.build(id="gauge-el", plugin_id="pl-1", source_element_id="tbl-1",
+                                 bindings={"value": "actual", "target": "target"},
+                                 extra_config={"format": "$.3~s"})
+        self.assertEqual(json.dumps(_sort(el)), json.dumps(_sort(self.golden)))
+
+    def test_numeric_extra_config_coerced_to_string(self):
+        el = plugin_embed.build(id="gauge-el", plugin_id="pl-1", source_element_id="tbl-1",
+                                 bindings={"value": "actual"},
+                                 extra_config={"decimals": 2})
+        self.assertEqual(el["config"]["decimals"], "2")
+        self.assertIsInstance(el["config"]["decimals"], str)
+
+    def test_empty_id_raises(self):
+        with self.assertRaises(ValueError):
+            plugin_embed.build(id="", plugin_id="pl-1", source_element_id="tbl-1", bindings={})
+
+    def test_empty_plugin_id_raises(self):
+        with self.assertRaises(ValueError):
+            plugin_embed.build(id="gauge-el", plugin_id="", source_element_id="tbl-1", bindings={})
+
+    def test_empty_source_element_id_raises(self):
+        with self.assertRaises(ValueError):
+            plugin_embed.build(id="gauge-el", plugin_id="pl-1", source_element_id="", bindings={})
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/shared/lib/test_plugin_embed.rb
+++ b/shared/lib/test_plugin_embed.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+# test_plugin_embed.rb — run directly: ruby shared/lib/test_plugin_embed.rb
+require 'json'
+require_relative 'plugin_embed'
+
+$failures = 0
+def check(desc)
+  ok = yield
+  puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}")
+  $failures += 1 unless ok
+end
+
+# Deep-sort hashes/arrays so twin/golden comparison is key-order-independent.
+def sort_deep(o)
+  case o
+  when Hash then o.keys.sort.each_with_object({}) { |k, h| h[k] = sort_deep(o[k]) }
+  when Array then o.map { |e| sort_deep(e) }
+  else o
+  end
+end
+
+golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'plugin_embed_golden.json')))
+
+check('gauge plugin embed matches golden (sorted-key identical)') do
+  el = PluginEmbed.build(id: 'gauge-el', plugin_id: 'pl-1', source_element_id: 'tbl-1',
+                          bindings: { 'value' => 'actual', 'target' => 'target' },
+                          extra_config: { 'format' => '$.3~s' })
+  JSON.generate(sort_deep(el)) == JSON.generate(sort_deep(golden))
+end
+
+check('numeric extra_config value is coerced to a string') do
+  el = PluginEmbed.build(id: 'gauge-el', plugin_id: 'pl-1', source_element_id: 'tbl-1',
+                          bindings: { 'value' => 'actual' },
+                          extra_config: { 'decimals' => 2 })
+  el['config']['decimals'] == '2' && el['config']['decimals'].is_a?(String)
+end
+
+check('empty id raises ArgumentError') do
+  begin
+    PluginEmbed.build(id: '', plugin_id: 'pl-1', source_element_id: 'tbl-1', bindings: {})
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+check('empty plugin_id raises ArgumentError') do
+  begin
+    PluginEmbed.build(id: 'gauge-el', plugin_id: '', source_element_id: 'tbl-1', bindings: {})
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+check('empty source_element_id raises ArgumentError') do
+  begin
+    PluginEmbed.build(id: 'gauge-el', plugin_id: 'pl-1', source_element_id: '', bindings: {})
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+exit($failures.zero? ? 0 : 1)

--- a/shared/lib/testdata/plugin_embed_golden.json
+++ b/shared/lib/testdata/plugin_embed_golden.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "format": "$.3~s",
+    "source": {
+      "elementId": "tbl-1",
+      "kind": "element"
+    },
+    "target": "target",
+    "value": "actual"
+  },
+  "id": "gauge-el",
+  "kind": "plugin",
+  "pluginId": "pl-1"
+}

--- a/shared/scripts/register-plugin.rb
+++ b/shared/scripts/register-plugin.rb
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# register-plugin.rb — idempotent Sigma custom-plugin registration helper
+# (WS2 "plugin-recreation" Task 4).
+#
+# Extracts the inline register/confirm dance already proven live in
+# `verify-plugin-gauge-e2e.rb` (Task 1 — see `plugins_by_name` /
+# `register_plugin` there) into a reusable module + CLI, so other
+# scripts/skills that need to register a Sigma plugin don't have to
+# re-derive the masked-404-tolerant confirmation logic.
+#
+# PluginRegister.register_or_get(name:, description:, url:) is IDEMPOTENT:
+#   1. GET /v2/plugins first — if a plugin with this exact `name` already
+#      exists, return its pluginId. Never creates a duplicate.
+#   2. Else POST /v2/plugins {name,description,url,type:"element"}, then
+#      re-GET /v2/plugins and find by name. A non-2xx POST is NEVER treated
+#      as a hard failure by itself — Sigma is documented to sometimes return
+#      a masked 404 (or other error) on an otherwise-successful register, so
+#      the confirming GET is always attempted before deciding.
+#   3. Only if, after POST+GET, the plugin still isn't found AND the POST
+#      response clearly indicated an auth/permission failure (401/403) does
+#      this raise PluginRegister::PermissionError: "plugin registration is
+#      permission-gated (org-admin) — <detail>". Any other unresolved case
+#      raises a plain error (never a faked pluginId).
+#
+# Usage (library):
+#   $LOAD_PATH.unshift File.expand_path('../scripts', __dir__)  # adjust as needed
+#   require 'register-plugin'
+#   plugin_id = PluginRegister.register_or_get(
+#     name: "My Plugin", description: "...", url: "https://example.com/plugin/"
+#   )
+#
+# Usage (CLI):
+#   ruby shared/scripts/register-plugin.rb "<name>" "<url>" ["<description>"]
+#   -> prints the pluginId to stdout on success (exit 0); on failure, prints
+#      an error to stderr and exits non-zero.
+#
+# Env: SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET (or
+#      ~/.sigma-migration/env — sigma_rest.rb self-bootstraps).
+#
+# Cross-reference: shared/scripts/verify-plugin-gauge-e2e.rb (WS2 Task 1) is
+# the origin of this logic and the live-proven reference implementation;
+# consumers should prefer this helper over re-inlining the same dance.
+
+require 'json'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'sigma_rest'
+
+module PluginRegister
+  # Raised only when a POST /v2/plugins failure is unambiguously an auth/
+  # permission problem (401/403) AND the confirming GET also came up empty.
+  class PermissionError < StandardError; end
+
+  module_function
+
+  # Look up a plugin by exact `name` via GET /v2/plugins. Returns the plugin
+  # Hash (with at least a 'pluginId' or 'id' key) or nil if none matches.
+  def find_by_name(name)
+    list = Sigma.request(:get, '/v2/plugins?pageSize=1000')
+    list = (JSON.parse(list) rescue nil) if list.is_a?(String)
+    entries = (list.is_a?(Hash) && (list['entries'] || list['plugins'])) || []
+    entries.find { |p| p['name'] == name }
+  end
+
+  # Idempotent register-or-get. Returns the pluginId (String). Raises
+  # PermissionError on a confirmed 401/403 with no plugin found afterward, or
+  # a plain RuntimeError for any other unresolved failure.
+  def register_or_get(name:, description:, url:)
+    existing = find_by_name(name)
+    existing_id = existing && (existing['pluginId'] || existing['id'])
+    return existing_id if existing_id
+
+    post_error = nil
+    begin
+      Sigma.request(:post, '/v2/plugins',
+                    body: JSON.generate(name: name, description: description, url: url, type: 'element'))
+    rescue Sigma::Error => e
+      # Never trust the POST's own status — the masked-404 quirk means even a
+      # successful register can raise here. Always fall through to the
+      # confirming GET below before deciding anything.
+      post_error = e
+    end
+
+    plugin = find_by_name(name)
+    plugin_id = plugin && (plugin['pluginId'] || plugin['id'])
+    return plugin_id if plugin_id
+
+    if post_error && post_error.message =~ /-> (401|403)\b/
+      raise PermissionError,
+            "plugin registration is permission-gated (org-admin) — #{post_error.message[0, 300]}"
+    end
+
+    raise "plugin registration failed: could not confirm pluginId for #{name.inspect} via " \
+          "GET /v2/plugins after POST#{post_error ? " (POST raised: #{post_error.message[0, 300]})" : ' (POST returned 2xx)'}"
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  name        = ARGV[0]
+  url         = ARGV[1]
+  description = ARGV[2] || ''
+
+  if name.nil? || url.nil?
+    warn 'Usage: ruby register-plugin.rb "<name>" "<url>" ["<description>"]'
+    exit 2
+  end
+
+  begin
+    plugin_id = PluginRegister.register_or_get(name: name, description: description, url: url)
+    puts plugin_id
+  rescue PluginRegister::PermissionError => e
+    warn e.message
+    exit 1
+  rescue StandardError => e
+    warn "register-plugin failed: #{e.message}"
+    exit 1
+  end
+end

--- a/shared/scripts/verify-plugin-gauge-e2e.rb
+++ b/shared/scripts/verify-plugin-gauge-e2e.rb
@@ -1,0 +1,519 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-plugin-gauge-e2e.rb — LIVE GO/NO-GO E2E proof of the Sigma custom
+# plugin lifecycle (WS2 "plugin-recreation" Task 1 — the gate for the whole
+# workstream). Creds-gated: needs live Sigma + a warehouse connection, so it
+# is NOT part of the offline CI corpus.
+#
+# Proves, against a live Sigma org, that a bespoke `@sigmacomputing/plugin`
+# can be:
+#   1. HOSTED somewhere Sigma can be told a URL for.
+#   2. REGISTERED — POST /v2/plugins -> pluginId (tolerating the documented
+#      "masked HTTP 404 on a successful register" quirk; a real 403 means
+#      registration is org-admin-gated — reported as a hard NO-GO).
+#   3. EMBEDDED in a workbook, bound to a real data element (bare-string
+#      `config` values only — the object form is silently rejected).
+#   4. DATA-PARITY VERIFIED (HARD GATE) — the bound element is exported and
+#      its actual/target values are compared against the known literals.
+#      This is the gate that must pass for GO; it does NOT depend on the
+#      plugin's host being reachable (it only exports the backing table).
+#   5. Screenshotted (BEST-EFFORT, soft) — only when the plugin's host is
+#      genuinely public, since Sigma's server-side PNG renderer cannot reach
+#      localhost.
+#
+# HOST NOTES (why this run picked what it picked):
+#   `netlify`/`vercel`/`surge` were not installed/authenticated in this
+#   environment. `ngrok` WAS authenticated, so it was evaluated as a public
+#   tunnel — but a live check (GET through the tunnel with a real browser
+#   User-Agent) showed ngrok's free-tier interstitial "visit site" warning
+#   page instead of the plugin content. Sigma's render server can't send the
+#   `ngrok-skip-browser-warning` header a human browser would, so a free
+#   ngrok tunnel does NOT count as a genuinely public host here — this
+#   script verifies that live (see `genuinely_public?`) rather than assuming
+#   it, and falls back to localhost when the tunnel fails the check.
+#
+# Usage:  ruby shared/scripts/verify-plugin-gauge-e2e.rb
+# Env:    SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET (or
+#         ~/.sigma-migration/env — sigma_rest.rb self-bootstraps);
+#         SIGMA_TEST_CONNECTION_ID (Snowflake; defaults to the shared demo
+#         test connection).
+# Exit:   0 = lifecycle proven (registered + embedded + bound +
+#         data-parity passed). 1 = NO-GO, raw evidence printed above the
+#         verdict — never a faked green.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+require 'tmpdir'
+require 'socket'
+require 'time'
+require 'shellwords'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'sigma_rest'
+require 'export_pool'
+require_relative 'register-plugin'
+
+RUN_TAG        = Time.now.utc.strftime('%Y%m%dT%H%M%SZ')
+PLUGIN_NAME    = "WS2 gauge (e2e) #{RUN_TAG}"
+CONNECTION_ID  = ENV.fetch('SIGMA_TEST_CONNECTION_ID', '362d859b-f432-4657-8e58-efc8535aa354')
+SRC_ELEMENT_ID = 'tbl-src'
+GAUGE_EL_ID    = 'gauge-el'
+PAGE_ID        = 'pg-1'
+
+def log(msg)
+  $stderr.puts("[verify-plugin-gauge-e2e] #{msg}")
+end
+
+GAUGE_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html>
+  <head>
+  <meta charset="utf-8">
+  <title>WS2 gauge (e2e stub)</title>
+  <style>
+    html,body{margin:0;padding:0;width:100%;height:100%;background:#fff;font-family:sans-serif;overflow:hidden}
+    #wrap{width:100%;height:100%;display:flex;align-items:center;justify-content:center}
+    #lbl{position:absolute;bottom:8px;left:0;right:0;text-align:center;font-size:12px;color:#555}
+  </style>
+  </head>
+  <body>
+  <div id="wrap"><svg id="gauge" viewBox="0 0 200 120"></svg></div>
+  <div id="lbl"></div>
+  <!-- React MUST load before the SDK: @sigmacomputing/plugin's UMD build has
+       React as a hard peer dep and throws at load without it, leaving
+       window.SigmaPlugin with no `client` (plugin then always synths). -->
+  <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+  <script>
+  // Temporary Task-1 stub — a minimal but real gauge, just enough to prove
+  // the lifecycle. The clean-room production plugin lands in Task 2.
+  function synth() { return { value: 82, target: 100 }; }
+
+  function polar(cx, cy, r, deg) {
+    var rad = (deg - 180) * Math.PI / 180;
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+  }
+  function arcPath(cx, cy, r, startDeg, endDeg) {
+    var s = polar(cx, cy, r, endDeg), e = polar(cx, cy, r, startDeg);
+    var large = (endDeg - startDeg) <= 180 ? 0 : 1;
+    return ['M', s.x, s.y, 'A', r, r, 0, large, 0, e.x, e.y].join(' ');
+  }
+
+  function render(value, target) {
+    var svg = document.getElementById('gauge');
+    var frac = target > 0 ? Math.max(0, Math.min(1, value / target)) : 0;
+    var color = frac >= 1 ? '#22c55e' : (frac >= 0.6 ? '#eab308' : '#ef4444');
+    svg.innerHTML =
+      '<path d="' + arcPath(100, 100, 80, 0, 180) + '" stroke="#e5e7eb" stroke-width="16" fill="none"/>' +
+      '<path d="' + arcPath(100, 100, 80, 0, 180 * frac) + '" stroke="' + color + '" stroke-width="16" fill="none"/>' +
+      '<text x="100" y="90" text-anchor="middle" font-size="28" fill="#111">' + value + '</text>' +
+      '<text x="100" y="112" text-anchor="middle" font-size="12" fill="#666">of ' + target + '</text>';
+    document.getElementById('lbl').textContent = 'value=' + value + ' target=' + target;
+  }
+
+  var s0 = synth(); render(s0.value, s0.target);   // immediate paint (standalone / pre-data)
+  var client = (window.SigmaPlugin && window.SigmaPlugin.client) ||
+               (window.Sigma && window.Sigma.client) || null;
+
+  if (client) {
+    client.config.configureEditorPanel([
+      { name: 'source', type: 'element' },
+      { name: 'value', type: 'column', source: 'source', allowMultiple: false },
+      { name: 'target', type: 'column', source: 'source', allowMultiple: false }
+    ]);
+    client.config.subscribe(function (cfg) {
+      if (!cfg || !cfg.source) { var s = synth(); render(s.value, s.target); return; }
+      client.elements.subscribeToElementData(cfg.source, function (data) {
+        try {
+          var vc = cfg.value, tc = cfg.target;
+          if (data && vc && tc && data[vc] && data[tc] && data[vc].length) {
+            render(Number(data[vc][0]), Number(data[tc][0]));
+          } else { var s = synth(); render(s.value, s.target); }
+        } catch (e) { var s = synth(); render(s.value, s.target); }
+      });
+    });
+  }
+
+  new ResizeObserver(function () {
+    var el = document.getElementById('lbl');
+    var last = el.textContent.match(/value=(-?\\d+(\\.\\d+)?) target=(-?\\d+(\\.\\d+)?)/);
+    if (last) render(Number(last[1]), Number(last[3]));
+  }).observe(document.body);
+  </script>
+  </body>
+  </html>
+HTML
+
+# ---------------------------------------------------------------------------
+# Step 1: host the stub somewhere Sigma can be told a URL for.
+# ---------------------------------------------------------------------------
+
+def free_port
+  s = TCPServer.new('127.0.0.1', 0)
+  port = s.addr[1]
+  s.close
+  port
+end
+
+def wait_for(url, tries: 20, sleep_s: 0.25)
+  tries.times do
+    begin
+      res = Net::HTTP.get_response(URI(url))
+      return true if res.code.to_i == 200
+    rescue StandardError
+      # not up yet
+    end
+    sleep sleep_s
+  end
+  false
+end
+
+# Real (not assumed) check that a URL serves OUR content to a browser-like
+# client, rather than e.g. an ngrok free-tier interstitial warning page.
+def genuinely_public?(url)
+  uri = URI(url)
+  req = Net::HTTP::Get.new(uri)
+  req['User-Agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' \
+                      '(KHTML, like Gecko) Chrome/124.0 Safari/537.36'
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 15) do |h|
+    h.request(req)
+  end
+  res.code.to_i == 200 && res.body.to_s.include?('WS2 gauge (e2e stub)')
+rescue StandardError => e
+  log "genuinely_public? check raised: #{e.message}"
+  false
+end
+
+def netlify_authed?
+  return false if `which netlify 2>/dev/null`.strip.empty?
+  out = `netlify status 2>&1`
+  $?.success? && out !~ /not logged in/i
+rescue StandardError
+  false
+end
+
+def ngrok_authed?
+  return false if `which ngrok 2>/dev/null`.strip.empty?
+  `ngrok config check 2>&1` =~ /Valid configuration/i ? true : false
+rescue StandardError
+  false
+end
+
+def start_ngrok(port)
+  pid = spawn('ngrok', 'http', port.to_s, '--log=stdout',
+              out: File::NULL, err: File::NULL)
+  public_url = nil
+  30.times do
+    begin
+      res = Net::HTTP.get_response(URI('http://127.0.0.1:4040/api/tunnels'))
+      if res.code.to_i == 200
+        data = JSON.parse(res.body)
+        t = (data['tunnels'] || []).find { |x| x['proto'] == 'https' } ||
+            (data['tunnels'] || []).first
+        public_url = t && t['public_url']
+      end
+    rescue StandardError
+      nil
+    end
+    break if public_url
+    sleep 0.5
+  end
+  [pid, public_url]
+end
+
+def host_stub
+  dir = Dir.mktmpdir('ws2-gauge-')
+  FileUtils.mkdir_p(File.join(dir, 'gauge'))
+  File.write(File.join(dir, 'gauge', 'index.html'), GAUGE_HTML)
+  port = free_port
+  http_pid = spawn('python3', '-m', 'http.server', port.to_s, chdir: dir,
+                    out: File::NULL, err: File::NULL)
+  local_url = "http://localhost:#{port}/gauge/"
+  raise "local http.server on port #{port} never came up" unless wait_for(local_url)
+  log "local stub serving at #{local_url}"
+
+  pids = [http_pid]
+
+  # netlify/vercel/surge preferred if authenticated — none available here.
+  if netlify_authed?
+    log 'netlify CLI authenticated — turnkey deploy not implemented in this ' \
+        'script; falling back to localhost (see report).'
+  end
+
+  if ngrok_authed?
+    log 'ngrok is authenticated — attempting a public tunnel...'
+    ngrok_pid, tunnel_url = start_ngrok(port)
+    if tunnel_url
+      pids << ngrok_pid
+      if genuinely_public?("#{tunnel_url}/gauge/")
+        log "ngrok tunnel #{tunnel_url} verified genuinely public (serves our content to a browser UA)."
+        return { url: "#{tunnel_url}/gauge/", public: true, pids: pids, note: 'ngrok public tunnel' }
+      else
+        log 'ngrok tunnel did NOT serve our content to a browser User-Agent ' \
+            '(free-tier interstitial confirmed live) — not counted as public. ' \
+            'Falling back to localhost.'
+      end
+    else
+      log 'ngrok did not produce a tunnel URL in time — falling back to localhost.'
+    end
+  else
+    log 'no public static-host CLI authenticated (netlify/vercel/surge/ngrok) — using localhost.'
+  end
+
+  { url: local_url, public: false, pids: pids,
+    note: 'localhost only — data-parity still provable; visual step will SKIP' }
+end
+
+# ---------------------------------------------------------------------------
+# Step 2: register the plugin (tolerate the masked-404-on-success quirk; a
+# real 403 is a hard NO-GO — registration is org-admin-gated).
+# ---------------------------------------------------------------------------
+
+# Thin wrapper around the shared PluginRegister.register_or_get helper
+# (register-plugin.rb), which is the live-proven origin of this exact
+# register/confirm dance — reusing it instead of re-inlining keeps the
+# masked-404-tolerant confirmation logic in one place. Maps register_or_get's
+# return/raise shape back onto the {forbidden:, plugin:} shape this script's
+# caller (below) already expects, so downstream behavior is unchanged.
+def register_plugin(name, description, url)
+  plugin_id = PluginRegister.register_or_get(name: name, description: description, url: url)
+  { forbidden: false, plugin: { 'pluginId' => plugin_id, 'name' => name } }
+rescue PluginRegister::PermissionError => e
+  { forbidden: true, detail: e.message }
+rescue StandardError => e
+  # Any other unresolved failure (register_or_get already retried the
+  # confirming GET internally) — surface as "not found", same as the old
+  # inline version's `{ forbidden: false, plugin: nil }` fallthrough.
+  log "register_or_get raised (not a permission error): #{e.message[0, 300]}"
+  { forbidden: false, plugin: nil }
+end
+
+# ---------------------------------------------------------------------------
+# Step 3: POST a minimal workbook — custom-SQL table (known literals) + the
+# plugin element bound to it. POST/PUT /v2/workbooks/spec is documented to
+# return YAML — never JSON.parse it directly; scrape workbookId instead.
+# ---------------------------------------------------------------------------
+
+def home_folder_id
+  me = Sigma.request(:get, '/v2/whoami')
+  uid = me && me['userId']
+  raise 'could not resolve userId from /v2/whoami' unless uid
+  mem = Sigma.request(:get, "/v2/members/#{uid}")
+  home = mem && mem['homeFolderId']
+  raise 'could not resolve homeFolderId' unless home
+  home
+end
+
+def reference_schema_version
+  wbs = Sigma.request(:get, '/v2/workbooks?limit=10')
+  entries = (wbs && (wbs['entries'] || wbs['workbooks'])) || []
+  entries.each do |w|
+    wid = w['workbookId'] || w['id']
+    next unless wid
+    spec = (Sigma.request(:get, "/v2/workbooks/#{wid}/spec", accept: 'application/json') rescue nil)
+    return spec['schemaVersion'] if spec.is_a?(Hash) && spec['schemaVersion']
+  end
+  raise 'could not discover schemaVersion from any existing workbook'
+end
+
+# POST/PUT /v2/workbooks/spec: response is documented as YAML. Never rely on
+# Sigma.request's accept:'application/json' auto-parse here (it would raise
+# on a YAML body) — request a non-JSON accept so the raw string always comes
+# back, then self-parse (JSON first in case the org actually returns JSON,
+# else scrape `workbookId:` out of the YAML text). A non-JSON response body
+# is NOT treated as a failure.
+def post_or_put_workbook_spec(method, path, spec_hash)
+  raw = Sigma.request(method, path, body: JSON.generate(spec_hash),
+                                     content_type: 'application/json', accept: 'application/yaml')
+  parsed = (JSON.parse(raw) rescue nil)
+  return parsed if parsed.is_a?(Hash) && parsed['workbookId']
+  m = raw.to_s.match(/^\s*workbookId:\s*"?'?([\w-]+)"?'?\s*$/)
+  raise "no workbookId in #{method.upcase} response: #{raw.to_s[0, 500]}" unless m
+  { 'workbookId' => m[1], 'raw' => raw }
+end
+
+# NOTE — the 82/100 test literals below are the SAME numbers GAUGE_HTML's
+# synth() fallback renders (see above). That coincidence is exactly what let
+# the original silent-synth bug hide in plain sight: a screenshot of the
+# broken plugin (client undefined, always synthing) looked identical to a
+# screenshot of a working one bound to this source. A screenshot — even a
+# genuinely live one — cannot distinguish "reading real data" from "showing
+# the synthetic fallback" here; export_and_check's element-level data-parity
+# assertion below is the actual gate.
+def build_spec(home, schema_version, plugin_id, actual_formula, target_formula)
+  {
+    'name' => "WS2 gauge plugin lifecycle — E2E proof (#{RUN_TAG})",
+    'folderId' => home,
+    'schemaVersion' => schema_version,
+    'description' => 'Live proof: register/embed/bind/data-parity a custom Sigma plugin. Throwaway test artifact.',
+    'pages' => [
+      {
+        'id' => PAGE_ID,
+        'name' => 'WS2 Gauge E2E',
+        'elements' => [
+          {
+            'id' => SRC_ELEMENT_ID, 'kind' => 'table', 'name' => 'Gauge source (e2e)',
+            'source' => {
+              'kind' => 'sql', 'connectionId' => CONNECTION_ID,
+              'statement' => 'SELECT 82 AS actual, 100 AS target',
+            },
+            'columns' => [
+              { 'id' => 'actual', 'name' => 'Actual', 'formula' => actual_formula },
+              { 'id' => 'target', 'name' => 'Target', 'formula' => target_formula },
+            ],
+          },
+          {
+            'id' => GAUGE_EL_ID, 'kind' => 'plugin', 'pluginId' => plugin_id, 'name' => 'Gauge (e2e)',
+            'config' => {
+              'source' => { 'kind' => 'element', 'elementId' => SRC_ELEMENT_ID },
+              'value' => 'actual',
+              'target' => 'target',
+            },
+          },
+        ],
+      },
+    ],
+  }
+end
+
+# ---------------------------------------------------------------------------
+# Step 4: data-parity (HARD) — export the bound element, assert the numbers.
+# ---------------------------------------------------------------------------
+
+def export_and_check(wb, element_id, deadline_s: 60)
+  qid = ExportPool.start_json_export(wb, element_id, nil)
+  return { ok: false, reason: 'export POST did not return a queryId' } unless qid
+  deadline = ExportPool::Deadline.new(deadline_s)
+  status, body = ExportPool.poll_json_download(qid, deadline)
+  return { ok: false, reason: "poll status=#{status}", status: status } unless status == :ok
+  rows = ExportPool.parse_json_rows(body)
+  row = rows.first
+  return { ok: false, reason: 'export returned zero rows', rows: rows } unless row
+
+  actual_key = row.keys.find { |k| k.to_s.strip.casecmp('actual').zero? }
+  target_key = row.keys.find { |k| k.to_s.strip.casecmp('target').zero? }
+  actual_val = actual_key && row[actual_key]
+  target_val = target_key && row[target_key]
+  ok = actual_val.to_s.strip.to_f == 82.0 && target_val.to_s.strip.to_f == 100.0 &&
+       !actual_key.nil? && !target_key.nil?
+  { ok: ok, row: row, actual: actual_val, target: target_val, reason: ok ? nil : 'value mismatch or missing column' }
+end
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+verdict = { go: false }
+pids_to_kill = []
+
+begin
+  # --- Step 1: host -----------------------------------------------------
+  host = host_stub
+  pids_to_kill = host[:pids]
+  log "PLUGIN_URL = #{host[:url]} (public=#{host[:public]}) — #{host[:note]}"
+
+  # --- Step 2: register --------------------------------------------------
+  reg = register_plugin(PLUGIN_NAME, 'recreate-as-plugin gauge proof (WS2 Task 1 live E2E)', host[:url])
+  if reg[:forbidden]
+    verdict = { go: false, blocker: '403 registration permission-gated (org-admin only)', detail: reg[:detail],
+                host: host }
+    log "NO-GO: #{verdict[:blocker]} — #{reg[:detail]}"
+  elsif reg[:plugin].nil?
+    verdict = { go: false, blocker: 'plugin registration not found via GET /v2/plugins after POST (not a 403 — ' \
+                                     'unexplained)', host: host }
+    log "NO-GO: #{verdict[:blocker]}"
+  else
+    plugin = reg[:plugin]
+    plugin_id = plugin['pluginId'] || plugin['id']
+    log "plugin registered: pluginId=#{plugin_id} name=#{plugin['name'].inspect}"
+
+    # --- Step 3: workbook (with a small live-verified formula-prefix retry) --
+    home = home_folder_id
+    schema_version = reference_schema_version
+    log "home folder=#{home} schemaVersion=#{schema_version}"
+
+    candidates = [
+      ['[Custom SQL/Actual]', '[Custom SQL/Target]'],
+      ['[Custom SQL/ACTUAL]', '[Custom SQL/TARGET]'],
+      ['[Custom SQL/actual]', '[Custom SQL/target]'],
+      ['[actual]', '[target]'],
+    ]
+
+    wb = nil
+    parity = nil
+    tried = []
+    candidates.each_with_index do |(af, tf), i|
+      spec = build_spec(home, schema_version, plugin_id, af, tf)
+      method = wb.nil? ? :post : :put
+      path = wb.nil? ? '/v2/workbooks/spec' : "/v2/workbooks/#{wb}/spec"
+      begin
+        resp = post_or_put_workbook_spec(method, path, spec)
+      rescue StandardError => e
+        tried << { formulas: [af, tf], error: e.message[0, 400] }
+        log "#{method.upcase} attempt #{i + 1} (#{af}/#{tf}) raised: #{e.message[0, 300]}"
+        next
+      end
+      wb ||= resp['workbookId']
+      unless wb
+        tried << { formulas: [af, tf], error: "no workbookId in response: #{resp.inspect[0, 300]}" }
+        next
+      end
+      log "workbook #{wb} — attempt #{i + 1} formulas=#{af}/#{tf}"
+      result = (export_and_check(wb, SRC_ELEMENT_ID) rescue { ok: false, reason: $!.message })
+      tried << { formulas: [af, tf], result: result }
+      if result[:ok]
+        parity = result
+        log "data-parity PASSED with formulas #{af}/#{tf}: actual=#{result[:actual]} target=#{result[:target]}"
+        break
+      else
+        log "attempt #{i + 1} formulas=#{af}/#{tf} did not pass: #{result[:reason]} (row=#{result[:row].inspect})"
+      end
+    end
+
+    if parity.nil?
+      verdict = { go: false, blocker: 'data-parity FAILED for every candidate formula prefix — no faked green',
+                  workbook_id: wb, plugin_id: plugin_id, host: host, tried: tried }
+      log 'NO-GO: data-parity never passed (see attempts above).'
+    else
+      # --- Step 5: visual (best-effort) ------------------------------------
+      visual = { attempted: false }
+      if host[:public]
+        png_script = File.expand_path('sigma-export-png.py', __dir__)
+        out_png = File.join(Dir.tmpdir, "gauge-e2e-#{RUN_TAG}.png")
+        cmd = ['python3', png_script, '--workbook', wb, '--page', PAGE_ID, '--out', out_png]
+        log "public host — attempting screenshot: #{cmd.join(' ')}"
+        png_out = `#{cmd.map { |c| Shellwords.escape(c) }.join(' ')} 2>&1` rescue nil
+        ok_png = $?.success? && File.exist?(out_png)
+        visual = { attempted: true, ok: ok_png, path: (ok_png ? out_png : nil), log: png_out.to_s[0, 500] }
+        log(ok_png ? "screenshot saved to #{out_png}" : "screenshot attempt output: #{png_out}")
+      else
+        log 'SKIP visual (localhost not reachable by render server)'
+        visual = { attempted: false, skip_reason: 'localhost not reachable by render server' }
+      end
+
+      verdict = {
+        go: true, workbook_id: wb, plugin_id: plugin_id, host: host, parity: parity, visual: visual,
+        formulas_used: tried.last && tried.last[:formulas],
+      }
+    end
+  end
+ensure
+  pids_to_kill.each do |pid|
+    begin
+      Process.kill('TERM', pid)
+      Process.wait(pid)
+    rescue StandardError
+      nil
+    end
+  end
+end
+
+puts
+puts '=' * 78
+puts verdict[:go] ? 'GO' : 'NO-GO'
+puts '=' * 78
+puts JSON.pretty_generate(verdict)
+exit(verdict[:go] ? 0 : 1)


### PR DESCRIPTION
## What & why

Adds a new `sigma-plugin-authoring` skill to the `sigma-authoring` plugin: SDK-surface and
interactivity-pattern references, a lifecycle reference, and a clean-room radial-gauge exemplar
plugin (`@sigmacomputing/plugin`) with a static-shape test suite, for converters that want to
recreate a source viz as a Sigma plugin rather than approximate it with a native element.

This capability is **live-verified end-to-end**: a real Sigma workbook rendered the gauge
plugin reading distinguishable bound data (45 vs. 90), not just a static-shape check. Two
gotchas are captured in the references so future authors don't rediscover them the hard way:
the SDK's UMD build requires React to be loaded first (`reference/plugin-lifecycle.md` §7), and
Sigma's PNG export cannot hydrate plugin data (`reference/plugin-lifecycle.md` §8) — so plugin
visuals must be verified live, not by screenshot.

Bumps `sigma-authoring` 1.2.0 -> 1.3.0 (minor: new skill, additive).

## Merge order

This is PR 2 of 3, stacked on PR 1 (`feat/ws2-plugin-shared`, shared `plugin_embed` +
`register-plugin` + `coverage_catalog.plugin_archetype`) since this skill's exemplar and test
build on those shared helpers. Please land PR 1 first.

## Scope

- Plugin(s) touched: `sigma-authoring` (new skill only; existing skills untouched)
- [x] This PR touches exactly one plugin

## Checklist

- [x] `ruby plugins/sigma-authoring/skills/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb` — 8/8 green
- [x] `ruby tools/check-agent-variants.rb` — green
- [x] `ruby tools/lint-skills.rb` — green
- [x] `bash tools/check-plugin-version-bump.sh <feat/ws2-plugin-shared tip> HEAD` — green:
  `sigma-authoring 1.2.0 -> 1.3.0, OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)