### PR TITLE
fix(domo): beast-mode ref uses MakeDate(y,m,d), not 3-arg Date() (9777)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md
@@ -208,11 +208,13 @@ string** (`"day"`, `"month"`, `"year"`, …) and use **format tokens** (`YYYY`,
 | `DATE_FORMAT(d, fmt)` | `DateFormat([d], <translated tokens>)` — see specifier table |
 | `TIME_FORMAT(d, fmt)` | `DateFormat([d], <translated tokens>)` (hours/min/sec only) |
 | `STR_TO_DATE(s, fmt)` | `DateParse([s], <translated tokens>)` |
-| `UNIX_TIMESTAMP(d)` | `DateDiff("second", Date(1970,1,1), [d])` |
-| `FROM_UNIXTIME(n, fmt)` | `DateFormat(DateAdd("second", [n], Date(1970,1,1)), <tokens>)` |
-| `TO_DAYS(d)` / `FROM_DAYS(n)` | `DateDiff("day", Date(0,1,1), [d])` / inverse — rarely needed; warn |
+| `UNIX_TIMESTAMP(d)` | `DateDiff("second", MakeDate(1970,1,1), [d])` |
+| `FROM_UNIXTIME(n, fmt)` | `DateFormat(DateAdd("second", [n], MakeDate(1970,1,1)), <tokens>)` |
+| `TO_DAYS(d)` / `FROM_DAYS(n)` | `DateDiff("day", MakeDate(0,1,1), [d])` / inverse — rarely needed; warn |
 | `TIME_TO_SEC(d)` / `SEC_TO_TIME(n)` | arithmetic; no pure time type — warn |
 | `TIMESTAMP(d)` | `[d]` cast to datetime — usually a no-op in Sigma |
+
+> **Date construction:** Sigma's `Date()` is a **1-arg cast** (string/expr → date type). To build a date from year/month/day, use **`MakeDate(y, m, d)`** — never `Date(y, m, d)` (a 3-arg `Date(...)` fails the workbook/DM export).
 
 ### MySQL `DATE_FORMAT` specifier → Sigma `DateFormat` token
 


### PR DESCRIPTION
## What & why

`refs/beast-mode-to-sigma.md` hardcoded `Date(1970,1,1)`/`Date(0,1,1)` in the `UNIX_TIMESTAMP`/`FROM_UNIXTIME`/`TO_DAYS` mapping rows. Sigma's `Date()` is a **1-arg cast**; a 3-arg `Date(...)` fails the export — the 3-arg constructor is `MakeDate(y,m,d)`. An agent following the ref reproduced the field bug (`Date(2016,7,27)` → error-type DM columns). Fixed those rows to `MakeDate` + added a "date construction" note.

**The mcp converter itself is correct** — `convert_sql_to_sigma_formula` (`lookSqlToSigmaRules`/`lookConvertExpression`) never emits a 3-arg `Date(...)` (only `DateDiff` + a 1-arg `DATE→Date` cast). So this is a domo-plugin doc fix only; **no external-repo change needed.**

Bead: beads-sigma-9777.

## Scope
- Plugin(s) touched: `domo-to-sigma` (ref doc + version).
- [x] Exactly one plugin.

## Checklist
- [x] `check-shared` green (545); `lint-skills` green; `hygiene-sweep` clean (pre-commit hook)
- [x] Bumped `plugin.json` 0.3.0 → 0.3.1 (ref doc fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)