### PR TITLE
qlik-to-sigma: prompt for a QlikView sheet screenshot to arm the visual gates

### DIFF
--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -211,8 +211,12 @@ staleness) blocks GREEN.
 >
 > **Scope / caveats (be honest with customers):** a `-prj` folder has **no live engine**, so
 > parity is **warehouse-only** (Sigma vs. the source warehouse — no Qlik-side value snapshot), and
-> chart-kind/layout fidelity is best-effort (there is no QlikView renderer to diff against — do the
-> Phase-5 visual-QA review). Relationships are inferred from **shared field names only** (a `-prj`
+> chart-kind/layout fidelity is best-effort (there is no QlikView renderer to diff against). Because
+> QlikView has **no capture API**, the `--prj` discovery step (`qlik-prj-discover.py`) prints an
+> `[ASSIST]` telling you to **`AskUserQuestion` for a screenshot of each sheet** and drop them in
+> `<workdir>/dashboards/<sheetId>.png` — that **arms** the source-side gates (Phase-1d source-anchors,
+> visual-compare, visual-similarity). If the user has none, those gates are **WAIVED with a stated
+> reason** at Phase 6 (never a silent skip). Relationships are inferred from **shared field names only** (a `-prj`
 > folder carries no row counts) → review join directions in Sigma. All **13 QlikView chart types**
 > are mapped (bar/line/combo/pie/scatter/straight-table/pivot-table exactly; gauge→KPI, and
 > radar/grid/block/funnel/mekko→closest Sigma kind, each flagged as an **approximation** in the

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -764,8 +764,26 @@ unless opts[:dry_run]
   puts "   ✓ rendered #{pngs.size}/#{content_pages.size} full-page PNG(s) for visual QA → #{vqa}"
   if pngs.any?
     puts '   VISUAL QA (mandatory review — do not skip): open each PNG and check vs'
-    puts '   refs/layout-visual-qa.md AND the source Qlik sheet capture — populated controls,'
-    puts '   titles present, right chart kinds, sensible colors/heights, no overlaps/dead zones.'
+    if opts[:prj]
+      # QlikView has no capture API — the source reference is a USER-PROVIDED screenshot
+      # per sheet (landed by the qlik-prj-discover assist). Armed if present, else WAIVED.
+      dash = File.join(WORK, 'dashboards')
+      shots = Dir[File.join(dash, '*.{png,jpg,jpeg,PNG,JPG,JPEG}')]
+      if shots.any?
+        puts "   refs/layout-visual-qa.md AND the #{shots.size} user-provided QlikView screenshot(s) in"
+        puts "   #{dash} (QlikView has no capture API) — right chart kinds, titles, populated data,"
+        puts '   sensible colors/heights, no overlaps/dead zones. Transcribe source-anchor values from'
+        puts '   those screenshots (Phase 1d) so verify-anchors + visual-similarity arm.'
+      else
+        puts '   refs/layout-visual-qa.md ONLY. No source screenshots were provided for this QlikView'
+        puts "   app (drop one PNG per sheet in #{dash} to arm the source-side gates) — the source-anchor"
+        puts '   / visual-compare / visual-similarity gates are WAIVED; STATE that waiver + reason in the'
+        puts '   Phase-6 report (never a silent skip).'
+      end
+    else
+      puts '   refs/layout-visual-qa.md AND the source Qlik sheet capture — populated controls,'
+      puts '   titles present, right chart kinds, sensible colors/heights, no overlaps/dead zones.'
+    end
   end
 end
 mark('phase5b-visual-qa')

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-prj-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-prj-discover.py
@@ -352,6 +352,30 @@ def main():
     for w in warnings:
         print("  ! " + w)
 
+    # Visual-fidelity assist. QlikView has NO live engine and NO reporting/capture API
+    # (qlik-screenshot.py is Qlik CLOUD only), so there is nothing to auto-render as the
+    # source reference — the visual gates (Phase-1d source-anchors, visual-compare,
+    # visual-similarity) can only run against a USER-PROVIDED screenshot of each sheet.
+    # Mirror intake.rb's file-mode assist: tell the agent to ASK for them, and land them
+    # where the gates read them. Without them the gates WAIVE with a stated reason.
+    dash = os.path.join(out, "dashboards")
+    os.makedirs(dash, exist_ok=True)
+    have = [f for f in os.listdir(dash) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
+    print()
+    if have:
+        print("  [visual] %d source screenshot(s) present in %s — visual gates ARMED." % (len(have), dash))
+    else:
+        print("  [ASSIST] QlikView has NO live source to auto-render (no engine, no capture API).")
+        print("  Source-side visual fidelity can only be checked against a SCREENSHOT of each sheet.")
+        print("  ASK THE USER (AskUserQuestion) for one PNG per QlikView sheet, drop them here:")
+        print("    %s/<sheetId>.png" % dash)
+        for sh in layout:
+            print('      - %s  "%s"  (%d chart(s))' % (sh["sheetId"], sh["title"], len(sh["cells"])))
+        print("  They ARM the visual gates (Phase-1d source-anchors, visual-compare, visual-similarity) —")
+        print("  the ONLY source-side fidelity check for QlikView, since chart kinds + layout cannot be")
+        print("  auto-verified. If the user has none, WAIVE those gates at Phase 6 with a stated reason")
+        print("  (never a silent skip).")
+
 
 def root_name(root):
     n = root.find("Name")


### PR DESCRIPTION
## What

Closes a fidelity gap in the QlikView (`.qvw` `-prj`) path: QlikView has **no live engine and no capture API**, so the `--prj` migration had no source-side reference image — the visual gates (Phase-1d source-anchors, visual-compare, visual-similarity) silently self-skipped, so layout/chart-kind errors could ship unseen. This mirrors `intake.rb`'s file-mode behavior for QlikView.

- **`qlik-prj-discover.py`**: creates `<workdir>/dashboards/` and prints an `[ASSIST]` — if no screenshots are present, instruct the agent to `AskUserQuestion` for one PNG per sheet (listed by id + title + chart count) and drop them there; if present, report the gates **ARMED**.
- **`migrate-qlik.rb` Phase-5b**: for a `--prj` run, point the visual-QA review at the user-provided screenshots in `dashboards/` (armed), or — when none — state that the source-anchor / visual-compare / visual-similarity gates are **WAIVED with a reason** (never a silent skip). Non-QlikView paths keep the `qlik-screenshot.py` capture wording.
- **SKILL.md**: documents the screenshot step in the QlikView scope note.
- plugin `1.2.1 → 1.2.2`.

## Verification

- Grounding tests pass (5/5).
- `qlik-prj-discover.py` prints the ASK assist listing the sheet(s), and flips to `ARMED` once a PNG is dropped in `dashboards/`.
- A live `--prj` run shows the Phase-6 **WAIVER** text (no screenshots) and still builds a **GREEN** workbook (21/21 columns resolve, 0 errors, layout GREEN).

Follow-up to #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)