### PR TITLE
docs(sigma-workbooks): composition + styling + composable-richness authoring guidance (WS3)

### DIFF
--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.3.0",
+  "version": "1.6.0",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
@@ -271,7 +271,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | File | When to load |
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
-| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and three opinionated layout patterns (`exec` KPI-strip dashboards, `master-detail` pick-one-see-its-detail, optional `overview` KPI/trend/pivot stack) backed by `shared/lib/composition.rb` — plus an optional, independently-selectable richness menu (comparative KPI cards, AI-insight callout, grain/filter controls, wide pivot) backed by `shared/lib/kpi_card.rb` and `shared/lib/richness.rb`. Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -264,7 +264,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | File | When to load |
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
-| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and three opinionated layout patterns (`exec` KPI-strip dashboards, `master-detail` pick-one-see-its-detail, optional `overview` KPI/trend/pivot stack) backed by `shared/lib/composition.rb` — plus an optional, independently-selectable richness menu (comparative KPI cards, AI-insight callout, grain/filter controls, wide pivot) backed by `shared/lib/kpi_card.rb` and `shared/lib/richness.rb`. Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
@@ -264,7 +264,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | File | When to load |
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
-| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and three opinionated layout patterns (`exec` KPI-strip dashboards, `master-detail` pick-one-see-its-detail, optional `overview` KPI/trend/pivot stack) backed by `shared/lib/composition.rb` — plus an optional, independently-selectable richness menu (comparative KPI cards, AI-insight callout, grain/filter controls, wide pivot) backed by `shared/lib/kpi_card.rb` and `shared/lib/richness.rb`. Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -264,7 +264,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | File | When to load |
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
-| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and three opinionated layout patterns (`exec` KPI-strip dashboards, `master-detail` pick-one-see-its-detail, optional `overview` KPI/trend/pivot stack) backed by `shared/lib/composition.rb` — plus an optional, independently-selectable richness menu (comparative KPI cards, AI-insight callout, grain/filter controls, wide pivot) backed by `shared/lib/kpi_card.rb` and `shared/lib/richness.rb`. Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -269,7 +269,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | File | When to load |
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
-| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and three opinionated layout patterns (`exec` KPI-strip dashboards, `master-detail` pick-one-see-its-detail, optional `overview` KPI/trend/pivot stack) backed by `shared/lib/composition.rb` — plus an optional, independently-selectable richness menu (comparative KPI cards, AI-insight callout, grain/filter controls, wide pivot) backed by `shared/lib/kpi_card.rb` and `shared/lib/richness.rb`. Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/layout.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/layout.md
@@ -1,6 +1,6 @@
 # Layout
 
-Recipe book for the top-level `layout` XML — when to write it, the two-tag grammar, and the silent-failure traps to watch for. `layout` is a page-level property; its value is the XML string described below. **Default to writing explicit `layout` XML for multi-element workbooks.**
+Recipe book for the `layout` XML — when to write it, the two-tag grammar, and the silent-failure traps to watch for. `layout` is a **single workbook-top-level property** (one XML string holding one `<Page>` block per page — see the grammar below), **not** a per-page field: setting `pages[].layout` silently no-ops and Sigma falls back to auto-arrange (a common, hard-to-spot trap). Its value is the XML string described below. **Default to writing explicit `layout` XML for multi-element workbooks.**
 
 Container *elements* (the `kind: "container"` JSON placeholders that pair with `<GridContainer>` in this XML) are covered in **Container elements** below.
 
@@ -97,7 +97,7 @@ Use stacked rows when you want a section header above a row of charts inside the
 
 ## Page-level fields: `visibility` and `backgroundImage`
 
-Besides `id`, `name`, `elements`, and `layout`, a page supports two optional fields:
+Besides `id`, `name`, and `elements` — and the workbook-top-level `layout` XML whose `<Page id>` block references this page's elements (see the top of this doc; `layout` is NOT a page field) — a page supports two optional fields:
 
 - **`visibility`** — set to `hidden` to hide the page from end users. Omit for a visible page.
 - **`backgroundImage`** — a page-wide background image, same shape as a container's `backgroundImage`: a required `url` plus an optional `style` block (`fit`, `horizontalAlign`, `verticalAlign`, `tiling`). `url` supports `{{formula}}` references.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
@@ -102,6 +102,7 @@ Every field below **round-trips and renders** — verified live 2026-06-26 (POST
 **Gotchas:**
 - The server **lowercases hex** on save (`#0F172A` → `#0f172a`) — cosmetic, not a drop; don't treat it as a failed round-trip.
 - `themeOverrides` is the spec path to **donut/pie slice colors** — set `categoricalScheme` here (the per-element `color.scheme` is still silently dropped on donut/pie — see Recipe 5). This supersedes the old "set the theme in the UI" workaround.
+- `titleFont` sets every element's title **by default**, but a per-element `name:{fontSize,color}` (live-verified 2026-07-28 — see *Things that are NOT designable via spec* below, now corrected) **wins over** `titleFont` for that one element when both are set. Use `titleFont` for a workbook-wide title style and per-element `name` only where one title needs to stand out.
 - Theme vs. the recipes below: a theme is the global skin (selected, org-managed). The recipes here style individual elements from spec fields and **stack on top of** whatever theme is set. For a migration, prefer the source dashboard's look; reach for a theme only when the user asks to apply one.
 
 ---
@@ -530,15 +531,81 @@ value: Week
 
 ---
 
+## Composition styling — the `Styling` module
+
+The recipes above are written to hand-author; the same moves are also available as a small
+shared helper library — Ruby `shared/lib/styling.rb`, with a byte-identical Python twin
+`shared/lib/styling.py` — for applying a professional look on top of a layout built with the
+`Composition` engine (`reference/workflows/composition.md`) instead of re-transcribing hex
+codes and container shapes into every dashboard. Every field these helpers emit is one of the
+Task-1 live-verified GO surfaces above (`.superpowers/sdd/styling-task-1-report.md`); each
+helper is gated behind an internal `SURFACES` map so a future regression can flip a surface off
+in one place instead of emitting an unverified (or now-rejected) shape at every call site.
+
+### Theme
+
+`Styling.theme(accent: nil)` returns `DEFAULT_THEME` — **one** professional, host-agnostic
+palette: an 8-color categorical scale, `ink`/`muted` text colors, and the card/header container
+shapes below — or a shallow variant with `accent` swapped into categorical slot 0 (and
+`theme[:accent]`) when the caller supplies one. There's no branding/logo support and no second
+built-in palette: one palette, optionally re-tinted, matches this doc's stance in the note at the
+top — reach for a theme when the user wants design polish with no stated brand direction; a
+migration's source fidelity or a user's own branding always overrides this.
+
+### `chart_color(theme, categorical: false)`
+
+- Single-series (default): `{ "color": { "by": "single", "value": theme[:categorical][0] } }` —
+  merge onto a bar/line/area/combo element (Recipe 5's single-hue case).
+- Categorical (`categorical: true`): `{ "themeOverrides": { "categoricalScheme": theme[:categorical] } }`
+  — merge at the **workbook** level (a sibling of `pages`/`layout`), not per-element. This is the
+  verified path for donut/pie slice colors too (per-element `color.scheme` is still silently
+  dropped there — see Recipe 5 / *Workbook theme* above).
+
+### `kpi_accent(theme)`
+
+Returns `{ "color": theme[:accent] }` — merge into a KPI element's `name` object
+(`{ "name": { "text": "Revenue", "color": "#2563EB" } }`). This is the KPI **title** color,
+live-verified 2026-07-28 (see the corrected claim under *Things that are NOT designable* below) —
+distinct from `value.color`, which tints the number itself (already documented under
+*Field-observed idioms* above); combine both for a fully accented KPI card.
+
+### `format_for(semantic)`
+
+Returns a `format` fragment — `{ "kind": "number", "formatString": <d3> }` — for one of four
+semantics: `:currency` → `"$,.0f"`, `:integer` → `",.0f"`, `:percent` → `".1%"`, `:decimal` →
+`",.2f"`. These are **d3-format** strings, not Excel-style masks: `"$#,##0"` is hard-rejected at
+POST with a 400 (`Invalid number format string`), never silently dropped — never hand-write an
+Excel-style format string. See Recipe 6 above and `formatting.md` for the full grammar.
+
+### `header(id:, title:, theme:, page_cols: 24)` / `section_card(id:, band:, theme:, page_cols: 24)`
+
+Apply the Recipe-1 hero-header and Recipe-2-style card idioms on top of `Composition.bands()`
+output rather than hand-writing the container + child XML per dashboard:
+
+- `header` emits a `kind: container` styled `theme[:header]`
+  (`{backgroundColor:"#0F172A", borderRadius:"round"}`) plus a separate `kind: text` title child —
+  a container has no field of its own that renders visible text, see `layout.md`'s Container
+  elements section — and the wrapping `<GridContainer>`/`<LayoutElement>` XML fragment.
+- `section_card` wraps one `Composition.bands()` band (`{role:, ids:, r0:, r1:}`) in a
+  `kind: container` styled `theme[:card]`
+  (`{backgroundColor:"#FFFFFF", borderColor:"#E2E8F0", borderWidth:1, borderRadius:"round"}`),
+  tiling the band's element ids side-by-side inside it at the same relative split
+  `Composition.band` would use unwrapped.
+- Both container `style` shapes use the field name **`borderRadius`** (`square|round|pill`) —
+  never the guessed `cornerRadius`, which is silently dropped on readback (the *container-style*
+  row of Task 1's GO/NO-GO table). And **never combine `padding` with `borderColor`/`borderWidth`**
+  on the same container — POST 400s ("padding is 'none' but border fields... require default
+  padding"); omit `padding` (its default) whenever a border is set.
+
 ## Things that are NOT designable via spec (as of 2026-05-29)
 
 Don't waste a round-trip trying to set these — the spec API silently drops them.
 
 - **Chart tooltip customization** (spec-findings #10)
 - **Trellis / small-multiples layout** (spec-findings #11)
-- **Donut / pie slice colors** (spec-findings #22)
-- **KPI title color or "hide title" toggle** — `name` always renders as a black title
-- **Element title font size / font family** — the `name` field has no `style` sibling. (Text *elements* CAN set fonts via `<span style="font-family: …">` — see field-observed idioms above; it's only the title `name` that can't.)
+- **Donut / pie slice colors** (spec-findings #22, per-element `color.scheme`; use workbook-level `themeOverrides.categoricalScheme` instead — see *Workbook theme* above)
+- ~~**KPI title color or "hide title" toggle** — `name` always renders as a black title~~ — **RESOLVED, live-verified 2026-07-28**: `name` on a `kpi-chart` (or any element) *is* colorable — `{ "name": { "text": "Revenue", "color": "#2563EB" } }` survives readback and renders the title in that color (workbook `e0586f0d-a2cd-431c-b495-555acf3ccae0`; see `.superpowers/sdd/styling-task-1-report.md`). This supersedes the "`name` always renders as a black title" claim this doc carried until now — for *this exact shape only*: there is still no `showTitle: false` / "hide title" toggle, so the `name: ' '` (single-space) workaround in Recipe 2 above still stands for suppressing a duplicate title.
+- ~~**Element title font size / font family** — the `name` field has no `style` sibling.~~ — **PARTIALLY RESOLVED, live-verified 2026-07-28**: a per-element `name` object also takes `fontSize` — `{ "name": { "text": "Category Detail", "fontSize": 22, "color": "#DC2626" } }` on a non-KPI element (e.g. a table) survives readback and renders both a visibly larger size and a distinct color, **overriding the workbook-wide `titleFont`** (see *Workbook theme* above) for that one element when both are set. This supersedes the "the `name` field has no `style` sibling" claim this doc carried until now. Font *family* per title remains untested — only `fontSize`/`color` were probed; `themeOverrides.fonts.textFont` (*Workbook theme* above) is still the only verified lever for text font family, and it's global, not per-title.
 - ~~**Workbook-level palette / theme** via spec~~ — **RESOLVED**: now spec-authorable via top-level `themeName` + `themeOverrides` (see *Workbook theme* above).
 - **Chart `tooltip` / `trellis*` fields** (UI-only)
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/composition.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/composition.md
@@ -1,6 +1,6 @@
 # Composition: making the design choice
 
-A workbook spec that compiles cleanly and has correct data can still be unusable. Layout, element choice, label clarity, whether to add a comparison vs current state — these are design decisions, not API ones. **This skill has no opinions about what makes a good dashboard.** It asks you to ask.
+A workbook spec that compiles cleanly and has correct data can still be unusable. Layout, element choice, label clarity, whether to add a comparison vs current state — these are design decisions, not API ones. This skill used to claim no opinions on any of that; it now has two verified composition patterns (below) as opinionated starting points — good defaults, not templates to apply blindly. Genuinely ambiguous structural choices (scope, audience, what to group or sort on, single- vs multi-page) still get punted to the user, exactly as before — see the ladder and the ask-section that follow.
 
 ## Calibrate scope to the request
 
@@ -10,7 +10,7 @@ A rough sizing ladder (starting points, not rules):
 
 - **A single thing** — "show total revenue", "a table of orders", "one KPI" → one element. Skip explicit layout XML; auto-arrange is fine for a single element or a uniform stack of tables.
 - **A focused view** — "revenue over time with a region filter" → a few elements plus a control; light layout.
-- **A dashboard** — "a sales dashboard", "an exec overview" → the fuller pattern is appropriate: a KPI row up top, one or two charts, a supporting table, controls, explicit layout XML, and the base/source table on a hidden page (see Defaults below). This is the tier where polish is the point.
+- **A dashboard** — "a sales dashboard", "an exec overview" → the fuller pattern is appropriate: a KPI row up top, one or two charts, a supporting table, controls, explicit layout XML, and the base/source table on a hidden page (see `visibility: hidden` in `reference/specification/schema.md`, and the master-detail pattern below for a worked example). This is the tier where polish is the point.
 
 For concrete shapes at any tier, don't assemble from memory. Fetch a real workbook's spec (`GET /v2/workbooks/{id}/spec`, Steps 1–2) and read the relevant feature docs — a live spec shows current, valid, org-idiomatic structure, including the layout XML the OpenAPI doesn't model. Size up only when the request asks for it.
 
@@ -35,13 +35,211 @@ Agents quietly choose: how many KPIs, which chart kinds, multi-page vs single, w
 
 Example: *"Built a single-page dashboard with 4 KPIs across the top, a revenue-by-region bar chart, and a ranked store table sorted descending by revenue. Used Sales Amount over Net Orders for the headline metric. Tell me if you want any of these changed — different KPI mix, multi-page split, a different sort, etc."*
 
-## Defaults to fall back on when not asking
+## Patterns
 
-These are *defaults, not rules.* The skill doesn't claim they're right for every dashboard; they're starting points when the user's preference isn't known and stopping to ask isn't appropriate.
+Two layout patterns are wired into a shared composition engine (`shared/lib/composition.rb`, with a byte-identical Python twin `shared/lib/composition.py`). Both take a flat array of elements — each `{ id:, role: }` or `{ id:, kind: }` — and emit the `<LayoutElement elementId="..." gridColumn="a / b" gridRow="c / d"/>` lines for a single `<Page>`'s worth of layout XML. Wrap the engine's output in a `<Page id="<pageId>" ...>` block, then place the assembled XML — one shared prolog plus one `<Page>` block per page — in the **workbook-top-level `layout` field**, NOT `pages[].layout` (which silently no-ops and falls back to auto-arrange). See `reference/specification/layout.md` for the `<Page>`/`<GridContainer>` wrapper and this workbook-level placement. Elements are grouped into horizontal bands by `role`; a band with no elements is skipped and the next band simply starts where the last one left off, so array order doesn't matter — only the role tag does.
 
-- **Source/base tables go on a hidden page.** When a workbook needs a base table (warehouse-table or join source) to feed charts, KPIs, and grouped views, that base table doesn't belong in the dashboard view. Put it on a separate page with `visibility: hidden` (see `reference/specification/schema.md`) and source dashboard elements from it via `elementId`. The base table stays available to the workbook without dropping a million-row dump on the viewer.
-- **Sort ranked tables by the metric the user is ranking on.** "Bottom 10 stores by revenue" implies ascending by revenue; "top products" implies descending. Sorting alphabetically by name is rarely what a meeting attendee wants.
-- **Don't expose intermediate joins as visible elements.** Same rationale as the base-table rule — they're plumbing, not deliverables.
+Role resolution: give an element an explicit `role:`, or let `kind:` infer one — `kpi-chart` → `:kpi`; `table` / `pivot-table` / `input-table` → `:table`; any other kind (every chart kind) defaults to `:supporting`. `:hero`, `:control`, `:insight`, `:master`, and `:detail` are **never** inferred — tag those explicitly. An untagged element infers to `:supporting` — `:exec` places that (merged into its final `:supporting`+`:table` band), but `:master_detail` does NOT: it only consumes `:control`, `:master`, and `:detail`, so an untagged (or explicitly `:kpi`/`:hero`/`:insight`/`:supporting`/`:table`) element passed to `:master_detail` is a role the pattern doesn't place.
+
+An unrecognized explicit role raises (`compose: unknown role <x> for element <id>`) rather than silently dropping the element — and, separately, a *recognized* role the chosen pattern simply doesn't consume now raises too (`compose: role <role> (element <id>) is not used by pattern <pattern>`), e.g. tagging something `:master` and composing with `:exec`, or leaving something `:kpi`/untagged and composing with `:master_detail`. Neither case silently vanishes from the layout anymore.
+
+Within a band, elements split the available width evenly (`band()`, the same helper both patterns use) — the element count in any one band must evenly divide `page_cols` (default 24: 1, 2, 3, 4, 6, 8, 12, or 24 elements fit cleanly). An uneven count raises `ArgumentError` (Ruby) / `ValueError` (Python) rather than producing a lopsided or clipped layout — pick a clean count, or drop to hand-written layout XML for an odd one.
+
+### `exec` — KPI-strip dashboard
+
+Use this for the "dashboard" tier of the sizing ladder above: an exec overview, a sales dashboard, anything shaped like "a few headline numbers, one dominant chart, supporting detail." It is not the only shape a dashboard can take — it's the default starting point when nothing about the request argues for something else.
+
+Role → band, top to bottom (each optional; skipped if empty):
+
+| Role | Band height | Notes |
+|------|-------------|-------|
+| `:control` | 2 | Filters for the page. Thin, full-width if one control; split evenly if several. |
+| `:kpi` | 6 | The KPI strip — an even split across every `:kpi` element. This is the headline-numbers row. |
+| `:insight` | 3 | Optional narrative/callout band (a text element, a small annotation) between the KPIs and the hero. |
+| `:hero` | 12 | The dominant visual. Tag exactly **one** element `:hero` — `band()` will split the width evenly across *however many* `:hero` elements you pass, so more than one turns this into side-by-side heroes rather than one dominant chart. |
+| `:supporting` + `:table` | 9 | Merged into one final band and split evenly across whatever's left — secondary charts and the detail table together. |
+
+Call:
+
+```ruby
+require_relative 'shared/lib/composition'
+
+elements = [
+  { id: 'kpi1', role: :kpi }, { id: 'kpi2', role: :kpi },
+  { id: 'kpi3', role: :kpi }, { id: 'kpi4', role: :kpi },
+  { id: 'hero', role: :hero }, { id: 'tbl', role: :table }
+]
+Composition.compose(elements, pattern: :exec)
+```
+
+produces a 4-up KPI strip (each 6 of 24 columns, row 1–7), a full-width hero (row 7–19), and a full-width table (row 19–28) — the exact shape golden-tested in `shared/lib/testdata/composition_exec_golden.txt`.
+
+### `master-detail` — pick one, see its detail
+
+Use this when the request is shaped like "browse/pick from a list or chart, see the detail for the one selected" — a directory next to a drill-down table, "click a region to see its orders," an index/detail pairing. This is a different shape from `exec`: there's no KPI strip, just one selection surface and one surface that responds to it.
+
+Role → band, top to bottom:
+
+| Role | Band height | Notes |
+|------|-------------|-------|
+| `:control` | 2 | Optional thin, full-width row. If omitted, the master/detail band below starts at row 1 instead of row 3. |
+| `:master` + `:detail` | 14 | Share one tall band, split evenly. With exactly one of each on the default 24-column grid, that's master at columns 1–13 and detail at 13–25. |
+
+`:master` and `:detail` are resolved **only** from an explicit `role:` — never inferred from `kind:`. A bar chart or a table can be either side of this pattern (or neither, in a different pattern), so the engine can't guess which one is the selection surface.
+
+Call:
+
+```ruby
+elements = [
+  { id: 'ctl', role: :control },
+  { id: 'master-chart', role: :master, kind: 'bar-chart' },
+  { id: 'detail-tbl', role: :detail, kind: 'table' }
+]
+Composition.compose(elements, pattern: :master_detail)
+```
+
+(note the pattern name is the symbol `:master_detail`, underscore — the hyphen is only in prose) produces a full-width control row (row 1–3), then master at columns 1–13 and detail at columns 13–25 sharing row 3–17 — see `shared/lib/testdata/composition_master_detail_golden.txt`. Drop the `:control` element and the master/detail band starts at row 1 instead.
+
+**Critical semantics — verified live against a real Sigma org (2026-07-28, `shared/scripts/verify-master-detail-e2e.rb`), not just spec-shape-valid:**
+
+- **The control filters the detail element only.** Wire it as a `filters[]` entry on the control pointing at the detail table — `{ source: { kind: table, elementId: <detail-element-id> }, columnId: <dimension-column> }` (see `reference/specification/controls.md`). Do not add the master to that `filters[]` array.
+- **The master stays whole.** It is the selection surface the viewer picks from, not a filtered view of the current pick — it must keep rendering every category/row, not just the selected one. Live proof: setting the control's value and exporting the master still returns every category with its correct (unfiltered) totals. This is the intended shape, not a bug to "fix" by also filtering the master.
+- **Put the underlying source table on a hidden page** (`pages[].visibility: hidden`, `reference/specification/schema.md`) and have both the master and the detail `source` from it via `elementId` — same rationale as any base table: it's plumbing the pattern needs, not a deliverable the viewer should see directly.
+- **Clicking the master to set the control's value is a manual UI step — there is no spec node for it.** The spec-authorable half of this pattern is only the control → detail `filters[]` binding above; "clicking a mark sets a control's value" has no representation in the workbook spec and has to be wired by hand in the Sigma UI after the workbook is built. (For automated verification instead of a manual click, the control's value can be driven programmatically through the export API's `parameters` map — see `reference/workflows/validate.md` — but that's a test-time convenience, not a substitute for the real UI interaction.)
+
+### Other defaults
+
+Two general, pattern-independent authoring defaults still apply no matter which composition pattern (or none) is in play:
+
+- **Sort ranked tables by the ranking metric, descending.** "Top 10 stores by revenue" or "top products" implies ranking by the metric in view, highest first — sorting alphabetically by name is rarely what the request meant.
+- **Don't expose intermediate/staging joins as visible elements.** A join or blend built only to feed other elements is plumbing, not a deliverable — keep it on a hidden page (or off the dashboard entirely), same rationale as a source/base table.
+
+**Styling:** once a page is composed, apply a professional look on top — theme, chart color, KPI accent, number format, header/card containers — via the shared `Styling` module; see `reference/specification/styling.md`'s *Composition styling* section.
+
+## Richness — optional building blocks
+
+Everything below is a **menu, not a fixed template.** Each capability is independent and
+optional — usable alone, in any combination, or not at all. None of it is auto-applied:
+offer what fits the request and let the user choose, the same calibrate/ask ethos as the
+rest of this doc. This is not a clone of any one dashboard's branded look — no logos, no
+imposed layout, no house style forced onto every workbook. Reach for these when the
+request calls for polish; a plain KPI-and-chart page (composed with `:exec`, or with no
+pattern at all) is still a completely valid answer on its own.
+
+Each item below emits one spec fragment — via `shared/lib/richness.rb` (Ruby canonical,
+byte-identical `shared/lib/richness.py` twin) or the existing `shared/lib/kpi_card.rb`/
+`.py` — that drops into whatever layout is already being built. None of them assemble a
+whole page by themselves.
+
+### Comparative KPI cards (+ optional value styling)
+
+The house default for a KPI is comparative: a value column plus a `comparisonColumn`
+rendered as a Δ badge (see `refs/kpi-comparison.md` and `KpiCard.build`/`kpi_card.build`).
+That comparison is itself optional — a plain single-value KPI is a valid, simpler choice;
+calling `KpiCard.build` with no `comparison_column_id` emits a plain card, no Δ badge.
+
+On top of that, `KpiCard.build`/`kpi_card.build` takes two further optional kwargs —
+`value_color:` / `value_font_size:` — that accent the number itself:
+`value: {columnId: ..., color: '#FDE047', fontSize: 44}`. Leave both `nil` (the default)
+and the emitted card is byte-identical to a call that never knew these kwargs existed.
+Live-verified: the color renders as a genuinely distinct hue against the default black,
+and the font-size change is directly measurable in the rendered PNG, not just accepted on
+POST.
+
+### AI-insight callout (opt-in, org-dependent)
+
+`Richness.ai_insight(id:, model:, prompt:)` / `richness.ai_insight(...)` builds a `text`
+element whose `body` is a Cortex-backed formula:
+
+```
+{{ Replace(CallText("SNOWFLAKE.CORTEX.COMPLETE", "<model>", "<prompt>"), '"', "") }}
+```
+
+`CallText`'s real signature is `CallText(<warehouse_function_name>, ...args)` — there is
+**no separate connection argument**; it runs against the referenced column's own
+element/connection. `llama3.1-8b` and `mistral-large2` are live-verified against Sigma's
+own Sample Database Snowflake connection, returning genuinely generated (non-echoed)
+sentences, not an echo of the prompt.
+
+**Opt-in caveat, stated plainly:** this only renders real text where the target org has a
+usable Cortex model configured on its own connection. Offer it, don't force it — and
+never substitute a hand-written or faked summary sentence when an org's Cortex isn't
+available; an unconfigured org just sees a blank or erroring element until Cortex is set
+up there. Meant to sit in a light-tint container alongside the rest of the page, not as a
+load-bearing element the rest of the dashboard depends on.
+
+### Control-driven interactivity (optional)
+
+Two independent, optional pieces, both reusing already-verified control shapes:
+
+- **Dynamic grain.** `Richness.grain_control(id:)` emits a `segmented` Week/Month/Day
+  control (default Month); `Richness.trend_dimension(grain_control_id:, date_ref:)`
+  returns the matching dimension formula for a trend chart —
+  `Switch([<id>],"Week",DateTrunc("week",<date_ref>),"Month",DateTrunc("month",<date_ref>),
+  DateTrunc("day",<date_ref>))`. Live-verified: switching the control across Week/Month/Day
+  changed the chart's exported bucket count exactly as expected (Month=3, Week=14, Day=90
+  over 90 days of data).
+- **Filter row.** `Richness.filter_row(controls:)` emits one or more `list` controls wired
+  to a control → element `filters[]` binding — the same control-filters-target shape
+  already verified for the master-detail pattern above, offered here as a standalone
+  filter row rather than tied to one specific layout.
+
+Use either, both, or neither — a page composed with no controls at all is just as valid a
+choice as one with both.
+
+### Wide pivot (optional)
+
+`Richness.wide_pivot(id:, source_element_id:, rows_by:, values:)` emits a `pivot-table`
+biased wide rather than crosstabbed: `rowsBy` takes the row shelves, `columnsBy` is always
+`[]`, and `values` is a plain list of metric column-id strings (not `{id: ...}` objects —
+matching the existing pivot precedent). Grand totals are a UI-only setting, not a spec
+field, so this helper doesn't emit or guess one. Reach for this when the request wants a
+wide detail table rather than a small-multiple crosstab; a regular table, or a pivot with
+`columnsBy` populated, are equally valid alternatives depending on what's actually asked
+for.
+
+### Composition pattern choice: `:overview` as one more option
+
+`Composition.compose`/`compose` (see *Patterns* above) offers a third pattern alongside
+`:exec` and `:master_detail`: `pattern: :overview`, an optional stack of full-width bands,
+each skipped if its role has no elements:
+
+| Role | Band height | Notes |
+|------|-------------|-------|
+| `:header` | 3 | Optional title band. |
+| `:control` | 2 | Optional filter row. |
+| `:kpi` | 8 | Taller than `:exec`'s KPI band — room for a comparison badge and title without clipping. |
+| `:kpi2` | 8 | Optional second KPI row (e.g. rate/percentage metrics kept visually distinct from the headline row). |
+| `:trend` | 12 | A grain-driven or plain trend chart. |
+| `:pivot` | 14 | A wide pivot or detail table. |
+| `:base` | 9 | The base/source row — hide it if it's plumbing, not a deliverable, same convention as the rest of this doc. |
+
+This is **one composition choice among three** (`:exec`, `:master_detail`, `:overview`) —
+plus hand-placed layout XML when none of the three fits. Nothing about a "dashboard"
+request implies `:overview` specifically; pick whichever pattern's shape matches what was
+actually asked for, or ask if that's ambiguous, same as the sizing ladder above.
+
+### What's not here: in-card KPI sparkline (NO-GO)
+
+A sparkline living inside a KPI card itself (title → value → Δ badge → mini trend line,
+all one element) is **not currently spec-authorable.** Adding a real, non-aggregate date
+dimension (e.g. `DateTrunc("month", [Src/Date])`) to a `kpi-chart`'s own `columns` — the
+specific shape this round of testing targeted — still renders no line: the card shows
+title, value, and the Δ badge only, with visible empty space where a spark would go.
+Separately, `trend: {shape: "line"}` was **stripped outright on this readback**
+(`kpi_trend: null`) — narrower than `kpis.md`'s existing claim that the bare `trend` field
+alone "is accepted and persists on readback, but inert without a UI binding."
+
+So: KPI cards in this menu are comparative (value + Δ badge), not comparative-with-spark.
+If a trend needs to sit alongside a KPI, use a separate trend chart — the `:trend` band
+above, or a supporting chart next to the KPI strip — rather than trying to author a
+sparkline inside the KPI element itself.
+
+This is a candidate for a later re-probe, not a closed question — other builds are
+reported to achieve an in-card spark, plausibly through a data-model/Metrics-level
+mechanism rather than the `kpi-chart` `trend` field tested here. Don't claim the in-card
+spark works until a workbook built purely from spec (never opened in the editor) is shown
+actually rendering one.
 
 ## Image-driven cases have their own composition guide
 


### PR DESCRIPTION
Re-lands the WS3 sigma-workbooks docs from the auto-closed #528 (its base branch `feat/ws3-shared` was deleted when #526 merged, which GitHub closed the stacked PR). Content is the same reviewed commit, cleanly cherry-picked onto main atop the now-merged #526 libs. Docs-only + plugin version bump 1.3.0→1.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)