### PR TITLE
feat(ws4): Sigma agent + gradient header/cards + actions/input-tables (authoring skills)

### DIFF
--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
@@ -246,8 +246,9 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `refs/kpi-comparison.md` + `examples/comparative-kpi-card.yaml` | Comparative KPI card, delta badge, vs.-prior / vs.-target number. The verified, readback-stable `comparisonColumn` + `comparison:{display:"delta"}` shape, its gotchas, the `KpiCard.build`/`kpi_card.build` emitter that produces it, and a clone-able spec fragment. |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, cross-connection linked-table pull, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors, gradient headers/cards + motif menu, the composite-sparkline pattern. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat panel, "ask a question about this data." The workbook-top-level `agents:[]` array + the `chat` element — read-only analyst vs. write/action-tool agent, the org-feature gate, and the graceful-degrade fallback. |
 
 ### Sources
 
@@ -276,6 +277,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
+| `reference/workflows/actions.md` | Button, click-to-write, insert a row, reset/set a control, write-back workflow, append-only log, modal / overlay. Verified `insert-rows`/`clear-control`/`set-control-value` effect shapes (+ `open-overlay`/`close-overlay` for modals), the append-only-log recipe, and the masked-error catalog (`inputMode`, entry-control fields, element-scoped `clear-control`) — backed by `shared/lib/actions.rb`. |
 
 ## Quick Formula Rules
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -239,8 +239,9 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `refs/kpi-comparison.md` + `examples/comparative-kpi-card.yaml` | Comparative KPI card, delta badge, vs.-prior / vs.-target number. The verified, readback-stable `comparisonColumn` + `comparison:{display:"delta"}` shape, its gotchas, the `KpiCard.build`/`kpi_card.build` emitter that produces it, and a clone-able spec fragment. |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, cross-connection linked-table pull, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors, gradient headers/cards + motif menu, the composite-sparkline pattern. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat panel, "ask a question about this data." The workbook-top-level `agents:[]` array + the `chat` element — read-only analyst vs. write/action-tool agent, the org-feature gate, and the graceful-degrade fallback. |
 
 ### Sources
 
@@ -269,6 +270,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
+| `reference/workflows/actions.md` | Button, click-to-write, insert a row, reset/set a control, write-back workflow, append-only log, modal / overlay. Verified `insert-rows`/`clear-control`/`set-control-value` effect shapes (+ `open-overlay`/`close-overlay` for modals), the append-only-log recipe, and the masked-error catalog (`inputMode`, entry-control fields, element-scoped `clear-control`) — backed by `shared/lib/actions.rb`. |
 
 ## Quick Formula Rules
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
@@ -239,8 +239,9 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `refs/kpi-comparison.md` + `examples/comparative-kpi-card.yaml` | Comparative KPI card, delta badge, vs.-prior / vs.-target number. The verified, readback-stable `comparisonColumn` + `comparison:{display:"delta"}` shape, its gotchas, the `KpiCard.build`/`kpi_card.build` emitter that produces it, and a clone-able spec fragment. |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, cross-connection linked-table pull, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors, gradient headers/cards + motif menu, the composite-sparkline pattern. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat panel, "ask a question about this data." The workbook-top-level `agents:[]` array + the `chat` element — read-only analyst vs. write/action-tool agent, the org-feature gate, and the graceful-degrade fallback. |
 
 ### Sources
 
@@ -269,6 +270,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
+| `reference/workflows/actions.md` | Button, click-to-write, insert a row, reset/set a control, write-back workflow, append-only log, modal / overlay. Verified `insert-rows`/`clear-control`/`set-control-value` effect shapes (+ `open-overlay`/`close-overlay` for modals), the append-only-log recipe, and the masked-error catalog (`inputMode`, entry-control fields, element-scoped `clear-control`) — backed by `shared/lib/actions.rb`. |
 
 ## Quick Formula Rules
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -239,8 +239,9 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `refs/kpi-comparison.md` + `examples/comparative-kpi-card.yaml` | Comparative KPI card, delta badge, vs.-prior / vs.-target number. The verified, readback-stable `comparisonColumn` + `comparison:{display:"delta"}` shape, its gotchas, the `KpiCard.build`/`kpi_card.build` emitter that produces it, and a clone-able spec fragment. |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, cross-connection linked-table pull, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors, gradient headers/cards + motif menu, the composite-sparkline pattern. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat panel, "ask a question about this data." The workbook-top-level `agents:[]` array + the `chat` element — read-only analyst vs. write/action-tool agent, the org-feature gate, and the graceful-degrade fallback. |
 
 ### Sources
 
@@ -269,6 +270,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
+| `reference/workflows/actions.md` | Button, click-to-write, insert a row, reset/set a control, write-back workflow, append-only log, modal / overlay. Verified `insert-rows`/`clear-control`/`set-control-value` effect shapes (+ `open-overlay`/`close-overlay` for modals), the append-only-log recipe, and the masked-error catalog (`inputMode`, entry-control fields, element-scoped `clear-control`) — backed by `shared/lib/actions.rb`. |
 
 ## Quick Formula Rules
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -244,8 +244,9 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `refs/kpi-comparison.md` + `examples/comparative-kpi-card.yaml` | Comparative KPI card, delta badge, vs.-prior / vs.-target number. The verified, readback-stable `comparisonColumn` + `comparison:{display:"delta"}` shape, its gotchas, the `KpiCard.build`/`kpi_card.build` emitter that produces it, and a clone-able spec fragment. |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, cross-connection linked-table pull, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors, gradient headers/cards + motif menu, the composite-sparkline pattern. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat panel, "ask a question about this data." The workbook-top-level `agents:[]` array + the `chat` element — read-only analyst vs. write/action-tool agent, the org-feature gate, and the graceful-degrade fallback. |
 
 ### Sources
 
@@ -274,6 +275,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
+| `reference/workflows/actions.md` | Button, click-to-write, insert a row, reset/set a control, write-back workflow, append-only log, modal / overlay. Verified `insert-rows`/`clear-control`/`set-control-value` effect shapes (+ `open-overlay`/`close-overlay` for modals), the append-only-log recipe, and the masked-error catalog (`inputMode`, entry-control fields, element-scoped `clear-control`) — backed by `shared/lib/actions.rb`. |
 
 ## Quick Formula Rules
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/agents.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/agents.md
@@ -1,0 +1,148 @@
+# Agents & chat — the workbook AI agent
+
+A Sigma workbook can carry a **spec-authorable AI agent** that end users chat with
+inside the workbook. It is easy to miss: it is **not a page element** — it's a
+**workbook-top-level `agents:[]` array**, a sibling of `pages`/`layout`/`themeName`.
+An element-kind scan of `pages[].elements[]` alone will never find it and can wrongly
+conclude "not authorable." The agent is *surfaced* on a page via a small `chat`
+element that just references the agent's id.
+
+> **Not in the compiled/public OpenAPI as of this writing.** Unlike most of this
+> skill's surface, `agents[]` / `dataSources` / `tools` / the `chat` element kind
+> do not appear in the compiled Fern OpenAPI asset this skill points to (see
+> `SKILL.md`'s *Sources of truth*) — this shape was recovered by live POST +
+> GET-readback + render probing on a test org, not read off a schema. Treat field
+> names as verified-by-example, not exhaustive; if you need a field not listed
+> here, confirm it against a live workbook readback before relying on it.
+
+## Shape
+
+```yaml
+name: My Workbook
+schemaVersion: 1
+folderId: <folderId>
+agents:
+  - id: ag-analyst
+    name: Analyst
+    instructions: >-
+      You are an analyst for this dataset. Answer questions about revenue,
+      orders, and trends over time. Be concise and quantitative; cite the
+      numbers you used.
+    dataSources:
+      - kind: table
+        elementId: src          # an element id already in this workbook's pages
+pages:
+  - id: pg
+    name: Overview
+    elements:
+      - id: src
+        kind: table
+        # ...
+      - id: chat
+        kind: chat
+        agentId: ag-analyst     # the AGENT's `id` above, not an element id
+```
+
+| Field (agent entry) | Required | Notes |
+|---|---|---|
+| `id` | yes | The agent's handle — referenced by `chat.agentId`, not an element id. |
+| `name` | yes | Display name shown in the chat UI. |
+| `instructions` | yes | System-prompt-style guidance: role, scope, tone. |
+| `dataSources` | yes | Array of `{ kind: table, elementId: <id> }` — one entry per element (table/pivot/etc.) the agent may query. Maps 1:1 to the elements it can see; it cannot see elements not listed here. |
+| `tools` | — | **Omit entirely for a read-only analyst** (see below). Present only on a write/action agent. |
+
+The `chat` page element is minimal: `{ id, kind: "chat", agentId }` — no other
+fields observed. Lay it out like any other element (`gridColumn`/`gridRow` via
+`<LayoutElement>`), typically in a sidebar rail next to the dashboard body.
+
+## Read-only analyst vs. write/action agent
+
+**Read-only analyst — the common case.** The agent entry **omits the `tools` key
+entirely** — not `tools: []`. An empty-but-present `tools` array is a different
+(untested) shape; the verified read-only shape is the key's total absence. It can
+only read the elements named in `dataSources` and answer questions about them.
+
+**Write/action agent — adds `tools`.** Each tool gives the agent an action it can
+invoke (function-calling style), described to the agent via `name`/`description`
+so it knows when to call it:
+
+```yaml
+agents:
+  - id: ag-planner
+    name: Planner
+    instructions: You help log review notes against this dataset.
+    dataSources:
+      - kind: table
+        elementId: src
+    tools:
+      - toolId: log-note
+        kind: action
+        name: Log a review note
+        description: >-
+          Call this to record a review note from the conversation. Pass the
+          note text as the `note` input.
+        steps:
+          - kind: effect
+            effect: insert-rows
+            table: annotations          # an input-table element id (see actions.md)
+            values:
+              an-note:
+                type: agent-input
+                inputName: note         # the agent supplies this at call time
+```
+
+`value: { type: "agent-input", inputName }` is the tool-call analog of the
+`type: "control"` / `type: "constant"` value shapes an `insert-rows` effect takes
+from a button (see `reference/workflows/actions.md`) — instead of pulling from a
+control's current value or a hard-coded constant, the value comes from an argument
+the agent fills in when it decides to call the tool, keyed by `inputName`.
+
+> **Scope note:** the write/action agent shape above documents the *pattern*
+> from the design spec's live probe — it is not independently exercised end-to-end
+> in this pass (no automated test drives an agent into actually invoking a tool).
+> `Richness.agent`'s `tools:` parameter passes an already-shaped array through
+> **verbatim** (never reshapes it) for exactly this reason: confirm any non-trivial
+> tool/step shape against a live POST + readback before shipping it, same discipline
+> as any other agent-input shape in this doc.
+
+## Org-feature gate + graceful degrade
+
+Sigma's AI-agent feature is an **org-level toggle**. On an org where it's off,
+posting `agents:[]` + a `chat` element either renders nothing useful or fails —
+there's no reliable single error signature to detect this from the spec alone.
+**Don't gate on trial-and-error in a shared build.** The safe pattern:
+
+1. If you know (from asking the user, or a prior probe on that org) that AI agents
+   are enabled, use `agents[]` + `chat` as above.
+2. If you don't know, or you know they're **off**, degrade to a **static text
+   element** with a short list of sample prompts instead of a live chat — e.g.:
+
+   ```yaml
+   - id: chat-fallback
+     kind: text
+     body: |
+       **Ask about this data** (AI agents aren't enabled on this org)
+
+       Try asking your Sigma admin to enable workbook AI agents, then re-add a
+       live chat panel here. Sample questions this dataset can answer:
+       - "What was revenue last month vs. the month before?"
+       - "Which region had the most orders?"
+   ```
+
+Never POST a `chat` element as a cosmetic stand-in when you haven't confirmed the
+org supports it — that's the "faked surface" this skill's docs never do. The
+fallback text element is the honest alternative, not a workaround to make the
+gated feature look implemented.
+
+## Cross-links
+
+- `shared/lib/richness.rb` / `richness.py` — `Richness.agent(id:, name:,
+  instructions:, data_source_ids:, tools: [])` builds the `agents[]` entry
+  (`data_source_ids` maps to `dataSources`; empty `tools:` is omitted from the
+  emitted Hash, matching the read-only shape above). `Richness.chat(id:,
+  agent_id:)` builds the page element. Both are gated behind
+  `Richness::SURFACES[:agent]`; a NO-GO flip returns `{opt_in: true, id:}` rather
+  than emitting an unverified shape.
+- `reference/workflows/actions.md` — the `insert-rows`/`clear-control`/
+  `set-control-value` effect shapes a write-agent's tool `steps[]` reuses, and
+  the append-only-log input-table pattern a logging tool typically targets.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
@@ -170,6 +170,40 @@ filters:
 
 The text control carries the match `mode` and the search string as flat top-level fields. `mode` values include `equals`, `does-not-equal`, `contains`, `does-not-contain`, `starts-with`, `ends-with`, `like`, `matches-regexp`, and their negations.
 
+### Entry (write) text controls — 4 fields are mandatory
+
+The `text`/`text-area` shape above is for **filtering** a downstream column. A
+`text`/`text-area` control used the other way — capturing free-typed input for
+a formula or an action effect's `values` (e.g. a "review note" field feeding an
+`insert-rows` effect, see `reference/workflows/actions.md`'s append-only-log
+pattern) — needs **four additional flat fields** or the element **masked-fails**
+as the opaque `Invalid kind: control`, which reads like the control kind itself
+is broken:
+
+```yaml
+kind: control
+id: note-ctl
+controlId: NoteCtl
+name: Add a review note
+controlType: text-area          # or: text
+mode: equals
+case: insensitive
+includeNulls: when-no-value-is-selected
+showOperators: false
+```
+
+| Field | Value (verified) | Notes |
+|---|---|---|
+| `mode` | `equals` | Same field name as the filter-mode above; `equals` is the verified entry-control value. |
+| `case` | `insensitive` | Case sensitivity for the (unused, in an entry context) match. |
+| `includeNulls` | `when-no-value-is-selected` | Same enum as the date-range control's `includeNulls`. |
+| `showOperators` | `false` | Hides the operator picker — this control is for typing a value, not building a filter expression. |
+
+No `filters` binding is needed on an entry control used this way — its value is
+read via `{ type: control, control: <controlId> }` from wherever it's
+consumed (an action effect's `values`, a formula), not wired to filter another
+element's column.
+
 ## Number Range
 
 ```yaml

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/input-tables.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/input-tables.md
@@ -15,15 +15,41 @@ table, and a data model can read it through a warehouse view.
 
 1. **Write-enabled connection required.** `source: { kind: empty, connectionId }`
    must point at a connection with `writeAccess: true` (`GET /v2/connections`).
-   A non-write connection fails at POST. Linked tables (`kind: linked`) inherit
-   the parent's connection.
-2. **Data lands in `SIGDS_`-prefixed tables** in the connection's write schema.
+   A non-write connection fails at POST. A linked table's `source` carries its
+   **own** `connectionId` — see *Cross-connection linked tables* below; it is
+   not always simply inherited from the parent element.
+2. **`inputMode` is mandatory — omitting it masked-fails.** Every `input-table`
+   element requires `inputMode: edit | explore | view` (see `tables.md`). Leave
+   it out and the POST doesn't fail with a helpful "missing inputMode" — it
+   fails with the generic **`Invalid kind: "input-table"`**, which reads like
+   the element kind itself is rejected. If you hit that error on an
+   input-table, check `inputMode` first before suspecting anything else about
+   the shape.
+3. **Data lands in `SIGDS_`-prefixed tables** in the connection's write schema.
    Don't query or modify those directly — see "Reading the data" below.
-3. **Data is invisible until Publish.** A query of an input table before the
+4. **Data is invisible until Publish.** A query of an input table before the
    workbook is published returns **0 rows** — the query layer reads the
    published version. Publish, then re-query.
-4. **System columns take no `type`** (`ID`, `CREATED_AT`, `CREATED_BY`,
-   `UPDATED_AT`, `UPDATED_BY`) — adding one breaks the column.
+5. **System columns take no `type`** (`ID`, `CREATED_AT`, `CREATED_BY`,
+   `UPDATED_AT`, `UPDATED_BY`) — adding one breaks the column. They're also
+   never included in an `insert-rows` action effect's `values` — Sigma
+   auto-fills them at insert time (see `reference/workflows/actions.md`).
+
+### Cross-connection linked tables (verified)
+
+A **linked** input table's `source: { kind: linked, from: <parentElementId>,
+connectionId: <connectionId> }` carries its own `connectionId` — and that
+connection **can differ from the parent element's**. Verified live: a
+write-back input table on a write-enabled connection, linked (`from`) to a
+parent element (a pivot/table) sourced on a completely separate, **read-only**
+connection — the linked table still pulled every key row from the parent
+correctly. In other words, cross-connection linking (write-conn child, read-conn
+parent) is a supported pattern, not just same-connection linking. This is a
+narrower, more precise claim than "the connection is inherited" — the parent
+supplies the *keys* (via `{ id, key }` columns), not the *connection*; the
+linked table's own `connectionId` is what determines where its write-back rows
+actually live, and it must be a write-enabled connection regardless of what the
+parent uses.
 
 ## Three types
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/input-tables.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/input-tables.md
@@ -57,7 +57,7 @@ parent uses.
 |---|---|---|
 | **Empty** | Blank table; rows added/typed/pasted from scratch | `source: { kind: empty, connectionId }` |
 | **CSV** | Pre-populated from a CSV upload, then editable | created from an upload (UI); element is otherwise an empty-style input table |
-| **Linked** | Child of a parent element; key columns bind rows to the parent, entry/formula columns sit alongside | `source: { kind: linked, from: <parentElementId> }` + `{ id, key }` columns |
+| **Linked** | Child of a parent element; key columns bind rows to the parent, entry/formula columns sit alongside | `source: { kind: linked, from: <parentElementId>, connectionId: <connectionId> }` + `{ id, key }` columns |
 
 **Linked tables are spec-authorable as of the 2026-06-11 release** —
 `source.kind: linked` + `from` + `{ id, key }` columns POST and round-trip

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
@@ -597,6 +597,110 @@ output rather than hand-writing the container + child XML per dashboard:
   on the same container — POST 400s ("padding is 'none' but border fields... require default
   padding"); omit `padding` (its default) whenever a border is set.
 
+### `gradient_header(id:, title:, subtitle:, gradient:, motif:, motif_side:, logo_url:, page_cols: 24)` — sleek header via a data-URI SVG
+
+A step up from the flat `header` band above: instead of a solid `backgroundColor`,
+the container's `backgroundImage` is a composed **inline SVG, base64-encoded as a
+`data:image/svg+xml;base64,...` URI** — a `linearGradient` (the `gradient:` stops)
+optionally layered with a decorative motif `<g>`. Same `{ element:, layout: }`
+return contract as `header`, so it drops into the same composition call sites.
+
+```yaml
+- id: hdr-bg
+  kind: container
+  style: { borderRadius: round }
+  backgroundImage:
+    url: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0i..."   # composed gradient(+motif) SVG
+    style: { fit: cover }
+- id: hdr-title
+  kind: text
+  verticalAlign: middle
+  body: '# <span style="color: #FFFFFF">Overview</span>'
+```
+
+- `gradient:` is an array of **2–3 hex stops** (default: a neutral, host-agnostic
+  3-stop slate→navy→blue ramp in `DEFAULT_THEME[:header_gradient]` — not red; red,
+  like `theme(accent:)` elsewhere in this file, is a caller override, never a
+  built-in default).
+- `motif:` picks a decorative element layered on top of the gradient, positioned by
+  `motif_side:` (`:right` default, `:left`, `:center`). It's a **menu, not a fixed
+  look** — six geometric, trademark-free options in `Styling::MOTIFS`:
+
+  | Key | Look |
+  |---|---|
+  | `:glow` (default) | A soft radial highlight — the plainest, least busy option. |
+  | `:rings` | Concentric circles + crosshair lines — a "signal/target" mark. |
+  | `:grid` | A faint repeating grid pattern. |
+  | `:waves` | Three nested arcs — a soft "signal wave" mark. |
+  | `:dots` | A repeating dot pattern. |
+  | `:none` | No motif — a plain gradient. |
+
+  A **String** value for `motif:` starting with `http` or `data:` is treated as a
+  **bring-your-own image** and used verbatim as the background instead of composing
+  from the menu — useful for a caller with their own hero graphic. Every menu motif
+  is geometric (circles, grids, arcs, dots) — no logos, letterforms, or third-party
+  marks.
+- `logo_url:` (optional) adds a left-column `image` element inside the same band.
+- NO-GO on the `gradient_header` surface falls back to the plain `header` band
+  above (graceful — never a broken shape); NO-GO on just `motif` (surface still GO)
+  drops to a plain gradient with no decorative `<g>`.
+
+### `gradient_card(id:, kpi_element:, gradient:, page_cols: 24)` — gradient KPI card
+
+Decorate-only, like `section_card`: wraps a **caller-built** `kpi-chart` element
+(e.g. from `KpiCard.build`) in a gradient `backgroundImage` container — same
+composed-SVG technique as `gradient_header`, always `motif: :none` (a card this
+small has no room for a decorative mark). It never mutates `kpi_element` or
+`kpi_card.rb` — it returns `{ element:, child_layout:, patch: }`: the container
+element to add, the inner `<LayoutElement>` fragment positioning the KPI inside it,
+and a `patch` Hash (`{ value: { color: "#FFFFFF" }, name: { color: "#FFFFFF" } }`)
+the caller merges onto their own copy of the KPI's `value`/`name` objects so the
+title and value read white against the gradient. NO-GO returns the empty
+`{ element: [], child_layout: '', patch: {} }` marker — nothing half-decorated.
+
+### `sparkline(id:, source_element_id:, period_ref:, value_formula:, period_format:)` — the composite in-card sparkline (refines the earlier NO-GO)
+
+`reference/workflows/composition.md` documents an **in-kpi date-column sparkline**
+as NO-GO: adding a real date dimension to a `kpi-chart`'s own `columns` renders no
+line — that finding **still stands**, unchanged.
+
+What **is** live-verified GO is a different shape entirely: a **separate,
+borderless `line-chart`** element stacked *below* the KPI inside the same
+`gradient_card` (or any card) container — not a field on the KPI element at all.
+`Styling.sparkline` builds exactly this:
+
+```yaml
+- id: k-rev-spark
+  kind: line-chart
+  source: { kind: table, elementId: src }
+  columns:
+    - id: k-rev-spark-period
+      formula: '[Src/Period]'
+      format: { kind: datetime, formatString: "%b %Y" }
+    - id: k-rev-spark-value
+      formula: Sum([Src/Revenue])
+  xAxis: { columnId: k-rev-spark-period, format: { marks: none, labels: hidden } }
+  yAxis:
+    columnIds: [k-rev-spark-value]
+    format: { labels: hidden, marks: none, scale: { type: linear, zero: false, hideZeroLine: true } }
+  name: { visibility: hidden }
+  legend: { visibility: hidden }
+  lineAreaStyle: { interpolation: monotone }
+  style: { backgroundColor: transparent, padding: none }
+```
+
+Both axes hide their labels/marks (no chart chrome competing with the KPI above
+it); `scale.zero: false` so a small real trend isn't flattened against a forced
+zero baseline; `name`/`legend` hidden (no title, no legend on a mini chart);
+`backgroundColor: transparent` so it blends into the card around it. Place it in
+the same container as a `gradient_card`-wrapped (or plain) KPI, sized as a thin
+strip beneath the value.
+
+**So:** "no sparkline field on the KPI element" is still true and always will be
+(it's UI-only there) — but "no sparkline in the card" is not. The composite
+pattern (KPI + a stacked borderless line-chart, same card) is the GO way to get
+one.
+
 ## Things that are NOT designable via spec (as of 2026-05-29)
 
 Don't waste a round-trip trying to set these — the spec API silently drops them.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
@@ -645,17 +645,35 @@ return contract as `header`, so it drops into the same composition call sites.
   above (graceful — never a broken shape); NO-GO on just `motif` (surface still GO)
   drops to a plain gradient with no decorative `<g>`.
 
-### `gradient_card(id:, kpi_element:, gradient:, page_cols: 24)` — gradient KPI card
+### `gradient_card(id:, kpi_element:, gradient: DEFAULT_THEME[:card_gradient], page_cols: 24)` — gradient KPI card
 
 Decorate-only, like `section_card`: wraps a **caller-built** `kpi-chart` element
-(e.g. from `KpiCard.build`) in a gradient `backgroundImage` container — same
-composed-SVG technique as `gradient_header`, always `motif: :none` (a card this
-small has no room for a decorative mark). It never mutates `kpi_element` or
-`kpi_card.rb` — it returns `{ element:, child_layout:, patch: }`: the container
-element to add, the inner `<LayoutElement>` fragment positioning the KPI inside it,
-and a `patch` Hash (`{ value: { color: "#FFFFFF" }, name: { color: "#FFFFFF" } }`)
-the caller merges onto their own copy of the KPI's `value`/`name` objects so the
-title and value read white against the gradient. NO-GO returns the empty
+(e.g. from `KpiCard.build`) in a gradient `backgroundImage` container. `gradient:`
+is **optional** — it defaults to `DEFAULT_THEME[:card_gradient]` (a dark slate
+pair, `['#1E293B', '#0F172A']`), so a caller with no brand gradient in mind still
+gets a legible dark card; pass a caller-specific 2–3 hex-stop array to override it.
+
+The composed background is **two layers**, not one — the caller's (or default)
+gradient rect, THEN a dark **scrim**: a vertical `linearGradient` from black at
+~0.55 opacity at the top (where the KPI name+value sit) fading to 0 opacity
+toward the bottom (where a `sparkline` sits). This is what makes a white KPI
+value legible on **any** gradient, bright or dark — not just a dark one — while
+the brand gradient still reads through in the lower half (never fully blacked
+out). It never mutates `kpi_element` or `kpi_card.rb` — it returns
+`{ element:, child_layout:, patch: }`: the container element to add, the inner
+`<LayoutElement>` fragment positioning the KPI inside it, and a `patch` Hash
+the caller merges onto their own copy of the KPI's `value`/`name`/`style` objects:
+
+```yaml
+value: { color: "#FFFFFF" }
+name:  { color: "#FFFFFF" }
+style: { backgroundColor: transparent, padding: none }
+```
+
+so the title and value read white against the gradient. **Merge all three keys
+— `value`, `name`, AND `style`** — not just `value`/`name`: the KPI element keeps
+its own opaque background otherwise, so a live render shows white-on-white even
+with the scrim in place. NO-GO returns the empty
 `{ element: [], child_layout: '', patch: {} }` marker — nothing half-decorated.
 
 ### `sparkline(id:, source_element_id:, period_ref:, value_formula:, period_format:)` — the composite in-card sparkline (refines the earlier NO-GO)

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/tables.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/tables.md
@@ -186,7 +186,7 @@ The `input-table` element is an editable table — users type values directly in
 `source` is one of:
 
 - `{ kind: empty, connectionId: <YOUR_CONNECTION_ID> }` — provisions a fresh, blank warehouse table.
-- `{ kind: linked, from: <elementId> }` — rows are linked to another element; the connection is inherited, and editable rows are matched to source rows by the `key` columns.
+- `{ kind: linked, from: <elementId> }` — rows are linked to another element, matched to source rows by the `key` columns. ⚠ A linked input table carries its **own** `connectionId` (the write target); it is NOT simply inherited from the parent and may differ from the parent's connection — cross-connection linking (write-conn child, read-conn parent) is supported. See `input-tables.md` → *Cross-connection linked tables*.
 
 `columns[]` items come in four shapes (each also accepts optional `name`, `description`, `hidden`, `format`):
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/actions.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/actions.md
@@ -1,0 +1,201 @@
+# Actions — buttons, effects, and write-back workflows
+
+Buttons wire a user click to one or more **effects** — insert rows into an
+input table, reset a control, set a control's value, or open/close a modal.
+They live in `elements[]` like any other element, not nested inside another
+element.
+
+## Button shape
+
+```yaml
+id: btn-log
+kind: button
+text: Log note
+appearance: filled        # filled | outline
+actions:
+  - id: a-log
+    trigger: on-click
+    effects:
+      - effect: insert-rows
+        table: annotations
+        values:
+          an-note: { type: control, control: NoteCtl }
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | Element id. |
+| `kind` | yes | Always `button`. |
+| `text` | yes | Button label. |
+| `appearance` | — | `filled` \| `outline`. |
+| `actions` | yes | Array; each entry is `{ id, trigger, effects: [...] }`. `trigger: on-click` is the verified case (the OpenAPI also lists `on-select`/`on-primary-cta-click`/`on-secondary-cta-click`/`on-close` for other element/modal contexts — not exercised here). |
+
+A button typically carries one `actions[]` entry with one or more `effects[]` —
+effects in the same action run together off the same click.
+
+## Verified effects
+
+These three round-tripped and rendered correctly on a live test-org build:
+
+### `insert-rows` — write a row into an input table
+
+```yaml
+effect: insert-rows
+table: annotations             # an input-table element's id
+values:
+  an-note: { type: control, control: NoteCtl }
+  an-tag:  { type: constant, value: { type: text, value: "manual" } }
+```
+
+`values` is a map of the input table's **own column ids** to a value descriptor:
+- `{ type: control, control: <controlId> }` — the current value of a control.
+- `{ type: constant, value: { type: text, value: <literal> } }` — a hard-coded
+  literal.
+
+**Never include a system column** (`ID`/`CREATED_AT`/`CREATED_BY`/`UPDATED_AT`/
+`UPDATED_BY`) in `values` — Sigma auto-fills those; see *the append-only-log
+pattern* below.
+
+### `clear-control` — reset a control (page scope only)
+
+```yaml
+effect: clear-control
+scope: { type: page, page: pg }
+usePublishedValue: true
+```
+
+The OpenAPI's `scope` discriminator actually has **three** shapes —
+`{ type: control, control: <controlId> }` (clear one control), `{ type:
+container, container: <containerElementId> }` (clear every control in a
+container), and `{ type: page, page: <pageId> }` (clear every control on a
+page). **Only `page` scope is live-verified here** — an element/container-scoped
+`clear-control` masked-failed the button in live testing (the button silently
+didn't work; no clear error pointed at the cause). Until `control`/`container`
+scope is independently re-verified, build resets around `page` scope only.
+
+### `set-control-value` — set a control programmatically
+
+```yaml
+effect: set-control-value
+control: RegionFilter
+value: { type: constant, value: { type: text, value: "West" } }
+```
+
+The only verified `value` shape is a constant text value (e.g. a "quick filter
+preset" button). Useful paired with a `list`/`segmented` control to give users a
+one-click shortcut into a known filter state.
+
+## Modals: `open-overlay` / `close-overlay`
+
+A workbook page can be marked `type: modal` — a page that renders as an overlay
+rather than a navigable tab. A button's effect opens/closes it:
+
+```yaml
+pages:
+  - id: pg
+    name: Main
+    elements: [ ... , btn-open ]
+  - id: modal-detail
+    type: modal
+    name: Detail
+    elements: [ ... ]
+```
+
+```yaml
+# on the trigger button (lives on the main page)
+effect: open-overlay
+overlayId: modal-detail    # the modal PAGE's `id`, not an element id
+
+# on a close button (typically inside the modal itself)
+effect: close-overlay
+```
+
+`open-overlay` requires `overlayId`; `close-overlay` takes no other fields (it
+closes whatever overlay is open). **These two shapes are documented in the
+compiled OpenAPI** (unlike `insert-rows`, which isn't inlined there as of this
+writing) but were **not** part of this round's live-render probe — confirm with
+a POST + PNG export before shipping a modal flow, same discipline as any other
+shape in this doc.
+
+## The append-only-log pattern
+
+The recurring write-back shape: an **empty input table** as a log, a **control**
+to capture what the user types, and a **button** that inserts a row.
+
+```yaml
+# 1. The entry control — see controls.md's "Entry (write) text controls" note:
+#    these four fields are mandatory or the control masked-fails.
+- id: note-ctl
+  kind: control
+  controlId: NoteCtl
+  name: Add a review note
+  controlType: text-area
+  mode: equals
+  case: insensitive
+  includeNulls: when-no-value-is-selected
+  showOperators: false
+
+# 2. The button — inserts one row per click, reading the control's live value.
+- id: btn-log
+  kind: button
+  text: Log note
+  appearance: filled
+  actions:
+    - id: a-log
+      trigger: on-click
+      effects:
+        - effect: insert-rows
+          table: annotations
+          values:
+            an-note: { type: control, control: NoteCtl }
+
+# 3. The log itself — an empty input table. System columns take NO `type` and
+#    are auto-filled by Sigma (CREATED_AT/CREATED_BY) — never pass them in
+#    insert-rows `values` above; doing so breaks the column.
+- id: annotations
+  kind: input-table
+  inputMode: edit
+  source: { kind: empty, connectionId: <WRITE_CONNECTION_ID> }
+  columns:
+    - id: an-note
+      type: text
+      name: Review note
+    - id: CREATED_AT
+    - id: CREATED_BY
+```
+
+Each click appends a new, timestamped, attributed row — nothing is ever
+overwritten. This is the shape to reach for "log an action," "flag this record,"
+or "leave a comment," anywhere a durable audit trail matters more than an
+editable cell.
+
+## Masked-error catalog
+
+Sigma's spec validator returns the same opaque, unhelpful message for several
+distinct root causes on these element kinds. If you hit one of these, check the
+listed cause **first** before assuming the element kind itself is unsupported.
+
+| Error | Real cause | Fix |
+|---|---|---|
+| `Invalid kind: "input-table"` | `inputMode` was omitted. | Always set `inputMode: edit` (or `explore`/`view` — see `input-tables.md`). It's technically documented as required in `tables.md`, but omitting it produces this generic message rather than a field-specific one. |
+| `Invalid kind: "control"` (on a `text`/`text-area` control used for **entry**, not filtering) | One or more of `mode`, `case`, `includeNulls`, `showOperators` was omitted. | Set all four — see `controls.md`'s "Entry (write) text controls" section. |
+| Button silently does nothing on click | An element/container-scoped `clear-control`. | Use `scope: { type: page, page: <id> }` only (see above). |
+
+## Cross-links
+
+- `shared/lib/actions.rb` / `actions.py` — `Actions.button(id:, text:, effects:,
+  appearance:)`, `Actions.input_table_empty(id:, connection_id:, columns:,
+  name:)`, `Actions.input_table_linked(id:, from:, connection_id:, columns:,
+  name:)`, and the three effect builders `Actions.insert_rows_effect(table:,
+  values:)` / `Actions.clear_control_effect(page:)` /
+  `Actions.set_control_value_effect(control:, text:)` build exactly the shapes
+  above (`inputMode: "edit"` always emitted; `clear_control_effect` only ever
+  emits page scope). Gated behind `Actions::SURFACES`; a NO-GO flip returns
+  `{opt_in: true, id:}` (element builders) or `{}` (effect builders) rather than
+  a faked shape.
+- `reference/specification/input-tables.md` — the write-connection requirement,
+  the publish-before-query gate, and the linked-table cross-connection pattern.
+- `reference/specification/controls.md` — full control-element field reference.
+- `reference/specification/agents.md` — a write/action agent's `tools[].steps[]`
+  reuses these same effect shapes, driven by agent input instead of a button
+  click.

--- a/shared/lib/actions.py
+++ b/shared/lib/actions.py
@@ -1,0 +1,198 @@
+"""actions.py — Python twin of shared/lib/actions.rb. Thin, spec-authorable
+builders for buttons, input tables (write-back), and the action effects that
+connect them -- the "Component C" piece of docs/superpowers/specs/
+2026-07-29-ws4-agent-gradient-actions-design.md. Byte-identical output
+(shared/lib/testdata/actions_golden.json).
+
+    import actions
+    btn = actions.button(id="btn-log", text="Log note",
+                          effects=[actions.insert_rows_effect(table="annotations", values={...})])
+    tbl = actions.input_table_empty(id="annotations", connection_id=WRITE, columns=[...])
+
+Live-verified shape facts (design doc "Live-verified shape facts"; reference
+build: /private/tmp/.../scratchpad/build-plugs-command-center.rb, symbols
+btn_reset/btn_preset/btn_log/targets/annotations), verified on a Plugs
+command-center workbook on a test org:
+  - `inputMode: "edit"` on an input-table element is MANDATORY. Omit it and
+    the POST masked-fails as `Invalid kind:"input-table"` -- a misleading
+    message; the real cause is the missing inputMode. Both input_table_*
+    builders below always emit it.
+  - Empty input table: source={kind:"empty",connectionId:<WRITE conn>}.
+    Linked input table: source={kind:"linked",from:<parent element id>,
+    connectionId:<WRITE conn>} -- the parent element (`from`) may live on a
+    DIFFERENT (read-only) connection than the write-back table itself
+    (verified: a Sample-DB pivot fed a write-conn linked table). System
+    columns (e.g. CREATED_AT/CREATED_BY) take no `type` and are auto-filled
+    by Sigma -- callers pass them as bare {"id": ...} column entries and
+    never include them in insert-rows `values`.
+  - Button: {id, kind:"button", text, appearance:"filled"|"outline",
+    actions:[{id, trigger:"on-click", effects:[...]}]}. `action_id` defaults
+    to "a-<id>" (deterministic -- no time/random) so callers don't have to
+    invent a second id for the single action most buttons carry; pass
+    action_id= explicitly for a different handle.
+  - Effects verified live: insert-rows (values is a pass-through dict of
+    colId -> {type:"control",control:} | {type:"constant",value:{type:"text",value:}}
+    entries -- this module does not reshape `values`, callers build it),
+    clear-control (an ELEMENT-scoped clear-control masked-failed the button
+    live -- only page scope is verified, so this builder only emits
+    scope={type:"page",page:}), set-control-value (constant text value).
+
+All builders are gated through SURFACES (same discipline as richness.py/
+styling.py): a NO-GO flip on `button`/`input_table_empty`/`input_table_linked`
+returns {"opt_in": True, "id": id} (never a faked element); a NO-GO flip on
+`effects` (the 3 effect builders share one gate -- they're trivial shape
+helpers, not independently-risky surfaces) returns {} (never a faked effect
+spliced into a caller's actions: array).
+"""
+
+SURFACES = {
+    "button": True,             # {kind:"button"} + actions:[{trigger,effects}] -- WS4 GO (Plugs command-center reference build)
+    "input_table_empty": True,  # input-table, source.kind:"empty" -- WS4 GO; inputMode:"edit" mandatory (masked-error fix)
+    "input_table_linked": True, # input-table, source.kind:"linked" (cross-connection from a read-only parent) -- WS4 GO
+    "effects": True,            # insert-rows / clear-control / set-control-value shape helpers -- WS4 GO, one gate for all 3
+}
+
+
+def button(id, text, effects, appearance="filled", trigger="on-click", action_id=None, surfaces=None):
+    """Returns a `button` element: {id, kind:"button", text, appearance,
+    actions:[{id, trigger, effects}]}. `effects` is a pass-through list --
+    build entries with insert_rows_effect/clear_control_effect/
+    set_control_value_effect (or already-shaped dicts) and pass them here
+    verbatim; this builder never reshapes them. `action_id` defaults to the
+    deterministic "a-<id>" when omitted (None) -- pass action_id="" or any
+    other string explicitly to use a different handle. NO-GO surface ->
+    {"opt_in": True, "id": id}.
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not id:
+        raise ValueError("id required")
+    if not text:
+        raise ValueError("text required")
+    if not s["button"]:
+        return {"opt_in": True, "id": id}
+    aid = "a-%s" % id if action_id is None else action_id
+    return {
+        "id": id,
+        "kind": "button",
+        "text": text,
+        "appearance": appearance,
+        "actions": [{"id": aid, "trigger": trigger, "effects": effects}],
+    }
+
+
+def input_table_empty(id, connection_id, columns, name=None, surfaces=None):
+    """Returns an `input-table` element sourced empty (a fresh write-back
+    table, e.g. an append-only log): {id, kind:"input-table",
+    inputMode:"edit", source:{kind:"empty",connectionId:}, columns:}.
+    `inputMode:"edit"` is ALWAYS emitted -- it is mandatory (see module
+    docstring's masked-error note). `columns` is passed through verbatim
+    (already-shaped column entries, including bare {"id":"CREATED_AT"}
+    system-column entries with no `type`). `name` (optional; a text-style
+    dict or plain string, caller's choice -- passed through verbatim) is
+    OMITTED entirely when not given, not emitted as None. NO-GO surface ->
+    {"opt_in": True, "id": id}.
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not id:
+        raise ValueError("id required")
+    if not connection_id:
+        raise ValueError("connection_id required")
+    if not columns:
+        raise ValueError("columns required")
+    if not s["input_table_empty"]:
+        return {"opt_in": True, "id": id}
+    out = {
+        "id": id,
+        "kind": "input-table",
+        "inputMode": "edit",
+        "source": {"kind": "empty", "connectionId": connection_id},
+        "columns": columns,
+    }
+    if name is not None:
+        out["name"] = name
+    return out
+
+
+def input_table_linked(id, from_, connection_id, columns, name=None, surfaces=None):
+    """Returns an `input-table` element sourced linked from a parent element
+    (e.g. a write-back "targets" table keyed off a read-only pivot):
+    {id, kind:"input-table", inputMode:"edit", source:{kind:"linked",from:,
+    connectionId:}, columns:}. `from_` is the PARENT element's id --
+    verified live to work even when the parent sits on a different
+    (read-only) connection than `connection_id` (the write connection this
+    table itself lives on). Same `columns`/`name` pass-through contract as
+    input_table_empty. NO-GO surface -> {"opt_in": True, "id": id}.
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not id:
+        raise ValueError("id required")
+    if not from_:
+        raise ValueError("from required")
+    if not connection_id:
+        raise ValueError("connection_id required")
+    if not columns:
+        raise ValueError("columns required")
+    if not s["input_table_linked"]:
+        return {"opt_in": True, "id": id}
+    out = {
+        "id": id,
+        "kind": "input-table",
+        "inputMode": "edit",
+        "source": {"kind": "linked", "from": from_, "connectionId": connection_id},
+        "columns": columns,
+    }
+    if name is not None:
+        out["name"] = name
+    return out
+
+
+def insert_rows_effect(table, values, surfaces=None):
+    """Returns an `insert-rows` effect dict: {effect, table, values}.
+    `values` is a pass-through dict of colId -> {type:"control",control:} |
+    {type:"constant",value:{type:"text",value:}} entries (or any other
+    already-shaped value descriptor) -- never reshaped here; system columns
+    (CREATED_AT/CREATED_BY) are never included, Sigma auto-fills them.
+    NO-GO surface -> {} (never a faked effect spliced into a caller's
+    actions: array).
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not table:
+        raise ValueError("table required")
+    if not s["effects"]:
+        return {}
+    return {"effect": "insert-rows", "table": table, "values": values}
+
+
+def clear_control_effect(page, surfaces=None):
+    """Returns a `clear-control` effect dict: {effect,
+    scope:{type:"page",page:}, usePublishedValue:True}. Page scope ONLY --
+    an element-scoped clear-control masked-failed the button live (design
+    doc), so this builder never emits any other scope shape. NO-GO
+    surface -> {}.
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not page:
+        raise ValueError("page required")
+    if not s["effects"]:
+        return {}
+    return {"effect": "clear-control", "scope": {"type": "page", "page": page}, "usePublishedValue": True}
+
+
+def set_control_value_effect(control, text, surfaces=None):
+    """Returns a `set-control-value` effect dict: {effect, control,
+    value:{type:"constant",value:{type:"text",value:text}}}. `text` is
+    always wrapped as a constant text value (the only shape verified live --
+    see design doc's btn_preset example). NO-GO surface -> {}.
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not control:
+        raise ValueError("control required")
+    if not text:
+        raise ValueError("text required")
+    if not s["effects"]:
+        return {}
+    return {
+        "effect": "set-control-value",
+        "control": control,
+        "value": {"type": "constant", "value": {"type": "text", "value": text}},
+    }

--- a/shared/lib/actions.rb
+++ b/shared/lib/actions.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+#
+# actions.rb — Ruby twin of shared/lib/actions.py. Thin, spec-authorable
+# builders for buttons, input tables (write-back), and the action effects
+# that connect them — the "Component C" piece of docs/superpowers/specs/
+# 2026-07-29-ws4-agent-gradient-actions-design.md. Ruby 2.6, stdlib only.
+# Twins emit byte-identical output (shared/lib/testdata/actions_golden.json).
+#
+#   require_relative 'lib/actions'
+#   btn = Actions.button(id: 'btn-log', text: 'Log note',
+#                         effects: [Actions.insert_rows_effect(table: 'annotations', values: {...})])
+#   tbl = Actions.input_table_empty(id: 'annotations', connection_id: WRITE, columns: [...])
+#
+# Live-verified shape facts (design doc "Live-verified shape facts"; reference
+# build: /private/tmp/.../scratchpad/build-plugs-command-center.rb, symbols
+# btn_reset/btn_preset/btn_log/targets/annotations), verified on a Plugs
+# command-center workbook on a test org:
+#   - `inputMode:"edit"` on an input-table element is MANDATORY. Omit it and
+#     the POST masked-fails as `Invalid kind:"input-table"` — a misleading
+#     message; the real cause is the missing inputMode. Both input_table_*
+#     builders below always emit it.
+#   - Empty input table: source:{kind:"empty",connectionId:<WRITE conn>}.
+#     Linked input table: source:{kind:"linked",from:<parent element id>,
+#     connectionId:<WRITE conn>} — the parent element (`from`) may live on a
+#     DIFFERENT (read-only) connection than the write-back table itself
+#     (verified: a Sample-DB pivot fed a write-conn linked table). System
+#     columns (e.g. CREATED_AT/CREATED_BY) take no `type` and are auto-filled
+#     by Sigma — callers pass them as bare {'id'=>...} column entries and
+#     never include them in insert-rows `values`.
+#   - Button: {id, kind:"button", text, appearance:"filled"|"outline",
+#     actions:[{id, trigger:"on-click", effects:[...]}]}. `action_id:`
+#     defaults to "a-<id>" (deterministic — no time/random) so callers don't
+#     have to invent a second id for the single action most buttons carry;
+#     pass action_id: explicitly for a different handle.
+#   - Effects verified live: insert-rows (values is a pass-through Hash of
+#     colId => {type:"control",control:} | {type:"constant",value:{type:"text",value:}}
+#     entries — this module does not reshape `values`, callers build it),
+#     clear-control (an ELEMENT-scoped clear-control masked-failed the button
+#     live — only page scope is verified, so this builder only emits
+#     scope:{type:"page",page:}), set-control-value (constant text value).
+#
+# All builders are gated through Actions::SURFACES (same discipline as
+# richness.rb/styling.rb): a NO-GO flip on `button`/`input_table_empty`/
+# `input_table_linked` returns {'opt_in'=>true,'id'=>id} (never a faked
+# element); a NO-GO flip on `effects` (the 3 effect builders share one gate —
+# they're trivial shape helpers, not independently-risky surfaces) returns
+# {} (never a faked effect spliced into a caller's actions: array).
+
+require 'json'
+
+module Actions
+  SURFACES = {
+    button: true,             # {kind:"button"} + actions:[{trigger,effects}] — WS4 GO (Plugs command-center reference build)
+    input_table_empty: true,  # input-table, source.kind:"empty" — WS4 GO; inputMode:"edit" mandatory (masked-error fix)
+    input_table_linked: true, # input-table, source.kind:"linked" (cross-connection from a read-only parent) — WS4 GO
+    effects: true             # insert-rows / clear-control / set-control-value shape helpers — WS4 GO, one gate for all 3
+  }.freeze
+
+  # Returns a `button` element: {id, kind:"button", text, appearance,
+  # actions:[{id, trigger, effects}]}. `effects` is a pass-through array —
+  # build entries with insert_rows_effect/clear_control_effect/
+  # set_control_value_effect (or already-shaped Hashes) and pass them here
+  # verbatim; this builder never reshapes them. `action_id:` defaults to
+  # the deterministic "a-<id>" when omitted (nil) — pass action_id: '' or
+  # any other string explicitly to use a different handle. NO-GO surface ->
+  # {'opt_in'=>true,'id'=>id}.
+  def self.button(id:, text:, effects:, appearance: 'filled', trigger: 'on-click', action_id: nil, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'text required' if text.to_s.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:button]
+
+    aid = action_id.nil? ? "a-#{id}" : action_id
+    {
+      'id' => id,
+      'kind' => 'button',
+      'text' => text,
+      'appearance' => appearance,
+      'actions' => [{ 'id' => aid, 'trigger' => trigger, 'effects' => effects }]
+    }
+  end
+
+  # Returns an `input-table` element sourced empty (a fresh write-back table,
+  # e.g. an append-only log): {id, kind:"input-table", inputMode:"edit",
+  # source:{kind:"empty",connectionId:}, columns:}. `inputMode:"edit"` is
+  # ALWAYS emitted — it is mandatory (see module docstring's masked-error
+  # note). `columns` is passed through verbatim (already-shaped column
+  # entries, including bare {'id'=>'CREATED_AT'} system-column entries with
+  # no `type`). `name:` (optional; a text-style Hash or plain string, caller's
+  # choice — passed through verbatim) is OMITTED entirely when not given, not
+  # emitted as nil. NO-GO surface -> {'opt_in'=>true,'id'=>id}.
+  def self.input_table_empty(id:, connection_id:, columns:, name: nil, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'connection_id required' if connection_id.to_s.empty?
+    raise ArgumentError, 'columns required' if columns.nil? || columns.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:input_table_empty]
+
+    out = {
+      'id' => id,
+      'kind' => 'input-table',
+      'inputMode' => 'edit',
+      'source' => { 'kind' => 'empty', 'connectionId' => connection_id },
+      'columns' => columns
+    }
+    out['name'] = name unless name.nil?
+    out
+  end
+
+  # Returns an `input-table` element sourced linked from a parent element
+  # (e.g. a write-back "targets" table keyed off a read-only pivot):
+  # {id, kind:"input-table", inputMode:"edit", source:{kind:"linked",from:,
+  # connectionId:}, columns:}. `from` is the PARENT element's id — verified
+  # live to work even when the parent sits on a different (read-only)
+  # connection than `connection_id` (the write connection this table itself
+  # lives on). Same `columns`/`name:` pass-through contract as
+  # input_table_empty. NO-GO surface -> {'opt_in'=>true,'id'=>id}.
+  def self.input_table_linked(id:, from:, connection_id:, columns:, name: nil, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'from required' if from.to_s.empty?
+    raise ArgumentError, 'connection_id required' if connection_id.to_s.empty?
+    raise ArgumentError, 'columns required' if columns.nil? || columns.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:input_table_linked]
+
+    out = {
+      'id' => id,
+      'kind' => 'input-table',
+      'inputMode' => 'edit',
+      'source' => { 'kind' => 'linked', 'from' => from, 'connectionId' => connection_id },
+      'columns' => columns
+    }
+    out['name'] = name unless name.nil?
+    out
+  end
+
+  # Returns an `insert-rows` effect Hash: {effect, table, values}. `values`
+  # is a pass-through Hash of colId => {type:"control",control:} |
+  # {type:"constant",value:{type:"text",value:}} entries (or any other
+  # already-shaped value descriptor) — never reshaped here; system columns
+  # (CREATED_AT/CREATED_BY) are never included, Sigma auto-fills them.
+  # NO-GO surface -> {} (never a faked effect spliced into a caller's
+  # actions: array).
+  def self.insert_rows_effect(table:, values:, surfaces: SURFACES)
+    raise ArgumentError, 'table required' if table.to_s.empty?
+    return {} unless surfaces[:effects]
+
+    { 'effect' => 'insert-rows', 'table' => table, 'values' => values }
+  end
+
+  # Returns a `clear-control` effect Hash: {effect, scope:{type:"page",page:},
+  # usePublishedValue:true}. Page scope ONLY — an element-scoped
+  # clear-control masked-failed the button live (design doc), so this
+  # builder never emits any other scope shape. NO-GO surface -> {}.
+  def self.clear_control_effect(page:, surfaces: SURFACES)
+    raise ArgumentError, 'page required' if page.to_s.empty?
+    return {} unless surfaces[:effects]
+
+    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => page }, 'usePublishedValue' => true }
+  end
+
+  # Returns a `set-control-value` effect Hash: {effect, control,
+  # value:{type:"constant",value:{type:"text",value:text}}}. `text` is
+  # always wrapped as a constant text value (the only shape verified live —
+  # see design doc's btn_preset example). NO-GO surface -> {}.
+  def self.set_control_value_effect(control:, text:, surfaces: SURFACES)
+    raise ArgumentError, 'control required' if control.to_s.empty?
+    raise ArgumentError, 'text required' if text.to_s.empty?
+    return {} unless surfaces[:effects]
+
+    {
+      'effect' => 'set-control-value',
+      'control' => control,
+      'value' => { 'type' => 'constant', 'value' => { 'type' => 'text', 'value' => text } }
+    }
+  end
+end

--- a/shared/lib/richness.py
+++ b/shared/lib/richness.py
@@ -1,4 +1,4 @@
-"""richness.py — Python twin of shared/lib/richness.rb. Four independent,
+"""richness.py — Python twin of shared/lib/richness.rb. Independent,
 optional "richness" pieces for a dashboard page -- each helper emits ONE
 spec-authorable fragment, never a whole workbook/page. Byte-identical output
 (shared/lib/testdata/richness_golden.json).
@@ -7,6 +7,8 @@ spec-authorable fragment, never a whole workbook/page. Byte-identical output
     richness.ai_insight(id="ai-1", prompt="Say hello.")
     ctl = richness.grain_control(id="GrainCtl")
     dim = richness.trend_dimension(grain_control_id="GrainCtl", date_ref="[Src/Date]")
+    ag = richness.agent(id="ag-1", name="Analyst", instructions="Be helpful.", data_source_ids=["src"])
+    chat = richness.chat(id="chat-1", agent_id="ag-1")
 
 GO/NO-GO provenance (.superpowers/sdd/richness-task-1-report.md, workbook
 05cd3ac1-c8cc-4252-bad6-38b33d87bf45):
@@ -52,9 +54,21 @@ the shared module:
     so the two always differ; trend_dimension's `grain_control_id` must be
     given that `controlId` (not the element `id`) -- see its docstring
     below.
+
+WS4 Task-1 addition -- agent + chat (docs/superpowers/specs/
+2026-07-29-ws4-agent-gradient-actions-design.md, "Live-verified shape
+facts"): the Sigma workbook AI agent is a workbook-TOP-LEVEL `agents:[]`
+array entry (not a page element), verified live building a Plugs
+command-center workbook (reference build: build-plugs-command-center.rb).
+Read-only analyst = the entry OMITS `tools` entirely. The page-level `chat`
+element just references the agent's id. Sigma's AI-agent feature is an
+org-level toggle -- when it's off for a target org, callers should degrade
+to a static text element with sample prompts rather than POST a chat
+element that will masked-fail; that fallback pattern is documented in the
+actions/agent workflow doc, not re-derived here.
 """
 
-# GO/NO-GO map. All 4 are GO today; a NO-GO flip makes the gated helper
+# GO/NO-GO map. All 5 are GO today; a NO-GO flip makes the gated helper
 # return an empty/opt-in marker instead of emitting an unverified (or
 # 400-rejected) shape -- never a silently-wrong fallback.
 SURFACES = {
@@ -62,6 +76,7 @@ SURFACES = {
     "dynamic_grain": True,  # grain_control (segmented control) + trend_dimension (Switch+DateTrunc dimension formula) -- richness Task-1 GO
     "filter_row": True,     # list control(s) -> element filter, reusing the already-GO master-detail control/filter shape
     "wide_pivot": True,     # pivot-table rowsBy + columnsBy:[] + values, reusing the already-GO general Sigma pivot shape
+    "agent": True,          # workbook-level agents[] entry + page-level {kind:"chat"} element -- WS4 Task-1 GO; org-feature-gated on the Sigma side (see agent/chat docstrings for the graceful-degrade contract)
 }
 
 DEFAULT_MODEL = "llama3.1-8b"
@@ -213,3 +228,59 @@ def wide_pivot(id, source_element_id, rows_by, values, columns, surfaces=None):
         "columnsBy": [],
         "values": values,
     }
+
+
+def agent(id, name, instructions, data_source_ids, tools=None, surfaces=None):
+    """Returns a workbook-level `agents[]` entry (NOT a page element -- the
+    workbook spec's top-level `agents:` array; pair with `chat` below for
+    the page-level element that surfaces it). `data_source_ids` map 1:1, in
+    order, to `dataSources:[{"kind":"table","elementId":}, ...]`. `tools`
+    empty/None (the default) means a READ-ONLY analyst -- the returned dict
+    OMITS the `tools` key entirely (not `tools=[]`); this exact omission is
+    the live-verified read-only shape (WS4 design doc). Pass a non-empty
+    `tools` list (already-shaped {"toolId","kind":"action","name",
+    "description","steps":[...]} entries) for a write/action agent -- added
+    verbatim, never reshaped here. Sigma's AI-agent feature is an org-level
+    gate: when it's off for the target org, the agent/chat surface degrades
+    to a static element rather than a 400 (see `chat`'s docstring and the
+    actions/agent workflow doc for the caller-side fallback pattern).
+    NO-GO surface -> {"opt_in": True, "id": id}: never emit a faked agent.
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not id:
+        raise ValueError("id required")
+    if not name:
+        raise ValueError("name required")
+    if not instructions:
+        raise ValueError("instructions required")
+    if not s["agent"]:
+        return {"opt_in": True, "id": id}
+    out = {
+        "id": id,
+        "name": name,
+        "instructions": instructions,
+        "dataSources": [{"kind": "table", "elementId": eid} for eid in (data_source_ids or [])],
+    }
+    if tools:
+        out["tools"] = tools
+    return out
+
+
+def chat(id, agent_id, surfaces=None):
+    """Returns the page-level `chat` element that surfaces an `agent`
+    entry: {id, kind: "chat", agentId}. `agent_id` is the AGENT's `id` (the
+    same string used in the `agents[]` entry `agent` built above), not an
+    element id. Same org-feature gate as `agent` -- when Sigma AI agents are
+    off for the target org, callers should degrade to a static text element
+    with sample prompts instead (Connor's fallback; documented in the
+    actions/agent workflow doc, not re-derived here). NO-GO surface ->
+    {"opt_in": True, "id": id}: never emit a faked chat element.
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not id:
+        raise ValueError("id required")
+    if not agent_id:
+        raise ValueError("agent_id required")
+    if not s["agent"]:
+        return {"opt_in": True, "id": id}
+    return {"id": id, "kind": "chat", "agentId": agent_id}

--- a/shared/lib/richness.rb
+++ b/shared/lib/richness.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 #
-# richness.rb — Ruby twin of shared/lib/richness.py. Four independent,
-# optional "richness" pieces for a dashboard page — each helper emits ONE
+# richness.rb — Ruby twin of shared/lib/richness.py. Independent, optional
+# "richness" pieces for a dashboard page — each helper emits ONE
 # spec-authorable fragment, never a whole workbook/page. Consumed by callers
 # that already have Composition/Styling output and want to layer in an
 # AI-generated insight, a dynamic date-grain control+dimension, a filter row,
-# or a wide (non-crosstab) pivot table. Ruby 2.6, stdlib only. Twins emit
-# byte-identical output (shared/lib/testdata/richness_golden.json).
+# a wide (non-crosstab) pivot table, or a workbook AI agent + chat element.
+# Ruby 2.6, stdlib only. Twins emit byte-identical output
+# (shared/lib/testdata/richness_golden.json).
 #
 #   require_relative 'lib/richness'
 #   Richness.ai_insight(id: 'ai-1', prompt: 'Say hello.')
 #   ctl = Richness.grain_control(id: 'GrainCtl')
 #   dim = Richness.trend_dimension(grain_control_id: 'GrainCtl', date_ref: '[Src/Date]')
+#   ag = Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'Be helpful.', data_source_ids: ['src'])
+#   chat = Richness.chat(id: 'chat-1', agent_id: 'ag-1')
 #
 # GO/NO-GO provenance (.superpowers/sdd/richness-task-1-report.md, workbook
 # 05cd3ac1-c8cc-4252-bad6-38b33d87bf45):
@@ -57,18 +60,31 @@
 #     "<id>-ctl") so the two always differ; trend_dimension's
 #     `grain_control_id:` must be given that `controlId` (not the element
 #     `id`) — see its docstring below.
+#
+# WS4 Task-1 addition — agent + chat (docs/superpowers/specs/
+# 2026-07-29-ws4-agent-gradient-actions-design.md, "Live-verified shape
+# facts"): the Sigma workbook AI agent is a workbook-TOP-LEVEL `agents:[]`
+# array entry (not a page element), verified live building a Plugs
+# command-center workbook (reference build: build-plugs-command-center.rb).
+# Read-only analyst = the entry OMITS `tools` entirely. The page-level
+# `chat` element just references the agent's id. Sigma's AI-agent feature is
+# an org-level toggle — when it's off for a target org, callers should
+# degrade to a static text element with sample prompts rather than POST a
+# chat element that will masked-fail; that fallback pattern is documented in
+# the actions/agent workflow doc, not re-derived here.
 
 require 'json'
 
 module Richness
-  # GO/NO-GO map. All 4 are GO today; a NO-GO flip makes the gated helper
+  # GO/NO-GO map. All 5 are GO today; a NO-GO flip makes the gated helper
   # return an empty/opt-in marker instead of emitting an unverified (or
   # 400-rejected) shape — never a silently-wrong fallback.
   SURFACES = {
     ai_insight: true,     # CallText/AI-insight text element (richness Task-1 GO; renders real text only where the target org's connection has Cortex configured — NEVER a fabricated summary)
     dynamic_grain: true,  # grain_control (segmented control) + trend_dimension (Switch+DateTrunc dimension formula) — richness Task-1 GO
     filter_row: true,     # list control(s) -> element filter, reusing the already-GO master-detail control/filter shape
-    wide_pivot: true      # pivot-table rowsBy + columnsBy:[] + values, reusing the already-GO general Sigma pivot shape
+    wide_pivot: true,     # pivot-table rowsBy + columnsBy:[] + values, reusing the already-GO general Sigma pivot shape
+    agent: true           # workbook-level agents[] entry + page-level {kind:"chat"} element — WS4 Task-1 GO; org-feature-gated on the Sigma side (see agent/chat docstrings for the graceful-degrade contract)
   }.freeze
 
   DEFAULT_MODEL = 'llama3.1-8b'
@@ -197,5 +213,51 @@ module Richness
       'columnsBy' => [],
       'values' => values
     }
+  end
+
+  # Returns a workbook-level `agents[]` entry (NOT a page element — the
+  # workbook spec's top-level `agents:` array; pair with `chat` below for the
+  # page-level element that surfaces it). `data_source_ids` map 1:1, in
+  # order, to `dataSources:[{kind:"table",elementId:}, ...]`. `tools:` empty
+  # (the default) means a READ-ONLY analyst — the returned Hash OMITS the
+  # `tools` key entirely (not `tools:[]`); this exact omission is the
+  # live-verified read-only shape (WS4 design doc). Pass a non-empty
+  # `tools:` array (already-shaped `{toolId,kind:"action",name,description,
+  # steps:[...]}` entries) for a write/action agent — added verbatim, never
+  # reshaped here. Sigma's AI-agent feature is an org-level gate: when it's
+  # off for the target org, the agent/chat surface degrades to a static
+  # element rather than a 400 (see `chat`'s docstring and the actions/agent
+  # workflow doc for the caller-side fallback pattern). NO-GO surface ->
+  # {'opt_in'=>true,'id'=>id}: never emit a faked agent.
+  def self.agent(id:, name:, instructions:, data_source_ids:, tools: [], surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'name required' if name.to_s.empty?
+    raise ArgumentError, 'instructions required' if instructions.to_s.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:agent]
+
+    out = {
+      'id' => id,
+      'name' => name,
+      'instructions' => instructions,
+      'dataSources' => (data_source_ids || []).map { |eid| { 'kind' => 'table', 'elementId' => eid } }
+    }
+    out['tools'] = tools unless tools.nil? || tools.empty?
+    out
+  end
+
+  # Returns the page-level `chat` element that surfaces an `agent` entry:
+  # {id, kind:"chat", agentId}. `agent_id` is the AGENT's `id` (the same
+  # string used in the `agents[]` entry `agent` built above), not an
+  # element id. Same org-feature gate as `agent` — when Sigma AI agents are
+  # off for the target org, callers should degrade to a static text element
+  # with sample prompts instead (Connor's fallback; documented in the
+  # actions/agent workflow doc, not re-derived here). NO-GO surface ->
+  # {'opt_in'=>true,'id'=>id}: never emit a faked chat element.
+  def self.chat(id:, agent_id:, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'agent_id required' if agent_id.to_s.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:agent]
+
+    { 'id' => id, 'kind' => 'chat', 'agentId' => agent_id }
   end
 end

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -389,5 +389,5 @@ def sparkline(id, source_element_id, period_ref, value_formula, period_format="%
         "name": {"visibility": "hidden"},
         "legend": {"visibility": "hidden"},
         "lineAreaStyle": {"interpolation": "monotone"},
-        "style": {"backgroundColor": "transparent"},
+        "style": {"backgroundColor": "transparent", "padding": "none"},
     }

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -318,21 +318,36 @@ def gradient_card(id, kpi_element, gradient, page_cols=24, surfaces=None):
     build-plugs-command-center.rb). Decorate-only, like section_card():
     kpi_element is READ ONLY here (its "id" is read to build child_layout) --
     it is never mutated, and kpi_card.py (WS1, fanned to converters) is never
-    touched. Instead this returns a patch dict the caller merges onto their
-    own copy of the kpi element's value/name objects to turn the value +
-    title white (e.g. kpi_element["value"].update(patch["value"])) so they
-    read against the gradient, matching card(...)'s native-white KPI text.
-    gradient is required (one gradient per card -- distinct KPI cards
-    typically carry distinct gradients, matching the reference build's
-    per-KPI KG[i] array) and reuses compose_gradient_svg()/svg_data_uri()
-    from Task 2 with motif="none" (a plain gradient, no decorative motif --
-    a card this small has no room for one; motif_side is irrelevant when the
-    motif is "none" so "right" is passed as an inert default). child_layout
-    is only the inner <LayoutElement> fragment positioning kpi_element's id
-    inside the container at the composition kpi-band height (rows 1..7,
-    matching composition.bands()'s own "kpi" role height) -- placing the
-    container itself on the page is the caller's job (same "decorate, don't
-    own layout" contract as section_card()), so no outer <GridContainer> is
+    touched. Instead this returns a patch dict the caller MERGES (never
+    replaces) onto their own copy of three top-level keys on the kpi
+    element:
+        kpi_element["value"] = dict(kpi_element["value"], **patch["value"])
+        kpi_element["name"]  = dict(kpi_element["name"], **patch["name"])
+        kpi_element["style"] = dict(kpi_element.get("style", {}), **patch["style"])
+    A shallow merge is REQUIRED, not a wholesale replace of the value/name
+    dicts -- kpi_element["value"] carries columnId (and optionally
+    fontSize) that this patch must not clobber; merge overlays only the
+    color key. patch["style"] is new here (Task 6 live-render fix): the WS1
+    kpi_card.py shape never sets a style key of its own, so this is
+    additive, but callers should still merge rather than assign in case a
+    future kpi_element does carry one. Turning the value + title white is
+    not enough by itself -- the KPI element still keeps its own opaque
+    background, so a live render shows white-on-white; patch["style"] sets
+    backgroundColor:"transparent" (letting the gradient card behind show
+    through) and padding:"none" (edge-to-edge, matching card(...)'s native
+    shape in build-plugs-command-center.rb) so the white value/title are
+    actually legible against the gradient. gradient is required (one
+    gradient per card -- distinct KPI cards typically carry distinct
+    gradients, matching the reference build's per-KPI KG[i] array) and
+    reuses compose_gradient_svg()/svg_data_uri() from Task 2 with
+    motif="none" (a plain gradient, no decorative motif -- a card this small
+    has no room for one; motif_side is irrelevant when the motif is "none"
+    so "right" is passed as an inert default). child_layout is only the
+    inner <LayoutElement> fragment positioning kpi_element's id inside the
+    container at the composition kpi-band height (rows 1..7, matching
+    composition.bands()'s own "kpi" role height) -- placing the container
+    itself on the page is the caller's job (same "decorate, don't own
+    layout" contract as section_card()), so no outer <GridContainer> is
     returned here. NO-GO -> {"element":[],"child_layout":"","patch":{}}
     (graceful: nothing to merge, nothing to lay out, never a broken/
     half-decorated card).
@@ -346,7 +361,8 @@ def gradient_card(id, kpi_element, gradient, page_cols=24, surfaces=None):
                      "backgroundImage": {"url": bg_url, "style": {"fit": "cover"}}}
     child_layout = '<LayoutElement elementId="%s" gridColumn="1 / %d" gridRow="1 / 7"/>' % (
         kpi_element["id"], page_cols + 1)
-    patch = {"value": {"color": "#FFFFFF"}, "name": {"color": "#FFFFFF"}}
+    patch = {"value": {"color": "#FFFFFF"}, "name": {"color": "#FFFFFF"},
+             "style": {"backgroundColor": "transparent", "padding": "none"}}
     return {"element": [container_el], "child_layout": child_layout, "patch": patch}
 
 

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -20,6 +20,11 @@ DEFAULT_THEME = {
     # for gradient_header(). NOT red -- red is a caller override, same
     # discipline as theme(accent=) tinting the flat palette above.
     "header_gradient": ["#0F172A", "#1E3A8A", "#2563EB"],
+    # WS4 Task 6 (live-render fix): dark default so gradient_card()'s
+    # gradient can be omitted -- a caller with no brand gradient in mind
+    # still gets a legible dark card (paired with the scrim in
+    # compose_card_svg() below, white KPI text stays legible either way).
+    "card_gradient": ["#1E293B", "#0F172A"],
 }
 
 def theme(accent=None):
@@ -66,7 +71,11 @@ SURFACES = {
     # readback + a real render. NO-GO gradient_card -> the empty
     # {"element":[],"child_layout":"","patch":{}} marker (graceful -- never
     # mutates or half-decorates the caller's kpi_element). NO-GO sparkline ->
-    # {"opt_in":True,"id":} (never a faked chart shape).
+    # {"opt_in":True,"id":} (never a faked chart shape). WS4 Task 6
+    # (live-render fix, user-reported "can't see the numbers"):
+    # gradient_card()'s composed background now also carries a dark scrim
+    # (see compose_card_svg()/CARD_SCRIM_TOP_OPACITY) so white KPI text
+    # stays legible on ANY caller gradient, not just dark ones.
     "gradient_card": True,
     "sparkline": True,
 }
@@ -78,6 +87,13 @@ D3_FORMATS = {
     "percent": ".1%",
     "decimal": ",.2f",
 }
+
+# WS4 Task 6 (live-render fix, user-reported): opacity of the dark scrim
+# composed behind a gradient_card()'s top band (where the KPI name+value
+# sit), fading to 0 by the bottom (where a sparkline() sits) -- see
+# compose_card_svg(). A single named constant so a future legibility
+# regression is a one-line tune, not a hunt through the SVG string.
+CARD_SCRIM_TOP_OPACITY = 0.55
 
 # Motif menu for gradient_header() (WS4 Task 2, design doc "Component B" +
 # the live-verified HDRBG concentric-ring <g> in
@@ -311,7 +327,34 @@ def gradient_header(id, title, subtitle=None, gradient=None, motif="glow", motif
     return {"element": elements, "layout": "\n".join(lines)}
 
 
-def gradient_card(id, kpi_element, gradient, page_cols=24, surfaces=None):
+def compose_card_svg(gradient):
+    """Composes the gradient_card() background SVG (WS4 Task 6, live-render
+    fix, user-reported "can't see the numbers"): same viewBox + gradient-rect
+    technique as compose_gradient_svg() (always motif "none" -- a card this
+    small has no room for a decorative mark), PLUS a second rect layered on
+    top filled with a vertical black scrim linearGradient --
+    CARD_SCRIM_TOP_OPACITY opacity at the top (y=0, where the KPI name+value
+    sit) fading to 0 opacity by the bottom (y=210, where a sparkline() sits)
+    -- so a white KPI value stays legible on ANY caller gradient, bright or
+    dark, while the brand gradient still reads through in the lower half
+    (never fully blacked out). Kept as its own composer (not a
+    compose_gradient_svg() option) so gradient_header()'s output -- already
+    live-verified without a scrim -- is untouched.
+    """
+    if not isinstance(gradient, list) or len(gradient) not in (2, 3):
+        raise ValueError("compose_card_svg: gradient must be a list of 2-3 hex stops (got %r)" % (gradient,))
+    offsets = ["0", "1"] if len(gradient) == 2 else ["0", "0.5", "1"]
+    stops = "".join('<stop offset="%s" stop-color="%s"/>' % (offsets[i], hex_) for i, hex_ in enumerate(gradient))
+    return ('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 210" preserveAspectRatio="xMidYMid slice">'
+            '<defs><linearGradient id="cg" x1="0" y1="0" x2="1" y2="0.45">%s</linearGradient>'
+            '<linearGradient id="card-scrim" x1="0" y1="0" x2="0" y2="1">'
+            '<stop offset="0" stop-color="#000000" stop-opacity="%s"/>'
+            '<stop offset="1" stop-color="#000000" stop-opacity="0"/></linearGradient></defs>'
+            '<rect width="1600" height="210" fill="url(#cg)"/><rect width="1600" height="210" fill="url(#card-scrim)"/></svg>') % (
+        stops, CARD_SCRIM_TOP_OPACITY)
+
+
+def gradient_card(id, kpi_element, gradient=None, page_cols=24, surfaces=None):
     """Wraps a caller-built kpi-chart element (a dict, e.g. from kpi_card.build)
     in a gradient backgroundImage CARD container (WS4 Task 3, design doc
     "Component B" + the live-verified card(...) shape in
@@ -327,7 +370,7 @@ def gradient_card(id, kpi_element, gradient, page_cols=24, surfaces=None):
     A shallow merge is REQUIRED, not a wholesale replace of the value/name
     dicts -- kpi_element["value"] carries columnId (and optionally
     fontSize) that this patch must not clobber; merge overlays only the
-    color key. patch["style"] is new here (Task 6 live-render fix): the WS1
+    color key. patch["style"] (Task 6 live-render fix): the WS1
     kpi_card.py shape never sets a style key of its own, so this is
     additive, but callers should still merge rather than assign in case a
     future kpi_element does carry one. Turning the value + title white is
@@ -336,27 +379,30 @@ def gradient_card(id, kpi_element, gradient, page_cols=24, surfaces=None):
     backgroundColor:"transparent" (letting the gradient card behind show
     through) and padding:"none" (edge-to-edge, matching card(...)'s native
     shape in build-plugs-command-center.rb) so the white value/title are
-    actually legible against the gradient. gradient is required (one
-    gradient per card -- distinct KPI cards typically carry distinct
-    gradients, matching the reference build's per-KPI KG[i] array) and
-    reuses compose_gradient_svg()/svg_data_uri() from Task 2 with
-    motif="none" (a plain gradient, no decorative motif -- a card this small
-    has no room for one; motif_side is irrelevant when the motif is "none"
-    so "right" is passed as an inert default). child_layout is only the
-    inner <LayoutElement> fragment positioning kpi_element's id inside the
-    container at the composition kpi-band height (rows 1..7, matching
-    composition.bands()'s own "kpi" role height) -- placing the container
-    itself on the page is the caller's job (same "decorate, don't own
-    layout" contract as section_card()), so no outer <GridContainer> is
-    returned here. NO-GO -> {"element":[],"child_layout":"","patch":{}}
-    (graceful: nothing to merge, nothing to lay out, never a broken/
-    half-decorated card).
+    actually legible against the gradient. gradient is OPTIONAL -- it
+    defaults to DEFAULT_THEME["card_gradient"] (a dark slate pair), so a
+    caller with no brand gradient in mind still gets a legible dark card;
+    pass a caller-specific 2-3 hex-stop list to override it (distinct KPI
+    cards typically carry distinct gradients, matching the reference
+    build's per-KPI KG[i] array). The composed background is now TWO layers
+    (see compose_card_svg()): the gradient rect, then a dark scrim -- this
+    is what makes the white value/title legible on a bright/medium gradient
+    too, not just a dark one (WS4 Task 6, user-reported "can't see the
+    numbers"). child_layout is only the inner <LayoutElement> fragment
+    positioning kpi_element's id inside the container at the composition
+    kpi-band height (rows 1..7, matching composition.bands()'s own "kpi"
+    role height) -- placing the container itself on the page is the
+    caller's job (same "decorate, don't own layout" contract as
+    section_card()), so no outer <GridContainer> is returned here.
+    NO-GO -> {"element":[],"child_layout":"","patch":{}} (graceful: nothing
+    to merge, nothing to lay out, never a broken/half-decorated card).
     """
     s = SURFACES if surfaces is None else surfaces
     if not s["gradient_card"]:
         return {"element": [], "child_layout": "", "patch": {}}
 
-    bg_url = svg_data_uri(compose_gradient_svg(gradient, "none", "right"))
+    grad = DEFAULT_THEME["card_gradient"] if gradient is None else gradient
+    bg_url = svg_data_uri(compose_card_svg(grad))
     container_el = {"id": id, "kind": "container", "style": {"borderRadius": "round"},
                      "backgroundImage": {"url": bg_url, "style": {"fit": "cover"}}}
     child_layout = '<LayoutElement elementId="%s" gridColumn="1 / %d" gridRow="1 / 7"/>' % (

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -52,8 +52,11 @@ SURFACES = {
     # carrying a composed <linearGradient>+motif SVG survived readback + a
     # real render. Two independent gates: gradient_header (the whole surface;
     # NO-GO falls back to the flat header() band) and motif (the optional
-    # decorative <g> layered on top; NO-GO degrades to a plain gradient with
-    # no motif, never a broken shape).
+    # decorative <g> layered on top of a *menu-key* motif; NO-GO degrades
+    # that case to a plain gradient with no motif, never a broken shape. It
+    # does NOT touch a bring-your-own image URL -- that path has nothing to
+    # do with the decorative SVG-fragment library this gate protects, so it
+    # is honored unconditionally).
     "gradient_header": True,
     "motif": True,
 }
@@ -244,18 +247,22 @@ def gradient_header(id, title, subtitle=None, gradient=None, motif="glow", motif
     bring-your-own `http`/`data:` URL string used verbatim as the background
     (SVG compose skipped). NO-GO gradient_header falls back to the existing
     flat header() band (graceful, never a broken/fake surface). NO-GO motif
-    (gradient_header still GO) silently drops the motif <g>, keeping the
-    plain gradient -- also graceful, never broken.
+    (gradient_header still GO) silently drops the motif <g> for a
+    *menu-key* motif, keeping the plain gradient -- also graceful, never
+    broken. A bring-your-own motif URL is checked FIRST and honored
+    unconditionally, regardless of SURFACES["motif"] -- that gate exists
+    only to protect the decorative SVG-fragment library, not the caller's
+    own image (an arbitrary URL in backgroundImage.url either way).
     """
     s = SURFACES if surfaces is None else surfaces
     if not s["gradient_header"]:
         return header(id, title, DEFAULT_THEME, page_cols=page_cols, surfaces=surfaces)
 
     grad = DEFAULT_THEME["header_gradient"] if gradient is None else gradient
-    effective_motif = motif if s["motif"] else "none"
-    if bring_your_own_motif(effective_motif):
-        bg_url = effective_motif
+    if bring_your_own_motif(motif):
+        bg_url = motif
     else:
+        effective_motif = motif if s["motif"] else "none"
         bg_url = svg_data_uri(compose_gradient_svg(grad, effective_motif, motif_side))
 
     container_id = "%s-bg" % id

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -2,6 +2,7 @@
 styling helpers that decorate Composition output: theme (palette), chart color,
 KPI accent, number format, header/section container. Byte-identical output.
 """
+import base64
 import copy
 import composition  # sibling module in shared/lib; caller must have this dir on sys.path (see test_styling.py)
 
@@ -15,6 +16,10 @@ DEFAULT_THEME = {
               "borderWidth": 1, "borderRadius": "round"},
     "header": {"backgroundColor": "#0F172A", "borderRadius": "round"},
     "accent": "#2563EB",
+    # WS4 Task 2: neutral 3-stop gradient (dark slate -> navy -> accent blue)
+    # for gradient_header(). NOT red -- red is a caller override, same
+    # discipline as theme(accent=) tinting the flat palette above.
+    "header_gradient": ["#0F172A", "#1E3A8A", "#2563EB"],
 }
 
 def theme(accent=None):
@@ -42,6 +47,15 @@ SURFACES = {
     "format_string": True,       # format:{kind:"number",formatString:<d3>} -- Excel-style formatString is 400-rejected, never emitted
     "container_style": True,     # container style:{backgroundColor,borderRadius,borderColor,borderWidth} (borderRadius, NOT cornerRadius; never combine with padding)
     "typography": True,          # themeOverrides.titleFont + per-element name:{fontSize} -- GO, but no helper below emits it (out of this task's scope); kept for a complete surface map
+    # WS4 Task 2 (build-plugs-command-center.rb HDRBG probe): container
+    # backgroundImage:{url:"data:image/svg+xml;base64,...",style:{fit:"cover"}}
+    # carrying a composed <linearGradient>+motif SVG survived readback + a
+    # real render. Two independent gates: gradient_header (the whole surface;
+    # NO-GO falls back to the flat header() band) and motif (the optional
+    # decorative <g> layered on top; NO-GO degrades to a plain gradient with
+    # no motif, never a broken shape).
+    "gradient_header": True,
+    "motif": True,
 }
 
 # d3-format grammar (NOT Excel) -- Task-1 verified surviving strings.
@@ -51,6 +65,45 @@ D3_FORMATS = {
     "percent": ".1%",
     "decimal": ",.2f",
 }
+
+# Motif menu for gradient_header() (WS4 Task 2, design doc "Component B" +
+# the live-verified HDRBG concentric-ring <g> in
+# build-plugs-command-center.rb). Each fragment is a fixed, deterministic SVG
+# string local to its own origin (0,0) -- gradient_header wraps it in a
+# positioning <g transform="translate(x,86)"> per motif_side, so the
+# fragments themselves never hardcode a page position. All geometric,
+# trademark-free, white low-opacity strokes/fills. "none" is the
+# empty-string identity (no motif layered on the gradient).
+GLOW_MOTIF_FRAGMENT = ('<defs><radialGradient id="motif-glow" cx="0.5" cy="0.5" r="0.6">'
+                       '<stop offset="0" stop-color="#FFFFFF" stop-opacity="0.2"/>'
+                       '<stop offset="1" stop-color="#FFFFFF" stop-opacity="0"/></radialGradient></defs>'
+                       '<rect x="-260" y="-105" width="520" height="210" fill="url(#motif-glow)"/>')
+RINGS_MOTIF_FRAGMENT = ('<g fill="none" stroke="#FFFFFF" stroke-opacity="0.12" stroke-width="1.4">'
+                        '<circle r="40"/><circle r="74"/><circle r="108"/>'
+                        '<line x1="-130" y1="0" x2="130" y2="0"/><line x1="0" y1="-130" x2="0" y2="130"/></g>')
+GRID_MOTIF_FRAGMENT = ('<defs><pattern id="motif-grid" width="40" height="40" patternUnits="userSpaceOnUse">'
+                       '<path d="M 40 0 L 0 0 0 40" fill="none" stroke="#FFFFFF" stroke-opacity="0.12" stroke-width="1"/>'
+                       '</pattern></defs><rect x="-260" y="-105" width="520" height="210" fill="url(#motif-grid)"/>')
+WAVES_MOTIF_FRAGMENT = ('<g fill="none" stroke="#FFFFFF" stroke-opacity="0.14" stroke-width="2">'
+                        '<path d="M -150 0 A 150 150 0 0 1 150 0"/>'
+                        '<path d="M -110 0 A 110 110 0 0 1 110 0"/>'
+                        '<path d="M -70 0 A 70 70 0 0 1 70 0"/></g>')
+DOTS_MOTIF_FRAGMENT = ('<defs><pattern id="motif-dots" width="24" height="24" patternUnits="userSpaceOnUse">'
+                       '<circle cx="4" cy="4" r="2" fill="#FFFFFF" fill-opacity="0.16"/></pattern></defs>'
+                       '<rect x="-260" y="-105" width="520" height="210" fill="url(#motif-dots)"/>')
+
+MOTIFS = {
+    "glow": lambda: GLOW_MOTIF_FRAGMENT,
+    "rings": lambda: RINGS_MOTIF_FRAGMENT,
+    "grid": lambda: GRID_MOTIF_FRAGMENT,
+    "waves": lambda: WAVES_MOTIF_FRAGMENT,
+    "dots": lambda: DOTS_MOTIF_FRAGMENT,
+    "none": lambda: "",
+}
+
+# motif_side -> x translate (page-space, viewBox 0 0 1600 210); y is fixed
+# at 86 for every side (matches the HDRBG reference's vertical placement).
+GRADIENT_MOTIF_X = {"right": 1440, "left": 160, "center": 800}
 
 
 def chart_color(theme, categorical=False, surfaces=None):
@@ -145,3 +198,97 @@ def section_card(id, band, theme, page_cols=24, surfaces=None):
         '</GridContainer>',
     ])
     return {"element": container_el, "wrap": wrap}
+
+
+def bring_your_own_motif(motif):
+    """True when `motif` is a caller-supplied image reference (bring-your-own),
+    not a MOTIFS menu key.
+    """
+    return isinstance(motif, str) and (motif.startswith("http") or motif.startswith("data:"))
+
+
+def svg_data_uri(svg):
+    """data:image/svg+xml;base64,... URI for an inline SVG string."""
+    return "data:image/svg+xml;base64," + base64.b64encode(svg.encode()).decode()
+
+
+def compose_gradient_svg(gradient, motif, motif_side):
+    """Composes the gradient_header background SVG: viewBox 0 0 1600 210, a
+    linearGradient from `gradient`'s 2-3 hex stops, plus an optional motif
+    <g> positioned per motif_side. `motif` here is always a MOTIFS key
+    (bring-your-own URLs are handled by the caller before this is reached --
+    see gradient_header).
+    """
+    if not isinstance(gradient, list) or len(gradient) not in (2, 3):
+        raise ValueError("compose_gradient_svg: gradient must be a list of 2-3 hex stops (got %r)" % (gradient,))
+    offsets = ["0", "1"] if len(gradient) == 2 else ["0", "0.5", "1"]
+    stops = "".join('<stop offset="%s" stop-color="%s"/>' % (offsets[i], hex_) for i, hex_ in enumerate(gradient))
+    motif_fn = MOTIFS.get(motif)
+    if motif_fn is None:
+        raise ValueError("compose_gradient_svg: unknown motif %r" % (motif,))
+    frag = motif_fn()
+    tx = GRADIENT_MOTIF_X.get(motif_side, GRADIENT_MOTIF_X["right"])
+    motif_group = "" if frag == "" else '<g transform="translate(%d,86)">%s</g>' % (tx, frag)
+    return ('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 210" preserveAspectRatio="xMidYMid slice">'
+            '<defs><linearGradient id="hg" x1="0" y1="0" x2="1" y2="0.45">%s</linearGradient></defs>'
+            '<rect width="1600" height="210" fill="url(#hg)"/>%s</svg>') % (stops, motif_group)
+
+
+def gradient_header(id, title, subtitle=None, gradient=None, motif="glow", motif_side="right",
+                     logo_url=None, page_cols=24, surfaces=None):
+    """Sleek gradient header band (rows 1..4): a container whose
+    backgroundImage is a composed data-URI SVG (linearGradient + optional
+    motif), an optional left-side logo image, a white title text element,
+    and an optional subtitle text element. Same {"element":, "layout":}
+    contract as header(). `motif` is a MOTIFS key (default "glow") or a
+    bring-your-own `http`/`data:` URL string used verbatim as the background
+    (SVG compose skipped). NO-GO gradient_header falls back to the existing
+    flat header() band (graceful, never a broken/fake surface). NO-GO motif
+    (gradient_header still GO) silently drops the motif <g>, keeping the
+    plain gradient -- also graceful, never broken.
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not s["gradient_header"]:
+        return header(id, title, DEFAULT_THEME, page_cols=page_cols, surfaces=surfaces)
+
+    grad = DEFAULT_THEME["header_gradient"] if gradient is None else gradient
+    effective_motif = motif if s["motif"] else "none"
+    if bring_your_own_motif(effective_motif):
+        bg_url = effective_motif
+    else:
+        bg_url = svg_data_uri(compose_gradient_svg(grad, effective_motif, motif_side))
+
+    container_id = "%s-bg" % id
+    logo_id = "%s-logo" % id
+    title_id = "%s-title" % id
+    subtitle_id = "%s-subtitle" % id
+
+    container_el = {"id": container_id, "kind": "container", "style": {"borderRadius": "round"},
+                     "backgroundImage": {"url": bg_url, "style": {"fit": "cover"}}}
+    title_el = {"id": title_id, "kind": "text", "verticalAlign": "middle",
+                "body": '# <span style="color: #FFFFFF">%s</span>' % title}
+
+    elements = [container_el]
+    if logo_url:
+        elements.append({"id": logo_id, "kind": "image", "url": logo_url, "style": {"fit": "contain"}})
+    elements.append(title_el)
+    if subtitle:
+        elements.append({"id": subtitle_id, "kind": "text", "verticalAlign": "middle",
+                          "body": '<span style="color: #CBD5E1">%s</span>' % subtitle})
+
+    r0, r1 = 1, 4
+    title_r1 = 3 if subtitle else r1
+    text_c0 = 3 if logo_url else 1
+    lines = ['<GridContainer elementId="%s" type="grid" gridColumn="1 / %d" gridRow="%d / %d" '
+             'gridTemplateColumns="repeat(%d, 1fr)" gridTemplateRows="auto">' % (
+                 container_id, page_cols + 1, r0, r1, page_cols)]
+    if logo_url:
+        lines.append('  <LayoutElement elementId="%s" gridColumn="1 / 3" gridRow="%d / %d"/>' % (logo_id, r0, r1))
+    lines.append('  <LayoutElement elementId="%s" gridColumn="%d / %d" gridRow="%d / %d"/>' % (
+        title_id, text_c0, page_cols + 1, r0, title_r1))
+    if subtitle:
+        lines.append('  <LayoutElement elementId="%s" gridColumn="%d / %d" gridRow="%d / %d"/>' % (
+            subtitle_id, text_c0, page_cols + 1, title_r1, r1))
+    lines.append('</GridContainer>')
+
+    return {"element": elements, "layout": "\n".join(lines)}

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -59,6 +59,16 @@ SURFACES = {
     # is honored unconditionally).
     "gradient_header": True,
     "motif": True,
+    # WS4 Task 3 (build-plugs-command-center.rb card(...)/_spark(...) probe):
+    # a gradient backgroundImage CARD container (gradient_card(), wrapping a
+    # caller-built kpi-chart with a white-text patch) and a separate
+    # borderless line-chart composite sparkline (sparkline()) both survived
+    # readback + a real render. NO-GO gradient_card -> the empty
+    # {"element":[],"child_layout":"","patch":{}} marker (graceful -- never
+    # mutates or half-decorates the caller's kpi_element). NO-GO sparkline ->
+    # {"opt_in":True,"id":} (never a faked chart shape).
+    "gradient_card": True,
+    "sparkline": True,
 }
 
 # d3-format grammar (NOT Excel) -- Task-1 verified surviving strings.
@@ -299,3 +309,85 @@ def gradient_header(id, title, subtitle=None, gradient=None, motif="glow", motif
     lines.append('</GridContainer>')
 
     return {"element": elements, "layout": "\n".join(lines)}
+
+
+def gradient_card(id, kpi_element, gradient, page_cols=24, surfaces=None):
+    """Wraps a caller-built kpi-chart element (a dict, e.g. from kpi_card.build)
+    in a gradient backgroundImage CARD container (WS4 Task 3, design doc
+    "Component B" + the live-verified card(...) shape in
+    build-plugs-command-center.rb). Decorate-only, like section_card():
+    kpi_element is READ ONLY here (its "id" is read to build child_layout) --
+    it is never mutated, and kpi_card.py (WS1, fanned to converters) is never
+    touched. Instead this returns a patch dict the caller merges onto their
+    own copy of the kpi element's value/name objects to turn the value +
+    title white (e.g. kpi_element["value"].update(patch["value"])) so they
+    read against the gradient, matching card(...)'s native-white KPI text.
+    gradient is required (one gradient per card -- distinct KPI cards
+    typically carry distinct gradients, matching the reference build's
+    per-KPI KG[i] array) and reuses compose_gradient_svg()/svg_data_uri()
+    from Task 2 with motif="none" (a plain gradient, no decorative motif --
+    a card this small has no room for one; motif_side is irrelevant when the
+    motif is "none" so "right" is passed as an inert default). child_layout
+    is only the inner <LayoutElement> fragment positioning kpi_element's id
+    inside the container at the composition kpi-band height (rows 1..7,
+    matching composition.bands()'s own "kpi" role height) -- placing the
+    container itself on the page is the caller's job (same "decorate, don't
+    own layout" contract as section_card()), so no outer <GridContainer> is
+    returned here. NO-GO -> {"element":[],"child_layout":"","patch":{}}
+    (graceful: nothing to merge, nothing to lay out, never a broken/
+    half-decorated card).
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not s["gradient_card"]:
+        return {"element": [], "child_layout": "", "patch": {}}
+
+    bg_url = svg_data_uri(compose_gradient_svg(gradient, "none", "right"))
+    container_el = {"id": id, "kind": "container", "style": {"borderRadius": "round"},
+                     "backgroundImage": {"url": bg_url, "style": {"fit": "cover"}}}
+    child_layout = '<LayoutElement elementId="%s" gridColumn="1 / %d" gridRow="1 / 7"/>' % (
+        kpi_element["id"], page_cols + 1)
+    patch = {"value": {"color": "#FFFFFF"}, "name": {"color": "#FFFFFF"}}
+    return {"element": [container_el], "child_layout": child_layout, "patch": patch}
+
+
+def sparkline(id, source_element_id, period_ref, value_formula, period_format="%b %Y", surfaces=None):
+    """Composite in-card sparkline (WS4 Task 3): a separate, borderless mini
+    line-chart element meant to sit BELOW a kpi-chart inside the same
+    gradient_card() container -- NOT a date column bound inside the
+    kpi-chart itself (that in-kpi shape was the WS3 NO-GO; this standalone
+    line-chart is the live-verified GO pattern, matching _spark(...) in
+    build-plugs-command-center.rb). Two columns: a period dimension
+    (period_ref's formula, formatted kind:"datetime"/period_format) and a
+    value (value_formula's formula). Both axes hide their labels/marks so no
+    chrome competes with the kpi above it; the y-axis scale is zero:False (a
+    small trend doesn't get flattened against a forced-zero baseline) with
+    hideZeroLine:True; name/legend are hidden (no title, no legend on a
+    sparkline); the line uses a smooth monotone interpolation; the
+    background is transparent so the chart blends into the gradient card
+    above/around it. NO-GO -> {"opt_in":True,"id":id} (never a faked/broken
+    chart shape).
+    """
+    s = SURFACES if surfaces is None else surfaces
+    if not s["sparkline"]:
+        return {"opt_in": True, "id": id}
+
+    period_col_id = "%s-period" % id
+    value_col_id = "%s-value" % id
+    return {
+        "id": id,
+        "kind": "line-chart",
+        "source": {"kind": "table", "elementId": source_element_id},
+        "columns": [
+            {"id": period_col_id, "formula": period_ref, "name": "Period",
+             "format": {"kind": "datetime", "formatString": period_format}},
+            {"id": value_col_id, "formula": value_formula, "name": "Value"},
+        ],
+        "xAxis": {"columnId": period_col_id, "format": {"marks": "none", "labels": "hidden"}},
+        "yAxis": {"columnIds": [value_col_id],
+                  "format": {"labels": "hidden", "marks": "none",
+                             "scale": {"type": "linear", "zero": False, "hideZeroLine": True}}},
+        "name": {"visibility": "hidden"},
+        "legend": {"visibility": "hidden"},
+        "lineAreaStyle": {"interpolation": "monotone"},
+        "style": {"backgroundColor": "transparent"},
+    }

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -3,6 +3,7 @@
 # helpers that decorate Composition output: theme (palette), chart color,
 # KPI accent, number format, header/section container. Ruby 2.6, stdlib only.
 require_relative 'composition'
+require 'base64'
 
 module Styling
   # One professional, host-agnostic palette. No branding.
@@ -14,7 +15,11 @@ module Styling
     card: { 'backgroundColor' => '#FFFFFF', 'borderColor' => '#E2E8F0',
             'borderWidth' => 1, 'borderRadius' => 'round' },
     header: { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' },
-    accent: '#2563EB'
+    accent: '#2563EB',
+    # WS4 Task 2: neutral 3-stop gradient (dark slate -> navy -> accent blue)
+    # for Styling.gradient_header. NOT red -- red is a caller override, same
+    # discipline as theme(accent:) tinting the flat palette above.
+    header_gradient: %w[#0F172A #1E3A8A #2563EB]
   }.freeze
 
   # Returns a theme; an accent override tints categorical slot 0 + accent.
@@ -40,7 +45,16 @@ module Styling
     categorical_scheme: true, # workbook-level themeOverrides:{categoricalScheme:[...]}
     format_string: true,      # format:{kind:"number",formatString:<d3>} — Excel-style formatString is 400-rejected, never emitted
     container_style: true,    # container style:{backgroundColor,borderRadius,borderColor,borderWidth} (borderRadius, NOT cornerRadius; never combine with padding)
-    typography: true          # themeOverrides.titleFont + per-element name:{fontSize} — GO, but no helper below emits it (out of this task's scope); kept for a complete surface map
+    typography: true,         # themeOverrides.titleFont + per-element name:{fontSize} — GO, but no helper below emits it (out of this task's scope); kept for a complete surface map
+    # WS4 Task 2 (build-plugs-command-center.rb HDRBG probe): container
+    # backgroundImage:{url:"data:image/svg+xml;base64,...",style:{fit:"cover"}}
+    # carrying a composed <linearGradient>+motif SVG survived readback + a
+    # real render. Two independent gates: gradient_header (the whole surface;
+    # NO-GO falls back to the flat Styling.header band) and motif (the
+    # optional decorative <g> layered on top; NO-GO degrades to a plain
+    # gradient with no motif, never a broken shape).
+    gradient_header: true,
+    motif: true
   }.freeze
 
   # d3-format grammar (NOT Excel) — Task-1 verified surviving strings.
@@ -50,6 +64,45 @@ module Styling
     percent: '.1%',
     decimal: ',.2f'
   }.freeze
+
+  # Motif menu for Styling.gradient_header (WS4 Task 2, design doc "Component
+  # B" + the live-verified HDRBG concentric-ring <g> in
+  # build-plugs-command-center.rb). Each fragment is a fixed, deterministic
+  # SVG string local to its own origin (0,0) -- gradient_header wraps it in a
+  # positioning <g transform="translate(x,86)"> per motif_side, so the
+  # fragments themselves never hardcode a page position. All geometric,
+  # trademark-free, white low-opacity strokes/fills. :none is the
+  # empty-string identity (no motif layered on the gradient).
+  GLOW_MOTIF_FRAGMENT = '<defs><radialGradient id="motif-glow" cx="0.5" cy="0.5" r="0.6">' \
+                        '<stop offset="0" stop-color="#FFFFFF" stop-opacity="0.2"/>' \
+                        '<stop offset="1" stop-color="#FFFFFF" stop-opacity="0"/></radialGradient></defs>' \
+                        '<rect x="-260" y="-105" width="520" height="210" fill="url(#motif-glow)"/>'
+  RINGS_MOTIF_FRAGMENT = '<g fill="none" stroke="#FFFFFF" stroke-opacity="0.12" stroke-width="1.4">' \
+                         '<circle r="40"/><circle r="74"/><circle r="108"/>' \
+                         '<line x1="-130" y1="0" x2="130" y2="0"/><line x1="0" y1="-130" x2="0" y2="130"/></g>'
+  GRID_MOTIF_FRAGMENT = '<defs><pattern id="motif-grid" width="40" height="40" patternUnits="userSpaceOnUse">' \
+                        '<path d="M 40 0 L 0 0 0 40" fill="none" stroke="#FFFFFF" stroke-opacity="0.12" stroke-width="1"/>' \
+                        '</pattern></defs><rect x="-260" y="-105" width="520" height="210" fill="url(#motif-grid)"/>'
+  WAVES_MOTIF_FRAGMENT = '<g fill="none" stroke="#FFFFFF" stroke-opacity="0.14" stroke-width="2">' \
+                         '<path d="M -150 0 A 150 150 0 0 1 150 0"/>' \
+                         '<path d="M -110 0 A 110 110 0 0 1 110 0"/>' \
+                         '<path d="M -70 0 A 70 70 0 0 1 70 0"/></g>'
+  DOTS_MOTIF_FRAGMENT = '<defs><pattern id="motif-dots" width="24" height="24" patternUnits="userSpaceOnUse">' \
+                        '<circle cx="4" cy="4" r="2" fill="#FFFFFF" fill-opacity="0.16"/></pattern></defs>' \
+                        '<rect x="-260" y="-105" width="520" height="210" fill="url(#motif-dots)"/>'
+
+  MOTIFS = {
+    glow: -> { GLOW_MOTIF_FRAGMENT },
+    rings: -> { RINGS_MOTIF_FRAGMENT },
+    grid: -> { GRID_MOTIF_FRAGMENT },
+    waves: -> { WAVES_MOTIF_FRAGMENT },
+    dots: -> { DOTS_MOTIF_FRAGMENT },
+    none: -> { '' }
+  }.freeze
+
+  # motif_side -> x translate (page-space, viewBox 0 0 1600 210); y is fixed
+  # at 86 for every side (matches the HDRBG reference's vertical placement).
+  GRADIENT_MOTIF_X = { right: 1440, left: 160, center: 800 }.freeze
 
   # Chart color patch: single-series `color:{by:"single",value:}` (categorical
   # slot 0) by default, or the workbook-level categorical-scheme patch when
@@ -129,5 +182,95 @@ module Styling
       '</GridContainer>'
     ].join("\n")
     { element: container_el, wrap: wrap }
+  end
+
+  # True when `motif` is a caller-supplied image reference (bring-your-own),
+  # not a Styling::MOTIFS menu key.
+  def self.bring_your_own_motif?(motif)
+    motif.is_a?(String) && (motif.start_with?('http') || motif.start_with?('data:'))
+  end
+
+  # data:image/svg+xml;base64,... URI for an inline SVG string. Ruby 2.6
+  # stdlib only (Base64.strict_encode64 -- no embedded newlines, unlike encode64).
+  def self.svg_data_uri(svg)
+    'data:image/svg+xml;base64,' + Base64.strict_encode64(svg)
+  end
+
+  # Composes the gradient_header background SVG: viewBox 0 0 1600 210, a
+  # linearGradient from `gradient`'s 2-3 hex stops, plus an optional motif
+  # <g> positioned per motif_side. `motif` here is always a Styling::MOTIFS
+  # key (bring-your-own URLs are handled by the caller before this is
+  # reached -- see gradient_header).
+  def self.compose_gradient_svg(gradient, motif, motif_side)
+    unless gradient.is_a?(Array) && [2, 3].include?(gradient.length)
+      raise ArgumentError, "compose_gradient_svg: gradient must be an array of 2-3 hex stops (got #{gradient.inspect})"
+    end
+    offsets = gradient.length == 2 ? %w[0 1] : %w[0 0.5 1]
+    stops = gradient.each_with_index.map { |hex, i| "<stop offset=\"#{offsets[i]}\" stop-color=\"#{hex}\"/>" }.join
+    motif_key = motif.is_a?(String) ? motif.to_sym : motif
+    motif_fn = MOTIFS.fetch(motif_key) { raise ArgumentError, "compose_gradient_svg: unknown motif #{motif.inspect}" }
+    frag = motif_fn.call
+    tx = GRADIENT_MOTIF_X.fetch(motif_side, GRADIENT_MOTIF_X[:right])
+    motif_group = frag.empty? ? '' : "<g transform=\"translate(#{tx},86)\">#{frag}</g>"
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 210" preserveAspectRatio="xMidYMid slice">' \
+      "<defs><linearGradient id=\"hg\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"0.45\">#{stops}</linearGradient></defs>" \
+      "<rect width=\"1600\" height=\"210\" fill=\"url(#hg)\"/>#{motif_group}</svg>"
+  end
+
+  # Sleek gradient header band (rows 1..4): a container whose backgroundImage
+  # is a composed data-URI SVG (linearGradient + optional motif), an optional
+  # left-side logo image, a white title text element, and an optional
+  # subtitle text element. Same { element:, layout: } contract as
+  # Styling.header. `motif:` is a Styling::MOTIFS key (default :glow) or a
+  # bring-your-own `http`/`data:` URL string used verbatim as the background
+  # (SVG compose skipped). NO-GO gradient_header falls back to the existing
+  # flat Styling.header band (graceful, never a broken/fake surface). NO-GO
+  # motif (gradient_header still GO) silently drops the motif <g>, keeping
+  # the plain gradient -- also graceful, never broken.
+  def self.gradient_header(id:, title:, subtitle: nil, gradient: DEFAULT_THEME[:header_gradient],
+                            motif: :glow, motif_side: :right, logo_url: nil, page_cols: 24, surfaces: SURFACES)
+    unless surfaces[:gradient_header]
+      return header(id: id, title: title, theme: DEFAULT_THEME, page_cols: page_cols, surfaces: surfaces)
+    end
+
+    effective_motif = surfaces[:motif] ? motif : :none
+    bg_url = if bring_your_own_motif?(effective_motif)
+               effective_motif
+             else
+               svg_data_uri(compose_gradient_svg(gradient, effective_motif, motif_side))
+             end
+
+    container_id = "#{id}-bg"
+    logo_id = "#{id}-logo"
+    title_id = "#{id}-title"
+    subtitle_id = "#{id}-subtitle"
+
+    container_el = { 'id' => container_id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
+                     'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
+    title_el = { 'id' => title_id, 'kind' => 'text', 'verticalAlign' => 'middle',
+                 'body' => "# <span style=\"color: #FFFFFF\">#{title}</span>" }
+
+    elements = [container_el]
+    elements << { 'id' => logo_id, 'kind' => 'image', 'url' => logo_url, 'style' => { 'fit' => 'contain' } } if logo_url
+    elements << title_el
+    if subtitle
+      elements << { 'id' => subtitle_id, 'kind' => 'text', 'verticalAlign' => 'middle',
+                    'body' => "<span style=\"color: #CBD5E1\">#{subtitle}</span>" }
+    end
+
+    r0 = 1
+    r1 = 4
+    title_r1 = subtitle ? 3 : r1
+    text_c0 = logo_url ? 3 : 1
+    lines = ["<GridContainer elementId=\"#{container_id}\" type=\"grid\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"#{r0} / #{r1}\" " \
+              "gridTemplateColumns=\"repeat(#{page_cols}, 1fr)\" gridTemplateRows=\"auto\">"]
+    lines << "  <LayoutElement elementId=\"#{logo_id}\" gridColumn=\"1 / 3\" gridRow=\"#{r0} / #{r1}\"/>" if logo_url
+    lines << "  <LayoutElement elementId=\"#{title_id}\" gridColumn=\"#{text_c0} / #{page_cols + 1}\" gridRow=\"#{r0} / #{title_r1}\"/>"
+    if subtitle
+      lines << "  <LayoutElement elementId=\"#{subtitle_id}\" gridColumn=\"#{text_c0} / #{page_cols + 1}\" gridRow=\"#{title_r1} / #{r1}\"/>"
+    end
+    lines << '</GridContainer>'
+
+    { element: elements, layout: lines.join("\n") }
   end
 end

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -57,7 +57,17 @@ module Styling
     # nothing to do with the decorative SVG-fragment library this gate
     # protects, so it is honored unconditionally).
     gradient_header: true,
-    motif: true
+    motif: true,
+    # WS4 Task 3 (build-plugs-command-center.rb `card(...)`/`_spark(...)` probe):
+    # a gradient backgroundImage CARD container (Styling.gradient_card, wrapping
+    # a caller-built kpi-chart with a white-text patch) and a separate borderless
+    # `line-chart` composite sparkline (Styling.sparkline) both survived readback
+    # + a real render. NO-GO gradient_card -> the empty {element:[],child_layout:
+    # '',patch:{}} marker (graceful — never mutates or half-decorates the
+    # caller's kpi_element). NO-GO sparkline -> {'opt_in'=>true,'id'=>} (never a
+    # faked chart shape).
+    gradient_card: true,
+    sparkline: true
   }.freeze
 
   # d3-format grammar (NOT Excel) — Task-1 verified surviving strings.
@@ -279,5 +289,80 @@ module Styling
     lines << '</GridContainer>'
 
     { element: elements, layout: lines.join("\n") }
+  end
+
+  # Wraps a caller-built kpi-chart element (a Hash, e.g. from KpiCard.build)
+  # in a gradient backgroundImage CARD container (WS4 Task 3, design doc
+  # "Component B" + the live-verified `card(...)` shape in
+  # build-plugs-command-center.rb). Decorate-only, like `section_card`:
+  # `kpi_element` is READ ONLY here (its `id` is read to build `child_layout`)
+  # -- it is never mutated, and `kpi_card.rb` (WS1, fanned to converters) is
+  # never touched. Instead this returns a `patch` Hash the caller merges onto
+  # their own copy of the kpi element's `value`/`name` objects to turn the
+  # value + title white (e.g. `kpi_element['value'].merge!(patch['value'])`)
+  # so they read against the gradient, matching `card(...)`'s native-white
+  # KPI text. `gradient:` is required (one gradient per card -- distinct KPI
+  # cards typically carry distinct gradients, matching the reference build's
+  # per-KPI `KG[i]` array) and reuses `compose_gradient_svg`/`svg_data_uri`
+  # from Task 2 with `motif: :none` (a plain gradient, no decorative motif --
+  # a card this small has no room for one; `motif_side` is irrelevant when
+  # the motif is `:none` so `:right` is passed as an inert default).
+  # `child_layout` is only the inner `<LayoutElement>` fragment positioning
+  # `kpi_element`'s id inside the container at the Composition kpi-band
+  # height (rows 1..7, matching `Composition.bands`' own `:kpi` role height)
+  # -- placing the container itself on the page is the caller's job (same
+  # "decorate, don't own layout" contract as `section_card`), so no outer
+  # `<GridContainer>` is returned here. NO-GO -> `{element:[],
+  # child_layout:'',patch:{}}` (graceful: nothing to merge, nothing to lay
+  # out, never a broken/half-decorated card).
+  def self.gradient_card(id:, kpi_element:, gradient:, page_cols: 24, surfaces: SURFACES)
+    return { element: [], child_layout: '', patch: {} } unless surfaces[:gradient_card]
+
+    bg_url = svg_data_uri(compose_gradient_svg(gradient, :none, :right))
+    container_el = { 'id' => id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
+                      'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
+    child_layout = "<LayoutElement elementId=\"#{kpi_element['id']}\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"1 / 7\"/>"
+    patch = { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' } }
+    { element: [container_el], child_layout: child_layout, patch: patch }
+  end
+
+  # Composite in-card sparkline (WS4 Task 3): a separate, borderless mini
+  # `line-chart` element meant to sit BELOW a kpi-chart inside the same
+  # `gradient_card` container -- NOT a date column bound inside the
+  # kpi-chart itself (that in-kpi shape was the WS3 NO-GO; this standalone
+  # line-chart is the live-verified GO pattern, matching `_spark(...)` in
+  # build-plugs-command-center.rb). Two columns: a period dimension
+  # (`period_ref`'s formula, formatted `kind:"datetime"`/`period_format`)
+  # and a value (`value_formula`'s formula). Both axes hide their
+  # labels/marks so no chrome competes with the kpi above it; the y-axis
+  # scale is `zero:false` (a small trend doesn't get flattened against a
+  # forced-zero baseline) with `hideZeroLine:true`; `name`/`legend` are
+  # hidden (no title, no legend on a sparkline); the line uses a smooth
+  # `monotone` interpolation; the background is transparent so the chart
+  # blends into the gradient card above/around it. NO-GO -> `{'opt_in'=>
+  # true,'id'=>id}` (never a faked/broken chart shape).
+  def self.sparkline(id:, source_element_id:, period_ref:, value_formula:, period_format: '%b %Y', surfaces: SURFACES)
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:sparkline]
+
+    period_col_id = "#{id}-period"
+    value_col_id = "#{id}-value"
+    {
+      'id' => id,
+      'kind' => 'line-chart',
+      'source' => { 'kind' => 'table', 'elementId' => source_element_id },
+      'columns' => [
+        { 'id' => period_col_id, 'formula' => period_ref, 'name' => 'Period',
+          'format' => { 'kind' => 'datetime', 'formatString' => period_format } },
+        { 'id' => value_col_id, 'formula' => value_formula, 'name' => 'Value' }
+      ],
+      'xAxis' => { 'columnId' => period_col_id, 'format' => { 'marks' => 'none', 'labels' => 'hidden' } },
+      'yAxis' => { 'columnIds' => [value_col_id],
+                    'format' => { 'labels' => 'hidden', 'marks' => 'none',
+                                  'scale' => { 'type' => 'linear', 'zero' => false, 'hideZeroLine' => true } } },
+      'name' => { 'visibility' => 'hidden' },
+      'legend' => { 'visibility' => 'hidden' },
+      'lineAreaStyle' => { 'interpolation' => 'monotone' },
+      'style' => { 'backgroundColor' => 'transparent' }
+    }
   end
 end

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -19,7 +19,12 @@ module Styling
     # WS4 Task 2: neutral 3-stop gradient (dark slate -> navy -> accent blue)
     # for Styling.gradient_header. NOT red -- red is a caller override, same
     # discipline as theme(accent:) tinting the flat palette above.
-    header_gradient: %w[#0F172A #1E3A8A #2563EB]
+    header_gradient: %w[#0F172A #1E3A8A #2563EB],
+    # WS4 Task 6 (live-render fix): dark default so Styling.gradient_card's
+    # `gradient:` can be omitted -- a caller with no brand gradient in mind
+    # still gets a legible dark card (paired with the scrim in
+    # compose_card_svg below, white KPI text stays legible either way).
+    card_gradient: %w[#1E293B #0F172A]
   }.freeze
 
   # Returns a theme; an accent override tints categorical slot 0 + accent.
@@ -65,7 +70,10 @@ module Styling
     # + a real render. NO-GO gradient_card -> the empty {element:[],child_layout:
     # '',patch:{}} marker (graceful — never mutates or half-decorates the
     # caller's kpi_element). NO-GO sparkline -> {'opt_in'=>true,'id'=>} (never a
-    # faked chart shape).
+    # faked chart shape). WS4 Task 6 (live-render fix, user-reported "can't see
+    # the numbers"): gradient_card's composed background now also carries a
+    # dark scrim (see compose_card_svg/CARD_SCRIM_TOP_OPACITY) so white KPI
+    # text stays legible on ANY caller gradient, not just dark ones.
     gradient_card: true,
     sparkline: true
   }.freeze
@@ -77,6 +85,13 @@ module Styling
     percent: '.1%',
     decimal: ',.2f'
   }.freeze
+
+  # WS4 Task 6 (live-render fix, user-reported): opacity of the dark scrim
+  # composed behind a gradient_card's top band (where the KPI name+value
+  # sit), fading to 0 by the bottom (where a sparkline sits) -- see
+  # compose_card_svg. A single named constant so a future legibility
+  # regression is a one-line tune, not a hunt through the SVG string.
+  CARD_SCRIM_TOP_OPACITY = 0.55
 
   # Motif menu for Styling.gradient_header (WS4 Task 2, design doc "Component
   # B" + the live-verified HDRBG concentric-ring <g> in
@@ -291,6 +306,32 @@ module Styling
     { element: elements, layout: lines.join("\n") }
   end
 
+  # Composes the gradient_card background SVG (WS4 Task 6, live-render fix,
+  # user-reported "can't see the numbers"): same viewBox + gradient-rect
+  # technique as compose_gradient_svg (always motif :none -- a card this
+  # small has no room for a decorative mark), PLUS a second rect layered on
+  # top filled with a vertical black scrim `linearGradient` --
+  # CARD_SCRIM_TOP_OPACITY opacity at the top (y=0, where the KPI name+value
+  # sit) fading to 0 opacity by the bottom (y=210, where a Styling.sparkline
+  # sits) -- so a white KPI value stays legible on ANY caller gradient,
+  # bright or dark, while the brand gradient still reads through in the
+  # lower half (never fully blacked out). Kept as its own composer (not a
+  # compose_gradient_svg option) so gradient_header's output -- already
+  # live-verified without a scrim -- is untouched.
+  def self.compose_card_svg(gradient)
+    unless gradient.is_a?(Array) && [2, 3].include?(gradient.length)
+      raise ArgumentError, "compose_card_svg: gradient must be an array of 2-3 hex stops (got #{gradient.inspect})"
+    end
+    offsets = gradient.length == 2 ? %w[0 1] : %w[0 0.5 1]
+    stops = gradient.each_with_index.map { |hex, i| "<stop offset=\"#{offsets[i]}\" stop-color=\"#{hex}\"/>" }.join
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 210" preserveAspectRatio="xMidYMid slice">' \
+      "<defs><linearGradient id=\"cg\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"0.45\">#{stops}</linearGradient>" \
+      "<linearGradient id=\"card-scrim\" x1=\"0\" y1=\"0\" x2=\"0\" y2=\"1\">" \
+      "<stop offset=\"0\" stop-color=\"#000000\" stop-opacity=\"#{CARD_SCRIM_TOP_OPACITY}\"/>" \
+      '<stop offset="1" stop-color="#000000" stop-opacity="0"/></linearGradient></defs>' \
+      '<rect width="1600" height="210" fill="url(#cg)"/><rect width="1600" height="210" fill="url(#card-scrim)"/></svg>'
+  end
+
   # Wraps a caller-built kpi-chart element (a Hash, e.g. from KpiCard.build)
   # in a gradient backgroundImage CARD container (WS4 Task 3, design doc
   # "Component B" + the live-verified `card(...)` shape in
@@ -306,34 +347,36 @@ module Styling
   # A shallow `Hash#merge` is REQUIRED, not a wholesale replace of the
   # `value`/`name` hashes -- kpi_element['value'] carries `columnId` (and
   # optionally `fontSize`) that this patch must not clobber; merge overlays
-  # only the `color` key. `patch['style']` is new here (Task 6 live-render
-  # fix): the WS1 KpiCard.build shape never sets a `style` key of its own, so
-  # this is additive, but callers should still merge rather than assign in
-  # case a future kpi_element does carry one. Turning the value + title white
-  # is not enough by itself -- the KPI element still keeps its own opaque
+  # only the `color` key. `patch['style']` (Task 6 live-render fix): the WS1
+  # KpiCard.build shape never sets a `style` key of its own, so this is
+  # additive, but callers should still merge rather than assign in case a
+  # future kpi_element does carry one. Turning the value + title white is
+  # not enough by itself -- the KPI element still keeps its own opaque
   # background, so a live render shows white-on-white; `patch['style']` sets
   # `backgroundColor: 'transparent'` (letting the gradient card behind show
   # through) and `padding: 'none'` (edge-to-edge, matching `card(...)`'s
   # native shape in build-plugs-command-center.rb) so the white value/title
-  # are actually legible against the gradient. `gradient:` is required (one
-  # gradient per card -- distinct KPI cards typically carry distinct
-  # gradients, matching the reference build's per-KPI `KG[i]` array) and
-  # reuses `compose_gradient_svg`/`svg_data_uri` from Task 2 with
-  # `motif: :none` (a plain gradient, no decorative motif -- a card this
-  # small has no room for one; `motif_side` is irrelevant when the motif is
-  # `:none` so `:right` is passed as an inert default). `child_layout` is
-  # only the inner `<LayoutElement>` fragment positioning `kpi_element`'s id
-  # inside the container at the Composition kpi-band height (rows 1..7,
-  # matching `Composition.bands`' own `:kpi` role height) -- placing the
-  # container itself on the page is the caller's job (same "decorate, don't
-  # own layout" contract as `section_card`), so no outer `<GridContainer>` is
-  # returned here. NO-GO -> `{element:[],child_layout:'',patch:{}}`
-  # (graceful: nothing to merge, nothing to lay out, never a broken/
-  # half-decorated card).
-  def self.gradient_card(id:, kpi_element:, gradient:, page_cols: 24, surfaces: SURFACES)
+  # are actually legible against the gradient. `gradient:` is OPTIONAL --
+  # it defaults to `DEFAULT_THEME[:card_gradient]` (a dark slate pair), so a
+  # caller with no brand gradient in mind still gets a legible dark card;
+  # pass a caller-specific 2-3 hex-stop array to override it (distinct KPI
+  # cards typically carry distinct gradients, matching the reference
+  # build's per-KPI `KG[i]` array). The composed background is now TWO
+  # layers (see compose_card_svg): the gradient rect, then a dark scrim --
+  # this is what makes the white value/title legible on a bright/medium
+  # gradient too, not just a dark one (WS4 Task 6, user-reported "can't see
+  # the numbers"). `child_layout` is only the inner `<LayoutElement>`
+  # fragment positioning `kpi_element`'s id inside the container at the
+  # Composition kpi-band height (rows 1..7, matching `Composition.bands`'
+  # own `:kpi` role height) -- placing the container itself on the page is
+  # the caller's job (same "decorate, don't own layout" contract as
+  # `section_card`), so no outer `<GridContainer>` is returned here.
+  # NO-GO -> `{element:[],child_layout:'',patch:{}}` (graceful: nothing to
+  # merge, nothing to lay out, never a broken/half-decorated card).
+  def self.gradient_card(id:, kpi_element:, gradient: DEFAULT_THEME[:card_gradient], page_cols: 24, surfaces: SURFACES)
     return { element: [], child_layout: '', patch: {} } unless surfaces[:gradient_card]
 
-    bg_url = svg_data_uri(compose_gradient_svg(gradient, :none, :right))
+    bg_url = svg_data_uri(compose_card_svg(gradient))
     container_el = { 'id' => id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
                       'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
     child_layout = "<LayoutElement elementId=\"#{kpi_element['id']}\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"1 / 7\"/>"

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -297,24 +297,39 @@ module Styling
   # build-plugs-command-center.rb). Decorate-only, like `section_card`:
   # `kpi_element` is READ ONLY here (its `id` is read to build `child_layout`)
   # -- it is never mutated, and `kpi_card.rb` (WS1, fanned to converters) is
-  # never touched. Instead this returns a `patch` Hash the caller merges onto
-  # their own copy of the kpi element's `value`/`name` objects to turn the
-  # value + title white (e.g. `kpi_element['value'].merge!(patch['value'])`)
-  # so they read against the gradient, matching `card(...)`'s native-white
-  # KPI text. `gradient:` is required (one gradient per card -- distinct KPI
-  # cards typically carry distinct gradients, matching the reference build's
-  # per-KPI `KG[i]` array) and reuses `compose_gradient_svg`/`svg_data_uri`
-  # from Task 2 with `motif: :none` (a plain gradient, no decorative motif --
-  # a card this small has no room for one; `motif_side` is irrelevant when
-  # the motif is `:none` so `:right` is passed as an inert default).
-  # `child_layout` is only the inner `<LayoutElement>` fragment positioning
-  # `kpi_element`'s id inside the container at the Composition kpi-band
-  # height (rows 1..7, matching `Composition.bands`' own `:kpi` role height)
-  # -- placing the container itself on the page is the caller's job (same
-  # "decorate, don't own layout" contract as `section_card`), so no outer
-  # `<GridContainer>` is returned here. NO-GO -> `{element:[],
-  # child_layout:'',patch:{}}` (graceful: nothing to merge, nothing to lay
-  # out, never a broken/half-decorated card).
+  # never touched. Instead this returns a `patch` Hash the caller MERGES
+  # (never replaces) onto their own copy of three top-level keys on the kpi
+  # element:
+  #   kpi_element['value'] = kpi_element['value'].merge(patch['value'])
+  #   kpi_element['name']  = kpi_element['name'].merge(patch['name'])
+  #   kpi_element['style'] = (kpi_element['style'] || {}).merge(patch['style'])
+  # A shallow `Hash#merge` is REQUIRED, not a wholesale replace of the
+  # `value`/`name` hashes -- kpi_element['value'] carries `columnId` (and
+  # optionally `fontSize`) that this patch must not clobber; merge overlays
+  # only the `color` key. `patch['style']` is new here (Task 6 live-render
+  # fix): the WS1 KpiCard.build shape never sets a `style` key of its own, so
+  # this is additive, but callers should still merge rather than assign in
+  # case a future kpi_element does carry one. Turning the value + title white
+  # is not enough by itself -- the KPI element still keeps its own opaque
+  # background, so a live render shows white-on-white; `patch['style']` sets
+  # `backgroundColor: 'transparent'` (letting the gradient card behind show
+  # through) and `padding: 'none'` (edge-to-edge, matching `card(...)`'s
+  # native shape in build-plugs-command-center.rb) so the white value/title
+  # are actually legible against the gradient. `gradient:` is required (one
+  # gradient per card -- distinct KPI cards typically carry distinct
+  # gradients, matching the reference build's per-KPI `KG[i]` array) and
+  # reuses `compose_gradient_svg`/`svg_data_uri` from Task 2 with
+  # `motif: :none` (a plain gradient, no decorative motif -- a card this
+  # small has no room for one; `motif_side` is irrelevant when the motif is
+  # `:none` so `:right` is passed as an inert default). `child_layout` is
+  # only the inner `<LayoutElement>` fragment positioning `kpi_element`'s id
+  # inside the container at the Composition kpi-band height (rows 1..7,
+  # matching `Composition.bands`' own `:kpi` role height) -- placing the
+  # container itself on the page is the caller's job (same "decorate, don't
+  # own layout" contract as `section_card`), so no outer `<GridContainer>` is
+  # returned here. NO-GO -> `{element:[],child_layout:'',patch:{}}`
+  # (graceful: nothing to merge, nothing to lay out, never a broken/
+  # half-decorated card).
   def self.gradient_card(id:, kpi_element:, gradient:, page_cols: 24, surfaces: SURFACES)
     return { element: [], child_layout: '', patch: {} } unless surfaces[:gradient_card]
 
@@ -322,7 +337,8 @@ module Styling
     container_el = { 'id' => id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
                       'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
     child_layout = "<LayoutElement elementId=\"#{kpi_element['id']}\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"1 / 7\"/>"
-    patch = { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' } }
+    patch = { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' },
+              'style' => { 'backgroundColor' => 'transparent', 'padding' => 'none' } }
     { element: [container_el], child_layout: child_layout, patch: patch }
   end
 

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -362,7 +362,7 @@ module Styling
       'name' => { 'visibility' => 'hidden' },
       'legend' => { 'visibility' => 'hidden' },
       'lineAreaStyle' => { 'interpolation' => 'monotone' },
-      'style' => { 'backgroundColor' => 'transparent' }
+      'style' => { 'backgroundColor' => 'transparent', 'padding' => 'none' }
     }
   end
 end

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -51,8 +51,11 @@ module Styling
     # carrying a composed <linearGradient>+motif SVG survived readback + a
     # real render. Two independent gates: gradient_header (the whole surface;
     # NO-GO falls back to the flat Styling.header band) and motif (the
-    # optional decorative <g> layered on top; NO-GO degrades to a plain
-    # gradient with no motif, never a broken shape).
+    # optional decorative <g> layered on top of a *menu-key* motif; NO-GO
+    # degrades that case to a plain gradient with no motif, never a broken
+    # shape. It does NOT touch a bring-your-own image URL -- that path has
+    # nothing to do with the decorative SVG-fragment library this gate
+    # protects, so it is honored unconditionally).
     gradient_header: true,
     motif: true
   }.freeze
@@ -225,18 +228,22 @@ module Styling
   # bring-your-own `http`/`data:` URL string used verbatim as the background
   # (SVG compose skipped). NO-GO gradient_header falls back to the existing
   # flat Styling.header band (graceful, never a broken/fake surface). NO-GO
-  # motif (gradient_header still GO) silently drops the motif <g>, keeping
-  # the plain gradient -- also graceful, never broken.
+  # motif (gradient_header still GO) silently drops the motif <g> for a
+  # *menu-key* motif, keeping the plain gradient -- also graceful, never
+  # broken. A bring-your-own motif URL is checked FIRST and honored
+  # unconditionally, regardless of SURFACES[:motif] -- that gate exists only
+  # to protect the decorative SVG-fragment library, not the caller's own
+  # image (an arbitrary URL in backgroundImage.url either way).
   def self.gradient_header(id:, title:, subtitle: nil, gradient: DEFAULT_THEME[:header_gradient],
                             motif: :glow, motif_side: :right, logo_url: nil, page_cols: 24, surfaces: SURFACES)
     unless surfaces[:gradient_header]
       return header(id: id, title: title, theme: DEFAULT_THEME, page_cols: page_cols, surfaces: surfaces)
     end
 
-    effective_motif = surfaces[:motif] ? motif : :none
-    bg_url = if bring_your_own_motif?(effective_motif)
-               effective_motif
+    bg_url = if bring_your_own_motif?(motif)
+               motif
              else
+               effective_motif = surfaces[:motif] ? motif : :none
                svg_data_uri(compose_gradient_svg(gradient, effective_motif, motif_side))
              end
 

--- a/shared/lib/test_actions.py
+++ b/shared/lib/test_actions.py
@@ -1,0 +1,228 @@
+import json, os, sys, unittest
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import actions
+
+
+def _sort(o):
+    if isinstance(o, dict):
+        return {k: _sort(o[k]) for k in sorted(o)}
+    if isinstance(o, list):
+        return [_sort(e) for e in o]
+    return o
+
+
+class SurfacesTest(unittest.TestCase):
+    def test_surfaces_all_4_actions_surfaces_are_go(self):
+        expected = ["button", "effects", "input_table_empty", "input_table_linked"]
+        self.assertEqual(sorted(actions.SURFACES.keys()), sorted(expected))
+        self.assertTrue(all(actions.SURFACES.values()))
+
+
+class ButtonTest(unittest.TestCase):
+    def test_default_appearance_trigger_and_default_action_id(self):
+        el = actions.button(id="btn-log", text="Log note",
+                             effects=[{"effect": "insert-rows", "table": "annotations", "values": {}}])
+        self.assertEqual(el, {
+            "id": "btn-log", "kind": "button", "text": "Log note", "appearance": "filled",
+            "actions": [{"id": "a-btn-log", "trigger": "on-click",
+                         "effects": [{"effect": "insert-rows", "table": "annotations", "values": {}}]}],
+        })
+
+    def test_custom_appearance_and_trigger_are_honored(self):
+        el = actions.button(id="btn-reset", text="Reset filters", appearance="outline", trigger="on-load",
+                             effects=[])
+        self.assertEqual(el["appearance"], "outline")
+        self.assertEqual(el["actions"][0]["trigger"], "on-load")
+
+    def test_explicit_action_id_overrides_default(self):
+        el = actions.button(id="btn-reset", text="Reset filters", action_id="a-reset", effects=[])
+        self.assertEqual(el["actions"][0]["id"], "a-reset")
+
+    def test_effects_list_is_passed_through_verbatim(self):
+        effects = [{"effect": "insert-rows", "table": "t", "values": {"c": 1}},
+                   {"effect": "clear-control", "scope": {"type": "page", "page": "pg"}, "usePublishedValue": True}]
+        el = actions.button(id="btn-log", text="Log note", effects=effects)
+        self.assertEqual(el["actions"][0]["effects"], effects)
+        self.assertEqual(len(el["actions"][0]["effects"]), 2)
+
+    def test_id_required(self):
+        with self.assertRaises(ValueError):
+            actions.button(id="", text="x", effects=[])
+
+    def test_text_required(self):
+        with self.assertRaises(ValueError):
+            actions.button(id="btn-x", text="", effects=[])
+
+    def test_no_go_surface_returns_opt_in_marker(self):
+        surfaces = dict(actions.SURFACES, button=False)
+        el = actions.button(id="btn-log", text="Log note", effects=[], surfaces=surfaces)
+        self.assertEqual(el, {"opt_in": True, "id": "btn-log"})
+
+
+ANNOTATION_COLUMNS = [
+    {"id": "an-note", "type": "text", "name": "Review note"},
+    {"id": "CREATED_AT"}, {"id": "CREATED_BY"},
+]
+
+
+class InputTableEmptyTest(unittest.TestCase):
+    def test_input_mode_edit_present_and_source_kind_empty(self):
+        el = actions.input_table_empty(id="annotations", connection_id="write-conn-1", columns=ANNOTATION_COLUMNS)
+        self.assertEqual(el, {
+            "id": "annotations", "kind": "input-table", "inputMode": "edit",
+            "source": {"kind": "empty", "connectionId": "write-conn-1"},
+            "columns": ANNOTATION_COLUMNS,
+        })
+
+    def test_name_omitted_entirely_when_not_given(self):
+        el = actions.input_table_empty(id="annotations", connection_id="write-conn-1", columns=ANNOTATION_COLUMNS)
+        self.assertNotIn("name", el)
+
+    def test_name_passed_through_verbatim_when_given(self):
+        name = {"text": "Review log (append-only)", "fontWeight": "bold", "fontSize": 15, "color": "#1A1A1A"}
+        el = actions.input_table_empty(id="annotations", connection_id="write-conn-1", columns=ANNOTATION_COLUMNS,
+                                        name=name)
+        self.assertEqual(el["name"], name)
+
+    def test_id_required(self):
+        with self.assertRaises(ValueError):
+            actions.input_table_empty(id="", connection_id="c", columns=ANNOTATION_COLUMNS)
+
+    def test_connection_id_required(self):
+        with self.assertRaises(ValueError):
+            actions.input_table_empty(id="x", connection_id="", columns=ANNOTATION_COLUMNS)
+
+    def test_columns_required_none(self):
+        with self.assertRaises(ValueError):
+            actions.input_table_empty(id="x", connection_id="c", columns=None)
+
+    def test_columns_required_empty_list(self):
+        with self.assertRaises(ValueError):
+            actions.input_table_empty(id="x", connection_id="c", columns=[])
+
+    def test_no_go_surface_returns_opt_in_marker(self):
+        surfaces = dict(actions.SURFACES, input_table_empty=False)
+        el = actions.input_table_empty(id="annotations", connection_id="write-conn-1", columns=ANNOTATION_COLUMNS,
+                                        surfaces=surfaces)
+        self.assertEqual(el, {"opt_in": True, "id": "annotations"})
+
+
+TARGET_COLUMNS = [
+    {"id": "tg-fam", "key": "fp-fam"},
+    {"id": "tg-actual", "key": "fp-rev", "name": "Actual Revenue"},
+    {"id": "tg-target", "type": "number", "name": "Target Revenue"},
+    {"id": "tg-var", "name": "Variance vs Target", "formula": "[Actual Revenue] - [Target Revenue]"},
+]
+
+
+class InputTableLinkedTest(unittest.TestCase):
+    def test_source_kind_linked_carries_from_and_connection_id(self):
+        el = actions.input_table_linked(id="targets", from_="fam-pivot", connection_id="write-conn-1",
+                                         columns=TARGET_COLUMNS)
+        self.assertEqual(el, {
+            "id": "targets", "kind": "input-table", "inputMode": "edit",
+            "source": {"kind": "linked", "from": "fam-pivot", "connectionId": "write-conn-1"},
+            "columns": TARGET_COLUMNS,
+        })
+
+    def test_id_required(self):
+        with self.assertRaises(ValueError):
+            actions.input_table_linked(id="", from_="f", connection_id="c", columns=TARGET_COLUMNS)
+
+    def test_from_required(self):
+        with self.assertRaises(ValueError):
+            actions.input_table_linked(id="x", from_="", connection_id="c", columns=TARGET_COLUMNS)
+
+    def test_connection_id_required(self):
+        with self.assertRaises(ValueError):
+            actions.input_table_linked(id="x", from_="f", connection_id="", columns=TARGET_COLUMNS)
+
+    def test_columns_required_empty_list(self):
+        with self.assertRaises(ValueError):
+            actions.input_table_linked(id="x", from_="f", connection_id="c", columns=[])
+
+    def test_no_go_surface_returns_opt_in_marker(self):
+        surfaces = dict(actions.SURFACES, input_table_linked=False)
+        el = actions.input_table_linked(id="targets", from_="fam-pivot", connection_id="write-conn-1",
+                                         columns=TARGET_COLUMNS, surfaces=surfaces)
+        self.assertEqual(el, {"opt_in": True, "id": "targets"})
+
+
+class InsertRowsEffectTest(unittest.TestCase):
+    def test_shape_values_passed_through_verbatim(self):
+        values = {"an-note": {"type": "control", "control": "NoteCtl"}}
+        self.assertEqual(actions.insert_rows_effect(table="annotations", values=values),
+                          {"effect": "insert-rows", "table": "annotations", "values": values})
+
+    def test_table_required(self):
+        with self.assertRaises(ValueError):
+            actions.insert_rows_effect(table="", values={})
+
+    def test_no_go_surface_returns_empty_dict(self):
+        surfaces = dict(actions.SURFACES, effects=False)
+        self.assertEqual(actions.insert_rows_effect(table="annotations", values={}, surfaces=surfaces), {})
+
+
+class ClearControlEffectTest(unittest.TestCase):
+    def test_shape(self):
+        self.assertEqual(actions.clear_control_effect(page="pg"),
+                          {"effect": "clear-control", "scope": {"type": "page", "page": "pg"},
+                           "usePublishedValue": True})
+
+    def test_page_required(self):
+        with self.assertRaises(ValueError):
+            actions.clear_control_effect(page="")
+
+    def test_no_go_surface_returns_empty_dict(self):
+        surfaces = dict(actions.SURFACES, effects=False)
+        self.assertEqual(actions.clear_control_effect(page="pg", surfaces=surfaces), {})
+
+
+class SetControlValueEffectTest(unittest.TestCase):
+    def test_shape(self):
+        self.assertEqual(actions.set_control_value_effect(control="RegionF", text="West"), {
+            "effect": "set-control-value", "control": "RegionF",
+            "value": {"type": "constant", "value": {"type": "text", "value": "West"}},
+        })
+
+    def test_control_required(self):
+        with self.assertRaises(ValueError):
+            actions.set_control_value_effect(control="", text="West")
+
+    def test_text_required(self):
+        with self.assertRaises(ValueError):
+            actions.set_control_value_effect(control="RegionF", text="")
+
+    def test_no_go_surface_returns_empty_dict(self):
+        surfaces = dict(actions.SURFACES, effects=False)
+        self.assertEqual(actions.set_control_value_effect(control="RegionF", text="West", surfaces=surfaces), {})
+
+
+class GoldenTest(unittest.TestCase):
+    def setUp(self):
+        with open(os.path.join(os.path.dirname(__file__), "testdata", "actions_golden.json")) as f:
+            self.golden = json.load(f)
+
+    def test_helpers_match_actions_golden(self):
+        button_effects = [
+            actions.insert_rows_effect(table="annotations",
+                                        values={"an-note": {"type": "control", "control": "NoteCtl"}}),
+            actions.clear_control_effect(page="pg"),
+        ]
+        actual = {
+            "button": actions.button(id="btn-log", text="Log note", appearance="filled", effects=button_effects),
+            "input_table_empty": actions.input_table_empty(
+                id="annotations", connection_id="write-conn-1", columns=ANNOTATION_COLUMNS,
+                name={"text": "Review log (append-only)", "fontWeight": "bold", "fontSize": 15, "color": "#1A1A1A"}),
+            "input_table_linked": actions.input_table_linked(
+                id="targets", from_="fam-pivot", connection_id="write-conn-1", columns=TARGET_COLUMNS),
+            "insert_rows_effect": actions.insert_rows_effect(
+                table="annotations", values={"an-note": {"type": "control", "control": "NoteCtl"}}),
+            "clear_control_effect": actions.clear_control_effect(page="pg"),
+            "set_control_value_effect": actions.set_control_value_effect(control="RegionF", text="West"),
+        }
+        self.assertEqual(json.dumps(_sort(actual)), json.dumps(_sort(self.golden)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/shared/lib/test_actions.rb
+++ b/shared/lib/test_actions.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+# test_actions.rb — run directly: ruby shared/lib/test_actions.rb
+require 'json'
+require_relative 'actions'
+$failures = 0
+def check(desc); ok = yield; puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}"); $failures += 1 unless ok; end
+
+# Deep-sort hashes/arrays so twin/golden comparison is key-order-independent.
+def sort_deep(o)
+  case o
+  when Hash then o.keys.sort.each_with_object({}) { |k, h| h[k] = sort_deep(o[k]) }
+  when Array then o.map { |e| sort_deep(e) }
+  else o
+  end
+end
+
+check('SURFACES: all 4 actions surfaces are GO') do
+  expected = %i[button effects input_table_empty input_table_linked]
+  Actions::SURFACES.keys.sort == expected.sort && Actions::SURFACES.values.all? { |v| v == true }
+end
+
+# --- button -------------------------------------------------------------
+
+check('button: default appearance/trigger + default action_id "a-<id>"') do
+  el = Actions.button(id: 'btn-log', text: 'Log note',
+                       effects: [{ 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => {} }])
+  el == {
+    'id' => 'btn-log', 'kind' => 'button', 'text' => 'Log note', 'appearance' => 'filled',
+    'actions' => [{ 'id' => 'a-btn-log', 'trigger' => 'on-click',
+                    'effects' => [{ 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => {} }] }]
+  }
+end
+check('button: custom appearance + trigger are honored') do
+  el = Actions.button(id: 'btn-reset', text: 'Reset filters', appearance: 'outline', trigger: 'on-load', effects: [])
+  el['appearance'] == 'outline' && el['actions'][0]['trigger'] == 'on-load'
+end
+check('button: explicit action_id: overrides the "a-<id>" default') do
+  el = Actions.button(id: 'btn-reset', text: 'Reset filters', action_id: 'a-reset', effects: [])
+  el['actions'][0]['id'] == 'a-reset'
+end
+check('button: effects array is passed through verbatim (caller builds via effect builders)') do
+  effects = [{ 'effect' => 'insert-rows', 'table' => 't', 'values' => { 'c' => 1 } },
+             { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'pg' }, 'usePublishedValue' => true }]
+  el = Actions.button(id: 'btn-log', text: 'Log note', effects: effects)
+  el['actions'][0]['effects'] == effects && el['actions'][0]['effects'].length == 2
+end
+check('button: id required') do
+  begin; Actions.button(id: '', text: 'x', effects: []); false
+  rescue ArgumentError; true; end
+end
+check('button: text required') do
+  begin; Actions.button(id: 'btn-x', text: '', effects: []); false
+  rescue ArgumentError; true; end
+end
+check('button: NO-GO surface -> opt-in marker') do
+  el = Actions.button(id: 'btn-log', text: 'Log note', effects: [],
+                       surfaces: Actions::SURFACES.merge(button: false))
+  el == { 'opt_in' => true, 'id' => 'btn-log' }
+end
+
+# --- input_table_empty ---------------------------------------------------
+
+ANNOTATION_COLUMNS = [
+  { 'id' => 'an-note', 'type' => 'text', 'name' => 'Review note' },
+  { 'id' => 'CREATED_AT' }, { 'id' => 'CREATED_BY' }
+].freeze
+
+check('input_table_empty: inputMode:"edit" is present (masked-error fix) + source.kind:"empty"') do
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS)
+  el == {
+    'id' => 'annotations', 'kind' => 'input-table', 'inputMode' => 'edit',
+    'source' => { 'kind' => 'empty', 'connectionId' => 'write-conn-1' },
+    'columns' => ANNOTATION_COLUMNS
+  }
+end
+check('input_table_empty: name: omitted entirely when not given') do
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS)
+  !el.key?('name')
+end
+check('input_table_empty: name: passed through verbatim when given') do
+  name = { 'text' => 'Review log (append-only)', 'fontWeight' => 'bold', 'fontSize' => 15, 'color' => '#1A1A1A' }
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS,
+                                  name: name)
+  el['name'] == name
+end
+check('input_table_empty: id required') do
+  begin; Actions.input_table_empty(id: '', connection_id: 'c', columns: ANNOTATION_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_empty: connection_id required') do
+  begin; Actions.input_table_empty(id: 'x', connection_id: '', columns: ANNOTATION_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_empty: columns required (nil)') do
+  begin; Actions.input_table_empty(id: 'x', connection_id: 'c', columns: nil); false
+  rescue ArgumentError; true; end
+end
+check('input_table_empty: columns required (empty array)') do
+  begin; Actions.input_table_empty(id: 'x', connection_id: 'c', columns: []); false
+  rescue ArgumentError; true; end
+end
+check('input_table_empty: NO-GO surface -> opt-in marker') do
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS,
+                                  surfaces: Actions::SURFACES.merge(input_table_empty: false))
+  el == { 'opt_in' => true, 'id' => 'annotations' }
+end
+
+# --- input_table_linked ---------------------------------------------------
+
+TARGET_COLUMNS = [
+  { 'id' => 'tg-fam', 'key' => 'fp-fam' },
+  { 'id' => 'tg-actual', 'key' => 'fp-rev', 'name' => 'Actual Revenue' },
+  { 'id' => 'tg-target', 'type' => 'number', 'name' => 'Target Revenue' },
+  { 'id' => 'tg-var', 'name' => 'Variance vs Target', 'formula' => '[Actual Revenue] - [Target Revenue]' }
+].freeze
+
+check('input_table_linked: source.kind:"linked" carries from + connectionId') do
+  el = Actions.input_table_linked(id: 'targets', from: 'fam-pivot', connection_id: 'write-conn-1',
+                                   columns: TARGET_COLUMNS)
+  el == {
+    'id' => 'targets', 'kind' => 'input-table', 'inputMode' => 'edit',
+    'source' => { 'kind' => 'linked', 'from' => 'fam-pivot', 'connectionId' => 'write-conn-1' },
+    'columns' => TARGET_COLUMNS
+  }
+end
+check('input_table_linked: id required') do
+  begin; Actions.input_table_linked(id: '', from: 'f', connection_id: 'c', columns: TARGET_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_linked: from required') do
+  begin; Actions.input_table_linked(id: 'x', from: '', connection_id: 'c', columns: TARGET_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_linked: connection_id required') do
+  begin; Actions.input_table_linked(id: 'x', from: 'f', connection_id: '', columns: TARGET_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_linked: columns required (empty array)') do
+  begin; Actions.input_table_linked(id: 'x', from: 'f', connection_id: 'c', columns: []); false
+  rescue ArgumentError; true; end
+end
+check('input_table_linked: NO-GO surface -> opt-in marker') do
+  el = Actions.input_table_linked(id: 'targets', from: 'fam-pivot', connection_id: 'write-conn-1',
+                                   columns: TARGET_COLUMNS,
+                                   surfaces: Actions::SURFACES.merge(input_table_linked: false))
+  el == { 'opt_in' => true, 'id' => 'targets' }
+end
+
+# --- effect builders -------------------------------------------------------
+
+check('insert_rows_effect: {effect, table, values} — values passed through verbatim') do
+  values = { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
+  Actions.insert_rows_effect(table: 'annotations', values: values) ==
+    { 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => values }
+end
+check('insert_rows_effect: table required') do
+  begin; Actions.insert_rows_effect(table: '', values: {}); false
+  rescue ArgumentError; true; end
+end
+check('insert_rows_effect: NO-GO surface -> {}') do
+  Actions.insert_rows_effect(table: 'annotations', values: {},
+                              surfaces: Actions::SURFACES.merge(effects: false)) == {}
+end
+
+check('clear_control_effect: {effect, scope:{type:page,page}, usePublishedValue:true}') do
+  Actions.clear_control_effect(page: 'pg') ==
+    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'pg' }, 'usePublishedValue' => true }
+end
+check('clear_control_effect: page required') do
+  begin; Actions.clear_control_effect(page: ''); false
+  rescue ArgumentError; true; end
+end
+check('clear_control_effect: NO-GO surface -> {}') do
+  Actions.clear_control_effect(page: 'pg', surfaces: Actions::SURFACES.merge(effects: false)) == {}
+end
+
+check('set_control_value_effect: {effect, control, value:{type:constant,value:{type:text,value}}}') do
+  Actions.set_control_value_effect(control: 'RegionF', text: 'West') ==
+    { 'effect' => 'set-control-value', 'control' => 'RegionF',
+      'value' => { 'type' => 'constant', 'value' => { 'type' => 'text', 'value' => 'West' } } }
+end
+check('set_control_value_effect: control required') do
+  begin; Actions.set_control_value_effect(control: '', text: 'West'); false
+  rescue ArgumentError; true; end
+end
+check('set_control_value_effect: text required') do
+  begin; Actions.set_control_value_effect(control: 'RegionF', text: ''); false
+  rescue ArgumentError; true; end
+end
+check('set_control_value_effect: NO-GO surface -> {}') do
+  Actions.set_control_value_effect(control: 'RegionF', text: 'West',
+                                    surfaces: Actions::SURFACES.merge(effects: false)) == {}
+end
+
+# --- golden ------------------------------------------------------------------
+
+golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'actions_golden.json')))
+check('helpers match actions_golden.json (sorted-key identical)') do
+  button_effects = [
+    Actions.insert_rows_effect(table: 'annotations',
+                                values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }),
+    Actions.clear_control_effect(page: 'pg')
+  ]
+  actual = {
+    'button' => Actions.button(id: 'btn-log', text: 'Log note', appearance: 'filled', effects: button_effects),
+    'input_table_empty' => Actions.input_table_empty(
+      id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS,
+      name: { 'text' => 'Review log (append-only)', 'fontWeight' => 'bold', 'fontSize' => 15, 'color' => '#1A1A1A' }
+    ),
+    'input_table_linked' => Actions.input_table_linked(id: 'targets', from: 'fam-pivot',
+                                                        connection_id: 'write-conn-1', columns: TARGET_COLUMNS),
+    'insert_rows_effect' => Actions.insert_rows_effect(
+      table: 'annotations', values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
+    ),
+    'clear_control_effect' => Actions.clear_control_effect(page: 'pg'),
+    'set_control_value_effect' => Actions.set_control_value_effect(control: 'RegionF', text: 'West')
+  }
+  JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))
+end
+
+exit($failures.zero? ? 0 : 1)

--- a/shared/lib/test_richness.py
+++ b/shared/lib/test_richness.py
@@ -23,8 +23,8 @@ FILTER_CONTROLS = [
 
 
 class SurfacesTest(unittest.TestCase):
-    def test_surfaces_all_4_richness_surfaces_are_go(self):
-        expected = ["ai_insight", "dynamic_grain", "filter_row", "wide_pivot"]
+    def test_surfaces_all_5_richness_surfaces_are_go(self):
+        expected = ["agent", "ai_insight", "dynamic_grain", "filter_row", "wide_pivot"]
         self.assertEqual(sorted(richness.SURFACES.keys()), sorted(expected))
         self.assertTrue(all(richness.SURFACES.values()))
 
@@ -207,6 +207,72 @@ class WidePivotTest(unittest.TestCase):
         self.assertEqual(piv, {"opt_in": True, "id": "piv-1"})
 
 
+AGENT_TOOLS = [
+    {"toolId": "t-log-note", "kind": "action", "name": "Log note", "description": "Insert a review note.",
+     "steps": [{"kind": "effect", "effect": "insert-rows", "table": "annotations",
+                "value": {"type": "agent-input", "inputName": "note"}}]},
+]
+
+
+class AgentTest(unittest.TestCase):
+    def test_read_only_analyst_omits_tools_key_entirely(self):
+        el = richness.agent(id="ag-1", name="Analyst", instructions="Be a helpful retail analyst.",
+                             data_source_ids=["src"])
+        self.assertEqual(el, {
+            "id": "ag-1", "name": "Analyst", "instructions": "Be a helpful retail analyst.",
+            "dataSources": [{"kind": "table", "elementId": "src"}],
+        })
+        self.assertNotIn("tools", el)
+
+    def test_multiple_data_source_ids_map_to_multiple_data_sources_in_order(self):
+        el = richness.agent(id="ag-1", name="Analyst", instructions="x", data_source_ids=["src-a", "src-b"])
+        self.assertEqual(el["dataSources"], [
+            {"kind": "table", "elementId": "src-a"}, {"kind": "table", "elementId": "src-b"},
+        ])
+
+    def test_non_empty_tools_is_added_verbatim(self):
+        el = richness.agent(id="ag-2", name="Assistant", instructions="Act on my behalf.",
+                             data_source_ids=["src"], tools=AGENT_TOOLS)
+        self.assertEqual(el["tools"], AGENT_TOOLS)
+        self.assertIn("tools", el)
+
+    def test_id_required(self):
+        with self.assertRaises(ValueError):
+            richness.agent(id="", name="A", instructions="x", data_source_ids=["src"])
+
+    def test_name_required(self):
+        with self.assertRaises(ValueError):
+            richness.agent(id="ag-1", name="", instructions="x", data_source_ids=["src"])
+
+    def test_instructions_required(self):
+        with self.assertRaises(ValueError):
+            richness.agent(id="ag-1", name="A", instructions="", data_source_ids=["src"])
+
+    def test_no_go_surface_returns_opt_in_marker(self):
+        surfaces = dict(richness.SURFACES, agent=False)
+        el = richness.agent(id="ag-1", name="A", instructions="x", data_source_ids=["src"], surfaces=surfaces)
+        self.assertEqual(el, {"opt_in": True, "id": "ag-1"})
+
+
+class ChatTest(unittest.TestCase):
+    def test_id_kind_chat_agent_id_shape(self):
+        self.assertEqual(richness.chat(id="chat-1", agent_id="ag-1"),
+                          {"id": "chat-1", "kind": "chat", "agentId": "ag-1"})
+
+    def test_id_required(self):
+        with self.assertRaises(ValueError):
+            richness.chat(id="", agent_id="ag-1")
+
+    def test_agent_id_required(self):
+        with self.assertRaises(ValueError):
+            richness.chat(id="chat-1", agent_id="")
+
+    def test_no_go_surface_returns_opt_in_marker(self):
+        surfaces = dict(richness.SURFACES, agent=False)
+        el = richness.chat(id="chat-1", agent_id="ag-1", surfaces=surfaces)
+        self.assertEqual(el, {"opt_in": True, "id": "chat-1"})
+
+
 class GoldenTest(unittest.TestCase):
     def setUp(self):
         with open(os.path.join(os.path.dirname(__file__), "testdata", "richness_golden.json")) as f:
@@ -214,6 +280,11 @@ class GoldenTest(unittest.TestCase):
 
     def test_helpers_match_richness_golden(self):
         actual = {
+            "agent": richness.agent(id="ag-1", name="Analyst", instructions="Be a helpful retail analyst.",
+                                     data_source_ids=["src"]),
+            "agent_with_tools": richness.agent(id="ag-2", name="Assistant", instructions="Act on my behalf.",
+                                                data_source_ids=["src"], tools=AGENT_TOOLS),
+            "chat": richness.chat(id="chat-1", agent_id="ag-1"),
             "ai_insight": richness.ai_insight(id="ai-rev", prompt="Summarize revenue trends for the period."),
             "ai_insight_custom_model": richness.ai_insight(
                 id="ai-rev2", model="mistral-large2", prompt="Say one nice thing about the data."),

--- a/shared/lib/test_richness.rb
+++ b/shared/lib/test_richness.rb
@@ -14,8 +14,8 @@ def sort_deep(o)
   end
 end
 
-check('SURFACES: all 4 richness surfaces are GO') do
-  expected = %i[ai_insight dynamic_grain filter_row wide_pivot]
+check('SURFACES: all 5 richness surfaces are GO') do
+  expected = %i[agent ai_insight dynamic_grain filter_row wide_pivot]
   Richness::SURFACES.keys.sort == expected.sort && Richness::SURFACES.values.all? { |v| v == true }
 end
 
@@ -197,11 +197,80 @@ check('wide_pivot: NO-GO surface -> opt-in marker') do
   piv == { 'opt_in' => true, 'id' => 'piv-1' }
 end
 
+# --- agent / chat -------------------------------------------------------------
+
+AGENT_TOOLS = [
+  { 'toolId' => 't-log-note', 'kind' => 'action', 'name' => 'Log note', 'description' => 'Insert a review note.',
+    'steps' => [{ 'kind' => 'effect', 'effect' => 'insert-rows', 'table' => 'annotations',
+                  'value' => { 'type' => 'agent-input', 'inputName' => 'note' } }] }
+].freeze
+
+check('agent: read-only analyst (tools: []) OMITS the tools key entirely') do
+  el = Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'Be a helpful retail analyst.',
+                       data_source_ids: ['src'])
+  el == {
+    'id' => 'ag-1', 'name' => 'Analyst', 'instructions' => 'Be a helpful retail analyst.',
+    'dataSources' => [{ 'kind' => 'table', 'elementId' => 'src' }]
+  } && !el.key?('tools')
+end
+check('agent: multiple data_source_ids map to multiple dataSources entries, in order') do
+  el = Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'x', data_source_ids: %w[src-a src-b])
+  el['dataSources'] == [{ 'kind' => 'table', 'elementId' => 'src-a' }, { 'kind' => 'table', 'elementId' => 'src-b' }]
+end
+check('agent: non-empty tools: is added verbatim') do
+  el = Richness.agent(id: 'ag-2', name: 'Assistant', instructions: 'Act on my behalf.',
+                       data_source_ids: ['src'], tools: AGENT_TOOLS)
+  el['tools'] == AGENT_TOOLS && el.key?('tools')
+end
+check('agent: id required') do
+  begin
+    Richness.agent(id: '', name: 'A', instructions: 'x', data_source_ids: ['src']); false
+  rescue ArgumentError; true; end
+end
+check('agent: name required') do
+  begin
+    Richness.agent(id: 'ag-1', name: '', instructions: 'x', data_source_ids: ['src']); false
+  rescue ArgumentError; true; end
+end
+check('agent: instructions required') do
+  begin
+    Richness.agent(id: 'ag-1', name: 'A', instructions: '', data_source_ids: ['src']); false
+  rescue ArgumentError; true; end
+end
+check('agent: NO-GO surface -> opt-in marker, never a faked agent') do
+  el = Richness.agent(id: 'ag-1', name: 'A', instructions: 'x', data_source_ids: ['src'],
+                       surfaces: Richness::SURFACES.merge(agent: false))
+  el == { 'opt_in' => true, 'id' => 'ag-1' }
+end
+
+check('chat: {id, kind: chat, agentId} shape') do
+  Richness.chat(id: 'chat-1', agent_id: 'ag-1') == { 'id' => 'chat-1', 'kind' => 'chat', 'agentId' => 'ag-1' }
+end
+check('chat: id required') do
+  begin
+    Richness.chat(id: '', agent_id: 'ag-1'); false
+  rescue ArgumentError; true; end
+end
+check('chat: agent_id required') do
+  begin
+    Richness.chat(id: 'chat-1', agent_id: ''); false
+  rescue ArgumentError; true; end
+end
+check('chat: NO-GO surface -> opt-in marker, never a faked chat element') do
+  el = Richness.chat(id: 'chat-1', agent_id: 'ag-1', surfaces: Richness::SURFACES.merge(agent: false))
+  el == { 'opt_in' => true, 'id' => 'chat-1' }
+end
+
 # --- golden ------------------------------------------------------------------
 
 golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'richness_golden.json')))
 check('helpers match richness_golden.json (sorted-key identical)') do
   actual = {
+    'agent' => Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'Be a helpful retail analyst.',
+                               data_source_ids: ['src']),
+    'agent_with_tools' => Richness.agent(id: 'ag-2', name: 'Assistant', instructions: 'Act on my behalf.',
+                                          data_source_ids: ['src'], tools: AGENT_TOOLS),
+    'chat' => Richness.chat(id: 'chat-1', agent_id: 'ag-1'),
     'ai_insight' => Richness.ai_insight(id: 'ai-rev', prompt: 'Summarize revenue trends for the period.'),
     'ai_insight_custom_model' => Richness.ai_insight(id: 'ai-rev2', model: 'mistral-large2',
                                                       prompt: 'Say one nice thing about the data.'),

--- a/shared/lib/test_styling.py
+++ b/shared/lib/test_styling.py
@@ -1,3 +1,4 @@
+import base64
 import json, os, sys, unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import styling
@@ -90,9 +91,10 @@ class StylingHelpersTest(unittest.TestCase):
         with open(os.path.join(os.path.dirname(__file__), "testdata", "styling_golden.json")) as f:
             self.golden = json.load(f)
 
-    def test_surfaces_all_6_task1_surfaces_are_go(self):
+    def test_surfaces_all_8_surfaces_are_go(self):
         expected = ["categorical_scheme", "chart_color_by", "container_style",
-                    "format_string", "kpi_name_color", "typography"]
+                    "format_string", "kpi_name_color", "typography",
+                    "gradient_header", "motif"]
         self.assertEqual(sorted(styling.SURFACES.keys()), sorted(expected))
         self.assertTrue(all(styling.SURFACES.values()))
 
@@ -179,8 +181,121 @@ class StylingHelpersTest(unittest.TestCase):
             "format_for_decimal": styling.format_for("decimal"),
             "header": styling.header("hdr", "Dashboard", theme),
             "section_card": styling.section_card("card-1", band, theme),
+            "gradient_header_glow": styling.gradient_header(
+                "ghdr", "Command Center", subtitle="Live metrics", logo_url="https://example.com/logo.png"),
+            "gradient_header_rings_left": styling.gradient_header(
+                "ghdr2", "Ops", motif="rings", motif_side="left"),
+            "gradient_header_none": styling.gradient_header("ghdr3", "Plain", motif="none"),
+            "gradient_header_byo": styling.gradient_header("ghdr4", "Custom", motif="https://example.com/art.png"),
         }
         self.assertEqual(json.dumps(_sort(actual)), json.dumps(_sort(self.golden)))
+
+
+class MotifsTest(unittest.TestCase):
+    def test_default_theme_header_gradient_is_neutral_2_3_stop_hex_not_red(self):
+        hg = styling.DEFAULT_THEME["header_gradient"]
+        self.assertIsInstance(hg, list)
+        self.assertIn(len(hg), (2, 3))
+        for h in hg:
+            self.assertRegex(h, r"\A#[0-9A-Fa-f]{6}\Z")
+        self.assertNotIn("#E4002B", hg)
+        self.assertNotIn("#FF0000", hg)
+
+    def test_motifs_exactly_the_6_menu_keys(self):
+        self.assertEqual(sorted(styling.MOTIFS.keys()), sorted(["dots", "glow", "grid", "none", "rings", "waves"]))
+
+    def test_motifs_non_empty_deterministic_fragments(self):
+        for k in ["glow", "rings", "grid", "waves", "dots"]:
+            frag = styling.MOTIFS[k]()
+            self.assertIsInstance(frag, str)
+            self.assertNotEqual(frag, "")
+            self.assertEqual(frag, styling.MOTIFS[k]())
+
+    def test_motifs_none_returns_empty_string(self):
+        self.assertEqual(styling.MOTIFS["none"](), "")
+
+
+class GradientHeaderTest(unittest.TestCase):
+    def _decode(self, h):
+        url = h["element"][0]["backgroundImage"]["url"]
+        return base64.b64decode(url.replace("data:image/svg+xml;base64,", "")).decode()
+
+    def test_default_glow_right_container_shape(self):
+        h = styling.gradient_header("ghdr", "Command Center")
+        bg = h["element"][0]
+        self.assertEqual(bg["kind"], "container")
+        self.assertEqual(bg["style"], {"borderRadius": "round"})
+        self.assertTrue(bg["backgroundImage"]["url"].startswith("data:image/svg+xml;base64,"))
+        self.assertEqual(bg["backgroundImage"]["style"], {"fit": "cover"})
+        self.assertTrue(any(e["kind"] == "text" and e["id"] == "ghdr-title" for e in h["element"]))
+        self.assertIn("<GridContainer", h["layout"])
+        self.assertIn('elementId="ghdr-title"', h["layout"])
+
+    def test_decoded_svg_carries_gradient_and_requested_motif(self):
+        h = styling.gradient_header("ghdr", "X", motif="rings")
+        svg = self._decode(h)
+        self.assertIn("linearGradient", svg)
+        self.assertIn('<circle r="40"/>', svg)
+        self.assertIn('<g transform="translate(1440,86)">', svg)
+
+    def test_motif_none_has_no_motif_group(self):
+        h = styling.gradient_header("ghdr", "X", motif="none")
+        svg = self._decode(h)
+        self.assertNotIn("<g transform=", svg)
+
+    def test_motif_side_left_translates_to_x_160(self):
+        h = styling.gradient_header("ghdr", "X", motif="rings", motif_side="left")
+        svg = self._decode(h)
+        self.assertIn("translate(160,86)", svg)
+
+    def test_logo_url_present_adds_logo_element_and_split_layout(self):
+        h = styling.gradient_header("ghdr", "X", logo_url="https://example.com/logo.png")
+        self.assertEqual(len(h["element"]), 3)
+        self.assertEqual(h["element"][1], {"id": "ghdr-logo", "kind": "image",
+                                            "url": "https://example.com/logo.png", "style": {"fit": "contain"}})
+        self.assertIn('elementId="ghdr-logo" gridColumn="1 / 3"', h["layout"])
+        self.assertIn('elementId="ghdr-title" gridColumn="3 / 25"', h["layout"])
+
+    def test_no_logo_url_title_spans_full_width(self):
+        h = styling.gradient_header("ghdr", "X")
+        self.assertFalse(any(e["kind"] == "image" for e in h["element"]))
+        self.assertIn('elementId="ghdr-title" gridColumn="1 / 25"', h["layout"])
+
+    def test_subtitle_adds_separate_element_and_split_rows(self):
+        h = styling.gradient_header("ghdr", "X", subtitle="Sub")
+        self.assertEqual(len(h["element"]), 3)
+        self.assertEqual(h["element"][2]["kind"], "text")
+        self.assertEqual(h["element"][2]["id"], "ghdr-subtitle")
+        self.assertIn("Sub", h["element"][2]["body"])
+        self.assertIn('elementId="ghdr-title" gridColumn="1 / 25" gridRow="1 / 3"', h["layout"])
+        self.assertIn('elementId="ghdr-subtitle" gridColumn="1 / 25" gridRow="3 / 4"', h["layout"])
+
+    def test_bring_your_own_http_url_used_verbatim(self):
+        h = styling.gradient_header("ghdr", "X", motif="https://example.com/art.png")
+        self.assertEqual(h["element"][0]["backgroundImage"]["url"], "https://example.com/art.png")
+
+    def test_bring_your_own_data_url_used_verbatim(self):
+        uri = "data:image/png;base64,AAAA"
+        h = styling.gradient_header("ghdr", "X", motif=uri)
+        self.assertEqual(h["element"][0]["backgroundImage"]["url"], uri)
+
+    def test_gradient_wrong_stop_count_raises(self):
+        with self.assertRaises(ValueError):
+            styling.gradient_header("ghdr", "X", gradient=["#111111"])
+
+    def test_no_go_gradient_header_falls_back_to_flat_header(self):
+        surfaces = dict(styling.SURFACES, gradient_header=False)
+        h = styling.gradient_header("ghdr", "X", surfaces=surfaces)
+        expected = styling.header("ghdr", "X", styling.DEFAULT_THEME, surfaces=surfaces)
+        self.assertEqual(h, expected)
+
+    def test_no_go_motif_drops_motif_group_keeps_gradient(self):
+        surfaces = dict(styling.SURFACES, motif=False)
+        h = styling.gradient_header("ghdr", "X", motif="https://example.com/art.png", surfaces=surfaces)
+        bg = h["element"][0]["backgroundImage"]["url"]
+        svg = base64.b64decode(bg.replace("data:image/svg+xml;base64,", "")).decode()
+        self.assertTrue(bg.startswith("data:image/svg+xml;base64,"))
+        self.assertNotIn("<g transform=", svg)
 
 
 if __name__ == "__main__":

--- a/shared/lib/test_styling.py
+++ b/shared/lib/test_styling.py
@@ -289,13 +289,31 @@ class GradientHeaderTest(unittest.TestCase):
         expected = styling.header("ghdr", "X", styling.DEFAULT_THEME, surfaces=surfaces)
         self.assertEqual(h, expected)
 
-    def test_no_go_motif_drops_motif_group_keeps_gradient(self):
+    def test_no_go_motif_menu_key_falls_back_to_plain_gradient(self):
         surfaces = dict(styling.SURFACES, motif=False)
-        h = styling.gradient_header("ghdr", "X", motif="https://example.com/art.png", surfaces=surfaces)
+        h = styling.gradient_header("ghdr", "X", motif="rings", surfaces=surfaces)
         bg = h["element"][0]["backgroundImage"]["url"]
         svg = base64.b64decode(bg.replace("data:image/svg+xml;base64,", "")).decode()
         self.assertTrue(bg.startswith("data:image/svg+xml;base64,"))
+        self.assertIn("linearGradient", svg)
         self.assertNotIn("<g transform=", svg)
+
+    def test_no_go_motif_does_not_suppress_bring_your_own_url(self):
+        surfaces = dict(styling.SURFACES, motif=False)
+        h = styling.gradient_header("ghdr", "X", motif="https://example.com/art.png", surfaces=surfaces)
+        self.assertEqual(h["element"][0]["backgroundImage"]["url"], "https://example.com/art.png")
+
+    def test_motif_side_center_translates_to_x_800_and_is_valid(self):
+        h = styling.gradient_header("ghdr", "X", motif="rings", motif_side="center")
+        svg = self._decode(h)
+        self.assertIn("translate(800,86)", svg)
+        self.assertTrue(any(e["kind"] == "text" and e["id"] == "ghdr-title" for e in h["element"]))
+        self.assertIn("<GridContainer", h["layout"])
+        self.assertIn('elementId="ghdr-title"', h["layout"])
+
+    def test_unrecognized_motif_symbol_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            styling.gradient_header("ghdr", "X", motif="sparkles")
 
 
 if __name__ == "__main__":

--- a/shared/lib/test_styling.py
+++ b/shared/lib/test_styling.py
@@ -337,7 +337,16 @@ class GradientCardSparklineTest(unittest.TestCase):
         self.assertEqual(gc["element"][0]["backgroundImage"]["style"], {"fit": "cover"})
         self.assertEqual(gc["child_layout"],
                           '<LayoutElement elementId="kpi-rev" gridColumn="1 / 25" gridRow="1 / 7"/>')
-        self.assertEqual(gc["patch"], {"value": {"color": "#FFFFFF"}, "name": {"color": "#FFFFFF"}})
+        self.assertEqual(gc["patch"], {"value": {"color": "#FFFFFF"}, "name": {"color": "#FFFFFF"},
+                                        "style": {"backgroundColor": "transparent", "padding": "none"}})
+
+    def test_gradient_card_patch_style_is_transparent_padding_none_for_legibility(self):
+        """Task 6 live-render fix: value/name color alone renders white-on-white
+        because the KPI element keeps its own opaque background. The patch
+        must also carry style.backgroundColor=transparent + style.padding=none
+        so the gradient shows through and the white text is legible."""
+        gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"])
+        self.assertEqual(gc["patch"]["style"], {"backgroundColor": "transparent", "padding": "none"})
 
     def test_gradient_card_decoded_svg_has_gradient_no_motif_group(self):
         gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"])

--- a/shared/lib/test_styling.py
+++ b/shared/lib/test_styling.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import json, os, sys, unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import styling
@@ -91,10 +92,10 @@ class StylingHelpersTest(unittest.TestCase):
         with open(os.path.join(os.path.dirname(__file__), "testdata", "styling_golden.json")) as f:
             self.golden = json.load(f)
 
-    def test_surfaces_all_8_surfaces_are_go(self):
+    def test_surfaces_all_10_surfaces_are_go(self):
         expected = ["categorical_scheme", "chart_color_by", "container_style",
                     "format_string", "kpi_name_color", "typography",
-                    "gradient_header", "motif"]
+                    "gradient_header", "motif", "gradient_card", "sparkline"]
         self.assertEqual(sorted(styling.SURFACES.keys()), sorted(expected))
         self.assertTrue(all(styling.SURFACES.values()))
 
@@ -171,6 +172,8 @@ class StylingHelpersTest(unittest.TestCase):
     def test_helpers_match_styling_golden(self):
         theme = self.theme
         band = {"role": "kpi", "ids": ["k1", "k2", "k3"], "r0": 7, "r1": 13}
+        gc_kpi_el = {"id": "kpi-rev", "kind": "kpi-chart", "name": {"text": "Revenue"},
+                     "value": {"columnId": "rev-cur"}}
         actual = {
             "chart_color_single": styling.chart_color(theme),
             "chart_color_categorical": styling.chart_color(theme, categorical=True),
@@ -187,6 +190,8 @@ class StylingHelpersTest(unittest.TestCase):
                 "ghdr2", "Ops", motif="rings", motif_side="left"),
             "gradient_header_none": styling.gradient_header("ghdr3", "Plain", motif="none"),
             "gradient_header_byo": styling.gradient_header("ghdr4", "Custom", motif="https://example.com/art.png"),
+            "gradient_card": styling.gradient_card("card-1", gc_kpi_el, ["#0F172A", "#2563EB"]),
+            "sparkline": styling.sparkline("spark-rev", "tbl", "[Table/Month]", "Sum([Table/Revenue])"),
         }
         self.assertEqual(json.dumps(_sort(actual)), json.dumps(_sort(self.golden)))
 
@@ -314,6 +319,76 @@ class GradientHeaderTest(unittest.TestCase):
     def test_unrecognized_motif_symbol_raises_value_error(self):
         with self.assertRaises(ValueError):
             styling.gradient_header("ghdr", "X", motif="sparkles")
+
+
+class GradientCardSparklineTest(unittest.TestCase):
+    """WS4 Task 3: styling.gradient_card + styling.sparkline."""
+
+    GC_KPI_EL = {"id": "kpi-rev", "kind": "kpi-chart", "name": {"text": "Revenue"},
+                 "value": {"columnId": "rev-cur"}}
+
+    def test_gradient_card_go_returns_container_child_layout_and_white_patch(self):
+        gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"])
+        self.assertEqual(len(gc["element"]), 1)
+        self.assertEqual(gc["element"][0]["id"], "card-1")
+        self.assertEqual(gc["element"][0]["kind"], "container")
+        self.assertEqual(gc["element"][0]["style"], {"borderRadius": "round"})
+        self.assertTrue(gc["element"][0]["backgroundImage"]["url"].startswith("data:image/svg+xml;base64,"))
+        self.assertEqual(gc["element"][0]["backgroundImage"]["style"], {"fit": "cover"})
+        self.assertEqual(gc["child_layout"],
+                          '<LayoutElement elementId="kpi-rev" gridColumn="1 / 25" gridRow="1 / 7"/>')
+        self.assertEqual(gc["patch"], {"value": {"color": "#FFFFFF"}, "name": {"color": "#FFFFFF"}})
+
+    def test_gradient_card_decoded_svg_has_gradient_no_motif_group(self):
+        gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"])
+        url = gc["element"][0]["backgroundImage"]["url"]
+        svg = base64.b64decode(url.replace("data:image/svg+xml;base64,", "")).decode()
+        self.assertIn("linearGradient", svg)
+        self.assertNotIn("<g transform=", svg)
+
+    def test_gradient_card_does_not_mutate_kpi_element(self):
+        kpi_el = {"id": "kpi-rev2", "kind": "kpi-chart", "name": {"text": "Revenue"},
+                  "value": {"columnId": "rev-cur", "fontSize": 32}}
+        snapshot = copy.deepcopy(kpi_el)
+        styling.gradient_card("card-2", kpi_el, ["#0F172A", "#2563EB"])
+        self.assertEqual(kpi_el, snapshot)
+
+    def test_gradient_card_respects_custom_page_cols(self):
+        gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"], page_cols=12)
+        self.assertEqual(gc["child_layout"],
+                          '<LayoutElement elementId="kpi-rev" gridColumn="1 / 13" gridRow="1 / 7"/>')
+
+    def test_gradient_card_no_go_returns_empty_marker(self):
+        surfaces = dict(styling.SURFACES, gradient_card=False)
+        gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"], surfaces=surfaces)
+        self.assertEqual(gc, {"element": [], "child_layout": "", "patch": {}})
+
+    def test_sparkline_go_returns_borderless_line_chart(self):
+        sp = styling.sparkline("spark-rev", "tbl", "[Table/Month]", "Sum([Table/Revenue])")
+        self.assertEqual(sp["id"], "spark-rev")
+        self.assertEqual(sp["kind"], "line-chart")
+        self.assertEqual(sp["source"], {"kind": "table", "elementId": "tbl"})
+        self.assertEqual(len(sp["columns"]), 2)
+        self.assertEqual(sp["columns"][0]["formula"], "[Table/Month]")
+        self.assertEqual(sp["columns"][0]["format"], {"kind": "datetime", "formatString": "%b %Y"})
+        self.assertEqual(sp["columns"][1]["formula"], "Sum([Table/Revenue])")
+        self.assertEqual(sp["xAxis"]["format"], {"marks": "none", "labels": "hidden"})
+        self.assertEqual(sp["yAxis"]["format"]["labels"], "hidden")
+        self.assertEqual(sp["yAxis"]["format"]["marks"], "none")
+        self.assertEqual(sp["yAxis"]["format"]["scale"], {"type": "linear", "zero": False, "hideZeroLine": True})
+        self.assertEqual(sp["name"], {"visibility": "hidden"})
+        self.assertEqual(sp["legend"], {"visibility": "hidden"})
+        self.assertEqual(sp["lineAreaStyle"], {"interpolation": "monotone"})
+        self.assertEqual(sp["style"], {"backgroundColor": "transparent"})
+
+    def test_sparkline_custom_period_format(self):
+        sp = styling.sparkline("spark-rev", "tbl", "[Table/Month]", "Sum([Table/Revenue])", period_format="%Y-%m")
+        self.assertEqual(sp["columns"][0]["format"], {"kind": "datetime", "formatString": "%Y-%m"})
+
+    def test_sparkline_no_go_returns_opt_in_marker(self):
+        surfaces = dict(styling.SURFACES, sparkline=False)
+        sp = styling.sparkline("spark-rev", "tbl", "[Table/Month]", "Sum([Table/Revenue])", surfaces=surfaces)
+        self.assertEqual(sp, {"opt_in": True, "id": "spark-rev"})
 
 
 if __name__ == "__main__":

--- a/shared/lib/test_styling.py
+++ b/shared/lib/test_styling.py
@@ -379,7 +379,7 @@ class GradientCardSparklineTest(unittest.TestCase):
         self.assertEqual(sp["name"], {"visibility": "hidden"})
         self.assertEqual(sp["legend"], {"visibility": "hidden"})
         self.assertEqual(sp["lineAreaStyle"], {"interpolation": "monotone"})
-        self.assertEqual(sp["style"], {"backgroundColor": "transparent"})
+        self.assertEqual(sp["style"], {"backgroundColor": "transparent", "padding": "none"})
 
     def test_sparkline_custom_period_format(self):
         sp = styling.sparkline("spark-rev", "tbl", "[Table/Month]", "Sum([Table/Revenue])", period_format="%Y-%m")

--- a/shared/lib/test_styling.py
+++ b/shared/lib/test_styling.py
@@ -355,6 +355,27 @@ class GradientCardSparklineTest(unittest.TestCase):
         self.assertIn("linearGradient", svg)
         self.assertNotIn("<g transform=", svg)
 
+    def test_gradient_card_svg_layers_dark_scrim_over_caller_gradient(self):
+        """Task 6 live-render fix, user-reported ("can't see the numbers"): the
+        composed background must be TWO layers -- the caller's gradient rect,
+        THEN a dark scrim rect on top -- so white KPI text stays legible on
+        any gradient, bright or dark."""
+        gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"])
+        url = gc["element"][0]["backgroundImage"]["url"]
+        svg = base64.b64decode(url.replace("data:image/svg+xml;base64,", "")).decode()
+        self.assertIn('id="card-scrim"', svg)
+        self.assertIn('stop-opacity="%s"' % styling.CARD_SCRIM_TOP_OPACITY, svg)
+        self.assertIn('stop-opacity="0"', svg)
+        self.assertEqual(svg.count("<rect "), 2)  # the caller's gradient rect, THEN the scrim rect on top
+
+    def test_gradient_card_gradient_defaults_to_dark_slate_pair_when_omitted(self):
+        gc = styling.gradient_card("card-1", self.GC_KPI_EL)
+        url = gc["element"][0]["backgroundImage"]["url"]
+        svg = base64.b64decode(url.replace("data:image/svg+xml;base64,", "")).decode()
+        default_gradient = styling.DEFAULT_THEME["card_gradient"]
+        self.assertIn(default_gradient[0], svg)
+        self.assertIn(default_gradient[1], svg)
+
     def test_gradient_card_does_not_mutate_kpi_element(self):
         kpi_el = {"id": "kpi-rev2", "kind": "kpi-chart", "name": {"text": "Revenue"},
                   "value": {"columnId": "rev-cur", "fontSize": 32}}

--- a/shared/lib/test_styling.rb
+++ b/shared/lib/test_styling.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # test_styling.rb — run directly: ruby shared/lib/test_styling.rb
 require 'json'
+require 'base64'
 require_relative 'styling'
 require_relative 'composition'
 $failures = 0
@@ -84,8 +85,9 @@ end
 
 # --- Task 3: chart_color, kpi_accent, format_for, header, section_card ---
 
-check('SURFACES: all 6 Task-1 surfaces are GO') do
-  expected = %i[categorical_scheme chart_color_by container_style format_string kpi_name_color typography]
+check('SURFACES: all 8 surfaces (Task-1 six + WS4 gradient_header/motif) are GO') do
+  expected = %i[categorical_scheme chart_color_by container_style format_string kpi_name_color typography
+                gradient_header motif]
   Styling::SURFACES.keys.sort == expected.sort && Styling::SURFACES.values.all? { |v| v == true }
 end
 
@@ -158,6 +160,114 @@ check('section_card: NO-GO container_style returns bare band render, no containe
   sc[:element].nil? && !sc[:wrap].include?('GridContainer') && sc[:wrap].scan('<LayoutElement').length == 2
 end
 
+# --- Task 2: Styling::MOTIFS + Styling.gradient_header ---
+
+check('DEFAULT_THEME[:header_gradient] is a neutral 2-3 stop hex gradient, not red') do
+  hg = Styling::DEFAULT_THEME[:header_gradient]
+  hg.is_a?(Array) && [2, 3].include?(hg.length) && hg.all? { |h| h =~ /\A#[0-9A-Fa-f]{6}\z/ } &&
+    !hg.include?('#E4002B') && !hg.include?('#FF0000')
+end
+
+check('MOTIFS: exactly the 6 menu keys') do
+  Styling::MOTIFS.keys.sort == %i[dots glow grid none rings waves].sort
+end
+
+check('MOTIFS: glow/rings/grid/waves/dots each return a non-empty deterministic SVG fragment') do
+  %i[glow rings grid waves dots].all? do |k|
+    frag = Styling::MOTIFS[k].call
+    frag.is_a?(String) && !frag.empty? && frag == Styling::MOTIFS[k].call
+  end
+end
+check('MOTIFS: :none returns an empty string') do
+  Styling::MOTIFS[:none].call == ''
+end
+
+check('gradient_header (default :glow, :right): container has data-URI SVG backgroundImage + title element + GridContainer layout') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'Command Center')
+  bg = h[:element][0]
+  bg['kind'] == 'container' && bg['style'] == { 'borderRadius' => 'round' } &&
+    bg['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
+    bg['backgroundImage']['style'] == { 'fit' => 'cover' } &&
+    h[:element].any? { |e| e['kind'] == 'text' && e['id'] == 'ghdr-title' } &&
+    h[:layout].include?('<GridContainer') && h[:layout].include?('elementId="ghdr-title"')
+end
+
+check('gradient_header: decoded SVG carries the linearGradient + the requested motif group') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings)
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('linearGradient') && svg.include?('<circle r="40"/>') && svg.include?('<g transform="translate(1440,86)">')
+end
+
+check('gradient_header motif :none: no motif <g> group in the decoded SVG') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :none)
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  !svg.include?('<g transform=')
+end
+
+check('gradient_header motif_side: :left translates the motif group to x=160') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, motif_side: :left)
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('translate(160,86)')
+end
+
+check('gradient_header: logo_url present -> logo element + logo/title split layout (logo col 1/3)') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', logo_url: 'https://example.com/logo.png')
+  h[:element].length == 3 &&
+    h[:element][1] == { 'id' => 'ghdr-logo', 'kind' => 'image', 'url' => 'https://example.com/logo.png',
+                         'style' => { 'fit' => 'contain' } } &&
+    h[:layout].include?('elementId="ghdr-logo" gridColumn="1 / 3"') &&
+    h[:layout].include?('elementId="ghdr-title" gridColumn="3 / 25"')
+end
+
+check('gradient_header: no logo_url -> title spans full width, no logo element') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X')
+  h[:element].none? { |e| e['kind'] == 'image' } &&
+    h[:layout].include?('elementId="ghdr-title" gridColumn="1 / 25"')
+end
+
+check('gradient_header: subtitle -> separate subtitle text element + split layout rows') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', subtitle: 'Sub')
+  h[:element].length == 3 &&
+    h[:element][2]['kind'] == 'text' && h[:element][2]['id'] == 'ghdr-subtitle' &&
+    h[:element][2]['body'].include?('Sub') &&
+    h[:layout].include?('elementId="ghdr-title" gridColumn="1 / 25" gridRow="1 / 3"') &&
+    h[:layout].include?('elementId="ghdr-subtitle" gridColumn="1 / 25" gridRow="3 / 4"')
+end
+
+check('gradient_header: bring-your-own http(s) URL used verbatim, SVG compose skipped') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png')
+  h[:element][0]['backgroundImage']['url'] == 'https://example.com/art.png'
+end
+check('gradient_header: bring-your-own data: URL used verbatim') do
+  uri = 'data:image/png;base64,AAAA'
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: uri)
+  h[:element][0]['backgroundImage']['url'] == uri
+end
+
+check('gradient_header: gradient with != 2-3 stops raises ArgumentError') do
+  begin
+    Styling.gradient_header(id: 'ghdr', title: 'X', gradient: ['#111111'])
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+check('gradient_header: NO-GO gradient_header surface falls back to flat Styling.header output') do
+  surfaces = Styling::SURFACES.merge(gradient_header: false)
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', surfaces: surfaces)
+  expected = Styling.header(id: 'ghdr', title: 'X', theme: Styling::DEFAULT_THEME, surfaces: surfaces)
+  h == expected
+end
+
+check('gradient_header: NO-GO motif surface (gradient_header still GO) drops the motif group, keeps the gradient') do
+  surfaces = Styling::SURFACES.merge(motif: false)
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png', surfaces: surfaces)
+  bg = h[:element][0]['backgroundImage']['url']
+  svg = Base64.decode64(bg.sub('data:image/svg+xml;base64,', ''))
+  bg.start_with?('data:image/svg+xml;base64,') && !svg.include?('<g transform=')
+end
+
 golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'styling_golden.json')))
 check('helpers match styling_golden.json (sorted-key identical)') do
   theme = Styling::DEFAULT_THEME
@@ -171,7 +281,12 @@ check('helpers match styling_golden.json (sorted-key identical)') do
     'format_for_percent' => Styling.format_for(:percent),
     'format_for_decimal' => Styling.format_for(:decimal),
     'header' => Styling.header(id: 'hdr', title: 'Dashboard', theme: theme),
-    'section_card' => Styling.section_card(id: 'card-1', band: band, theme: theme)
+    'section_card' => Styling.section_card(id: 'card-1', band: band, theme: theme),
+    'gradient_header_glow' => Styling.gradient_header(id: 'ghdr', title: 'Command Center', subtitle: 'Live metrics',
+                                                        logo_url: 'https://example.com/logo.png'),
+    'gradient_header_rings_left' => Styling.gradient_header(id: 'ghdr2', title: 'Ops', motif: :rings, motif_side: :left),
+    'gradient_header_none' => Styling.gradient_header(id: 'ghdr3', title: 'Plain', motif: :none),
+    'gradient_header_byo' => Styling.gradient_header(id: 'ghdr4', title: 'Custom', motif: 'https://example.com/art.png')
   }
   JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))
 end

--- a/shared/lib/test_styling.rb
+++ b/shared/lib/test_styling.rb
@@ -85,9 +85,9 @@ end
 
 # --- Task 3: chart_color, kpi_accent, format_for, header, section_card ---
 
-check('SURFACES: all 8 surfaces (Task-1 six + WS4 gradient_header/motif) are GO') do
+check('SURFACES: all 10 surfaces (Task-1 six + WS4 gradient_header/motif/gradient_card/sparkline) are GO') do
   expected = %i[categorical_scheme chart_color_by container_style format_string kpi_name_color typography
-                gradient_header motif]
+                gradient_header motif gradient_card sparkline]
   Styling::SURFACES.keys.sort == expected.sort && Styling::SURFACES.values.all? { |v| v == true }
 end
 
@@ -291,6 +291,77 @@ check('gradient_header: unrecognized motif symbol raises ArgumentError') do
   end
 end
 
+# --- Task 3: Styling.gradient_card + Styling.sparkline ---
+
+GC_KPI_EL = { 'id' => 'kpi-rev', 'kind' => 'kpi-chart', 'name' => { 'text' => 'Revenue' },
+              'value' => { 'columnId' => 'rev-cur' } }.freeze
+
+check('gradient_card: GO returns a gradient container + child_layout positioning the kpi + a white-text patch') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
+  gc[:element].length == 1 &&
+    gc[:element][0]['id'] == 'card-1' && gc[:element][0]['kind'] == 'container' &&
+    gc[:element][0]['style'] == { 'borderRadius' => 'round' } &&
+    gc[:element][0]['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
+    gc[:element][0]['backgroundImage']['style'] == { 'fit' => 'cover' } &&
+    gc[:child_layout] == '<LayoutElement elementId="kpi-rev" gridColumn="1 / 25" gridRow="1 / 7"/>' &&
+    gc[:patch] == { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' } }
+end
+
+check('gradient_card: decoded SVG carries the linearGradient stops (motif: :none -- no motif group)') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('linearGradient') && !svg.include?('<g transform=')
+end
+
+check('gradient_card: does NOT mutate the passed kpi_element hash') do
+  kpi_el = { 'id' => 'kpi-rev2', 'kind' => 'kpi-chart', 'name' => { 'text' => 'Revenue' },
+             'value' => { 'columnId' => 'rev-cur', 'fontSize' => 32 } }
+  snapshot = Marshal.load(Marshal.dump(kpi_el))
+  Styling.gradient_card(id: 'card-2', kpi_element: kpi_el, gradient: %w[#0F172A #2563EB])
+  kpi_el == snapshot
+end
+
+check('gradient_card: respects a custom page_cols in child_layout gridColumn span') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB], page_cols: 12)
+  gc[:child_layout] == '<LayoutElement elementId="kpi-rev" gridColumn="1 / 13" gridRow="1 / 7"/>'
+end
+
+check('gradient_card: NO-GO gradient_card surface -> empty element/child_layout/patch, no crash') do
+  surfaces = Styling::SURFACES.merge(gradient_card: false)
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB], surfaces: surfaces)
+  gc == { element: [], child_layout: '', patch: {} }
+end
+
+check('sparkline: GO returns a borderless line-chart with hidden axes/legend/name + transparent bg + datetime format') do
+  sp = Styling.sparkline(id: 'spark-rev', source_element_id: 'tbl', period_ref: '[Table/Month]',
+                          value_formula: 'Sum([Table/Revenue])')
+  sp['id'] == 'spark-rev' && sp['kind'] == 'line-chart' &&
+    sp['source'] == { 'kind' => 'table', 'elementId' => 'tbl' } &&
+    sp['columns'].length == 2 &&
+    sp['columns'][0]['formula'] == '[Table/Month]' &&
+    sp['columns'][0]['format'] == { 'kind' => 'datetime', 'formatString' => '%b %Y' } &&
+    sp['columns'][1]['formula'] == 'Sum([Table/Revenue])' &&
+    sp['xAxis']['format'] == { 'marks' => 'none', 'labels' => 'hidden' } &&
+    sp['yAxis']['format']['labels'] == 'hidden' && sp['yAxis']['format']['marks'] == 'none' &&
+    sp['yAxis']['format']['scale'] == { 'type' => 'linear', 'zero' => false, 'hideZeroLine' => true } &&
+    sp['name'] == { 'visibility' => 'hidden' } && sp['legend'] == { 'visibility' => 'hidden' } &&
+    sp['lineAreaStyle'] == { 'interpolation' => 'monotone' } &&
+    sp['style'] == { 'backgroundColor' => 'transparent' }
+end
+
+check('sparkline: custom period_format flows into the period column format') do
+  sp = Styling.sparkline(id: 'spark-rev', source_element_id: 'tbl', period_ref: '[Table/Month]',
+                          value_formula: 'Sum([Table/Revenue])', period_format: '%Y-%m')
+  sp['columns'][0]['format'] == { 'kind' => 'datetime', 'formatString' => '%Y-%m' }
+end
+
+check('sparkline: NO-GO sparkline surface -> opt_in marker, never a broken chart shape') do
+  surfaces = Styling::SURFACES.merge(sparkline: false)
+  sp = Styling.sparkline(id: 'spark-rev', source_element_id: 'tbl', period_ref: '[Table/Month]',
+                          value_formula: 'Sum([Table/Revenue])', surfaces: surfaces)
+  sp == { 'opt_in' => true, 'id' => 'spark-rev' }
+end
+
 golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'styling_golden.json')))
 check('helpers match styling_golden.json (sorted-key identical)') do
   theme = Styling::DEFAULT_THEME
@@ -309,7 +380,10 @@ check('helpers match styling_golden.json (sorted-key identical)') do
                                                         logo_url: 'https://example.com/logo.png'),
     'gradient_header_rings_left' => Styling.gradient_header(id: 'ghdr2', title: 'Ops', motif: :rings, motif_side: :left),
     'gradient_header_none' => Styling.gradient_header(id: 'ghdr3', title: 'Plain', motif: :none),
-    'gradient_header_byo' => Styling.gradient_header(id: 'ghdr4', title: 'Custom', motif: 'https://example.com/art.png')
+    'gradient_header_byo' => Styling.gradient_header(id: 'ghdr4', title: 'Custom', motif: 'https://example.com/art.png'),
+    'gradient_card' => Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB]),
+    'sparkline' => Styling.sparkline(id: 'spark-rev', source_element_id: 'tbl', period_ref: '[Table/Month]',
+                                      value_formula: 'Sum([Table/Revenue])')
   }
   JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))
 end

--- a/shared/lib/test_styling.rb
+++ b/shared/lib/test_styling.rb
@@ -304,7 +304,13 @@ check('gradient_card: GO returns a gradient container + child_layout positioning
     gc[:element][0]['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
     gc[:element][0]['backgroundImage']['style'] == { 'fit' => 'cover' } &&
     gc[:child_layout] == '<LayoutElement elementId="kpi-rev" gridColumn="1 / 25" gridRow="1 / 7"/>' &&
-    gc[:patch] == { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' } }
+    gc[:patch] == { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' },
+                    'style' => { 'backgroundColor' => 'transparent', 'padding' => 'none' } }
+end
+
+check('gradient_card: patch style makes the KPI transparent + padding:none so white text is legible on the gradient (Task 6 live-render fix)') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
+  gc[:patch]['style'] == { 'backgroundColor' => 'transparent', 'padding' => 'none' }
 end
 
 check('gradient_card: decoded SVG carries the linearGradient stops (motif: :none -- no motif group)') do

--- a/shared/lib/test_styling.rb
+++ b/shared/lib/test_styling.rb
@@ -346,7 +346,7 @@ check('sparkline: GO returns a borderless line-chart with hidden axes/legend/nam
     sp['yAxis']['format']['scale'] == { 'type' => 'linear', 'zero' => false, 'hideZeroLine' => true } &&
     sp['name'] == { 'visibility' => 'hidden' } && sp['legend'] == { 'visibility' => 'hidden' } &&
     sp['lineAreaStyle'] == { 'interpolation' => 'monotone' } &&
-    sp['style'] == { 'backgroundColor' => 'transparent' }
+    sp['style'] == { 'backgroundColor' => 'transparent', 'padding' => 'none' }
 end
 
 check('sparkline: custom period_format flows into the period column format') do

--- a/shared/lib/test_styling.rb
+++ b/shared/lib/test_styling.rb
@@ -260,12 +260,35 @@ check('gradient_header: NO-GO gradient_header surface falls back to flat Styling
   h == expected
 end
 
-check('gradient_header: NO-GO motif surface (gradient_header still GO) drops the motif group, keeps the gradient') do
+check('gradient_header: NO-GO motif surface + menu-key motif falls back to the plain gradient (:none)') do
   surfaces = Styling::SURFACES.merge(motif: false)
-  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png', surfaces: surfaces)
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, surfaces: surfaces)
   bg = h[:element][0]['backgroundImage']['url']
   svg = Base64.decode64(bg.sub('data:image/svg+xml;base64,', ''))
-  bg.start_with?('data:image/svg+xml;base64,') && !svg.include?('<g transform=')
+  bg.start_with?('data:image/svg+xml;base64,') && svg.include?('linearGradient') && !svg.include?('<g transform=')
+end
+
+check('gradient_header: NO-GO motif surface does NOT suppress a bring-your-own URL (honored verbatim)') do
+  surfaces = Styling::SURFACES.merge(motif: false)
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png', surfaces: surfaces)
+  h[:element][0]['backgroundImage']['url'] == 'https://example.com/art.png'
+end
+
+check('gradient_header motif_side: :center translates the motif group to x=800 and produces a valid header') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, motif_side: :center)
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('translate(800,86)') &&
+    h[:element].any? { |e| e['kind'] == 'text' && e['id'] == 'ghdr-title' } &&
+    h[:layout].include?('<GridContainer') && h[:layout].include?('elementId="ghdr-title"')
+end
+
+check('gradient_header: unrecognized motif symbol raises ArgumentError') do
+  begin
+    Styling.gradient_header(id: 'ghdr', title: 'X', motif: :sparkles)
+    false
+  rescue ArgumentError
+    true
+  end
 end
 
 golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'styling_golden.json')))

--- a/shared/lib/test_styling.rb
+++ b/shared/lib/test_styling.rb
@@ -319,6 +319,23 @@ check('gradient_card: decoded SVG carries the linearGradient stops (motif: :none
   svg.include?('linearGradient') && !svg.include?('<g transform=')
 end
 
+check('gradient_card: composed SVG layers a dark scrim (id="card-scrim") over the caller gradient so white ' \
+      'KPI text stays legible on any gradient, bright or dark (Task 6 live-render fix, user-reported)') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('id="card-scrim"') &&
+    svg.include?("stop-opacity=\"#{Styling::CARD_SCRIM_TOP_OPACITY}\"") &&
+    svg.include?('stop-opacity="0"') &&
+    svg.scan('<rect ').length == 2 # the caller's gradient rect, THEN the scrim rect on top
+end
+
+check('gradient_card: gradient: can be omitted -- defaults to DEFAULT_THEME[:card_gradient] (a dark slate pair)') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL)
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  default_gradient = Styling::DEFAULT_THEME[:card_gradient]
+  svg.include?(default_gradient[0]) && svg.include?(default_gradient[1])
+end
+
 check('gradient_card: does NOT mutate the passed kpi_element hash') do
   kpi_el = { 'id' => 'kpi-rev2', 'kind' => 'kpi-chart', 'name' => { 'text' => 'Revenue' },
              'value' => { 'columnId' => 'rev-cur', 'fontSize' => 32 } }

--- a/shared/lib/testdata/actions_golden.json
+++ b/shared/lib/testdata/actions_golden.json
@@ -1,0 +1,122 @@
+{
+  "button": {
+    "id": "btn-log",
+    "kind": "button",
+    "text": "Log note",
+    "appearance": "filled",
+    "actions": [
+      {
+        "id": "a-btn-log",
+        "trigger": "on-click",
+        "effects": [
+          {
+            "effect": "insert-rows",
+            "table": "annotations",
+            "values": {
+              "an-note": {
+                "type": "control",
+                "control": "NoteCtl"
+              }
+            }
+          },
+          {
+            "effect": "clear-control",
+            "scope": {
+              "type": "page",
+              "page": "pg"
+            },
+            "usePublishedValue": true
+          }
+        ]
+      }
+    ]
+  },
+  "input_table_empty": {
+    "id": "annotations",
+    "kind": "input-table",
+    "inputMode": "edit",
+    "source": {
+      "kind": "empty",
+      "connectionId": "write-conn-1"
+    },
+    "columns": [
+      {
+        "id": "an-note",
+        "type": "text",
+        "name": "Review note"
+      },
+      {
+        "id": "CREATED_AT"
+      },
+      {
+        "id": "CREATED_BY"
+      }
+    ],
+    "name": {
+      "text": "Review log (append-only)",
+      "fontWeight": "bold",
+      "fontSize": 15,
+      "color": "#1A1A1A"
+    }
+  },
+  "input_table_linked": {
+    "id": "targets",
+    "kind": "input-table",
+    "inputMode": "edit",
+    "source": {
+      "kind": "linked",
+      "from": "fam-pivot",
+      "connectionId": "write-conn-1"
+    },
+    "columns": [
+      {
+        "id": "tg-fam",
+        "key": "fp-fam"
+      },
+      {
+        "id": "tg-actual",
+        "key": "fp-rev",
+        "name": "Actual Revenue"
+      },
+      {
+        "id": "tg-target",
+        "type": "number",
+        "name": "Target Revenue"
+      },
+      {
+        "id": "tg-var",
+        "name": "Variance vs Target",
+        "formula": "[Actual Revenue] - [Target Revenue]"
+      }
+    ]
+  },
+  "insert_rows_effect": {
+    "effect": "insert-rows",
+    "table": "annotations",
+    "values": {
+      "an-note": {
+        "type": "control",
+        "control": "NoteCtl"
+      }
+    }
+  },
+  "clear_control_effect": {
+    "effect": "clear-control",
+    "scope": {
+      "type": "page",
+      "page": "pg"
+    },
+    "usePublishedValue": true
+  },
+  "set_control_value_effect": {
+    "effect": "set-control-value",
+    "control": "RegionF",
+    "value": {
+      "type": "constant",
+      "value": {
+        "type": "text",
+        "value": "West"
+      }
+    }
+  }
+}

--- a/shared/lib/testdata/richness_golden.json
+++ b/shared/lib/testdata/richness_golden.json
@@ -1,4 +1,45 @@
 {
+  "agent": {
+    "id": "ag-1",
+    "name": "Analyst",
+    "instructions": "Be a helpful retail analyst.",
+    "dataSources": [
+      {
+        "kind": "table",
+        "elementId": "src"
+      }
+    ]
+  },
+  "agent_with_tools": {
+    "id": "ag-2",
+    "name": "Assistant",
+    "instructions": "Act on my behalf.",
+    "dataSources": [
+      {
+        "kind": "table",
+        "elementId": "src"
+      }
+    ],
+    "tools": [
+      {
+        "toolId": "t-log-note",
+        "kind": "action",
+        "name": "Log note",
+        "description": "Insert a review note.",
+        "steps": [
+          {
+            "kind": "effect",
+            "effect": "insert-rows",
+            "table": "annotations",
+            "value": {
+              "type": "agent-input",
+              "inputName": "note"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "ai_insight": {
     "body": "{{ Replace(CallText(\"SNOWFLAKE.CORTEX.COMPLETE\", \"llama3.1-8b\", \"Summarize revenue trends for the period.\") , '\"', \"\") }}",
     "id": "ai-rev",
@@ -8,6 +49,11 @@
     "body": "{{ Replace(CallText(\"SNOWFLAKE.CORTEX.COMPLETE\", \"mistral-large2\", \"Say one nice thing about the data.\") , '\"', \"\") }}",
     "id": "ai-rev2",
     "kind": "text"
+  },
+  "chat": {
+    "id": "chat-1",
+    "kind": "chat",
+    "agentId": "ag-1"
   },
   "filter_row": [
     {

--- a/shared/lib/testdata/styling_golden.json
+++ b/shared/lib/testdata/styling_golden.json
@@ -35,6 +35,116 @@
     "formatString": ".1%",
     "kind": "number"
   },
+  "gradient_header_byo": {
+    "element": [
+      {
+        "id": "ghdr4-bg",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "https://example.com/art.png",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      },
+      {
+        "id": "ghdr4-title",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "# <span style=\"color: #FFFFFF\">Custom</span>"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"ghdr4-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ghdr4-title\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n</GridContainer>"
+  },
+  "gradient_header_glow": {
+    "element": [
+      {
+        "id": "ghdr-bg",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNDQwLDg2KSI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJtb3RpZi1nbG93IiBjeD0iMC41IiBjeT0iMC41IiByPSIwLjYiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI0ZGRkZGRiIgc3RvcC1vcGFjaXR5PSIwLjIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNGRkZGRkYiIHN0b3Atb3BhY2l0eT0iMCIvPjwvcmFkaWFsR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9Ii0yNjAiIHk9Ii0xMDUiIHdpZHRoPSI1MjAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI21vdGlmLWdsb3cpIi8+PC9nPjwvc3ZnPg==",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      },
+      {
+        "id": "ghdr-logo",
+        "kind": "image",
+        "url": "https://example.com/logo.png",
+        "style": {
+          "fit": "contain"
+        }
+      },
+      {
+        "id": "ghdr-title",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "# <span style=\"color: #FFFFFF\">Command Center</span>"
+      },
+      {
+        "id": "ghdr-subtitle",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "<span style=\"color: #CBD5E1\">Live metrics</span>"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"ghdr-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ghdr-logo\" gridColumn=\"1 / 3\" gridRow=\"1 / 4\"/>\n  <LayoutElement elementId=\"ghdr-title\" gridColumn=\"3 / 25\" gridRow=\"1 / 3\"/>\n  <LayoutElement elementId=\"ghdr-subtitle\" gridColumn=\"3 / 25\" gridRow=\"3 / 4\"/>\n</GridContainer>"
+  },
+  "gradient_header_none": {
+    "element": [
+      {
+        "id": "ghdr3-bg",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48L3N2Zz4=",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      },
+      {
+        "id": "ghdr3-title",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "# <span style=\"color: #FFFFFF\">Plain</span>"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"ghdr3-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ghdr3-title\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n</GridContainer>"
+  },
+  "gradient_header_rings_left": {
+    "element": [
+      {
+        "id": "ghdr2-bg",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjAsODYpIj48ZyBmaWxsPSJub25lIiBzdHJva2U9IiNGRkZGRkYiIHN0cm9rZS1vcGFjaXR5PSIwLjEyIiBzdHJva2Utd2lkdGg9IjEuNCI+PGNpcmNsZSByPSI0MCIvPjxjaXJjbGUgcj0iNzQiLz48Y2lyY2xlIHI9IjEwOCIvPjxsaW5lIHgxPSItMTMwIiB5MT0iMCIgeDI9IjEzMCIgeTI9IjAiLz48bGluZSB4MT0iMCIgeTE9Ii0xMzAiIHgyPSIwIiB5Mj0iMTMwIi8+PC9nPjwvZz48L3N2Zz4=",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      },
+      {
+        "id": "ghdr2-title",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "# <span style=\"color: #FFFFFF\">Ops</span>"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"ghdr2-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ghdr2-title\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n</GridContainer>"
+  },
   "header": {
     "element": [
       {

--- a/shared/lib/testdata/styling_golden.json
+++ b/shared/lib/testdata/styling_golden.json
@@ -259,7 +259,8 @@
       "interpolation": "monotone"
     },
     "style": {
-      "backgroundColor": "transparent"
+      "backgroundColor": "transparent",
+      "padding": "none"
     }
   }
 }

--- a/shared/lib/testdata/styling_golden.json
+++ b/shared/lib/testdata/styling_golden.json
@@ -44,7 +44,7 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNTYzRUIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYwMCIgaGVpZ2h0PSIyMTAiIGZpbGw9InVybCgjaGcpIi8+PC9zdmc+",
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iY2ciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNTYzRUIiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iY2FyZC1zY3JpbSIgeDE9IjAiIHkxPSIwIiB4Mj0iMCIgeTI9IjEiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzAwMDAwMCIgc3RvcC1vcGFjaXR5PSIwLjU1Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDAwMDAwIiBzdG9wLW9wYWNpdHk9IjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYwMCIgaGVpZ2h0PSIyMTAiIGZpbGw9InVybCgjY2cpIi8+PHJlY3Qgd2lkdGg9IjE2MDAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI2NhcmQtc2NyaW0pIi8+PC9zdmc+",
           "style": {
             "fit": "cover"
           }

--- a/shared/lib/testdata/styling_golden.json
+++ b/shared/lib/testdata/styling_golden.json
@@ -35,6 +35,32 @@
     "formatString": ".1%",
     "kind": "number"
   },
+  "gradient_card": {
+    "element": [
+      {
+        "id": "card-1",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNTYzRUIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYwMCIgaGVpZ2h0PSIyMTAiIGZpbGw9InVybCgjaGcpIi8+PC9zdmc+",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      }
+    ],
+    "child_layout": "<LayoutElement elementId=\"kpi-rev\" gridColumn=\"1 / 25\" gridRow=\"1 / 7\"/>",
+    "patch": {
+      "value": {
+        "color": "#FFFFFF"
+      },
+      "name": {
+        "color": "#FFFFFF"
+      }
+    }
+  },
   "gradient_header_byo": {
     "element": [
       {
@@ -178,5 +204,62 @@
       }
     },
     "wrap": "<GridContainer elementId=\"card-1\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"7 / 13\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"k1\" gridColumn=\"1 / 9\" gridRow=\"1 / 7\"/>\n  <LayoutElement elementId=\"k2\" gridColumn=\"9 / 17\" gridRow=\"1 / 7\"/>\n  <LayoutElement elementId=\"k3\" gridColumn=\"17 / 25\" gridRow=\"1 / 7\"/>\n</GridContainer>"
+  },
+  "sparkline": {
+    "id": "spark-rev",
+    "kind": "line-chart",
+    "source": {
+      "kind": "table",
+      "elementId": "tbl"
+    },
+    "columns": [
+      {
+        "id": "spark-rev-period",
+        "formula": "[Table/Month]",
+        "name": "Period",
+        "format": {
+          "kind": "datetime",
+          "formatString": "%b %Y"
+        }
+      },
+      {
+        "id": "spark-rev-value",
+        "formula": "Sum([Table/Revenue])",
+        "name": "Value"
+      }
+    ],
+    "xAxis": {
+      "columnId": "spark-rev-period",
+      "format": {
+        "marks": "none",
+        "labels": "hidden"
+      }
+    },
+    "yAxis": {
+      "columnIds": [
+        "spark-rev-value"
+      ],
+      "format": {
+        "labels": "hidden",
+        "marks": "none",
+        "scale": {
+          "type": "linear",
+          "zero": false,
+          "hideZeroLine": true
+        }
+      }
+    },
+    "name": {
+      "visibility": "hidden"
+    },
+    "legend": {
+      "visibility": "hidden"
+    },
+    "lineAreaStyle": {
+      "interpolation": "monotone"
+    },
+    "style": {
+      "backgroundColor": "transparent"
+    }
   }
 }

--- a/shared/lib/testdata/styling_golden.json
+++ b/shared/lib/testdata/styling_golden.json
@@ -58,6 +58,10 @@
       },
       "name": {
         "color": "#FFFFFF"
+      },
+      "style": {
+        "backgroundColor": "transparent",
+        "padding": "none"
       }
     }
   },

--- a/shared/scripts/verify-ws4-e2e.rb
+++ b/shared/scripts/verify-ws4-e2e.rb
@@ -266,6 +266,11 @@ def build_gradient_kpi(id:, title:, cur_formula:, pri_formula:, fmt_sym:, gradie
   patched_card = JSON.parse(JSON.generate(card)) # deep copy, never mutate `card`
   patched_card['value'] = patched_card['value'].merge(gc[:patch]['value'])
   patched_card['name']  = patched_card['name'].merge(gc[:patch]['name'])
+  # Task 6 fix: gradient_card's patch also carries 'style' (backgroundColor:
+  # transparent, padding: none) so the KPI sits transparently on the gradient
+  # card behind it -- without this the white value/name text renders
+  # white-on-white against the KPI's own opaque background.
+  patched_card['style'] = (patched_card['style'] || {}).merge(gc[:patch]['style'] || {})
 
   spark = Styling.sparkline(id: "#{id}-spark", source_element_id: SRC_ID,
                              period_ref: 'DateTrunc("month",[Src/Date])',

--- a/shared/scripts/verify-ws4-e2e.rb
+++ b/shared/scripts/verify-ws4-e2e.rb
@@ -62,6 +62,7 @@ require 'time'
 require 'base64'
 require 'fileutils'
 require 'shellwords'
+require 'tmpdir'
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'sigma_rest'
@@ -475,7 +476,7 @@ end
 # Main
 # ---------------------------------------------------------------------------
 
-SCRATCH = ENV.fetch('SCRATCH_DIR', '/private/tmp/claude-502/-Users-tjwells/0fd12afc-2738-4328-a4d5-67e7ce57b185/scratchpad')
+SCRATCH = ENV.fetch('SCRATCH_DIR', Dir.tmpdir)
 FileUtils.mkdir_p(SCRATCH)
 
 verdict = { probe_completed: false }

--- a/shared/scripts/verify-ws4-e2e.rb
+++ b/shared/scripts/verify-ws4-e2e.rb
@@ -1,0 +1,638 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-ws4-e2e.rb — LIVE GO/NO-GO probe for WS4 (docs/superpowers/specs/
+# 2026-07-29-ws4-agent-gradient-actions-design.md, Task 6). Creds-gated: needs
+# a live Sigma org + a read connection + a write-enabled connection, so it is
+# NOT part of the offline CI corpus (same class as
+# verify-richness-surfaces-e2e.rb / verify-styling-surfaces-e2e.rb, which this
+# script mirrors structurally — home-folder/schemaVersion resolution, the
+# POST/PUT-spec YAML-or-JSON response parse, and the sigma-export-png.py
+# render helper are all copied from those, not re-derived).
+#
+# UNLIKE the richness/styling probes, this script builds its workbook ENTIRELY
+# from the shared-lib helpers under test (Richness.agent/chat,
+# Styling.gradient_header/gradient_card/sparkline, Actions.*, plus the
+# already-shipped KpiCard.build) — it never hand-inlines a shape those
+# helpers already emit. The reference build this mirrors is
+# scratchpad/build-plugs-command-center.rb (a real Plugs-data command center
+# using the same helpers pre-refactor); this probe is deliberately generic
+# (no product/company theming) since it is a shared-lib regression gate, not
+# a demo.
+#
+# THE SURFACES UNDER TEST (one workbook, four pages):
+#   pg-main    — Styling.gradient_header (:glow motif, the "hero" case) +
+#                two comparative KPI cards (KpiCard.build) each wrapped in
+#                Styling.gradient_card + a Styling.sparkline underneath +
+#                Richness.agent/chat (a read-only analyst + its chat rail).
+#   pg-actions — Styling.gradient_header (:rings motif, a second live motif
+#                in a real page-header context) + Actions.input_table_empty
+#                (an append-only review log) + Actions.input_table_linked
+#                (write-back category targets, keyed off a read-only pivot on
+#                the DIFFERENT read connection) + an entry text-area control
+#                + three Actions.button instances, one per verified effect
+#                (insert_rows_effect / clear_control_effect /
+#                set_control_value_effect).
+#   pg-motifs  — a small side-by-side gallery: Styling::MOTIFS :glow and
+#                :rings again (smaller, for a direct visual A/B) plus ONE
+#                bring-your-own image (a caller-supplied data: URI SVG passed
+#                verbatim as `motif:`, per gradient_header's documented
+#                bring-your-own path — this is NOT a MOTIFS library key, it
+#                REPLACES the whole gradient+motif background).
+#   pg-data    — hidden; the source table + the read-only category pivot that
+#                feeds the linked input table.
+#
+# Usage:  ruby shared/scripts/verify-ws4-e2e.rb
+# Env (ALL from ENV; this script NEVER hardcodes a connection/org/workbook id
+# — the hygiene-sweep gate blocks literal test-org ids in tracked files):
+#   SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET (or SIGMA_API_TOKEN,
+#     or ~/.sigma-migration/env — sigma_rest.rb self-bootstraps from there).
+#   SIGMA_TEST_CONNECTION_ID  — a READ connection (source table's warehouse).
+#   SIGMA_WRITE_CONNECTION_ID — a write-enabled connection (input tables).
+# Missing creds OR either connection id ⇒ this script SKIPS cleanly (exit 0,
+# a clear "SKIP:" message), never a faked pass.
+# Exit: 0 = the probe ran to completion (POST + readback + render all
+#   attempted; per-surface structural verdicts printed — visual confirmation
+#   of the render is the calling agent's job, same discipline as the other
+#   verify-*-e2e.rb scripts) OR a clean SKIP. 1 = the probe itself could not
+#   complete (e.g. the workbook never POSTed) — a hard failure, never green.
+
+require 'json'
+require 'time'
+require 'base64'
+require 'fileutils'
+require 'shellwords'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'sigma_rest'
+require 'kpi_card'
+require 'richness'
+require 'styling'
+require 'actions'
+
+def log(msg)
+  $stderr.puts("[verify-ws4-e2e] #{msg}")
+end
+
+def skip!(msg)
+  puts "SKIP: #{msg}"
+  log "SKIP: #{msg}"
+  exit 0
+end
+
+# --- creds + ENV gate (never hardcode; skip cleanly, never fake a pass) -----
+unless ENV['SIGMA_BASE_URL'].to_s != '' &&
+       (ENV['SIGMA_API_TOKEN'].to_s != '' || (ENV['SIGMA_CLIENT_ID'].to_s != '' && ENV['SIGMA_CLIENT_SECRET'].to_s != ''))
+  skip!('no Sigma credentials in ENV or ~/.sigma-migration/env — set SIGMA_BASE_URL + ' \
+        'SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (or SIGMA_API_TOKEN) to run this live probe.')
+end
+
+CONNECTION_ID = ENV['SIGMA_TEST_CONNECTION_ID'].to_s
+WRITE_CONNECTION_ID = ENV['SIGMA_WRITE_CONNECTION_ID'].to_s
+if CONNECTION_ID.empty? || WRITE_CONNECTION_ID.empty?
+  skip!('SIGMA_TEST_CONNECTION_ID and/or SIGMA_WRITE_CONNECTION_ID not set in ENV — this probe ' \
+        'never hardcodes connection ids (hygiene-sweep gate); export both (a read connection and a ' \
+        'write-enabled connection) and re-run.')
+end
+
+RUN_TAG = Time.now.utc.strftime('%Y%m%dT%H%M%SZ')
+
+PG_MAIN    = 'pg-main'
+PG_ACTIONS = 'pg-actions'
+PG_MOTIFS  = 'pg-motifs'
+PG_DATA    = 'pg-data'
+
+SRC_ID  = 'src'
+CAT_PIVOT_ID = 'cat-pivot'
+
+NOTE_CTL_ID     = 'note-ctl'
+NOTE_CTL_HANDLE = 'NoteCtl'
+
+# Generic synthetic demo data (region/category/revenue/orders/margin + a real
+# DATE column, 90 consecutive days) — no customer/personal/company names, same
+# shape discipline as verify-richness-surfaces-e2e.rb's DEMO_SQL. Two regions x
+# two categories gives the KPI/pivot/linked-table surfaces genuine grouping
+# structure to work with.
+DEMO_SQL = <<~SQL.strip
+  WITH RECURSIVE seq(i) AS (
+    SELECT 0
+    UNION ALL
+    SELECT i + 1 FROM seq WHERE i < 89
+  ),
+  days AS (
+    SELECT DATEADD(day, i, DATE '2026-01-01') AS d, i FROM seq
+  ),
+  dims AS (
+    SELECT * FROM (VALUES
+      ('North', 'Widgets',  1.00),
+      ('South', 'Widgets',  0.80),
+      ('North', 'Gadgets',  0.60),
+      ('South', 'Gadgets',  0.50)
+    ) AS t(region, category, mult)
+  )
+  SELECT
+    days.d AS date,
+    dims.region,
+    dims.category,
+    ROUND((800 + MOD(days.i, 30) * 30 + days.i * 3) * dims.mult, 2) AS revenue,
+    (20 + MOD(days.i, 15)) AS orders,
+    ROUND(0.15 + MOD(days.i, 10) * 0.01, 2) AS margin
+  FROM days CROSS JOIN dims
+SQL
+
+ALIASES = %w[date region category revenue orders margin].freeze
+DISPLAY = { 'date' => 'Date', 'region' => 'Region', 'category' => 'Category',
+            'revenue' => 'Revenue', 'orders' => 'Orders', 'margin' => 'Margin' }.freeze
+
+# Comparative period predicates — anchor "current" on the latest COMPLETE
+# month (Max month - 1), not the max month itself (which may be a partial
+# month in real data); mirrors build-plugs-command-center.rb's MREF/CUR/PRI.
+MREF = 'DateAdd("month",-1,DateTrunc("month",Max([Src/Date])))'
+CUR = lambda { |expr| "If(DateTrunc(\"month\",[Src/Date]) = #{MREF}, #{expr}, Null)" }
+PRI = lambda { |expr| "If(DateTrunc(\"month\",[Src/Date]) = DateAdd(\"month\",-1,#{MREF}), #{expr}, Null)" }
+
+# One professional gradient per KPI card (distinct, non-red, matching
+# Styling::DEFAULT_THEME[:header_gradient]'s "not red" discipline).
+GRADIENTS = {
+  'k-rev' => %w[#0F172A #2563EB],
+  'k-ord' => %w[#134E4A #14B8A6]
+}.freeze
+
+# A bring-your-own header background (WS4 design doc: a String motif starting
+# http/data: is used VERBATIM as the whole background — gradient_header skips
+# its own SVG compose entirely for this case). Built here with
+# Styling.svg_data_uri (the same public helper gradient_header itself uses)
+# so it's still deterministic + geometric + trademark-free, just NOT drawn
+# from Styling::MOTIFS.
+BYO_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 210" preserveAspectRatio="xMidYMid slice">' \
+          '<defs><linearGradient id="byo" x1="0" y1="0" x2="1" y2="1">' \
+          '<stop offset="0" stop-color="#134E4A"/><stop offset="1" stop-color="#059669"/>' \
+          '</linearGradient></defs>' \
+          '<rect width="1600" height="210" fill="url(#byo)"/>' \
+          '<g fill="none" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="2">' \
+          '<polygon points="1440,40 1478,63 1478,109 1440,132 1402,109 1402,63"/>' \
+          '<polygon points="1500,86 1538,109 1538,155 1500,178 1462,155 1462,109"/>' \
+          '<polygon points="1380,86 1418,109 1418,155 1380,178 1342,155 1342,109"/>' \
+          '</g></svg>'
+BYO_URI = Styling.svg_data_uri(BYO_SVG)
+
+# ---------------------------------------------------------------------------
+# Shared helpers (same pattern as verify-richness-surfaces-e2e.rb).
+# ---------------------------------------------------------------------------
+
+def home_folder_id
+  me = Sigma.request(:get, '/v2/whoami')
+  uid = me && me['userId']
+  raise 'could not resolve userId from /v2/whoami' unless uid
+  mem = Sigma.request(:get, "/v2/members/#{uid}")
+  home = mem && mem['homeFolderId']
+  raise 'could not resolve homeFolderId' unless home
+  home
+end
+
+def reference_schema_version
+  wbs = Sigma.request(:get, '/v2/workbooks?limit=10')
+  entries = (wbs && (wbs['entries'] || wbs['workbooks'])) || []
+  entries.each do |w|
+    wid = w['workbookId'] || w['id']
+    next unless wid
+    spec = (Sigma.request(:get, "/v2/workbooks/#{wid}/spec", accept: 'application/json') rescue nil)
+    return spec['schemaVersion'] if spec.is_a?(Hash) && spec['schemaVersion']
+  end
+  raise 'could not discover schemaVersion from any existing workbook'
+end
+
+# POST/PUT /v2/workbooks/spec: response is documented as YAML. Request a
+# non-JSON accept so the raw string always comes back, then self-parse (JSON
+# first in case the org actually returns JSON, else scrape `workbookId:` out
+# of the YAML text) — same discipline as verify-richness-surfaces-e2e.rb.
+def post_workbook_spec(spec_hash)
+  raw = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec_hash),
+                                                    content_type: 'application/json', accept: 'application/yaml')
+  parsed = (JSON.parse(raw) rescue nil)
+  return parsed['workbookId'] if parsed.is_a?(Hash) && parsed['workbookId']
+  m = raw.to_s.match(/^\s*workbookId:\s*"?'?([\w-]+)"?'?\s*$/)
+  raise "no workbookId in POST response: #{raw.to_s[0, 600]}" unless m
+  m[1]
+end
+
+def render_png(wb, out_path, page_id: nil, w: 1600, h: 1200)
+  png_script = File.expand_path('sigma-export-png.py',
+                                 File.join(__dir__, '..', '..', 'plugins', 'tableau-to-sigma', 'skills',
+                                            'tableau-to-sigma', 'scripts'))
+  cmd = ['python3', png_script, '--workbook', wb, '--out', out_path, '--w', w.to_s, '--h', h.to_s]
+  cmd += ['--page', page_id] if page_id
+  out = `#{cmd.map { |c| Shellwords.escape(c) }.join(' ')} 2>&1`
+  ok = $?.success? && File.exist?(out_path)
+  { ok: ok, path: (ok ? out_path : nil), log: out.to_s[0, 800] }
+end
+
+# Retarget a Styling.gradient_header layout snippet from its fixed default
+# page position (rows 1..4, r0/r1 hardcoded inside gradient_header — it has
+# no row_start param) to an arbitrary row range, for the pg-motifs gallery
+# where three instances are stacked on one page. Safe ONLY when `subtitle` was
+# nil for that call — with no subtitle, title_r1 == r1, so both the
+# container's and the title's gridRow attributes read the identical literal
+# `gridRow="1 / 4"` string, and a single global substitution retargets both
+# consistently. (Each gradient_header call uses a distinct `id:`, so element
+# ids never collide across the three gallery instances — only this row-range
+# substring needs adjusting.)
+def retarget_header_rows(layout, r0, r1)
+  layout.gsub('gridRow="1 / 4"', "gridRow=\"#{r0} / #{r1}\"")
+end
+
+# ---------------------------------------------------------------------------
+# Builds one gradient KPI card: KpiCard.build (comparative Current/Prior) ->
+# Styling.gradient_card (wraps it in a gradient background, returns a
+# white-text patch merged onto a COPY, never mutating the original kpi Hash)
+# -> Styling.sparkline (a separate borderless line-chart stacked below the
+# kpi inside the SAME container). Returns the three elements + the inner
+# layout fragment (relative to the outer GridContainer the caller still has
+# to place on the page — gradient_card's own contract: "placing the container
+# on the page is the caller's job").
+# ---------------------------------------------------------------------------
+def build_gradient_kpi(id:, title:, cur_formula:, pri_formula:, fmt_sym:, gradient:, spark_value_formula:)
+  fmt = Styling.format_for(fmt_sym)
+  card = KpiCard.build(
+    id: id, name: title, source_element_id: SRC_ID,
+    columns: [
+      { 'id' => "#{id}-cur", 'name' => 'Current', 'formula' => cur_formula, 'format' => fmt },
+      { 'id' => "#{id}-pri", 'name' => 'Prior', 'formula' => pri_formula, 'format' => fmt }
+    ],
+    value_column_id: "#{id}-cur", comparison_column_id: "#{id}-pri", good_direction: :up
+  )
+  gc = Styling.gradient_card(id: "#{id}-bg", kpi_element: card, gradient: gradient)
+
+  patched_card = JSON.parse(JSON.generate(card)) # deep copy, never mutate `card`
+  patched_card['value'] = patched_card['value'].merge(gc[:patch]['value'])
+  patched_card['name']  = patched_card['name'].merge(gc[:patch]['name'])
+
+  spark = Styling.sparkline(id: "#{id}-spark", source_element_id: SRC_ID,
+                             period_ref: 'DateTrunc("month",[Src/Date])',
+                             value_formula: spark_value_formula)
+
+  inner_layout = [
+    gc[:child_layout],
+    "  <LayoutElement elementId=\"#{spark['id']}\" gridColumn=\"1 / 25\" gridRow=\"7 / 11\"/>"
+  ].join("\n")
+
+  { container: gc[:element].first, kpi: patched_card, spark: spark, inner_layout: inner_layout }
+end
+
+# ---------------------------------------------------------------------------
+# Spec construction — every surface below is built by requiring/calling the
+# WS4 shared-lib helpers (Richness/Styling/Actions/KpiCard), never a
+# hand-inlined shape.
+# ---------------------------------------------------------------------------
+
+def build_spec(home, schema_version)
+  # ---- source + read-only category pivot (hidden Data page) --------------
+  src_cols = ALIASES.map { |a| { 'id' => "c_#{a}", 'name' => DISPLAY[a], 'formula' => "[Custom SQL/#{a}]" } }
+  src = { 'id' => SRC_ID, 'kind' => 'table', 'name' => 'Src',
+          'source' => { 'kind' => 'sql', 'connectionId' => CONNECTION_ID, 'statement' => DEMO_SQL },
+          'columns' => src_cols }
+
+  cat_pivot = { 'id' => CAT_PIVOT_ID, 'kind' => 'pivot-table', 'source' => { 'kind' => 'table', 'elementId' => SRC_ID },
+                'columns' => [
+                  { 'id' => 'cp-cat', 'name' => 'Category', 'formula' => '[Src/Category]' },
+                  { 'id' => 'cp-rev', 'name' => 'Actual Revenue', 'formula' => 'Sum([Src/Revenue])',
+                    'format' => Styling.format_for(:currency) }
+                ],
+                'rowsBy' => [{ 'id' => 'cp-cat' }], 'columnsBy' => [], 'values' => ['cp-rev'] }
+
+  # ==== SURFACE: Styling.gradient_header — hero (glow motif) ===============
+  hdr_main = Styling.gradient_header(id: 'hdr-main', title: 'WS4 Surfaces — Live Probe',
+                                      subtitle: 'Sigma agent + gradient header/cards + actions/input-tables',
+                                      motif: :glow)
+
+  # ==== SURFACE: KpiCard.build + Styling.gradient_card + Styling.sparkline =
+  k_rev = build_gradient_kpi(id: 'k-rev', title: 'Revenue',
+                              cur_formula: "Sum(#{CUR.call('[Src/Revenue]')})",
+                              pri_formula: "Sum(#{PRI.call('[Src/Revenue]')})",
+                              fmt_sym: :currency, gradient: GRADIENTS['k-rev'],
+                              spark_value_formula: 'Sum([Src/Revenue])')
+  k_ord = build_gradient_kpi(id: 'k-ord', title: 'Orders',
+                              cur_formula: "Sum(#{CUR.call('[Src/Orders]')})",
+                              pri_formula: "Sum(#{PRI.call('[Src/Orders]')})",
+                              fmt_sym: :integer, gradient: GRADIENTS['k-ord'],
+                              spark_value_formula: 'Sum([Src/Orders])')
+
+  # ==== SURFACE: Richness.agent + Richness.chat (read-only analyst) ========
+  agent = Richness.agent(id: 'ag-ws4', name: 'WS4 Analyst',
+                          instructions: 'You are an analyst for this dataset. Answer questions about revenue, ' \
+                                        'orders, margin, region, and category, and trends over time. Be concise ' \
+                                        'and quantitative; cite the numbers you used.',
+                          data_source_ids: [SRC_ID])
+  chat_hd = { 'id' => 'chat-hd', 'kind' => 'text', 'verticalAlign' => 'middle', 'body' => '**Ask the WS4 Analyst**' }
+  chat = Richness.chat(id: 'chat', agent_id: 'ag-ws4')
+
+  # ==== SURFACE: Styling.gradient_header — second live motif (:rings) ======
+  hdr_actions = Styling.gradient_header(id: 'hdr-actions', title: 'Actions & Write-back',
+                                         subtitle: 'buttons, effects, and input tables',
+                                         gradient: %w[#111827 #6D28D9], motif: :rings)
+
+  # ==== SURFACE: entry text-area control (the 4 required trailing fields) =
+  note_ctl = { 'id' => NOTE_CTL_ID, 'kind' => 'control', 'controlId' => NOTE_CTL_HANDLE,
+               'name' => 'Add a review note', 'controlType' => 'text-area',
+               'mode' => 'equals', 'case' => 'insensitive',
+               'includeNulls' => 'when-no-value-is-selected', 'showOperators' => false }
+
+  # ==== SURFACE: Actions.button x3, one per verified effect ================
+  btn_reset = Actions.button(id: 'btn-reset', text: 'Reset filters', appearance: 'outline',
+                              effects: [Actions.clear_control_effect(page: PG_ACTIONS)])
+  btn_preset = Actions.button(id: 'btn-preset', text: 'Preset note', appearance: 'outline',
+                               effects: [Actions.set_control_value_effect(control: NOTE_CTL_HANDLE,
+                                                                           text: 'Reviewed - looks good')])
+  btn_log = Actions.button(id: 'btn-log', text: 'Log note', appearance: 'filled',
+                            effects: [Actions.insert_rows_effect(table: 'review-log',
+                                                                  values: { 'rl-note' => { 'type' => 'control',
+                                                                                            'control' => NOTE_CTL_HANDLE } })])
+
+  # ==== SURFACE: Actions.input_table_linked (write conn, keyed off the ====
+  #      READ-conn cat_pivot — the cross-connection linked-table pattern) ===
+  targets = Actions.input_table_linked(
+    id: 'targets', from: CAT_PIVOT_ID, connection_id: WRITE_CONNECTION_ID,
+    columns: [
+      { 'id' => 'tg-cat', 'key' => 'cp-cat' },
+      { 'id' => 'tg-actual', 'key' => 'cp-rev', 'name' => 'Actual Revenue' },
+      { 'id' => 'tg-target', 'type' => 'number', 'name' => 'Target Revenue', 'format' => Styling.format_for(:currency) },
+      { 'id' => 'tg-var', 'name' => 'Variance vs Target', 'formula' => '[Actual Revenue] - [Target Revenue]',
+        'format' => Styling.format_for(:currency) }
+    ],
+    name: { 'text' => 'Category revenue targets (enter a target per category ->)', 'fontWeight' => 'bold', 'fontSize' => 15 }
+  )
+
+  # ==== SURFACE: Actions.input_table_empty (append-only review log) =======
+  review_log = Actions.input_table_empty(
+    id: 'review-log', connection_id: WRITE_CONNECTION_ID,
+    columns: [
+      { 'id' => 'rl-note', 'type' => 'text', 'name' => 'Review note' },
+      { 'id' => 'CREATED_AT' }, { 'id' => 'CREATED_BY' }
+    ],
+    name: { 'text' => 'Review log (append-only)', 'fontWeight' => 'bold', 'fontSize' => 15 }
+  )
+
+  # ==== SURFACE: pg-motifs gallery — :glow, :rings again (smaller, direct ==
+  #      A/B) + ONE bring-your-own image (verbatim, not a MOTIFS key) =======
+  gh_glow = Styling.gradient_header(id: 'hdr-glow', title: 'Motif: glow (default)', motif: :glow)
+  gh_rings = Styling.gradient_header(id: 'hdr-rings-gallery', title: 'Motif: rings', motif: :rings,
+                                      gradient: %w[#111827 #6D28D9])
+  gh_byo = Styling.gradient_header(id: 'hdr-byo', title: 'Motif: bring-your-own (verbatim data: URI)', motif: BYO_URI)
+
+  motif_layout = [
+    retarget_header_rows(gh_glow[:layout], 1, 5),
+    retarget_header_rows(gh_rings[:layout], 6, 10),
+    retarget_header_rows(gh_byo[:layout], 11, 15)
+  ].join("\n")
+
+  # ---- page layouts ---------------------------------------------------
+  pg_main_layout = <<~XML
+    <?xml version="1.0" encoding="utf-8"?>
+    <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="#{PG_MAIN}">
+    #{hdr_main[:layout]}
+      <GridContainer elementId="#{k_rev[:container]['id']}" type="grid" gridColumn="1 / 13" gridRow="6 / 18" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    #{k_rev[:inner_layout]}
+      </GridContainer>
+      <GridContainer elementId="#{k_ord[:container]['id']}" type="grid" gridColumn="13 / 25" gridRow="6 / 18" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    #{k_ord[:inner_layout]}
+      </GridContainer>
+      <LayoutElement elementId="chat-hd" gridColumn="1 / 25" gridRow="18 / 19"/>
+      <LayoutElement elementId="chat" gridColumn="1 / 25" gridRow="19 / 36"/>
+    </Page>
+  XML
+
+  pg_actions_layout = <<~XML
+    <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="#{PG_ACTIONS}">
+    #{hdr_actions[:layout]}
+      <LayoutElement elementId="#{NOTE_CTL_ID}" gridColumn="1 / 13" gridRow="5 / 8"/>
+      <LayoutElement elementId="btn-reset" gridColumn="13 / 17" gridRow="5 / 8"/>
+      <LayoutElement elementId="btn-preset" gridColumn="17 / 21" gridRow="5 / 8"/>
+      <LayoutElement elementId="btn-log" gridColumn="21 / 25" gridRow="5 / 8"/>
+      <LayoutElement elementId="targets" gridColumn="1 / 25" gridRow="8 / 20"/>
+      <LayoutElement elementId="review-log" gridColumn="1 / 25" gridRow="20 / 30"/>
+    </Page>
+  XML
+
+  pg_motifs_layout = <<~XML
+    <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="#{PG_MOTIFS}">
+    #{motif_layout}
+    </Page>
+  XML
+
+  pg_data_layout = <<~XML
+    <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="#{PG_DATA}">
+      <LayoutElement elementId="#{SRC_ID}" gridColumn="1 / 25" gridRow="1 / 10"/>
+      <LayoutElement elementId="#{CAT_PIVOT_ID}" gridColumn="1 / 25" gridRow="10 / 20"/>
+    </Page>
+  XML
+
+  {
+    'name' => "WS4 surfaces probe — E2E proof (#{RUN_TAG})",
+    'folderId' => home,
+    'schemaVersion' => schema_version,
+    'description' => 'Live GO/NO-GO proof of WS4 shared-lib surfaces: Richness.agent/chat, ' \
+                      'Styling.gradient_header (+motif menu)/gradient_card/sparkline, Actions.* ' \
+                      '(buttons/effects, empty + linked input tables). Throwaway test artifact.',
+    'agents' => [agent],
+    'pages' => [
+      { 'id' => PG_MAIN, 'name' => 'Overview',
+        'elements' => [
+          *hdr_main[:element],
+          k_rev[:container], k_rev[:kpi], k_rev[:spark],
+          k_ord[:container], k_ord[:kpi], k_ord[:spark],
+          chat_hd, chat
+        ] },
+      { 'id' => PG_ACTIONS, 'name' => 'Actions & Write-back',
+        'elements' => [
+          *hdr_actions[:element],
+          note_ctl, btn_reset, btn_preset, btn_log,
+          targets, review_log
+        ] },
+      { 'id' => PG_MOTIFS, 'name' => 'Motif gallery',
+        'elements' => [*gh_glow[:element], *gh_rings[:element], *gh_byo[:element]] },
+      { 'id' => PG_DATA, 'name' => 'Data', 'visibility' => 'hidden',
+        'elements' => [src, cat_pivot] },
+    ],
+    # IMPORTANT (live-discovered, this task): layout is a single WORKBOOK-TOP-
+    # LEVEL field (sibling of `pages`), matching build-plugs-command-center.rb
+    # — NOT a per-page `layout` key (the shape verify-richness-surfaces-e2e.rb
+    # uses). An isolated A/B POST probe during this task's run confirmed a
+    # per-page `layout` key is silently IGNORED and replaced by Sigma's own
+    # auto-arrange (all elements squeezed into the left half of the page,
+    # stacked in element-array order) — only ONE combined top-level `layout`
+    # string (a single leading XML prolog, then each page's own <Page> block
+    # concatenated) is actually honored.
+    'layout' => [pg_main_layout, pg_actions_layout, pg_motifs_layout, pg_data_layout].join("\n")
+  }
+end
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+SCRATCH = ENV.fetch('SCRATCH_DIR', '/private/tmp/claude-502/-Users-tjwells/0fd12afc-2738-4328-a4d5-67e7ce57b185/scratchpad')
+FileUtils.mkdir_p(SCRATCH)
+
+verdict = { probe_completed: false }
+
+begin
+  home = home_folder_id
+  schema_version = reference_schema_version
+  log "home folder=#{home} schemaVersion=#{schema_version}"
+
+  spec = build_spec(home, schema_version)
+  wb = post_workbook_spec(spec)
+  raise 'no workbookId returned from POST' if wb.to_s.empty?
+  workbook_url = "#{ENV['SIGMA_BASE_URL']}/workbook/#{wb}"
+  log "workbook #{wb} (#{workbook_url})"
+
+  # --- structural (GET) readback ------------------------------------------
+  spec_back = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'application/json')
+  els = spec_back['pages'].flat_map { |p| p['elements'] || [] }
+  find_el = ->(id) { els.find { |e| e['id'] == id } }
+  agents_back = spec_back['agents'] || []
+
+  hdr_main_bg    = find_el.call('hdr-main-bg')
+  hdr_actions_bg = find_el.call('hdr-actions-bg')
+  hdr_byo_bg     = find_el.call('hdr-byo-bg')
+  agent_back     = agents_back.find { |a| a['id'] == 'ag-ws4' }
+  chat_back      = find_el.call('chat')
+  k_rev_bg       = find_el.call('k-rev-bg')
+  k_rev_kpi      = find_el.call('k-rev')
+  k_rev_spark    = find_el.call('k-rev-spark')
+  k_ord_bg       = find_el.call('k-ord-bg')
+  k_ord_kpi      = find_el.call('k-ord')
+  k_ord_spark    = find_el.call('k-ord-spark')
+  review_log_el  = find_el.call('review-log')
+  targets_el     = find_el.call('targets')
+  btn_reset_el   = find_el.call('btn-reset')
+  btn_preset_el  = find_el.call('btn-preset')
+  btn_log_el     = find_el.call('btn-log')
+
+  surfaces = {
+    'gradient_header :glow (hero, pg-main)' => {
+      post_accepted: !!(hdr_main_bg && hdr_main_bg.dig('backgroundImage', 'url').to_s.start_with?('data:image/svg+xml;base64,')),
+      render_hint: 'Read the pg-main render — top band should show a dark-slate->blue diagonal gradient with a soft ' \
+                    'radial glow motif (top-right) behind the white title/subtitle text.'
+    },
+    'gradient_header :rings (pg-actions)' => {
+      post_accepted: !!(hdr_actions_bg && hdr_actions_bg.dig('backgroundImage', 'url').to_s.start_with?('data:image/svg+xml;base64,')),
+      render_hint: 'Read the pg-actions render — header band should show the purple gradient with concentric-ring ' \
+                    '"signal" motif (top-right).'
+    },
+    'gradient_header bring-your-own (pg-motifs)' => {
+      post_accepted: !!(hdr_byo_bg && hdr_byo_bg.dig('backgroundImage', 'url') == BYO_URI),
+      render_hint: 'Read the pg-motifs render (bottom band) — should show the teal/green diagonal gradient with the ' \
+                    'hexagon-tile pattern verbatim (NOT the glow/rings library motifs), proving the bring-your-own ' \
+                    'path bypasses SVG compose entirely.'
+    },
+    'Richness.agent (workbook-level, read-only)' => {
+      post_accepted: !!(agent_back && agent_back['dataSources'].is_a?(Array) &&
+                         agent_back['dataSources'].any? { |d| d['elementId'] == SRC_ID } && !agent_back.key?('tools')),
+      render_hint: 'Structural only (agents[] is workbook metadata, not directly visible) — the chat element below ' \
+                    'is what actually surfaces it.'
+    },
+    'Richness.chat rail (pg-main)' => {
+      post_accepted: !!(chat_back && chat_back['kind'] == 'chat' && chat_back['agentId'] == 'ag-ws4'),
+      render_hint: 'Read the pg-main render — bottom of the page should show either a live chat panel (if AI ' \
+                    'agents are enabled on this org) or a "not enabled" placeholder. Report exactly which.'
+    },
+    'KpiCard + gradient_card + sparkline (Revenue)' => {
+      post_accepted: !!(k_rev_bg && k_rev_bg.dig('backgroundImage', 'url').to_s.start_with?('data:') &&
+                         k_rev_kpi && k_rev_kpi['comparisonColumn'] &&
+                         k_rev_kpi.dig('value', 'color').to_s.downcase == '#ffffff' &&
+                         k_rev_spark && k_rev_spark['kind'] == 'line-chart'),
+      render_hint: 'Read the pg-main render (left KPI card) — should show a blue gradient card, a white Revenue ' \
+                    'value + delta badge, and a TIGHT sparkline directly under it (no large blank gap — this ' \
+                    'validates the Task-3 padding:none fix).'
+    },
+    'KpiCard + gradient_card + sparkline (Orders)' => {
+      post_accepted: !!(k_ord_bg && k_ord_bg.dig('backgroundImage', 'url').to_s.start_with?('data:') &&
+                         k_ord_kpi && k_ord_kpi['comparisonColumn'] &&
+                         k_ord_kpi.dig('value', 'color').to_s.downcase == '#ffffff' &&
+                         k_ord_spark && k_ord_spark['kind'] == 'line-chart'),
+      render_hint: 'Read the pg-main render (right KPI card) — same check as Revenue, teal gradient.'
+    },
+    'Actions.input_table_empty (review-log)' => {
+      post_accepted: !!(review_log_el && review_log_el['kind'] == 'input-table' && review_log_el['inputMode'] == 'edit' &&
+                         review_log_el.dig('source', 'kind') == 'empty'),
+      render_hint: 'Read the pg-actions render — the log grid renders EMPTY (no rows) until a real click inserts ' \
+                    'one; that is EXPECTED, not a failure. Confirm the column header ("Review note") is visible.'
+    },
+    'Actions.input_table_linked (targets, cross-connection)' => {
+      post_accepted: !!(targets_el && targets_el['kind'] == 'input-table' && targets_el['inputMode'] == 'edit' &&
+                         targets_el.dig('source', 'kind') == 'linked' && targets_el.dig('source', 'from') == CAT_PIVOT_ID),
+      render_hint: 'Read the pg-actions render — the Targets grid should show one row per category with REAL ' \
+                    '"Actual Revenue" figures pulled from the read-connection pivot (not blank) — confirm honestly; ' \
+                    'the Target/Variance columns are expected EMPTY until a value is typed in.'
+    },
+    'Actions.button + clear_control_effect (Reset filters)' => {
+      post_accepted: !!(btn_reset_el && btn_reset_el['kind'] == 'button' &&
+                         btn_reset_el.dig('actions', 0, 'effects', 0, 'effect') == 'clear-control' &&
+                         btn_reset_el.dig('actions', 0, 'effects', 0, 'scope', 'page') == PG_ACTIONS),
+      render_hint: 'Read the pg-actions render — "Reset filters" outline button should be visible.'
+    },
+    'Actions.button + set_control_value_effect (Preset note)' => {
+      post_accepted: !!(btn_preset_el && btn_preset_el['kind'] == 'button' &&
+                         btn_preset_el.dig('actions', 0, 'effects', 0, 'effect') == 'set-control-value' &&
+                         btn_preset_el.dig('actions', 0, 'effects', 0, 'control') == NOTE_CTL_HANDLE),
+      render_hint: 'Read the pg-actions render — "Preset note" outline button should be visible.'
+    },
+    'Actions.button + insert_rows_effect (Log note)' => {
+      post_accepted: !!(btn_log_el && btn_log_el['kind'] == 'button' &&
+                         btn_log_el.dig('actions', 0, 'effects', 0, 'effect') == 'insert-rows' &&
+                         btn_log_el.dig('actions', 0, 'effects', 0, 'table') == 'review-log'),
+      render_hint: 'Read the pg-actions render — "Log note" filled button should be visible.'
+    }
+  }
+
+  # --- render ----------------------------------------------------------
+  page_main_png    = File.join(SCRATCH, "ws4-e2e-#{RUN_TAG}-pg-main.png")
+  page_actions_png = File.join(SCRATCH, "ws4-e2e-#{RUN_TAG}-pg-actions.png")
+  page_motifs_png  = File.join(SCRATCH, "ws4-e2e-#{RUN_TAG}-pg-motifs.png")
+
+  render_main    = render_png(wb, page_main_png, page_id: PG_MAIN, w: 1700, h: 1500)
+  render_actions = render_png(wb, page_actions_png, page_id: PG_ACTIONS, w: 1700, h: 1600)
+  render_motifs  = render_png(wb, page_motifs_png, page_id: PG_MOTIFS, w: 1700, h: 900)
+
+  log "render pg-main: ok=#{render_main[:ok]} path=#{render_main[:path]} #{render_main[:ok] ? '' : render_main[:log]}"
+  log "render pg-actions: ok=#{render_actions[:ok]} path=#{render_actions[:path]} #{render_actions[:ok] ? '' : render_actions[:log]}"
+  log "render pg-motifs: ok=#{render_motifs[:ok]} path=#{render_motifs[:path]} #{render_motifs[:ok] ? '' : render_motifs[:log]}"
+
+  verdict = {
+    probe_completed: true,
+    workbook_id: wb,
+    workbook_url: workbook_url,
+    render_pg_main_png: render_main[:path],
+    render_pg_actions_png: render_actions[:path],
+    render_pg_motifs_png: render_motifs[:path],
+    render_ok: { pg_main: render_main[:ok], pg_actions: render_actions[:ok], pg_motifs: render_motifs[:ok] },
+    surfaces: surfaces
+  }
+rescue StandardError => e
+  verdict = { probe_completed: false, fatal_error: "#{e.class}: #{e.message}", backtrace: e.backtrace&.first(15) }
+  log "FATAL — probe did not complete: #{e.class}: #{e.message}"
+end
+
+puts
+puts '=' * 78
+puts verdict[:probe_completed] ? 'PROBE COMPLETED (per-surface POST-accept below — RENDER is a visual read ' \
+                                  'the calling agent must do honestly against the PNGs, never auto-claimed here)' :
+                                  'PROBE FAILED (fatal)'
+puts '=' * 78
+if verdict[:probe_completed]
+  puts "workbook_id: #{verdict[:workbook_id]}"
+  puts "workbook_url: #{verdict[:workbook_url]}"
+  puts
+  puts format('%-55s %-8s', 'SURFACE', 'POST')
+  verdict[:surfaces].each do |name, v|
+    puts format('%-55s %-8s', name, v[:post_accepted] ? 'PASS' : 'FAIL')
+  end
+  puts
+  puts "render pg-main: ok=#{verdict[:render_ok][:pg_main]} -> #{verdict[:render_pg_main_png]}"
+  puts "render pg-actions: ok=#{verdict[:render_ok][:pg_actions]} -> #{verdict[:render_pg_actions_png]}"
+  puts "render pg-motifs: ok=#{verdict[:render_ok][:pg_motifs]} -> #{verdict[:render_pg_motifs_png]}"
+  puts
+end
+puts JSON.pretty_generate(verdict)
+exit(verdict[:probe_completed] ? 0 : 1)


### PR DESCRIPTION
Folds three live-verified millersigma patterns into the sigma-workbooks authoring skill (enhancement-only; converters untouched):

- **Sigma agent** — `Richness.agent` + `Richness.chat` (read-only analyst default; write-tool shape documented) + `agents.md`.
- **Gradient header + KPI cards** — `Styling.gradient_header` with a motif menu (`:glow` default · rings/grid/waves/dots/none/bring-your-own URL), `Styling.gradient_card` (dark scrim so white KPI values stay legible on any gradient), `Styling.sparkline` (composite in-card).
- **Actions / input tables** — new `actions.rb` (buttons + empty/linked input tables + effect builders) + `actions.md` + gap-fills to input-tables/controls/styling/tables docs.

Gated `SURFACES`, byte-identical Ruby/Python twins + golden fixtures, plus a creds-gated live E2E (`verify-ws4-e2e.rb`). Live-verified end-to-end: agent greeting renders, linked input table pulls cross-connection actuals, gradient KPI values legible. Plugin version 1.6.0→1.7.0. Stacks on the now-merged WS3 (#526/#532).

🤖 Generated with [Claude Code](https://claude.com/claude-code)