### PR TITLE
docs(controls): standardize masked-error string to quoted form

### DIFF
--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
@@ -29,7 +29,7 @@ A `control` element has exactly these fields:
 | `name` | — | Display label. |
 | `style` | — | Presentation options for the widget. |
 
-The value/widget fields (`mode`, `selectionMode`, `values`, range bounds, etc.) are **flat top-level siblings of `controlType`**, NOT nested in a separate "value object" — verified against a live workbook 2026-06-15. Different `controlType`s carry different value fields (the per-type recipes below show which), but they are always flat. Omitting them — or nesting them — yields the opaque `Invalid kind: control` rejection.
+The value/widget fields (`mode`, `selectionMode`, `values`, range bounds, etc.) are **flat top-level siblings of `controlType`**, NOT nested in a separate "value object" — verified against a live workbook 2026-06-15. Different `controlType`s carry different value fields (the per-type recipes below show which), but they are always flat. Omitting them — or nesting them — yields the opaque `Invalid kind: "control"` rejection.
 
 `filters[]` items are `{ source: { kind: table, elementId: ... }, columnId: ... }`. The `columnId` is the column on the target element to filter.
 
@@ -61,13 +61,13 @@ filters:                 # the TARGETS it filters — one entry per element+colu
     columnId: scoped-col-region
 ```
 
-> **Verified working shape** (pulled from a live, successfully-POSTed workbook 2026-06-15). A list control carries `source` / `mode` / `selectionMode` / `values` as **flat top-level siblings** — NOT inside a nested "value object." The single most common mistake is omitting `source`/`mode`/`selectionMode`/`values` (or nesting them); Sigma then rejects the element with the opaque catch-all `Invalid kind: control`, which means **the inner fields are wrong, NOT that controls are unsupported** (see `reference/workflows/validate.md`). `segmented` and `hierarchy` are the other list-style widgets — same wiring (value-list `source` + `filters` targets).
+> **Verified working shape** (pulled from a live, successfully-POSTed workbook 2026-06-15). A list control carries `source` / `mode` / `selectionMode` / `values` as **flat top-level siblings** — NOT inside a nested "value object." The single most common mistake is omitting `source`/`mode`/`selectionMode`/`values` (or nesting them); Sigma then rejects the element with the opaque catch-all `Invalid kind: "control"`, which means **the inner fields are wrong, NOT that controls are unsupported** (see `reference/workflows/validate.md`). `segmented` and `hierarchy` are the other list-style widgets — same wiring (value-list `source` + `filters` targets).
 
 > **A control cannot bind to a map element** (`point-map` / `region-map` / `geography-map`). Pointing a list control's `source` (value list) or a `filters[]` target at a map element fails the POST with `Dependency not found: '<mapElementId>'` (live-verified 2026-06-26). Back the control with a real `table` element (e.g. a small dimension/directory table on the same column) for both the value list and the filter target. To also scope the map, filter it indirectly (e.g. drive the map's source element off the same filtered table, or apply the predicate in the data model) rather than targeting the map element directly.
 
 ## Date Range
 
-A date-range control filters one or more date columns. The widget shape is determined by `mode`, and each mode takes different additional fields — all of them **flat top-level siblings of `controlType`** (verified against a live workbook 2026-06-15; a nested `value:{mode,unit}` object is rejected with `Invalid kind: control`). No `source` is needed — the column is defined by the `filters` binding.
+A date-range control filters one or more date columns. The widget shape is determined by `mode`, and each mode takes different additional fields — all of them **flat top-level siblings of `controlType`** (verified against a live workbook 2026-06-15; a nested `value:{mode,unit}` object is rejected with `Invalid kind: "control"`). No `source` is needed — the column is defined by the `filters` binding.
 
 ```yaml
 kind: control
@@ -177,7 +177,7 @@ The `text`/`text-area` shape above is for **filtering** a downstream column. A
 a formula or an action effect's `values` (e.g. a "review note" field feeding an
 `insert-rows` effect, see `reference/workflows/actions.md`'s append-only-log
 pattern) — needs **four additional flat fields** or the element **masked-fails**
-as the opaque `Invalid kind: control`, which reads like the control kind itself
+as the opaque `Invalid kind: "control"`, which reads like the control kind itself
 is broken:
 
 ```yaml
@@ -258,7 +258,7 @@ filters:
     columnId: col-amount
 ```
 
-> A nested `value:{low,high}` object is rejected with `Invalid kind: control`. The most common slider mistake is omitting `mode` — without the comparator the element is rejected even though `low`/`high`/`value` are present.
+> A nested `value:{low,high}` object is rejected with `Invalid kind: "control"`. The most common slider mistake is omitting `mode` — without the comparator the element is rejected even though `low`/`high`/`value` are present.
 
 ## Single-value types
 


### PR DESCRIPTION
Cosmetic doc-consistency: controls.md's 5 `Invalid kind: control` → `Invalid kind: "control"` (the quoted form Sigma actually emits, matching the WS4 agents/actions/input-tables docs). Follow-up from the WS4 final review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)