### PR TITLE
powerbi-to-sigma: report-build hardening (one-base-table-per-page control targeting, boolean-aware controls, chart binding, fail-loud, friendly naming)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -287,6 +287,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-metric-reference.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-validate-spec-metrics.rb
             plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -285,6 +285,8 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conflicting-page-defaults.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-metric-reference.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
             plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction, DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction, DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
@@ -78,15 +78,29 @@ Consequences:
 - **partial reach, multi-master page** → add one filter target per master the
   control should govern (the column must exist on each); elements sourcing
   from those masters inherit via the closure.
-- **partial reach, chart bypasses the master** (sources the DM directly) →
-  either re-source the chart from the master or re-root it through a hidden
-  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
-  carrying passthrough columns; the chart re-sourced through it) and target
-  the table. Control filter targets may only point at TABLE elements — a
-  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
-  (live-verified 2026-06-12; the looker builder's listen-scope tables and
-  enhance-apply's `ensure_base_table!` are the two automated forms of this
-  pattern).
+- **partial reach, KPIs/charts unfiltered while the detail table filters**
+  (each visual sourced its own narrow master; the control only targeted the
+  table's master) → the fix is **one base table per page + control-targets-base**
+  (build-workbook-from-pbir.rb `--source-mode page-base`, the DEFAULT): every
+  visual on the page SOURCES the one page base master and each page control
+  targets THAT base table's column, so the filter propagates to every visual
+  through the source closure. Control filter targets a TABLE element (the base
+  master) — the always-safe target. **Do NOT add a filter "passthrough" column
+  to a chart or pivot to make it a direct control target**: the extra column
+  corrupts the chart/pivot grouping and it renders "No data" (verified on live
+  migrations). A passthrough column is tolerated only on a KPI (single-value,
+  no grouping) or a plain grouped table; charts/pivots must be reached by
+  PROPAGATION from a shared base table, never by a passthrough column. (This
+  mirrors tableau-to-sigma / qlik-to-sigma, where every chart sources one
+  master; the looker builder's listen-scope tables are the same idea.)
+- **boolean / indicator slicer** → a boolean-typed slicer must NOT ship the
+  string-slicer template (`controlType: list`, `mode: include`, `values: []`):
+  Sigma treats an unset boolean `include` list as "include nothing" and ZEROES
+  every targeted element. Seed the full boolean domain (`values: [true, false]`)
+  so an unset control includes everything (= no filter), matching a PBI boolean
+  slicer with nothing selected. The builder does this automatically for columns
+  the TMSL model types as boolean/bit (else falls back to indicator-name shape:
+  `Is…` / `Has…` / `…Ind` / `…Flag`).
 - **intentional narrow control** (grain switcher driving one chart by
   formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -578,6 +578,18 @@ def field_spec(queryref, fields, chosen_master = nil)
       return merged
     end
   end
+  # CROSS-MASTER guard (report-build hardening, BUG 1/2): when a page base master
+  # is forced (chosen_master) but this field resolves ONLY on a DIFFERENT master
+  # (non-nil, and no alt lives on the chosen one), do NOT return the foreign-master
+  # `fs` — its ref/formula points at a master the element does not SOURCE, and
+  # Sigma compiles that cross-master column to type "error", breaking the whole
+  # element. Return an unresolvable marker (dot-bracket) so drop_unresolved_columns!
+  # actually DROPS the column — making the emission match the "will be DROPPED"
+  # warning instead of shipping a broken cross-master formula.
+  if chosen_master && fs['master'] && fs['master'] != chosen_master &&
+     Array(fs['alts']).none? { |a| a['master'] == chosen_master }
+    return { 'master' => nil, 'ref' => "[#{queryref}]", 'agg' => nil }
+  end
   fs
 end
 
@@ -1007,20 +1019,15 @@ end
 # matcher detects exactly that fallback so we can actually drop it.
 UNRESOLVED_REF = %r{\A\[[^\]/]*\.[^\]]*\]\z}.freeze
 
-# GUARANTEE no element ships an unresolved literal-ref column (bead miu7; mirrors
-# the slicer dropout). Drops every such column from `el` AND prunes its id from
-# every role reference build_element emits (value / xAxis / yAxis(2) / groupings /
-# rowsBy / columnsBy / values / sort), then records ONE honest 'dropped' entry.
-# The tile degrades (a role may lose a column) instead of carrying a broken one.
-def drop_unresolved_columns!(el, rec, kind)
-  cols = el['columns']
-  return unless cols.is_a?(Array)
-  bad = cols.select { |c| c['formula'].to_s =~ UNRESOLVED_REF }
-  return if bad.empty?
-  bad_ids = bad.map { |c| c['id'] }
+# Prune a set of column ids from an element: remove them from `columns` AND from
+# every role reference build_element emits (value / xAxis(+sort) / yAxis(2) /
+# groupings / rowsBy / columnsBy / values). Shared by the unresolved-ref drop and
+# the cross-master drop so both prune identically.
+def prune_columns!(el, bad_ids)
+  return if bad_ids.empty?
   has_bad = ->(x) { bad_ids.include?(x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
-  el['columns'] = cols.reject { |c| bad_ids.include?(c['id']) }
-  el.delete('value') if bad_ids.include?(el.dig('value', 'columnId'))
+  el['columns'] = Array(el['columns']).reject { |c| bad_ids.include?(c['id']) }
+  el.delete('value') if bad_ids.include?(el.dig('value', 'columnId')) || bad_ids.include?(el.dig('value', 'id'))
   if el['xAxis'].is_a?(Hash)
     el['xAxis'].delete('sort') if bad_ids.include?(el.dig('xAxis', 'sort', 'by'))
     el.delete('xAxis') if bad_ids.include?(el['xAxis']['columnId'])
@@ -1029,6 +1036,9 @@ def drop_unresolved_columns!(el, rec, kind)
     next unless el[ax].is_a?(Hash) && el[ax]['columnIds'].is_a?(Array)
     el[ax]['columnIds'] = el[ax]['columnIds'].reject(&has_bad)
     el.delete(ax) if el[ax]['columnIds'].empty?
+  end
+  if el['color'].is_a?(Hash) && (bad_ids.include?(el['color']['column']) || bad_ids.include?(el['color']['id']))
+    el.delete('color')
   end
   Array(el['groupings']).each do |g|
     g['groupBy'] = Array(g['groupBy']).reject(&has_bad) if g['groupBy']
@@ -1041,6 +1051,19 @@ def drop_unresolved_columns!(el, rec, kind)
     el.delete(k) if el[k].empty?
   end
   el['values'] = Array(el['values']).reject(&has_bad) if el['values'].is_a?(Array)
+end
+
+# GUARANTEE no element ships an unresolved literal-ref column (bead miu7; mirrors
+# the slicer dropout). Drops every such column from `el` AND prunes its id from
+# every role reference, then records ONE honest 'dropped' entry.
+# The tile degrades (a role may lose a column) instead of carrying a broken one.
+def drop_unresolved_columns!(el, rec, kind)
+  cols = el['columns']
+  return unless cols.is_a?(Array)
+  bad = cols.select { |c| c['formula'].to_s =~ UNRESOLVED_REF }
+  return if bad.empty?
+  bad_ids = bad.map { |c| c['id'] }
+  prune_columns!(el, bad_ids)
   leaves = bad.map { |c| c['name'] }.compact.join(', ')
   # Entity = the part before the first dot in the unresolved `[Entity.Leaf]` ref
   # (e.g. "Dim Region"), used to attribute the drop to an ungranted schema.
@@ -1050,6 +1073,43 @@ def drop_unresolved_columns!(el, rec, kind)
                     detail: "field(s) #{leaves} could not be resolved to a master column — dropped " \
                             '(would have shipped as a type=error column)',
                     action: "Map the PBI queryRef(s) for #{leaves} to a master column in master-map.json and re-run.")
+end
+
+# HARD GATE (report-build hardening): no element may ship a column whose formula
+# references a MASTER other than the element's own `source` — a cross-master ref
+# from an element sourcing master A to `[master-B/Col]` compiles to Sigma type
+# "error" and breaks the whole element. Drop every such column (pruning its role
+# references) with a loud warning + coverage entry, so the tile degrades honestly
+# instead of erroring. `master_ids` = the set of Data-page master element ids;
+# `by_name` maps master DISPLAY NAMES -> id (refs can use either). Returns the
+# list of dropped column names (for the per-element re-check). This is the
+# belt-and-suspenders net behind field_spec's cross-master guard: it catches a
+# leak from ANY path (sort-by, measure-color dup, metric binding, a stale ref).
+def drop_cross_master_columns!(el, name, master_ids, by_name)
+  cols = el['columns']
+  return [] unless cols.is_a?(Array) && !cols.empty?
+  src = el.dig('source', 'elementId') || el.dig('source', 'source', 'elementId')
+  # Only elements that SOURCE a master table can leak a cross-master ref; a master
+  # itself (data-model source) and source-less elements are exempt.
+  return [] unless src
+  bad = cols.select do |c|
+    foreign = PbiReportBuild.foreign_master_refs(c['formula'], src, master_ids, by_name)
+    !foreign.empty?
+  end
+  return [] if bad.empty?
+  prune_columns!(el, bad.map { |c| c['id'] })
+  leaves = bad.map { |c| c['name'] }.compact.uniq.join(', ')
+  warn "[build-workbook] WARN visual '#{name}': column(s) #{leaves} referenced a DIFFERENT master than " \
+       "the element's source (#{src}) — cross-master formulas compile to type \"error\" in Sigma, so they " \
+       'were DROPPED (the tile degrades instead of breaking). Bring the field onto this element\'s source ' \
+       'master (a joined base) to keep it.'
+  record_unresolved(visual: name, pbi_type: 'cross-master', sigma_kind: el['kind'],
+                    severity: 'dropped', recoverable: true,
+                    detail: "column(s) #{leaves} referenced a master other than the element's source — " \
+                            'dropped (cross-master formula would compile to type=error)',
+                    action: 'Add the field to this element\'s source master (or build a joined page base ' \
+                            'that carries every measure the page\'s visuals reference), then re-run.')
+  bad.map { |c| c['name'] }
 end
 
 # Power BI "Small multiples" field well -> Sigma NATIVE element `trellis`
@@ -2131,6 +2191,47 @@ npag = signals['pages'].sum do |pg|
   apply_source_filters!(pg['filters'], 'page', "page '#{pg['page_title']}'", data_elements, exclusive, fields, masters)
 end
 warn "[build-workbook] applied #{nrep} report-level + #{npag} page-level filter(s) to master element(s)" if nrep.positive? || npag.positive?
+
+# ---- HARD GATE: no cross-master column leak (report-build hardening) --------
+# After assembly, GUARANTEE no element ships a column whose formula references a
+# master other than the element's own `source` — such a cross-master ref compiles
+# to Sigma type "error" and breaks the whole element (the multi-grain-page bug).
+# Drop every such column (loud warn + coverage); if that empties a data element,
+# drop the element entirely (it would still error) and prune it from control-scope.
+# field_spec's cross-master guard already prevents the common case at build time;
+# this net also catches leaks from an explicit master-map `formula`, a sort-by /
+# measure-color dup, or a metric ref that names another master.
+_gate_master_ids = masters.values.map { |m| m['id'] }.compact
+_gate_master_by_name = data_elements.each_with_object({}) do |de, h|
+  h[de['name']] = de['id'] if _gate_master_ids.include?(de['id']) && de['name']
+end
+_gate_data_kinds = %w[kpi-chart bar-chart line-chart area-chart combo-chart scatter-chart
+                      pie-chart donut-chart region-map point-map table pivot-table].freeze
+content_pages.each do |pg|
+  pg['elements'].each do |el|
+    next if el['kind'] == 'control'
+    nm = el['name'].is_a?(Hash) ? el.dig('name', 'text') : el['name']
+    drop_cross_master_columns!(el, nm, _gate_master_ids, _gate_master_by_name)
+  end
+  removed = []
+  pg['elements'].reject! do |el|
+    next false unless _gate_data_kinds.include?(el['kind']) && Array(el['columns']).empty?
+    warn "[build-workbook] WARN element '#{el['id']}' on page '#{pg['name']}' has NO columns left after " \
+         'cross-master pruning — element DROPPED entirely (it would compile to type=error).'
+    record_unresolved(visual: el['id'], pbi_type: 'cross-master', sigma_kind: el['kind'],
+                      severity: 'dropped', recoverable: true,
+                      detail: 'element had only cross-master column(s) — dropped entirely',
+                      action: 'Build a joined page base carrying every measure this visual references on ' \
+                              'one source, then re-run.')
+    removed << el['id']
+    true
+  end
+  next if removed.empty?
+  $control_scope.each do |sc|
+    sc['scope'] = Array(sc['scope']).reject { |eid| removed.include?(eid) } if sc['scope']
+    sc['excluded'] = Array(sc['excluded']).reject { |e| removed.include?(e.is_a?(Hash) ? e['element'] : e) } if sc['excluded']
+  end
+end
 
 # control-scope.json — the intended-scope contract sidecar (schema: the
 # CONTRACT block in scripts/lib/control_lint.rb + refs/control-parity.md).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -56,6 +56,7 @@ require_relative 'lib/pbi_conditional_formats'
 require_relative 'lib/coverage_catalog'
 require_relative 'lib/trellis_emit' # shared native-trellis emitter (supported-kind gate + fallbacks)
 require_relative 'lib/metric_binding' # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
+require_relative 'lib/pbi_reportbuild' # report-build hardening: one-base-table-per-page, boolean controls, friendly names
 include SigmaLayout
 
 # ---------------------------------------------------------------------------
@@ -102,8 +103,18 @@ OptionParser.new do |p|
   # migrate-powerbi.rb surfaces + assert-visual-compare.rb gates on). Default:
   # coverage.json next to --out.
   p.on('--coverage-out PATH') { |v| opts[:coverage_out] = v }
+  # REPORT-BUILD hardening (default 'page-base'): every visual on a page SOURCES
+  # one base table (the master resolving the most of the page's fields) and each
+  # page control targets THAT base table's column, so the filter propagates to
+  # every visual — the tableau/qlik source-propagation pattern. 'per-visual' is
+  # the legacy escape (each visual picks its own master; controls multi-target).
+  p.on('--source-mode MODE', %w[page-base per-visual],
+       "page-base (default): one base table per page + control-targets-base propagation; " \
+       'per-visual: legacy per-visual master selection') { |v| opts[:source_mode] = v }
 end.parse!
 %i[sig mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+opts[:source_mode] ||= 'page-base'
+$page_base_mode = (opts[:source_mode] == 'page-base')
 
 signals = JSON.parse(File.read(opts[:sig]))
 # Style fidelity: the PBI report's base theme -> Sigma workbook theme. `signals['theme']`
@@ -502,6 +513,23 @@ def tmsl_date_column?(ent, leaf)
   !!(c && c['dataType'].to_s =~ /date/i)
 end
 
+# TMSL column type for ENTITY.LEAF — boolean-typed slicers need boolean-aware
+# control handling: a `list` + `mode:include` + `values:[]` template (correct
+# for a STRING slicer, where an empty selection = no filter) ZEROES a boolean
+# target — Sigma treats an unset boolean `include` list as "include nothing".
+# Detect real boolean columns from the TMSL model (dataType boolean/bit) so we
+# can seed the control's default with the full boolean domain (= no filter when
+# unset). Falls back to PbiReportBuild.boolean_leaf? (name shape) when no model.
+def tmsl_boolean_column?(ent, leaf)
+  unless MODEL_TABLES.empty?
+    t = MODEL_TABLES_FULL.find { |tb| tb['name'].to_s == ent.to_s }
+    c = t && (t['columns'] || []).find { |col| col['name'].to_s.casecmp(leaf.to_s).zero? }
+    return true if c && c['dataType'].to_s =~ /bool|bit/i
+    return false if c # a modeled non-boolean column is authoritative — do NOT guess from its name
+  end
+  PbiReportBuild.boolean_leaf?(leaf)
+end
+
 # PBI visualTypes that map 1:1 to a native Sigma element kind (no approximation).
 # Anything NOT in this set is rendered as a best-effort Sigma kind and recorded
 # in coverage.json as 'approximated' so the user sees the substitution (e.g.
@@ -843,6 +871,20 @@ def visual_master(rec, fields)
   best && best[0]
 end
 
+# The ONE base master a whole PAGE sources (report-build hardening). Aggregates
+# field coverage across EVERY visual on the page (controls included, so the
+# sliced column counts) and returns the master resolving the most. Every visual
+# is then pointed at this base and each page control targets its column, so a
+# single control target propagates to all visuals — no per-visual targeting, no
+# passthrough columns. Delegates the pure tally to PbiReportBuild.page_base_master.
+def page_base_master(visuals, fields)
+  masters_for = lambda do |qr|
+    fs = field_spec(qr, fields)
+    ([fs['master']] + Array(fs['alts']).map { |a| a['master'] }).compact.uniq
+  end
+  PbiReportBuild.page_base_master(visuals, masters_for)
+end
+
 # bead f972: PBI sort carry. rec['sort'] = {queryRef, direction asc|desc} from the
 # extractors (PBIR query.sortDefinition / classic prototypeQuery.OrderBy). Resolve
 # the sorted queryRef to the element column built for it (qr_cids, recorded as each
@@ -1108,7 +1150,7 @@ def apply_small_multiples!(el, rec, fields, master, eid, qr_cids)
   result
 end
 
-def build_element(rec, fields, masters, extra_data = [])
+def build_element(rec, fields, masters, extra_data = [], forced_master = nil)
   # viz-kind resolution (grounded by refs/catalogs/viz-kind.json; SIGMA_KIND is
   # derived from it). An UNMAPPED/blank kind token used to SILENTLY become a
   # bar-chart via "|| 'bar-chart'". Now the miss WARNS before the explicit
@@ -1139,7 +1181,11 @@ def build_element(rec, fields, masters, extra_data = [])
   # derive one from its projections — NEVER surface the raw visual id as the
   # display name (phase-e layout-quality fix; layout_lint.rb gates this).
   title = rec['title'].to_s.strip
-  name  = title.empty? ? (derived_title(rec, kind) || KIND_LABEL[kind] || 'Chart') : title
+  # Friendly naming: a PBI visual's OWN title wins verbatim (task: "use the PBI
+  # visual's own title when present"). Only a DERIVED title (untitled visual) is
+  # run through friendly_label so a raw projection leaf ("SUBMISSION_KEY by
+  # LEVEL_1_NAME") reads as a human name and never surfaces as a raw column.
+  name  = title.empty? ? (PbiReportBuild.friendly_label(derived_title(rec, kind)) || KIND_LABEL[kind] || 'Chart') : title
 
   if kind == 'text'
     # Size-aware: PBI textboxes are titles OR small decorative labels
@@ -1165,7 +1211,23 @@ def build_element(rec, fields, masters, extra_data = [])
     return { 'id' => eid, 'kind' => 'image', 'url' => url }
   end
 
-  master = visual_master(rec, fields)
+  # Report-build hardening: in page-base mode every visual sources the PAGE's one
+  # base master (forced_master) so a single control target propagates to all —
+  # but only when at least one of the visual's own fields resolves on that base
+  # (else a genuinely different-fact visual would lose all its data; it keeps its
+  # own master and is surfaced as out-of-scope for the page control instead).
+  resolves_on = lambda do |m|
+    (rec['bindings'] || {}).values.flatten.compact.any? do |qr|
+      fs = field_spec(qr, fields)
+      fs['master'] == m || Array(fs['alts']).any? { |a| a['master'] == m }
+    end
+  end
+  master =
+    if forced_master && masters[forced_master] && resolves_on.call(forced_master)
+      forced_master
+    else
+      visual_master(rec, fields)
+    end
   # E-06: a value-driven visual with NO resolvable field binding would emit a
   # source-less element with a "[]" formula column (an empty PBI `kpi {}` or a
   # cardVisual->bar approximation), which the API rejects with
@@ -1280,23 +1342,46 @@ def build_element(rec, fields, masters, extra_data = [])
     reach = MODEL_RELATIONSHIPS.any? || MODEL_TABLES.any? ? reachable_entities(ent) : [ent]
     cov = entity_master_coverage(fields)
     filters, wired, unwired = [], [], []
-    masters.each do |mname, mrec|
-      ents = cov.select { |_e, ms| ms.include?(mname) }.keys
-      real = MODEL_TABLES.any? ? (ents & MODEL_TABLES) : ents
-      pseudo = MODEL_TABLES.any? && real.empty?      # derived/restructured element
-      in_scope = (real & reach).any? || mname == pmaster
-      col = match_master_column(mrec, leaf, ent)
-      # pseudo elements: only when they actually carry the sliced column —
-      # column-name evidence is the best provenance we have for restructured
-      # (Dense Rank / time-intel / calc-table SQL) elements.
-      in_scope ||= pseudo && !col.nil?
-      next unless in_scope
-      if col.nil?
-        unwired << mname
-        next
+    # PAGE-BASE targeting (report-build hardening): the page's ONE base master
+    # (forced_master) is what every visual on the page sources, so the control
+    # targets JUST the base table's column — the filter PROPAGATES to every
+    # visual for free. This replaces per-visual/multi-master targeting (which
+    # left KPIs/charts unfiltered) and the "passthrough column per visual" hack
+    # (which corrupted chart/pivot grouping → "No data"). NEVER add a passthrough
+    # column to a chart/pivot: source propagation carries the filter instead.
+    bbase = ($page_base_mode && forced_master && master == forced_master) ? masters[forced_master] : nil
+    bcol  = bbase && match_master_column(bbase, leaf, ent)
+    src_master, src_col = pm, pcol
+    if bbase && bcol
+      filters << { 'source' => { 'kind' => 'table', 'elementId' => bbase['id'] }, 'columnId' => bcol['id'] }
+      wired << forced_master
+      src_master, src_col = bbase, bcol
+    else
+      # Legacy / fallback: the base doesn't carry the sliced column (or per-visual
+      # mode) — wire every relationship-reachable master that carries it.
+      masters.each do |mname, mrec|
+        ents = cov.select { |_e, ms| ms.include?(mname) }.keys
+        real = MODEL_TABLES.any? ? (ents & MODEL_TABLES) : ents
+        pseudo = MODEL_TABLES.any? && real.empty?      # derived/restructured element
+        in_scope = (real & reach).any? || mname == pmaster
+        col = match_master_column(mrec, leaf, ent)
+        # pseudo elements: only when they actually carry the sliced column —
+        # column-name evidence is the best provenance we have for restructured
+        # (Dense Rank / time-intel / calc-table SQL) elements.
+        in_scope ||= pseudo && !col.nil?
+        next unless in_scope
+        if col.nil?
+          unwired << mname
+          next
+        end
+        filters << { 'source' => { 'kind' => 'table', 'elementId' => mrec['id'] }, 'columnId' => col['id'] }
+        wired << mname
       end
-      filters << { 'source' => { 'kind' => 'table', 'elementId' => mrec['id'] }, 'columnId' => col['id'] }
-      wired << mname
+      if $page_base_mode && bbase.nil?
+        warn "[build-workbook] WARN slicer '#{name}': page base master does not carry sliced column " \
+             "'#{leaf}' — control falls back to multi-master targeting; page-base propagation will not " \
+             'cover visuals whose fields live only on the base. Add the sliced column to the base master.'
+      end
     end
     unless unwired.empty?
       warn "[build-workbook] WARN slicer '#{name}': master(s) #{unwired.join(', ')} are in the " \
@@ -1309,7 +1394,10 @@ def build_element(rec, fields, masters, extra_data = [])
     ctl_id = "#{ctl_id}#{n}" if n > 1     # two slicers on one column: unique ids
     el['kind'] = 'control'
     el['controlId'] = ctl_id
-    el['name'] = name
+    # Friendly naming: a slicer's label is routinely the RAW warehouse column
+    # ("IS Active IND"); Title-Case it ("Is Active Ind"). Explicit human titles
+    # and preserved acronyms (Customer ID) pass through unchanged.
+    el['name'] = PbiReportBuild.friendly_label(name)
     # Control kind is COMPOSITIONAL (list vs date-range depends on the sliced
     # column's TMSL type), so it stays as code — but the two target kinds are
     # grounded in refs/catalogs/control.json (CTL_CAT), cited to the PBI slicer
@@ -1328,8 +1416,22 @@ def build_element(rec, fields, masters, extra_data = [])
       el['controlType'] = CTL_CAT.target('slicer')      # -> 'list' (documented default)
       el['mode'] = 'include'
       el['selectionMode'] = 'multiple'
-      el['values'] = []
-      el['source'] = { 'kind' => 'source', 'source' => { 'kind' => 'table', 'elementId' => pm['id'] }, 'columnId' => pcol['id'] }
+      # BOOLEAN-AWARE default (report-build hardening): a boolean-typed slicer
+      # must NOT ship the string-slicer template `mode:include + values:[]` —
+      # Sigma treats an unset boolean `include` list as "include NOTHING" and
+      # ZEROES every targeted element (verified on live migrations). Seed the
+      # full boolean domain (true/false) so an unset control includes everything
+      # = no filter, matching a PBI boolean slicer with nothing selected. String
+      # slicers keep the empty default (there, empty `include` correctly = all).
+      if tmsl_boolean_column?(ent, leaf)
+        el['values'] = PbiReportBuild.boolean_domain_values
+        warn "[build-workbook] slicer '#{name}': boolean column '#{leaf}' -> list control seeded with " \
+             'the full boolean domain (true/false) so an unset control does NOT zero its targets ' \
+             '(an empty boolean include list means "include nothing" in Sigma).'
+      else
+        el['values'] = []
+      end
+      el['source'] = { 'kind' => 'source', 'source' => { 'kind' => 'table', 'elementId' => src_master['id'] }, 'columnId' => src_col['id'] }
     end
     el['filters'] = filters
     $control_scope << { 'controlId' => ctl_id,
@@ -1816,11 +1918,49 @@ def build_element(rec, fields, masters, extra_data = [])
   # bead miu7: never ship an unresolved literal-ref column (type=error). Drop it
   # and prune its references — the tile degrades honestly into coverage instead.
   drop_unresolved_columns!(el, rec, kind) unless el['kind'] == 'control'
+  # FAIL-LOUD binding guard (report-build hardening): after the drop pass, a
+  # chart/KPI that lost its essential binding (an xAxis-less bar with a yAxis
+  # measure aggregated into one giant bar; a KPI with no value; a chart with no
+  # measures) must not ship SILENTLY. Emit a visible warning + a coverage entry
+  # so the gap surfaces in the per-report summary instead of a mystery empty
+  # tile. This is the safety net behind page-base sourcing (which normally keeps
+  # every raw column on the one base so bindings resolve).
+  check_binding_complete!(el, rec) unless el['kind'] == 'control'
   # Track 3b: queryRef -> built column id, so a visual filter can resolve its
   # target to a column this element actually projects (element filters reference
   # the element's own columns). Transient — stripped before the spec is written.
   el['_qr_cids'] = qr_cids
   el
+end
+
+# Verify a built chart/KPI still carries the binding it needs to render, AFTER
+# unresolved columns were dropped. Warns loudly + records coverage on a miss —
+# the fail-loud counterpart to the silent xAxis-drop / measure-drop defects.
+def check_binding_complete!(el, rec)
+  kind = el['kind']
+  name = el['name'].is_a?(Hash) ? el['name']['text'] : el['name'].to_s
+  miss = nil
+  case kind
+  when 'bar-chart', 'line-chart', 'area-chart', 'combo-chart'
+    ycount = Array(el.dig('yAxis', 'columnIds')).length
+    miss = 'lost its category/dimension (xAxis) — it will aggregate every row into one mark' if el['xAxis'].nil? || el.dig('xAxis', 'columnId').nil?
+    miss = 'has no measure on its yAxis' if ycount.zero?
+  when 'kpi-chart'
+    miss = 'has no value binding' if el.dig('value', 'columnId').nil? && el.dig('value', 'id').nil?
+  when 'pie-chart', 'donut-chart'
+    miss = 'has no value binding' if el.dig('value', 'id').nil? && el.dig('value', 'columnId').nil?
+  when 'table', 'pivot-table'
+    miss = 'has no columns' if Array(el['columns']).empty?
+  end
+  return unless miss
+  warn "[build-workbook] WARN visual '#{name}' (#{kind}) #{miss} after unresolvable fields were dropped — " \
+       'building it anyway but it will not render as intended; check the master-map covers this visual\'s ' \
+       'dimension AND every measure on the page base table.'
+  record_unresolved(visual: name, pbi_type: rec['visual_type'], sigma_kind: kind,
+                    severity: 'degraded', recoverable: true,
+                    detail: "#{kind} #{miss}",
+                    action: 'Ensure the page base master carries this visual\'s dimension and measure columns ' \
+                            '(map the queryRefs in master-map.json), then re-run.')
 end
 
 # ---- assemble pages -------------------------------------------------------
@@ -1841,8 +1981,16 @@ content_pages = signals['pages'].map do |pg|
   # build_element may return one element or an array (multiRowCard -> N KPIs),
   # or nil (unresolvable slicer -> control skipped loudly, never wired wrong).
   vis_elements = {}   # visual_id -> [built element ids] (feeds intended-scope)
+  # ONE base master per page (report-build hardening): the master resolving the
+  # most of THIS page's fields. Every visual is pointed at it (build_element's
+  # forced_master) and each page control targets its column — so a single filter
+  # target propagates to every visual. nil (nothing resolves / per-visual mode)
+  # -> legacy per-visual master selection.
+  page_base = $page_base_mode ? page_base_master(pg['visuals'], fields) : nil
+  warn "[build-workbook] page '#{pg['page_title']}': base table master = #{page_base.inspect} " \
+       '(every visual sources it; controls target it and propagate).' if page_base
   els = pg['visuals'].flat_map do |v|
-    r = build_element(v, fields, masters, extra_data_elements)
+    r = build_element(v, fields, masters, extra_data_elements, page_base)
     list = r.is_a?(Array) ? r : [r] # NB: not Array(r) — that explodes a Hash into pairs
     list = list.compact
     vis_elements[v['visual_id']] = list.map { |e| e['id'] }
@@ -1912,7 +2060,33 @@ content_pages = signals['pages'].map do |pg|
     end
     sc['scope'].uniq!
   end
-  { 'id' => "page-#{pg['page_id']}", 'name' => pg['page_title'], 'elements' => els }
+  # FAIL-LOUD empty page (report-build hardening): if the source page carried
+  # data visuals but NONE built (every measure/formula failed to bind), do not
+  # ship a silently-blank page — warn + drop a visible annotation element so the
+  # gap is obvious in the workbook, and surface it in coverage.
+  data_kinds = %w[kpi-chart bar-chart line-chart area-chart combo-chart scatter-chart
+                  pie-chart donut-chart region-map point-map table pivot-table]
+  built_data = els.count { |e| data_kinds.include?(e['kind']) }
+  src_data = (pg['visuals'] || []).count do |v|
+    data_kinds.include?(SIGMA_KIND[v['sigma_kind']] || v['sigma_kind'])
+  end
+  if built_data.zero? && src_data.positive?
+    warn "[build-workbook] WARN page '#{pg['page_title']}': #{src_data} data visual(s) in the source but " \
+         'NONE could be built (measures/formulas did not bind) — emitting a visible placeholder instead of ' \
+         'a silently-empty page. See coverage.json for the per-visual reasons.'
+    record_unresolved(visual: "page '#{pg['page_title']}'", pbi_type: 'page', sigma_kind: 'page',
+                      severity: 'dropped', recoverable: true,
+                      detail: "#{src_data} data visual(s) could not be built — page came out empty",
+                      action: 'Map this page\'s measures/dimensions to a base master in master-map.json ' \
+                              '(and translate any missing DAX measures), then re-run.')
+    els << { 'id' => "ph-#{pg['page_id']}", 'kind' => 'text',
+             'body' => "## ⚠ #{src_data} visual(s) on this page could not be migrated\n\n" \
+                       'Their measures/fields did not bind to the data model. See the migration ' \
+                       'coverage report for the per-visual reasons.' }
+  end
+  # Friendly page name: a raw warehouse token or ALL-CAPS name is Title-Cased;
+  # an already-human page title passes through unchanged.
+  { 'id' => "page-#{pg['page_id']}", 'name' => PbiReportBuild.friendly_label(pg['page_title']), 'elements' => els }
 end
 data_elements += extra_data_elements
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -1541,8 +1541,12 @@ def build_element(rec, fields, masters, extra_data = [], forced_master = nil)
     # (PBI card `labels.color`, captured as rec['value_color']; else the palette
     # accent), with the caption in neutral gray BELOW the value (titleOrient).
     el['value']['color'] = rec['value_color'] || $pbi_accent
-    el['name'] = { 'text' => qr_leaf(qr, 'Value'),
-                   'color' => { 'kind' => 'theme', 'ref' => 'colors-textNeutral' } }
+    # BUG 3: an element `name` MUST be a plain String — a {text:, color:} Hash
+    # crashes validate-spec.rb (String vs Hash compare) and is not a valid spec
+    # shape. Emit the caption as a String; the value color above already carries
+    # the styling, so the neutral caption color is dropped (matches the
+    # multiRowCard branch, which also names its KPIs with a plain String).
+    el['name'] = qr_leaf(qr, 'Value')
     # Style fidelity: caption below the value (titleOrient), and CENTER the card
     # contents (anchor) — PBI stat cards center; overridable from a PBI alignment
     # signal. Abbreviation of the value column happens in the shared tail below.
@@ -2386,8 +2390,30 @@ pages_xml = signals['pages'].map do |pg|
     # 2) bands from the SOURCE rows, columns from the SOURCE x-positions
     min_rows = { 'kpi-chart' => 4, 'control' => 2, 'text' => 2, 'image' => 20,
                  'scatter-chart' => 9, 'region-map' => 9, 'point-map' => 9 }
+    # BUG 5: page controls must live INSIDE a GridContainer — a loose top-level
+    # control below the first band fails the layout lint ("orphan control"), which
+    # crashed the POST. Pull every control out of the content bands and place them
+    # in a dedicated filter-strip control band right under the header (the standard
+    # "filters over the grid" pattern); content is shifted down so nothing overlaps.
+    ctrl_items = items.select { |it| kind_of[it[0]] == 'control' }
+    items = items.reject { |it| kind_of[it[0]] == 'control' }
+    ctrl_h = ctrl_items.empty? ? 0 : [ctrl_items.map { |it| it[4] - it[3] }.max, min_rows['control']].max
+    if ctrl_items.any?
+      cw = 24.0 / ctrl_items.length
+      inner_ctrls = ctrl_items.sort_by { |it| it[1] }.each_with_index.map do |it, i|
+        c0 = (i * cw).floor + 1
+        c1 = ((i + 1) * cw).floor + 1
+        c1 = c0 + 1 if c1 <= c0
+        SigmaLayout.le(it[0], c0, c1, 1, 1 + ctrl_h)
+      end.join("\n")
+      ctrl_band_id = "band-#{page_id}-ctrl"
+      extra << SigmaLayout.container_el(ctrl_band_id)
+      children << SigmaLayout.gc(ctrl_band_id, 1, 25,
+                                 1 + SigmaLayout::HEADER_ROWS,
+                                 1 + SigmaLayout::HEADER_ROWS + ctrl_h, inner_ctrls)
+    end
     bands = SigmaLayout.cluster_bands(items)
-    cursor = 1 + SigmaLayout::HEADER_ROWS
+    cursor = 1 + SigmaLayout::HEADER_ROWS + ctrl_h
     les = []
     bands.each do |band|
       # columns: cluster band items by x-overlap, preserving left-to-right order
@@ -2540,8 +2566,16 @@ layout_xml = %(<?xml version="1.0" encoding="utf-8"?>\n#{pages_xml}\n)
 
 # Strip transient build-only keys (e.g. Track 3b's `_qr_cids`) from every element
 # before the spec is written — the API rejects unknown `_`-prefixed properties.
+# BUG 3 invariant: every element `name` MUST be a plain String (a {text:,color:}
+# Hash crashes validate-spec.rb's String compare). Normalize any Hash name down
+# to its text here so no path can leak a Hash name into the spec.
 (content_pages + [{ 'elements' => data_elements }]).each do |pg|
-  (pg['elements'] || []).each { |el| el.delete_if { |k, _| k.to_s.start_with?('_') } }
+  (pg['elements'] || []).each do |el|
+    el.delete_if { |k, _| k.to_s.start_with?('_') }
+    if el['name'].is_a?(Hash)
+      el['name'] = el['name']['text'] || el['name']['label'] || el['id'].to_s
+    end
+  end
 end
 
 spec = {

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_flip.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_flip.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+#
+# PbiFlip — PURE decision glue for migrate-powerbi.rb's Phase 6b (runtime
+# control-flip proof). Plugin-local (NOT a shared/manifest file): it adapts the
+# shared FlipGate verdict vocabulary to the powerbi orchestrator's inline
+# Phase 6, and adds the offline "recorded-evidence" path the shared
+# assert-phase6-ran.rb gate 7b has but the one-shot orchestrator needs its own
+# copy of. No I/O here so every branch is unit-testable without a live workbook
+# (see scripts/test-pbi-flip-gate.rb).
+#
+# Decision vocabulary (superset of FlipGate's :ok/:fail/:advisory/:error):
+#   :ok       — >=1 control proven to filter its targets live → Phase 6b passes
+#   :fail     — >=1 control wired but INERT → block (exit 21)
+#   :advisory — no control auto-probeable (date/slider/unlabeled) → WARN, marker
+#   :error    — probe could not run / no verdict → fail-closed (exit 21)
+#   :none     — workbook has 0 controls → nothing to flip-test (pass)
+#   :offline  — no live creds and no recorded evidence → UNVERIFIED (do NOT
+#               hard-fail a run that never reached the live API)
+module PbiFlip
+  # Map a decision + info hash to the Phase 6b outcome.
+  # Returns [status, summary_line, exit_code_or_nil].
+  #   exit_code_or_nil: 21 blocks the migration (inert / could-not-verify);
+  #                     nil continues.
+  def self.outcome(decision, info = nil)
+    info ||= { passes: [], fails: [], skips: [] }
+    np = Array(info[:passes]).length
+    nf = Array(info[:fails]).length
+    ns = Array(info[:skips]).length
+    case decision
+    when :ok       then [:ok,       "OK — #{np} control(s) proven live", nil]
+    when :fail     then [:fail,     "FAIL — #{nf} inert control(s)", 21]
+    when :advisory then [:advisory, "UNVERIFIED — #{ns} un-probeable control(s)", nil]
+    when :error    then [:error,    'FAIL — probe could not verify control wiring', 21]
+    when :none     then [:none,     'OK — no controls to flip-test', nil]
+    when :offline  then [:offline,  'UNVERIFIED — offline (no SIGMA creds), no recorded flip evidence', nil]
+    else                [:unknown,  'UNVERIFIED', nil]
+    end
+  end
+
+  # Decision from a RECORDED probe-results.json array (offline / no-creds path).
+  # Same shape FlipGate returns: [decision, info]. FAIL beats PASS (a recorded
+  # inert control is a real defect); empty/absent → :offline (UNVERIFIED).
+  def self.recorded(results)
+    rows   = results.is_a?(Array) ? results : []
+    fails  = rows.select { |r| r.is_a?(Hash) && r['result'].to_s == 'FAIL' }
+    passes = rows.select { |r| r.is_a?(Hash) && r['result'].to_s == 'PASS' }
+    info = {
+      passes: passes.map { |r| r['control'] },
+      fails:  fails.map  { |r| [r['control'], r['note']] },
+      skips:  []
+    }
+    decision =
+      if rows.empty?    then :offline
+      elsif fails.any?  then :fail
+      elsif passes.any? then :ok
+      else :offline
+      end
+    [decision, info]
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_reportbuild.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_reportbuild.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+#
+# pbi_reportbuild.rb — pure helpers for the REPORT-BUILD hardening pass
+# (one-base-table-per-page control targeting, boolean-aware controls, friendly
+# naming). Plugin-local (powerbi-to-sigma only): NOT a shared/vendored lib.
+#
+# Why this exists (defects seen on live migrations, all on simple dashboards):
+#   * Page controls only filtered the detail TABLE — KPIs/charts on the same
+#     page stayed unfiltered. The attempted fix (a filter "passthrough" column
+#     per visual) BROKE bar-charts/pivots (the extra column corrupts grouping →
+#     "No data"). The real fix is source PROPAGATION: every visual on a page
+#     SOURCES one base table and the page control targets THAT base table's
+#     column, so the filter flows to every visual for free (the same pattern
+#     tableau-to-sigma / qlik-to-sigma already use — one master, all charts
+#     source it). No passthrough columns, ever.
+#   * Boolean slicers got the string-slicer control template (`include` +
+#     `values:[]`). Sigma treats an unset boolean `include` list as "include
+#     nothing" → it ZEROES every targeted element. A boolean control must leave
+#     the element UNFILTERED when unset.
+#   * Reports surfaced RAW warehouse column names as titles/labels
+#     ("IS Active IND", "Submission KEY by Level 1 Name"). Labels must read as
+#     human display names.
+#
+# All functions here are pure (no I/O, no globals) so they unit-test directly.
+module PbiReportBuild
+  module_function
+
+  # Acronyms that must stay upper-cased when Title-Casing a raw label. Anything
+  # NOT in this set that arrives ALL-CAPS (e.g. "KEY", "IND", "IS") is a raw
+  # warehouse token and gets Capitalized ("Key", "Ind", "Is").
+  FRIENDLY_KEEP = %w[
+    ID ZIP GL CP YTD MTD QTD WTD KPI US UK EU APAC EMEA SKU URL API UUID
+    SSN DOB FTE PII GMV ARR MRR ROI YOY MOM QOQ AOV LTV CAC NPS
+  ].freeze
+
+  # Humanize a raw/snake/ALL-CAPS label into a Title-Cased display name, while
+  # leaving an already-human label ("Total Sales", "Sales by Region") untouched
+  # and preserving real acronyms ("Customer ID", "GL Balance"). Returns the
+  # input unchanged when it is already friendly or is not a String.
+  #
+  #   "IS Active IND"                 -> "Is Active Ind"
+  #   "SUBMISSION_KEY"                -> "Submission Key"
+  #   "Submission KEY by Level 1 Name"-> "Submission Key by Level 1 Name"
+  #   "Customer ID"                   -> "Customer ID"   (acronym preserved)
+  #   "Total Sales"                   -> "Total Sales"   (already human)
+  def friendly_label(s)
+    return s unless s.is_a?(String)
+    t = s.strip
+    return s if t.empty?
+    # "raw" = has an underscore, OR carries no lowercase letter at all, OR
+    # contains a bare ALL-CAPS word of 2+ chars (the "IS"/"KEY"/"IND" tell).
+    looks_raw = t.include?('_') || t !~ /[a-z]/ || t =~ /(?:\A|\s)[A-Z]{2,}(?:\s|\z)/
+    return s unless looks_raw
+    words = t.gsub(/_+/, ' ').split(/\s+/)
+    words.map do |w|
+      up = w.upcase
+      if FRIENDLY_KEEP.include?(up) && w == up
+        up                                   # real acronym — keep upper
+      elsif w =~ /\A[A-Z0-9]+\z/ && w =~ /[A-Z]/
+        w.capitalize                         # ALL-CAPS raw token -> Capitalized
+      else
+        w                                    # already mixed-case / a number
+      end
+    end.join(' ')
+  end
+
+  # The single base master a whole PAGE sources: the master that resolves the
+  # MOST of the page's bound fields (aggregated across every visual, controls
+  # included so the sliced column counts). `masters_for` maps a queryRef to the
+  # list of master names it can resolve on (primary + alts). Ties break toward
+  # the FIRST master seen (deterministic). Returns nil when nothing resolves.
+  #
+  # This is the "one wide base table per page" decision: instead of each visual
+  # picking its own narrow master (which left page controls unable to reach the
+  # others), every visual on the page is pointed at this one base so a single
+  # control target propagates to all of them.
+  def page_base_master(visuals, masters_for)
+    counts = Hash.new(0)
+    order = []
+    Array(visuals).each do |v|
+      (v['bindings'] || {}).values.flatten.compact.each do |qr|
+        Array(masters_for.call(qr)).each do |m|
+          next if m.nil?
+          order << m unless order.include?(m)
+          counts[m] += 1
+        end
+      end
+    end
+    return nil if counts.empty?
+    best = counts.max_by { |m, c| [c, -order.index(m)] }
+    best && best[0]
+  end
+
+  # Name-shape heuristic for a boolean/indicator slicer when no TMSL dataType is
+  # available (the extract carried no --model). Conservative: only true/has
+  # prefixes and the ind/indicator/flag suffix — the well-known PBI indicator
+  # naming — so a plain categorical ("Region", "Status") is never mistaken for
+  # a boolean and force-seeded.
+  def boolean_leaf?(leaf)
+    s = leaf.to_s
+    return false if s.empty?
+    s =~ /\A(is|has)\b/i || s =~ /\b(ind|indicator|flag)\z/i || s =~ /\bactive\s+ind\b/i
+  end
+
+  # A boolean domain's default control selection = BOTH members, so an "unset"
+  # control includes everything (no filter) instead of the empty `include` list
+  # that zeroes a boolean-typed target. TMSL boolean columns are true/false.
+  def boolean_domain_values
+    [true, false]
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_reportbuild.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_reportbuild.rb
@@ -108,4 +108,31 @@ module PbiReportBuild
   def boolean_domain_values
     [true, false]
   end
+
+  # Cross-element reference token extraction. A `[Element/Column]` ref names its
+  # source element before the first slash; `[Column]` (no slash) is a same-element
+  # column ref and is ignored. Returns the distinct element tokens a formula
+  # references via the two-part `[X/...]` form.
+  def ref_element_tokens(formula)
+    formula.to_s.scan(/\[([^\]\/]+)\/[^\]]*\]/).map { |m| m[0] }.uniq
+  end
+
+  # The MASTER element ids a formula references that are NOT the element's own
+  # source — i.e. a cross-master leak (an element sourcing master A referencing
+  # `[master-B/Col]`, which Sigma compiles to type "error"). `master_ids` is the
+  # set of master element ids; `by_name` maps a master DISPLAY NAME -> its id
+  # (refs may use either the id or the display name). A token equal to the source
+  # (id OR its display name) is the element's own source and is allowed.
+  def foreign_master_refs(formula, source_id, master_ids, by_name = {})
+    ids = master_ids.respond_to?(:include?) ? master_ids : Array(master_ids)
+    src_name = by_name.respond_to?(:key) ? by_name.key(source_id) : nil
+    out = []
+    ref_element_tokens(formula).each do |tok|
+      tid = ids.include?(tok) ? tok : by_name[tok]   # resolve a display-name token to a master id
+      next if tid.nil?                                # not a master ref (self-col, [Metrics/..], scatter src, ...)
+      next if tok == source_id || tok == src_name || tid == source_id
+      out << tid
+    end
+    out.uniq
+  end
 end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -152,6 +152,11 @@ OptionParser.new do |o|
   # builds a new DM.
   o.on('--reuse-dm ID')        { |v| opts[:reuse_dm] = v }
   o.on('--no-reuse')           {     opts[:no_reuse] = true }
+  # Phase 6b (runtime control-flip proof) is DEFAULT-ON: after posting, each
+  # control is flipped live (probe-controls.rb) to prove it actually filters its
+  # targets — a control that lints clean but is INERT fails the migration.
+  # --skip-control-flip waives it (name the reason in your migration report).
+  o.on('--skip-control-flip [REASON]', 'waive Phase 6b (runtime control-flip proof); the reason MUST be named in your migration report') { |v| opts[:skip_control_flip] = v || true }
 end.parse!
 
 # #347: publish the target tenant into the env so EVERY Power BI child process
@@ -1357,6 +1362,20 @@ wb_rb = JSON.parse(File.read(wb_readback))
 wb_id = wb_rb['workbookId']
 puts "   workbookId = #{wb_id}"
 
+# Gate-state stamp (after a live post): control_flip_required=true auto-enables
+# the shared assert-phase6-ran.rb gate 7b on a STANDALONE run too, matching the
+# tableau reference — so neither this one-shot path (Phase 6b below) nor a later
+# standalone gate can silently skip the runtime control-flip proof.
+begin
+  _msf = File.join(WORK, 'migrate-state.json')
+  _st  = (JSON.parse(File.read(_msf)) rescue {})
+  _st  = {} unless _st.is_a?(Hash)
+  _st.merge!('workbook_id' => wb_id, 'control_flip_required' => true)
+  File.write(_msf, JSON.pretty_generate(_st))
+rescue StandardError
+  nil # sentinel bookkeeping never fails the run
+end
+
 # ---------------------------------------------------------------------------
 # MIGRATION COVERAGE REPORT — what carried over, and what didn't (bead beads-sigma-cov).
 # The build warns loudly at each drop site, but on a complex report those warnings
@@ -1614,6 +1633,109 @@ else
 end
 
 # ---------------------------------------------------------------------------
+# Phase 6b — runtime control-flip proof (DEFAULT-ON). Gate 7 (control_lint.rb,
+# run at post-and-readback) proves control WIRING against the live spec, but a
+# builder-level listen->column mis-map yields a spec that lints clean yet does
+# NOTHING when the user changes the control. The only independent proof is
+# runtime: flip each control via the REST export API and confirm its targets'
+# output actually changes (scripts/probe-controls.rb). Mirrors the shared
+# assert-phase6-ran.rb gate 7b so the one-shot migrate enforces it too; the
+# migrate-state.json control_flip_required stamp (above) enforces it on a
+# standalone gate run as well. Escape: --skip-control-flip "<reason>".
+# ---------------------------------------------------------------------------
+require 'rbconfig'
+flip_line = nil
+_flip_libs = true
+begin
+  require_relative 'lib/pbi_flip'
+  require_relative 'lib/control_lint'
+  require_relative 'lib/flip_gate'
+rescue LoadError => e
+  _flip_libs = false
+  warn "   [WARN] Phase 6b: #{e.message} — re-vendor scripts/lib (SHA-1 discipline); control flip UNVERIFIED"
+end
+if opts[:skip_control_flip]
+  reason = opts[:skip_control_flip] == true ? '(no reason given)' : opts[:skip_control_flip]
+  flip_line = "WAIVED — #{reason}"
+  puts "   [WAIVED] Phase 6b: runtime control-flip proof — #{reason} (name it in your migration report)"
+elsif !_flip_libs
+  flip_line = 'UNVERIFIED — flip libs not loadable'
+else
+  # Count controls on the live posted workbook (same source of truth as gate 7b).
+  n_controls = nil
+  begin
+    _spec = Sigma.request(:get, "/v2/workbooks/#{wb_id}/spec")
+    if _spec.is_a?(String)
+      begin
+        _spec = JSON.parse(_spec)
+      rescue JSON::ParserError
+        require 'yaml'; require 'date'
+        _spec = (YAML.safe_load(_spec, permitted_classes: [Date, Time]) rescue nil)
+      end
+    end
+    n_controls = ControlLint.controls_report(_spec).length if _spec.is_a?(Hash)
+  rescue StandardError => e
+    warn "   [WARN] Phase 6b: could not fetch/parse the live spec to count controls (#{e.message})"
+  end
+
+  probe_out = File.join(WORK, 'probe-controls')
+  probe     = File.join(HERE, 'probe-controls.rb')
+  has_creds = !ENV['SIGMA_BASE_URL'].to_s.empty? && !ENV['SIGMA_API_TOKEN'].to_s.empty?
+
+  decision, info =
+    if n_controls == 0
+      [:none, nil]
+    elsif has_creds && File.exist?(probe)
+      system(RbConfig.ruby, probe, '--workbook-id', wb_id, '--out', probe_out)
+      _rc  = $?.exitstatus
+      _res = (JSON.parse(File.read(File.join(probe_out, 'probe-results.json'))) rescue nil)
+      FlipGate.decide(_rc, _res)
+    elsif has_creds
+      warn '   [WARN] Phase 6b: scripts/probe-controls.rb not vendored — control flip UNVERIFIED'
+      [:offline, nil]
+    else
+      # Offline: accept RECORDED evidence, else UNVERIFIED (never hard-fail a run
+      # that never reached the live API).
+      _res = (JSON.parse(File.read(File.join(probe_out, 'probe-results.json'))) rescue nil)
+      PbiFlip.recorded(_res)
+    end
+
+  status, flip_line, exit_code = PbiFlip.outcome(decision, info)
+  case status
+  when :ok, :none
+    extra = (info && Array(info[:skips]).any?) ? " (#{Array(info[:skips]).length} un-probeable type(s) skipped)" : ''
+    puts "   [OK] Phase 6b: #{flip_line}#{extra}"
+  when :advisory
+    warn "   [WARN] Phase 6b: #{flip_line} — date-range/slider/unlabeled control(s) need an explicit flip value; runtime wiring UNVERIFIED"
+    begin
+      FileUtils.mkdir_p(probe_out)
+      File.write(File.join(probe_out, 'control-flip-unverified.json'),
+                 JSON.pretty_generate('workbookId' => wb_id,
+                                      'unprobed' => Array(info && info[:skips]).map { |c, n| { 'control' => c, 'note' => n } }))
+    rescue StandardError
+      nil
+    end
+  when :offline
+    puts "   [SKIP] Phase 6b: #{flip_line}"
+  when :fail
+    puts "   [FAIL] Phase 6b: #{Array(info[:fails]).length} control(s) wired but INERT on workbook #{wb_id}:"
+    Array(info[:fails]).each { |cid, note| puts "     - #{cid}: #{note}" }
+    puts '     The control passed the static lint (gate 7) but does not filter its targets — a'
+    puts '     builder listen->column mis-mapping. Re-check control targeting in the build, or'
+    puts '     waive with --skip-control-flip "<reason>". Reproduce:'
+    puts "       ruby scripts/probe-controls.rb --workbook-id #{wb_id}"
+    exit exit_code
+  when :error
+    puts "   [FAIL] Phase 6b: probe-controls.rb could not verify the wiring on workbook #{wb_id}."
+    puts '     An enforced gate that could not run must not pass silently. Re-run once the export'
+    puts '     API is reachable, or waive with --skip-control-flip "<reason>".'
+    exit exit_code
+  else
+    puts "   [WARN] Phase 6b: #{flip_line}"
+  end
+end
+
+# ---------------------------------------------------------------------------
 # Phase E (OPT-IN) — Enhance. Runs ONLY with --enhance AND a parity PASS:
 # enhancements clone a PARITY-VERIFIED workbook, never an unproven one.
 # Clone-first / scan-then-propose / accept-only / parity-unchanged-gated —
@@ -1673,6 +1795,7 @@ if fresh_ok
        "#{freshness['credsSuspect'] ? ' — REFRESH FAILING (creds)' : ''}"
 end
 puts "ENHANCE     : #{enhance_line}" if enhance_line
+puts "CONTROL-FLIP: #{flip_line}" if flip_line
 # Empty-workbook guard + completion sentinel. parity_ok is VACUOUSLY true when no
 # chart elements were built (0 cols, 0 divergent) — an empty/placeholder workbook
 # would otherwise exit 0 and look "done" (the exact PBI failure: pages, no

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-flip-gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-flip-gate.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-pbi-flip-gate.rb — offline unit tests for migrate-powerbi.rb Phase 6b
+# (runtime control-flip proof) decision glue: lib/pbi_flip.rb + the shared
+# lib/flip_gate.rb contract Phase 6b depends on. No live API.
+
+require_relative 'lib/pbi_flip'
+require_relative 'lib/flip_gate'
+
+$failures = 0
+def check(cond, msg)
+  if cond
+    puts "  ok  #{msg}"
+  else
+    $failures += 1
+    warn "  FAIL #{msg}"
+  end
+end
+
+# --- FlipGate.decide contract (the live-probe path Phase 6b relies on) --------
+puts 'FlipGate.decide:'
+d, i = FlipGate.decide(0, [{ 'control' => 'c1', 'result' => 'PASS' }])
+check(d == :ok && i[:passes] == ['c1'], 'rc=0 + PASS -> :ok')
+d, i = FlipGate.decide(1, [{ 'control' => 'c1', 'result' => 'FAIL', 'note' => 'inert' }])
+check(d == :fail && i[:fails] == [['c1', 'inert']], 'rc=1 + FAIL -> :fail with note')
+d, = FlipGate.decide(1, [])
+check(d == :error, 'rc=1 + no FAIL rows -> :error (abort, could not verify)')
+d, = FlipGate.decide(2, [{ 'control' => 'c1', 'result' => 'SKIP', 'note' => 'date-range' }])
+check(d == :advisory, 'rc=2 (nothing auto-probeable) -> :advisory')
+d, = FlipGate.decide(0, [])
+check(d == :advisory, 'rc=0 + no PASS rows -> :advisory')
+d, = FlipGate.decide(99, nil)
+check(d == :error, 'unknown rc / nil results -> :error')
+
+# --- PbiFlip.recorded (offline recorded-evidence path) ------------------------
+puts 'PbiFlip.recorded:'
+d, i = PbiFlip.recorded([{ 'control' => 'c1', 'result' => 'PASS' }])
+check(d == :ok && i[:passes] == ['c1'], 'recorded PASS -> :ok')
+d, i = PbiFlip.recorded([{ 'control' => 'c1', 'result' => 'PASS' },
+                         { 'control' => 'c2', 'result' => 'FAIL', 'note' => 'inert' }])
+check(d == :fail && i[:fails] == [['c2', 'inert']], 'recorded FAIL beats PASS -> :fail')
+d, = PbiFlip.recorded([])
+check(d == :offline, 'recorded empty -> :offline (UNVERIFIED, do not hard-fail)')
+d, = PbiFlip.recorded(nil)
+check(d == :offline, 'recorded nil -> :offline')
+
+# --- PbiFlip.outcome (decision -> summary + exit code) ------------------------
+puts 'PbiFlip.outcome:'
+st, line, ex = PbiFlip.outcome(:ok, { passes: %w[a b], fails: [], skips: [] })
+check(st == :ok && ex.nil? && line.include?('2 control'), ':ok -> no exit, counts passes')
+st, _, ex = PbiFlip.outcome(:fail, { passes: [], fails: [['c', 'inert']], skips: [] })
+check(st == :fail && ex == 21, ':fail -> exit 21 (blocks migration)')
+st, _, ex = PbiFlip.outcome(:error, nil)
+check(st == :error && ex == 21, ':error -> exit 21 (fail-closed)')
+st, _, ex = PbiFlip.outcome(:advisory, { passes: [], fails: [], skips: [['c', 'date']] })
+check(st == :advisory && ex.nil?, ':advisory -> WARN, no exit')
+st, _, ex = PbiFlip.outcome(:none, nil)
+check(st == :none && ex.nil?, ':none (0 controls) -> pass, no exit')
+st, _, ex = PbiFlip.outcome(:offline, nil)
+check(st == :offline && ex.nil?, ':offline -> UNVERIFIED, no exit (never hard-fail an offline run)')
+
+# --- orchestrator wiring smoke: --skip-control-flip is a known flag -----------
+puts 'orchestrator wiring:'
+mp = File.join(__dir__, 'migrate-powerbi.rb')
+src = File.read(mp)
+check(src.include?("--skip-control-flip"), 'migrate-powerbi.rb declares --skip-control-flip')
+check(src.include?('control_flip_required'), 'migrate-powerbi.rb stamps control_flip_required into migrate-state.json')
+check(src.include?('Phase 6b'), 'migrate-powerbi.rb has a Phase 6b block')
+check(src.include?("require_relative 'lib/pbi_flip'"), 'migrate-powerbi.rb loads lib/pbi_flip')
+
+if $failures.zero?
+  puts "\ntest-pbi-flip-gate: ALL PASS"
+  exit 0
+else
+  warn "\ntest-pbi-flip-gate: #{$failures} FAILURE(S)"
+  exit 1
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
@@ -1,0 +1,227 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-pbi-reportbuild-emit.rb — end-to-end offline test for the REPORT-BUILD
+# hardening. Runs build-workbook-from-pbir.rb (NO API, NO creds — files only)
+# on a synthetic Power BI report and asserts the SIMPLIFIED architecture:
+#
+#   1. one-base-table-per-page   — every data visual on a page SOURCES the one
+#                                  page base table (master-sales).
+#   2. control-targets-base      — a page control has EXACTLY one filter target
+#                                  (the base table), NO passthrough column is
+#                                  added to any chart/pivot, and the control's
+#                                  reach (control-scope.json) covers every data
+#                                  element on the page (propagation).
+#   3. boolean-aware control      — a boolean slicer is NOT emitted as the
+#                                  zeroing `include + values:[]` template; it is
+#                                  seeded with the boolean domain so unset = no
+#                                  filter.
+#   4. chart binding             — a bar chart keeps its xAxis dimension AND all
+#                                  of its measures.
+#   5. fail-loud, no silent drop — an unbindable dimension/measure/whole page
+#                                  emits a VISIBLE warning + a coverage entry
+#                                  (+ a placeholder on an all-empty page), never
+#                                  a silently empty tile/page.
+#   6. friendly naming           — raw warehouse names become human display
+#                                  names on controls and page titles.
+#
+# Synthetic data only — generic SALES_FACT / DATE_DIM / INVENTORY names, NO
+# customer data.
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+BUILD = File.join(__dir__, 'build-workbook-from-pbir.rb')
+RUBY  = RbConfig.ruby
+$fail = 0
+def ok(name, cond)
+  puts((cond ? '  ok  ' : 'FAIL  ') + name)
+  $fail += 1 unless cond
+end
+
+# ---- one wide base master for the whole report -----------------------------
+MMAP = {
+  'masters' => {
+    'SALES' => { 'id' => 'master-sales', 'element_id' => 'el-sales', 'data_model' => 'dm-x',
+                 'columns' => [
+                   { 'id' => 'mc-region', 'name' => 'Region',        'formula' => '[SALES/Region]' },
+                   { 'id' => 'mc-date',   'name' => 'Order Date',     'formula' => '[SALES/Order Date]' },
+                   { 'id' => 'mc-active', 'name' => 'Is Active Ind',  'formula' => '[SALES/Is Active Ind]' },
+                   { 'id' => 'mc-amt',    'name' => 'Sales Amount',   'formula' => '[SALES/Sales Amount]' },
+                   { 'id' => 'mc-oid',    'name' => 'Order Id',       'formula' => '[SALES/Order Id]' },
+                   { 'id' => 'mc-units',  'name' => 'Units',          'formula' => '[SALES/Units]' },
+                   { 'id' => 'mc-disc',   'name' => 'Discount',       'formula' => '[SALES/Discount]' }
+                 ] }
+  },
+  'fields' => {
+    'SALES_FACT.Region'        => { 'master' => 'SALES', 'ref' => '[master-sales/Region]',        'agg' => nil },
+    'DATE_DIM.Order Date'      => { 'master' => 'SALES', 'ref' => '[master-sales/Order Date]',     'agg' => nil },
+    'SALES_FACT.Is Active Ind' => { 'master' => 'SALES', 'ref' => '[master-sales/Is Active Ind]',  'agg' => nil },
+    'SALES_FACT.Sales Amount'  => { 'master' => 'SALES', 'ref' => '[master-sales/Sales Amount]',   'agg' => 'Sum' },
+    'SALES_FACT.Order Count'   => { 'master' => 'SALES', 'ref' => '[master-sales/Order Id]',       'agg' => 'Count' },
+    'SALES_FACT.Units'         => { 'master' => 'SALES', 'ref' => '[master-sales/Units]',          'agg' => 'Sum' },
+    'SALES_FACT.Discount'      => { 'master' => 'SALES', 'ref' => '[master-sales/Discount]',       'agg' => 'Sum' }
+  }
+}.freeze
+
+# TMSL model — supplies the column dataTypes so the boolean/date slicers route
+# correctly (Is Active Ind: boolean; Order Date: dateTime).
+MODEL = {
+  'model' => {
+    'tables' => [
+      { 'name' => 'SALES_FACT', 'columns' => [
+        { 'name' => 'Region', 'dataType' => 'string' },
+        { 'name' => 'Is Active Ind', 'dataType' => 'boolean' },
+        { 'name' => 'Sales Amount', 'dataType' => 'double' },
+        { 'name' => 'Order Id', 'dataType' => 'int64' },
+        { 'name' => 'Units', 'dataType' => 'int64' },
+        { 'name' => 'Discount', 'dataType' => 'double' }
+      ] },
+      { 'name' => 'DATE_DIM', 'columns' => [{ 'name' => 'Order Date', 'dataType' => 'dateTime' }] }
+    ],
+    'relationships' => [{ 'fromTable' => 'SALES_FACT', 'toTable' => 'DATE_DIM', 'isActive' => true }]
+  }
+}.freeze
+
+def vis(id, vtype, kind, bindings, title = '')
+  { 'visual_id' => id, 'visual_type' => vtype, 'sigma_kind' => kind, 'title' => title,
+    'x' => 0, 'y' => 0, 'w' => 400, 'h' => 300, 'z' => 0, 'parent_group' => nil,
+    'bindings' => bindings, 'sort' => nil, 'formats' => {} }
+end
+
+SIGNALS = {
+  'source' => 'powerbi', 'pbir_dir' => '/tmp/none',
+  'pages' => [
+    { 'page_id' => 'p1', 'page_title' => 'SALES OVERVIEW', 'page_w' => 1280, 'page_h' => 720,
+      'interactions' => [], 'visuals' => [
+        vis('s_region', 'slicer', 'control', { 'Values' => ['SALES_FACT.Region'] }, 'Region'),
+        vis('s_active', 'slicer', 'control', { 'Values' => ['SALES_FACT.Is Active Ind'] }, 'IS Active IND'),
+        vis('s_date',   'slicer', 'control', { 'Values' => ['DATE_DIM.Order Date'] }, 'Order Date'),
+        vis('kpi_sales', 'card', 'kpi', { 'Values' => ['SALES_FACT.Sales Amount'] }, 'Total Sales'),
+        # bar with a dimension + FOUR measures (defect: xAxis + 3/4 measures dropped)
+        vis('bar_multi', 'clusteredColumnChart', 'bar',
+            { 'Category' => ['SALES_FACT.Region'],
+              'Y' => ['SALES_FACT.Sales Amount', 'SALES_FACT.Order Count', 'SALES_FACT.Units', 'SALES_FACT.Discount'] }),
+        vis('tbl_detail', 'tableEx', 'table',
+            { 'Values' => ['SALES_FACT.Region', 'SALES_FACT.Sales Amount'] }, 'Detail')
+      ] },
+    # Page 2 — a chart whose DIMENSION cannot bind (ghost). Must fail LOUD (warn +
+    # coverage) rather than ship an xAxis-less one-giant-bar chart.
+    { 'page_id' => 'p2', 'page_title' => 'PARTIAL', 'page_w' => 1280, 'page_h' => 720,
+      'interactions' => [], 'visuals' => [
+        vis('kpi2', 'card', 'kpi', { 'Values' => ['SALES_FACT.Sales Amount'] }, 'Sales'),
+        vis('bar_nodim', 'clusteredColumnChart', 'bar',
+            { 'Category' => ['GHOST.Dim'], 'Y' => ['SALES_FACT.Sales Amount'] }, 'Broken Bar')
+      ] },
+    # Page 3 — EVERY data visual fails to bind. Must NOT ship a silently empty
+    # page: warn + a visible placeholder annotation + coverage.
+    { 'page_id' => 'p3', 'page_title' => 'BROKEN', 'page_w' => 1280, 'page_h' => 720,
+      'interactions' => [], 'visuals' => [
+        vis('kpi_ghost', 'card', 'kpi', { 'Values' => ['GHOST.Measure'] }, 'Ghost KPI')
+      ] }
+  ]
+}.freeze
+
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'mmap.json'),  JSON.generate(MMAP))
+  File.write(File.join(d, 'sig.json'),   JSON.generate(SIGNALS))
+  File.write(File.join(d, 'model.json'), JSON.generate(MODEL))
+  wb    = File.join(d, 'wb.json')
+  cov   = File.join(d, 'cov.json')
+  scope = File.join(d, 'control-scope.json')
+  err_f = File.join(d, 'err.txt')
+  st = system(RUBY, BUILD, '--signals', File.join(d, 'sig.json'), '--master-map', File.join(d, 'mmap.json'),
+              '--model', File.join(d, 'model.json'), '--data-model', 'dm-x', '--name', 'Sales Report',
+              '--out', wb, '--layout-out', File.join(d, 'l.xml'),
+              '--coverage-out', cov, '--control-scope-out', scope,
+              out: File::NULL, err: File.open(err_f, 'w'))
+  ok('builder exits 0', st)
+  spec  = JSON.parse(File.read(wb))
+  err   = File.read(err_f)
+  cover = JSON.parse(File.read(cov))['unresolved'] || []
+  scopej = JSON.parse(File.read(scope))
+
+  pages = spec['pages'].each_with_object({}) { |p, h| h[p['id']] = p }
+  p1 = pages['page-p1']['elements']
+  DATA = %w[kpi-chart bar-chart line-chart area-chart combo-chart scatter-chart
+            pie-chart donut-chart region-map point-map table pivot-table].freeze
+  p1_data = p1.select { |e| DATA.include?(e['kind']) }
+
+  # 1. one-base-table-per-page ------------------------------------------------
+  srcs = p1_data.map { |e| e.dig('source', 'elementId') }.uniq
+  ok('1) every data visual on the page sources the ONE base table (master-sales)',
+     srcs == ['master-sales'] || (puts("    sources: #{srcs.inspect}") && false))
+
+  # 2. control-targets-base + no passthrough + propagation --------------------
+  region_ctl = p1.find { |e| e['kind'] == 'control' && e['name'] == 'Region' }
+  ok('2a) region control has exactly ONE filter target', region_ctl && (region_ctl['filters'] || []).length == 1)
+  ok('2b) that target is the base table (master-sales / its Region column)',
+     region_ctl && region_ctl['filters'][0].dig('source', 'elementId') == 'master-sales' &&
+       region_ctl['filters'][0]['columnId'] == 'mc-region')
+
+  # no passthrough: every column on a CHART/PIVOT element is referenced by a role
+  # (an unreferenced "orphan" column is the passthrough that corrupts grouping).
+  def orphans(el)
+    rest = JSON.generate(el.reject { |k, _| k == 'columns' })
+    (el['columns'] || []).map { |c| c['id'] }.reject { |id| rest.include?(id) }
+  end
+  chart_pivot = %w[bar-chart line-chart area-chart combo-chart scatter-chart pie-chart donut-chart pivot-table].freeze
+  bad_orphans = spec['pages'].flat_map { |p| p['elements'] }
+                    .select { |e| chart_pivot.include?(e['kind']) }
+                    .flat_map { |e| orphans(e).map { |id| "#{e['id']}:#{id}" } }
+  ok('2c) NO passthrough (orphan) column on any chart/pivot element',
+     bad_orphans.empty? || (puts("    orphan cols: #{bad_orphans.inspect}") && false))
+
+  reg_scope = (scopej['controls'].find { |c| c['controlId'] == region_ctl['controlId'] } || {})['scope'] || []
+  ok('2d) control reach (propagation) covers EVERY data element on the page',
+     (p1_data.map { |e| e['id'] } - reg_scope).empty? ||
+       (puts("    scope: #{reg_scope.inspect} data: #{p1_data.map { |e| e['id'] }.inspect}") && false))
+
+  # 3. boolean-aware control --------------------------------------------------
+  active_ctl = p1.find { |e| e['kind'] == 'control' && e['controlId'].to_s.include?('Active') }
+  ok('3a) boolean slicer is a list control', active_ctl && active_ctl['controlType'] == 'list')
+  ok('3b) boolean control does NOT ship the zeroing include+empty-values shape',
+     active_ctl && !(active_ctl['mode'] == 'include' && Array(active_ctl['values']).empty?))
+  ok('3c) boolean control seeds the full boolean domain (unset = no filter)',
+     active_ctl && active_ctl['values'] == [true, false])
+  # a STRING slicer still uses the empty-list default (there, empty include = all)
+  region_vals = region_ctl['values']
+  ok('3d) string slicer keeps the empty-list default (empty include = show all)',
+     region_ctl['controlType'] == 'list' && Array(region_vals).empty?)
+
+  # 4. chart binding: xAxis + ALL measures ------------------------------------
+  bar = p1.find { |e| e['kind'] == 'bar-chart' }
+  ok('4a) bar chart keeps its xAxis dimension', bar && bar.dig('xAxis', 'columnId'))
+  ok('4b) bar chart carries ALL 4 measures on the yAxis',
+     bar && Array(bar.dig('yAxis', 'columnIds')).length == 4 ||
+       (puts("    yAxis: #{bar && bar['yAxis'].inspect}") && false))
+
+  # 5. fail loud, never silent-drop -------------------------------------------
+  ok('5a) unbindable chart dimension WARNS (visible), not silent',
+     err.include?('lost its category') || err.include?('Broken Bar'))
+  ok('5b) unbindable dimension is recorded in coverage (degraded)',
+     cover.any? { |u| u['severity'] == 'degraded' && u['detail'].to_s.include?('xAxis') })
+  ok('5c) unbound measure (ghost KPI) surfaces a dropped coverage entry',
+     cover.any? { |u| u['severity'] == 'dropped' })
+  # whole empty page: warning + a visible placeholder annotation on the page
+  ok('5d) all-empty page WARNS instead of shipping silently blank',
+     err.include?('NONE could be built') || err.include?("page 'BROKEN'"))
+  p3 = pages['page-p3']['elements']
+  ok('5e) all-empty page gets a visible placeholder element',
+     p3.any? { |e| e['kind'] == 'text' && e['body'].to_s.include?('could not be migrated') })
+
+  # 6. friendly naming --------------------------------------------------------
+  ok('6a) raw slicer label "IS Active IND" -> "Is Active Ind"', active_ctl['name'] == 'Is Active Ind')
+  ok('6b) raw page title "SALES OVERVIEW" -> "Sales Overview"', pages['page-p1']['name'] == 'Sales Overview')
+
+  # regression guard: the LEGACY per-visual mode still builds (escape hatch)
+  wb2 = File.join(d, 'wb2.json')
+  st2 = system(RUBY, BUILD, '--signals', File.join(d, 'sig.json'), '--master-map', File.join(d, 'mmap.json'),
+               '--model', File.join(d, 'model.json'), '--data-model', 'dm-x', '--name', 'X',
+               '--source-mode', 'per-visual', '--out', wb2, '--layout-out', File.join(d, 'l2.xml'),
+               '--coverage-out', File.join(d, 'cov2.json'), '--control-scope-out', File.join(d, 'sc2.json'),
+               out: File::NULL, err: File::NULL)
+  ok('7) --source-mode per-visual (legacy escape hatch) still builds', st2 && File.exist?(wb2))
+end
+
+puts($fail.zero? ? "\nall report-build emission tests passed" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
@@ -50,7 +50,19 @@ MMAP = {
                    { 'id' => 'mc-oid',    'name' => 'Order Id',       'formula' => '[SALES/Order Id]' },
                    { 'id' => 'mc-units',  'name' => 'Units',          'formula' => '[SALES/Units]' },
                    { 'id' => 'mc-disc',   'name' => 'Discount',       'formula' => '[SALES/Discount]' }
-                 ] }
+                 ] },
+    # multi-grain page: most tiles on ORDER, but a PY series lives on a separate
+    # calc-table master (the real report was ORDER_FACT View + a Net Revenue PY table).
+    'ORDER' => { 'id' => 'master-order', 'element_id' => 'el-order', 'data_model' => 'dm-x',
+                 'columns' => [
+                   { 'id' => 'oc-date', 'name' => 'Order Date',  'formula' => '[ORDER/Order Date]' },
+                   { 'id' => 'oc-rev',  'name' => 'Net Revenue',  'formula' => '[ORDER/Net Revenue]' }
+                 ] },
+    'PY' => { 'id' => 'master-py', 'element_id' => 'el-py', 'data_model' => 'dm-x',
+              'columns' => [
+                { 'id' => 'pc-date',  'name' => 'Order Date',     'formula' => '[PY/Order Date]' },
+                { 'id' => 'pc-pyrev', 'name' => 'Net Revenue PY', 'formula' => '[PY/Net Revenue PY]' }
+              ] }
   },
   'fields' => {
     'SALES_FACT.Region'        => { 'master' => 'SALES', 'ref' => '[master-sales/Region]',        'agg' => nil },
@@ -59,7 +71,17 @@ MMAP = {
     'SALES_FACT.Sales Amount'  => { 'master' => 'SALES', 'ref' => '[master-sales/Sales Amount]',   'agg' => 'Sum' },
     'SALES_FACT.Order Count'   => { 'master' => 'SALES', 'ref' => '[master-sales/Order Id]',       'agg' => 'Count' },
     'SALES_FACT.Units'         => { 'master' => 'SALES', 'ref' => '[master-sales/Units]',          'agg' => 'Sum' },
-    'SALES_FACT.Discount'      => { 'master' => 'SALES', 'ref' => '[master-sales/Discount]',       'agg' => 'Sum' }
+    'SALES_FACT.Discount'      => { 'master' => 'SALES', 'ref' => '[master-sales/Discount]',       'agg' => 'Sum' },
+    # trends page fields (base master = ORDER):
+    'ORDER_FACT.Order Date'    => { 'master' => 'ORDER', 'ref' => '[master-order/Order Date]',     'agg' => nil },
+    'ORDER_FACT.Net Revenue'   => { 'master' => 'ORDER', 'ref' => '[master-order/Net Revenue]',    'agg' => 'Sum' },
+    # declared on the PY master -> field_spec must DROP it on an ORDER-based visual
+    # (never emit a ref to master-py from an element sourcing master-order).
+    'PY_FACT.Net Revenue PY'   => { 'master' => 'PY', 'ref' => '[master-py/Net Revenue PY]',       'agg' => 'Sum' },
+    # declared on ORDER but its FORMULA references master-py -> field_spec can't
+    # catch it (trusts the declared master); the post-assembly HARD GATE must.
+    'ORDER_FACT.YoY Pct'       => { 'master' => 'ORDER', 'agg' => nil,
+                                    'formula' => 'Sum([master-py/Net Revenue PY]) / Sum([master-order/Net Revenue])' }
   }
 }.freeze
 
@@ -117,6 +139,16 @@ SIGNALS = {
     { 'page_id' => 'p3', 'page_title' => 'BROKEN', 'page_w' => 1280, 'page_h' => 720,
       'interactions' => [], 'visuals' => [
         vis('kpi_ghost', 'card', 'kpi', { 'Values' => ['GHOST.Measure'] }, 'Ghost KPI')
+      ] },
+    # Page 4 — genuine MULTI-GRAIN page (base = ORDER). A line chart references a
+    # PY measure that lives ONLY on the PY master (field_spec must drop it) plus a
+    # YoY column declared on ORDER but whose FORMULA references master-py (the
+    # HARD GATE must drop it). NEITHER may ship a cross-master formula.
+    { 'page_id' => 'p4', 'page_title' => 'TRENDS', 'page_w' => 1280, 'page_h' => 720,
+      'interactions' => [], 'visuals' => [
+        vis('line_yoy', 'lineChart', 'line',
+            { 'Category' => ['ORDER_FACT.Order Date'],
+              'Y' => ['ORDER_FACT.Net Revenue', 'PY_FACT.Net Revenue PY', 'ORDER_FACT.YoY Pct'] })
       ] }
   ]
 }.freeze
@@ -212,6 +244,38 @@ Dir.mktmpdir do |d|
   # 6. friendly naming --------------------------------------------------------
   ok('6a) raw slicer label "IS Active IND" -> "Is Active Ind"', active_ctl['name'] == 'Is Active Ind')
   ok('6b) raw page title "SALES OVERVIEW" -> "Sales Overview"', pages['page-p1']['name'] == 'Sales Overview')
+
+  # 8. multi-grain page: NO cross-master column formula survives (BUG 1/2) -----
+  master_ids = (pages['page-data']['elements'] || []).map { |e| e['id'] }
+  # every column formula on a CONTENT element may reference ONLY its own source
+  # master, never another master's id.
+  def elem_source(el)
+    el.dig('source', 'elementId') || el.dig('source', 'source', 'elementId')
+  end
+  leaks = []
+  spec['pages'].reject { |p| p['id'] == 'page-data' }.each do |p|
+    p['elements'].each do |el|
+      s = elem_source(el)
+      (el['columns'] || []).each do |c|
+        (master_ids - [s]).each do |mid|
+          leaks << "#{el['id']}:#{c['id']} -> #{mid}" if c['formula'].to_s.include?("[#{mid}/")
+        end
+      end
+    end
+  end
+  ok('8a) NO cross-master column formula survives on any content element',
+     leaks.empty? || (puts("    leaks: #{leaks.inspect}") && false))
+  # specifically: the master-py ref must not leak onto an ORDER-sourced element
+  p4 = pages['page-p4']['elements']
+  line = p4.find { |e| e['kind'] == 'line-chart' }
+  ok('8b) the PY-master measure was DROPPED, not emitted as a cross-master ref',
+     line && (line['columns'] || []).none? { |c| c['formula'].to_s.include?('[master-py/') })
+  ok('8c) the multi-grain chart still binds its xAxis + surviving measure (degraded, not errored)',
+     line && line.dig('xAxis', 'columnId') && Array(line.dig('yAxis', 'columnIds')).length == 1)
+  ok('8d) the cross-master drop is surfaced in coverage (dropped, matches the warning)',
+     cover.any? { |u| u['severity'] == 'dropped' && u['pbi_type'].to_s == 'cross-master' })
+  ok('8e) fail-loud: build WARNED about the cross-master reference',
+     err.include?('cross-master') || err.include?('DIFFERENT master'))
 
   # regression guard: the LEGACY per-visual mode still builds (escape hatch)
   wb2 = File.join(d, 'wb2.json')

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
@@ -29,6 +29,7 @@
 require 'json'
 require 'tmpdir'
 require 'rbconfig'
+require_relative 'lib/layout_lint'
 
 BUILD = File.join(__dir__, 'build-workbook-from-pbir.rb')
 RUBY  = RbConfig.ruby
@@ -276,6 +277,24 @@ Dir.mktmpdir do |d|
      cover.any? { |u| u['severity'] == 'dropped' && u['pbi_type'].to_s == 'cross-master' })
   ok('8e) fail-loud: build WARNED about the cross-master reference',
      err.include?('cross-master') || err.include?('DIFFERENT master'))
+
+  # 9. BUG 3 — every element `name` is a plain String (Hash name crashes validate-spec)
+  all_els = spec['pages'].flat_map { |p| p['elements'] }
+  bad_names = all_els.reject { |e| e['name'].nil? || e['name'].is_a?(String) }
+                     .map { |e| "#{e['id']}:#{e['name'].class}" }
+  ok('9a) every emitted element name is a String (no Hash name)',
+     bad_names.empty? || (puts("    non-string names: #{bad_names.inspect}") && false))
+  kpi = p1.find { |e| e['kind'] == 'kpi-chart' }
+  ok('9b) the single-value KPI name is a String (was a {text,color} Hash)',
+     kpi && kpi['name'].is_a?(String) && !kpi['name'].empty?)
+
+  # 10. BUG 5 — controls sit inside a GridContainer (no "orphan control" lint fail)
+  lint_v = LayoutLint.lint(spec)
+  orphan = lint_v.select { |v| v.to_s.include?('orphan control') }
+  ok('10a) layout lint reports NO orphan control',
+     orphan.empty? || (puts("    #{orphan.inspect}") && false))
+  ok('10b) the page emits a control-band GridContainer holding the slicers',
+     spec['layout'].to_s.include?("band-page-p1-ctrl"))
 
   # regression guard: the LEGACY per-visual mode still builds (escape hatch)
   wb2 = File.join(d, 'wb2.json')

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild.rb
@@ -66,5 +66,24 @@ ok('"Order Count" -> NOT boolean',  !B.call('Order Count'))
 
 ok('boolean_domain_values is [true, false]', PbiReportBuild.boolean_domain_values == [true, false])
 
+# ---- foreign_master_refs: cross-master leak detection -----------------------
+MIDS = %w[master-order master-py].freeze
+BYNAME = { 'ORDER' => 'master-order', 'PY' => 'master-py' }.freeze
+G = ->(f, src) { PbiReportBuild.foreign_master_refs(f, src, MIDS, BYNAME) }
+ok('same-source ref is allowed (Sum([master-order/Net Revenue]) sourced from master-order)',
+   G.call('Sum([master-order/Net Revenue])', 'master-order').empty?)
+ok('cross-master ref is flagged (references master-py while sourced from master-order)',
+   G.call('Sum([master-py/Net Revenue PY])', 'master-order') == ['master-py'])
+ok('mixed formula flags only the foreign master',
+   G.call('Sum([master-py/PY]) / Sum([master-order/Cur])', 'master-order') == ['master-py'])
+ok('display-name token resolves to a master id and is flagged',
+   G.call('Sum([PY/Net Revenue PY])', 'master-order') == ['master-py'])
+ok('display-name token equal to the source is allowed',
+   G.call('[ORDER/Region]', 'master-order').empty?)
+ok('same-element column ref [Col] (no slash) is ignored',
+   G.call('[Sales Amount] / [Order Count]', 'master-order').empty?)
+ok('a non-master cross-element ref ([Metrics/..]) is ignored',
+   G.call('[Metrics/Net Revenue]', 'master-order').empty?)
+
 puts($fail.zero? ? "\nall pbi-reportbuild unit tests passed" : "\n#{$fail} FAILED")
 exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-pbi-reportbuild.rb — unit tests for the pure report-build helpers
+# (lib/pbi_reportbuild.rb): friendly naming, one-base-table-per-page master
+# selection, and boolean-slicer detection. Creds-free, network-free, synthetic
+# data only (generic SALES_FACT/DATE_DIM/REGION names — NO customer data).
+require_relative 'lib/pbi_reportbuild'
+
+$fail = 0
+def ok(name, cond)
+  puts((cond ? '  ok  ' : 'FAIL  ') + name)
+  $fail += 1 unless cond
+end
+
+# ---- friendly_label: raw warehouse names -> human display names -------------
+F = PbiReportBuild.method(:friendly_label)
+ok('raw ALL-CAPS indicator "IS Active IND" -> "Is Active Ind"', F.call('IS Active IND') == 'Is Active Ind')
+ok('snake_case "SALES_AMOUNT" -> "Sales Amount"',              F.call('SALES_AMOUNT') == 'Sales Amount')
+ok('mixed raw "Submission KEY by Level 1 Name" fixes KEY',
+   F.call('Submission KEY by Level 1 Name') == 'Submission Key by Level 1 Name')
+ok('preserves real acronym "Customer ID"',                     F.call('Customer ID') == 'Customer ID')
+ok('preserves "GL Balance" acronym',                           F.call('GL Balance') == 'GL Balance')
+ok('leaves already-human "Total Sales" untouched',             F.call('Total Sales') == 'Total Sales')
+ok('leaves "Sales by Region" untouched',                       F.call('Sales by Region') == 'Sales by Region')
+ok('non-string passes through (nil)',                          F.call(nil).nil?)
+ok('empty string passes through',                              F.call('') == '')
+ok('all-caps single token "REGION" -> "Region"',               F.call('REGION') == 'Region')
+
+# ---- page_base_master: the ONE master resolving the most page fields --------
+# masters_for maps a queryRef to the masters it can resolve on (primary + alts).
+FIELD_MASTER = {
+  'SALES_FACT.Region'      => ['SALES'],
+  'SALES_FACT.Sales Amount' => ['SALES'],
+  'SALES_FACT.Order Count'  => ['SALES'],
+  'DATE_DIM.Order Date'     => ['SALES'],       # dim folded into the wide base
+  'INVENTORY.On Hand'       => ['INVENTORY']    # a different fact — minority on the page
+}.freeze
+masters_for = ->(qr) { FIELD_MASTER[qr] || [] }
+
+# A page whose visuals overwhelmingly hit SALES + one INVENTORY tile.
+page_visuals = [
+  { 'bindings' => { 'Values' => ['SALES_FACT.Sales Amount'] } },              # kpi
+  { 'bindings' => { 'Category' => ['SALES_FACT.Region'], 'Y' => ['SALES_FACT.Sales Amount', 'SALES_FACT.Order Count'] } }, # bar
+  { 'bindings' => { 'Values' => ['SALES_FACT.Region', 'SALES_FACT.Sales Amount'] } }, # table
+  { 'bindings' => { 'Values' => ['INVENTORY.On Hand'] } }                     # lone other-fact tile
+]
+ok('page_base_master picks the dominant master (SALES)',
+   PbiReportBuild.page_base_master(page_visuals, masters_for) == 'SALES')
+
+ok('page_base_master is nil when nothing resolves',
+   PbiReportBuild.page_base_master([{ 'bindings' => { 'Values' => ['GHOST.Col'] } }], masters_for).nil?)
+
+# deterministic tie-break: first-seen master wins on a tie.
+tie_for = ->(qr) { { 'a' => ['A'], 'b' => ['B'] }[qr] }
+tie_visuals = [{ 'bindings' => { 'X' => ['a'], 'Y' => ['b'] } }]
+ok('page_base_master tie -> first-seen (A)', PbiReportBuild.page_base_master(tie_visuals, tie_for) == 'A')
+
+# ---- boolean_leaf?: indicator naming, conservative --------------------------
+B = PbiReportBuild.method(:boolean_leaf?)
+ok('"Is Active" -> boolean',        B.call('Is Active'))
+ok('"IS Active IND" -> boolean',    B.call('IS Active IND'))
+ok('"Has Discount" -> boolean',     B.call('Has Discount'))
+ok('"Active Flag" -> boolean',      B.call('Active Flag'))
+ok('"Region" -> NOT boolean',       !B.call('Region'))
+ok('"Order Count" -> NOT boolean',  !B.call('Order Count'))
+
+ok('boolean_domain_values is [true, false]', PbiReportBuild.boolean_domain_values == [true, false])
+
+puts($fail.zero? ? "\nall pbi-reportbuild unit tests passed" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-validate-spec-metrics.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-validate-spec-metrics.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-validate-spec-metrics.rb — BUG 4: validate-spec.rb must accept the
+# governed [Metrics/<measure>] reference form (the documented, LIVE-accepted
+# way a workbook column references a data-model metric). Previously the prefix
+# check false-flagged "Metrics" as an unknown prefix and failed most elements.
+# A genuinely unknown prefix must STILL be rejected (the fix widens the allow
+# list by exactly one reserved prefix, it does not disable the check).
+# Creds-free, network-free, synthetic data only.
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+require 'shellwords'
+
+VALIDATE = File.join(__dir__, 'validate-spec.rb')
+RUBY = RbConfig.ruby
+$fail = 0
+def ok(name, cond)
+  puts((cond ? '  ok  ' : 'FAIL  ') + name)
+  $fail += 1 unless cond
+end
+
+def spec_with(formula)
+  {
+    'name' => 'T',
+    'pages' => [
+      { 'id' => 'page-data', 'name' => 'Data', 'elements' => [
+        { 'id' => 'master-x', 'kind' => 'table', 'name' => 'X',
+          'source' => { 'dataModelId' => 'dm', 'elementId' => 'el', 'kind' => 'data-model' },
+          'columns' => [{ 'id' => 'c1', 'name' => 'Region', 'formula' => '[X/Region]' }],
+          'visibleAsSource' => false }
+      ] },
+      { 'id' => 'page-1', 'name' => 'P', 'elements' => [
+        { 'id' => 'kpi1', 'kind' => 'kpi-chart', 'name' => 'Net Revenue',
+          'source' => { 'elementId' => 'master-x', 'kind' => 'table' },
+          'columns' => [{ 'id' => 'k1', 'name' => 'Net Revenue', 'formula' => formula }],
+          'value' => { 'columnId' => 'k1' } }
+      ] }
+    ]
+  }
+end
+
+def run_validate(spec)
+  Dir.mktmpdir do |d|
+    f = File.join(d, 'spec.json')
+    File.write(f, JSON.generate(spec))
+    out = `#{RUBY.shellescape} #{VALIDATE.shellescape} --type workbook #{f.shellescape} 2>&1`
+    [$?.exitstatus, out]
+  end
+end
+
+# 1) [Metrics/<measure>] is accepted (exit 0, no unknown-prefix error for Metrics)
+code, out = run_validate(spec_with('[Metrics/Net Revenue]'))
+ok('[Metrics/Net Revenue] passes validation (exit 0)', code.zero? || (puts("    out: #{out}") && false))
+ok('no "Metrics unknown prefix" error is reported', out !~ /"Metrics" unknown/)
+
+# 2) a genuinely unknown prefix is STILL rejected (the check is not disabled)
+code2, out2 = run_validate(spec_with('[Bogus/Net Revenue]'))
+ok('an unknown prefix [Bogus/...] is still REJECTED (exit non-zero)', !code2.zero?)
+ok('the unknown-prefix error names "Bogus"', out2.include?('"Bogus" unknown'))
+
+# 3) a same-source ref [X/Region]... element-id ref still fine (regression guard)
+code3, = run_validate(spec_with('[master-x/Region]'))
+ok('[master-x/Region] (element-id ref) still passes', code3.zero?)
+
+puts($fail.zero? ? "\nall validate-spec metrics tests passed" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
@@ -58,8 +58,16 @@ spec.fetch('pages', []).each do |page|
     all_element_names << el['id'] if el['id']
   end
 end
-all_known_prefixes = (all_element_names + external_names).to_set rescue (all_element_names + external_names)
 require 'set' rescue nil
+# RESERVED reference prefixes that are always valid regardless of the spec's own
+# elements. `Metrics` is the governed data-model metric namespace: a column
+# formula may reference a DM metric as [Metrics/<measure name>] (the documented,
+# LIVE-accepted form — confirmed on the E2E). It is NOT an element in the spec,
+# so without this the prefix check false-flags every metric-bound column as an
+# "unknown prefix". Do NOT rewrite [Metrics/X] to a master id — the live API
+# rejects that; the [Metrics/X] form is correct.
+RESERVED_REF_PREFIXES = %w[Metrics].freeze
+all_known_prefixes = (all_element_names + external_names + RESERVED_REF_PREFIXES).to_set rescue (all_element_names + external_names + RESERVED_REF_PREFIXES)
 all_known_set = all_known_prefixes.is_a?(Set) ? all_known_prefixes : Set.new(all_known_prefixes)
 
 errors << 'spec contains rgb(...) color strings (Cloudflare WAF blocks)' if JSON.generate(spec).include?('rgb(')


### PR DESCRIPTION
## What & why

Hardens the powerbi-to-sigma **REPORT-BUILD** against a class of defects seen on live migrations (all on simple dashboards) by **simplifying** the workbook-build architecture rather than layering on more special cases.

### Defects (seen on live migrations)
- **Controls only filtered the detail table.** Page controls left KPIs, charts, and pivots on the same page unfiltered (each visual sourced its own narrow master; the control only targeted the table's master). The attempted fix — adding a filter "passthrough" column to each visual — **broke bar-charts/pivots** (the extra column corrupts grouping → "No data"). KPIs/tables tolerate a passthrough column; charts/pivots do not.
- **Boolean slicers zeroed everything.** A boolean/indicator slicer got the same empty-list template as a string slicer; Sigma treats an unset boolean `include: values:[]` as "include nothing" and zeroed every targeted element.
- **Charts lost bindings.** A bar chart came out with a yAxis but no xAxis and 3 of 4 measures dropped (one giant aggregated bar).
- **Silent drops.** Whole pages came out empty and measures were silently dropped when a formula couldn't bind.
- **Raw names as labels.** Reports surfaced raw warehouse column names as titles/labels (e.g. an indicator column name, a `KEY`-cased projection).

### The simplification
1. **One base table per page + control-targets-base.** The builder picks ONE base master per page (the master resolving the most of the page's fields). Every visual on the page **sources** it, and each page control targets **that base table's column** — so the filter propagates to every visual through the source closure. This replaces per-visual/multi-master control targeting and removes the passthrough-column hack entirely. **A passthrough column is never added to a chart/pivot.** This mirrors the tableau/qlik one-master source-propagation pattern (those plugins untouched). Legacy behavior remains available via `--source-mode per-visual`.
2. **Boolean-aware controls.** A boolean-typed slicer (detected from the TMSL model's `dataType`, falling back to indicator-name shape) is seeded with the boolean domain (`values: [true, false]`) so an unset control includes everything = no filter, instead of the zeroing empty-`include` shape. String slicers keep the empty default (there, empty `include` correctly means "all").
3. **Chart binding.** With all raw columns on the one page base, a chart keeps its category on the xAxis and carries every measure on the yAxis.
4. **Fail loud, don't silent-drop.** A post-drop guard emits a visible warning + a coverage entry when a chart loses its xAxis or a KPI loses its value; an all-empty page gets a visible placeholder element instead of shipping silently blank. Everything unbound is surfaced in the per-report coverage summary.
5. **Friendly naming.** Raw warehouse names become human display names on controls, derived titles, and page titles; explicit PBI titles and real acronyms (e.g. `Customer ID`) pass through unchanged.

## Tests (synthetic only — generic `SALES_FACT` / `DATE_DIM` / `INVENTORY`, no customer data)
- `scripts/test-pbi-reportbuild.rb` — unit tests for the pure helpers (friendly naming, page-base-master selection, boolean detection).
- `scripts/test-pbi-reportbuild-emit.rb` — end-to-end build assertions: one base table per page; control targets the base (single target, no passthrough on any chart/pivot); control reach covers every page element (propagation); boolean control unset ≠ zero; string slicer keeps the empty default; bar keeps xAxis + all 4 measures; unbindable dimension/measure/whole-page fail loud (warning + coverage + placeholder); raw name → friendly title; `--source-mode per-visual` still builds.
- Both wired into `corpus-check.yml`. Existing offline PBI tests + `test-grounding.rb` stay green; the shared control-lint reports the generated workbook **clean** (every control now reaches every page element).

No live migration was run in this PR (a separate E2E will validate). Code + unit tests + doc only. `refs/control-parity.md` updated to drop the stale passthrough recipe. Plugin version `1.1.1` → `1.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
