### PR TITLE
quicksight-to-sigma: make the runtime control-flip proof default-on

### DIFF
--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -671,9 +671,14 @@ fin_out, fin_st = Open3.capture2e(*fin)
 fin_out.each_line { |l| puts "   #{l.rstrip}" }
 parity_ok = fin_st.success?
 
-# the shared HARD GATE: parity sentinel + orphan + error-column + layout checks.
+# the shared HARD GATE: parity sentinel + orphan + error-column + layout checks,
+# plus gate 7b — the runtime control-flip proof (--require-control-flip): flips
+# each control live via probe-controls.rb and FAILS if a control is wired but
+# INERT (a static-lint-clean spec that does nothing when the user changes it).
+# DEFAULT-ON here, mirroring looker; waive with --skip-control-flip on this gate.
 gate_out, gate_st = Open3.capture2e('ruby', File.join(HERE, 'assert-phase6-ran.rb'),
-                                    '--workdir', WORK, '--workbook-id', wb_id)
+                                    '--workdir', WORK, '--workbook-id', wb_id,
+                                    '--require-control-flip')
 gate_out.each_line { |l| puts "   #{l.rstrip}" }
 gate_ok = gate_st.success?
 


### PR DESCRIPTION
Passes `--require-control-flip` on the shared `assert-phase6-ran.rb` hard gate that migrate-quicksight.rb already runs, so **gate 7b** (the runtime control-flip proof via `probe-controls.rb`) runs by default. A control that passes the static control lint but is **inert at runtime** now fails the migration (exit 21) instead of shipping.

quicksight already vendors `assert-phase6-ran.rb`, `lib/flip_gate.rb`, and `probe-controls.rb`, so no vendoring was needed. Mirrors the looker reference. Waive on the gate with `--skip-control-flip "<reason>"`.

- plugin.json: 1.2.0 → 1.2.1
- offline ruby tests: 7/7 green; check-shared clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)