### PR TITLE
thoughtspot-to-sigma: make the runtime control-flip proof default-on

### DIFF
--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
@@ -625,8 +625,13 @@ def main():
         json.dump(actuals, open(os.path.join(pdir, "parity-actuals.json"), "w"), indent=2)
         rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-thoughtspot.rb"),
                      "--workdir", pdir, "--finalize"], check=False)
+        # --require-control-flip: gate 7b runs the runtime control-flip proof
+        # (probe-controls.rb) by default, so a control that lints clean but is
+        # INERT at runtime FAILS the migration. Mirrors the looker reference;
+        # waive on the gate with --skip-control-flip "<reason>".
         grc, _ = run(["ruby", os.path.join(HERE, "assert-phase6-ran.rb"),
-                      "--workdir", pdir, "--workbook-id", wb], check=False)
+                      "--workdir", pdir, "--workbook-id", wb,
+                      "--require-control-flip"], check=False)
         summary = json.load(open(os.path.join(pdir, "parity-final.json")))
         overall.append((name, wb, summary, grc))
 


### PR DESCRIPTION
Passes `--require-control-flip` on the shared `assert-phase6-ran.rb` hard gate that migrate-thoughtspot.py runs per workbook, so **gate 7b** (runtime control-flip proof) runs by default. An inert-but-lint-clean control now fails the migration (exit 21).

thoughtspot already vendors the gate + `lib/flip_gate.rb` + `probe-controls.rb`. Mirrors the looker reference. Waive with `--skip-control-flip "<reason>"`.

- plugin.json: 1.1.0 → 1.1.1
- offline ruby tests: 2/2 green; check-shared clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)