### PR TITLE
domo-to-sigma: make the runtime control-flip proof default-on

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/flip_gate.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -619,6 +619,10 @@ def run_live!(opts)
 
   hr('assert-phase6-ran')
   args = ['--workdir', OUT, '--workbook-id', workbook_id]
+  # gate 7b (runtime control-flip proof) DEFAULT-ON: flip each control live via
+  # probe-controls.rb and FAIL if a control is wired but INERT. Mirrors the
+  # looker reference; waive with --skip-control-flip "<reason>".
+  args += ['--require-control-flip']
   args += ['--skip-visual-gate', 'Tier B — private render endpoint unavailable'] if tier_b
   args += ['--skip-parity-gate', 'no --parity-plan supplied to migrate-domo.rb'] unless opts[:parity_plan]
   ok, code, _out = run_script!('assert-phase6-ran.rb', *args)

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -124,7 +124,8 @@
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/flip_gate.rb",
         "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/flip_gate.rb",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/flip_gate.rb",
-        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/flip_gate.rb"
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/flip_gate.rb",
+        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/flip_gate.rb"
       ]
     },
     {


### PR DESCRIPTION
migrate-domo.rb already runs the shared `assert-phase6-ran.rb` hard gate, but domo was **missing `lib/flip_gate.rb`** — which gate 7b needs — so the flip test could never run. This:

- vendors the shared `lib/flip_gate.rb` into domo (manifest + byte-identical copy; check-shared clean at 536), closing a pre-existing sync gap (domo had `assert-phase6-ran.rb` + `probe-controls.rb` but not `flip_gate.rb`);
- passes `--require-control-flip` so the flip proof runs by **default** — an inert control now fails the migration (exit 21).

Mirrors the looker reference. Waive with `--skip-control-flip "<reason>"`.

- plugin.json: 0.3.1 → 0.3.2
- domo test/ suite: 16/16 green; check-shared clean

> Note: touches `shared/manifest.json` (registers domo's adoption of the shared lib) alongside the plugin files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)