### PR TITLE
microstrategy-to-sigma: make the runtime control-flip proof default-on

### DIFF
--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
@@ -1292,6 +1292,28 @@ def main():
     open(args.out_layout, "w").write(layout_xml)
     json.dump(control_scope, open(args.control_scope_out, "w"), indent=1)
 
+    # gate 7b (runtime control-flip proof) DEFAULT-ON: stamp control_flip_required
+    # into <workdir>/migrate-state.json (next to the workbook spec) so the agent's
+    # `assert-phase6-ran.rb --workdir <dir>` auto-enables the live flip test — a
+    # control that lints clean (gate 7) but is INERT at runtime then FAILS the
+    # gate (exit 21) instead of shipping. Mirrors the tableau pass-1 stamp; merge,
+    # never clobber, any existing state.
+    _state_path = os.path.join(os.path.dirname(os.path.abspath(args.out_wb)),
+                               "migrate-state.json")
+    try:
+        _state = {}
+        if os.path.exists(_state_path):
+            with open(_state_path) as _sf:
+                _loaded = json.load(_sf)
+                if isinstance(_loaded, dict):
+                    _state = _loaded
+        _state["control_flip_required"] = True
+        json.dump(_state, open(_state_path, "w"), indent=1)
+        print(f"gate: stamped control_flip_required=true -> {_state_path} "
+              f"(gate 7b runtime control-flip proof DEFAULT-ON)")
+    except OSError:
+        pass  # state bookkeeping never fails the conversion
+
     print(f"fact table: {b.table_info[b.fact_tid]['name']}")
     for j in b.derive_joins():
         print(f"join: {b.table_info[b.fact_tid]['tableName']}.{j['fact_col']} = "


### PR DESCRIPTION
microstrategy is agent-driven (`convert.py` emits specs; the agent posts and runs `assert-phase6-ran.rb` per SKILL.md), so there's no orchestrator line to pass a flag. Instead `convert.py` now **stamps `control_flip_required=true`** into `<workdir>/migrate-state.json` next to the workbook spec. The shared gate reads that stamp and auto-enables **gate 7b** — so an inert-but-lint-clean control fails the gate (exit 21) without the agent having to remember a flag. Mirrors the tableau pass-1 stamp.

microstrategy already vendors the gate + `lib/flip_gate.rb` + `probe-controls.rb`. Waive with `--skip-control-flip "<reason>"`.

- plugin.json: 0.2.0 → 0.2.1
- tests: 2 ruby + 5 python green; check-shared clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)