### PR TITLE
qlik-to-sigma: add gate 7b (runtime control-flip proof), default-on

### DIFF
--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/flip_gate.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/flip_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# FlipGate — pure decision logic for gate 7b (the runtime control flip test).
+#
+# Gate 7 (control_lint.rb) asserts control wiring against the LIVE spec plus the
+# control-scope.json sidecar — but that sidecar is derived by build_workbook.py
+# from the SAME `listen` data it used to wire the spec, so a builder-level
+# mis-mapping produces a spec and a sidecar that AGREE and gate 7 passes. The
+# only independent proof is runtime: flip a control via the REST export API and
+# confirm its targets' output actually changes (scripts/probe-controls.rb).
+#
+# This module turns probe-controls.rb's exit code + parsed probe-results.json
+# into a gate verdict. It is pure (no I/O) so the branch logic is unit-testable
+# without a live workbook — see the plugin tests/ for coverage.
+#
+# SHARED lib, vendored byte-identical into every plugin that runs
+# assert-phase6-ran.rb (SHA-1 discipline — tools/check-shared.rb).
+module FlipGate
+  # probe-controls.rb exit codes (see its header):
+  #   0 = every auto-probeable control flipped correctly (SKIPs allowed)
+  #   1 = at least one FAIL (a control is wired but inert, or a flip leaked)
+  #   2 = nothing could be auto-probed (all controls are date-range / slider /
+  #       unlabeled types that need an explicit --value)
+  #
+  # results: the parsed probe-results.json array (or nil if it could not be read
+  # — e.g. probe crashed before writing it).
+  #
+  # Returns [decision, info]:
+  #   decision ∈ :ok | :fail | :advisory | :error
+  #     :ok       — ≥1 control proven to filter its targets live → gate passes
+  #     :fail     — ≥1 control FAILed the flip → gate blocks GREEN (exit 21)
+  #     :advisory — no control was auto-probeable → loud WARN + marker, no fail
+  #                 (we genuinely cannot flip these types; do not block a
+  #                  legitimately date-only dashboard)
+  #     :error    — probe could not run / produced no verdict → fail-closed
+  #                 (exit 21): an opted-in gate that could not verify must not
+  #                 silently pass; re-run or waive with --skip-control-flip
+  #   info: { passes:[cid,...], fails:[[cid,note],...], skips:[[cid,note],...] }
+  def self.decide(probe_rc, results)
+    rows   = results.is_a?(Array) ? results : []
+    pick   = ->(name) { rows.select { |r| val(r, 'result').to_s == name } }
+    passes = pick.call('PASS')
+    fails  = pick.call('FAIL')
+    skips  = pick.call('SKIP')
+    info = {
+      passes: passes.map { |r| val(r, 'control') },
+      fails:  fails.map  { |r| [val(r, 'control'), val(r, 'note')] },
+      skips:  skips.map  { |r| [val(r, 'control'), val(r, 'note')] }
+    }
+
+    decision =
+      case probe_rc
+      when 1
+        # rc==1 with FAIL rows is a real inert/leaky control; rc==1 with none
+        # is an abort (bad args, columns fetch failed, …) — could not verify.
+        fails.any? ? :fail : :error
+      when 0
+        passes.any? ? :ok : :advisory
+      when 2
+        :advisory
+      else
+        :error
+      end
+    [decision, info]
+  end
+
+  # Read a field from a probe result row whether it was parsed from JSON (string
+  # keys) or built in-process (symbol keys).
+  def self.val(row, key)
+    return nil unless row.is_a?(Hash)
+    row[key] || row[key.to_sym]
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -135,6 +135,7 @@ OptionParser.new do |o|
   o.on('--no-reuse')          {     opts[:no_reuse] = true }
   o.on('--dry-run')           {     opts[:dry_run]  = true }
   o.on('--skip-layout-lint')  {     opts[:skip_layout_lint] = true }
+  o.on('--skip-control-flip [REASON]') { |v| opts[:skip_control_flip] = v || true } # waive gate 7b (runtime control-flip proof); name the reason in your report
   # Resolve + print which converter would run (vendored vs explicit dev build), then
   # exit 0 — no creds/args needed. Used by the converter-default regression test.
   o.on('--print-converter')   {     opts[:print_converter] = true }
@@ -981,6 +982,48 @@ else
   ctl_violations.each { |v| puts "       - #{v}" }
 end
 control_ok = ctl_violations.empty?
+
+# 7b — runtime control-flip proof (gate 7b). Gate 7 proves control WIRING, but a
+# builder listen->column mis-map can lint clean yet do NOTHING at runtime. Flip
+# each control live via probe-controls.rb and FAIL (RED) if a control is INERT —
+# the only independent proof the wiring works. DEFAULT-ON; --skip-control-flip
+# "<reason>" waives; offline/dry-run/0-controls SKIP (never hard-fail a run that
+# never reached the live API). Mirrors the powerbi Phase 6b + the shared gate 7b.
+puts
+puts '   ── CONTROL FLIP (gate 7b: each control actually FILTERS at runtime) ──'
+require 'flip_gate'
+flip_ok = true
+_flip_tok = (Sigma.auth_token rescue ENV['SIGMA_API_TOKEN'])
+if opts[:skip_control_flip]
+  puts "     [WAIVED] #{opts[:skip_control_flip] == true ? '(no reason given)' : opts[:skip_control_flip]} (name it in your report)"
+elsif ctl_rows.empty?
+  puts '     [OK] no controls — nothing to flip-test'
+elsif ENV['SIGMA_BASE_URL'].to_s.empty? || _flip_tok.to_s.empty?
+  puts '     [SKIP] offline (no SIGMA creds) — runtime flip UNVERIFIED'
+else
+  _probe_out = File.join(WORK, 'probe-controls')
+  system('ruby', File.join(HERE, 'probe-controls.rb'), '--workbook-id', WB_ID, '--out', _probe_out)
+  _probe_rc = $?.exitstatus
+  _results = (JSON.parse(File.read(File.join(_probe_out, 'probe-results.json'))) rescue nil)
+  _decision, _info = FlipGate.decide(_probe_rc, _results)
+  case _decision
+  when :ok
+    puts "     [OK] #{_info[:passes].length} control(s) proven live" \
+         "#{_info[:skips].any? ? "; #{_info[:skips].length} un-probeable skipped" : ''}"
+  when :fail
+    puts "     [FAIL] #{_info[:fails].length} control(s) wired but INERT on workbook #{WB_ID}:"
+    _info[:fails].each { |cid, note| puts "       - #{cid}: #{note}" }
+    puts '       Static lint clean (gate 7) but does not filter — a builder listen->column'
+    puts '       mis-map. Fix the build, or waive with --skip-control-flip "<reason>".'
+    flip_ok = false
+  when :advisory
+    puts "     [WARN] no control auto-probeable (#{_info[:skips].length} date/slider/unlabeled) — runtime wiring UNVERIFIED"
+  when :error
+    puts '     [FAIL] probe-controls.rb could not verify the wiring — an enforced gate must not pass silently.'
+    puts '       Re-run once the export API is reachable, or waive with --skip-control-flip "<reason>".'
+    flip_ok = false
+  end
+end
 mark('phase6-parity')
 
 # ---------------------------------------------------------------------------
@@ -997,6 +1040,7 @@ puts "LAYOUT      : #{layout_ok ? 'GREEN' : 'RED'} — gate 6 layout lint" \
      "#{(defined?(layout_violations) && layout_violations && layout_violations.any?) ? ", #{layout_violations.size} violation(s)" : (opts[:skip_layout_lint] ? ' (skipped)' : '')}"
 puts "CONTROLS    : #{control_ok ? 'GREEN' : 'RED'} — gate 7 control lint, #{ctl_rows.size} control(s) checked" \
      "#{ctl_violations.any? ? ", #{ctl_violations.size} violation(s)" : ''}"
+puts "CONTROL-FLIP: #{flip_ok ? 'GREEN' : 'RED'} — gate 7b runtime flip proof#{opts[:skip_control_flip] ? ' (waived)' : ''}"
 puts "freshness   : Qlik last reload #{app_meta['lastReloadTime'] || '?'} (#{stale_days} days ago)" if stale_days
 puts "warnings    : #{conv_warnings.size} converter, #{(wb_res['warnings'] || []).size} workbook-build" if conv_warnings.any? || (wb_res['warnings'] || []).any?
 # Empty-workbook guard + completion sentinel (parity with tableau/powerbi). A
@@ -1004,13 +1048,13 @@ puts "warnings    : #{conv_warnings.size} converter, #{(wb_res['warnings'] || []
 # stamp a run-scoped success marker only on a genuine green so verify-complete.rb
 # (the done-check the SKILL points at) can't green an empty/hand-built result.
 n_elements = wb_res['elements'].to_i
-built_ok = parity_ok && layout_ok && control_ok && n_elements.positive?
+built_ok = parity_ok && layout_ok && control_ok && flip_ok && n_elements.positive?
 puts 'ELEMENTS    : 0 workbook elements built — EMPTY workbook, NOT done (investigate the build).' if n_elements.zero?
 begin
   succ = File.join(WORK, 'phase6-success.json')
   if built_ok
     File.write(succ, JSON.pretty_generate('workbookId' => WB_ID, 'chartCount' => n_elements,
-                                          'gates' => 'parity+layout+control',
+                                          'gates' => 'parity+layout+control+flip',
                                           'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   elsif File.exist?(succ)
     File.delete(succ)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-complete.rb
@@ -52,8 +52,10 @@ end
 
 # 5) the orchestrator wires the empty-workbook guard + success stamp.
 mt = File.read(File.join(DIR, 'migrate-qlik.rb'))
-check(mt.include?('built_ok = parity_ok && layout_ok && control_ok && n_elements.positive?'),
+check(mt.include?('built_ok = parity_ok && layout_ok && control_ok && flip_ok && n_elements.positive?'),
       'orchestrator requires real elements for a green (no empty pass)', fails)
+check(mt.include?("require 'flip_gate'") && mt.include?('FlipGate.decide'),
+      'orchestrator runs gate 7b (runtime control-flip proof) before a green', fails)
 check(mt.include?('phase6-success.json'), 'orchestrator stamps the success sentinel', fails)
 # 6) SKILL carries THE ONE PATH / no-hand-drive directive.
 sk = File.read(File.join(DIR, '..', 'SKILL.md'))

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -124,7 +124,8 @@
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/flip_gate.rb",
         "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/flip_gate.rb",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/flip_gate.rb",
-        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/flip_gate.rb"
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/flip_gate.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/flip_gate.rb"
       ]
     },
     {


### PR DESCRIPTION
migrate-qlik.rb already runs gate 6 (layout lint) + gate 7 (control lint) inline, but nothing proved the controls actually **filter at runtime** — a builder listen→column mis-map can satisfy gate 7 while the control does nothing live. This adds **gate 7b**: after the control lint, flip each control via the vendored `probe-controls.rb` + `FlipGate.decide`; a wired-but-inert control turns the run RED (blocks the green exit) like a parity/layout/control failure. `flip_ok` folded into `built_ok`.

- vendors the shared `lib/flip_gate.rb` into qlik (manifest + byte-identical copy; check-shared clean at 536) — the one dep qlik lacked (it already had `control_lint.rb` + `probe-controls.rb`);
- DEFAULT-ON; `--skip-control-flip "<reason>"` waives; offline/dry-run/0-controls SKIP (never hard-fail a run that never reached the live API).

- plugin.json: 1.2.2 → 1.2.3
- qlik tests: 9/9 green (incl. updated verify-complete guard); check-shared clean

> Note: touches `shared/manifest.json` (registers qlik's adoption of the shared lib) alongside the plugin files. Effectively delivers the qlik half of beads-sigma-p5y2.1 (gate wiring into migrate-qlik.rb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)