### PR TITLE
fix(shared): rank DM-reuse candidates by relevance, not updatedAt recency

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData → Sigma",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/find-or-pick-dm.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-reuse-ranking.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-reuse-ranking.rb
@@ -1,0 +1,144 @@
+#!/usr/bin/env ruby
+# test-dm-reuse-ranking.rb — find-or-pick-dm.rb must rank spec-fetch candidates by
+# RELEVANCE (name affinity to the signature's tables), not by updatedAt recency.
+#
+# The bug this guards (live-caught on a large org: 500 data models): --limit was spent on the N
+# most-recently-UPDATED DMs. Recency is uncorrelated with whether a DM covers the
+# workbook's tables, so on a large org the picker scored ~5% of the DMs chosen by
+# when they were last touched, never scored the DM sitting on the very same table,
+# reported "no reusable DM found", and every migration posted another duplicate —
+# reuse-first was silently inert.
+#
+# The fixture is built so RECENCY RANKING FAILS AND RELEVANCE RANKING PASSES: the
+# one reusable DM is the OLDEST entry, parked behind 29 recently-touched decoys
+# and outside a --limit=5 window.
+#
+# Loopback WEBrick over http:// (same harness as test-put-layout-prune.rb) —
+# offline, creds-free. Run: ruby scripts/test-dm-reuse-ranking.rb
+require 'webrick'
+require 'json'
+require 'tmpdir'
+require 'open3'
+require 'time'
+
+$fail = 0
+def ok(desc); r = yield; puts "#{r ? '  ok  ' : ' FAIL '} #{desc}"; $fail += 1 unless r; end
+
+PICKER = File.expand_path('find-or-pick-dm.rb', __dir__)
+TARGET_TABLE = 'ACME.SALES.PIPELINE_FACT'
+TARGET_COLS  = %w[SALE_DATE SALESPERSON LEAD_NAME SEGMENT REGION FORECASTED_MONTHLY_REVENUE
+                  OPPORTUNITY_STAGE WEIGHTED_REVENUE].freeze
+REUSABLE_ID  = 'dm-pipeline-fact'
+
+# 22 decoys, all touched TODAY; then 7 name-affine LOOK-ALIKES that share the
+# signature's name tokens but NOT its table; and last, the one genuinely reusable
+# DM, touched a year ago so it sorts LAST under updatedAt-desc and cannot survive a
+# recency window. affine_count (8) > --limit (5), so this also proves the fetch AND
+# scoring budgets widen together for affine candidates.
+def dm_list
+  decoys = (1..22).map do |i|
+    { 'dataModelId' => "dm-decoy-#{i}", 'name' => "Bench Complex Fixture #{i}",
+      'updatedAt' => (Time.now.utc - i * 60).iso8601 }
+  end
+  lookalikes = (1..7).map do |i|
+    { 'dataModelId' => "dm-lookalike-#{i}", 'name' => "Pipeline Fact Lookalike #{i}",
+      'updatedAt' => (Time.now.utc - (100 + i) * 60).iso8601 }
+  end
+  decoys + lookalikes + [{ 'dataModelId' => REUSABLE_ID, 'name' => 'Pipeline Fact Model',
+                           'updatedAt' => (Time.now.utc - 365 * 24 * 3600).iso8601 }]
+end
+
+def spec_for(id)
+  if id == REUSABLE_ID
+    { 'pages' => [{ 'elements' => [
+      { 'source' => { 'kind' => 'warehouse-table', 'path' => %w[ACME SALES PIPELINE_FACT] },
+        'columns' => TARGET_COLS.map { |c| { 'name' => c } } }
+    ] }] }
+  else
+    { 'pages' => [{ 'elements' => [
+      { 'source' => { 'kind' => 'warehouse-table', 'path' => %w[BENCH PUBLIC UNRELATED_FACT] },
+        'columns' => [{ 'name' => 'SOME_ID' }, { 'name' => 'SOME_VALUE' }] }
+    ] }] }
+  end
+end
+
+server = WEBrick::HTTPServer.new(BindAddress: '127.0.0.1', Port: 0,
+                                 Logger: WEBrick::Log.new(File::NULL),
+                                 AccessLog: [])
+server.mount_proc('/v2/dataModels') do |req, res|
+  res['Content-Type'] = 'application/json'
+  if (m = req.path.match(%r{/v2/dataModels/([^/]+)/spec}))
+    res.body = JSON.generate(spec_for(m[1]))
+  else
+    res.body = JSON.generate({ 'entries' => dm_list, 'nextPage' => nil })
+  end
+end
+Thread.new { server.start }
+sleep 0.2
+base = "http://127.0.0.1:#{server.config[:Port]}"
+env = { 'SIGMA_BASE_URL' => base, 'SIGMA_CLIENT_ID' => nil, 'SIGMA_API_TOKEN' => 'offline-test' }
+
+begin
+  Dir.mktmpdir do |work|
+    sig = { 'tableau_workbook' => 'Pipeline Fact',
+            'warehouse_tables' => [TARGET_TABLE],
+            'referenced_columns' => TARGET_COLS }
+    sig_path = File.join(work, 'sig.json')
+    out_path = File.join(work, 'dm-match.json')
+    File.write(sig_path, JSON.pretty_generate(sig))
+
+    # --limit 5: far too small to reach the reusable DM by recency (it is 30th of 30).
+    _, err, st = Open3.capture3(env, 'ruby', PICKER, '--workbook-signature', sig_path,
+                                '--out', out_path, '--limit', '5', '--auto-pick')
+    res = JSON.parse(File.read(out_path))
+
+    ok('the reusable DM is SCORED despite being the oldest and outside --limit') do
+      (res['candidates'] || []).any? { |c| c['dm_id'] == REUSABLE_ID }
+    end
+    ok('it is RECOMMENDED (relevance ranking reached it; recency never would)') do
+      res['recommended_dm_id'] == REUSABLE_ID
+    end
+    ok('its score reflects the real table+column match, not the name') do
+      res['score'].to_f >= 0.6
+    end
+    ok('name-affine candidates are fetched AND scored past --limit (8 affine > limit 5)') do
+      res.dig('candidate_pool', 'scored').to_i == 8
+    end
+    ok('candidate_pool records the org total and the ranking dimension') do
+      res.dig('candidate_pool', 'total_in_org') == 30 &&
+        res.dig('candidate_pool', 'ranked_by').to_s.include?('name-affinity')
+    end
+    ok('ranking_version is stamped so stale-ranking caches cannot be replayed') do
+      res['ranking_version'].to_i >= 2
+    end
+    ok('stderr names the ranking dimension (operator-visible, not silent)') do
+      err.include?('name-affinity')
+    end
+    ok('exit 0 on a recommendation') { st.exitstatus.zero? }
+
+    # A signature with NO affine DM must still not claim the org has nothing:
+    # the build-new verdict has to disclose that the pool was truncated.
+    sig2 = { 'tableau_workbook' => 'Zzz Unrelated',
+             'warehouse_tables' => ['OTHER.ELSEWHERE.ZZZ_NOTHING'],
+             'referenced_columns' => %w[ALPHA BETA GAMMA] }
+    sig2_path = File.join(work, 'sig2.json')
+    out2_path = File.join(work, 'dm-match2.json')
+    File.write(sig2_path, JSON.pretty_generate(sig2))
+    _, err2, st2 = Open3.capture3(env, 'ruby', PICKER, '--workbook-signature', sig2_path,
+                                  '--out', out2_path, '--limit', '5', '--auto-pick')
+    res2 = JSON.parse(File.read(out2_path))
+
+    ok('no match → exit 1 (caller builds new)') { st2.exitstatus == 1 }
+    ok('NO SILENT CAPS: the build-new rationale discloses the scored/total pool') do
+      res2['rationale'].to_s.match?(/scanned 5 of 30 DM\(s\) scored/)
+    end
+    ok('truncation is flagged in candidate_pool and on stderr') do
+      res2.dig('candidate_pool', 'truncated') == true && err2.include?('were NOT scored')
+    end
+  end
+ensure
+  server.shutdown
+end
+
+puts($fail.zero? ? "\nALL PASS — DM-reuse candidates are relevance-ranked, widened past --limit, and truncation is disclosed" : "\n#{$fail} FAILURE(S)")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-phase-cache.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-phase-cache.rb
@@ -93,6 +93,14 @@ def sig_sha(sig)
   Digest::SHA256.hexdigest(JSON.generate(canon))
 end
 
+# Read RANKING_VERSION out of the picker rather than hardcoding it, so bumping the
+# ranking generation can never silently desync this fixture from the implementation.
+def picker_ranking_version
+  m = File.read(PICKER)[/^RANKING_VERSION\s*=\s*(\d+)/, 1]
+  raise "RANKING_VERSION not found in #{PICKER}" unless m
+  m.to_i
+end
+
 def run_picker(dir, extra = [])
   Open3.capture3(PICKER_ENV, 'ruby', PICKER,
                  '--workbook-signature', File.join(dir, 'workbook-signature.json'),
@@ -101,7 +109,11 @@ end
 
 Dir.mktmpdir do |work|
   File.write(File.join(work, 'workbook-signature.json'), JSON.pretty_generate(SIG))
+  # ranking_version must match the picker's current RANKING_VERSION: the re-entry
+  # cache deliberately refuses to replay a recommendation computed under an older
+  # candidate ranking (a stale recency-ranked result would hide the relevance fix).
   cached = { 'signature_sha256' => sig_sha(SIG), 'scanned_at' => Time.now.utc.iso8601,
+             'ranking_version' => picker_ranking_version,
              'recommended_dm_id' => 'dm-example-1', 'auto_picked' => true, 'score' => 0.9,
              'rationale' => 'AUTO-PICKED (fixture)', 'candidates' => [] }
   File.write(File.join(work, 'dm-match.json'), JSON.pretty_generate(cached))

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,

--- a/shared/scripts/find-or-pick-dm.rb
+++ b/shared/scripts/find-or-pick-dm.rb
@@ -39,17 +39,31 @@ require 'uri'
 require 'optparse'
 require 'digest'
 require 'time'
+require 'set'
 
-# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
-# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
-# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
-# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
-# picker run with no score regression. beads-sigma-3kw.
-opts = { limit: 25, min_score: 0.6 }
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
 OptionParser.new do |p|
   p.on('--workbook-signature P') { |v| opts[:sig]      = v }
   p.on('--out P')                { |v| opts[:out]      = v }
   p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
   p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
   p.on('--force-new')            { |_| opts[:force_new]= true }
   p.on('--auto-pick',
@@ -74,7 +88,12 @@ def http_get(path)
     req = Net::HTTP::Get.new(uri)
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
     req['Accept'] = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
     if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
       Sigma.refresh_token!
       next
@@ -110,7 +129,12 @@ CACHE_MAX_AGE = 24 * 3600
 if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
   prev = (JSON.parse(File.read(opts[:out])) rescue nil)
   prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
-  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
     warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
     warn "best score: #{prev['score']}  →  #{prev['rationale']}"
     exit(prev['recommended_dm_id'].nil? ? 1 : 0)
@@ -154,16 +178,62 @@ loop do
   break if page.nil? || page.empty?
 end
 
-# Deterministic ranking: updatedAt desc, then name asc.
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
 # NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
 # every timestamp rescues to 0, and the sort silently degrades to name-ascending
 # (recently-updated DMs past the --limit window are never scanned).
 require 'time'
-all_dms = all_dms.sort_by do |dm|
-  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
 end
 
-warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
 
 # 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
 def normalize_fqn(s)
@@ -184,7 +254,7 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?
@@ -220,7 +290,10 @@ warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
 dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
 
 dm_signatures = []
-all_dms.take(opts[:limit]).each do |dm|
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
   dm_id = dm['dataModelId'] || dm['id']
   spec = dm_specs[dm_id]
   next unless spec
@@ -388,7 +461,14 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
-ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
 auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
@@ -409,16 +489,37 @@ rationale =
   elsif best['score'] >= opts[:min_score]
     'ambiguous match — ASK USER before reusing'
   else
-    'no candidate above min-score; build a new DM'
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
   end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
 
 result = {
   'workbook_signature_path' => opts[:sig],
   # Re-entry cache stamp (see the header block): same signature within 24h ⇒
   # the next invocation reuses this file instead of re-scanning the org.
   'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
   'scanned_at'              => Time.now.utc.iso8601,
   'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
   'recommended_dm_id'       => recommended_dm_id,
   'auto_picked'             => auto_picked,
   'ambiguous_wide_tie'      => ambiguous_wide_tie,


### PR DESCRIPTION
## The bug

`find-or-pick-dm.rb` spent its `--limit` spec-fetch budget on the **N most-recently-updated** data models. Recency is uncorrelated with whether a DM covers the workbook's tables, so on an org grown to **500 DMs** the picker scored 25 of them (**5%**) chosen by *when they were last touched*, never scored the DM sitting on the very same warehouse table, reported "no reusable DM found", and the caller posted yet another near-duplicate model.

**Reuse-first was silently inert.** The field symptom was repeatedly getting freshly posted data models on every migration.

The in-code justification for `limit=25` ("top score saturates by ~25 DMs in this org") was measured when the org was small; it quietly became a correctness bug as the org grew.

## Measured, live, same workbook signature

| | best score | top candidates |
|---|---|---|
| before | **0.14** | unrelated benchmark models |
| after | **0.70** | the actual duplicates of the very model the migration would have re-created |

## Changes

- **Relevance ranking.** Order the fetch queue by name affinity to the signature's own table names (leaf table tokens + source document name, stop-worded), then `updatedAt` desc, then name asc for determinism. This only **orders** which specs get fetched — scoring still runs on the fetched spec's tables/columns, so a name coincidence can never by itself produce a reuse recommendation.
- **Widen fetch *and* scoring together.** Every name-affine DM is fetched past `--limit`, capped by a new `--max-fetch` (default 120). The scoring loop had a *second* `.take(opts[:limit])` that would have fetched specs and then dropped them unscored — caught by the new test.
- **No silent caps.** `candidate_pool {total_in_org, scored, truncated, ranked_by}` goes into `dm-match.json`, truncation is warned on stderr, and any no-recommendation rationale is suffixed with `[scanned N of M DM(s) scored … K NOT scored]`, so "build a new DM" can never read as "the org has nothing reusable" when only part of the org was scored.
- **`ranking_version` in the cache key.** The 24h re-entry cache refuses to replay a result computed under the old recency ranking — otherwise this fix would stay invisible for a day on exactly the orgs that need it.
- **Wide-tie guard now requires clearing `--min-score`.** Without that floor, a pile of *irrelevant* DMs all scoring ~0.0 tripped it and got reported as "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and actively misleading. Widened ranking surfaces more zero-score DMs, so it matters more now. The genuine case still fires — verified live, three real duplicates at 0.70 still report AMBIGUOUS and refuse to auto-pick.
- **Scheme-derived TLS** instead of hardcoded `use_ssl: true` (the `put-layout.rb` pattern). Production `SIGMA_BASE_URL` is https so behaviour is unchanged; hardcoded TLS made the scan untestable offline — which is how the recency-window bug shipped under a green suite.

## Tests

New `scripts/test-dm-reuse-ranking.rb` — 11 assertions, offline WEBrick loopback, creds-free. The fixture is built so **recency ranking fails and relevance ranking passes**: the one reusable DM is the *oldest* of 30 and outside `--limit=5`, parked behind 7 name-affine look-alikes that share name tokens but *not* the table. It also pins the widening (8 affine > limit 5 ⇒ 8 scored), the pool disclosure, and the `ranking_version` stamp.

`test-phase-cache.rb`'s `dm-match` cache fixture now carries `ranking_version`, read out of the picker so the fixture cannot desync from the implementation.

Also green locally: `check-shared` (540 copies match canonical), `hygiene-sweep`, domo `test-reuse-check.rb`, tableau `test-phase-cache.rb`.

## Scope

Shared-file change: canonical `shared/scripts/find-or-pick-dm.rb` + fan-out via `tools/sync-shared.rb` to all 10 targets. All 10 affected plugins take a **patch** version bump, since the reuse behaviour is user-facing in each.

## Note / possible follow-up

On an org that *already* has duplicates, the correct-but-blunt outcome is an `AMBIGUOUS` N-way tie among identical models, so the picker asks rather than auto-reusing. That's the intended safety behaviour (identically-named DMs can still differ structurally) and it's a large improvement on silently building another one — but if duplicate sprawl is already widespread, an operator will see the prompt often. Worth considering whether an exact table+column-superset match among tied duplicates should auto-collapse to the oldest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)