### PR TITLE
powerbi-to-sigma: derived field_map entries must wrap their ALTS (fixes pie rendering blank + day-grain date axis)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -289,6 +289,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-validate-spec-metrics.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-viz-role-routing.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-alt-agg-wrapper.rb
             plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_field_alts.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_field_alts.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+#
+# PbiFieldAlts — synthesize a derived field_map entry, applying the SAME transform to
+# the primary ref and to every inherited alt.
+#
+# WHY THIS EXISTS (found 2026-07-30 by reading the rendered dashboard PNG, not by any
+# numeric check — every value check was green):
+#
+# A classic Power BI report binds an aggregated measure as "Sum(TABLE.COL)". No
+# field_map key exists in that shape, so migrate-powerbi.rb synthesizes one from the
+# plain-column entry. The old code was:
+#
+#     field_map[r] = base.merge('ref' => "Sum(#{base['ref']})", 'agg' => nil)
+#
+# `Hash#merge` copies every key — including `alts`, the alternate resolutions of the
+# same field on OTHER masters (the joined "View" element, chiefly). Only the top-level
+# `ref` was wrapped, so the alts kept their BARE column refs. Under
+# one-base-table-per-page the chosen base master is normally the View, so field_spec
+# swaps in the alt — and the aggregation silently disappears. Measured:
+#
+#     'Sum(ABSENCE_RECORDS.HOURS)' -> ref  "Sum([master-06cf9224/Hours])"    correct
+#                                     alts [{ref: "[master-e55e899b/Hours]"}]  BARE
+#
+# A pie chart whose value column is a row-level column cannot compute slice angles:
+# Sigma rendered its legend and no slices. The same defect hit the date-hierarchy
+# branch (which wraps in DateTrunc), so a chart that should plot by YEAR plotted at DAY
+# grain — a dense spiky line on the same dashboard.
+#
+# `merge` also ALIASES the alts array, so wrapping them in place would corrupt the
+# plain-column entry that legitimately wants bare refs. Hence the deep copy.
+#
+# This bug class is invisible to the field-binding coverage gate: the ref RESOLVES, it
+# just resolves to the wrong formula. Numbers-green, render-broken.
+module PbiFieldAlts
+  module_function
+
+  # base  : the plain-column field_map entry to derive from
+  # block : ref String -> wrapped String (e.g. ->(r) { "Sum(#{r})" })
+  #
+  # Returns a NEW entry whose `ref` is wrapped and whose `alts` are deep-copied with
+  # their `ref` (and `formula`, when present — the builder prefers it, so a stale
+  # unwrapped formula would reintroduce the bug) wrapped by the same block. `agg` is
+  # cleared because the wrapper IS the aggregation now; leaving it set would make the
+  # builder aggregate twice.
+  def wrapped_entry(base)
+    out = base.merge('ref' => yield(base['ref'].to_s), 'agg' => nil)
+    alts = base['alts']
+    return out unless alts.is_a?(Array) && !alts.empty?
+    out['alts'] = alts.map do |a|
+      b = a.dup                                  # never mutate the caller's alt
+      b['ref'] = yield(a['ref'].to_s) if a['ref']
+      b['formula'] = yield(a['formula'].to_s) if a['formula']
+      b['agg'] = nil
+      b
+    end
+    out
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -69,7 +69,8 @@ require 'fileutils'
 require 'open3'
 require 'digest'
 require 'set'
-require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
+require_relative 'lib/py_resolve'
+require_relative 'lib/pbi_field_alts' # derived field_map entries must wrap their ALTS too (pie/date-grain render bug) # real-Python resolver (Windows Store-stub safe)
 begin; require_relative 'lib/modeling_advisory'; rescue LoadError; end # shared, vendor-neutral CDW join-cost advisory (optional; synced from shared/)
 
 HERE = __dir__
@@ -1396,11 +1397,14 @@ all_visuals.flat_map { |v| (v['bindings'] || {}).values.flatten }.uniq.each do |
   if (m = r.match(/\A([A-Za-z ]+)\((.+)\)\z/)) && agg_names[m[1].downcase.delete(' ')]
     base = fm_norm[norm_key.call(m[2])]
     next unless base && base['ref'].to_s =~ /\A\[[^\]]+\]\z/
-    field_map[r] = base.merge('ref' => "#{agg_names[m[1].downcase.delete(' ')]}(#{base['ref']})", 'agg' => nil)
+    _fn = agg_names[m[1].downcase.delete(' ')]
+    # wrap the ALTS as well, not just the primary ref — see lib/pbi_field_alts.rb
+    field_map[r] = PbiFieldAlts.wrapped_entry(base) { |ref| "#{_fn}(#{ref})" }
   elsif (m = r.match(/\A(.+?)\.Variation\..*\.(Year|Quarter|Month|Week|Day)\z/i))
     base = fm_norm[norm_key.call(m[1])]
     next unless base && base['ref'].to_s =~ /\A\[[^\]]+\]\z/
-    field_map[r] = base.merge('ref' => "DateTrunc(\"#{m[2].downcase}\", #{base['ref']})", 'agg' => nil)
+    _lvl = m[2].downcase
+    field_map[r] = PbiFieldAlts.wrapped_entry(base) { |ref| "DateTrunc(\"#{_lvl}\", #{ref})" }
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-alt-agg-wrapper.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-alt-agg-wrapper.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+# Regression test: a SYNTHESIZED field_map entry must wrap its inherited ALTS in the
+# same transform as its primary ref.
+#
+# THE BUG (found by reading the rendered dashboard PNG, 2026-07-30 — not by any
+# numeric check): "Hours by Location" (a pieChart) rendered its LEGEND and no slices.
+#
+# Mechanism. A classic report binds an aggregated measure as "Sum(TABLE.COL)". No
+# field_map key exists in that shape, so migrate-powerbi.rb synthesizes one from the
+# plain-column entry:
+#     field_map[r] = base.merge('ref' => "Sum(#{base['ref']})", 'agg' => nil)
+# `base.merge` copies EVERY key — including `alts`, the alternate resolutions on other
+# masters. Only the TOP-LEVEL ref got wrapped; the alts kept their BARE column refs.
+# When the page's chosen base master is the joined "View" (which is the normal case
+# under one-base-table-per-page), field_spec swaps in the alt — and the aggregation is
+# silently gone. Measured on a real report:
+#     'Sum(ABSENCE_RECORDS.HOURS)' -> ref  "Sum([master-06cf9224/Hours])"   correct
+#                                     alts [{ref: "[master-e55e899b/Hours]"}]  BARE
+# A pie whose value column is a row-level column cannot compute slice angles, so Sigma
+# draws the legend and nothing else.
+#
+# The SAME defect hits the date-hierarchy branch, which wraps in
+# DateTrunc("year", ...): its alts lost the DateTrunc, so a chart that should plot by
+# YEAR plotted at DAY grain (visible as a dense spiky line on the same dashboard).
+#
+# NOTE this class of bug is invisible to the field-binding coverage gate: the ref
+# RESOLVES, it just resolves to the wrong formula. Numbers-green, render-broken — which
+# is exactly why the PNG has to be read.
+#
+# Usage:  ruby scripts/test-alt-agg-wrapper.rb
+require 'json'
+require_relative 'lib/pbi_field_alts'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# The exact shape measured on the real report.
+BASE = {
+  'master' => 'ABSENCE_RECORDS',
+  'ref' => '[master-06cf9224/Hours]',
+  'agg' => nil,
+  'alts' => [{ 'master' => 'ABSENCE_RECORDS View',
+               'ref' => '[master-e55e899b/Hours]', 'agg' => nil }]
+}.freeze
+
+puts "\n1. an AGGREGATE wrapper is applied to the primary ref AND to every alt"
+e = PbiFieldAlts.wrapped_entry(BASE) { |ref| "Sum(#{ref})" }
+check(e['ref'] == 'Sum([master-06cf9224/Hours])', "primary ref wrapped (got #{e['ref']})", fails)
+check(e['alts'].size == 1, 'alt count preserved', fails)
+check(e['alts'][0]['ref'] == 'Sum([master-e55e899b/Hours])',
+      "ALT ref wrapped too (got #{e['alts'][0]['ref'].inspect}) — this is the pie bug", fails)
+check(e['alts'][0]['master'] == 'ABSENCE_RECORDS View', 'alt master untouched', fails)
+
+puts "\n2. the source entry is NOT mutated (alts are shared by reference in the caller)"
+check(BASE['ref'] == '[master-06cf9224/Hours]', 'base primary ref unchanged', fails)
+check(BASE['alts'][0]['ref'] == '[master-e55e899b/Hours]',
+      'base ALT unchanged — merge must deep-copy alts, not alias them', fails)
+check(!e['alts'].equal?(BASE['alts']), 'the alts array is a new object, not the same one', fails)
+check(!e['alts'][0].equal?(BASE['alts'][0]), 'each alt hash is a copy', fails)
+
+puts "\n3. the DateTrunc (date-hierarchy) wrapper behaves identically"
+d = PbiFieldAlts.wrapped_entry(BASE) { |ref| "DateTrunc(\"year\", #{ref})" }
+check(d['ref'] == 'DateTrunc("year", [master-06cf9224/Hours])', 'primary DateTrunc applied', fails)
+check(d['alts'][0]['ref'] == 'DateTrunc("year", [master-e55e899b/Hours])',
+      "ALT DateTrunc applied (got #{d['alts'][0]['ref'].inspect}) — the day-grain line-chart bug", fails)
+
+puts "\n4. an entry with NO alts still works, and agg is cleared"
+plain = { 'master' => 'T', 'ref' => '[m/C]', 'agg' => 'Sum' }
+p2 = PbiFieldAlts.wrapped_entry(plain) { |ref| "Sum(#{ref})" }
+check(p2['ref'] == 'Sum([m/C])', 'no-alts entry wraps its ref', fails)
+check(p2['agg'].nil?, "agg cleared (the wrapper IS the aggregation now; got #{p2['agg'].inspect})", fails)
+check(!p2.key?('alts') || p2['alts'].nil? || p2['alts'].empty?, 'no alts invented', fails)
+
+puts "\n5. a `formula` on an alt is wrapped too when present, never left stale"
+# An alt may carry a verbatim `formula` instead of a bare ref; if we wrap the ref but
+# leave a stale unwrapped formula, the builder prefers the formula and the bug returns.
+withf = { 'master' => 'T', 'ref' => '[m/C]', 'agg' => nil,
+          'alts' => [{ 'master' => 'V', 'ref' => '[v/C]', 'formula' => '[v/C]', 'agg' => nil }] }
+w = PbiFieldAlts.wrapped_entry(withf) { |ref| "Sum(#{ref})" }
+check(w['alts'][0]['ref'] == 'Sum([v/C])', 'alt ref wrapped', fails)
+check(w['alts'][0]['formula'] == 'Sum([v/C])',
+      "alt formula wrapped too (got #{w['alts'][0]['formula'].inspect})", fails)
+
+puts "\n6. the orchestrator actually USES the helper at both synthesis sites"
+src = File.read(File.join(__dir__, 'migrate-powerbi.rb'))
+check(src.include?('PbiFieldAlts'), 'migrate-powerbi.rb requires/uses PbiFieldAlts', fails)
+# neither synthesis site may still hand-roll base.merge('ref' => ...)
+bad = src.scan(/base\.merge\('ref'\s*=>/).size
+check(bad.zero?,
+      "no synthesis site still hand-rolls base.merge('ref' => …) (found #{bad})", fails)
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |f| puts "  - #{f}" }
+exit(fails.empty? ? 0 : 1)


### PR DESCRIPTION
## How this was found

By **reading the rendered dashboard PNG**. Every numeric check was green — 99 columns resolved, 0 error-typed, parity PASS. But a `pieChart` showed its legend and **no slices**, and a line chart that should plot by year plotted at day grain.

<sub>The run already prints "VISUAL QA (mandatory review — do not skip)". This is the bug that instruction exists to catch.</sub>

## Root cause

A classic report binds an aggregated measure as `Sum(TABLE.COL)`. No `field_map` key exists in that shape, so the orchestrator synthesizes one from the plain-column entry:

```ruby
field_map[r] = base.merge('ref' => "Sum(#{base['ref']})", 'agg' => nil)
```

`Hash#merge` copies **every** key — including `alts`, the alternate resolutions of the same field on other masters (chiefly the joined **View** element). Only the top-level `ref` was wrapped; the alts kept their **bare** column refs. Under one-base-table-per-page the chosen page base normally *is* the View, so `field_spec` swaps in the alt and the aggregation silently disappears:

```
'Sum(ABSENCE_RECORDS.HOURS)' -> ref  "Sum([master-06cf9224/Hours])"      ✅ correct
                                alts [{ref: "[master-e55e899b/Hours]"}]  ❌ bare
```

A pie whose value column is row-level cannot compute slice angles. The **identical** defect hit the date-hierarchy branch (which wraps in `DateTrunc`), producing the day-grain axis — one cause, two visible symptoms.

## Fix

`lib/pbi_field_alts.rb` applies the transform to the primary ref **and every alt**, used at both synthesis sites. Three details that matter:

- **Deep-copies the alts.** `merge` aliases that array, so wrapping in place would corrupt the plain-column entry that legitimately wants bare refs.
- **Wraps an alt's `formula` too.** The builder prefers `formula` over `ref`, so a stale unwrapped formula would reintroduce the bug.
- **Clears `agg`.** The wrapper *is* the aggregation; leaving it set would aggregate twice.

## Why the coverage gate did not catch this

Worth stating plainly, because it bounds what the recently-added field-loss gate can promise: this bug class is **invisible** to it. The queryRef *resolves* — it just resolves to the wrong formula. Binding coverage reported 100%. Numbers-green, render-broken. Reading the PNG is not optional.

## Verification

Live end-to-end on a real report, before → after:

| | before | after |
|---|---|---|
| pie value | `[master-e55e899b/Hours]` | `Sum([master-e55e899b/Hours])` |
| line axis | `[master-e55e899b/Hire Date (EMPLOYEES)]` | `DateTrunc("year", [master-e55e899b/Hire Date (EMPLOYEES)])` |
| rendered pie | legend only, no slices | real slices (9.3k / 7.78k / 7.42k / 4.87k) |
| rendered line | dense day-grain spikes | clean 2020–2026 trend |

Re-rendered visual-QA PNG confirms both. 32/32 offline suites pass; `test-alt-agg-wrapper.rb` fails against the pre-fix code.

## Notes

- Single-plugin PR; version bumped 1.3.0 → 1.3.1 (patch).
- Independent of the open field-coverage PR #561; if that lands first this needs a version re-bump only.
- CI note: the repo's `corpus-check` workflow currently fails one job ("full ruby suite … tableau-to-sigma", 7 FAILED) on `main` itself, identically — pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)