### PR TITLE
powerbi-to-sigma: key masters on PBI table identity so role-playing dimensions stay distinct

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -292,6 +292,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-alt-agg-wrapper.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-field-binding-coverage.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-field-loss-gate.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-roleplaying-dims.rb
             plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_master_key.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_master_key.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+#
+# PbiMasterKey — key a workbook master on the PBI TABLE identity, not the warehouse
+# table, so ROLE-PLAYING DIMENSION copies stay distinct.
+#
+# THE BUG (measured on real customer report R2, 2026-07-30). The model imports the SAME
+# warehouse table six times under different names to get six role-playing date
+# dimensions (`DATE_DIM Policy Count`, `… Quoted date`, `… prod trans date`,
+# `… submission date`, `… submission eff date`, `… uw quotes`), each a different column
+# subset. The converter names every emitted element after the WAREHOUSE table, so all
+# six arrive named `DATE_DIM`. migrate-powerbi.rb then keyed masters on that name:
+#
+#     mkey = cname                        # "DATE_DIM" for all six
+#     mid  = "master-#{SHA1(cname)[0,8]}" # one id for all six
+#     masters[mkey] = { ... }             # OVERWRITES — last copy wins
+#     field_map["#{cname}.#{col}"] = ...  # "DATE_DIM.CALENDAR_DATE"
+#
+# Six masters collapsed into one (only the last copy's columns survived), while the
+# report's visuals bind under the PBI name — `DATE_DIM submission date.CALENDAR_DATE`,
+# a key that never existed. The `physical_to_pbi` alias patch was a 1:1 Hash over a 1:N
+# problem, so five of the six copies got no alias at all. Result: dropped columns, and
+# controls silently targeting the WRONG date dimension.
+#
+# HOW ELEMENTS ARE MATCHED BACK TO TABLES. The converter emits one element per model
+# table in table order, so POSITION is a good primary signal — but relying on it alone
+# is fragile (calculated tables become Custom SQL elements, joined "View" elements are
+# appended, and any future reordering would silently mis-key every copy). Verified on
+# R2: column NAME SETS are unique across the six copies (6 of 6) while column COUNTS are
+# not (only 3 distinct). So the column set is the authoritative signal and position is
+# only a tie-break. An element nothing explains returns nil — the caller then falls back
+# to the element name, which is the old behaviour, so an unmatched element can never be
+# mis-attributed to some other table.
+require 'digest'
+require 'set'
+
+module PbiMasterKey
+  module_function
+
+  # A column formula "[DATE_DIM/Calendar Date]" or "[FACT/DIM/Col]" -> its leaf,
+  # normalized for comparison against a TMSL column name ("CALENDAR_DATE").
+  def norm_col(s)
+    leaf = s.to_s.gsub(/\A\[|\]\z/, '').split('/').last.to_s
+    leaf = leaf.sub(/\s+\([^)]*\)\s*\z/, '')   # drop Sigma's " (RelName)" disambiguator
+    leaf.downcase.gsub(/[^a-z0-9]/, '')
+  end
+
+  def norm_table(s)
+    s.to_s.downcase.gsub(/[^a-z0-9]/, '')
+  end
+
+  # The warehouse table a TMSL table's Power Query M points at (the path tail), or nil.
+  def physical_tail(table)
+    e = ((table['partitions'] || [])[0] || {}).dig('source', 'expression')
+    e = e.join("\n") if e.is_a?(Array)
+    e.to_s[/\[\s*Name\s*=\s*"([^"]+)"\s*,\s*Kind\s*=\s*"(?:Table|View)"\s*\]/i, 1]
+  end
+
+  # normalized physical table -> [PBI table name, ...]   (1:N — the whole point)
+  def physical_to_pbi(tables)
+    out = {}
+    (tables || []).each do |t|
+      tail = physical_tail(t)
+      next if tail.nil? || t['name'].to_s.empty?
+      (out[norm_table(tail)] ||= []) << t['name']
+    end
+    out
+  end
+
+  # element index -> { table:, confidence: } (table nil when nothing explains it).
+  #
+  # ORDER IS AUTHORITATIVE. The converter emits one element per model table in table
+  # order, so the k-th emitted element whose warehouse path tail is X corresponds to the
+  # k-th model table that sources X. Measured on 4 real models: this assigns 20/21,
+  # 26/28, 11/11 and 13/13 base elements, and on the 6-copy DATE_DIM model it recovers
+  # all six copies BY NAME.
+  #
+  # A first attempt made the COLUMN SET authoritative (require the table to cover the
+  # element's columns) and it was WORSE THAN THE OLD BEHAVIOUR on real data — distinct
+  # masters fell 18->12 and 21->14, because the converter adds columns the TMSL table
+  # does not have (time-intel, window helpers), so "cover" failed and the element went
+  # unresolved. The column set is still valuable, but as a CONFIDENCE signal: the caller
+  # can warn when the k-th table does not look like the k-th element. Measured agreement
+  # at a 0.8 overlap threshold: 18/20, 25/26, 11/11, 13/13.
+  def pbi_table_for_elements(elements, tables)
+    by_tail = {}
+    (tables || []).each do |t|
+      tl = physical_tail(t)
+      next unless tl
+      (by_tail[norm_table(tl)] ||= []) << t
+    end
+    seen = Hash.new(0)
+    out = {}
+    (elements || []).each_with_index do |el, idx|
+      path = el.dig('source', 'path')
+      tl = norm_table(path.is_a?(Array) && !path.empty? ? path[-1] : el['name'])
+      list = by_tail[tl] || []
+      k = seen[tl]
+      seen[tl] += 1
+      if k >= list.size
+        out[idx] = { 'table' => nil, 'confidence' => 0.0 }
+        next
+      end
+      t = list[k]
+      out[idx] = { 'table' => t['name'], 'confidence' => column_overlap(el, t) }
+    end
+    out
+  end
+
+  # Fraction of the element's columns the table explains (0.0..1.0). A LOW value means
+  # the order-based assignment disagrees with the column evidence — worth warning about,
+  # not worth overriding, since the converter legitimately adds columns.
+  def column_overlap(element, table)
+    elc = (element['columns'] || []).map { |c| norm_col(c['formula'] || c['name']) }.to_set
+    return 0.0 if elc.empty?
+    tc = (table['columns'] || []).map { |c| norm_col(c['name']) }.to_set
+    ((elc & tc).size.to_f / elc.size).round(3)
+  end
+
+  # Convenience: index -> table name only.
+  def table_names(elements, tables)
+    pbi_table_for_elements(elements, tables).transform_values { |v| v['table'] }
+  end
+
+  # The master key IS the PBI table name — that is the identity the report's queryRefs
+  # use. Kept as a function so the intent is explicit at the call site.
+  def master_key(pbi_table_name)
+    pbi_table_name.to_s
+  end
+
+  def master_id(key)
+    "master-#{Digest::SHA1.hexdigest(key.to_s)[0, 8]}"
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -70,7 +70,8 @@ require 'open3'
 require 'digest'
 require 'set'
 require_relative 'lib/py_resolve'
-require_relative 'lib/pbi_field_alts' # derived field_map entries must wrap their ALTS too (pie/date-grain render bug) # real-Python resolver (Windows Store-stub safe)
+require_relative 'lib/pbi_field_alts'
+require_relative 'lib/pbi_master_key' # role-playing dim copies must key on PBI table identity # derived field_map entries must wrap their ALTS too (pie/date-grain render bug) # real-Python resolver (Windows Store-stub safe)
 begin; require_relative 'lib/modeling_advisory'; rescue LoadError; end # shared, vendor-neutral CDW join-cost advisory (optional; synced from shared/)
 
 HERE = __dir__
@@ -541,13 +542,10 @@ all_measures.each { |tbl, mname, _| measure_orig_table[mname] = tbl }
 # dim NAME columns (beads-sigma-<1b>). Capture the map so the master-map can alias every
 # key under the friendly entity too.
 _normt = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]/, '') }
-physical_to_pbi = {} # normalized physical path-tail -> PBI friendly table name
-tables.each do |t|
-  _e = ((t['partitions'] || [])[0] || {}).dig('source', 'expression')
-  _e = _e.join("\n") if _e.is_a?(Array)
-  _tail = _e.to_s[/\[\s*Name\s*=\s*"([^"]+)"\s*,\s*Kind\s*=\s*"(?:Table|View)"\s*\]/i, 1]
-  physical_to_pbi[_normt.call(_tail)] = t['name'] if _tail && t['name'] && !t['name'].to_s.empty?
-end
+# 1:N, not 1:1. A model can import the SAME warehouse table under several names (six
+# role-playing DATE_DIMs on real report R2); the old 1:1 Hash kept only the LAST, so five
+# of the six copies got no alias at all.
+physical_to_pbi = PbiMasterKey.physical_to_pbi(tables)
 modes = tables.flat_map { |t| (t['partitions'] || []).map { |p| p['mode'] } }.compact.uniq
 mode_summ = modes.empty? ? 'unknown' : modes.join('/')
 
@@ -1025,6 +1023,24 @@ field_map = {}
 # so this is NOT a positional index — see lib/pbi_element_match.rb for the full
 # rationale + the run-2 SAFETY_INCIDENTS overwrite it prevents.
 dmel_for = PbiElementMatch.pair(conv_elements, dm_elements)
+# element index -> {table, confidence}. ORDER is authoritative (the converter emits one
+# element per model table in table order); the column-set overlap is a CONFIDENCE signal
+# only — making it authoritative measured WORSE than the old behaviour on 4 real models.
+_pbi_tbl_for = PbiMasterKey.pbi_table_for_elements(conv_elements, tables)
+_rp_dupes = _pbi_tbl_for.values.map { |v| v['table'] }.compact
+             .group_by { |n| n }.select { |_n, g| g.size > 1 }
+_lowconf = _pbi_tbl_for.values.select { |v| v['table'] && v['confidence'] < 0.8 }
+unless _lowconf.empty?
+  puts "   master-map: #{_lowconf.size} element(s) attributed by ORDER with low column agreement " \
+       "(#{_lowconf.map { |v| "#{v['table']} #{(v['confidence'] * 100).round}%" }.first(4).join(', ')}) — " \
+       'the converter adds columns the model lacks, so this is usually benign; verify if a tile looks wrong.'
+end
+_rp_groups = tables.group_by { |t| PbiMasterKey.norm_table(PbiMasterKey.physical_tail(t).to_s) }
+                   .select { |k, g| !k.empty? && g.size > 1 }
+unless _rp_groups.empty?
+  puts "   master-map: #{_rp_groups.size} role-playing dimension group(s) kept DISTINCT " \
+       "(#{_rp_groups.map { |k, g| "#{g.size}x #{k}" }.join(', ')}) — previously collapsed into one master."
+end
 conv_elements.each_with_index do |cel, cel_idx|
   cname = cel['name']
   dmel = dmel_for[cel_idx]
@@ -1035,8 +1051,16 @@ conv_elements.each_with_index do |cel, cel_idx|
             spec_elements[cel_idx]
   spec_name_for = (spec_el && spec_el['columns'] || [])
                   .each_with_object({}) { |c, h| h[c['formula'].to_s] = c['name'] if c['name'] }
-  mkey = cname
-  mid  = "master-#{Digest::SHA1.hexdigest(cname)[0, 8]}"
+  # ROLE-PLAYING DIMENSIONS. `cname` is the WAREHOUSE table (the converter names every
+  # element after it), so a model importing the same table N times under N names — six
+  # role-playing DATE_DIMs on real report R2 — collapsed into ONE master here:
+  # masters[mkey] overwrote (last copy won) and all N shared one id, while the report's
+  # visuals bind under the PBI name ("DATE_DIM submission date.CALENDAR_DATE"), a key
+  # that never existed. Key on the PBI table instead; fall back to `cname` when the
+  # element cannot be attributed, which is exactly the old behaviour.
+  _pbi_tbl = _pbi_tbl_for[cel_idx] && _pbi_tbl_for[cel_idx]['table']
+  mkey = _pbi_tbl || cname
+  mid  = PbiMasterKey.master_id(mkey)
   # Bug A: key the master-column id on the FULL cross-element path (not the leaf)
   # and use Sigma's disambiguated display name. For a JOIN/View element, base and
   # related columns can share a leaf ("Customer Key"), so leaf-keying collides on
@@ -1428,7 +1452,12 @@ unless physical_to_pbi.empty?
   field_map.each do |k, v|
     ent, dot, leaf = k.rpartition('.')
     next if dot.empty? || ent.empty? || leaf.empty?
-    pbi = physical_to_pbi[_normt.call(ent)]
+    pbis = Array(physical_to_pbi[_normt.call(ent)])
+    # With N>1 copies the physical name is AMBIGUOUS — aliasing it to one of them is how
+    # a control ended up filtering the wrong date dimension. Alias only the unambiguous
+    # 1:1 case; the N-copy case is already keyed correctly under each PBI table name.
+    next unless pbis.size == 1
+    pbi = pbis.first
     next unless pbi && _normt.call(pbi) != _normt.call(ent)
     ak = "#{pbi}.#{leaf}"
     aliases[ak] = v unless field_map.key?(ak) || aliases.key?(ak)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-roleplaying-dims.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-roleplaying-dims.rb
@@ -1,0 +1,136 @@
+#!/usr/bin/env ruby
+# Regression test: ROLE-PLAYING DIMENSION copies must stay distinct.
+#
+# THE BUG (measured on real customer report R2, 2026-07-30): the model imports the SAME
+# warehouse table SIX times under different names to get six role-playing date
+# dimensions —
+#     DATE_DIM Policy Count / Quoted date / prod trans date /
+#     submission date / submission eff date / uw quotes
+# — each a different column subset of CSA-style DATE_DIM (31/31/35/31/31/30 data columns).
+#
+# The converter names each emitted element after the WAREHOUSE table, so all six come
+# out named "DATE_DIM". migrate-powerbi.rb then did:
+#     mkey = cname                                    # the warehouse name
+#     mid  = "master-#{SHA1(cname)[0,8]}"
+#     masters[mkey] = { ... }                          # <-- OVERWRITES, last wins
+#     field_map["#{cname}.#{col}"] = ...               # "DATE_DIM.CALENDAR_DATE"
+# so six masters collapsed into one (only the LAST copy's columns survived, and all six
+# shared one id), while the report's visuals bind under the PBI name
+# ("DATE_DIM submission date.CALENDAR_DATE") — a key that never existed. The
+# `physical_to_pbi` alias patch is a 1:1 Hash over a 1:N problem, so five of the six got
+# no alias at all. Net effect: dropped columns, and controls silently targeting the
+# WRONG date dimension.
+#
+# Measured facts this fix relies on (verified against R2):
+#   * column NAME SETS are unique across the six copies (6 of 6) — column COUNTS are
+#     not (only 3 distinct), so counts alone cannot disambiguate.
+#   * the converter emits one element per model table IN TABLE ORDER, so position is a
+#     valid primary signal, verified by column-set agreement.
+#
+# Usage:  ruby scripts/test-roleplaying-dims.rb
+require 'json'
+require_relative 'lib/pbi_master_key'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# --- R2's shape, reduced: 3 PBI tables all sourcing DATE_DIM, distinct column sets ----
+def tbl(name, cols)
+  m = 'let Source = Snowflake.Databases("h","W"), ' \
+      '#"N1" = Source{[Name = "CSA", Kind = "Database"]}[Data], ' \
+      '#"N2" = #"N1"{[Name = "TJ", Kind = "Schema"]}[Data], ' \
+      '#"N3" = #"N2"{[Name = "DATE_DIM", Kind = "Table"]}[Data] in #"N3"'
+  # a non-DATE_DIM table points at its own warehouse table
+  m = m.sub('Name = "DATE_DIM"', %(Name = "#{name}")) unless name.start_with?('DATE_DIM')
+  { 'name' => name,
+    'columns' => cols.map { |c| { 'name' => c, 'sourceColumn' => c } },
+    'partitions' => [{ 'name' => name, 'mode' => 'import',
+                       'source' => { 'type' => 'm', 'expression' => m } }] }
+end
+
+TABLES = [
+  tbl('FACT',                     %w[FACT_KEY AMOUNT DATE_KEY]),
+  tbl('DATE_DIM submission date', %w[CALENDAR_DATE FISCAL_YEAR SUBMISSION_FLAG]),
+  tbl('DATE_DIM quoted date',     %w[CALENDAR_DATE FISCAL_YEAR QUOTED_FLAG]),
+  tbl('DATE_DIM uw quotes',       %w[CALENDAR_DATE UW_FLAG])
+].freeze
+
+# what the converter emits: one element per table, IN ORDER, each named after the
+# warehouse table — so three identical names.
+ELEMENTS = [
+  { 'id' => 'e0', 'name' => 'FACT', 'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ FACT] },
+    'columns' => [{ 'formula' => '[FACT/Fact Key]' }, { 'formula' => '[FACT/Amount]' }, { 'formula' => '[FACT/Date Key]' }] },
+  { 'id' => 'e1', 'name' => 'DATE_DIM', 'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ DATE_DIM] },
+    'columns' => [{ 'formula' => '[DATE_DIM/Calendar Date]' }, { 'formula' => '[DATE_DIM/Fiscal Year]' }, { 'formula' => '[DATE_DIM/Submission Flag]' }] },
+  { 'id' => 'e2', 'name' => 'DATE_DIM', 'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ DATE_DIM] },
+    'columns' => [{ 'formula' => '[DATE_DIM/Calendar Date]' }, { 'formula' => '[DATE_DIM/Fiscal Year]' }, { 'formula' => '[DATE_DIM/Quoted Flag]' }] },
+  { 'id' => 'e3', 'name' => 'DATE_DIM', 'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ DATE_DIM] },
+    'columns' => [{ 'formula' => '[DATE_DIM/Calendar Date]' }, { 'formula' => '[DATE_DIM/Uw Flag]' }] }
+].freeze
+
+puts "\n1. each converter element resolves to its OWN PBI table"
+map = PbiMasterKey.table_names(ELEMENTS, TABLES)
+check(map[0] == 'FACT', "element 0 -> FACT (got #{map[0].inspect})", fails)
+check(map[1] == 'DATE_DIM submission date', "element 1 -> submission date (got #{map[1].inspect})", fails)
+check(map[2] == 'DATE_DIM quoted date', "element 2 -> quoted date (got #{map[2].inspect})", fails)
+check(map[3] == 'DATE_DIM uw quotes', "element 3 -> uw quotes (got #{map[3].inspect})", fails)
+check(map.values.uniq.size == 4, 'all four resolve to DISTINCT PBI tables — no collapse', fails)
+
+puts "\n2. ORDER is authoritative; the column set is a CONFIDENCE signal, not an override"
+# This contract was inverted in the first draft: making the column set authoritative
+# (requiring the table to COVER the element's columns) measured WORSE than the old
+# behaviour on 4 real models — distinct masters fell 18->12 and 21->14, because the
+# converter adds columns the TMSL table lacks (time-intel, window helpers) so cover
+# failed and elements went unresolved. Order assigns 20/21, 26/28, 11/11, 13/13 on the
+# same models and recovers all six DATE_DIM copies by name.
+full = PbiMasterKey.pbi_table_for_elements(ELEMENTS, TABLES)
+check(full[1]['confidence'] == 1.0,
+      "a clean match reports confidence 1.0 (got #{full[1]['confidence'].inspect})", fails)
+# an element carrying a column its table does NOT have is still assigned (order wins),
+# but its confidence drops so the caller can warn.
+extra = ELEMENTS[1].merge('columns' => ELEMENTS[1]['columns'] + [{ 'formula' => '[DATE_DIM/Invented Col]' }])
+low = PbiMasterKey.pbi_table_for_elements([ELEMENTS[0], extra], TABLES)
+check(low[1]['table'] == 'DATE_DIM submission date',
+      'an element with a converter-added column is STILL assigned by order', fails)
+check(low[1]['confidence'] < 1.0 && low[1]['confidence'] > 0.5,
+      "and its confidence drops below 1.0 (got #{low[1]['confidence'].inspect})", fails)
+
+puts "\n3. master keys and ids are DISTINCT per copy (the collapse)"
+keys = map.values.map { |t| PbiMasterKey.master_key(t) }
+check(keys.uniq.size == 4, "4 distinct master keys (got #{keys.uniq.size})", fails)
+ids = keys.map { |k| PbiMasterKey.master_id(k) }
+check(ids.uniq.size == 4, "4 distinct master ids (got #{ids.uniq.size}) — all six shared one before", fails)
+check(ids.all? { |i| i.start_with?('master-') }, 'ids keep the master- prefix', fails)
+
+puts "\n4. a single-copy model is UNCHANGED (no regression for the common case)"
+one_tbl = [tbl('ORDERS', %w[ORDER_ID AMOUNT])]
+one_el  = [{ 'id' => 'z', 'name' => 'ORDERS', 'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ ORDERS] },
+             'columns' => [{ 'formula' => '[ORDERS/Order Id]' }, { 'formula' => '[ORDERS/Amount]' }] }]
+m3 = PbiMasterKey.table_names(one_el, one_tbl)
+check(m3[0] == 'ORDERS', 'single table resolves to itself', fails)
+check(PbiMasterKey.master_key('ORDERS') == 'ORDERS',
+      'master_key of a table whose PBI name == warehouse name is that name verbatim', fails)
+
+puts "\n5. physical->PBI is 1:N, not 1:1 (five of six copies got no alias before)"
+p2p = PbiMasterKey.physical_to_pbi(TABLES)
+check(p2p['datedim'].is_a?(Array), 'the map holds an ARRAY per physical table', fails)
+check(p2p['datedim'].sort == ['DATE_DIM quoted date', 'DATE_DIM submission date', 'DATE_DIM uw quotes'],
+      "all three DATE_DIM copies are recorded (got #{p2p['datedim'].inspect})", fails)
+check(p2p['fact'] == ['FACT'], 'a single-copy table still maps to a one-element array', fails)
+
+puts "\n6. an element the tables cannot explain returns nil, never a wrong guess"
+orphan = [{ 'id' => 'o', 'name' => 'MYSTERY', 'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ MYSTERY] },
+            'columns' => [{ 'formula' => '[MYSTERY/Nope]' }] }]
+m4 = PbiMasterKey.table_names(orphan, TABLES)
+check(m4[0].nil?, "an unmatched element maps to nil (got #{m4[0].inspect}) — caller falls back to the element name", fails)
+# a SEVENTH element for a table that only has three copies must also be nil, not a reuse
+seventh = ELEMENTS + [ELEMENTS[1].merge('id' => 'e4')]
+m5 = PbiMasterKey.table_names(seventh, TABLES)
+check(m5[4].nil?, "a copy beyond the table count maps to nil (got #{m5[4].inspect}), never a duplicate claim", fails)
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |f| puts "  - #{f}" }
+exit(fails.empty? ? 0 : 1)


### PR DESCRIPTION
## Why

This is the last of the three root causes from the original diagnosis.

Real report **R2** imports the *same* warehouse table **six times** under different names to get six role-playing date dimensions — `DATE_DIM Policy Count`, `… Quoted date`, `… prod trans date`, `… submission date`, `… submission eff date`, `… uw quotes` — each a different column subset. The converter names every element after the **warehouse** table, so all six arrive named `DATE_DIM`, and the master-map keyed on that:

```ruby
mkey = cname                        # "DATE_DIM" for all six
mid  = "master-#{SHA1(cname)[0,8]}" # ONE id for all six
masters[mkey] = { ... }             # OVERWRITES — last copy won
```

Six masters collapsed into one (only the last copy's columns survived), while the report's visuals bind under the **PBI** name — `DATE_DIM submission date.CALENDAR_DATE`, a key that never existed. Result: dropped columns, and **controls silently targeting the wrong date dimension**. `physical_to_pbi` was a 1:1 Hash over a 1:N problem, so five of the six copies got no alias at all.

## The design, and the version of it I threw away

`lib/pbi_master_key.rb` attributes each converter element to its PBI table and keys the master on that, falling back to the element name when it can't — exactly the old behaviour, so an unattributable element is never *mis*-attributed.

**Order is authoritative.** That was not my first design. I first made the **column set** authoritative (require the table to cover the element's columns) — my unit tests passed, and then it measured **worse than the old behaviour on all four real models**: distinct masters fell 18→12 and 21→14, because the converter adds columns the TMSL table doesn't have (time-intel, window helpers), so "cover" failed and elements went unresolved. The converter emits one element per model table *in table order*, so the k-th element whose warehouse tail is X is the k-th table sourcing X. Column overlap is kept as a **confidence signal that warns** (< 0.8) rather than overriding.

Column name-sets *are* unique across R2's six copies (6 of 6) where counts are not (3 of 6) — that's what makes the confidence check meaningful even though it isn't the primary signal.

## Measured on the four real models

base elements → distinct masters:

| model | base | old | new | unresolved | low-confidence |
|---|---|---|---|---|---|
| R1 | 21 | 18 | **20** | 1 | 2 |
| R2 | 28 | 21 | **26** | 2 | 1 |
| R3 | 11 | 11 | 11 | 0 | 0 |
| R4 | 13 | 13 | 13 | 0 | 0 |

R2 recovers **all six** `DATE_DIM` copies by name.

## Aliasing is now ambiguity-safe

The physical→PBI alias is emitted **only** for the unambiguous 1:1 case. With N copies the physical name is ambiguous, and aliasing it to one of them is precisely how a control ended up filtering the wrong date dimension. The N-copy case needs no alias — it is already keyed correctly under each PBI table name.

## Verification

- **41/41 offline suites** (31 `scripts/` + 3 `tests/` + 3 Python + the new suite). The count now includes `tests/`, which an earlier PR missed by globbing only `scripts/` — that omission is what let #558 land a red `main`.
- **Backwards compatibility proven live** on a single-copy report: master keys, master **ids**, and all **128** field refs are byte-identical to before — 0 lost, 0 added — with 99 columns resolving and 0 error-typed.
- The role-playing group count and any low-confidence attributions are printed, so an operator sees what was kept distinct rather than having to infer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)