### PR TITLE
chore(powerbi): re-vendor converter — CROSSFILTER / DAX-comment / case-insensitivity fixes (mcp #114)

### DIFF
--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/PROVENANCE.json
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "907cfd3",
-  "source_commit_date": "2026-07-29",
+  "source_commit": "12919f2",
+  "source_commit_date": "2026-07-30",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "powerbi.mjs",
   "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/powerbi.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/powerbi.mjs
@@ -1,4 +1,4 @@
-// ../wt-pbi-dax-fidelity/build/sigma-ids.js
+// ../mcp-fresh/build/sigma-ids.js
 var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 var _usedIds = /* @__PURE__ */ new Set();
 var _idCounter = 0;
@@ -280,7 +280,7 @@ function buildDerivedElements(elements) {
   return derived;
 }
 
-// ../wt-pbi-dax-fidelity/build/powerbi.js
+// ../mcp-fresh/build/powerbi.js
 var PBI_COMMUNITY_LINKS = {
   lod: "community.sigmacomputing.com/t/tableau-level-of-detail-or-lod-calculations-in-sigma/6427",
   groupings: "community.sigmacomputing.com/t/how-to-use-groupings-aggregate-calculations/2003",
@@ -1827,6 +1827,81 @@ function extractUseRelationships(dax) {
   }
   return { dax: f, pairs };
 }
+function stripDaxComments(dax) {
+  const src = String(dax ?? "");
+  let out = "";
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '"') {
+      out += c;
+      i++;
+      while (i < src.length) {
+        if (src[i] === '"') {
+          if (src[i + 1] === '"') {
+            out += '""';
+            i += 2;
+            continue;
+          }
+          out += '"';
+          i++;
+          break;
+        }
+        out += src[i];
+        i++;
+      }
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "*") {
+      const end = src.indexOf("*/", i + 2);
+      i = end === -1 ? src.length : end + 2;
+      out += " ";
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "/") {
+      while (i < src.length && src[i] !== "\n")
+        i++;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+function extractCrossFilters(dax) {
+  let f = dax;
+  const pairs = [];
+  const re = /\bCROSSFILTER\s*\(/gi;
+  for (let guard = 0; guard < 20; guard++) {
+    re.lastIndex = 0;
+    const m = re.exec(f);
+    if (!m)
+      break;
+    const { args, endPos } = splitCallArgs(f, m.index + m[0].length);
+    if (args.length >= 2) {
+      const a = _pbiParseQualifiedRef(args[0]);
+      const b = _pbiParseQualifiedRef(args[1]);
+      const dir = (args[2] || "").trim().replace(/^["']|["']$/g, "") || "Both";
+      if (a && b)
+        pairs.push({ a, b, direction: dir });
+    }
+    let start = m.index, end = endPos;
+    let i = start - 1;
+    while (i >= 0 && /\s/.test(f[i]))
+      i--;
+    if (f[i] === ",")
+      start = i;
+    else {
+      let j = end;
+      while (j < f.length && /\s/.test(f[j]))
+        j++;
+      if (f[j] === ",")
+        end = j + 1;
+    }
+    f = f.slice(0, start) + f.slice(end);
+  }
+  return { dax: f, pairs };
+}
 function findModelRelationship(model, p) {
   for (const r of model.relationships || []) {
     const fwd = r.fromTable === p.a.table && r.fromColumn === p.a.column && r.toTable === p.b.table && r.toColumn === p.b.column;
@@ -1983,6 +2058,15 @@ function convertPowerBIToSigma(modelJson, options = {}) {
   };
   const relActivationNames = /* @__PURE__ */ new Map();
   const measureAltPath = {};
+  const processCrossFilters = (measureName, expr) => {
+    if (!/\bCROSSFILTER\s*\(/i.test(expr))
+      return expr;
+    const cf = extractCrossFilters(expr);
+    for (const pair of cf.pairs) {
+      warnings.push(`\u26A0 "${measureName}": CROSSFILTER(${pair.a.table}[${pair.a.column}], ${pair.b.table}[${pair.b.column}], ${pair.direction}) \u2014 Sigma has no cross-filter-direction control, so the modifier is dropped and the relationship keeps its model direction. The aggregate itself is unchanged; if the source measure relied on that direction change to widen or narrow its filter context, verify the number.`);
+    }
+    return cf.dax;
+  };
   const processUseRelationships = (measureName, expr) => {
     if (!/\bUSERELATIONSHIP\s*\(/i.test(expr))
       return expr;
@@ -2228,8 +2312,8 @@ SELECT 1 AS _placeholder`;
     for (const m of t.measures || []) {
       if (m.name)
         measureToElementId[m.name] = elementId;
-      const mExprRaw = Array.isArray(m.expression) ? m.expression.join("\n") : String(m.expression || "");
-      const mExpr = processUseRelationships(m.name, mExprRaw);
+      const mExprRaw = stripDaxComments(Array.isArray(m.expression) ? m.expression.join("\n") : String(m.expression || ""));
+      const mExpr = processUseRelationships(m.name, processCrossFilters(m.name, mExprRaw));
       const mWin = pbiParseRankx(mExpr, measureAggMap);
       if (mWin && lowerPBIWindowCalc(mWin, m.name, srcElProxy, winCtx, warnings)) {
         continue;
@@ -2264,10 +2348,28 @@ SELECT 1 AS _placeholder`;
         ...Object.values(pbiToSigmaName),
         ...Object.keys(pbiToSigmaName)
       ]);
+      const canonicalCol = /* @__PURE__ */ new Map();
+      for (const d of colDisplays) {
+        const k = d.toLowerCase();
+        if (!canonicalCol.has(k))
+          canonicalCol.set(k, d);
+      }
       for (let pass = 0; pass < 5; pass++) {
         const metricNames = new Set(metrics.map((mm) => mm.name));
+        const canonicalMetric = /* @__PURE__ */ new Map();
+        for (const n of metricNames) {
+          const k = String(n).toLowerCase();
+          if (!canonicalMetric.has(k))
+            canonicalMetric.set(k, String(n));
+        }
         const before = metrics.length;
         for (let i = metrics.length - 1; i >= 0; i--) {
+          metrics[i].formula = String(metrics[i].formula).replace(/\[([^\]\/]+)\]/g, (whole, ref) => {
+            if (colDisplays.has(ref) || metricNames.has(ref))
+              return whole;
+            const c = canonicalCol.get(ref.toLowerCase()) || canonicalMetric.get(ref.toLowerCase());
+            return c ? `[${c}]` : whole;
+          });
           const refs = (String(metrics[i].formula).match(/\[([^\]\/]+)\]/g) || []).map((r) => r.slice(1, -1));
           const bad = refs.find((r) => !colDisplays.has(r) && !metricNames.has(r));
           if (bad) {
@@ -2334,7 +2436,7 @@ SELECT 1 AS _placeholder`;
         if (!t)
           continue;
         for (const m of t.measures || []) {
-          const moExpr = processUseRelationships(m.name, Array.isArray(m.expression) ? m.expression.join("\n") : String(m.expression || ""));
+          const moExpr = processUseRelationships(m.name, processCrossFilters(m.name, stripDaxComments(Array.isArray(m.expression) ? m.expression.join("\n") : String(m.expression || ""))));
           const homeEl = homeElFor(moExpr);
           if (m.name)
             measureToElementId[m.name] = homeEl.id;
@@ -2731,9 +2833,11 @@ SELECT 1 AS _placeholder`;
 export {
   convertPowerBIToSigma,
   expandMeasureRefs,
+  extractCrossFilters,
   extractUseRelationships,
   hasBareWindowFn,
   isAggCombination,
   pbiDaxToSigma,
-  pbiParseEarlierWindow
+  pbiParseEarlierWindow,
+  stripDaxComments
 };


### PR DESCRIPTION
## Why this PR exists separately

The skill runs the **committed bundle** at `converter/powerbi.mjs`. Merging the converter source PR ([sigma-data-model-mcp#114](https://github.com/twells89/sigma-data-model-mcp/pull/114), `12919f2`) changes **nothing** in the skill until the bundle is re-vendored. This is that step.

## What it picks up

- **`CROSSFILTER(...)` is stripped.** It's a CALCULATE *modifier* — its column args are relationship endpoints, not values the aggregate reads. `USERELATIONSHIP` was already stripped; its sibling wasn't, so the endpoints leaked into the metric formula and the cross-table guard dropped the measure. Now stripped **with a warning**, since dropping a direction change does alter filter semantics.
- **Column refs resolve case-insensitively** (DAX semantics) and are rewritten to the canonical spelling, so a real model typo (`AGENt_KEY` vs `AGENT_KEY`) no longer drops a measure — and the emitted formula doesn't carry a name Sigma can't resolve either.
- **DAX comments are stripped**, string-literal aware. The filter-predicate detector had been matching words *inside* a comment, so a measure was dropped because of a comment. **19 measures across the 4 real models carry comments**, so this is general.

## Verified through the skill's vendored path, not just upstream

| model | metrics kept before | after |
|---|---|---|
| R1 | 11 | **13** (`Tiered CP Prem`, `Tiered GL Prem`) |
| R2 | 20 | 20 |
| R3 | 7 | 7 |
| R4 | 0 | 0 |
| **total** | **38** | **40** — nothing lost |

I ran the comparison by importing *this branch's* `converter/powerbi.mjs` against `main`'s, so the number reflects what the skill will actually do — not what the source repo does.

`PROVENANCE.json` now pins `12919f2`. **42/42** offline suites pass, a count that includes `tests/` — the directory an earlier PR missed by globbing only `scripts/`.

## Honest scope note

+2 measures is materially less than the "13 false cross-table drops" that the original spike estimated. Direct measurement found 7 measures using `CROSSFILTER` and only 2 recoverable; the rest drop for independent reasons (genuine cross-table `SELECTEDVALUE`, real foreign refs). The comment fix's value is broader than its drop count, since a comment can corrupt a translation without producing a drop at all.

Version bumped to 1.5.1 (patch — vendored artifact refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)