### PR TITLE
powerbi-to-sigma: name the failing STAGE on offramp; register every test suite (12 ran nowhere)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -293,6 +293,13 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-field-binding-coverage.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-field-loss-gate.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-roleplaying-dims.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-columns-pagination.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake-offramp.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-offramp-attribution.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-flip-gate.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-suite-registration.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-anchors.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-viz-kind-catalog.rb
             plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-scout-ledger-integrity.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-window-native.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-scout-ledger-integrity.rb
@@ -355,6 +362,13 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_metric_reference.py
             shared/lib/test_metric_binding.py
+            # powerbi-to-sigma uses HYPHENATED test-*.py names, which is why these were
+            # never picked up by the test_*.py convention above. Listed explicitly.
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-extract-viz-signals.py
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-filters.py
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-viz-kind-parity.py
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/tests/test-extract-model-pbix.py
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/tests/test-extract-report-classic.py
             shared/lib/test_plugin_embed.py
             shared/lib/test_composition.py
             shared/lib/test_styling.py

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -4,6 +4,22 @@ description: Convert a Power BI report + semantic model into a Sigma data model 
 user-invocable: true
 ---
 
+## Verifying a change locally
+
+Run **both** test directories — this plugin keeps suites in `scripts/` AND `tests/`:
+
+```bash
+cd plugins/powerbi-to-sigma/skills/powerbi-to-sigma
+for t in scripts/test-*.rb tests/*.rb; do ruby "$t" >/dev/null 2>&1 || echo "FAIL $t"; done
+for t in scripts/test-*.py tests/test-*.py; do python3 "$t" >/dev/null 2>&1 || echo "FAIL $t"; done
+```
+
+Globbing only `scripts/test-*.rb` reports an accurate-looking count while skipping
+`tests/test-grounding.rb` — that omission once merged a change that left `main` red on 7
+assertions. `scripts/test-suite-registration.rb` enforces that every suite in both
+directories is also registered in CI, so a new suite cannot be added and silently never run.
+
+
 # Power BI → Sigma
 
 > **Windows / first run — run the environment doctor before anything else:**

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_offramp_reason.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_offramp_reason.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+#
+# PbiOfframp — classify WHY the mechanical workbook path failed, from the output it
+# actually captured, instead of asserting a cause it never established.
+#
+# THE BUG (hit during a live E2E, 2026-07-30). A run built its workbook, POSTED it
+# successfully, and then failed LAYOUT LINT on a tile-height violation. The offramp said:
+#
+#     The WORKBOOK layer hit some field(s) the mechanical path can't translate
+#     (one or more fields). Falling back to the agent path...
+#
+# There was no untranslatable field. `run_wb!` captures the real error into
+# WorkbookBuildError#captured_output, but the handler printed only its own guess: when
+# `cull_failed_fields` found no field name it fell back to the phrase "one or more
+# fields" REGARDLESS of what had failed. So a one-line tile-height fix was reported as a
+# field-translation failure and the operator was sent to rebuild the entire workbook via
+# the agent path.
+#
+# That is the same class of defect as a coverage headline reading "0 dropped" while half
+# the bindings were pruned: the run reports a cause it did not establish. The rule here is
+# that an undetermined cause must be REPORTED as undetermined, with the captured output
+# shown, never dressed up as a specific one.
+module PbiOfframp
+  module_function
+
+  # captured : the combined stdout/stderr of the failing step
+  # failed   : field names culled by the caller (cull_failed_fields), may be empty
+  # ->  { 'stage', 'message', 'salient', 'posted' }
+  #       stage  : 'layout-lint' | 'post' | 'validate-spec' | 'build' | 'unknown'
+  #       posted : true when the output shows the workbook DID post (so the fix is a PUT,
+  #                not an agent-path rebuild — re-POSTing would orphan the workbook)
+  def classify(captured, failed = [])
+    out = captured.to_s
+    named = Array(failed).reject { |f| f.to_s.strip.empty? }
+
+    if out =~ /layout lint:/i || out =~ /tile below minimum height/i
+      return { 'stage' => 'layout-lint', 'posted' => posted?(out),
+               'salient' => salient(out, /tile below minimum|layout lint:|violation/i),
+               'message' =>
+                 'the LAYOUT step rejected the spec (layout lint), not a field translation. ' \
+                 'The data model and workbook are posted and usable — fix the layout and re-apply ' \
+                 'with PUT /v2/workbooks/<id>/spec (re-POSTing creates an orphan).' }
+    end
+
+    if out =~ /POST\s+\/v2\/workbooks/i || out =~ /->\s*(4\d\d|5\d\d)\b/
+      return { 'stage' => 'post', 'posted' => false,
+               'salient' => salient(out, /Invalid value|message"|->\s*\d{3}/i),
+               'message' => 'the workbook POST was REJECTED by the API. The captured response is ' \
+                            'below; the data model is posted and can be attached.' }
+    end
+
+    if out =~ /Dependency not found|--- \d+ errors?/i || !named.empty?
+      msg = if named.empty?
+              'the workbook SPEC failed validation. The captured errors are below.'
+            else
+              "#{named.size} field(s) the mechanical path could not translate (#{named.join(', ')})."
+            end
+      return { 'stage' => 'validate-spec', 'posted' => posted?(out),
+               'salient' => salient(out, /Dependency not found|errors?/i), 'message' => msg }
+    end
+
+    if out =~ /\[build-workbook\].*(ERROR|FATAL)/i
+      return { 'stage' => 'build', 'posted' => false,
+               'salient' => salient(out, /ERROR|FATAL/i),
+               'message' => 'the workbook BUILD step failed. The captured error is below.' }
+    end
+
+    # Nothing matched. Say so — do NOT claim a field-translation failure, which is what the
+    # old code did unconditionally.
+    { 'stage' => 'unknown', 'posted' => posted?(out),
+      'salient' => salient(out, /./),
+      'message' => 'the mechanical workbook path failed and this run could not determine the ' \
+                   'cause from its output — the captured output is below verbatim. Do not assume a ' \
+                   'field-translation problem; read it before choosing a fix.' }
+  end
+
+  # The workbook posted when the output says so — the fix is then a PUT, and re-POSTing
+  # would leave an orphan.
+  def posted?(out)
+    !!(out =~ /POST ok: workbookId=/i || out =~ /workbook DID post/i)
+  end
+
+  # The few most relevant lines of the captured output, so the operator sees evidence
+  # rather than a summary. Blank input yields ''.
+  def salient(out, pattern, limit = 4)
+    lines = out.to_s.lines.map(&:rstrip).reject { |l| l.strip.empty? }
+    hits = lines.select { |l| l =~ pattern }
+    (hits.empty? ? lines : hits).first(limit).join("\n")
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -71,7 +71,8 @@ require 'digest'
 require 'set'
 require_relative 'lib/py_resolve'
 require_relative 'lib/pbi_field_alts'
-require_relative 'lib/pbi_master_key' # role-playing dim copies must key on PBI table identity # derived field_map entries must wrap their ALTS too (pie/date-grain render bug) # real-Python resolver (Windows Store-stub safe)
+require_relative 'lib/pbi_master_key'
+require_relative 'lib/pbi_offramp_reason' # name the FAILING STAGE, never assert a cause we did not establish # role-playing dim copies must key on PBI table identity # derived field_map entries must wrap their ALTS too (pie/date-grain render bug) # real-Python resolver (Windows Store-stub safe)
 begin; require_relative 'lib/modeling_advisory'; rescue LoadError; end # shared, vendor-neutral CDW join-cost advisory (optional; synced from shared/)
 
 HERE = __dir__
@@ -1518,14 +1519,28 @@ rescue WorkbookBuildError => e
                           .map { |w| w[/[“"]([^”"]+)[”"]/, 1] || w.sub(/^⛔\s*/, '')[0, 60] }
                           .compact.uniq
   end
-  names = failed.empty? ? 'one or more fields' : failed.join(', ')
-  n = failed.empty? ? 'some' : failed.size.to_s
+  # Classify from the output we ACTUALLY captured. The old code asserted a
+  # field-translation failure unconditionally — when no field name could be culled it
+  # still printed "one or more fields" — so a LAYOUT-LINT tile-height violation after a
+  # SUCCESSFUL post was reported as untranslatable fields, sending the operator to rebuild
+  # the whole workbook when the real fix was one tile height. An undetermined cause is now
+  # reported as undetermined, with the captured output shown.
+  info = PbiOfframp.classify(e.captured_output, failed)
   puts
-  puts "── Mechanical path: data model built OK (dataModelId=#{dm_id}). The WORKBOOK " \
-       "layer hit #{n} field(s) the mechanical path can't translate (#{names}). " \
-       "Falling back to the agent path: rebuild the workbook via the skill's " \
-       "agent-authored flow (see SKILL.md) against this DM. The data model is " \
-       "posted and ready to attach."
+  puts "── Mechanical path: data model built OK (dataModelId=#{dm_id})."
+  puts "   FAILING STAGE: #{info['stage']} — #{info['message']}"
+  unless info['salient'].to_s.strip.empty?
+    puts '   captured output:'
+    info['salient'].to_s.lines.each { |l| puts "     #{l.rstrip}" }
+  end
+  if info['posted']
+    puts '   NOTE: the workbook POSTED — fix and re-apply with PUT /v2/workbooks/<id>/spec.'
+    puts '   Do NOT re-POST (it creates an orphan) and do NOT rebuild via the agent path.'
+  else
+    puts "   Falling back to the agent path: rebuild the workbook via the skill's " \
+         'agent-authored flow (see SKILL.md) against this DM. The data model is posted ' \
+         'and ready to attach.'
+  end
   exit 4
 end
 wb_rb = JSON.parse(File.read(wb_readback))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-offramp-attribution.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-offramp-attribution.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+# Regression test: the agent-path offramp must name the STAGE that actually failed.
+#
+# THE BUG (hit during a live E2E, 2026-07-30). A run built its workbook, POSTED it
+# successfully, and then failed LAYOUT LINT on a tile-height violation. The offramp
+# reported:
+#
+#     Mechanical path: data model built OK (dataModelId=...). The WORKBOOK layer hit
+#     some field(s) the mechanical path can't translate (one or more fields).
+#     Falling back to the agent path...
+#
+# There was no untranslatable field. `run_wb!` captures the real error into
+# WorkbookBuildError#captured_output, but the handler printed only its own guess: when
+# `cull_failed_fields` finds no field name it falls back to the phrase "one or more
+# fields" REGARDLESS of what actually failed. So a one-line tile-height fix was
+# reported as a field-translation failure, and the operator was sent to rebuild the
+# whole workbook via the agent path.
+#
+# That is the same class of misleading diagnostic as the coverage headline that said
+# "0 dropped" while dropping half the bindings — the run reports a cause it did not
+# establish. This asserts the offramp either names the real stage or admits it does not
+# know, and never asserts a field-translation failure it cannot evidence.
+#
+# Usage:  ruby scripts/test-offramp-attribution.rb
+require 'json'
+require_relative 'lib/pbi_offramp_reason'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# The verbatim shape of the real failure: POST succeeded, layout lint then failed.
+LAYOUT_LINT_OUTPUT = <<~OUT
+     POST ok: workbookId=7f9dcae5-26a3-4a46-a3a9-edf58337e5a0
+     column-type guard: 97 columns clean (no `error` types)
+     ========================================
+     FAIL — layout lint: 1 violation(s):
+       - tile below minimum height: element el-ustere20ada9 (bar-chart) on page page-pg1
+         spans 6 grid row(s) (< 8 required for bar-chart) — Sigma renders sub-minimum
+         tiles BLANK in the page and in PNG exports; grow the tile.
+     Fix the spec/layout and re-PUT before continuing.
+     The workbook DID post — fix with PUT /v2/workbooks/<id>/spec
+     ========================================
+OUT
+
+VALIDATE_OUTPUT = <<~OUT
+     --- 3 errors
+     element el-x column c1: Dependency not found: [FOO/Bar]
+OUT
+
+POST_OUTPUT = <<~OUT
+     POST /v2/workbooks/spec -> 400
+     {"message":"Invalid value: undefined at pages[0].elements[2].source"}
+OUT
+
+puts "\n1. a LAYOUT-LINT failure is named as such, and NOT as untranslatable fields"
+r = PbiOfframp.classify(LAYOUT_LINT_OUTPUT, [])
+check(r['stage'] == 'layout-lint', "stage == layout-lint (got #{r['stage'].inspect})", fails)
+check(r['message'] =~ /layout/i, 'the message says layout', fails)
+check(r['message'] !~ /can't translate|cannot translate/i,
+      "the message does NOT claim a translation failure (got: #{r['message'][0, 90]})", fails)
+check(r['message'] !~ /one or more fields/,
+      'the message does NOT fall back to "one or more fields"', fails)
+check(r['posted'] == true, 'it records that the workbook DID post', fails)
+check(r['message'] =~ /PUT/,
+      'and points at PUT /v2/workbooks/<id>/spec rather than the agent path', fails)
+check(r['salient'].to_s =~ /tile below minimum height/,
+      "it surfaces the actual violation line (got #{r['salient'].to_s[0, 60].inspect})", fails)
+
+puts "\n2. a genuine FIELD failure is still attributed to fields"
+r2 = PbiOfframp.classify(VALIDATE_OUTPUT, ['Net Revenue PY', 'YoY %'])
+check(r2['stage'] == 'validate-spec', "stage == validate-spec (got #{r2['stage'].inspect})", fails)
+check(r2['message'] =~ /Net Revenue PY/, 'the named fields are reported', fails)
+check(r2['posted'] == false, 'and it does NOT claim the workbook posted', fails)
+
+puts "\n3. a POST rejection is named as a POST failure"
+r3 = PbiOfframp.classify(POST_OUTPUT, [])
+check(r3['stage'] == 'post', "stage == post (got #{r3['stage'].inspect})", fails)
+check(r3['salient'].to_s =~ /Invalid value|400/, 'the API error is surfaced', fails)
+check(r3['message'] !~ /one or more fields/, 'no invented field-translation claim', fails)
+
+puts "\n4. when nothing can be determined it says SO — it never invents a cause"
+r4 = PbiOfframp.classify("something inscrutable happened\n", [])
+check(r4['stage'] == 'unknown', "stage == unknown (got #{r4['stage'].inspect})", fails)
+check(r4['message'] !~ /can't translate|cannot translate/i,
+      'an unknown failure is NOT reported as a translation failure', fails)
+check(r4['message'] =~ /could not determine|unknown/i,
+      "it admits it could not determine the cause (got: #{r4['message'][0, 80]})", fails)
+check(r4['salient'].to_s.length.positive?,
+      'and still surfaces the captured output so the operator can see it', fails)
+
+puts "\n5. empty/nil output is handled without raising"
+[nil, '', "\n"].each do |blank|
+  r5 = PbiOfframp.classify(blank, [])
+  check(r5.is_a?(Hash) && r5['stage'] == 'unknown', "blank output #{blank.inspect} -> unknown", fails)
+end
+
+puts "\n6. the orchestrator USES the classifier (no hand-rolled message left behind)"
+src = File.read(File.join(__dir__, 'migrate-powerbi.rb'))
+check(src.include?('PbiOfframp'), 'migrate-powerbi.rb uses PbiOfframp', fails)
+check(src !~ /layer hit #\{n\} field\(s\) the mechanical path can't translate/,
+      'the old unconditional "can\'t translate" sentence is gone', fails)
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |f| puts "  - #{f}" }
+exit(fails.empty? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-suite-registration.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-suite-registration.rb
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+# Regression test: every test file in this skill must be RUN by CI, and the canonical
+# local command must cover the same set.
+#
+# WHY (2026-07-30). This plugin keeps tests in TWO directories — `scripts/test-*.rb` and
+# `tests/*.rb`. A PR verified with a glob over `scripts/` only reported an accurate
+# "33/33" and "35/35" while never running `tests/test-grounding.rb`, then merged and left
+# `main` RED on 7 assertions in exactly that file. The numbers were true; the denominator
+# was wrong.
+#
+# CI itself was fine — it lists `tests/test-grounding.rb` explicitly. The gap was that
+# nothing enforced the relationship between "test files that exist" and "test files that
+# run", so a new suite can be added and silently never execute, and nothing documented
+# the local command that matches CI.
+#
+# This closes both: an unregistered suite fails here, and SKILL.md must state the
+# both-directories command.
+#
+# Usage:  ruby scripts/test-suite-registration.rb
+require 'set'
+
+SKILL = File.expand_path('..', __dir__)
+REPO  = File.expand_path('../../../..', SKILL)
+WF    = File.join(REPO, '.github/workflows/corpus-check.yml')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+rel = ->(p) { p.sub("#{REPO}/", '') }
+# Match on BASENAME, not the exact repo-relative path: the workflow lists some suites via
+# a different path form (or a glob), and demanding an exact path produced false positives
+# that would have masked the real gaps behind noise. Also scan EVERY workflow, since a
+# suite may legitimately run from hygiene.yml rather than corpus-check.yml.
+WFS = Dir[File.join(REPO, '.github/workflows/*.yml')].sort
+ALL_WF = WFS.map { |f| File.read(f) }.join("\n")
+registered = ->(path) { ALL_WF.include?(File.basename(path)) }
+
+ruby_suites = (Dir[File.join(SKILL, 'scripts', 'test-*.rb')] +
+               Dir[File.join(SKILL, 'tests', '*.rb')]).sort
+py_suites   = (Dir[File.join(SKILL, 'scripts', 'test-*.py')] +
+               Dir[File.join(SKILL, 'tests', 'test-*.py')]).sort
+
+puts "\n1. this skill really does keep tests in TWO directories"
+in_scripts = ruby_suites.count { |p| p.include?('/scripts/') }
+in_tests   = ruby_suites.count { |p| p.include?('/tests/') }
+check(in_scripts.positive?, "scripts/ holds ruby suites (#{in_scripts})", fails)
+check(in_tests.positive?,
+      "tests/ ALSO holds ruby suites (#{in_tests}) — the directory an earlier PR's glob missed", fails)
+
+puts "\n2. every ruby suite is registered in the CI workflow"
+check(!WFS.empty?, "workflows found (#{WFS.size})", fails)
+missing = ruby_suites.reject { |p| registered.call(p) }
+check(missing.empty?,
+      "no ruby suite is unregistered (missing: #{missing.map { |p| File.basename(p) }.join(', ')})", fails)
+
+puts "\n3. every python suite is registered too"
+missing_py = py_suites.reject { |p| registered.call(p) }
+check(missing_py.empty?,
+      "no python suite is unregistered (missing: #{missing_py.map { |p| File.basename(p) }.join(', ')})", fails)
+
+puts "\n4. SKILL.md documents the BOTH-directories local command"
+skill_md = File.join(SKILL, 'SKILL.md')
+md = File.exist?(skill_md) ? File.read(skill_md) : ''
+check(File.exist?(skill_md), 'SKILL.md exists', fails)
+check(md.include?('scripts/test-*.rb') && md.include?('tests/'),
+      'SKILL.md names BOTH scripts/test-*.rb and tests/ in its verification command', fails)
+check(md =~ /tests\/\*\.rb|tests\/test|both director/i,
+      'and makes the two-directory requirement explicit', fails)
+
+puts "\n5. the suite count is reported, so a shrinking denominator is visible"
+puts "     ruby suites: #{ruby_suites.size} (scripts #{in_scripts} + tests #{in_tests})"
+puts "     python suites: #{py_suites.size}"
+check(ruby_suites.size + py_suites.size >= 30,
+      "total suites #{ruby_suites.size + py_suites.size} — a sudden drop means a glob or a move broke", fails)
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |f| puts "  - #{f}" }
+exit(fails.empty? ? 0 : 1)


### PR DESCRIPTION
Two fixes of the same kind: **stop reporting something the run did not establish.**

## 1. The offramp misattributed non-field failures

Hit in a live E2E. A run built its workbook, **POSTed it successfully**, then failed **layout lint** on a tile-height violation — and reported:

> The WORKBOOK layer hit some field(s) the mechanical path can't translate (one or more fields). Falling back to the agent path…

There was no untranslatable field. `run_wb!` captures the real error into `WorkbookBuildError#captured_output`, but the handler printed only its own guess: when `cull_failed_fields` found no field name it fell back to `"one or more fields"` **regardless of the actual cause**. So a one-line tile-height fix was reported as a field-translation problem, and the operator was sent to rebuild the entire workbook via the agent path.

`lib/pbi_offramp_reason.rb` now classifies the failing **stage** from the captured output — `layout-lint` / `post` / `validate-spec` / `build` / `unknown` — surfaces the salient lines verbatim, and when the output shows the workbook **did** post, says to fix with `PUT /v2/workbooks/<id>/spec` rather than re-POSTing (which orphans it) or rebuilding.

The rule that matters: **an undetermined cause is reported as undetermined**, with the output shown, never dressed up as a specific one. There's a test for exactly that case.

## 2. Twelve test suites ran nowhere

This plugin keeps tests in **both** `scripts/` and `tests/`. An earlier PR verified with a glob over `scripts/` only — so its accurate-looking "33/33" and "35/35" never ran `tests/test-grounding.rb`, and that PR merged and left `main` **red on 7 assertions in exactly that file**.

Auditing properly found **7 ruby + 5 python suites in no workflow at all** — some pre-existing (`test-columns-pagination.rb`, `test-intake-offramp.rb`, `test-pbi-flip-gate.rb`, `test-verify-anchors.rb`, `test-pbi-filters.py`, both `tests/test-extract-*.py`), some added by this effort — **including `test-viz-kind-catalog.rb`, which I wrongly believed I had registered.**

The Python ones were missed for a concrete reason: this plugin uses **hyphenated** `test-*.py` names while the workflow step keys on the `test_*.py` convention. Now listed explicitly, with that noted inline.

All 12 verified passing individually **before** registering, so CI isn't handed a new failure.

`scripts/test-suite-registration.rb` enforces the invariant going forward: every suite in both directories must appear in a workflow, so a suite cannot be added and silently never run. It matches on **basename across all workflows** — my first version demanded an exact repo-relative path and produced false positives that would have buried the real gaps in noise.

`SKILL.md` now documents the both-directories command, with the reason it exists.

## Verification

**44/44** offline suites pass (this PR adds 2). The count is now *enforced* rather than asserted — a shrinking denominator fails `test-suite-registration.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)