### PR TITLE
chore(powerbi): re-vendor converter — cross-table triage hop-3 + metric-blocker attribution (mcp#119)

### DIFF
--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/PROVENANCE.json
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/PROVENANCE.json
@@ -1,6 +1,6 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "967e7d6",
+  "source_commit": "c3f892c",
   "source_commit_date": "2026-07-31",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "powerbi.mjs",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/powerbi.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/converter/powerbi.mjs
@@ -425,7 +425,7 @@ function isNeverHostable(rawDax) {
 }
 function triageCrossTable(args) {
   const { metricName, sigmaFormula, rawDax, homeTable, refs, columnOwners, relationships } = args;
-  const maxDepth = args.maxDepth ?? 2;
+  const maxDepth = args.maxDepth ?? 3;
   const metricRefSet = new Set(args.metricRefs ?? []);
   const dependsOnMetrics = [...new Set(refs.filter((r) => metricRefSet.has(r)))];
   const columnRefs = refs.filter((r) => !metricRefSet.has(r));
@@ -525,6 +525,15 @@ function describeVerdict(t) {
     return `TRIAGE: hostable on "${safe.baseTable} View" (${hop(safe)}, fan-out SAFE).`;
   const risky = t.candidates[0];
   return `TRIAGE: "${risky.baseTable} View" (${hop(risky)}) covers it but FAN-OUT RISK \u2014 [${risky.unsafeRefs.join(", ")}] would double-count across the join; rebuild at the visual's grain.`;
+}
+function isNoCoveringView(t) {
+  return !t.neverHostable && t.candidates.length === 0;
+}
+function describeMetricBlocker(b) {
+  if (b.kind === "cross-element-metric") {
+    return `TRIAGE: references metric "${b.metric}", which is declared on a DIFFERENT element ("${b.ownerTable}") \u2014 Sigma metrics cannot reference another element's metric, at any join distance; no hop limit fixes this. Recreate the dependency as a workbook-level calculation, or duplicate "${b.metric}" onto this element.`;
+  }
+  return `TRIAGE: depends on sibling metric "${b.metric}", which was itself dropped \u2014 its own drop reason: ${b.siblingReason} That dependency, not column reachability, is this measure's real blocker; resolve "${b.metric}" first, or rewrite this measure without it.`;
 }
 
 // ../mcp-fresh/build/powerbi.js
@@ -2307,6 +2316,13 @@ function convertPowerBIToSigma(modelJson, options = {}) {
     }
   }
   const triageRels = (model.relationships || []).filter((r) => r.fromTable && r.toTable).map((r) => ({ from: r.fromTable, to: r.toTable }));
+  const allMetricOwner = /* @__PURE__ */ Object.create(null);
+  for (const _t of model.tables || []) {
+    for (const _m of _t.measures || []) {
+      if (_m?.name && !allMetricOwner[_m.name])
+        allMetricOwner[_m.name] = _t.name;
+    }
+  }
   const measureToElementId = {};
   const measureAggMap = pbiBuildMeasureAggMap(model);
   const measureDaxMap = {};
@@ -2619,6 +2635,7 @@ SELECT 1 AS _placeholder`;
         if (!canonicalCol.has(k))
           canonicalCol.set(k, d);
       }
+      const siblingDropReason = /* @__PURE__ */ new Map();
       for (let pass = 0; pass < 5; pass++) {
         const metricNames = new Set(metrics.map((mm) => mm.name));
         const canonicalMetric = /* @__PURE__ */ new Map();
@@ -2648,9 +2665,24 @@ SELECT 1 AS _placeholder`;
               refs: [...new Set(refs)],
               columnOwners: triageColumnOwners,
               relationships: triageRels,
-              metricRefs: [...metricNames]
+              metricRefs: [...metricNames],
+              // Explicit, not just inherited from triageCrossTable's own default —
+              // measured on R1-R4: 9 of 32 `no-covering-View` drops are a filtered
+              // dimension reachable at 3 hops, not 2 (see powerbi-crosstable-triage.ts).
+              maxDepth: 3
             });
-            warnings.push(`\u26A0 "${metrics[i].name}": references "[${bad}]" which is not a column or metric on this element (cross-table measure) \u2014 dropped; recreate in a workbook element at the visual's grain (the joined "View" element has the dim columns). ${describeTriage(_triage)}`);
+            let _blocker = null;
+            if (isNoCoveringView(_triage)) {
+              if (allMetricOwner[bad] && allMetricOwner[bad] !== tableName) {
+                _blocker = { kind: "cross-element-metric", metric: bad, ownerTable: allMetricOwner[bad] };
+              } else if (siblingDropReason.has(bad)) {
+                _blocker = { kind: "dropped-sibling", metric: bad, siblingReason: siblingDropReason.get(bad) };
+              }
+            }
+            const _reasonText = _blocker ? describeMetricBlocker(_blocker) : describeTriage(_triage);
+            const _warning = _blocker ? `\u26A0 "${metrics[i].name}": references "[${bad}]" which is not a column or metric on this element (cross-table measure) \u2014 dropped. ${_reasonText}` : `\u26A0 "${metrics[i].name}": references "[${bad}]" which is not a column or metric on this element (cross-table measure) \u2014 dropped; recreate in a workbook element at the visual's grain (the joined "View" element has the dim columns). ${_reasonText}`;
+            warnings.push(_warning);
+            siblingDropReason.set(metrics[i].name, _reasonText);
             metrics.splice(i, 1);
           }
         }


### PR DESCRIPTION
## Summary

Re-vendors the Power BI converter bundle so the cross-table measure triage improvements merged upstream ([mcp#119](https://github.com/twells89/sigma-data-model-mcp/pull/119)) reach operators. Until this lands the skill runs the stale bundle (`source_commit` `967e7d6`, mcp#117 only, verified to carry none of #119 — zero occurrences of `isNoCoveringView`/`MetricBlocker`/`describeMetricBlocker`).

**Operator impact:**
- Raises the cross-table triage hop limit **2 → 3**, so a measure whose covering dimension sits 3 joins from its home fact now surfaces a re-homing candidate instead of "no View covers it." **Measured, not projected:** 13 → 16 of 108 measures now classify as safely re-homable — this is a work-list for an operator to act on, not automatic recovery of the other 92.
- Measures blocked by a dependency on **another element's metric** (or on an already-dropped sibling metric) now report that as the real blocker instead of misreporting a column-coverage problem.

## Verification

- **Symbol check** (`grep -a` — the bundle contains literal NUL/SOH bytes that make plain `grep` report false negatives): `isNoCoveringView`, `MetricBlocker`, `describeMetricBlocker` all present (2 occurrences each) in the regenerated bundle.
- **Hand-patch check:** rebuilt the prior `source_commit` (967e7d6) from a clean worktree and diffed that fresh bundle against the one actually shipped at that commit — zero substantive delta (only esbuild's checkout-path bundler comments differ). No local hand-patches exist in the powerbi bundle to lose or reapply.
- **End-to-end proof:** built a synthetic 4-table snowflake TMSL model (`SALES_FACT → AGENT_DIM → REGION_DIM → COUNTRY_DIM`) with a cross-table measure on `SALES_FACT`, and ran it through both bundles via plain `node` (no tsx, no MCP):
  - OLD (967e7d6): `TRIAGE: ambiguous — 2 Views cover it ("REGION_DIM View", "AGENT_DIM View")`
  - NEW (this branch, c3f892c): `TRIAGE: ambiguous — 3 Views cover it ("REGION_DIM View", "AGENT_DIM View", "SALES_FACT View")`

  The third candidate is only reachable under the raised hop limit — direct proof the behavioral change is live in the vendored bundle, not just the symbol grep.
- **Corpus:** `corpus/run-corpus.sh --check powerbi` — 3/3 cases pass, including the structural golden comparison (5 elements, 56 columns, 15 metrics, 2 relationships, 8 warnings unchanged).
- **converter-default-test.sh:** all pass (vendored bundle is still the default; dev-override still honored).
- **Plugin test suites:** `scripts/test-*.rb` 38/38 pass; `tests/*.rb` 1/1 pass.
- **Gates:** `tools/test-converter-provenance.sh` all pass (including Part D's tableau-specific string-pin, untouched by this change); `tools/check-plugin-version-bump.sh origin/main HEAD` → `powerbi-to-sigma 1.7.0 -> 1.7.1, OK`.
- `tools/hygiene-sweep.sh` clean.

## Scope

`powerbi-to-sigma` only — `shared/` was not touched by the vendor script.

## Version bump

**Patch** (1.7.0 → 1.7.1): this changes which warnings an existing conversion emits and how accurately they're worded (more measures get a real re-homing suggestion instead of a dead end; blocked measures report their true blocker) — no new field, skill, capability, or spec shape is exposed. Bug-fix-level under semver, not a new capability.

## Test plan

- [x] `grep -a` for `isNoCoveringView` / `MetricBlocker` / `describeMetricBlocker` in the regenerated bundle — all present
- [x] Rebuild-vs-shipped diff at the prior `source_commit` — empty (no hand-patches)
- [x] Synthetic cross-table TMSL model through old vs new bundle — `TRIAGE:` hop-count changes 2 → 3 as expected
- [x] `corpus/run-corpus.sh --check powerbi` — 3/3
- [x] `corpus/converter-default-test.sh` — all pass
- [x] `scripts/test-*.rb` — 38/38
- [x] `tests/*.rb` — 1/1
- [x] `tools/test-converter-provenance.sh` — all pass
- [x] `tools/check-plugin-version-bump.sh origin/main HEAD` — OK, 1.7.0 -> 1.7.1
- [x] `tools/hygiene-sweep.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)