### PR TITLE
domo-to-sigma: fix 3 bugs found during the Track B live parity run

### DIFF
--- a/corpus/domo/live-shapes/MANIFEST.md
+++ b/corpus/domo/live-shapes/MANIFEST.md
@@ -41,8 +41,15 @@ Evidence and the full story:
   `VALUE`; treating SERIES as a dimension yields a chart with ZERO measures
 - **`columnOverrides`** — a Domo-only column derived from one that does exist,
   rather than emitting a reference the warehouse cannot resolve
-- **multi-dataset page** — the `ds-dim` card is expected to be SKIPPED with a named
-  warning (one master per dataset is bead ziht), not silently mis-bound
+- **multi-dataset page** — the `ds-dim` card now routes to its own hidden
+  sub-master (`master-ds-dim`, one master per DataSet — bead ziht landed) rather
+  than being SKIPPED, **provided** a live `dm-ids.json`/`dm-spec.json` pair is
+  available to resolve `ds-dim` to its data-model element; absent that pair, the
+  card still falls back to today's named-warning SKIP rather than a silent
+  mis-bind. `corpus/run-corpus.sh --check` for this case only validates
+  `golden/data-model.json` (build-dm.rb's output) — no golden `chart-specs.json`
+  exists here, so this case does not exercise the sub-master routing itself;
+  that is pinned by `test/test-migrate-domo.rb`'s full-chain fixture instead
 
 ## Converter
 

--- a/docs/superpowers/plans/2026-07-31-domo-track-b-parity-spine.md
+++ b/docs/superpowers/plans/2026-07-31-domo-track-b-parity-spine.md
@@ -1,0 +1,1060 @@
+# Track B — the parity spine: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the three known converter defects blocking `domo-to-sigma`'s parity gate —
+`2ef7` (a card's row `limit` is dropped), `ziht` (a page spanning more than one Domo
+DataSet drops every off-dominant-dataset card), and `08sf` (a chart/table card's Summary
+Number is silently lost) — so a live Domo migration run can reach gate 1
+(`parity-final.json`) without any known, already-diagnosed fidelity break blocking it.
+
+**Architecture:** All three fixes live in `build-workbook.rb` (Phase 5, chart-layer
+converter), with one small upstream change in `domo-discover.rb` (card normalization)
+and one small addition to `migrate-domo.rb` (an extra env var for `ziht`). Nothing
+touches `build-workbook-spec.rb` — it is vendored from `tableau-to-sigma` verbatim
+("do not diverge this copy" per its own header) and both new capabilities route through
+mechanisms it already supports unmodified: the existing `data_elements` passthrough
+(for `ziht`'s per-DataSet sub-masters) and the existing per-element `columns`/`filters`
+shape (for `2ef7`'s top-n filter). `08sf`'s companion KPI is sourced the same way the
+`master`/`sub-master` element already is, via the existing `build_kpi` function, just
+invoked a second time per card and threaded through a new side-channel global
+(`$companion_elements`), mirroring the file's own existing `$warnings` side-channel
+convention rather than changing `build_element`'s return contract (which the 20+
+existing assertions in `test-build-workbook.rb` depend on being a single Hash-or-nil).
+
+**Tech Stack:** Ruby (no new gems — this repo's scripts are dependency-free stdlib
+Ruby: `json`, `optparse`, `net/http`). Hand-rolled test framework already established
+in `test/test-*.rb` (`eq`/`ok` helpers writing to `$failures`, run via `ruby
+test/test-<name>.rb` or `bash test/run-all.sh`, which globs `test/test-*.rb` — no
+explicit test-file registration needed, unlike the sibling `sigma-data-model-mcp` repo).
+
+## Global Constraints
+
+- Never touch `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook-spec.rb`
+  — it is VENDORED ("Fix upstream and re-vendor; do not diverge this copy"). All new
+  behavior must route through inputs that file already accepts unmodified
+  (`chart-specs.json`'s existing `data_elements` key, standard element `columns`/
+  `filters` shapes).
+- Never break the single-Hash-or-nil return contract of `build_element`,
+  `build_table`, `build_axis_chart`, `build_kpi`, etc. — `test-build-workbook.rb`'s
+  existing ~25 assertions call these directly and must keep passing unchanged.
+- Every new warning goes through the existing `warn_card(card, msg)` helper — never a
+  bare `warn`/`puts` — so it lands in `discovery/warnings.json` like every other
+  fidelity note in this file.
+- No network/credentials in any test added by this plan — all three tasks are unit
+  tests against bare Ruby hashes (matching `test-build-workbook.rb`'s existing style)
+  or fixture files already checked in.
+- Ruby 2.6 locally vs Ruby 3.x in CI is a standing hazard in this repo — avoid adding
+  a keyword parameter to an existing method that has call sites still passing a bare
+  trailing hash (none of the functions touched here take keyword args, so this is a
+  non-issue for this plan, but keep new methods positional-only to stay consistent).
+- **Out of scope for this plan** (explicitly deferred, not silently dropped): the live
+  parity run itself (`build-parity-plan.rb` → `verify-warehouse.rb --out
+  parity-final.json`), orphan-workbook cleanup, and control gates 7/7b/7c. Those are
+  operational steps against a live Domo + Sigma target — "run it and read the result,"
+  not pre-scriptable TDD — and are the natural next phase once this plan's fixes are
+  merged. Track C (`pageLayoutV4`) and Track E (vendor the converter) are separate
+  tracks per the design doc and not touched here.
+
+---
+
+### Task 1: `domo-discover.rb` — carry a card's row `limit` through normalization
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/domo-discover.rb:277-368` (`normalize_card`)
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-discover.rb`
+
+**Interfaces:**
+- Produces: `normalize_card(raw, card_id, card_meta: nil)` now includes a `'limit'`
+  key in its returned Hash (an Integer, present only when the source component
+  declared one — dropped by the existing trailing `.compact` otherwise). Task 2
+  reads `card['limit']` from this normalized card.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-discover.rb`. In the Shape A
+fixture (starts at line 86), add a `'limit'` key to `chartBody`, and add an assertion
+after line 116 (`eq(a['cardFormulas'].size, ...)`):
+
+```ruby
+  'chartBody' => {
+    'columns' => [
+      { 'column' => 'store_region', 'alias' => 'Store Region' },
+      { 'column' => 'sales_amount', 'alias' => 'Sales', 'aggregation' => 'SUM',
+        'format' => { 'type' => 'CURRENCY' } },
+    ],
+    'groupBy' => [{ 'column' => 'store_region' }],
+    'orderBy' => [{ 'column' => 'sales_amount' }],
+    'filters' => [{ 'column' => 'status', 'operand' => 'IN', 'values' => %w[Active Pending] }],
+    'limit' => 25,
+  },
+```
+
+```ruby
+eq(a['limit'], 25, 'limit carried through Shape A normalization (bead 2ef7)')
+```
+
+In the Shape B fixture (starts at line 119), add `'limit'` to `main` and an assertion
+after line 143 (`eq(b['cardFormulas'].first['name'], ...)`):
+
+```ruby
+    'subscriptions' => { 'main' => {
+      'columns' => [
+        { 'column' => 'project_id' },
+        { 'column' => 'calculation_xyz', 'formulaId' => 'calculation_xyz' },
+      ],
+      'filters' => [{ 'column' => 'region', 'filterType' => 'IN', 'values' => ['West'] }],
+      'groupBy' => [{ 'column' => 'project_id' }],
+      'orderBy' => [{ 'column' => 'project_id' }],
+      'limit' => 25,
+    } },
+```
+
+```ruby
+eq(b['limit'], 25, 'limit carried through Shape B normalization (bead 2ef7)')
+```
+
+Also add a third check confirming absence stays absent (no card in the corpus has a
+Top-N limit today — the normalizer must not fabricate one):
+
+```ruby
+puts "== normalize_card: no limit declared -> key absent, not zero =="
+no_limit = normalize_card({ 'chartType' => 'badge_table', 'chartBody' => { 'columns' => [{ 'column' => 'x' }] } }, 'card-C')
+ok(!no_limit.key?('limit'), 'no limit key when the source declared none (compact drops nil, never defaults to 0)')
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-discover.rb`
+Expected: FAIL — `exp 25 / got nil` for both new `limit` assertions (the third,
+"no limit key", already passes since the key doesn't exist yet at all — that's fine,
+it's a regression guard for after Step 3, not a red/green signal on its own).
+
+- [ ] **Step 3: Implement**
+
+In `normalize_card` (Shape B branch, `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/domo-discover.rb`), add a `'limit'` entry. Insert it right after the existing `'orderBy'` line (currently line 330):
+
+```ruby
+      'groupBy'            => Array(main['groupBy']).map { |c| c['column'] }.compact,
+      'orderBy'            => Array(main['orderBy']).map { |c| c['column'] }.compact,
+      'limit'              => main['limit'],
+      'filters'            => filters,
+```
+
+In the Shape A branch, insert after the existing `'orderBy'` line (currently line 360):
+
+```ruby
+      'groupBy'            => norm_columns({ 'columns' => body['groupBy'] }).map { |c| c['column'] },
+      'orderBy'            => norm_columns({ 'columns' => body['orderBy'] }).map { |c| c['column'] },
+      'limit'              => body['limit'],
+      'filters'            => filters,
+```
+
+Both branches already end in `.compact` (lines 336 and 366), so a `nil` `limit` (the
+common case — most cards have none) is dropped rather than emitted as `"limit" => null`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-discover.rb`
+Expected: `ALL PASS`, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/domo-discover.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-discover.rb
+git commit -m "domo: carry a card's row limit through normalize_card (bead 2ef7, part 1)"
+```
+
+---
+
+### Task 2: `build-workbook.rb` — translate a Domo row `limit` to a Sigma top-n filter
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb:481-522` (`build_table`)
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+
+**Interfaces:**
+- Consumes: `card['limit']` (Integer or absent), produced by Task 1.
+- Produces: `build_table(card)` now sets `el['filters']` to a one-entry array
+  `[{'id', 'columnId', 'kind'=>'top-n', 'rankingFunction'=>'rank', 'mode'=>'top-n',
+  'rowCount'}]` when `card['limit']` is a positive integer and the card has at least
+  one measure column. No change to `el`'s shape otherwise.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`, right
+before the final `puts` / `if $failures.zero?` block (currently lines 192-193):
+
+```ruby
+puts "== bead 2ef7: card['limit'] -> Sigma top-n element filter (table) =="
+$warnings = []
+topn = build_element({ 'id' => 'c22', 'title' => 'Order Detail (Top 25)', 'chartType' => 'badge_table',
+                       'sigmaKindHint' => 'table', 'limit' => 25,
+                       'columns' => [ { 'column' => 'order_id' },
+                                      { 'column' => 'net_revenue', 'aggregation' => 'SUM', 'alias' => 'Net Revenue' } ] }, {})
+eq(topn['kind'], 'table', 'still a table element')
+ok(topn.key?('filters'), 'limit produced an element filter')
+eq(topn['filters'].first['kind'], 'top-n', 'filter kind is top-n')
+eq(topn['filters'].first['rankingFunction'], 'rank', 'rankingFunction is rank')
+eq(topn['filters'].first['mode'], 'top-n', 'mode is top-n')
+eq(topn['filters'].first['rowCount'], 25, 'rowCount carries the Domo limit as a NUMBER LITERAL')
+eq(topn['filters'].first['columnId'], topn['columns'].last['id'], 'ranks by the measure column (Net Revenue), not the dimension')
+
+puts "== bead 2ef7: no limit declared -> no filters key at all =="
+no_topn = build_element({ 'id' => 'c23', 'title' => 'All Orders', 'chartType' => 'badge_table',
+                          'sigmaKindHint' => 'table',
+                          'columns' => [ { 'column' => 'order_id' },
+                                         { 'column' => 'net_revenue', 'aggregation' => 'SUM' } ] }, {})
+ok(!no_topn.key?('filters'), 'no limit -> no filters key (never emit an empty/default top-n)')
+
+puts "== bead 2ef7: limit with no measure column -> no filter (nothing to rank by)" \
+     ' — never crash, never emit a columnId:nil filter =='
+no_measure = build_element({ 'id' => 'c24', 'title' => 'Dim Only', 'chartType' => 'badge_table',
+                             'sigmaKindHint' => 'table', 'limit' => 10,
+                             'columns' => [ { 'column' => 'order_id' } ] }, {})
+ok(!no_measure.key?('filters'), 'no measure column -> no top-n filter emitted')
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+Expected: FAIL on the new "limit produced an element filter" checks (`topn` has no
+`'filters'` key yet); the "no limit" and "no measure" checks already pass (nothing to
+regress there yet, but keep them — they pin the negative cases once Step 3 lands).
+
+- [ ] **Step 3: Implement**
+
+Replace `build_table` (currently `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb:481-522`) with:
+
+```ruby
+def build_table(card)
+  dims, meas = split_cols(card)
+  mcols = meas.map { |m| measure_col(m, card) }
+  cols = dims.map { |d| dim_col(d, card).merge('style' => { 'textWrap' => 'wrap' }) } + mcols
+  cols = (card['columns'] || []).map { |c| dim_col(c, card).merge('style' => { 'textWrap' => 'wrap' }) } if cols.empty?
+  el = {
+    'id' => eid(card), 'kind' => 'table', 'name' => card['title'],
+    'source' => { 'kind' => 'table', 'elementId' => 'master' },
+    'columns' => cols, 'order' => cols.map { |c| c['id'] },
+  }
+
+  # A Sigma `table` with NO `groupings` shows raw DETAIL rows — the
+  # sigma-workbooks spec calls this "the #1 migration bug for aggregated source
+  # vizzes" (reference/specification/tables.md § groupings). A Domo table card
+  # with a dimension + an aggregated measure IS an aggregated query, so it MUST
+  # carry a groupings entry; without one the dimension repeats per warehouse row
+  # and each measure cell shows a ROW value instead of the group total.
+  #
+  # Caught live by the anchors oracle (2026-07-30): the source card printed
+  # 58,494.90 gross profit for Online, and the migrated table's closest value was
+  # 487.96 — a single row — because groupBy was dropped. Charts don't need this
+  # (they aggregate by their axis/value binding); only `table` does.
+  #
+  # `calculations` must be AGGREGATE expressions, which measure_col already emits
+  # (Sum(...)/CountDistinct(...)/an inlined aggregate Beast Mode). A grouped
+  # table's SORT must nest inside the grouping — an element-level sort 400s.
+  unless dims.empty? || meas.empty?
+    grouping = {
+      'id' => "grp-#{eid(card)}",
+      'groupBy' => dims.map { |d| dim_col(d, card)['id'] },
+      'calculations' => mcols.map { |m| m['id'] },
+    }
+    el['groupings'] = [grouping]
+  end
+
+  # #7: in-cell data bars belong ONLY to a real Domo table card that declared them.
+  bars = Array(card['conditionalFormats']).select { |cf| cf.to_s.downcase.include?('databar') || cf.dig('format', 'dataBar') }
+  unless bars.empty?
+    el['conditionalFormats'] = [{ 'type' => 'dataBars', 'columnIds' => mcols.map { |m| m['id'] } }]
+  end
+
+  # bead 2ef7: a Domo card's row LIMIT (e.g. limit:25 on a "Top 25" table) has no
+  # query-level analog in Sigma — without a translation the table just renders
+  # every warehouse row (872 instead of 25, live-validated 2026-07-30). The Sigma
+  # analog is an element-level top-n FILTER: `rowCount` takes a number literal
+  # only (reference/specification/tables.md "top-N, element-level row filters") —
+  # it cannot be bound to a control, so this is a direct, static translation.
+  # Ranks by the FIRST measure (mirrors the existing "sort by first measure"
+  # convention in build_axis_chart's xa['sort']) — Sigma's top-n ranks
+  # DESCENDING only; an ascending Domo orderBy has no equivalent here and is left
+  # alone rather than silently reversed. No measure column -> nothing to rank by
+  # -> no filter emitted (never a columnId: nil filter).
+  limit = card['limit'].to_i
+  if limit.positive? && mcols.any?
+    el['filters'] = [{
+      'id' => "topn-#{el['id']}", 'columnId' => mcols.first['id'],
+      'kind' => 'top-n', 'rankingFunction' => 'rank', 'mode' => 'top-n', 'rowCount' => limit,
+    }]
+  end
+  el
+end
+```
+
+(The only substantive changes: `mcols` is now a named local, reused in `groupings`,
+`conditionalFormats`, and the new `filters` block instead of being recomputed
+inline three times; and the new `limit`-guarded block at the end.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+Expected: `ALL PASS`, exit 0 — including every pre-existing assertion in this file
+(the `mcols` refactor must not change any existing table-card behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+git commit -m "domo: translate a card's row limit to a Sigma top-n filter (bead 2ef7)"
+```
+
+---
+
+### Task 3: `build-workbook.rb` — resolve a DataSet to its live DM element (bead `ziht`, part A)
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb` (new
+  functions, no existing function touched — additive)
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+
+**Interfaces:**
+- Consumes: `discovery/dm-spec.json` (written by `build-dm.rb`, already at
+  `build-workbook.rb`'s own `OUT` dir — no new env var for this file) and a NEW
+  `ENV['DOMO_DM_IDS_PATH']` pointing at `dm-ids.json` (written by `post-and-readback.rb
+  --type datamodel`, which lives in `migrate-domo.rb`'s `OUT` — a *different*
+  directory than `DISCOVERY`, hence the new env var; wired in Task 5).
+- Produces: `dataset_element_map` → `{datasetId => live_dm_element_hash}` (memoized,
+  `{}` when either input file is absent — the offline/unit-test default). `sub_master_for(ds_id)` →
+  a Sigma `table` element Hash sourcing that DataSet's live DM element (auto-passthrough
+  of its columns, mirroring `build-workbook-spec.rb`'s own master-building convention),
+  or `nil` when `ds_id` has no entry in `dataset_element_map`. Memoized in `$sub_masters`
+  (keyed by `datasetId`) — Task 5 reads `$sub_masters.values` to populate
+  `chart-specs.json`'s `data_elements` array (a key `build-workbook-spec.rb` already
+  folds into the hidden Data page, unmodified).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`, right
+before the final `puts` / `if $failures.zero?` block:
+
+```ruby
+puts "== bead ziht: dataset_element_map resolves datasetId -> live DM element =="
+Dir.mktmpdir do |dir|
+  dm_spec_path = File.join(dir, 'dm-spec.json')
+  dm_ids_path  = File.join(dir, 'dm-ids.json')
+  File.write(dm_spec_path, JSON.generate('pages' => [{ 'elements' => [
+    { 'id' => 'el-fact-1', 'name' => 'Order Fact', '_datasetId' => 'ds-fact' },
+    { 'id' => 'el-dim-1',  'name' => 'Customer Dim', '_datasetId' => 'ds-dim' },
+  ] }]))
+  File.write(dm_ids_path, JSON.generate('dataModelId' => 'dm-live-1', 'pages' => [{ 'elements' => [
+    { 'id' => 'el-fact-1', 'name' => 'Order Fact', 'columnLabels' => ['Order Id', 'Region'] },
+    { 'id' => 'el-dim-1',  'name' => 'Customer Dim', 'columnLabels' => ['Customer Id', 'Segment'] },
+  ] }]))
+  stub_const('DM_SPEC_PATH', dm_spec_path) do
+    stub_const('DM_IDS_PATH', dm_ids_path) do
+      $ds_element_map = nil # force recompute against this dir's fixtures
+      map = dataset_element_map
+      eq(map.keys.sort, %w[ds-dim ds-fact], 'both datasets resolved')
+      eq(map['ds-dim']['id'], 'el-dim-1', 'ds-dim resolves to its own live element, not the fact')
+
+      $sub_masters = {}
+      sm = sub_master_for('ds-dim')
+      ok(!sm.nil?, 'sub-master built for a resolvable dataset')
+      eq(sm['kind'], 'table', 'sub-master is a table element')
+      eq(sm['visibleAsSource'], false, 'sub-master is hidden, like the primary master')
+      eq(sm['source'], { 'kind' => 'data-model', 'dataModelId' => 'dm-live-1', 'elementId' => 'el-dim-1' },
+         'sub-master sources the LIVE DM element for ds-dim, dataModelId included')
+      eq(sm['columns'].map { |c| c['name'] }, ['Customer Id', 'Segment'], 'auto-passthrough of the DM element\'s own columns')
+      eq(sm['columns'].first['formula'], '[Customer Dim/Customer Id]', 'column formula qualifies by the DM element\'s own name')
+
+      ok(sub_master_for('ds-dim').equal?(sm), 'memoized — a second call returns the SAME object, not a rebuild')
+      eq($ds_element_map.dig('ds-nope'), nil, 'unknown dataset -> nil, not an exception')
+      ok(sub_master_for('ds-nope').nil?, 'sub_master_for on an unresolvable dataset -> nil (caller falls back to today\'s skip)')
+    end
+  end
+end
+
+puts "== bead ziht: dataset_element_map degrades to {} when the inputs are absent (offline / unit-test default) =="
+stub_const('DM_SPEC_PATH', '/nonexistent/dm-spec.json') do
+  stub_const('DM_IDS_PATH', nil) do
+    $ds_element_map = nil
+    eq(dataset_element_map, {}, 'no dm-spec/dm-ids -> empty map, never an exception')
+  end
+end
+```
+
+This test needs two small additions to the test file's own header (it doesn't yet
+`require 'tmpdir'` or have a `stub_const` helper — add both near the top, right after
+the existing `require_relative '../scripts/build-workbook'` line):
+
+```ruby
+require_relative '../scripts/build-workbook'
+require 'tmpdir'
+
+# Temporarily override a top-level constant for the duration of a block, then
+# ALWAYS restore it — even on assertion failure — mirroring the with_domo_stub
+# pattern in test-discover.rb. Ruby warns on constant reassignment; silence it
+# locally rather than suppressing warnings globally.
+def stub_const(name, value)
+  target = Object
+  old = target.const_get(name) if target.const_defined?(name)
+  silence_warnings { target.send(:remove_const, name) if target.const_defined?(name); target.const_set(name, value) }
+  yield
+ensure
+  silence_warnings { target.send(:remove_const, name) if target.const_defined?(name); target.const_set(name, old) if old }
+end
+
+def silence_warnings
+  old_verbose = $VERBOSE
+  $VERBOSE = nil
+  yield
+ensure
+  $VERBOSE = old_verbose
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+Expected: FAIL with `NameError: uninitialized constant DM_SPEC_PATH` (or similar) —
+neither the constants nor `dataset_element_map`/`sub_master_for` exist yet.
+
+- [ ] **Step 3: Implement**
+
+Add to `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb`, right
+after the existing `$warnings = []` / `warn_card` definitions (currently lines 46-47):
+
+```ruby
+$companion_elements = [] # bead 08sf — Task 5 populates this
+$sub_masters = {}        # bead ziht — datasetId => sub-master element Hash
+
+# bead ziht: dm-spec.json is build-dm.rb's PRE-post spec (already at this
+# script's own OUT dir — build-dm.rb writes it to discovery/, same as
+# cards.json/pages.json). It carries `_datasetId` on every DM element
+# (build-dm.rb) — a client-assigned tag Sigma neither knows nor round-trips.
+# dm-ids.json is the POST-readback (client ids are preserved by Sigma on
+# CREATE, but only the readback carries the real `dataModelId` + confirms the
+# element actually posted) — it lives in migrate-domo.rb's OUT, a DIFFERENT
+# directory than DISCOVERY, so it needs its own env var.
+DM_SPEC_PATH = File.join(OUT, 'dm-spec.json')
+DM_IDS_PATH  = ENV['DOMO_DM_IDS_PATH']
+
+# Which live DM element serves each Domo DataSet, keyed by datasetId. Both
+# inputs are optional — a hand run of build-workbook.rb alone, or a unit test,
+# has neither, and this degrades to {} (the caller's existing warn+SKIP path
+# for a card whose DataSet doesn't match the workbook's dominant master).
+def dataset_element_map
+  return $ds_element_map if $ds_element_map
+  unless DM_IDS_PATH && File.exist?(DM_SPEC_PATH.to_s) && File.exist?(DM_IDS_PATH.to_s)
+    return $ds_element_map = {}
+  end
+  dm_spec = (JSON.parse(File.read(DM_SPEC_PATH)) rescue nil)
+  dm_ids  = (JSON.parse(File.read(DM_IDS_PATH)) rescue nil)
+  return $ds_element_map = {} unless dm_spec && dm_ids
+
+  ds_by_el_id = {}
+  (dm_spec['pages'] || []).each do |p|
+    (p['elements'] || []).each { |e| ds_by_el_id[e['id']] = e['_datasetId'] if e['_datasetId'] }
+  end
+  map = {}
+  (dm_ids['pages'] || []).flat_map { |p| p['elements'] || [] }.each do |e|
+    ds_id = ds_by_el_id[e['id']]
+    map[ds_id] = e if ds_id && !map.key?(ds_id)
+  end
+  $ds_element_map = map
+end
+
+def dm_id
+  return $dm_id if defined?($dm_id) && $dm_id
+  return $dm_id = nil unless DM_IDS_PATH && File.exist?(DM_IDS_PATH.to_s)
+  ids = (JSON.parse(File.read(DM_IDS_PATH)) rescue nil)
+  $dm_id = ids && ids['dataModelId']
+end
+
+# A hidden sub-master for a non-dominant DataSet — the same auto-passthrough
+# shape build-workbook-spec.rb builds for the primary `master` (every column of
+# the named DM element, by name), reimplemented here rather than shared because
+# that file is VENDORED and must not diverge (see its header). nil when the
+# DataSet has no resolvable live element yet (caller falls back to the existing
+# warn+SKIP stopgap).
+def sub_master_for(ds_id)
+  return $sub_masters[ds_id] if $sub_masters[ds_id]
+  live_el = dataset_element_map[ds_id]
+  return nil unless live_el
+  cols = (live_el['columnLabels'] || live_el['columns'] || []).map do |c|
+    nm = c.is_a?(String) ? c : (c['name'] || c['id'])
+    next nil if nm.to_s.empty?
+    { 'id' => mcol_id(nm), 'name' => nm, 'formula' => "[#{live_el['name']}/#{nm}]" }
+  end.compact
+  return nil if cols.empty?
+  $sub_masters[ds_id] = {
+    'id' => "master-#{ds_id.to_s.downcase.gsub(/\W+/, '-')}", 'kind' => 'table',
+    'name' => "Master (#{live_el['name'] || ds_id})", 'visibleAsSource' => false,
+    'source' => { 'kind' => 'data-model', 'dataModelId' => dm_id, 'elementId' => live_el['id'] },
+    'columns' => cols, 'order' => cols.map { |c| c['id'] },
+  }
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+Expected: `ALL PASS`, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+git commit -m "domo: resolve a DataSet to its live DM element + build a sub-master (bead ziht, part 1)"
+```
+
+---
+
+### Task 4: `build-workbook.rb` — companion KPI element for a chart/table's Summary Number (bead `08sf`)
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb` (new
+  function only — nothing else calls it yet; Task 5 wires it into `build_element`)
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+
+**Interfaces:**
+- Consumes: `build_kpi(card, overrides)` (existing), `eid(card, suffix)` (existing).
+- Produces: `build_summary_companion(card, overrides)` → a Sigma `kpi-chart` element
+  Hash (same shape `build_kpi` returns, with a distinct `id` so it never collides with
+  the primary chart/table element's own id) or `nil` when `build_kpi` can't resolve a
+  column. Built and tested standalone here (it depends only on the already-existing
+  `build_kpi`/`eid`, not on anything from Task 3) — Task 5 is what calls it from
+  `build_element`, so that task's tests land in forward-dependency order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`, right
+before the final `puts` / `if $failures.zero?` block:
+
+```ruby
+puts "== bead 08sf: build_summary_companion mirrors build_kpi but with a distinct id =="
+kpi_card = { 'id' => 'c29', 'title' => 'Revenue by Channel',
+             'summaryNumber' => { 'column' => 'net_revenue', 'aggregation' => 'SUM', 'label' => 'Total Revenue' } }
+companion = build_summary_companion(kpi_card, {})
+ok(!companion.nil?, 'companion built when the summary number has a resolvable column')
+eq(companion['kind'], 'kpi-chart', 'companion is a kpi-chart element')
+eq(companion['name'], 'Total Revenue', 'companion carries the summary number\'s own label')
+eq(companion['id'], "#{eid(kpi_card)}-summary",
+   'companion id is the primary element\'s id + a -summary suffix (never collides with it)')
+
+no_col_card = { 'id' => 'c30', 'title' => 'Orders', 'summaryNumber' => { 'column' => '', 'aggregation' => 'COUNT' } }
+ok(build_summary_companion(no_col_card, {}).nil?,
+   'nil when the summary number has no resolvable column (mirrors build_kpi\'s own "return nil unless col")')
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+Expected: FAIL with `NoMethodError: undefined method 'build_summary_companion'`.
+
+- [ ] **Step 3: Implement**
+
+Add anywhere below `build_kpi` in
+`plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb`:
+
+```ruby
+# bead 08sf: Domo prints a Summary Number above EVERY viz card, not just KPI
+# cards — a bar chart, a table, a combo all show one. Sigma's chart/table
+# elements have no summary slot, so the fix is a companion kpi-chart element
+# placed beside the primary one, reusing build_kpi (identical measure/format
+# resolution, including the #1 COUNT-of-row-key guard) with a distinct id so it
+# never collides with the primary element's own id.
+def build_summary_companion(card, overrides)
+  kpi = build_kpi(card, overrides)
+  return nil unless kpi
+  kpi['id'] = eid(card, '-summary')
+  kpi
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+Expected: `ALL PASS`, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+git commit -m "domo: build a companion KPI element for a card's Summary Number (bead 08sf)"
+```
+
+---
+
+### Task 5: wire multi-dataset routing + the companion KPI into `build_element` (bead `ziht` part B + bead `08sf` wiring)
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb:708-844`
+  (`build_element`, `build_controls`, the `$PROGRAM_NAME == __FILE__` main block)
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb:100`
+  (`BASE_ENV`)
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+
+**Interfaces:**
+- Consumes: `sub_master_for(ds_id)` / `dataset_element_map` (Task 3),
+  `build_summary_companion(card, overrides)` (Task 4).
+- Produces: `build_element(card, overrides, master_ds)` now returns a REAL element
+  (sourced from the card's own DataSet's sub-master) instead of `nil` whenever
+  `sub_master_for(card['datasetId'])` resolves — the existing warn+SKIP path is now
+  the fallback for only the case where no live DM element is known yet for that
+  DataSet. Every non-KPI card with a resolvable `summaryNumber` now also produces a
+  companion KPI via the `$companion_elements` side-channel. The main block writes
+  `$sub_masters.values` into `chart-specs.json`'s top-level `data_elements` key
+  (already read, unmodified, by `build-workbook-spec.rb:148`).
+
+This task deliberately combines both fixes in one pass: they touch the exact same
+function body (`build_element`'s post-Rule-0, pre-dispatch section), so splitting them
+into two edits of the same lines would mean the second edit immediately reverting or
+re-deriving the first's diff context for no isolation benefit.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`, right
+before the final `puts` / `if $failures.zero?` block:
+
+```ruby
+puts "== bead ziht: a card on a non-dominant DataSet routes to its own sub-master " \
+     '(not skipped) once a live DM element is resolvable =='
+Dir.mktmpdir do |dir|
+  dm_spec_path = File.join(dir, 'dm-spec.json')
+  dm_ids_path  = File.join(dir, 'dm-ids.json')
+  File.write(dm_spec_path, JSON.generate('pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', 'name' => 'Customer Dim', '_datasetId' => 'ds-dim' },
+  ] }]))
+  File.write(dm_ids_path, JSON.generate('dataModelId' => 'dm-live-1', 'pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', 'name' => 'Customer Dim', 'columnLabels' => ['Region', 'Segment'] },
+  ] }]))
+  stub_const('DM_SPEC_PATH', dm_spec_path) do
+    stub_const('DM_IDS_PATH', dm_ids_path) do
+      $ds_element_map = nil
+      $sub_masters = {}
+      $warnings = []
+      routed = build_element({ 'id' => 'c25', 'title' => 'Customers by Region', 'chartType' => 'badge_table',
+                               'sigmaKindHint' => 'table', 'datasetId' => 'ds-dim',
+                               'columns' => [ { 'column' => 'region' } ] }, {}, 'ds-fact')
+      ok(!routed.nil?, 'card is NOT skipped — a live sub-master was resolvable')
+      eq(routed['source'], { 'kind' => 'table', 'elementId' => 'master-ds-dim' }, 'routed to its own sub-master, not the shared master')
+      eq(routed['columns'].first['formula'], '[Master (Customer Dim)/Region]', 'formula re-qualified to the sub-master\'s namespace')
+      ok($warnings.any? { |w| w['warning'].include?('routed to sub-master') }, 'routing is reported, not silent')
+      ok($sub_masters.key?('ds-dim'), 'the sub-master was registered for the main block to emit under data_elements')
+    end
+  end
+end
+
+puts "== bead ziht: unresolvable DataSet still falls back to today's warn+SKIP =="
+$ds_element_map = {}
+$sub_masters = {}
+$warnings = []
+skipped = build_element({ 'id' => 'c26', 'title' => 'Orphan Dataset Card', 'chartType' => 'badge_table',
+                          'sigmaKindHint' => 'table', 'datasetId' => 'ds-unknown',
+                          'columns' => [ { 'column' => 'x' } ] }, {}, 'ds-fact')
+ok(skipped.nil?, 'still nil when no live DM element is resolvable for the DataSet (unchanged fallback)')
+ok($warnings.any? { |w| w['warning'].include?('SKIPPED') }, 'still warns loudly on fallback')
+
+puts "== bead ziht: build_controls skips (warns) a filter bound to a non-dominant DataSet\'s column " \
+     'rather than 400ing the whole POST binding it to the wrong master =='
+$warnings = []
+ctrls2 = build_controls([
+  { 'id' => 'c27', 'datasetId' => 'ds-fact', 'filters' => [{ 'column' => 'region' }] },
+  { 'id' => 'c28', 'datasetId' => 'ds-dim',  'filters' => [{ 'column' => 'segment' }] },
+], 'ds-fact')
+eq(ctrls2.size, 1, 'only the dominant-dataset filter becomes a control')
+eq(ctrls2.first['controlId'], 'Region', 'the surviving control is the dominant-dataset one')
+ok($warnings.any? { |w| w['warning'].include?('control filter') && w['warning'].include?('SKIPPED') },
+   'the non-dominant control is reported, not silently dropped')
+
+puts "== bead 08sf: a chart/table card with a summaryNumber gets a companion KPI via " \
+     'build_element, not just a warning =='
+$warnings = []
+$companion_elements = []
+chart_with_summary = build_element({ 'id' => 'c31', 'title' => 'Revenue by Channel', 'chartType' => 'badge_vert_bar',
+                                     'sigmaKindHint' => 'bar-chart',
+                                     'groupBy' => ['channel'],
+                                     'columns' => [ { 'column' => 'channel' },
+                                                    { 'column' => 'net_revenue', 'aggregation' => 'SUM', 'alias' => 'Net Revenue' } ],
+                                     'summaryNumber' => { 'column' => 'net_revenue', 'aggregation' => 'SUM', 'label' => 'Total Revenue' } }, {})
+eq(chart_with_summary['kind'], 'bar-chart', 'the primary element is still the bar chart, unchanged')
+eq($companion_elements.size, 1, 'exactly one companion KPI was produced')
+companion = $companion_elements.first
+eq(companion['kind'], 'kpi-chart', 'companion is a kpi-chart element')
+eq(companion['name'], 'Total Revenue', 'companion carries the summary number\'s own label')
+ok(companion['id'] != chart_with_summary['id'], 'companion has a DISTINCT id from the primary element (no duplicate-id 400)')
+ok($warnings.any? { |w| w['warning'].include?('companion KPI element') }, 'the companion is reported, not silent')
+
+puts "== bead 08sf: a card whose summaryNumber has no resolvable column still just warns " \
+     '(no crash, no half-built companion) =='
+$warnings = []
+$companion_elements = []
+no_companion = build_element({ 'id' => 'c32', 'title' => 'Orders', 'chartType' => 'badge_table',
+                               'sigmaKindHint' => 'table',
+                               'columns' => [ { 'column' => 'order_id' } ],
+                               'summaryNumber' => { 'column' => '', 'aggregation' => 'COUNT' } }, {})
+ok(!no_companion.nil?, 'primary element still built')
+eq($companion_elements.size, 0, 'no companion when the summary number has no resolvable column')
+ok($warnings.any? { |w| w['warning'].include?('NOT represented') }, 'still warns loudly on the unresolvable case (unchanged existing behavior)')
+
+puts "== bead 08sf: Rule 0 (summary IS the whole card) still short-circuits to a single " \
+     'KPI, no companion (unchanged) =='
+$warnings = []
+$companion_elements = []
+rule0 = build_element({ 'id' => 'c33', 'title' => 'One Number', 'chartType' => 'badge_table',
+                        'sigmaKindHint' => 'table', 'groupBy' => [], 'columns' => [{ 'column' => 'total', 'aggregation' => 'SUM' }],
+                        'summaryNumber' => { 'column' => 'total', 'aggregation' => 'SUM' } }, {})
+eq(rule0['kind'], 'kpi-chart', 'Rule 0 still routes straight to a single KPI')
+eq($companion_elements.size, 0, 'no companion is produced for a Rule-0 card (it IS the KPI, not a chart+companion)')
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+Expected: FAIL — `routed` is currently `nil` (today's unconditional skip),
+`build_controls` doesn't yet accept a second argument (`ArgumentError: wrong number
+of arguments`), and `$companion_elements` never gets populated by `build_element`.
+
+- [ ] **Step 3: Implement**
+
+Replace the current `dominant_dataset_id`/`build_element` block
+(`plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb:685-788`) —
+keep `dominant_dataset_id` exactly as-is (lines 697-706), and replace everything from
+the current `def build_element` (line 708) through its closing `end` (line 788) with:
+
+```ruby
+# Deep-rewrite every "[Master/" formula ref + the element's own source to point
+# at a per-DataSet sub-master instead of the shared primary master (bead ziht).
+# gsub (not sub) — an inlined aggregate Beast Mode formula can reference
+# [Master/...] more than once in a single string (e.g. an If() with two Sum()s).
+def retarget_to_submaster!(el, sm)
+  el['source'] = { 'kind' => 'table', 'elementId' => sm['id'] }
+  walk = lambda do |n|
+    case n
+    when Hash   then n.each { |k, v| n[k] = walk.call(v) }
+    when Array  then n.map! { |v| walk.call(v) }
+    when String then n.gsub('[Master/', "[#{sm['name']}/")
+    else n
+    end
+  end
+  walk.call(el)
+  el
+end
+
+def build_element(card, overrides, master_ds = nil)
+  ds = card['datasetId'].to_s
+  if master_ds && !ds.empty? && ds != master_ds
+    sm = sub_master_for(ds)
+    unless sm
+      warn_card(card, "SKIPPED — card is bound to DataSet #{ds} but this workbook's shared " \
+                      "master is built from #{master_ds}, and no live data-model element is " \
+                      'resolvable yet for its own DataSet (bead ziht). Rebuild this card by ' \
+                      'hand against its own source, or re-run once the data model has posted.')
+      return nil
+    end
+    before = $companion_elements.length
+    el = build_element_body(card, overrides)
+    return nil unless el
+    retarget_to_submaster!(el, sm)
+    $companion_elements[before..].each { |c| retarget_to_submaster!(c, sm) }
+    warn_card(card, "routed to sub-master '#{sm['name']}' for DataSet #{ds} (bead ziht) — " \
+                    'verify column coverage against the card PNG; the sub-master passes through ' \
+                    "every column of #{sm['name']}, not just the ones this card uses.")
+    return el
+  end
+  build_element_body(card, overrides)
+end
+
+def build_element_body(card, overrides)
+  card = prune_unresolvable_columns!(card)
+  # Rule 0: a summary-number card with no real grouping → KPI, never a table.
+  kind = card['sigmaKindHint']
+  is_kpi = kind == 'kpi-chart' ||
+           (card['summaryNumber'] && Array(card['groupBy']).empty? && (card['columns'] || []).size <= 1)
+  return build_kpi(card, overrides) if is_kpi
+
+  # Domo prints a Summary Number at the top of EVERY viz card, not just KPI cards.
+  # Sigma's chart/table elements have no summary slot, so Task 5 emits a companion
+  # KPI element (bead 08sf) via $companion_elements when one is resolvable.
+  sn = card['summaryNumber']
+  if sn.is_a?(Hash) && !sn['column'].to_s.empty?
+    companion = build_summary_companion(card, overrides)
+    if companion
+      $companion_elements << companion
+      warn_card(card, "source Summary Number ALSO represented as a companion KPI element " \
+                      "'#{companion['name']}' beside this #{kind || 'chart'} element (bead 08sf).")
+    else
+      agg = sn['aggregation'].to_s.empty? ? '(calc)' : sn['aggregation']
+      warn_card(card, "source Summary Number NOT represented: Domo prints " \
+                      "#{agg}(#{sn['column']}) above this card, but a Sigma " \
+                      "#{kind || 'chart'} element has no summary slot, and a companion KPI " \
+                      'could not be built (no resolvable column) — the headline value is dropped.')
+    end
+  end
+
+  if image_card?(card)
+    img = build_image(card)
+    return img if img
+    warn_card(card, "image card #{card['id']}: no captured PNG — export from Domo UI and embed manually.")
+  end
+
+  mapped = chart_kind_for(card)
+  kind = mapped || kind
+  ct = card['chartType'].to_s.downcase
+  if mapped && NO_NATIVE_EQUIVALENT.key?(ct)
+    warn_card(card, "no native Sigma equivalent for chartType '#{card['chartType']}' — " \
+                    "#{NO_NATIVE_EQUIVALENT[ct]} Tracked as a Sigma custom-plugin follow-up " \
+                    '(sigma-plugin-development skill) — not handled by this converter today.')
+  end
+
+  case kind
+  when 'bar-chart', 'line-chart', 'area-chart', 'scatter-chart'
+    build_axis_chart(card, kind)
+  when 'combo-chart' then build_combo(card)
+  when 'pie-chart', 'donut-chart' then build_pie_or_donut(card, kind)
+  when 'pivot-table'  then build_pivot(card)
+  when 'table'        then build_table(card)
+  when 'region-map'   then build_map(card)
+  when 'kpi-chart'
+    build_kpi(card, overrides) || begin
+      warn_card(card, "kpi-chart: chartType '#{card['chartType']}' has no summaryNumber to build a " \
+                      'value from — emitted a table instead so the card is not silently dropped.')
+      build_table(card)
+    end
+  else
+    warn_card(card, "unknown chartType '#{card['chartType']}' → emitted bar-chart; verify against the PNG.")
+    build_axis_chart(card, 'bar-chart')
+  end
+end
+```
+
+Now update `build_controls` (currently
+`plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb:791-813`) to
+accept the dominant dataset and skip (warn) a filter whose owning card is bound to a
+different one:
+
+```ruby
+def build_controls(cards, master_ds = nil)
+  seen = {}
+  controls = []
+  cards.each do |card|
+    ds = card['datasetId'].to_s
+    Array(card['filters']).each do |f|
+      col = f['column']; next if col.nil? || seen[col]
+      if master_ds && !ds.empty? && ds != master_ds
+        warn_card(card, "control filter on '#{col}' SKIPPED — its card is bound to DataSet " \
+                        "#{ds}, not this workbook's shared master (#{master_ds}); binding it to " \
+                        'master would 400 the whole workbook POST. Per-sub-master controls are ' \
+                        'not yet supported (bead ziht follow-up).')
+        next
+      end
+      seen[col] = true
+      disp = display_name(col)
+      controls << {
+        'id' => "ctl-#{col.to_s.downcase.gsub(/\W+/, '-')}",
+        'kind' => 'control',
+        'controlId' => disp.gsub(/\s+/, ''),
+        'controlType' => 'list',
+        'name' => disp,
+        'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'master' },
+                        'columnId' => mcol_id(disp) }],
+      }
+    end
+  end
+  controls
+end
+```
+
+Update the main block (currently
+`plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb:815-844`) to reset
+`$companion_elements` per page, collect it into that page's elements, pass `master_ds`
+into `build_controls`, and write `data_elements` into `chart-specs.json`:
+
+```ruby
+if $PROGRAM_NAME == __FILE__
+  cards = JSON.parse(File.read(File.join(OUT, 'cards.json'))) rescue []
+  pages = JSON.parse(File.read(File.join(OUT, 'pages.json'))) rescue []
+  overrides = (JSON.parse(File.read(File.join(OUT, 'kpi-overrides.json'))) rescue {}) || {}
+
+  cards = cards.reject { |c| c['_error'] || c['_tierB'] }
+  by_page = Hash.new { |h, k| h[k] = [] }
+  card_page = {}
+  pages.each do |p|
+    Array(p['cardIds'] || p['cards']).each { |cid| card_page[cid.to_s] = p['title'] || p['name'] || p['id'] }
+  end
+  cards.each { |c| by_page[card_page[c['id'].to_s] || 'Overview'] << c }
+  master_ds = dominant_dataset_id(cards)
+  by_page.each { |pname, pcards| warn_missing_geometry(pname, pcards) }
+
+  out_pages = by_page.map do |pname, pcards|
+    before = $companion_elements.length
+    els = pcards.map { |c| build_element(c, overrides, master_ds) }.compact
+    els += $companion_elements[before..]
+    els += build_controls(pcards, master_ds)
+    { 'name' => pname, 'elements' => els }
+  end
+
+  FileUtils.mkdir_p(OUT)
+  File.write(File.join(OUT, 'chart-specs.json'),
+             JSON.pretty_generate('pages' => out_pages, 'data_elements' => $sub_masters.values))
+  File.write(File.join(OUT, 'warnings.json'), JSON.pretty_generate($warnings))
+  warn "  wrote #{File.join(OUT, 'chart-specs.json')} (#{out_pages.sum { |p| p['elements'].size }} elements across #{out_pages.size} page(s), #{$sub_masters.size} sub-master(s))"
+  warn "  wrote #{File.join(OUT, 'warnings.json')} (#{$warnings.size} warning(s))"
+  $warnings.first(20).each { |w| warn "    ⚠ #{w['card']}: #{w['warning']}" }
+  warn "\n  Next: build-workbook-spec.rb --chart-specs discovery/chart-specs.json --dm-ids discovery/dm-ids.json ..."
+```
+
+Finally, in `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb`, add the
+new env var to `BASE_ENV` (currently line 100):
+
+```ruby
+BASE_ENV = { 'DOMO_DISCOVERY_DIR' => DISCOVERY, 'DOMO_DM_IDS_PATH' => File.join(OUT, 'dm-ids.json') }.freeze
+```
+
+This is safe unconditionally: the path is computed whether or not the file exists yet,
+and `build-workbook.rb` (Task 3) only reads it if `File.exist?` is true. By the time
+`build-workbook.rb` actually runs in `migrate-domo.rb`'s sequence
+(`phase_build_workbook!` at line 572, AFTER `post-and-readback.rb --type datamodel` at
+lines 560-570 has already written `dm-ids.json`), the file is present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb`
+Expected: `ALL PASS`, exit 0 — every pre-existing assertion plus the new ones from
+Tasks 2-5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+git commit -m "domo: route a non-dominant-dataset card to its own sub-master + wire in the companion KPI (bead ziht + bead 08sf)"
+```
+
+---
+
+### Task 6: full-chain regression, corpus check, and docs
+
+**Files:**
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb` (extend
+  its fixture, do not restructure the test)
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/refs/card-to-element.md` (document
+  all three shapes — currently documents neither)
+- Modify: `corpus/domo/live-shapes/MANIFEST.md` (the `ds-dim` card's documented
+  expectation changes from "SKIPPED" to "routed to its own sub-master")
+
+**Interfaces:** none new — this task only proves Tasks 1-5 compose correctly through
+the full `cards.json` → `chart-specs.json` → `workbook-spec.json` chain and leaves the
+docs accurate.
+
+- [ ] **Step 1: Write the failing test**
+
+Read `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb` in full
+first to find its existing offline-fixture invocation (it runs `migrate-domo.rb
+--offline <fixture-dir> --out <tmp-dir>` via `IO.popen` and asserts on
+`run-state.json` / `workbook-spec.json`). Identify which fixture directory it uses
+(under `test/fixtures/`) and add ONE new card to that fixture's `cards.json` (or add a
+sibling fixture dir if the existing one is shared by other assertions you'd rather not
+perturb) that exercises all three fixes on a SINGLE card set:
+
+- a table card with `"limit": 10` and a measure column (bead 2ef7)
+- a second card with `"datasetId"` different from the fixture's dominant dataset,
+  plus a matching entry in that fixture's `dm-spec.json`/`dm-ids.json` (or the
+  fixture's `--offline` mode's synthesized equivalents — follow whatever this test
+  already does to fake a posted DM) so `sub_master_for` resolves it (bead `ziht`)
+- a third card (any chart type) carrying a `summaryNumber` (bead `08sf`)
+
+Add assertions to the test (mirroring its existing style) that the final
+`workbook-spec.json`:
+1. contains an element with `filters[0].kind == 'top-n'` and the right `rowCount`
+2. contains an element sourced from a `master-<dataset>` sub-master (not the shared
+   `master`), and that sub-master appears once under the Data page
+3. contains one more `kpi-chart` element than there are cards with a genuine
+   summary-only Rule-0 card (i.e., a companion was emitted for the third card)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb`
+Expected: FAIL on whichever of the three new assertions the current fixture doesn't
+yet satisfy (it will — Tasks 1-5 are already implemented at this point in the plan, so
+this step is a genuine regression check of the WIRING between phases, not the
+individual functions; a failure here means something about how `migrate-domo.rb`
+invokes `build-workbook.rb`/`build-dm.rb` together doesn't line up with Task 5's
+assumptions — e.g. a path mismatch between `--offline` mode's synthesized `dm-ids.json`
+location and `DOMO_DM_IDS_PATH`).
+
+- [ ] **Step 3: Fix whatever the failure reveals**
+
+This step is intentionally open — Step 2's failure is the first real signal of
+whether Tasks 1-5's units compose correctly end-to-end. Common likely causes, in order
+of likelihood: (a) `--offline` mode may not run `post-and-readback.rb` at all, in which
+case `dm-ids.json` may need to be synthesized directly by the test fixture rather than
+produced by the real phase — read `migrate-domo.rb`'s `--offline` handling before
+assuming; (b) the new fixture's `_datasetId` tagging in a hand-written `dm-spec.json`
+fixture must match `build-dm.rb`'s real output shape exactly (Task 3's Step 1 test
+already covers the pure-function shape in isolation — this step is about whether the
+FIXTURE matches what `build-dm.rb` really emits, not about the function itself).
+
+- [ ] **Step 4: Run test to verify it passes, then run the full suite + corpus check**
+
+Run: `bash plugins/domo-to-sigma/skills/domo-to-sigma/test/run-all.sh`
+Expected: `== ALL SUITES PASS ==`, exit 0.
+
+Run: `bash corpus/run-corpus.sh --check domo`
+Expected: `corpus: N/N cases pass` with no new failures relative to the pre-plan
+baseline (run it once before starting this task, if you haven't already, to know that
+baseline number).
+
+- [ ] **Step 5: Update docs**
+
+In `plugins/domo-to-sigma/skills/domo-to-sigma/refs/card-to-element.md`, add a short
+section (near the existing Rule 0 documentation, since it directly complements it)
+covering:
+- the companion-KPI case (bead 08sf) — a chart/table that ALSO carries a summary
+  number gets a second, adjacent `kpi-chart` element, distinct from Rule 0 (where the
+  summary number IS the whole card)
+- the top-n translation (bead 2ef7) — `card['limit']` → an element-level `filters`
+  entry with `kind: top-n`, ranked by the first measure, descending only
+- the multi-dataset sub-master pattern (bead ziht) — one hidden sub-master per
+  non-dominant DataSet actually used by a card, referenced via
+  `chart-specs.json`'s `data_elements` key
+
+In `corpus/domo/live-shapes/MANIFEST.md`, update the sentence describing the `ds-dim`
+card (currently: *"the `ds-dim` card is expected to be SKIPPED with a named warning
+(one master per dataset is bead ziht), not silently mis-bound"*) to reflect the new
+behavior — it now routes to its own sub-master rather than being skipped, PROVIDED a
+live `dm-ids.json`/`dm-spec.json` pair is available; note that `corpus/run-corpus.sh
+--check` for this case only validates `data-model.json` today (confirmed: no golden
+`chart-specs.json` exists for this case), so this is a documentation-accuracy fix, not
+a new executable assertion — Task 6's Step 1 test is what actually pins the new
+behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures \
+        plugins/domo-to-sigma/skills/domo-to-sigma/refs/card-to-element.md \
+        corpus/domo/live-shapes/MANIFEST.md
+git commit -m "domo: full-chain regression for beads 2ef7/ziht/08sf + doc updates"
+```
+
+---
+
+## After this plan lands
+
+Per the design doc's own Track B gate order, items 4-6 (the live parity run —
+`build-parity-plan.rb` → `verify-warehouse.rb --out parity-final.json`; orphan
+cleanup via `cleanup-orphan-workbooks.rb`; and confirming control gates 7/7b/7c) are
+**not** part of this plan — they are a live run against a real Domo + Sigma target,
+which needs credentials this plan's implementer subagents won't have, and whose
+content ("does the parity run pass, what does gate 7b's control-flip proof actually
+show") can only be discovered by running it, not pre-scripted as TDD tasks. Once this
+plan's six tasks are merged, the natural next step is to run `migrate-domo.rb` live
+against the target instance and read `assert-phase6-ran.rb`'s own verdict — that is
+the bar this whole track exists to reach.

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/refs/card-to-element.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/refs/card-to-element.md
@@ -116,14 +116,29 @@ Rule 0 above covers the card where the Summary Number **is** the whole card
 But Domo also prints a Summary Number above a card that **is** a genuine
 chart or table — a bar chart with a real `groupBy`, say, still shows a big
 "Total Sales" number above its bars. Sigma's chart/table elements have no
-summary slot to carry that, so the fix is a **second, adjacent `kpi-chart`
+summary slot to carry that, so the fix is a **second, separate `kpi-chart`
 element** — a companion — built from the *same* Summary Number config Rule 0
 uses (same measure/aggregation/format resolution, including the COUNT-of-id
-guard), placed beside the primary chart/table element rather than replacing
-it. The companion's `id` is always the primary element's `id` + `-summary`
-so it never collides. When no resolvable column exists for the companion, the
+guard), rather than replacing the primary chart/table. The companion's `id`
+is always the primary element's `id` + `-summary` so it never collides. If
+the card's own primary chart/table element itself fails to build (e.g. no
+resolvable measure), the companion is dropped too — a standalone KPI with no
+primary beside it would be confusing, not a fix. When no resolvable column
+exists for the companion (independent of whether the primary built), the
 headline value is dropped with a named warning rather than silently emitted
 as a broken `Count([Master/])`.
+
+**Layout placement:** `build-domo-layout.rb` gives the companion its own
+zone via the same synthesis mechanism it already uses for an orphan control
+(a page-level filter with no backing card) — see `load_chart_specs_companions`
+/ `load_chart_specs_controls`. The companion lands wherever that page's
+kind-aware composition puts any other `kpi-chart` element (the page's shared
+KPI band, or — for a page with real pixel geometry — appended below the
+primary content), **not** guaranteed immediately adjacent to its own specific
+primary chart/table: the kind-grouped composition model buckets every KPI
+element on a page into one band together, regardless of which card produced
+it. Landing in the KPI band is the honest, tractable placement this
+converter can make today.
 
 ### Row limit → Sigma top-n filter (bead 2ef7)
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/refs/card-to-element.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/refs/card-to-element.md
@@ -109,6 +109,75 @@ So:
   (spec cannot carry it)."* Do not silently drop it and do not fake it with a
   table.
 
+### Companion KPI — a Summary Number beside a chart/table, not instead of it (bead 08sf)
+
+Rule 0 above covers the card where the Summary Number **is** the whole card
+(no real grouping, ≤1 column) — that becomes a `kpi-chart` and nothing else.
+But Domo also prints a Summary Number above a card that **is** a genuine
+chart or table — a bar chart with a real `groupBy`, say, still shows a big
+"Total Sales" number above its bars. Sigma's chart/table elements have no
+summary slot to carry that, so the fix is a **second, adjacent `kpi-chart`
+element** — a companion — built from the *same* Summary Number config Rule 0
+uses (same measure/aggregation/format resolution, including the COUNT-of-id
+guard), placed beside the primary chart/table element rather than replacing
+it. The companion's `id` is always the primary element's `id` + `-summary`
+so it never collides. When no resolvable column exists for the companion, the
+headline value is dropped with a named warning rather than silently emitted
+as a broken `Count([Master/])`.
+
+### Row limit → Sigma top-n filter (bead 2ef7)
+
+A Domo card's row **limit** ("Top 25 by revenue") has no query-level analog
+in Sigma — porting the card without translating it just renders every
+warehouse row instead of the limited set (live-validated: 872 rows instead of
+25). The fix is an **element-level `top-n` filter**:
+```jsonc
+"filters": [{
+  "id": "topn-<elementId>", "columnId": "<first measure column id>",
+  "kind": "top-n", "rankingFunction": "rank", "mode": "top-n", "rowCount": 25
+}]
+```
+- Ranked by the **first measure column** on the element (mirrors the
+  existing "sort by first measure" convention used for axis-chart x-axis
+  sorting).
+- Sigma's top-n `rowCount` is a **descending-only, static number literal** —
+  it cannot bind to a control, and an *ascending* Domo `orderBy` has no
+  equivalent, so it is left alone rather than silently reversed.
+- No measure column on the element → nothing to rank by → no filter is
+  emitted (never a `columnId: nil` filter).
+
+### One sub-master per non-dominant DataSet (bead ziht)
+
+Domo cards on the same page are frequently bound to **different DataSets** —
+a customer-dimension card sitting next to an order-fact chart. Every element
+this converter builds sources a single shared `master` table, built from
+whichever DataSet the page's cards use most (the **dominant** DataSet). A
+card bound to any *other* DataSet references columns `master` doesn't have —
+posting it unmodified 400s the **entire** workbook (`Dependency not found:
+'master/region'`, live-validated).
+
+The fix: resolve the card's own DataSet to its **live Sigma data-model
+element** (via the posted DM's readback, `dm-ids.json`, cross-referenced with
+`dm-spec.json`'s `_datasetId` tags) and build it a **hidden sub-master** —
+the same auto-passthrough shape (every column of the live element, by name)
+the primary `master` gets, named `master-<datasetId>`. The card's element is
+then retargeted: its `source.elementId` points at the sub-master instead of
+`master`, and every `[Master/...]` formula reference is rewritten to
+`[<sub-master name>/...]`. One sub-master per non-dominant DataSet **actually
+used** by a card — not one per DataSet in the data model.
+
+The sub-master itself is not a page element a user would browse to; it is
+carried through `chart-specs.json`'s top-level **`data_elements`** key and
+must land on the workbook's Data page alongside `master` (both the live
+`build-workbook-spec.rb` path and `migrate-domo.rb --offline`'s local
+assembly fold this key in) — a visible element retargeted to it would
+otherwise reference an id that doesn't exist on any page.
+
+When no live data-model element is yet resolvable for the card's DataSet
+(no `dm-ids.json`/`dm-spec.json` pair posted yet), the card is **skipped with
+a named warning** instead of silently mis-bound to the wrong master — rebuild
+it by hand, or re-run once the data model has posted.
+
 ---
 
 ## Full card-type → element map

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-domo-layout.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-domo-layout.rb
@@ -559,6 +559,39 @@ def load_chart_specs_controls(dir)
   out
 end
 
+# Final-review Important I1: load discovery/chart-specs.json's companion KPI
+# elements (bead 08sf's "-summary" elements, built by build_summary_companion
+# / eid(card, '-summary')), GROUPED BY PAGE NAME — same shape/contract as
+# load_chart_specs_controls directly above, and for the SAME underlying
+# reason: a companion KPI has no entry of its own in cards.json (it is
+# synthesized inside build-workbook.rb from a card that's really a chart or
+# table), so it would never reach this file's normal per-card kind resolution
+# (element_kind_for) and would never get a layout zone at all — present in
+# the workbook spec, but invisible on the migrated page. The caller (see
+# $PROGRAM_NAME == __FILE__) synthesizes a pseudo-card for each one it finds,
+# the exact same mechanism already used for an orphan control. Matched by the
+# id suffix build_summary_companion always uses ("-summary") plus kind
+# 'kpi-chart' so a coincidentally-named real KPI card is never mistaken for
+# one. Returns { page_name => [{'id'=>, 'name'=>}, ...] }; absent/unparsable
+# file -> {} (never raises, same degrade-gracefully contract as
+# load_chart_specs_controls).
+def load_chart_specs_companions(dir)
+  path = File.join(dir, 'chart-specs.json')
+  return {} unless File.exist?(path)
+  data = JSON.parse(File.read(path)) rescue nil
+  return {} unless data.is_a?(Hash) && data['pages'].is_a?(Array)
+  out = {}
+  data['pages'].each do |p|
+    pname = p['name']
+    next unless pname
+    comps = Array(p['elements']).select do |el|
+      el.is_a?(Hash) && el['kind'] == 'kpi-chart' && el['id'].to_s.end_with?('-summary') && el['name']
+    end
+    out[pname] = comps.map { |el| { 'id' => el['id'].to_s, 'name' => el['name'].to_s } } unless comps.empty?
+  end
+  out
+end
+
 # This card's best-known Sigma-ish kind string, per the priority above.
 # `kind_map` keys on "el-<cardId>" — build-workbook.rb's own element-id
 # convention for a card-derived element (confirmed against a live chart-specs
@@ -844,6 +877,47 @@ def build_stack_fallback(name, cards)
   { 'dashboard' => name, 'zone_tree' => zones, 'zones' => zones }
 end
 
+# I1 (final review, Important): rung 1 (build_dashboard) filters its input to
+# ONLY cards carrying real x/y/w/h — that's correct for genuine Domo cards
+# (a real page reports pixel geometry for ALL of its cards or NONE of them,
+# never a mix, live-validated), but a SYNTHESIZED pseudo-card (an orphan
+# control, or bead 08sf's companion KPI — see the $PROGRAM_NAME == __FILE__
+# block below) never carries geometry at all, so it silently falls out of
+# rung 1's own filter and never gets a zone — even on a page whose real cards
+# all have pixel geometry. Reuses the SAME "compose the remainder below the
+# primary content" idea rung 1.5 (build_dashboard_with_observed) already
+# applies to its own observed/unobserved split: run the geometry-less cards
+# through the kind-aware composition (build_dashboard_from_collections) and
+# append the result below whatever rung 1 already placed, proportionally
+# rescaled into whatever page fraction is left. A no-op (returns `dash`
+# unchanged) when every one of `cards` carried real geometry, which is true
+# for every ordinary (non-synthesized) page today.
+def append_geometryless_remainder(dash, cards, kind_map)
+  # Scoped to cards THIS file itself synthesized (`_synthesized` — see the
+  # main block below), never to an arbitrary real card that happens to carry
+  # no geometry: a real Domo page reports pixel geometry for ALL of its cards
+  # or NONE (live-validated), so a genuinely-geometry-less REAL card mixed in
+  # among geometry-bearing ones is a degraded/partial capture, not a case
+  # this remainder pass should rescue — it stays excluded from rung 1's
+  # output, unchanged (see test-build-domo-layout.rb's NoGeom/_error case).
+  synthesized = cards.select { |c| c['_synthesized'] }
+  return dash if synthesized.empty?
+
+  rest = build_dashboard_from_collections(dash['dashboard'], synthesized, kind_map)
+  return dash unless rest
+
+  dash_max_y = dash['zones'].map { |z| z['y_pct'].to_f + z['h_pct'].to_f }.max
+  remaining_budget = [100.0 - dash_max_y, 20.0].max
+  rest['zones'].each do |z|
+    shifted = z.dup
+    shifted['y_pct'] = (dash_max_y + z['y_pct'] / 100.0 * remaining_budget).round(2)
+    shifted['h_pct'] = (z['h_pct'] / 100.0 * remaining_budget).round(2)
+    dash['zone_tree'] << shifted
+    dash['zones'] << shifted
+  end
+  dash
+end
+
 # Orchestrates the fallback chain for one page's cards, highest-fidelity rung
 # first. Only returns nil when the page genuinely has zero cards. `kind_map`
 # threads through to rung 2/1.5's kind-aware composition (see
@@ -856,7 +930,7 @@ def build_dashboard_for_page(name, cards, kind_map = {}, observed = {})
   return nil if cards.empty?
 
   dash = build_dashboard(name, cards) # rung 1: genuine x/y/w/h pixel geometry
-  return dash if dash
+  return append_geometryless_remainder(dash, cards, kind_map) if dash
 
   unless observed.empty?
     dash = build_dashboard_with_observed(name, cards, observed, kind_map) # rung 1.5: operator-authored
@@ -915,12 +989,28 @@ if $PROGRAM_NAME == __FILE__
   # keyed by NAME (not id) so downstream zone_el_name/assign_controls
   # matching still resolves it to the real control element.
   orphan_controls_by_page = load_chart_specs_controls(OUT)
+  # I1 (final review, Important): a companion KPI element (bead 08sf) has no
+  # card of its own either — same problem as an orphan control immediately
+  # above, same fix. It lands wherever this file's kind-aware composition
+  # puts any other 'kpi-chart' element (the page's shared KPI band) rather
+  # than truly beside its own primary chart/table — the kind-grouped
+  # composition model (build_dashboard_from_collections's rung 2a) buckets
+  # ALL kpi-kind elements into one shared row regardless of which card
+  # produced them, so per-primary adjacency isn't a placement this model can
+  # express. Landing in the KPI band (a real, deliberate placement) beats not
+  # landing anywhere at all.
+  orphan_companions_by_page = load_chart_specs_companions(OUT)
   by_page.each do |pname, pcards|
     card_el_ids = pcards.map { |c| "el-#{c['id']}" }
     Array(orphan_controls_by_page[pname]).each do |ctl|
       next if card_el_ids.include?(ctl['id'])
       pcards << { 'id' => ctl['id'], 'title' => ctl['name'], 'chartType' => 'filter',
-                  'sigmaKindHint' => 'control', '_size' => '', '_pageOrder' => -1 }
+                  'sigmaKindHint' => 'control', '_size' => '', '_pageOrder' => -1, '_synthesized' => true }
+    end
+    Array(orphan_companions_by_page[pname]).each do |comp|
+      next if card_el_ids.include?(comp['id'])
+      pcards << { 'id' => comp['id'], 'title' => comp['name'], 'chartType' => 'badge_singlevalue',
+                  'sigmaKindHint' => 'kpi-chart', '_size' => '', '_pageOrder' => -1, '_synthesized' => true }
     end
   end
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-domo-layout.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-domo-layout.rb
@@ -912,8 +912,13 @@ def append_geometryless_remainder(dash, cards, kind_map)
     shifted = z.dup
     shifted['y_pct'] = (dash_max_y + z['y_pct'] / 100.0 * remaining_budget).round(2)
     shifted['h_pct'] = (z['h_pct'] / 100.0 * remaining_budget).round(2)
+    # build_dashboard (rung 1) constructs 'zone_tree' and 'zones' as the SAME
+    # array object (line 877: `'zone_tree' => zones, 'zones' => zones`), not
+    # two independent lists — appending to both double-inserts every
+    # synthesized zone (verified live: a companion KPI's elementId landed
+    # TWICE in the merged layout XML, once degenerate zero-width). One append
+    # reaches both keys.
     dash['zone_tree'] << shifted
-    dash['zones'] << shifted
   end
   dash
 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -383,13 +383,22 @@ def build_kpi(card, overrides)
   disp = display_name(col)
   label = (sn['label'] && !sn['label'].to_s.strip.empty?) ? sn['label'] : disp
   vid = mcol_id(disp).sub(/\Am-/, 'v-')
+  # LIVE-VALIDATED FIX (2026-07-31): an aggregate/window Beast Mode summary
+  # number is not a data-model column — mirrors measure_col's own
+  # inline_beast_mode_measure handling. Without this, a KPI (or bead 08sf's
+  # companion KPI, which calls build_kpi for a card whose summary is bound to
+  # an aggregate calc like "Margin Pct") emitted Sum([Master/Margin Pct]), a
+  # column that does not exist, 400ing the ENTIRE workbook POST. Only applies
+  # when NOT overridden — a kpi-overrides.json entry points at a real column.
+  value_col = (!ov && sn['_isCalc'] && inline_beast_mode_measure(card, sn)) ||
+              { 'id' => vid, 'name' => label,
+                'formula' => "#{sigma_agg(agg, sn['distinct'])}(#{mref(disp)})",
+                'format' => sigma_format(sn['format'], label) }.compact
   {
     'id' => eid(card), 'kind' => 'kpi-chart', 'name' => label,
     'source' => { 'kind' => 'table', 'elementId' => 'master' },
-    'columns' => [{ 'id' => vid, 'name' => label,
-                    'formula' => "#{sigma_agg(agg, sn['distinct'])}(#{mref(disp)})",
-                    'format' => sigma_format(sn['format'], label) }.compact],
-    'value' => { 'columnId' => vid },   # ⚠ columnId, NOT id (feedback_sigma_kpi_value_columnid)
+    'columns' => [value_col],
+    'value' => { 'columnId' => value_col['id'] },   # ⚠ columnId, NOT id (feedback_sigma_kpi_value_columnid)
   }
 end
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -393,6 +393,31 @@ def build_kpi(card, overrides)
   }
 end
 
+# bead 08sf: Domo prints a Summary Number above EVERY viz card, not just KPI
+# cards — a bar chart, a table, a combo all show one. Sigma's chart/table
+# elements have no summary slot, so the fix is a companion kpi-chart element
+# placed beside the primary one, reusing build_kpi (identical measure/format
+# resolution, including the #1 COUNT-of-row-key guard) with a distinct id so it
+# never collides with the primary element's own id.
+#
+# build_kpi's own "return nil unless col" guard is a bare truthiness check —
+# it only trips on a literal nil/false column, so an explicitly blank ''
+# column (as opposed to an absent one) sails through it and build_kpi would
+# happily emit a broken Count([Master/]) reference. Re-check for blank here,
+# scoped only to this new function (build_kpi itself is untouched), using the
+# same .to_s.strip.empty? convention prune_unresolvable_columns! already uses
+# elsewhere in this file for "no resolvable column".
+def build_summary_companion(card, overrides)
+  sn = card['summaryNumber'] || {}
+  ov = overrides[card['id']]
+  col = ov && ov['column'] || sn['column']
+  return nil if col.to_s.strip.empty?
+  kpi = build_kpi(card, overrides)
+  return nil unless kpi
+  kpi['id'] = eid(card, '-summary')
+  kpi
+end
+
 def build_axis_chart(card, kind)
   dims, meas = split_cols(card)
   if dims.empty? || meas.empty?

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -74,13 +74,36 @@ def dataset_element_map
   return $ds_element_map = {} unless dm_spec && dm_ids
 
   ds_by_el_id = {}
+  # LIVE-VALIDATED FIX (2026-07-31): build-dm.rb never sets an element-level
+  # `name` (rule 3), so the live readback's own `name` is null for both the
+  # primary master AND every other DM element. build-workbook-spec.rb already
+  # resolves this fallback for the ONE element it picks as the primary master
+  # (server assigns a name by kind: the warehouse table's last path segment,
+  # else "Custom SQL") — sub_master_for needs the identical resolution for
+  # every OTHER element, or its column formulas emit "[/Col]" (an empty table
+  # name — verified live against a nameless Customer Dim element: Sigma
+  # rejected "[/Phone]" as an invalid formula, which would 400 the whole
+  # workbook POST).
+  name_by_el_id = {}
   (dm_spec['pages'] || []).each do |p|
-    (p['elements'] || []).each { |e| ds_by_el_id[e['id']] = e['_datasetId'] if e['_datasetId'] }
+    (p['elements'] || []).each do |e|
+      ds_by_el_id[e['id']] = e['_datasetId'] if e['_datasetId']
+      src = e['source'] || {}
+      name_by_el_id[e['id']] =
+        if src['kind'] == 'warehouse-table' && !Array(src['path']).empty?
+          Array(src['path']).last
+        else
+          'Custom SQL'
+        end
+    end
   end
   map = {}
   (dm_ids['pages'] || []).flat_map { |p| p['elements'] || [] }.each do |e|
     ds_id = ds_by_el_id[e['id']]
-    map[ds_id] = e if ds_id && !map.key?(ds_id)
+    next unless ds_id && !map.key?(ds_id)
+    resolved = e.dup
+    resolved['name'] = name_by_el_id[e['id']] if e['name'].to_s.strip.empty?
+    map[ds_id] = resolved
   end
   $ds_element_map = map
 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -46,6 +46,76 @@ def mref(display) "[Master/#{display}]" end
 $warnings = []
 def warn_card(card, msg) $warnings << { 'card' => card['title'] || card['id'], 'warning' => msg } end
 
+$companion_elements = [] # bead 08sf — Task 5 populates this
+$sub_masters = {}        # bead ziht — datasetId => sub-master element Hash
+
+# bead ziht: dm-spec.json is build-dm.rb's PRE-post spec (already at this
+# script's own OUT dir — build-dm.rb writes it to discovery/, same as
+# cards.json/pages.json). It carries `_datasetId` on every DM element
+# (build-dm.rb) — a client-assigned tag Sigma neither knows nor round-trips.
+# dm-ids.json is the POST-readback (client ids are preserved by Sigma on
+# CREATE, but only the readback carries the real `dataModelId` + confirms the
+# element actually posted) — it lives in migrate-domo.rb's OUT, a DIFFERENT
+# directory than DISCOVERY, so it needs its own env var.
+DM_SPEC_PATH = File.join(OUT, 'dm-spec.json')
+DM_IDS_PATH  = ENV['DOMO_DM_IDS_PATH']
+
+# Which live DM element serves each Domo DataSet, keyed by datasetId. Both
+# inputs are optional — a hand run of build-workbook.rb alone, or a unit test,
+# has neither, and this degrades to {} (the caller's existing warn+SKIP path
+# for a card whose DataSet doesn't match the workbook's dominant master).
+def dataset_element_map
+  return $ds_element_map if $ds_element_map
+  unless DM_IDS_PATH && File.exist?(DM_SPEC_PATH.to_s) && File.exist?(DM_IDS_PATH.to_s)
+    return $ds_element_map = {}
+  end
+  dm_spec = (JSON.parse(File.read(DM_SPEC_PATH)) rescue nil)
+  dm_ids  = (JSON.parse(File.read(DM_IDS_PATH)) rescue nil)
+  return $ds_element_map = {} unless dm_spec && dm_ids
+
+  ds_by_el_id = {}
+  (dm_spec['pages'] || []).each do |p|
+    (p['elements'] || []).each { |e| ds_by_el_id[e['id']] = e['_datasetId'] if e['_datasetId'] }
+  end
+  map = {}
+  (dm_ids['pages'] || []).flat_map { |p| p['elements'] || [] }.each do |e|
+    ds_id = ds_by_el_id[e['id']]
+    map[ds_id] = e if ds_id && !map.key?(ds_id)
+  end
+  $ds_element_map = map
+end
+
+def dm_id
+  return $dm_id if defined?($dm_id) && $dm_id
+  return $dm_id = nil unless DM_IDS_PATH && File.exist?(DM_IDS_PATH.to_s)
+  ids = (JSON.parse(File.read(DM_IDS_PATH)) rescue nil)
+  $dm_id = ids && ids['dataModelId']
+end
+
+# A hidden sub-master for a non-dominant DataSet — the same auto-passthrough
+# shape build-workbook-spec.rb builds for the primary `master` (every column of
+# the named DM element, by name), reimplemented here rather than shared because
+# that file is VENDORED and must not diverge (see its header). nil when the
+# DataSet has no resolvable live element yet (caller falls back to the existing
+# warn+SKIP stopgap).
+def sub_master_for(ds_id)
+  return $sub_masters[ds_id] if $sub_masters[ds_id]
+  live_el = dataset_element_map[ds_id]
+  return nil unless live_el
+  cols = (live_el['columnLabels'] || live_el['columns'] || []).map do |c|
+    nm = c.is_a?(String) ? c : (c['name'] || c['id'])
+    next nil if nm.to_s.empty?
+    { 'id' => mcol_id(nm), 'name' => nm, 'formula' => "[#{live_el['name']}/#{nm}]" }
+  end.compact
+  return nil if cols.empty?
+  $sub_masters[ds_id] = {
+    'id' => "master-#{ds_id.to_s.downcase.gsub(/\W+/, '-')}", 'kind' => 'table',
+    'name' => "Master (#{live_el['name'] || ds_id})", 'visibleAsSource' => false,
+    'source' => { 'kind' => 'data-model', 'dataModelId' => dm_id, 'elementId' => live_el['id'] },
+    'columns' => cols, 'order' => cols.map { |c| c['id'] },
+  }
+end
+
 # ---- Domo chartType -> Sigma element kind (refs/card-to-element.md Problems 1-3) --
 #
 # `chartType` is a STRICT Domo enum, not a free-form string — substring matching

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -847,8 +847,15 @@ def retarget_to_submaster!(el, sm)
   el['source'] = { 'kind' => 'table', 'elementId' => sm['id'] } if el.key?('source')
   walk = lambda do |n|
     case n
-    when Hash   then n.each { |k, v| n[k] = walk.call(v) }
-    when Array  then n.map! { |v| walk.call(v) }
+    # LIVE-VALIDATED FIX (2026-07-31): AXIS_OFF ({'marks'=>'none'}.freeze) is a
+    # shared frozen constant referenced by every axis-chart element's
+    # xAxis/yAxis 'format' — mutating it in place raised FrozenError the first
+    # time this routed an axis-chart card (Domo page 'Orders Executive',
+    # "Customers by Region"). A frozen Hash/Array in this codebase is always
+    # static shared config, never a dynamic [Master/...] reference, so it's
+    # always safe to leave it untouched rather than walk into it.
+    when Hash   then (n.frozen? ? n : n.each { |k, v| n[k] = walk.call(v) })
+    when Array  then (n.frozen? ? n : n.map! { |v| walk.call(v) })
     when String then n.gsub('[Master/', "[#{sm['name']}/")
     else n
     end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -395,10 +395,15 @@ end
 
 # bead 08sf: Domo prints a Summary Number above EVERY viz card, not just KPI
 # cards — a bar chart, a table, a combo all show one. Sigma's chart/table
-# elements have no summary slot, so the fix is a companion kpi-chart element
-# placed beside the primary one, reusing build_kpi (identical measure/format
-# resolution, including the #1 COUNT-of-row-key guard) with a distinct id so it
-# never collides with the primary element's own id.
+# elements have no summary slot, so the fix is a separate companion kpi-chart
+# element, reusing build_kpi (identical measure/format resolution, including
+# the #1 COUNT-of-row-key guard) with a distinct id so it never collides with
+# the primary element's own id. build-domo-layout.rb synthesizes this
+# companion its own layout zone in the page's KPI band (kind-aware
+# composition) — it is NOT guaranteed to land immediately adjacent to its own
+# primary chart/table (that band groups ALL of a page's KPI-kind elements
+# together, regardless of which card produced them); see refs/card-to-
+# element.md's "Companion KPI" section for the honest placement description.
 #
 # build_kpi's own "return nil unless col" guard is a bare truthiness check —
 # it only trips on a literal nil/false column, so an explicitly blank ''
@@ -823,8 +828,14 @@ end
 # at a per-DataSet sub-master instead of the shared primary master (bead ziht).
 # gsub (not sub) — an inlined aggregate Beast Mode formula can reference
 # [Master/...] more than once in a single string (e.g. an If() with two Sum()s).
+#
+# M1 (final review): guard the `source` rewrite — build_image's element has NO
+# `source` key at all (it's a bare data-URI), and unconditionally setting one
+# would fabricate a bogus source binding on an image element that never had
+# one. Every other element kind here (chart/table/kpi/pivot/map) always
+# carries `source`, so this only ever actually skips for an image.
 def retarget_to_submaster!(el, sm)
-  el['source'] = { 'kind' => 'table', 'elementId' => sm['id'] }
+  el['source'] = { 'kind' => 'table', 'elementId' => sm['id'] } if el.key?('source')
   walk = lambda do |n|
     case n
     when Hash   then n.each { |k, v| n[k] = walk.call(v) }
@@ -839,7 +850,9 @@ end
 
 def build_element(card, overrides, master_ds = nil)
   ds = card['datasetId'].to_s
-  if master_ds && !ds.empty? && ds != master_ds
+  routed = master_ds && !ds.empty? && ds != master_ds
+  sm = nil
+  if routed
     sm = sub_master_for(ds)
     unless sm
       warn_card(card, "SKIPPED — card is bound to DataSet #{ds} but this workbook's shared " \
@@ -848,17 +861,35 @@ def build_element(card, overrides, master_ds = nil)
                       'hand against its own source, or re-run once the data model has posted.')
       return nil
     end
-    before = $companion_elements.length
-    el = build_element_body(card, overrides)
-    return nil unless el
+  end
+
+  before = $companion_elements.length
+  el = build_element_body(card, overrides)
+  if el.nil?
+    # C1 (final review, promoted from a deferred Task-5 minor to BLOCKING): a
+    # card whose primary element failed to build must not leave behind an
+    # orphaned companion KPI. build_element_body itself now defers pushing a
+    # companion onto $companion_elements until it knows the primary built (see
+    # below) — so in the ordinary case this slice is a no-op — but truncate
+    # here too, defensively, at the one call site that actually decides
+    # whether this card's build succeeded: a companion that somehow reached
+    # $companion_elements during a failed attempt must never survive it. For
+    # the ROUTED (non-dominant-dataset) case specifically, surviving here
+    # would mean a companion still sourcing the SHARED master's namespace
+    # instead of the sub-master's — reintroducing the exact "Dependency not
+    # found" whole-workbook-POST failure bead ziht exists to prevent.
+    $companion_elements.slice!(before..-1)
+    return nil
+  end
+
+  if routed
     retarget_to_submaster!(el, sm)
-    $companion_elements[before..].each { |c| retarget_to_submaster!(c, sm) }
+    $companion_elements[before..-1].each { |c| retarget_to_submaster!(c, sm) }
     warn_card(card, "routed to sub-master '#{sm['name']}' for DataSet #{ds} (bead ziht) — " \
                     'verify column coverage against the card PNG; the sub-master passes through ' \
                     "every column of #{sm['name']}, not just the ones this card uses.")
-    return el
   end
-  build_element_body(card, overrides)
+  el
 end
 
 def build_element_body(card, overrides)
@@ -869,17 +900,20 @@ def build_element_body(card, overrides)
            (card['summaryNumber'] && Array(card['groupBy']).empty? && (card['columns'] || []).size <= 1)
   return build_kpi(card, overrides) if is_kpi
 
-  # Domo prints a Summary Number at the top of EVERY viz card, not just KPI cards.
-  # Sigma's chart/table elements have no summary slot, so Task 5 emits a companion
-  # KPI element (bead 08sf) via $companion_elements when one is resolvable.
+  # Domo prints a Summary Number at the top of EVERY viz card, not just KPI
+  # cards. Sigma's chart/table elements have no summary slot, so this
+  # RESOLVES a companion KPI element (bead 08sf) here, but does NOT push it
+  # onto $companion_elements (or warn about it) until the primary element
+  # below is confirmed to have actually built — see the bottom of this
+  # method. M3/C1 (final review): a companion pushed before that point would
+  # outlive a primary that then fails to build, leaving an orphaned KPI with
+  # no chart/table beside it and a warning claiming it "represents" a card
+  # that was actually dropped.
   sn = card['summaryNumber']
+  companion = nil
   if sn.is_a?(Hash) && !sn['column'].to_s.empty?
     companion = build_summary_companion(card, overrides)
-    if companion
-      $companion_elements << companion
-      warn_card(card, "source Summary Number ALSO represented as a companion KPI element " \
-                      "'#{companion['name']}' beside this #{kind || 'chart'} element (bead 08sf).")
-    else
+    unless companion
       agg = sn['aggregation'].to_s.empty? ? '(calc)' : sn['aggregation']
       warn_card(card, "source Summary Number NOT represented: Domo prints " \
                       "#{agg}(#{sn['column']}) above this card, but a Sigma " \
@@ -888,39 +922,70 @@ def build_element_body(card, overrides)
     end
   end
 
-  if image_card?(card)
-    img = build_image(card)
-    return img if img
-    warn_card(card, "image card #{card['id']}: no captured PNG — export from Domo UI and embed manually.")
-  end
-
-  mapped = chart_kind_for(card)
-  kind = mapped || kind
-  ct = card['chartType'].to_s.downcase
-  if mapped && NO_NATIVE_EQUIVALENT.key?(ct)
-    warn_card(card, "no native Sigma equivalent for chartType '#{card['chartType']}' — " \
-                    "#{NO_NATIVE_EQUIVALENT[ct]} Tracked as a Sigma custom-plugin follow-up " \
-                    '(sigma-plugin-development skill) — not handled by this converter today.')
-  end
-
-  case kind
-  when 'bar-chart', 'line-chart', 'area-chart', 'scatter-chart'
-    build_axis_chart(card, kind)
-  when 'combo-chart' then build_combo(card)
-  when 'pie-chart', 'donut-chart' then build_pie_or_donut(card, kind)
-  when 'pivot-table'  then build_pivot(card)
-  when 'table'        then build_table(card)
-  when 'region-map'   then build_map(card)
-  when 'kpi-chart'
-    build_kpi(card, overrides) || begin
-      warn_card(card, "kpi-chart: chartType '#{card['chartType']}' has no summaryNumber to build a " \
-                      'value from — emitted a table instead so the card is not silently dropped.')
-      build_table(card)
+  el =
+    if image_card?(card)
+      img = build_image(card)
+      if img
+        img
+      else
+        # PNG absent (Tier B / not captured) — honest fallback: fall through
+        # to the existing placeholder path below (unchanged) + flag it so it
+        # gets fixed by hand rather than shipping a broken/empty image element.
+        warn_card(card, "image card #{card['id']}: no captured PNG — export from Domo UI and embed manually.")
+        nil
+      end
     end
-  else
-    warn_card(card, "unknown chartType '#{card['chartType']}' → emitted bar-chart; verify against the PNG.")
-    build_axis_chart(card, 'bar-chart')
+
+  if el.nil?
+    # #2/#3: chartType is a STRICT Domo enum — EXACT-match it (never substring)
+    # against the known-token table before falling back to any upstream hint.
+    mapped = chart_kind_for(card)
+    kind = mapped || kind
+    ct = card['chartType'].to_s.downcase
+    if mapped && NO_NATIVE_EQUIVALENT.key?(ct)
+      warn_card(card, "no native Sigma equivalent for chartType '#{card['chartType']}' — " \
+                      "#{NO_NATIVE_EQUIVALENT[ct]} Tracked as a Sigma custom-plugin follow-up " \
+                      '(sigma-plugin-development skill) — not handled by this converter today.')
+    end
+
+    el = case kind
+         when 'bar-chart', 'line-chart', 'area-chart', 'scatter-chart'
+           build_axis_chart(card, kind)
+         when 'combo-chart' then build_combo(card)
+         when 'pie-chart', 'donut-chart' then build_pie_or_donut(card, kind)
+         when 'pivot-table'  then build_pivot(card)
+         when 'table'        then build_table(card)
+         when 'region-map'   then build_map(card)
+         when 'kpi-chart'
+           # badge_filledgauge (and any other kpi-mapped chartType) may reach
+           # here without a summaryNumber — never silently drop the card;
+           # degrade to a table + warn rather than emit nil.
+           build_kpi(card, overrides) || begin
+             warn_card(card, "kpi-chart: chartType '#{card['chartType']}' has no summaryNumber to build a " \
+                             'value from — emitted a table instead so the card is not silently dropped.')
+             build_table(card)
+           end
+         else
+           warn_card(card, "unknown chartType '#{card['chartType']}' → emitted bar-chart; verify against the PNG.")
+           build_axis_chart(card, 'bar-chart')
+         end
   end
+
+  if companion
+    if el
+      $companion_elements << companion
+      warn_card(card, "source Summary Number ALSO represented as a companion KPI element " \
+                      "'#{companion['name']}' alongside this #{el['kind'] || kind || 'chart'} element " \
+                      '(bead 08sf) — see build-domo-layout.rb for where it lands on the page.')
+    else
+      warn_card(card, "source Summary Number's companion KPI element '#{companion['name']}' was NOT " \
+                      "emitted: the primary #{kind || 'chart'} element for this card failed to build, " \
+                      'and a standalone companion with no primary chart/table beside it would be ' \
+                      'confusing, not helpful (bead 08sf / C1).')
+    end
+  end
+
+  el
 end
 
 # ---- controls (bug #2: fan out to EVERY element via the shared master) ------

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -480,8 +480,8 @@ end
 
 def build_table(card)
   dims, meas = split_cols(card)
-  cols = dims.map { |d| dim_col(d, card).merge('style' => { 'textWrap' => 'wrap' }) } +   # #5 wrap text cols
-         meas.map { |m| measure_col(m, card) }
+  mcols = meas.map { |m| measure_col(m, card) }
+  cols = dims.map { |d| dim_col(d, card).merge('style' => { 'textWrap' => 'wrap' }) } + mcols
   cols = (card['columns'] || []).map { |c| dim_col(c, card).merge('style' => { 'textWrap' => 'wrap' }) } if cols.empty?
   el = {
     'id' => eid(card), 'kind' => 'table', 'name' => card['title'],
@@ -508,7 +508,7 @@ def build_table(card)
     grouping = {
       'id' => "grp-#{eid(card)}",
       'groupBy' => dims.map { |d| dim_col(d, card)['id'] },
-      'calculations' => meas.map { |m| measure_col(m, card)['id'] },
+      'calculations' => mcols.map { |m| m['id'] },
     }
     el['groupings'] = [grouping]
   end
@@ -516,7 +516,26 @@ def build_table(card)
   # #7: in-cell data bars belong ONLY to a real Domo table card that declared them.
   bars = Array(card['conditionalFormats']).select { |cf| cf.to_s.downcase.include?('databar') || cf.dig('format', 'dataBar') }
   unless bars.empty?
-    el['conditionalFormats'] = [{ 'type' => 'dataBars', 'columnIds' => meas.map { |m| measure_col(m, card)['id'] } }]
+    el['conditionalFormats'] = [{ 'type' => 'dataBars', 'columnIds' => mcols.map { |m| m['id'] } }]
+  end
+
+  # bead 2ef7: a Domo card's row LIMIT (e.g. limit:25 on a "Top 25" table) has no
+  # query-level analog in Sigma — without a translation the table just renders
+  # every warehouse row (872 instead of 25, live-validated 2026-07-30). The Sigma
+  # analog is an element-level top-n FILTER: `rowCount` takes a number literal
+  # only (reference/specification/tables.md "top-N, element-level row filters") —
+  # it cannot be bound to a control, so this is a direct, static translation.
+  # Ranks by the FIRST measure (mirrors the existing "sort by first measure"
+  # convention in build_axis_chart's xa['sort']) — Sigma's top-n ranks
+  # DESCENDING only; an ascending Domo orderBy has no equivalent here and is left
+  # alone rather than silently reversed. No measure column -> nothing to rank by
+  # -> no filter emitted (never a columnId: nil filter).
+  limit = card['limit'].to_i
+  if limit.positive? && mcols.any?
+    el['filters'] = [{
+      'id' => "topn-#{el['id']}", 'columnId' => mcols.first['id'],
+      'kind' => 'top-n', 'rankingFunction' => 'rank', 'mode' => 'top-n', 'rowCount' => limit,
+    }]
   end
   el
 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -819,16 +819,49 @@ def dominant_dataset_id(cards)
   counts.max_by { |_, n| n }.first
 end
 
+# Deep-rewrite every "[Master/" formula ref + the element's own source to point
+# at a per-DataSet sub-master instead of the shared primary master (bead ziht).
+# gsub (not sub) — an inlined aggregate Beast Mode formula can reference
+# [Master/...] more than once in a single string (e.g. an If() with two Sum()s).
+def retarget_to_submaster!(el, sm)
+  el['source'] = { 'kind' => 'table', 'elementId' => sm['id'] }
+  walk = lambda do |n|
+    case n
+    when Hash   then n.each { |k, v| n[k] = walk.call(v) }
+    when Array  then n.map! { |v| walk.call(v) }
+    when String then n.gsub('[Master/', "[#{sm['name']}/")
+    else n
+    end
+  end
+  walk.call(el)
+  el
+end
+
 def build_element(card, overrides, master_ds = nil)
   ds = card['datasetId'].to_s
   if master_ds && !ds.empty? && ds != master_ds
-    warn_card(card, "SKIPPED — card is bound to DataSet #{ds} but this workbook's shared " \
-                    "master is built from #{master_ds}. Multi-dataset pages need one master " \
-                    'per DataSet (not yet supported); emitting it would fail the entire ' \
-                    'workbook POST with "Dependency not found". Rebuild this card by hand ' \
-                    'against its own source.')
-    return nil
+    sm = sub_master_for(ds)
+    unless sm
+      warn_card(card, "SKIPPED — card is bound to DataSet #{ds} but this workbook's shared " \
+                      "master is built from #{master_ds}, and no live data-model element is " \
+                      'resolvable yet for its own DataSet (bead ziht). Rebuild this card by ' \
+                      'hand against its own source, or re-run once the data model has posted.')
+      return nil
+    end
+    before = $companion_elements.length
+    el = build_element_body(card, overrides)
+    return nil unless el
+    retarget_to_submaster!(el, sm)
+    $companion_elements[before..].each { |c| retarget_to_submaster!(c, sm) }
+    warn_card(card, "routed to sub-master '#{sm['name']}' for DataSet #{ds} (bead ziht) — " \
+                    'verify column coverage against the card PNG; the sub-master passes through ' \
+                    "every column of #{sm['name']}, not just the ones this card uses.")
+    return el
   end
+  build_element_body(card, overrides)
+end
+
+def build_element_body(card, overrides)
   card = prune_unresolvable_columns!(card)
   # Rule 0: a summary-number card with no real grouping → KPI, never a table.
   kind = card['sigmaKindHint']
@@ -837,38 +870,30 @@ def build_element(card, overrides, master_ds = nil)
   return build_kpi(card, overrides) if is_kpi
 
   # Domo prints a Summary Number at the top of EVERY viz card, not just KPI cards.
-  # Sigma's chart/table elements have no summary slot, so that headline number is
-  # dropped. Rule 0 already routes a card that is PRIMARILY a summary to a
-  # kpi-chart; this is the other case — a chart/table that ALSO prints one.
-  #
-  # Caught by the anchors oracle live (2026-07-30): 4 of 13 source anchors matched
-  # NOWHERE in the workbook, every one an overall summary whose per-group values
-  # were present and correct. Silent loss of a headline number is exactly what the
-  # anchors bar exists to surface, so name the card AND the lost value.
-  # Emitting a companion KPI element is tracked as bead 08sf.
+  # Sigma's chart/table elements have no summary slot, so Task 5 emits a companion
+  # KPI element (bead 08sf) via $companion_elements when one is resolvable.
   sn = card['summaryNumber']
   if sn.is_a?(Hash) && !sn['column'].to_s.empty?
-    agg = sn['aggregation'].to_s.empty? ? '(calc)' : sn['aggregation']
-    warn_card(card, "source Summary Number NOT represented: Domo prints " \
-                    "#{agg}(#{sn['column']}) above this card, but a Sigma " \
-                    "#{kind || 'chart'} element has no summary slot — the headline " \
-                    'value is dropped. Add a companion KPI element by hand if the ' \
-                    'number matters (bead 08sf).')
+    companion = build_summary_companion(card, overrides)
+    if companion
+      $companion_elements << companion
+      warn_card(card, "source Summary Number ALSO represented as a companion KPI element " \
+                      "'#{companion['name']}' beside this #{kind || 'chart'} element (bead 08sf).")
+    else
+      agg = sn['aggregation'].to_s.empty? ? '(calc)' : sn['aggregation']
+      warn_card(card, "source Summary Number NOT represented: Domo prints " \
+                      "#{agg}(#{sn['column']}) above this card, but a Sigma " \
+                      "#{kind || 'chart'} element has no summary slot, and a companion KPI " \
+                      'could not be built (no resolvable column) — the headline value is dropped.')
+    end
   end
 
   if image_card?(card)
     img = build_image(card)
     return img if img
-    # PNG absent (Tier B / not captured) — honest fallback: fall through to the
-    # existing placeholder path below (unchanged) + flag it so it gets fixed by
-    # hand rather than shipping a broken/empty image element.
     warn_card(card, "image card #{card['id']}: no captured PNG — export from Domo UI and embed manually.")
   end
 
-  # #2/#3: chartType is a STRICT Domo enum — EXACT-match it (never substring)
-  # against the known-token table before falling back to any upstream hint.
-  # element-kind for chart family is decided HERE, after Rule 0 (KPI) already
-  # had first refusal above.
   mapped = chart_kind_for(card)
   kind = mapped || kind
   ct = card['chartType'].to_s.downcase
@@ -887,9 +912,6 @@ def build_element(card, overrides, master_ds = nil)
   when 'table'        then build_table(card)
   when 'region-map'   then build_map(card)
   when 'kpi-chart'
-    # badge_filledgauge (and any other kpi-mapped chartType) may reach here
-    # without a summaryNumber — never silently drop the card; degrade to a
-    # table + warn rather than emit nil.
     build_kpi(card, overrides) || begin
       warn_card(card, "kpi-chart: chartType '#{card['chartType']}' has no summaryNumber to build a " \
                       'value from — emitted a table instead so the card is not silently dropped.')
@@ -902,12 +924,20 @@ def build_element(card, overrides, master_ds = nil)
 end
 
 # ---- controls (bug #2: fan out to EVERY element via the shared master) ------
-def build_controls(cards)
+def build_controls(cards, master_ds = nil)
   seen = {}
   controls = []
   cards.each do |card|
+    ds = card['datasetId'].to_s
     Array(card['filters']).each do |f|
       col = f['column']; next if col.nil? || seen[col]
+      if master_ds && !ds.empty? && ds != master_ds
+        warn_card(card, "control filter on '#{col}' SKIPPED — its card is bound to DataSet " \
+                        "#{ds}, not this workbook's shared master (#{master_ds}); binding it to " \
+                        'master would 400 the whole workbook POST. Per-sub-master controls are ' \
+                        'not yet supported (bead ziht follow-up).')
+        next
+      end
       seen[col] = true
       disp = display_name(col)
       controls << {
@@ -943,15 +973,18 @@ if $PROGRAM_NAME == __FILE__
   by_page.each { |pname, pcards| warn_missing_geometry(pname, pcards) }
 
   out_pages = by_page.map do |pname, pcards|
+    before = $companion_elements.length
     els = pcards.map { |c| build_element(c, overrides, master_ds) }.compact
-    els += build_controls(pcards)
+    els += $companion_elements[before..]
+    els += build_controls(pcards, master_ds)
     { 'name' => pname, 'elements' => els }
   end
 
   FileUtils.mkdir_p(OUT)
-  File.write(File.join(OUT, 'chart-specs.json'), JSON.pretty_generate('pages' => out_pages))
+  File.write(File.join(OUT, 'chart-specs.json'),
+             JSON.pretty_generate('pages' => out_pages, 'data_elements' => $sub_masters.values))
   File.write(File.join(OUT, 'warnings.json'), JSON.pretty_generate($warnings))
-  warn "  wrote #{File.join(OUT, 'chart-specs.json')} (#{out_pages.sum { |p| p['elements'].size }} elements across #{out_pages.size} page(s))"
+  warn "  wrote #{File.join(OUT, 'chart-specs.json')} (#{out_pages.sum { |p| p['elements'].size }} elements across #{out_pages.size} page(s), #{$sub_masters.size} sub-master(s))"
   warn "  wrote #{File.join(OUT, 'warnings.json')} (#{$warnings.size} warning(s))"
   $warnings.first(20).each { |w| warn "    ⚠ #{w['card']}: #{w['warning']}" }
   warn "\n  Next: build-workbook-spec.rb --chart-specs discovery/chart-specs.json --dm-ids discovery/dm-ids.json ..."

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/domo-discover.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/domo-discover.rb
@@ -328,6 +328,7 @@ def normalize_card(raw, card_id, card_meta: nil)
       'dateRangeFilter'    => main['dateRangeFilter'],
       'groupBy'            => Array(main['groupBy']).map { |c| c['column'] }.compact,
       'orderBy'            => Array(main['orderBy']).map { |c| c['column'] }.compact,
+      'limit'              => main['limit'],
       'filters'            => filters,
       'conditionalFormats' => Array(defn['conditionalFormats']),
       'cardFormulas'       => Array(defn['formulas']),  # {id,name,columnPositions,...}
@@ -358,6 +359,7 @@ def normalize_card(raw, card_id, card_meta: nil)
       'dateRangeFilter'    => body['dateRangeFilter'],
       'groupBy'            => norm_columns({ 'columns' => body['groupBy'] }).map { |c| c['column'] },
       'orderBy'            => norm_columns({ 'columns' => body['orderBy'] }).map { |c| c['column'] },
+      'limit'              => body['limit'],
       'filters'            => filters,
       'conditionalFormats' => Array(raw['conditionalFormats']),
       'cardFormulas'       => Array(raw['calculatedFields']),  # {formula,id,name,saveToDataSet}

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -97,7 +97,7 @@ FileUtils.mkdir_p(OUT)
 DISCOVERY = File.join(OUT, 'discovery')
 FileUtils.mkdir_p(DISCOVERY)
 SCRIPTS = __dir__
-BASE_ENV = { 'DOMO_DISCOVERY_DIR' => DISCOVERY }.freeze
+BASE_ENV = { 'DOMO_DISCOVERY_DIR' => DISCOVERY, 'DOMO_DM_IDS_PATH' => File.join(OUT, 'dm-ids.json') }.freeze
 
 DomoRunState.record(OUT, 'mode' => (opts[:offline] ? 'offline' : 'live'), 'started_at' => Time.now.utc.iso8601)
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -151,8 +151,27 @@ def seed_discovery!(fixture_dir)
   FileUtils.mkdir_p(DISCOVERY)
   copied = []
   Dir.glob(File.join(fixture_dir, '*.json')).sort.each do |f|
-    FileUtils.cp(f, File.join(DISCOVERY, File.basename(f)))
-    copied << File.basename(f)
+    base = File.basename(f)
+    if base == 'dm-ids.json'
+      # bead ziht (Task 6): dm-ids.json is a POST-READBACK artifact — the LIVE
+      # path writes it via post-and-readback.rb --type datamodel to
+      # DOMO_DM_IDS_PATH, which BASE_ENV above points at THIS run's OUT dir
+      # (not discovery/ — see build-workbook.rb's DM_IDS_PATH comment: it lives
+      # in migrate-domo.rb's OUT, a different directory than DISCOVERY,
+      # because a hand run of build-workbook.rb alone has no OUT of its own).
+      # --offline mode never runs post-and-readback.rb (no live DM exists to
+      # post — see the "post-and-readback" phase below, always skipped), so a
+      # fixture wanting to exercise sub_master_for's live-element resolution
+      # provides this file directly, as the synthesized equivalent of that
+      # readback. Route it to OUT/dm-ids.json to match DOMO_DM_IDS_PATH —
+      # dropping it in discovery/ alongside dm-spec.json (like every other
+      # fixture *.json) left it somewhere build-workbook.rb never looks.
+      FileUtils.cp(f, File.join(OUT, base))
+      copied << "#{base} (-> #{OUT}, matching DOMO_DM_IDS_PATH — not discovery/)"
+      next
+    end
+    FileUtils.cp(f, File.join(DISCOVERY, base))
+    copied << base
   end
   png_src = File.join(fixture_dir, 'png')
   if Dir.exist?(png_src)
@@ -226,6 +245,15 @@ def offline_build_workbook_spec!(chart_specs_path, name:, description:, folder_i
     seen_ids[c['id']] = true
   end
 
+  # bead ziht: build-workbook.rb may emit one hidden sub-master per
+  # non-dominant DataSet under chart-specs.json's top-level `data_elements`
+  # key (mirrors build-workbook-spec.rb's own `helper_elements` handling for
+  # the LIVE path — see its header comment on the Data page). Any visible
+  # element retargeted to one of these (retarget_to_submaster!) sources it by
+  # id, so it must land on the Data page here too or the reference dangles —
+  # the offline path had never wired this key in at all.
+  helper_elements = (specs['data_elements'].is_a?(Array) ? specs['data_elements'] : [])
+
   data_page = {
     'id' => 'page-data', 'name' => 'Data',
     'elements' => [{
@@ -234,8 +262,9 @@ def offline_build_workbook_spec!(chart_specs_path, name:, description:, folder_i
                     'note' => 'no live Domo/Sigma Data Model in --offline mode — replace with a real ' \
                               'data-model source (see post-and-readback --type datamodel) before posting.' },
       'columns' => master_columns, 'order' => master_columns.map { |c| c['id'] },
-    }],
+    }] + helper_elements,
   }
+  log "Data page: + #{helper_elements.size} hidden sub-master(s) [#{helper_elements.map { |h| h['id'] }.join(', ')}]" if helper_elements.any?
 
   used_ids = { 'page-data' => true }
   visible_pages = specs['pages'].map do |p|

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/cards.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/cards.json
@@ -54,5 +54,55 @@
     ],
     "filters": [],
     "x": 0, "y": 30, "w": 100, "h": 40
+  },
+  {
+    "id": "table_topn",
+    "title": "Top Projects",
+    "datasetId": "ds1",
+    "chartType": "badge_datagrid",
+    "sigmaKindHint": "table",
+    "groupBy": ["project_name"],
+    "columns": [
+      { "column": "project_name" },
+      { "column": "sales_amount", "aggregation": "SUM" }
+    ],
+    "filters": [],
+    "limit": 10,
+    "x": 0, "y": 70, "w": 50, "h": 30
+  },
+  {
+    "id": "dsdim1",
+    "title": "Region Detail",
+    "datasetId": "ds-dim",
+    "chartType": "badge_datagrid",
+    "sigmaKindHint": "table",
+    "groupBy": [],
+    "columns": [
+      { "column": "region" },
+      { "column": "segment" }
+    ],
+    "filters": [],
+    "x": 50, "y": 70, "w": 50, "h": 30
+  },
+  {
+    "id": "companion1",
+    "title": "Sales by Channel",
+    "datasetId": "ds1",
+    "chartType": "badge_vert_bar",
+    "sigmaKindHint": "bar-chart",
+    "groupBy": ["channel"],
+    "columns": [
+      { "column": "channel" },
+      { "column": "sales_amount", "aggregation": "SUM", "alias": "Sales" }
+    ],
+    "summaryNumber": {
+      "column": "sales_amount",
+      "aggregation": "SUM",
+      "label": "Total Channel Sales",
+      "format": { "type": "CURRENCY" },
+      "_defaultCountSuspect": false
+    },
+    "filters": [],
+    "x": 0, "y": 100, "w": 100, "h": 30
   }
 ]

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/dm-ids.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/dm-ids.json
@@ -1,0 +1,14 @@
+{
+  "dataModelId": "dm-fixture-1",
+  "pages": [
+    {
+      "id": "page-dm-data",
+      "name": "Data",
+      "visibility": null,
+      "elements": [
+        { "id": "el-fact-1", "kind": "table", "name": "Sales Fact", "columnLabels": ["Project Name", "Sales Amount"] },
+        { "id": "el-dim-1", "kind": "table", "name": "Customer Dim", "columnLabels": ["Region", "Segment"] }
+      ]
+    }
+  ]
+}

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/dm-spec.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/dm-spec.json
@@ -1,0 +1,46 @@
+{
+  "name": "Domo Migration",
+  "schemaVersion": 1,
+  "pages": [
+    {
+      "id": "page-dm-data",
+      "name": "Data",
+      "elements": [
+        {
+          "id": "el-fact-1",
+          "kind": "table",
+          "source": {
+            "connectionId": "<CONNECTION_ID>",
+            "kind": "warehouse-table",
+            "path": ["ANALYTICS", "PUBLIC", "SALES_FACT"]
+          },
+          "columns": [
+            { "id": "c-project-name", "formula": "[SALES_FACT/Project Name]" },
+            { "id": "c-sales-amount", "formula": "[SALES_FACT/Sales Amount]" }
+          ],
+          "metrics": [],
+          "order": ["c-project-name", "c-sales-amount"],
+          "relationships": [],
+          "_datasetId": "ds1"
+        },
+        {
+          "id": "el-dim-1",
+          "kind": "table",
+          "source": {
+            "connectionId": "<CONNECTION_ID>",
+            "kind": "warehouse-table",
+            "path": ["ANALYTICS", "PUBLIC", "CUSTOMER_DIM"]
+          },
+          "columns": [
+            { "id": "c-region", "formula": "[CUSTOMER_DIM/Region]" },
+            { "id": "c-segment", "formula": "[CUSTOMER_DIM/Segment]" }
+          ],
+          "metrics": [],
+          "order": ["c-region", "c-segment"],
+          "relationships": [],
+          "_datasetId": "ds-dim"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/pages.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/pages.json
@@ -2,6 +2,6 @@
   {
     "id": "p1",
     "title": "Overview",
-    "cardIds": ["kpi1", "bar1", "img1", "table1"]
+    "cardIds": ["kpi1", "bar1", "img1", "table1", "table_topn", "dsdim1", "companion1"]
   }
 ]

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-nogeom/chart-specs.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-nogeom/chart-specs.json
@@ -12,6 +12,11 @@
           "id": "ctl-region-filter",
           "kind": "control",
           "name": "Region Filter"
+        },
+        {
+          "id": "el-2003-summary",
+          "kind": "kpi-chart",
+          "name": "Detail Table Total"
         }
       ]
     }

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-domo-layout.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-domo-layout.rb
@@ -83,6 +83,45 @@ Dir.mktmpdir('domo-build-layout') do |dir|
 end
 
 # ===========================================================================
+# I1 (final review, Important): a companion KPI element (bead 08sf) on a page
+# that uses RUNG 1 (genuine x/y/w/h pixel geometry, build_dashboard) — the
+# exact shape test/fixtures/domo-estate/ (the migrate-domo.rb e2e fixture)
+# uses. rung 1's own geometry filter would otherwise silently drop the
+# companion pseudo-card (it never carries x/y/w/h) even though every real
+# card on the page has pixel geometry — append_geometryless_remainder is
+# what rescues it. Distinct from the rung-2a coverage above (the
+# domo-nogeom fixture, where NO card has pixel geometry at all).
+# ===========================================================================
+Dir.mktmpdir('domo-build-layout-rung1-companion') do |dir|
+  w = ->(name, obj) { File.write(File.join(dir, name), JSON.generate(obj)) }
+  w.call('cards.json', [
+    { 'id' => 'bar1', 'title' => 'Sales by Region', 'chartType' => 'badge_vert_bar',
+      'x' => 0, 'y' => 0, 'w' => 100, 'h' => 30 },
+  ])
+  w.call('pages.json', [{ 'id' => 'p1', 'title' => 'Overview', 'cardIds' => %w[bar1] }])
+  w.call('chart-specs.json', { 'pages' => [{ 'name' => 'Overview', 'elements' => [
+    { 'id' => 'el-bar1', 'kind' => 'bar-chart', 'name' => 'Sales by Region' },
+    { 'id' => 'el-bar1-summary', 'kind' => 'kpi-chart', 'name' => 'Total Sales' },
+  ] }] })
+
+  env = { 'DOMO_DISCOVERY_DIR' => dir }
+  out = IO.popen(env, ['ruby', File.join(SCRIPTS, 'build-domo-layout.rb')], err: [:child, :out], &:read)
+  ok($?.success?, "build-domo-layout.rb exits 0 on a rung-1 (pixel geometry) page carrying a companion KPI\n#{out unless $?.success?}")
+
+  dash = JSON.parse(File.read(File.join(dir, 'dashboard-layout.json'))).first
+  z_bar = dash['zones'].find { |z| z['id'].to_s == 'bar1' }
+  z_comp = dash['zones'].find { |z| z['id'].to_s == 'el-bar1-summary' }
+  ok(z_bar, "the real, pixel-geometry-bearing card's own zone is still placed (rung 1 unaffected)")
+  ok(z_comp, "the companion KPI (no geometry of its own) STILL gets a zone on a rung-1 page, " \
+             'not silently dropped by build_dashboard\'s own x/y/w/h filter (I1)')
+  if z_comp && z_bar
+    ok(z_comp['y_pct'].to_f >= z_bar['y_pct'].to_f + z_bar['h_pct'].to_f - 0.01,
+       "the companion's zone is appended BELOW the real content, not overlapping it")
+    eq(z_comp['caption'], 'Total Sales', "the companion zone's caption is its own name")
+  end
+end
+
+# ===========================================================================
 # Live-validation fix (refs/live-validation-2026-07-30.md): a real classic
 # Domo page's private read carries NO x/y/w/h at all — only a per-card
 # T-shirt size token (stacks['sizes']) and titled collections[] grouping
@@ -267,6 +306,27 @@ Dir.mktmpdir('domo-build-layout-nogeom') do |dir|
   eq(z_ctl['w_pct'], 100.0, 'the sole control on this page spans the full control band width')
   ok(z_ctl['y_pct'] < z_combo['y_pct'] && z_ctl['y_pct'] < ztable['y_pct'],
      'the control band sits ABOVE every other band on the page (house-style order: control -> ... -> table)')
+
+  # ---- "Detail": chart-specs-only companion KPI ("el-2003-summary", bead ----
+  # 08sf) — final review Important I1: a companion KPI has no card of its own
+  # either (build-workbook.rb synthesizes it from card 2003, the "Detail
+  # Table" card), so without load_chart_specs_companions it would never reach
+  # composition_class and would silently have no layout zone at all, even
+  # though it IS present in the workbook spec. Proves the fix is wired into
+  # the real CLI entrypoint, not just reachable in isolation.
+  z_comp = dzones.find { |z| z['id'].to_s == 'el-2003-summary' }
+  ok(z_comp, "the orphan companion KPI (NO backing card in cards.json — synthesized purely from " \
+             "chart-specs.json's 'kpi-chart' + '-summary'-suffixed element) still produced a zone " \
+             'through the real CLI entrypoint (I1)')
+  if z_comp
+    eq(z_comp['kind'], 'chart', "the companion's zone kind is 'chart' (not 'filter' — it's a KPI, not a control)")
+    eq(z_comp['chart_kind'], 'kpi', "the companion's zone chart_kind is the LOGICAL 'kpi' token " \
+                                     "(zone_chart_kind_for normalizes the Sigma element kind 'kpi-chart')")
+    eq(z_comp['caption'], 'Detail Table Total', "the zone's caption is the companion's OWN name — " \
+                                                 'downstream zone_el_name/els_by_name matching keys on ' \
+                                                 'name, not id, so this must be exact')
+    ok(z_comp['w_pct'].to_f.positive? && z_comp['h_pct'].to_f.positive?, 'the companion zone has a real, non-zero footprint')
+  end
 end
 
 # ===========================================================================

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -314,5 +314,107 @@ no_col_card = { 'id' => 'c30', 'title' => 'Orders', 'summaryNumber' => { 'column
 ok(build_summary_companion(no_col_card, {}).nil?,
    'nil when the summary number has no resolvable column (mirrors build_kpi\'s own "return nil unless col")')
 
+puts "== bead ziht: a card on a non-dominant DataSet routes to its own sub-master " \
+     '(not skipped) once a live DM element is resolvable =='
+Dir.mktmpdir do |dir|
+  dm_spec_path = File.join(dir, 'dm-spec.json')
+  dm_ids_path  = File.join(dir, 'dm-ids.json')
+  File.write(dm_spec_path, JSON.generate('pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', 'name' => 'Customer Dim', '_datasetId' => 'ds-dim' },
+  ] }]))
+  File.write(dm_ids_path, JSON.generate('dataModelId' => 'dm-live-1', 'pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', 'name' => 'Customer Dim', 'columnLabels' => ['Region', 'Segment'] },
+  ] }]))
+  stub_const('DM_SPEC_PATH', dm_spec_path) do
+    stub_const('DM_IDS_PATH', dm_ids_path) do
+      $ds_element_map = nil
+      $sub_masters = {}
+      $warnings = []
+      routed = build_element({ 'id' => 'c25', 'title' => 'Customers by Region', 'chartType' => 'badge_table',
+                               'sigmaKindHint' => 'table', 'datasetId' => 'ds-dim',
+                               'columns' => [ { 'column' => 'region' } ] }, {}, 'ds-fact')
+      ok(!routed.nil?, 'card is NOT skipped — a live sub-master was resolvable')
+      eq(routed['source'], { 'kind' => 'table', 'elementId' => 'master-ds-dim' }, 'routed to its own sub-master, not the shared master')
+      eq(routed['columns'].first['formula'], '[Master (Customer Dim)/Region]', 'formula re-qualified to the sub-master\'s namespace')
+      ok($warnings.any? { |w| w['warning'].include?('routed to sub-master') }, 'routing is reported, not silent')
+      ok($sub_masters.key?('ds-dim'), 'the sub-master was registered for the main block to emit under data_elements')
+    end
+  end
+end
+
+puts "== bead ziht: unresolvable DataSet still falls back to today's warn+SKIP =="
+$ds_element_map = {}
+$sub_masters = {}
+$warnings = []
+skipped = build_element({ 'id' => 'c26', 'title' => 'Orphan Dataset Card', 'chartType' => 'badge_table',
+                          'sigmaKindHint' => 'table', 'datasetId' => 'ds-unknown',
+                          'columns' => [ { 'column' => 'x' } ] }, {}, 'ds-fact')
+ok(skipped.nil?, 'still nil when no live DM element is resolvable for the DataSet (unchanged fallback)')
+ok($warnings.any? { |w| w['warning'].include?('SKIPPED') }, 'still warns loudly on fallback')
+
+puts "== bead ziht: build_controls skips (warns) a filter bound to a non-dominant DataSet\'s column " \
+     'rather than 400ing the whole POST binding it to the wrong master =='
+$warnings = []
+ctrls2 = build_controls([
+  { 'id' => 'c27', 'datasetId' => 'ds-fact', 'filters' => [{ 'column' => 'region' }] },
+  { 'id' => 'c28', 'datasetId' => 'ds-dim',  'filters' => [{ 'column' => 'segment' }] },
+], 'ds-fact')
+eq(ctrls2.size, 1, 'only the dominant-dataset filter becomes a control')
+eq(ctrls2.first['controlId'], 'Region', 'the surviving control is the dominant-dataset one')
+ok($warnings.any? { |w| w['warning'].include?('control filter') && w['warning'].include?('SKIPPED') },
+   'the non-dominant control is reported, not silently dropped')
+
+puts "== bead 08sf: a chart/table card with a summaryNumber gets a companion KPI via " \
+     'build_element, not just a warning =='
+$warnings = []
+$companion_elements = []
+chart_with_summary = build_element({ 'id' => 'c31', 'title' => 'Revenue by Channel', 'chartType' => 'badge_vert_bar',
+                                     'sigmaKindHint' => 'bar-chart',
+                                     'groupBy' => ['channel'],
+                                     'columns' => [ { 'column' => 'channel' },
+                                                    { 'column' => 'net_revenue', 'aggregation' => 'SUM', 'alias' => 'Net Revenue' } ],
+                                     'summaryNumber' => { 'column' => 'net_revenue', 'aggregation' => 'SUM', 'label' => 'Total Revenue' } }, {})
+eq(chart_with_summary['kind'], 'bar-chart', 'the primary element is still the bar chart, unchanged')
+eq($companion_elements.size, 1, 'exactly one companion KPI was produced')
+companion = $companion_elements.first
+eq(companion['kind'], 'kpi-chart', 'companion is a kpi-chart element')
+eq(companion['name'], 'Total Revenue', 'companion carries the summary number\'s own label')
+ok(companion['id'] != chart_with_summary['id'], 'companion has a DISTINCT id from the primary element (no duplicate-id 400)')
+ok($warnings.any? { |w| w['warning'].include?('companion KPI element') }, 'the companion is reported, not silent')
+
+puts "== bead 08sf: a card whose summaryNumber has no resolvable column still just warns " \
+     '(no crash, no half-built companion) =='
+$warnings = []
+$companion_elements = []
+# NOTE (task-5 self-review fix): a genuinely blank ('') summaryNumber column, with
+# only 1 total column and no groupBy, trips Rule 0's is_kpi check (unchanged, and
+# correctly so — see the Rule-0 test right below) BEFORE this code ever runs, and
+# even bypassing Rule 0, build_element_body's own outer guard
+# (`!sn['column'].to_s.empty?`) requires a raw non-blank column before it will even
+# attempt build_summary_companion. So a literal '' can never reach the "companion
+# could not be built" branch this test targets. A second (non-KPI-triggering)
+# column keeps this off the Rule-0 path, and a whitespace-only column (' ') passes
+# the outer guard's raw `.empty?` check while still failing
+# build_summary_companion's stricter `.strip.empty?` check — genuinely exercising
+# "column present but not resolvable", exactly the case this test names.
+no_companion = build_element({ 'id' => 'c32', 'title' => 'Orders', 'chartType' => 'badge_table',
+                               'sigmaKindHint' => 'table',
+                               'columns' => [ { 'column' => 'order_id' },
+                                              { 'column' => 'amount', 'aggregation' => 'SUM' } ],
+                               'summaryNumber' => { 'column' => ' ', 'aggregation' => 'COUNT' } }, {})
+ok(!no_companion.nil?, 'primary element still built')
+eq($companion_elements.size, 0, 'no companion when the summary number has no resolvable column')
+ok($warnings.any? { |w| w['warning'].include?('NOT represented') }, 'still warns loudly on the unresolvable case (unchanged existing behavior)')
+
+puts "== bead 08sf: Rule 0 (summary IS the whole card) still short-circuits to a single " \
+     'KPI, no companion (unchanged) =='
+$warnings = []
+$companion_elements = []
+rule0 = build_element({ 'id' => 'c33', 'title' => 'One Number', 'chartType' => 'badge_table',
+                        'sigmaKindHint' => 'table', 'groupBy' => [], 'columns' => [{ 'column' => 'total', 'aggregation' => 'SUM' }],
+                        'summaryNumber' => { 'column' => 'total', 'aggregation' => 'SUM' } }, {})
+eq(rule0['kind'], 'kpi-chart', 'Rule 0 still routes straight to a single KPI')
+eq($companion_elements.size, 0, 'no companion is produced for a Rule-0 card (it IS the KPI, not a chart+companion)')
+
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -11,11 +11,15 @@ require 'tmpdir'
 # locally rather than suppressing warnings globally.
 def stub_const(name, value)
   target = Object
-  old = target.const_get(name) if target.const_defined?(name)
+  existed = target.const_defined?(name)
+  old = target.const_get(name) if existed
   silence_warnings { target.send(:remove_const, name) if target.const_defined?(name); target.const_set(name, value) }
   yield
 ensure
-  silence_warnings { target.send(:remove_const, name) if target.const_defined?(name); target.const_set(name, old) if old }
+  silence_warnings do
+    target.send(:remove_const, name) if target.const_defined?(name)
+    target.const_set(name, old) if existed
+  end
 end
 
 def silence_warnings
@@ -282,6 +286,19 @@ stub_const('DM_SPEC_PATH', '/nonexistent/dm-spec.json') do
     eq(dataset_element_map, {}, 'no dm-spec/dm-ids -> empty map, never an exception')
   end
 end
+
+puts "== stub_const restores a constant whose ORIGINAL value was falsy (nil), not just truthy ones =="
+# DM_IDS_PATH's real original value in THIS offline test run is nil (nothing sets
+# DOMO_DM_IDS_PATH in the environment) — exactly the real-world case that used to
+# defeat restore-on-`ensure`'s old `if old` guard (nil is falsy, so the constant was
+# left REMOVED rather than restored to nil).
+ok(Object.const_defined?(:DM_IDS_PATH), 'DM_IDS_PATH is defined before the stub (as nil, since DOMO_DM_IDS_PATH is unset)')
+eq(DM_IDS_PATH, nil, 'sanity: DM_IDS_PATH really is nil in this offline test env')
+stub_const('DM_IDS_PATH', '/tmp/whatever-dm-ids.json') do
+  eq(DM_IDS_PATH, '/tmp/whatever-dm-ids.json', 'stubbed value visible inside the block')
+end
+ok(Object.const_defined?(:DM_IDS_PATH), 'DM_IDS_PATH still defined after stub block exits (regression: used to vanish when the original value was nil/falsy)')
+eq(DM_IDS_PATH, nil, 'restored to its original nil value, not left undefined')
 
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -189,5 +189,33 @@ dims, meas = split_cols({ 'columns' => [ { 'column' => 'region', 'mapping' => 'I
 eq(dims.map { |c| c['column'] }, ['region'], 'ITEM-mapped column is a dimension even with no aggregation/groupBy present')
 eq(meas.map { |c| c['column'] }, ['revenue'], 'VALUE-mapped column is a measure even with no aggregation present (fails under the old aggregation-only heuristic)')
 
+puts "== bead 2ef7: card['limit'] -> Sigma top-n element filter (table) =="
+$warnings = []
+topn = build_element({ 'id' => 'c22', 'title' => 'Order Detail (Top 25)', 'chartType' => 'badge_table',
+                       'sigmaKindHint' => 'table', 'limit' => 25,
+                       'columns' => [ { 'column' => 'order_id' },
+                                      { 'column' => 'net_revenue', 'aggregation' => 'SUM', 'alias' => 'Net Revenue' } ] }, {})
+eq(topn['kind'], 'table', 'still a table element')
+ok(topn.key?('filters'), 'limit produced an element filter')
+eq(topn['filters'].first['kind'], 'top-n', 'filter kind is top-n')
+eq(topn['filters'].first['rankingFunction'], 'rank', 'rankingFunction is rank')
+eq(topn['filters'].first['mode'], 'top-n', 'mode is top-n')
+eq(topn['filters'].first['rowCount'], 25, 'rowCount carries the Domo limit as a NUMBER LITERAL')
+eq(topn['filters'].first['columnId'], topn['columns'].last['id'], 'ranks by the measure column (Net Revenue), not the dimension')
+
+puts "== bead 2ef7: no limit declared -> no filters key at all =="
+no_topn = build_element({ 'id' => 'c23', 'title' => 'All Orders', 'chartType' => 'badge_table',
+                          'sigmaKindHint' => 'table',
+                          'columns' => [ { 'column' => 'order_id' },
+                                         { 'column' => 'net_revenue', 'aggregation' => 'SUM' } ] }, {})
+ok(!no_topn.key?('filters'), 'no limit -> no filters key (never emit an empty/default top-n)')
+
+puts "== bead 2ef7: limit with no measure column -> no filter (nothing to rank by)" \
+     ' — never crash, never emit a columnId:nil filter =='
+no_measure = build_element({ 'id' => 'c24', 'title' => 'Dim Only', 'chartType' => 'badge_table',
+                             'sigmaKindHint' => 'table', 'limit' => 10,
+                             'columns' => [ { 'column' => 'order_id' } ] }, {})
+ok(!no_measure.key?('filters'), 'no measure column -> no top-n filter emitted')
+
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -3,6 +3,28 @@
 #   ruby test/test-build-workbook.rb
 
 require_relative '../scripts/build-workbook'
+require 'tmpdir'
+
+# Temporarily override a top-level constant for the duration of a block, then
+# ALWAYS restore it — even on assertion failure — mirroring the with_domo_stub
+# pattern in test-discover.rb. Ruby warns on constant reassignment; silence it
+# locally rather than suppressing warnings globally.
+def stub_const(name, value)
+  target = Object
+  old = target.const_get(name) if target.const_defined?(name)
+  silence_warnings { target.send(:remove_const, name) if target.const_defined?(name); target.const_set(name, value) }
+  yield
+ensure
+  silence_warnings { target.send(:remove_const, name) if target.const_defined?(name); target.const_set(name, old) if old }
+end
+
+def silence_warnings
+  old_verbose = $VERBOSE
+  $VERBOSE = nil
+  yield
+ensure
+  $VERBOSE = old_verbose
+end
 
 $failures = 0
 def eq(a, b, m) if a == b then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}\n    exp #{b.inspect}\n    got #{a.inspect}" end end
@@ -216,6 +238,50 @@ no_measure = build_element({ 'id' => 'c24', 'title' => 'Dim Only', 'chartType' =
                              'sigmaKindHint' => 'table', 'limit' => 10,
                              'columns' => [ { 'column' => 'order_id' } ] }, {})
 ok(!no_measure.key?('filters'), 'no measure column -> no top-n filter emitted')
+
+puts "== bead ziht: dataset_element_map resolves datasetId -> live DM element =="
+Dir.mktmpdir do |dir|
+  dm_spec_path = File.join(dir, 'dm-spec.json')
+  dm_ids_path  = File.join(dir, 'dm-ids.json')
+  File.write(dm_spec_path, JSON.generate('pages' => [{ 'elements' => [
+    { 'id' => 'el-fact-1', 'name' => 'Order Fact', '_datasetId' => 'ds-fact' },
+    { 'id' => 'el-dim-1',  'name' => 'Customer Dim', '_datasetId' => 'ds-dim' },
+  ] }]))
+  File.write(dm_ids_path, JSON.generate('dataModelId' => 'dm-live-1', 'pages' => [{ 'elements' => [
+    { 'id' => 'el-fact-1', 'name' => 'Order Fact', 'columnLabels' => ['Order Id', 'Region'] },
+    { 'id' => 'el-dim-1',  'name' => 'Customer Dim', 'columnLabels' => ['Customer Id', 'Segment'] },
+  ] }]))
+  stub_const('DM_SPEC_PATH', dm_spec_path) do
+    stub_const('DM_IDS_PATH', dm_ids_path) do
+      $ds_element_map = nil # force recompute against this dir's fixtures
+      map = dataset_element_map
+      eq(map.keys.sort, %w[ds-dim ds-fact], 'both datasets resolved')
+      eq(map['ds-dim']['id'], 'el-dim-1', 'ds-dim resolves to its own live element, not the fact')
+
+      $sub_masters = {}
+      sm = sub_master_for('ds-dim')
+      ok(!sm.nil?, 'sub-master built for a resolvable dataset')
+      eq(sm['kind'], 'table', 'sub-master is a table element')
+      eq(sm['visibleAsSource'], false, 'sub-master is hidden, like the primary master')
+      eq(sm['source'], { 'kind' => 'data-model', 'dataModelId' => 'dm-live-1', 'elementId' => 'el-dim-1' },
+         'sub-master sources the LIVE DM element for ds-dim, dataModelId included')
+      eq(sm['columns'].map { |c| c['name'] }, ['Customer Id', 'Segment'], 'auto-passthrough of the DM element\'s own columns')
+      eq(sm['columns'].first['formula'], '[Customer Dim/Customer Id]', 'column formula qualifies by the DM element\'s own name')
+
+      ok(sub_master_for('ds-dim').equal?(sm), 'memoized — a second call returns the SAME object, not a rebuild')
+      eq($ds_element_map.dig('ds-nope'), nil, 'unknown dataset -> nil, not an exception')
+      ok(sub_master_for('ds-nope').nil?, 'sub_master_for on an unresolvable dataset -> nil (caller falls back to today\'s skip)')
+    end
+  end
+end
+
+puts "== bead ziht: dataset_element_map degrades to {} when the inputs are absent (offline / unit-test default) =="
+stub_const('DM_SPEC_PATH', '/nonexistent/dm-spec.json') do
+  stub_const('DM_IDS_PATH', nil) do
+    $ds_element_map = nil
+    eq(dataset_element_map, {}, 'no dm-spec/dm-ids -> empty map, never an exception')
+  end
+end
 
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -300,5 +300,19 @@ end
 ok(Object.const_defined?(:DM_IDS_PATH), 'DM_IDS_PATH still defined after stub block exits (regression: used to vanish when the original value was nil/falsy)')
 eq(DM_IDS_PATH, nil, 'restored to its original nil value, not left undefined')
 
+puts "== bead 08sf: build_summary_companion mirrors build_kpi but with a distinct id =="
+kpi_card = { 'id' => 'c29', 'title' => 'Revenue by Channel',
+             'summaryNumber' => { 'column' => 'net_revenue', 'aggregation' => 'SUM', 'label' => 'Total Revenue' } }
+companion = build_summary_companion(kpi_card, {})
+ok(!companion.nil?, 'companion built when the summary number has a resolvable column')
+eq(companion['kind'], 'kpi-chart', 'companion is a kpi-chart element')
+eq(companion['name'], 'Total Revenue', 'companion carries the summary number\'s own label')
+eq(companion['id'], "#{eid(kpi_card)}-summary",
+   'companion id is the primary element\'s id + a -summary suffix (never collides with it)')
+
+no_col_card = { 'id' => 'c30', 'title' => 'Orders', 'summaryNumber' => { 'column' => '', 'aggregation' => 'COUNT' } }
+ok(build_summary_companion(no_col_card, {}).nil?,
+   'nil when the summary number has no resolvable column (mirrors build_kpi\'s own "return nil unless col")')
+
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -480,5 +480,30 @@ Dir.mktmpdir do |dir|
   end
 end
 
+puts "== bead 08sf follow-up (live-found 2026-07-31): build_kpi inlines an aggregate " \
+     'Beast Mode summary number instead of referencing a non-existent DM column =='
+$translated_bms = {
+  'calculation_margin' => { 'id' => 'calculation_margin', 'name' => 'Margin Pct',
+                            'class' => 'aggregate',
+                            'sigmaFormula' => 'If(Sum([Net Revenue]) = 0, 0, Sum([Gross Profit]) / Sum([Net Revenue]))' },
+}
+calc_kpi = build_kpi({ 'id' => 'c34', 'title' => 'Margin % by Channel',
+                       'summaryNumber' => { 'column' => 'Margin Pct', 'beastModeId' => 'calculation_margin',
+                                            '_isCalc' => true, 'label' => 'Margin Pct' } }, {})
+ok(!calc_kpi.nil?, 'KPI still built for an aggregate-calc summary number')
+eq(calc_kpi['columns'][0]['formula'],
+   'If(Sum([Master/Net Revenue]) = 0, 0, Sum([Master/Gross Profit]) / Sum([Master/Net Revenue]))',
+   'formula is the INLINED, masterized Beast Mode expression — NOT Sum([Master/Margin Pct]), ' \
+   'a column that does not exist and would 400 the whole workbook POST')
+eq(calc_kpi['value'], { 'columnId' => calc_kpi['columns'][0]['id'] }, "value.columnId matches the inlined column's own id")
+$translated_bms = nil
+
+puts "== bead 08sf follow-up: a kpi-overrides.json entry still bypasses Beast Mode inlining =="
+override_kpi = build_kpi({ 'id' => 'c34', 'title' => 'Margin % by Channel',
+                           'summaryNumber' => { 'column' => 'Margin Pct', 'beastModeId' => 'calculation_margin',
+                                                '_isCalc' => true } },
+                         { 'c34' => { 'column' => 'net_revenue', 'aggregation' => 'SUM' } })
+eq(override_kpi['columns'][0]['formula'], 'Sum([Master/Net Revenue])', 'override still wins over the calc inlining')
+
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -279,6 +279,36 @@ Dir.mktmpdir do |dir|
   end
 end
 
+puts "== live-found 2026-07-31: a NAMELESS DM element (build-dm.rb's rule 3 — no element-level " \
+     'name) still resolves a real sub-master formula, not "[/Col]" (an invalid, empty-table-name formula) =='
+Dir.mktmpdir do |dir|
+  dm_spec_path = File.join(dir, 'dm-spec.json')
+  dm_ids_path  = File.join(dir, 'dm-ids.json')
+  # Mirrors build-dm.rb's REAL output shape: no element-level `name`, plus the
+  # warehouse-table `source.path` build-workbook-spec.rb's own name-fallback
+  # already reads for the primary master.
+  File.write(dm_spec_path, JSON.generate('pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', '_datasetId' => 'ds-dim',
+      'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ CUSTOMER_DIM] } },
+  ] }]))
+  File.write(dm_ids_path, JSON.generate('dataModelId' => 'dm-live-1', 'pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', 'name' => nil, 'columnLabels' => ['Customer Id', 'Region'] },
+  ] }]))
+  stub_const('DM_SPEC_PATH', dm_spec_path) do
+    stub_const('DM_IDS_PATH', dm_ids_path) do
+      $ds_element_map = nil
+      $sub_masters = {}
+      sm = sub_master_for('ds-dim')
+      ok(!sm.nil?, 'sub-master still built for a nameless DM element')
+      eq(sm['name'], 'Master (CUSTOMER_DIM)', "falls back to the warehouse table's own name (last path segment), " \
+                                              'the SAME resolution build-workbook-spec.rb uses for the primary master')
+      eq(sm['columns'].first['formula'], '[CUSTOMER_DIM/Customer Id]',
+         'formula is correctly table-qualified — never "[/Customer Id]" (an invalid, empty-table-name formula ' \
+         'that would 400 the whole workbook POST)')
+    end
+  end
+end
+
 puts "== bead ziht: dataset_element_map degrades to {} when the inputs are absent (offline / unit-test default) =="
 stub_const('DM_SPEC_PATH', '/nonexistent/dm-spec.json') do
   stub_const('DM_IDS_PATH', nil) do

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -314,6 +314,20 @@ no_col_card = { 'id' => 'c30', 'title' => 'Orders', 'summaryNumber' => { 'column
 ok(build_summary_companion(no_col_card, {}).nil?,
    'nil when the summary number has no resolvable column (mirrors build_kpi\'s own "return nil unless col")')
 
+puts "== M1 (final review, minor): retarget_to_submaster! must NOT fabricate a 'source' key on " \
+     'an element that never had one (build_image) =='
+img_el = { 'id' => 'el-img1', 'kind' => 'image', 'url' => 'data:image/png;base64,AAAA' }
+sm_fixture = { 'id' => 'master-ds-dim', 'name' => 'Master (Customer Dim)' }
+retarget_to_submaster!(img_el, sm_fixture)
+ok(!img_el.key?('source'), "an image element (no 'source' key to begin with) still has none after retargeting " \
+                            '— no bogus source fabricated (M1)')
+eq(img_el['url'], 'data:image/png;base64,AAAA', "the image element's other fields are untouched")
+
+chart_el = { 'id' => 'el-c1', 'kind' => 'bar-chart', 'source' => { 'kind' => 'table', 'elementId' => 'master' } }
+retarget_to_submaster!(chart_el, sm_fixture)
+eq(chart_el['source'], { 'kind' => 'table', 'elementId' => 'master-ds-dim' },
+   'an element that DOES carry a source key still gets retargeted normally (unchanged behavior)')
+
 puts "== bead ziht: a card on a non-dominant DataSet routes to its own sub-master " \
      '(not skipped) once a live DM element is resolvable =='
 Dir.mktmpdir do |dir|
@@ -415,6 +429,56 @@ rule0 = build_element({ 'id' => 'c33', 'title' => 'One Number', 'chartType' => '
                         'summaryNumber' => { 'column' => 'total', 'aggregation' => 'SUM' } }, {})
 eq(rule0['kind'], 'kpi-chart', 'Rule 0 still routes straight to a single KPI')
 eq($companion_elements.size, 0, 'no companion is produced for a Rule-0 card (it IS the KPI, not a chart+companion)')
+
+puts "== C1 (final review, Critical): a ROUTED card whose PRIMARY element fails to build " \
+     'must NOT leak its companion KPI un-retargeted into $companion_elements =='
+Dir.mktmpdir do |dir|
+  dm_spec_path = File.join(dir, 'dm-spec.json')
+  dm_ids_path  = File.join(dir, 'dm-ids.json')
+  File.write(dm_spec_path, JSON.generate('pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', 'name' => 'Customer Dim', '_datasetId' => 'ds-dim' },
+  ] }]))
+  File.write(dm_ids_path, JSON.generate('dataModelId' => 'dm-live-1', 'pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', 'name' => 'Customer Dim', 'columnLabels' => ['Region', 'Segment'] },
+  ] }]))
+  stub_const('DM_SPEC_PATH', dm_spec_path) do
+    stub_const('DM_IDS_PATH', dm_ids_path) do
+      $ds_element_map = nil
+      $sub_masters = {}
+      $warnings = []
+      $companion_elements = []
+      before_companions = $companion_elements.length
+
+      # Routed to ds-dim's sub-master (resolvable, per the fixture above), so
+      # this DOES take the routing path (not the warn+SKIP "unresolvable
+      # DataSet" fallback). Two non-aggregated dimension columns (no
+      # 'aggregation', no groupBy/mapping signal) means split_cols resolves
+      # ZERO measures, so build_axis_chart's own "could not resolve both a
+      # dimension and a measure" guard fires and returns nil for the PRIMARY
+      # element — while the card ALSO carries a resolvable summaryNumber, so
+      # build_element_body has a companion ready to go before it discovers
+      # the primary failed.
+      failed = build_element({ 'id' => 'c34', 'title' => 'Customers (no measure)', 'chartType' => 'badge_vert_bar',
+                               'datasetId' => 'ds-dim',
+                               'columns' => [ { 'column' => 'region' }, { 'column' => 'segment' } ],
+                               'summaryNumber' => { 'column' => 'net_revenue', 'aggregation' => 'SUM',
+                                                    'label' => 'Total Revenue' } },
+                             {}, 'ds-fact')
+
+      ok(failed.nil?, 'build_element still returns nil when the routed primary element failed to build')
+      eq($companion_elements.length, before_companions,
+         '$companion_elements did NOT grow — the companion built during the failed attempt was ' \
+         'dropped, never leaked un-retargeted against the shared master (C1)')
+
+      # M3: the warning sequence must not claim a companion "represents" a
+      # card whose primary element was actually dropped.
+      ok(!$warnings.any? { |w| w['warning'].include?('ALSO represented') },
+         'the misleading "ALSO represented" warning does NOT fire when the primary failed to build (M3)')
+      ok($warnings.any? { |w| w['warning'].include?('was NOT emitted') && w['warning'].include?('failed to build') },
+         'a warning explains the companion was dropped BECAUSE the primary failed (M3)')
+    end
+  end
+end
 
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -328,6 +328,19 @@ retarget_to_submaster!(chart_el, sm_fixture)
 eq(chart_el['source'], { 'kind' => 'table', 'elementId' => 'master-ds-dim' },
    'an element that DOES carry a source key still gets retargeted normally (unchanged behavior)')
 
+puts "== live-found 2026-07-31: retarget_to_submaster! must not raise FrozenError on a " \
+     'shared frozen constant (AXIS_OFF) nested inside an axis-chart element =='
+axis_el = { 'id' => 'el-axis1', 'kind' => 'bar-chart',
+            'source' => { 'kind' => 'table', 'elementId' => 'master' },
+            'columns' => [{ 'id' => 'd-region', 'formula' => '[Master/Region]' }],
+            'xAxis' => { 'columnId' => 'd-region', 'format' => AXIS_OFF },
+            'yAxis' => { 'columnIds' => ['m-count'], 'format' => AXIS_OFF } }
+retarget_to_submaster!(axis_el, sm_fixture)
+ok(true, 'retargeting an element referencing the frozen AXIS_OFF constant does not raise FrozenError')
+eq(axis_el['columns'].first['formula'], '[Master (Customer Dim)/Region]', 'the real formula ref is still rewritten')
+eq(axis_el['xAxis']['format'], AXIS_OFF, "the frozen shared format hash is left as-is (never a rewrite target)")
+ok(AXIS_OFF.frozen?, 'sanity: AXIS_OFF itself is still frozen (unmutated) after being walked')
+
 puts "== bead ziht: a card on a non-dominant DataSet routes to its own sub-master " \
      '(not skipped) once a live DM element is resolvable =='
 Dir.mktmpdir do |dir|

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-discover.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-discover.rb
@@ -94,6 +94,7 @@ shape_a = {
     'groupBy' => [{ 'column' => 'store_region' }],
     'orderBy' => [{ 'column' => 'sales_amount' }],
     'filters' => [{ 'column' => 'status', 'operand' => 'IN', 'values' => %w[Active Pending] }],
+    'limit' => 25,
   },
   'summaryNumber' => { 'columns' => [{ 'column' => 'sales_amount', 'aggregation' => 'SUM',
                                        'alias' => 'Total Revenue', 'format' => { 'type' => 'CURRENCY' } }] },
@@ -114,6 +115,7 @@ eq(a['summaryNumber']['aggregation'], 'SUM', 'summary number aggregation')
 eq(a['summaryNumber']['label'], 'Total Revenue', 'summary number label from alias')
 eq(a['summaryNumber']['_defaultCountSuspect'], false, 'SUM is not a COUNT-of-id suspect')
 eq(a['cardFormulas'].size, 1, 'card-local formula captured')
+eq(a['limit'], 25, 'limit carried through Shape A normalization (bead 2ef7)')
 
 puts "== normalize_card: Shape B =="
 shape_b = {
@@ -128,6 +130,7 @@ shape_b = {
       'filters' => [{ 'column' => 'region', 'filterType' => 'IN', 'values' => ['West'] }],
       'groupBy' => [{ 'column' => 'project_id' }],
       'orderBy' => [{ 'column' => 'project_id' }],
+      'limit' => 25,
     } },
     'formulas' => [{ 'id' => 'calculation_xyz', 'name' => 'Days Open', 'formula' => 'DATEDIFF(`close`,`open`)' }],
     'conditionalFormats' => [{ 'condition' => { 'column' => 'x' }, 'format' => {} }],
@@ -141,6 +144,11 @@ eq(b['columns'][1]['beastModeId'], 'calculation_xyz', 'beastModeId joined via ca
 eq(b['filters'], [{ 'column' => 'region', 'operator' => 'IN', 'values' => ['West'] }], 'filter normalized (filterType→operator)')
 eq(b['groupBy'], ['project_id'], 'groupBy flattened (Shape B)')
 eq(b['cardFormulas'].first['name'], 'Days Open', 'card formulas from definition.formulas')
+eq(b['limit'], 25, 'limit carried through Shape B normalization (bead 2ef7)')
+
+puts "== normalize_card: no limit declared -> key absent, not zero =="
+no_limit = normalize_card({ 'chartType' => 'badge_table', 'chartBody' => { 'columns' => [{ 'column' => 'x' }] } }, 'card-C')
+ok(!no_limit.key?('limit'), 'no limit key when the source declared none (compact drops nil, never defaults to 0)')
 
 puts "== norm_summary_number: COUNT-of-id trap =="
 sn = norm_summary_number({ 'columns' => [{ 'column' => 'project_id', 'aggregation' => 'COUNT' }] })

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -128,6 +128,29 @@ Dir.mktmpdir('migrate-domo-e2e') do |out_dir|
      "kpi-chart element count (#{kpi_els.size}) is one more than the #{rule0_kpi_cards} genuine Rule-0 " \
      'KPI card(s) — a companion KPI was emitted for the non-KPI card carrying a summaryNumber (bead 08sf)')
 
+  # Tightened per the final review (I2): a bare count bump could silently
+  # absorb an unrelated spurious KPI from a different bug. Assert the
+  # SPECIFIC companion element (id ends '-summary') is present, not just that
+  # the total moved by one.
+  companion_el = kpi_els.find { |e| e['id'].to_s.end_with?('-summary') }
+  ok(companion_el, "workbook-spec.json contains the SPECIFIC companion KPI element (id ending " \
+                   "'-summary'), not just an incidental kpi-chart count bump (bead 08sf)")
+
+  # ---- (g) final review Important I1/I2: the companion KPI element's id ---
+  # must appear in the MERGED <Page> layout XML, not just the element tree —
+  # otherwise it is present in the spec but never actually rendered on the
+  # migrated page (exactly what I1 found: build-domo-layout.rb derived zones
+  # from cards.json, and a companion's "-summary" id matches no card). Fixed
+  # via build-domo-layout.rb's load_chart_specs_companions + a
+  # pseudo-card synthesis, mirroring the pre-existing orphan-control pattern
+  # (see build-domo-layout.rb) — confirm it landed by checking the companion's
+  # own element id shows up as a LayoutElement's elementId= attribute.
+  if companion_el
+    ok(spec['layout'].to_s.include?(%(elementId="#{companion_el['id']}")),
+       "the companion KPI element '#{companion_el['id']}' has its OWN LayoutElement zone in the " \
+       'merged layout XML — it is placed on the page, not just present in the element tree (I1 fix)')
+  end
+
   # ---- idempotency: a second run with no --force is a no-op (all skip) --
   cmd2 = ['ruby', File.join(SCRIPTS, 'migrate-domo.rb'), '--offline', FIXTURE, '--out', out_dir]
   output2 = IO.popen(cmd2, err: [:child, :out], &:read)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -37,6 +37,12 @@ ok(cards.any? { |c| c['sigmaKindHint'] == 'kpi-chart' }, 'sanity: fixture cards.
 ok(cards.any? { |c| c['chartType'].to_s == 'image' }, 'sanity: fixture cards.json includes an image card')
 ok(File.exist?(File.join(FIXTURE, 'png', 'cards', 'img1.png')), 'sanity: fixture stages png/cards/img1.png for the image card')
 ok(cards.map { |c| c['x'] }.uniq.size >= 3, 'sanity: fixture geometry spans >= 3 distinct x values (a real 2D layout, not a stack)')
+ok(cards.any? { |c| c['limit'].to_i.positive? }, 'sanity: fixture cards.json includes a card with a row limit (bead 2ef7)')
+ok(cards.any? { |c| c['datasetId'] == 'ds-dim' }, 'sanity: fixture cards.json includes a card bound to a non-dominant DataSet (bead ziht)')
+ok(cards.any? { |c| c['summaryNumber'] && !Array(c['groupBy']).empty? },
+   'sanity: fixture cards.json includes a non-Rule-0 card (real grouping) that ALSO carries a summaryNumber (bead 08sf)')
+ok(File.exist?(File.join(FIXTURE, 'dm-spec.json')), 'sanity: fixture stages dm-spec.json (build-dm.rb pre-post shape) for the ds-dim sub-master')
+ok(File.exist?(File.join(FIXTURE, 'dm-ids.json')), 'sanity: fixture stages dm-ids.json (synthesized post-and-readback) for the ds-dim sub-master')
 
 Dir.mktmpdir('migrate-domo-e2e') do |out_dir|
   cmd = ['ruby', File.join(SCRIPTS, 'migrate-domo.rb'), '--offline', FIXTURE, '--out', out_dir]
@@ -89,6 +95,38 @@ Dir.mktmpdir('migrate-domo-e2e') do |out_dir|
        "KPI formula is <Agg>([Master/...]) — got #{formula.inspect}")
     ok(kpi_el.dig('value', 'columnId') == kpi_el.dig('columns', 0, 'id'), 'KPI value binds via value.columnId (not id)')
   end
+
+  # ---- (d) bead 2ef7: card['limit'] -> an element-level top-n filter -----
+  topn_el = all_elements.find { |e| e.dig('filters', 0, 'kind') == 'top-n' }
+  ok(topn_el, 'workbook-spec.json contains an element with a top-n filter (bead 2ef7)')
+  if topn_el
+    eq(topn_el.dig('filters', 0, 'rowCount'), 10, "top-n filter's rowCount matches the card's limit (10)")
+  end
+
+  # ---- (e) bead ziht: a card on a non-dominant DataSet (ds-dim) routes to --
+  # its own hidden sub-master (master-<dataset>), not the shared master, and
+  # that sub-master element appears exactly once under the Data page.
+  data_page = spec['pages'].find { |p| p['id'] == 'page-data' || p['name'] == 'Data' }
+  ok(data_page, 'workbook-spec.json has a Data page')
+  submaster_el = all_elements.find { |e| e.dig('source', 'elementId').to_s.start_with?('master-') }
+  ok(submaster_el, "workbook-spec.json contains an element sourced from a per-dataset sub-master " \
+                   "(bead ziht) — got source #{submaster_el && submaster_el['source']}")
+  if submaster_el && data_page
+    sm_id = submaster_el.dig('source', 'elementId')
+    on_data_page = Array(data_page['elements']).select { |e| e['id'] == sm_id }
+    eq(on_data_page.size, 1, "the sub-master '#{sm_id}' appears exactly once under the Data page")
+  end
+
+  # ---- (f) bead 08sf: a companion kpi-chart element for a card whose ------
+  # Summary Number is NOT the whole card (i.e. not a Rule-0 KPI card).
+  kpi_els = all_elements.select { |e| e['kind'] == 'kpi-chart' }
+  rule0_kpi_cards = cards.count do |c|
+    c['sigmaKindHint'] == 'kpi-chart' ||
+      (c['summaryNumber'] && Array(c['groupBy']).empty? && (c['columns'] || []).size <= 1)
+  end
+  eq(kpi_els.size, rule0_kpi_cards + 1,
+     "kpi-chart element count (#{kpi_els.size}) is one more than the #{rule0_kpi_cards} genuine Rule-0 " \
+     'KPI card(s) — a companion KPI was emitted for the non-KPI card carrying a summaryNumber (bead 08sf)')
 
   # ---- idempotency: a second run with no --force is a no-op (all skip) --
   cmd2 = ['ruby', File.join(SCRIPTS, 'migrate-domo.rb'), '--offline', FIXTURE, '--out', out_dir]


### PR DESCRIPTION
## What & why

Follow-up to #575 (Track B: top-n limit, multi-dataset routing, companion KPI). While running the live parity gate against all three `Orders Overview/Analysis/Executive` tier pages (`docs/handoff/2026-07-31-domo-to-gold.md`), three real bugs surfaced that no offline test had exercised — all found via an actual live `migrate-domo.rb` run, each fixed with a regression test before continuing:

1. **`build_kpi` didn't inline an aggregate Beast Mode summary number.** Unlike `measure_col`, it always emitted `Agg([Master/<col>])`, never checking `sn['_isCalc']`. A KPI (or bead 08sf's companion KPI) bound to an aggregate calc like "Margin Pct" emitted `Sum([Master/Margin Pct])` — a column that doesn't exist — 400ing the whole workbook POST. Hit by Tier 2's "Margin % by Channel" companion.
2. **`retarget_to_submaster!` mutated a shared frozen constant.** `AXIS_OFF` (`{'marks'=>'none'}.freeze`) is referenced by every axis-chart element's xAxis/yAxis format; the retargeting walk tried to reassign into it, raising `FrozenError`. Hit by Tier 3's first ziht-routed axis-chart card ("Customers by Region").
3. **`sub_master_for` never resolved a nameless DM element's server-assigned name.** `build-dm.rb` sets no element-level `name` (by design); `build-workbook-spec.rb` already has a fallback for this (server assigns a name by kind — the warehouse table's last path segment) for the *primary* master, but `sub_master_for` had no equivalent, so it emitted `[/Phone]` (an invalid, empty-table-name formula) for the Customer Dim sub-master. Also hit by Tier 3.

Bumps `domo-to-sigma` 0.8.0 → 0.8.1 (bug fixes, no new features).

## Live evidence

All three tier pages now reach `assert-phase6-ran.rb` exit 0 (1/2 waiver budget used each, all `visual-divergent` — pre-existing, out-of-scope palette/number-format/marker gaps, not touched by this PR):
- Tier 1 (`Orders Overview`) — workbook `6e5c9eb5-e1cf-492c-a110-c8d74eca086f`
- Tier 2 (`Orders Analysis`) — workbook `84041c96-555f-4ecd-b92a-2f637950f43c` — "Order Detail (Top 25)" table footer reads "25 rows – 6 columns" (bead 2ef7 confirmed limiting, not just present in spec)
- Tier 3 (`Orders Executive`) — workbook `d957032f-2f22-4c40-b9e7-511faef37b40` — "Customers by Region" (sourced from the Customer Dim dataset via bead ziht's sub-master routing) renders with an exact value match to the Domo source (South=8, West=9, Midwest=4, Northeast=4, total 25)

## Scope

- Plugin(s) touched: `domo-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green (no shared-lib files touched)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (20/20, all plugins); domo cases reconverted and pass (2/2)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in (`git status` clean)
- [x] Bumped `domo-to-sigma`'s `plugin.json` version 0.8.0 → 0.8.1 (strict semver ↑)

🤖 Generated with [Claude Code](https://claude.com/claude-code)