### PR TITLE
domo-to-sigma: fix 3 bugs found during the Track B live parity run

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -383,13 +383,22 @@ def build_kpi(card, overrides)
   disp = display_name(col)
   label = (sn['label'] && !sn['label'].to_s.strip.empty?) ? sn['label'] : disp
   vid = mcol_id(disp).sub(/\Am-/, 'v-')
+  # LIVE-VALIDATED FIX (2026-07-31): an aggregate/window Beast Mode summary
+  # number is not a data-model column — mirrors measure_col's own
+  # inline_beast_mode_measure handling. Without this, a KPI (or bead 08sf's
+  # companion KPI, which calls build_kpi for a card whose summary is bound to
+  # an aggregate calc like "Margin Pct") emitted Sum([Master/Margin Pct]), a
+  # column that does not exist, 400ing the ENTIRE workbook POST. Only applies
+  # when NOT overridden — a kpi-overrides.json entry points at a real column.
+  value_col = (!ov && sn['_isCalc'] && inline_beast_mode_measure(card, sn)) ||
+              { 'id' => vid, 'name' => label,
+                'formula' => "#{sigma_agg(agg, sn['distinct'])}(#{mref(disp)})",
+                'format' => sigma_format(sn['format'], label) }.compact
   {
     'id' => eid(card), 'kind' => 'kpi-chart', 'name' => label,
     'source' => { 'kind' => 'table', 'elementId' => 'master' },
-    'columns' => [{ 'id' => vid, 'name' => label,
-                    'formula' => "#{sigma_agg(agg, sn['distinct'])}(#{mref(disp)})",
-                    'format' => sigma_format(sn['format'], label) }.compact],
-    'value' => { 'columnId' => vid },   # ⚠ columnId, NOT id (feedback_sigma_kpi_value_columnid)
+    'columns' => [value_col],
+    'value' => { 'columnId' => value_col['id'] },   # ⚠ columnId, NOT id (feedback_sigma_kpi_value_columnid)
   }
 end
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -74,13 +74,36 @@ def dataset_element_map
   return $ds_element_map = {} unless dm_spec && dm_ids
 
   ds_by_el_id = {}
+  # LIVE-VALIDATED FIX (2026-07-31): build-dm.rb never sets an element-level
+  # `name` (rule 3), so the live readback's own `name` is null for both the
+  # primary master AND every other DM element. build-workbook-spec.rb already
+  # resolves this fallback for the ONE element it picks as the primary master
+  # (server assigns a name by kind: the warehouse table's last path segment,
+  # else "Custom SQL") — sub_master_for needs the identical resolution for
+  # every OTHER element, or its column formulas emit "[/Col]" (an empty table
+  # name — verified live against a nameless Customer Dim element: Sigma
+  # rejected "[/Phone]" as an invalid formula, which would 400 the whole
+  # workbook POST).
+  name_by_el_id = {}
   (dm_spec['pages'] || []).each do |p|
-    (p['elements'] || []).each { |e| ds_by_el_id[e['id']] = e['_datasetId'] if e['_datasetId'] }
+    (p['elements'] || []).each do |e|
+      ds_by_el_id[e['id']] = e['_datasetId'] if e['_datasetId']
+      src = e['source'] || {}
+      name_by_el_id[e['id']] =
+        if src['kind'] == 'warehouse-table' && !Array(src['path']).empty?
+          Array(src['path']).last
+        else
+          'Custom SQL'
+        end
+    end
   end
   map = {}
   (dm_ids['pages'] || []).flat_map { |p| p['elements'] || [] }.each do |e|
     ds_id = ds_by_el_id[e['id']]
-    map[ds_id] = e if ds_id && !map.key?(ds_id)
+    next unless ds_id && !map.key?(ds_id)
+    resolved = e.dup
+    resolved['name'] = name_by_el_id[e['id']] if e['name'].to_s.strip.empty?
+    map[ds_id] = resolved
   end
   $ds_element_map = map
 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -847,8 +847,15 @@ def retarget_to_submaster!(el, sm)
   el['source'] = { 'kind' => 'table', 'elementId' => sm['id'] } if el.key?('source')
   walk = lambda do |n|
     case n
-    when Hash   then n.each { |k, v| n[k] = walk.call(v) }
-    when Array  then n.map! { |v| walk.call(v) }
+    # LIVE-VALIDATED FIX (2026-07-31): AXIS_OFF ({'marks'=>'none'}.freeze) is a
+    # shared frozen constant referenced by every axis-chart element's
+    # xAxis/yAxis 'format' — mutating it in place raised FrozenError the first
+    # time this routed an axis-chart card (Domo page 'Orders Executive',
+    # "Customers by Region"). A frozen Hash/Array in this codebase is always
+    # static shared config, never a dynamic [Master/...] reference, so it's
+    # always safe to leave it untouched rather than walk into it.
+    when Hash   then (n.frozen? ? n : n.each { |k, v| n[k] = walk.call(v) })
+    when Array  then (n.frozen? ? n : n.map! { |v| walk.call(v) })
     when String then n.gsub('[Master/', "[#{sm['name']}/")
     else n
     end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -480,5 +480,30 @@ Dir.mktmpdir do |dir|
   end
 end
 
+puts "== bead 08sf follow-up (live-found 2026-07-31): build_kpi inlines an aggregate " \
+     'Beast Mode summary number instead of referencing a non-existent DM column =='
+$translated_bms = {
+  'calculation_margin' => { 'id' => 'calculation_margin', 'name' => 'Margin Pct',
+                            'class' => 'aggregate',
+                            'sigmaFormula' => 'If(Sum([Net Revenue]) = 0, 0, Sum([Gross Profit]) / Sum([Net Revenue]))' },
+}
+calc_kpi = build_kpi({ 'id' => 'c34', 'title' => 'Margin % by Channel',
+                       'summaryNumber' => { 'column' => 'Margin Pct', 'beastModeId' => 'calculation_margin',
+                                            '_isCalc' => true, 'label' => 'Margin Pct' } }, {})
+ok(!calc_kpi.nil?, 'KPI still built for an aggregate-calc summary number')
+eq(calc_kpi['columns'][0]['formula'],
+   'If(Sum([Master/Net Revenue]) = 0, 0, Sum([Master/Gross Profit]) / Sum([Master/Net Revenue]))',
+   'formula is the INLINED, masterized Beast Mode expression — NOT Sum([Master/Margin Pct]), ' \
+   'a column that does not exist and would 400 the whole workbook POST')
+eq(calc_kpi['value'], { 'columnId' => calc_kpi['columns'][0]['id'] }, "value.columnId matches the inlined column's own id")
+$translated_bms = nil
+
+puts "== bead 08sf follow-up: a kpi-overrides.json entry still bypasses Beast Mode inlining =="
+override_kpi = build_kpi({ 'id' => 'c34', 'title' => 'Margin % by Channel',
+                           'summaryNumber' => { 'column' => 'Margin Pct', 'beastModeId' => 'calculation_margin',
+                                                '_isCalc' => true } },
+                         { 'c34' => { 'column' => 'net_revenue', 'aggregation' => 'SUM' } })
+eq(override_kpi['columns'][0]['formula'], 'Sum([Master/Net Revenue])', 'override still wins over the calc inlining')
+
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -279,6 +279,36 @@ Dir.mktmpdir do |dir|
   end
 end
 
+puts "== live-found 2026-07-31: a NAMELESS DM element (build-dm.rb's rule 3 — no element-level " \
+     'name) still resolves a real sub-master formula, not "[/Col]" (an invalid, empty-table-name formula) =='
+Dir.mktmpdir do |dir|
+  dm_spec_path = File.join(dir, 'dm-spec.json')
+  dm_ids_path  = File.join(dir, 'dm-ids.json')
+  # Mirrors build-dm.rb's REAL output shape: no element-level `name`, plus the
+  # warehouse-table `source.path` build-workbook-spec.rb's own name-fallback
+  # already reads for the primary master.
+  File.write(dm_spec_path, JSON.generate('pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', '_datasetId' => 'ds-dim',
+      'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ CUSTOMER_DIM] } },
+  ] }]))
+  File.write(dm_ids_path, JSON.generate('dataModelId' => 'dm-live-1', 'pages' => [{ 'elements' => [
+    { 'id' => 'el-dim-1', 'name' => nil, 'columnLabels' => ['Customer Id', 'Region'] },
+  ] }]))
+  stub_const('DM_SPEC_PATH', dm_spec_path) do
+    stub_const('DM_IDS_PATH', dm_ids_path) do
+      $ds_element_map = nil
+      $sub_masters = {}
+      sm = sub_master_for('ds-dim')
+      ok(!sm.nil?, 'sub-master still built for a nameless DM element')
+      eq(sm['name'], 'Master (CUSTOMER_DIM)', "falls back to the warehouse table's own name (last path segment), " \
+                                              'the SAME resolution build-workbook-spec.rb uses for the primary master')
+      eq(sm['columns'].first['formula'], '[CUSTOMER_DIM/Customer Id]',
+         'formula is correctly table-qualified — never "[/Customer Id]" (an invalid, empty-table-name formula ' \
+         'that would 400 the whole workbook POST)')
+    end
+  end
+end
+
 puts "== bead ziht: dataset_element_map degrades to {} when the inputs are absent (offline / unit-test default) =="
 stub_const('DM_SPEC_PATH', '/nonexistent/dm-spec.json') do
   stub_const('DM_IDS_PATH', nil) do

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -328,6 +328,19 @@ retarget_to_submaster!(chart_el, sm_fixture)
 eq(chart_el['source'], { 'kind' => 'table', 'elementId' => 'master-ds-dim' },
    'an element that DOES carry a source key still gets retargeted normally (unchanged behavior)')
 
+puts "== live-found 2026-07-31: retarget_to_submaster! must not raise FrozenError on a " \
+     'shared frozen constant (AXIS_OFF) nested inside an axis-chart element =='
+axis_el = { 'id' => 'el-axis1', 'kind' => 'bar-chart',
+            'source' => { 'kind' => 'table', 'elementId' => 'master' },
+            'columns' => [{ 'id' => 'd-region', 'formula' => '[Master/Region]' }],
+            'xAxis' => { 'columnId' => 'd-region', 'format' => AXIS_OFF },
+            'yAxis' => { 'columnIds' => ['m-count'], 'format' => AXIS_OFF } }
+retarget_to_submaster!(axis_el, sm_fixture)
+ok(true, 'retargeting an element referencing the frozen AXIS_OFF constant does not raise FrozenError')
+eq(axis_el['columns'].first['formula'], '[Master (Customer Dim)/Region]', 'the real formula ref is still rewritten')
+eq(axis_el['xAxis']['format'], AXIS_OFF, "the frozen shared format hash is left as-is (never a rewrite target)")
+ok(AXIS_OFF.frozen?, 'sanity: AXIS_OFF itself is still frozen (unmutated) after being walked')
+
 puts "== bead ziht: a card on a non-dominant DataSet routes to its own sub-master " \
      '(not skipped) once a live DM element is resolvable =='
 Dir.mktmpdir do |dir|


### PR DESCRIPTION
## What & why

Follow-up to #575 (Track B: top-n limit, multi-dataset routing, companion KPI). While running the live parity gate against all three `Orders Overview/Analysis/Executive` tier pages (`docs/handoff/2026-07-31-domo-to-gold.md`), three real bugs surfaced that no offline test had exercised — all found via an actual live `migrate-domo.rb` run, each fixed with a regression test before continuing:

1. **`build_kpi` didn't inline an aggregate Beast Mode summary number.** Unlike `measure_col`, it always emitted `Agg([Master/<col>])`, never checking `sn['_isCalc']`. A KPI (or bead 08sf's companion KPI) bound to an aggregate calc like "Margin Pct" emitted `Sum([Master/Margin Pct])` — a column that doesn't exist — 400ing the whole workbook POST. Hit by Tier 2's "Margin % by Channel" companion.
2. **`retarget_to_submaster!` mutated a shared frozen constant.** `AXIS_OFF` (`{'marks'=>'none'}.freeze`) is referenced by every axis-chart element's xAxis/yAxis format; the retargeting walk tried to reassign into it, raising `FrozenError`. Hit by Tier 3's first ziht-routed axis-chart card ("Customers by Region").
3. **`sub_master_for` never resolved a nameless DM element's server-assigned name.** `build-dm.rb` sets no element-level `name` (by design); `build-workbook-spec.rb` already has a fallback for this (server assigns a name by kind — the warehouse table's last path segment) for the *primary* master, but `sub_master_for` had no equivalent, so it emitted `[/Phone]` (an invalid, empty-table-name formula) for the Customer Dim sub-master. Also hit by Tier 3.

Bumps `domo-to-sigma` 0.8.0 → 0.8.1 (bug fixes, no new features).

**Note on branch history:** this supersedes #577, which was closed unmerged — that branch continued directly off the already-squash-merged #575, which produced spurious merge conflicts against `main` (git's merge-base resolves to the wrong ancestor once a squash-merge lands). This PR carries the identical 4 commits cherry-picked onto a fresh branch off current `origin/main`, verified conflict-free.

## Live evidence

All three tier pages now reach `assert-phase6-ran.rb` exit 0 (1/2 waiver budget used each, all `visual-divergent` — pre-existing, out-of-scope palette/number-format/marker gaps, not touched by this PR):
- Tier 1 (`Orders Overview`) — workbook `6e5c9eb5-e1cf-492c-a110-c8d74eca086f`
- Tier 2 (`Orders Analysis`) — workbook `84041c96-555f-4ecd-b92a-2f637950f43c` — "Order Detail (Top 25)" table footer reads "25 rows – 6 columns" (bead 2ef7 confirmed limiting, not just present in spec)
- Tier 3 (`Orders Executive`) — workbook `d957032f-2f22-4c40-b9e7-511faef37b40` — "Customers by Region" (sourced from the Customer Dim dataset via bead ziht's sub-master routing) renders with an exact value match to the Domo source (South=8, West=9, Midwest=4, Northeast=4, total 25)

## Scope

- Plugin(s) touched: `domo-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green (no shared-lib files touched)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (20/20, all plugins); domo cases reconverted and pass (2/2)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in (`git status` clean)
- [x] Bumped `domo-to-sigma`'s `plugin.json` version 0.8.0 → 0.8.1 (strict semver ↑)

🤖 Generated with [Claude Code](https://claude.com/claude-code)