### PR TITLE
chore(qlik): re-vendor converter — literal masking + lookup declutter (mcp#120, #121)

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -165,6 +165,23 @@ jobs:
         run: |
           if [ -z "${RANGE_BASE:-}" ]; then echo "no diff range to check — skipping"; exit 0; fi
           bash tools/check-converter-provenance.sh "$RANGE_BASE" "$RANGE_HEAD"
+      - name: Converter-freshness guard (vendored-bundle staleness by age)
+        # Standing gate, NOT diff-scoped (unlike the pairing guard above, this
+        # runs every time regardless of RANGE_BASE): a merge to
+        # sigma-data-model-mcp changes nothing for any operator until someone
+        # runs tools/vendor-converters.sh and commits the regenerated bundle,
+        # and pre-existing drift nobody re-vendored in a long time has no diff
+        # to catch it on. CI cannot assume network access to that private repo,
+        # so this grades staleness by the AGE of each PROVENANCE.json's own
+        # source_commit_date (default threshold 14d, CONVERTER_STALENESS_DAYS)
+        # rather than asking upstream what's new — see the header comment in
+        # tools/check-converter-provenance.sh for the full trade-off. cognos-to-sigma
+        # vendors its own converter/*.ts in-skill (no source_repo/source_commit
+        # by design) and is reported explicitly as not-applicable, not flagged
+        # stale; its own freshness gate is tools/check-cognos-bundle.rb below.
+        # A STALE verdict that carries local_patches gets a note pointing at
+        # porting those patches upstream first, never "just re-vendor blind".
+        run: bash tools/check-converter-provenance.sh --freshness "$RANGE_HEAD"
       - name: Plugin-version-bump guard (release-hygiene diff gate)
         # #486: a change under plugins/<name>/** must move that plugin's
         # plugin.json "version" (strict semver) so `claude plugin update` sees a
@@ -194,7 +211,12 @@ jobs:
         # Proves the diff-pairing guard fails unpaired bundle changes, passes
         # paired ones, and schema-pins local_patches entries — plus the
         # string-pin on the real tableau PROVENANCE.json (synthetic fixture
-        # names only).
+        # names only). Also proves the --freshness staleness-by-age gate
+        # (Part E) fails a 40d-stale fixture and passes the same fixture
+        # dated today, reports an in-skill/cognos-shaped entry explicitly
+        # rather than silently, and surfaces the local_patches
+        # don't-re-vendor-blind note; plus --online's soft-pass when no local
+        # checkout is present (Part F).
         run: bash tools/test-converter-provenance.sh
       - name: Plugin-version-bump guard self-test (fixture repos, creds-free)
         # Proves the version-bump gate fails an unbumped plugin change, passes a

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.2.8",
+  "version": "1.3.0",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/converter/PROVENANCE.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/converter/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "867c669",
-  "source_commit_date": "2026-06-22",
+  "source_commit": "2f8c6cd",
+  "source_commit_date": "2026-07-31",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "qlik.mjs",
   "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/converter/qlik.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/converter/qlik.mjs
@@ -1,6 +1,25 @@
-// ../../../Users/tjwells/sigma-data-model-mcp/build/sigma-ids.js
+// ../mcp-fresh/build/sigma-ids.js
 var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 var _usedIds = /* @__PURE__ */ new Set();
+var _idCounter = 0;
+function encodeBase62(n, len) {
+  let x = n, s = "";
+  while (x > 0) {
+    s = SIGMA_CHARS[x % 62] + s;
+    x = Math.floor(x / 62);
+  }
+  return s.padStart(len, SIGMA_CHARS[0]);
+}
+function fnv1a32(s) {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+var NS_MODULUS = 62 ** 4;
+var NS_BLOCK = 1e6;
 var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "a",
   "an",
@@ -24,20 +43,21 @@ var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "via",
   "per"
 ]);
-function resetIds() {
+function resetIds(seed) {
   _usedIds.clear();
+  _idCounter = seed == null ? 0 : fnv1a32(seed) % NS_MODULUS * NS_BLOCK;
 }
 function sigmaShortId(len = 10) {
   let id;
   do {
-    id = Array.from({ length: len }, () => SIGMA_CHARS[Math.floor(Math.random() * SIGMA_CHARS.length)]).join("");
+    id = encodeBase62(++_idCounter, len);
   } while (_usedIds.has(id));
   _usedIds.add(id);
   return id;
 }
 function sigmaDisplayName(s) {
   const normalized = (s || "").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
-  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
+  const words = normalized.toLowerCase().split(/[_\s/-]+/).filter(Boolean);
   return words.map((w, i) => i === 0 || !SIGMA_LOWERCASE_WORDS.has(w) ? w.charAt(0).toUpperCase() + w.slice(1) : w).join(" ");
 }
 function formatFromMask(mask) {
@@ -178,6 +198,7 @@ function buildDerivedElements(elements) {
     const derivedName = `${srcEl.name || sigmaDisplayName(srcTableName)} View`;
     const viewCols = [];
     const viewOrder = [];
+    const folderByTarget = /* @__PURE__ */ new Map();
     for (const col of srcEl.columns || []) {
       if (!col.formula || col.formula.startsWith("/*"))
         continue;
@@ -202,6 +223,12 @@ function buildDerivedElements(elements) {
       if (!tgtEl || tgtEl.source?.kind !== "warehouse-table" && tgtEl.source?.kind !== "sql")
         continue;
       const tgtKeyIds = new Set((rel.keys || []).map((k) => k.targetColumnId));
+      let tgtTableName = "";
+      if (tgtEl.source?.kind === "warehouse-table") {
+        const tgtPath = tgtEl.source.path || [];
+        tgtTableName = tgtPath[tgtPath.length - 1] || "";
+      }
+      const tgtFolderName = tgtEl.name || (tgtTableName ? sigmaDisplayName(tgtTableName) : "") || rel.name;
       for (const col of tgtEl.columns || []) {
         if (tgtKeyIds.has(col.id))
           continue;
@@ -223,25 +250,44 @@ function buildDerivedElements(elements) {
         if (dispName.includes("/"))
           continue;
         const cId = sigmaShortId();
-        viewCols.push({ id: cId, formula: `[${baseName}/${rel.name}/${dispName}]` });
+        viewCols.push({ id: cId, formula: `[${baseName}/${rel.name}/${dispName}]`, hidden: true });
         viewOrder.push(cId);
+        let folder = folderByTarget.get(rel.targetElementId);
+        if (!folder) {
+          folder = { id: sigmaShortId(), name: tgtFolderName, items: [], relName: rel.name };
+          folderByTarget.set(rel.targetElementId, folder);
+        }
+        folder.items.push(cId);
+      }
+    }
+    if (folderByTarget.size > 1) {
+      const countByName = /* @__PURE__ */ new Map();
+      for (const f of folderByTarget.values())
+        countByName.set(f.name, (countByName.get(f.name) || 0) + 1);
+      for (const f of folderByTarget.values()) {
+        if ((countByName.get(f.name) || 0) > 1)
+          f.name = `${f.name} (${f.relName})`;
       }
     }
     if (viewCols.length > 0) {
-      derived.push({
+      const derivedEl = {
         id: sigmaShortId(),
         kind: "table",
         name: derivedName,
         source: { kind: "table", elementId: srcEl.id },
         columns: viewCols,
         order: viewOrder
-      });
+      };
+      if (folderByTarget.size > 0) {
+        derivedEl.folders = [...folderByTarget.values()].map(({ id, name, items }) => ({ id, name, items }));
+      }
+      derived.push(derivedEl);
     }
   }
   return derived;
 }
 
-// ../../../Users/tjwells/sigma-data-model-mcp/build/qlik.js
+// ../mcp-fresh/build/qlik.js
 function convertQlikToSigma(rawJson, options = {}) {
   resetIds();
   const { connectionId = "<CONNECTION_ID>", database: dbOverride = "", schema: schOverride = "" } = options;
@@ -445,7 +491,7 @@ function convertQlikToSigma(rawJson, options = {}) {
         ...ctx.verify ? { verify: true } : {},
         note: ctx.notes?.length ? ctx.notes.join(" ") : "Translated Qlik inter-record expression."
       });
-      warnings.push(`\u2139 "${title}": inter-record/window expression \u2192 ready Sigma formula in result.workbookPatterns \u2014 place as a calculation in a GROUPED workbook element (group by the chart's dimension); not emitted as a DM metric (a metric aggregates across rows, so it can't express a per-row window; native window funcs belong in a workbook element or a DM-element calc column).`);
+      warnings.push(`\u2139 "${title}": inter-record/window expression \u2192 ready Sigma formula in result.workbookPatterns \u2014 place as a calculation in a GROUPED workbook element (group by the chart's dimension); not emitted as a DM metric (window functions silently error there).`);
       continue;
     }
     if (!measuresByElement[bestElementId])
@@ -572,7 +618,7 @@ function convertQlikToSigma(rawJson, options = {}) {
         ...ctx.verify ? { verify: true } : {},
         note: (ctx.notes?.length ? ctx.notes.join(" ") : "Translated Qlik inter-record expression.") + " (Qlik master dimension.)"
       });
-      warnings.push(`\u2139 Calc dimension "${title}": inter-record/window expression \u2192 ready Sigma formula in result.workbookPatterns \u2014 place in a GROUPED workbook element; not emitted as a DM column (native window funcs also resolve in a DM-element calc column; grouped here for the partition/order that match the Qlik chart).`);
+      warnings.push(`\u2139 Calc dimension "${title}": inter-record/window expression \u2192 ready Sigma formula in result.workbookPatterns \u2014 place in a GROUPED workbook element; not emitted as a DM column (window functions silently error there).`);
       continue;
     }
     const distinctElIds = Object.keys(elementHits);
@@ -744,6 +790,61 @@ function convertQvdsToSigma(qvds, options = {}) {
   result.warnings = [...warnings, ...result.warnings];
   return result;
 }
+function parseQlikLoadScript(script) {
+  const s = script.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/^[ \t]*\/\/.*$/gm, " ");
+  const tables = [];
+  const blockRe = /(?:^|\n)[ \t]*(?:([A-Za-z_]\w*)\s*:\s*)?(?:[A-Za-z]+[ \t]+)?\b(?:LOAD|SQL\s+SELECT)\b([\s\S]*?)(?:\b(?:FROM|RESIDENT|INLINE|AUTOGENERATE)\b([\s\S]*?))?;/gi;
+  let m;
+  while (m = blockRe.exec(s)) {
+    const label = m[1];
+    const body = m[2] || "";
+    const tail = m[3] || "";
+    const fields = [];
+    for (const raw of splitTopLevel(body, ",")) {
+      let f = raw.trim();
+      if (!f || f === "*")
+        continue;
+      const asM = f.match(/\s+AS\s+(.+)$/is);
+      if (asM)
+        f = asM[1].trim();
+      f = f.replace(/^[\["']+|[\]"']+$/g, "").trim();
+      if (!/^[A-Za-z_][\w ]*$/.test(f))
+        continue;
+      fields.push(f);
+    }
+    if (!fields.length)
+      continue;
+    let name = label;
+    if (!name) {
+      const fileM = tail.match(/\[[^\]]*?([A-Za-z0-9_]+)\.(?:qvd|csv|txt|xlsx?)\b/i) || tail.match(/\b([A-Za-z0-9_]+)\s*$/);
+      name = fileM ? fileM[1] : `Table${tables.length + 1}`;
+    }
+    tables.push({ name, fields });
+  }
+  return tables;
+}
+function convertQvwPrjToSigma(prjFiles, options = {}) {
+  const warnings = [];
+  const find = (re) => prjFiles.filter((f) => re.test(f.name));
+  const scriptFile = find(/LoadScript\.txt$/i)[0] || find(/\.qvs$/i)[0];
+  if (!scriptFile) {
+    throw new Error('No LoadScript.txt found in the -prj folder. Enable "Create project folder" in QlikView Desktop and upload the full <name>-prj/ contents.');
+  }
+  const tables = parseQlikLoadScript(scriptFile.content);
+  if (!tables.length)
+    warnings.push("LoadScript.txt parsed but no LOAD tables recovered \u2014 check the script syntax.");
+  warnings.push("QlikView -prj ingestion: relationships are inferred from shared field names only (no row counts in a -prj folder) \u2014 review join directions in Sigma.");
+  warnings.push("This converter builds the DATA MODEL from LoadScript.txt only. Chart expressions, measures, and the workbook layout in CH*.xml / QlikViewProject.xml are handled by the qlik-to-sigma skill (scripts/qlik-prj-discover.py -> full data-model + workbook pipeline).");
+  const qtr = tables.map((t) => ({
+    qName: t.name,
+    qNoOfRows: 0,
+    qFields: t.fields.map((name) => ({ qName: name }))
+  }));
+  const appName = scriptFile.name.match(/^(.*?)-prj/i)?.[1] || "QlikView App";
+  const result = convertQlikToSigma({ appName, qtr, masterMeasures: [], masterDimensions: [] }, options);
+  result.warnings = [...warnings, ...result.warnings];
+  return result;
+}
 function qlikParseInput(raw) {
   let tables = [], masterMeasures = [], masterDimensions = [], appName = "";
   if (Array.isArray(raw?.qtr)) {
@@ -824,6 +925,51 @@ function splitTopLevel(s, delim) {
   out.push(s.slice(start));
   return out;
 }
+var QLIK_LIT_SENT = "";
+var QLIK_LIT_SENT_RE = new RegExp(`${QLIK_LIT_SENT}(\\d+)${QLIK_LIT_SENT}`, "g");
+var QLIK_LIT_SENT_FULL_RE = new RegExp(`^${QLIK_LIT_SENT}(\\d+)${QLIK_LIT_SENT}$`);
+function maskQlikLiterals(s, lits = []) {
+  let out = "";
+  let i = 0;
+  while (i < s.length) {
+    const ch = s[i];
+    if (ch === "[" || ch === '"' || ch === "'") {
+      const closeChar = ch === "[" ? "]" : ch;
+      const close = s.indexOf(closeChar, i + 1);
+      if (close !== -1) {
+        const raw = s.slice(i, close + 1);
+        out += `${QLIK_LIT_SENT}${lits.push({ kind: ch, raw }) - 1}${QLIK_LIT_SENT}`;
+        i = close + 1;
+        continue;
+      }
+    }
+    out += ch;
+    i++;
+  }
+  return { masked: out, lits };
+}
+function qlikLitInner(lits, idx) {
+  const lit = lits[idx];
+  return lit === void 0 ? "" : lit.raw.slice(1, -1);
+}
+function qlikResolveLit(s, lits) {
+  const m = s.trim().match(QLIK_LIT_SENT_FULL_RE);
+  return m ? qlikLitInner(lits, Number(m[1])) : s;
+}
+function restoreQlikLiterals(s, lits) {
+  return s.replace(QLIK_LIT_SENT_RE, (_m, i) => lits[Number(i)]?.raw ?? _m);
+}
+function qlikMaskNew(lits, kind, raw) {
+  return `${QLIK_LIT_SENT}${lits.push({ kind, raw }) - 1}${QLIK_LIT_SENT}`;
+}
+function unmaskQlikLiterals(s, lits) {
+  return s.replace(QLIK_LIT_SENT_RE, (_m, i) => {
+    const lit = lits[Number(i)];
+    if (!lit)
+      return _m;
+    return lit.kind === "'" ? `"${lit.raw.slice(1, -1)}"` : lit.raw;
+  });
+}
 function lowerRangeFns(f, warnings, name) {
   const re = /\bRange(Sum|Avg|Min|Max)\s*\(/i;
   let guard = 0;
@@ -873,11 +1019,12 @@ function lowerClass(f, warnings, name) {
   }
   return f;
 }
-function setValueToCondition(field, rawVal, op) {
+function setValueToCondition(field, rawVal, op, lits) {
   let v = rawVal.trim();
-  const qm = v.match(/^['"](.*)['"]$/);
-  if (qm) {
-    const inner = qm[1].trim();
+  const sentM = v.match(QLIK_LIT_SENT_FULL_RE);
+  const dqM = !sentM ? v.match(/^"(.*)"$/) : null;
+  if (sentM || dqM) {
+    const inner = (sentM ? qlikLitInner(lits, Number(sentM[1])) : dqM[1]).trim();
     const cmp = inner.match(/^(>=|<=|<>|>|<|=)\s*(.+)$/);
     if (cmp) {
       let cop = cmp[1];
@@ -887,24 +1034,38 @@ function setValueToCondition(field, rawVal, op) {
       }
       const rhs = cmp[2].trim();
       const rhsNum = /^-?\d+(\.\d+)?$/.test(rhs);
-      return `[${field}]${cop}${rhsNum ? rhs : `"${rhs}"`}`;
+      return `[${field}]${cop}${rhsNum ? rhs : qlikMaskNew(lits, '"', `"${rhs}"`)}`;
     }
-    return `[${field}]${op}"${inner}"`;
+    return `[${field}]${op}${qlikMaskNew(lits, '"', `"${inner}"`)}`;
   }
   if (/^-?\d+(\.\d+)?$/.test(v))
     return `[${field}]${op}${v}`;
   if (/^[A-Za-z0-9_]+$/.test(v))
-    return `[${field}]${op}"${v}"`;
+    return `[${field}]${op}${qlikMaskNew(lits, '"', `"${v}"`)}`;
   return null;
 }
-function clauseToCondition(clause) {
-  const m = clause.match(/^\s*\[?([A-Za-z0-9_ .]+?)\]?\s*(-=|\+=|=)\s*\{([\s\S]*)\}\s*$/);
-  if (!m)
-    return null;
-  const field = m[1].trim();
-  const setOp = m[2];
+function clauseToCondition(clause, lits) {
+  const sentFieldRe = new RegExp(`^\\s*${QLIK_LIT_SENT}(\\d+)${QLIK_LIT_SENT}\\s*(-=|\\+=|=)\\s*\\{([\\s\\S]*)\\}\\s*$`);
+  const sm = clause.match(sentFieldRe);
+  let field;
+  let setOp;
+  let body;
+  if (sm) {
+    const lit = lits[Number(sm[1])];
+    if (!lit)
+      return null;
+    field = lit.raw.slice(1, -1).trim();
+    setOp = sm[2];
+    body = sm[3].trim();
+  } else {
+    const m = clause.match(/^\s*\[?([A-Za-z0-9_ .]+?)\]?\s*(-=|\+=|=)\s*\{([\s\S]*)\}\s*$/);
+    if (!m)
+      return null;
+    field = m[1].trim();
+    setOp = m[2];
+    body = m[3].trim();
+  }
   const op = setOp === "-=" ? "<>" : "=";
-  const body = m[3].trim();
   if (body === "")
     return null;
   if (/[+\-*/](?![=\d])/.test(body) && /\}|\{/.test(body))
@@ -914,7 +1075,7 @@ function clauseToCondition(clause) {
   const vals = splitTopLevel(body, ",").map((v) => v.trim()).filter(Boolean);
   const conds = [];
   for (const v of vals) {
-    const c = setValueToCondition(field, v, op);
+    const c = setValueToCondition(field, v, op, lits);
     if (!c)
       return null;
     conds.push(c);
@@ -960,7 +1121,7 @@ function bracketKnownBareFields(expr, displayMap) {
   s = s.replace(new RegExp(SENT + "(\\d+)" + SENT, "g"), (_m, i) => tokens[+i]);
   return s.replace(/ {2,}/g, " ").trim();
 }
-function translateSetAnalysis(f, warnings, name) {
+function translateSetAnalysis(f, warnings, name, lits) {
   const aggRe = new RegExp(`\\b(${QLIK_SET_AGGS.join("|")})\\s*\\(\\s*\\{`, "i");
   let guard = 0;
   while (aggRe.test(f) && guard++ < 50) {
@@ -1004,7 +1165,7 @@ function translateSetAnalysis(f, warnings, name) {
     const clauses = splitTopLevel(modifiers, ",").map((c) => c.trim()).filter(Boolean);
     const conds = [];
     for (const cl of clauses) {
-      const c = clauseToCondition(cl);
+      const c = clauseToCondition(cl, lits);
       if (!c) {
         warnings?.push(`"${name}": Set Analysis clause "${cl}" could not be translated \u2014 left untranslated.`);
         return null;
@@ -1134,9 +1295,9 @@ var QLIK_FSV_SENTINEL = "__QLIK_FSV__";
 function tidyFormula(f) {
   return f.replace(/\(\s+/g, "(").replace(/\s+\)/g, ")").replace(/\s+,/g, ",").replace(/ {2,}/g, " ").trim();
 }
-var QLIK_GROUPED_REQUIRES = "Place as a calculation in a GROUPED workbook element: group by the Qlik chart's dimension(s), sort the element to match the chart's sort order, and put this formula at the grouping level. (Spec gotcha, live-verified 2026-06-11: the element-level `sort` field 400s on grouped tables \u2014 'Sort column not found' \u2014 so a grouped element computes Lag/Lead over the group key ASCENDING at POST time; apply any other sort in the UI afterwards, or pick the grouping key so ascending order matches the Qlik chart.) When placing in a workbook element, prefix base-column refs with the source element name ([Element/Col]). Native window functions (Rank/RankDense/Lag/Lead/RowNumber/Cumulative*/Moving*) resolve in DM-element calc columns and in workbook tables (grouped OR ungrouped/master) \u2014 live-verified 2026-07-15; only the *Over family (SumOver/CountOver/...) errors in every spec context. A GROUPED element is still the recommended placement here because it gives Lag/Lead the partition + ordering that match the Qlik chart.";
+var QLIK_GROUPED_REQUIRES = "Place as a calculation in a GROUPED workbook element: group by the Qlik chart's dimension(s), sort the element to match the chart's sort order, and put this formula at the grouping level. (Spec gotcha, live-verified 2026-06-11: the element-level `sort` field 400s on grouped tables \u2014 'Sort column not found' \u2014 so a grouped element computes Lag/Lead over the group key ASCENDING at POST time; apply any other sort in the UI afterwards, or pick the grouping key so ascending order matches the Qlik chart.) When placing in a workbook element, prefix base-column refs with the source element name ([Element/Col]). Window functions (Rank/RankDense/Lag/Lead) silently error in data-model calc columns/metrics and in workbook master calc columns \u2014 they only work in grouped workbook elements.";
 var QLIK_IR_RE = /\b(Rank|HRank|VRank|Above|Below|Before|After|Top|Bottom|Previous|Peek)\s*\(/i;
-function lowerInterRecordFns(f, warnings, name, original, ctx) {
+function lowerInterRecordFns(f, warnings, name, original, ctx, lits) {
   const flagUnsupported = (note2) => {
     warnings?.push(`\u26A0 "${name}": ${note2} \u2014 left untranslated (flagged in workbookPatterns).`);
     ctx?.patterns?.push({ kind: "unsupported", name, source: original, note: note2 });
@@ -1235,7 +1396,7 @@ function lowerInterRecordFns(f, warnings, name, original, ctx) {
       if (args.length > 2 && args[2]) {
         return flagUnsupported(`Peek() with a table argument reads another table's load buffer (script-time semantics, not chart semantics)`);
       }
-      const fieldRaw = (args[0] || "").trim().replace(/^['"\[]/, "").replace(/['"\]]$/, "");
+      const fieldRaw = qlikResolveLit((args[0] || "").trim(), lits).replace(/^['"\[]/, "").replace(/['"\]]$/, "").trim();
       if (!fieldRaw)
         return flagUnsupported("Peek() missing field argument");
       let row = -1;
@@ -1384,6 +1545,8 @@ function qlikExprToSigma(expr, warnings, name, ctx) {
   let f = expr.trim();
   if (f.startsWith("="))
     f = f.slice(1).trim();
+  const { masked, lits } = maskQlikLiterals(f);
+  f = masked;
   f = f.replace(/\bDual\s*\(/gi, (_m, off) => "DUAL(");
   if (f.includes("DUAL(")) {
     let guard = 0;
@@ -1404,7 +1567,7 @@ function qlikExprToSigma(expr, warnings, name, ctx) {
   }
   const fsvM = f.match(/^FirstSortedValue\s*\(/i);
   if (fsvM && matchClose(f, f.indexOf("("), "(", ")") === f.length - 1) {
-    return QLIK_FSV_SENTINEL + f;
+    return QLIK_FSV_SENTINEL + restoreQlikLiterals(f, lits);
   }
   if (/\bFirstSortedValue\s*\(/i.test(f)) {
     warnings?.push(`\u26A0 "${name}": FirstSortedValue() nested inside a larger expression \u2014 left untranslated (flagged in workbookPatterns).`);
@@ -1412,19 +1575,19 @@ function qlikExprToSigma(expr, warnings, name, ctx) {
     return null;
   }
   if (/\{\s*[\$1<][^}]*\}/.test(f) || /\{\s*<[^}]*>\s*\}/.test(f)) {
-    const translated = translateSetAnalysis(f, warnings, name);
+    const translated = translateSetAnalysis(f, warnings, name, lits);
     if (translated === null)
       return null;
     f = translated;
   }
   if (/\bAggr\s*\(/i.test(f)) {
-    return QLIK_AGGR_SENTINEL + f;
+    return QLIK_AGGR_SENTINEL + restoreQlikLiterals(f, lits);
   }
   if (/\bGet(?:Field)?(?:Selections?|CurrentSelections?|PossibleCount|SelectedCount|AlternativeCount|ExcludedCount)\s*\(/i.test(f)) {
     warnings?.push(`"${name}": uses a Qlik selection-state function \u2014 no Sigma equivalent.`);
     return null;
   }
-  const ir = lowerInterRecordFns(f, warnings, name, expr, ctx);
+  const ir = lowerInterRecordFns(f, warnings, name, expr, ctx, lits);
   if (ir === null)
     return null;
   f = ir;
@@ -1452,7 +1615,7 @@ function qlikExprToSigma(expr, warnings, name, ctx) {
   f = f.replace(/\bConcat\s*\(/gi, "ListAgg(");
   f = f.replace(/\bNum\s*\(\s*([^,)]+)(,([^)]+))?\)/gi, (_m, val, hasComma, fmt) => {
     if (hasComma && warnings)
-      warnings.push(`"${name}": Num() format argument "${(fmt || "").trim()}" stripped.`);
+      warnings.push(`"${name}": Num() format argument "${qlikResolveLit((fmt || "").trim(), lits)}" stripped.`);
     return val.trim();
   });
   f = f.replace(/\bText\s*\(/gi, "ToString(").replace(/\bDate\$\s*\(/gi, "ToString(");
@@ -1464,8 +1627,7 @@ function qlikExprToSigma(expr, warnings, name, ctx) {
     warnings?.push(`"${name}": YearToDate() approximated as Year(${field.trim()}) = Year(Today())`);
     return `Year(${field}) = Year(Today())`;
   });
-  f = f.replace(/'([^']*)'/g, '"$1"');
-  return f.trim();
+  return unmaskQlikLiterals(f, lits).trim();
 }
 export {
   QLIK_AGGR_SENTINEL,
@@ -1473,5 +1635,7 @@ export {
   QLIK_GROUPED_REQUIRES,
   convertQlikToSigma,
   convertQvdsToSigma,
+  convertQvwPrjToSigma,
+  parseQlikLoadScript,
   parseQvdHeader
 };

--- a/tools/check-converter-provenance.sh
+++ b/tools/check-converter-provenance.sh
@@ -3,6 +3,8 @@
 # (the standing vendoring rule made mechanical, 2026-07-18).
 #
 #   bash tools/check-converter-provenance.sh <BASE> <HEAD>
+#   bash tools/check-converter-provenance.sh --freshness [REF]
+#   bash tools/check-converter-provenance.sh --online <sigma-data-model-mcp checkout>
 #
 # Fails (exit 1) when the BASE..HEAD range:
 #   1) changes a vendored converter bundle (plugins/**/converter/*.mjs) without
@@ -18,14 +20,195 @@
 # Callers resolve the range (hygiene.yml derives it from the CI event); the
 # check itself is range-parameterized so tools/test-converter-provenance.sh
 # can drive it against throwaway fixture repos offline.
+#
+# --freshness [REF] (default REF=HEAD) — STANDING gate, state-based rather
+# than diff-based: a merge to sigma-data-model-mcp changes nothing for any
+# operator until someone runs tools/vendor-converters.sh and commits the
+# regenerated bundle, and nothing else in this repo notices when that hasn't
+# happened. Pass 1/2 above only look at what changed in a push/PR range, so a
+# bundle nobody has touched in months (pre-existing drift, not a regression in
+# this diff) sails through clean forever. --freshness instead re-reads every
+# plugins/**/converter/PROVENANCE.json at REF on EVERY run, independent of
+# what changed, and flags any vendored (source_repo-bearing) entry whose
+# source_commit_date is more than CONVERTER_STALENESS_DAYS (default 14) old.
+#
+#   Design trade-off (deliberate): CI cannot assume network access to the
+#   private twells89/sigma-data-model-mcp repo, so this cannot ask upstream
+#   "is there anything new" — the honest options were (a) a recorded
+#   expected-latest-commit ledger a human bumps by hand, (b) an online mode
+#   that soft-passes when unreachable, or (c) grading staleness by the AGE of
+#   the recorded source_commit_date. Chosen: (c) as the default/CI-wired
+#   gate, with (b) available locally (see --online below) for a human who
+#   does have a checkout. Age needs no separate file to keep in sync (the
+#   date is already written by vendor-converters.sh on every re-vendor) and
+#   it catches BOTH failure modes from the same signal: a merge that missed
+#   its follow-up vendor, and pre-existing drift nobody flagged. The honest
+#   cost: age is a proxy, not proof — a converter whose upstream genuinely
+#   hasn't changed in 14 days false-positives as "stale" (a human glance,
+#   confirms nothing to do, no code changes needed); conversely a bundle
+#   re-vendored yesterday against an upstream that merged something an hour
+#   later won't be flagged until the window elapses. That is the accepted
+#   latency of an offline check — --online below trades the "always
+#   available" property back for a real comparison when a checkout exists.
+#
+#   cognos-to-sigma is not a false-flagged case: its PROVENANCE.json has no
+#   source_repo/source_commit at all by design (converter/cli.ts is vendored
+#   IN this repo, not from sigma-data-model-mcp — see tools/check-cognos-bundle.rb,
+#   which is the freshness gate for THAT vendoring path). --freshness detects
+#   this shape (no "source_repo" key, same test check-converter-provenance's
+#   diff-pairing pass already uses) and reports it explicitly as
+#   "in-skill, not applicable" rather than silently omitting the plugin or
+#   miscounting its absent source_commit as staleness.
+#
+#   A STALE verdict also never implies "just re-vendor blindly": when the
+#   flagged PROVENANCE.json carries a non-empty local_patches array (e.g.
+#   tableau-to-sigma today), the report appends a note pointing at those
+#   entries / _upstream_and_revendor_tasks instead — a naive re-vendor
+#   overwrites PROVENANCE.json wholesale and drops any patch not yet landed
+#   upstream (see TASK 3 in that file).
+#
+# --online <checkout> — OPTIONAL, NOT wired into CI (needs a local
+# sigma-data-model-mcp clone + network to fetch it current). Compares each
+# vendored plugin's recorded source_commit against the checkout's actual HEAD
+# and reports whether the module's own src file changed since. Soft-passes
+# (exit 0, warning only) when the checkout path is missing/not a git repo —
+# this mode exists for a human doing a manual audit, not as a hard gate.
 set -uo pipefail
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 missing — provenance guard cannot run"; exit 1; }
+
+# --freshness [REF] — standing staleness report, independent of any diff
+# range (see header comment for the design/trade-off). Enumerates every
+# plugins/**/converter/PROVENANCE.json at REF, classifies each as vendored
+# (source_repo present) or in-skill (cognos-style — no source_repo), and for
+# vendored entries flags source_commit_date older than CONVERTER_STALENESS_DAYS.
+if [ "${1:-}" = "--freshness" ]; then
+  REF="${2:-HEAD}"
+  STALE_DAYS="${CONVERTER_STALENESS_DAYS:-14}"
+  files="$(git ls-tree -r --name-only "$REF" -- plugins 2>/dev/null | grep -E '^plugins/.+/converter/PROVENANCE\.json$' | sort || true)"
+  [ -n "$files" ] || { echo "no plugins/**/converter/PROVENANCE.json found at $REF"; exit 1; }
+  printf '%s\n' "$files" | python3 -c "
+import json, sys, datetime
+ref = sys.argv[1]
+stale_days = int(sys.argv[2])
+paths = [l.strip() for l in sys.stdin if l.strip()]
+today = datetime.date.today()
+fail = False
+print('%-24s %-12s %-12s %-6s  %s' % ('PLUGIN', 'SOURCE_COMMIT', 'PINNED', 'AGE_D', 'STATUS'))
+for p in paths:
+    plugin = p.split('/')[1]
+    raw = __import__('subprocess').run(['git', 'show', '%s:%s' % (ref, p)], capture_output=True, text=True)
+    if raw.returncode != 0:
+        print('::error file=%s::cannot read PROVENANCE.json at %s' % (p, ref))
+        fail = True
+        continue
+    try:
+        d = json.loads(raw.stdout)
+    except Exception as exc:
+        print('::error file=%s::not valid JSON (%s) — freshness cannot be assessed' % (p, exc))
+        fail = True
+        continue
+    if 'source_repo' not in d:
+        # in-skill converter (cognos-style): vendors converter/*.ts IN this
+        # repo, never from sigma-data-model-mcp. NONE/absent source_commit is
+        # legitimate here — reported explicitly, not silently skipped, and
+        # not counted as stale. Its own freshness gate is check-cognos-bundle.rb.
+        print('%-24s %-12s %-12s %-6s  %s' % (plugin, 'n/a', 'n/a', 'n/a',
+              'OK (in-skill converter, not vendored from sigma-data-model-mcp — '
+              'see tools/check-cognos-bundle.rb)'))
+        continue
+    commit = d.get('source_commit')
+    date_str = d.get('source_commit_date')
+    if not commit or not date_str:
+        print('::error file=%s::vendored converter (source_repo present) missing source_commit/source_commit_date — re-vendor via tools/vendor-converters.sh <sigma-data-model-mcp checkout> to record real provenance' % p)
+        fail = True
+        continue
+    try:
+        pinned = datetime.date.fromisoformat(date_str)
+    except ValueError:
+        print('::error file=%s::source_commit_date %r is not ISO YYYY-MM-DD' % (p, date_str))
+        fail = True
+        continue
+    age = (today - pinned).days
+    mod = (d.get('vendored_modules') or '').split(',')[0].strip()
+    mod = mod[:-4] if mod.endswith('.mjs') else (mod or '<module>')
+    if age > stale_days:
+        note = ''
+        lp = d.get('local_patches')
+        if isinstance(lp, list) and lp:
+            note = (' NOTE: local_patches has %d entr%s recorded — a naive re-vendor overwrites '
+                     'this file and drops any not yet landed upstream; port each open entry '
+                     'upstream first (see local_patches / _upstream_and_revendor_tasks in this '
+                     'file), then re-vendor — do not just re-vendor blind.'
+                     % (len(lp), 'y' if len(lp) == 1 else 'ies'))
+        print('::error file=%s::STALE — %s pinned at %s (%s, %dd old, exceeds %dd) — run: tools/vendor-converters.sh <sigma-data-model-mcp checkout> %s%s' % (p, plugin, commit, date_str, age, stale_days, mod, note))
+        fail = True
+    else:
+        print('%-24s %-12s %-12s %-6d  %s' % (plugin, commit, date_str, age, 'OK — within %dd freshness window' % stale_days))
+sys.exit(1 if fail else 0)
+" "$REF" "$STALE_DAYS"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "converter-freshness guard FAILED (a bundle is stale, or its provenance is unreadable/incomplete)."
+  else
+    echo "converter-freshness guard OK ($REF, threshold ${STALE_DAYS}d)"
+  fi
+  exit $rc
+fi
+
+# --online <checkout> — optional, human-driven, NOT wired into CI (needs a
+# local sigma-data-model-mcp clone; soft-passes when it's not there so it can
+# never become a silent hard requirement). Compares each vendored plugin's
+# recorded source_commit against the checkout's actual HEAD and reports
+# whether the module's own src/<mod>.ts changed since that commit.
+if [ "${1:-}" = "--online" ]; then
+  CHECKOUT="${2:?usage: check-converter-provenance.sh --online <sigma-data-model-mcp checkout>}"
+  if [ ! -d "$CHECKOUT/.git" ]; then
+    echo "WARN: $CHECKOUT is not a git checkout — --online cannot compare; soft-passing (offline --freshness is the hard gate)"
+    exit 0
+  fi
+  UP_HEAD="$(git -C "$CHECKOUT" rev-parse --short HEAD 2>/dev/null)" || {
+    echo "WARN: could not resolve HEAD in $CHECKOUT — soft-passing"
+    exit 0
+  }
+  files="$(git ls-tree -r --name-only HEAD -- plugins 2>/dev/null | grep -E '^plugins/.+/converter/PROVENANCE\.json$' | sort || true)"
+  fail=0
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    d="$(git show "HEAD:$p" 2>/dev/null)"
+    kind="$(printf '%s' "$d" | python3 -c 'import json,sys
+try: d=json.load(sys.stdin)
+except Exception: d={}
+print("in-skill" if "source_repo" not in d else "vendored")')"
+    [ "$kind" = "vendored" ] || continue
+    commit="$(printf '%s' "$d" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("source_commit") or "")')"
+    mod="$(printf '%s' "$d" | python3 -c 'import json,sys; m=(json.load(sys.stdin).get("vendored_modules") or "").split(",")[0].strip(); print(m[:-4] if m.endswith(".mjs") else m)')"
+    [ -n "$commit" ] || continue
+    srcfile="src/$mod.ts"
+    if ! git -C "$CHECKOUT" cat-file -e "$UP_HEAD:$srcfile" 2>/dev/null; then
+      echo "  ? $p: $srcfile not found at $CHECKOUT HEAD ($UP_HEAD) — skipping live compare for this module"
+      continue
+    fi
+    if ! git -C "$CHECKOUT" cat-file -e "$commit" 2>/dev/null; then
+      echo "  ? $p: recorded source_commit $commit not found in $CHECKOUT — cannot compute upstream delta"
+      continue
+    fi
+    behind="$(git -C "$CHECKOUT" rev-list --count "$commit..$UP_HEAD" -- "$srcfile" 2>/dev/null || echo '?')"
+    if [ "$behind" != "0" ] && [ "$behind" != "?" ]; then
+      echo "  BEHIND $p: pinned $commit, upstream $UP_HEAD is $behind commit(s) ahead on $srcfile — re-vendor"
+      fail=1
+    else
+      echo "  OK     $p: pinned $commit matches upstream $srcfile as of $UP_HEAD"
+    fi
+  done < <(printf '%s\n' "$files")
+  [ "$fail" -eq 0 ] && echo "converter --online check: no live drift found vs $CHECKOUT ($UP_HEAD)" || echo "converter --online check: live drift found vs $CHECKOUT ($UP_HEAD) — see BEHIND lines above"
+  exit $fail
+fi
 
 BASE="${1:?usage: check-converter-provenance.sh <BASE> <HEAD>}"
 HEAD="${2:?usage: check-converter-provenance.sh <BASE> <HEAD>}"
 
-# The schema pin needs a JSON parser; a missing runtime must fail the gate
-# loudly, never skip it green.
-command -v python3 >/dev/null 2>&1 || { echo "python3 missing — provenance schema pin cannot run"; exit 1; }
+# (python3 already checked above — the schema pin below needs it too.)
 
 # An unresolvable range must fail, not read as an empty (green) change list.
 changed="$(git diff --name-only "$BASE" "$HEAD")" || { echo "git diff $BASE..$HEAD failed — cannot check provenance pairing"; exit 1; }

--- a/tools/test-converter-provenance.sh
+++ b/tools/test-converter-provenance.sh
@@ -16,6 +16,18 @@
 #   Part D — string-pin: the real tableau converter PROVENANCE.json records
 #            the d8a049a in-place patch with the commit/summary/upstream_pr
 #            entry schema and carries the upstream-and-re-vendor task block
+#   Part E — --freshness (staleness-by-age gate, 2026-07-31): a vendored
+#            PROVENANCE.json whose source_commit_date is older than
+#            CONVERTER_STALENESS_DAYS fails naming the module + re-vendor
+#            command; the same fixture with today's date passes; a
+#            source_repo entry missing source_commit/source_commit_date
+#            fails; a stale entry carrying local_patches gets the
+#            do-not-re-vendor-blind note; an in-skill (cognos-shaped, no
+#            source_repo) entry is reported explicitly as not-applicable,
+#            never silently dropped or miscounted as stale
+#   Part F — --online soft-pass: with no local sigma-data-model-mcp checkout
+#            present, --online exits 0 with a warning rather than failing —
+#            it is a human-driven convenience, never a hard CI requirement
 #
 # All fixture names are synthetic (toolx) — no field-derived identifiers.
 # Runs standalone:  bash tools/test-converter-provenance.sh
@@ -161,6 +173,88 @@ for t in "TASK 1 —" "TASK 2 —" "TASK 3 —" "TASK 4 —"; do
 done
 grep -q "scripts/dev/vendor-converter.sh" "$REAL"
 check $? "TASK 3 names the second (skill-local) regenerator"
+
+echo "Part E — --freshness: staleness-by-age, in-skill shape, missing keys, local_patches note"
+new_repo "$TMP/freshness"
+TOOLX="plugins/toolx-to-sigma/skills/toolx-to-sigma/converter"
+TOOLY="plugins/tooly-to-sigma/skills/tooly-to-sigma/converter"
+mkdir -p "$TOOLX" "$TOOLY"
+OLD_DATE="$(python3 -c 'import datetime; print((datetime.date.today()-datetime.timedelta(days=40)).isoformat())')"
+TODAY_DATE="$(python3 -c 'import datetime; print(datetime.date.today().isoformat())')"
+
+cat > "$TOOLX/PROVENANCE.json" <<EOF
+{
+  "source_repo": "example/fixture-converters",
+  "source_commit": "aaaaaaa",
+  "source_commit_date": "$OLD_DATE",
+  "vendored_modules": "toolx.mjs"
+}
+EOF
+# tooly stands in for the cognos shape: in-skill converter, no source_repo,
+# so it has no source_commit at all by design — must be reported explicitly,
+# not silently skipped and not counted as stale.
+cat > "$TOOLY/PROVENANCE.json" <<'EOF'
+{
+  "source": "in-skill converter/cli.ts",
+  "vendored_modules": "cli.mjs",
+  "source_sha256": "deadbeef"
+}
+EOF
+E0="$(commit_all base)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E0" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "40d-old source_commit_date fails freshness (got $RC)"
+grep -q "STALE" "$TMP/out"; check $? "failure says STALE"
+grep -q "vendor-converters.sh <sigma-data-model-mcp checkout> toolx" "$TMP/out"
+check $? "failure names the re-vendor command with the correct module"
+grep -q "in-skill converter, not vendored from sigma-data-model-mcp" "$TMP/out"
+check $? "cognos-shaped (no source_repo) entry reported explicitly as not-applicable"
+! grep -q "tooly-to-sigma.*STALE\|STALE.*tooly-to-sigma" "$TMP/out"
+check $? "cognos-shaped entry is never counted as stale"
+
+sed -i.bak "s/$OLD_DATE/$TODAY_DATE/" "$TOOLX/PROVENANCE.json" && rm -f "$TOOLX/PROVENANCE.json.bak"
+E1="$(commit_all fresh)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E1" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 0 ]; check $? "today's source_commit_date passes freshness (got $RC)"
+grep -q "guard OK" "$TMP/out"; check $? "passing state reports guard OK"
+
+cat > "$TOOLX/PROVENANCE.json" <<'EOF'
+{
+  "source_repo": "example/fixture-converters",
+  "vendored_modules": "toolx.mjs"
+}
+EOF
+E2="$(commit_all missing-commit)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E2" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "vendored entry missing source_commit/source_commit_date fails (got $RC)"
+grep -q "missing source_commit/source_commit_date" "$TMP/out"; check $? "failure names the missing keys"
+
+cat > "$TOOLX/PROVENANCE.json" <<EOF
+{
+  "source_repo": "example/fixture-converters",
+  "source_commit": "bbbbbbb",
+  "source_commit_date": "$OLD_DATE",
+  "vendored_modules": "toolx.mjs",
+  "local_patches": [
+    { "commit": "1111111", "summary": "fixture patch", "upstream_pr": null }
+  ]
+}
+EOF
+E3="$(commit_all stale-with-patches)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E3" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "stale entry with local_patches still fails (got $RC)"
+grep -q "local_patches has 1 entry recorded" "$TMP/out"; check $? "failure surfaces the local_patches count"
+grep -q "do not just re-vendor blind" "$TMP/out"; check $? "failure points at the correct remediation (patch upstream, don't blind re-vendor)"
+
+echo '{ not json' > "$TOOLX/PROVENANCE.json"
+E4="$(commit_all bad-json)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E4" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "malformed JSON fails freshness (got $RC)"
+grep -q "not valid JSON" "$TMP/out"; check $? "failure says the file no longer parses"
+
+echo "Part F — --online soft-pass with no local checkout"
+bash "$GUARD" --online "$TMP/no-such-checkout-dir" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 0 ]; check $? "--online soft-passes when the checkout path doesn't exist (got $RC)"
+grep -q "soft-passing" "$TMP/out"; check $? "soft-pass explains why (no checkout to compare against)"
 
 echo
 if [ "$fails" -gt 0 ]; then


### PR DESCRIPTION
Bundle was pinned at `867c669`, so this picks up **more than today's fixes** — flagging that
rather than implying a one-change delta.

**mcp#120** stops Qlik expression scans from reading string-literal text as live syntax. Two
demonstrated defects: a literal containing a mapped function name had its content rewritten
(`'RangeSum(1) legacy code'` → `"(Coalesce(1, 0)) legacy code"`), and an unbalanced paren
inside a literal **silently dropped a real, separate translation** later in the same string.
Set Analysis clauses with bracketed or quoted field names now resolve back to raw text before
the field-name match — a field name is syntax, not data, and masking it made the whole measure
vanish.

**mcp#121** hides the derived View's related lookup columns and folds them one folder per
relationship target, dropping none.

Markers in the regenerated bundle: `maskQlikLiterals` 0→4, `qlikResolveLit` 0→3, `hidden` 0→1,
62 KB → 68 KB.

Built from a `build/` tree verified **behaviourally** in the same session via the powerbi
bundle (940 cols / 438 hidden / 10 folders, matching source). That check matters: see the note
in the powerbi PR — `vendor-converters.sh` bundles from `build/`, not `src/`, and will vendor a
stale `build/` silently while still stamping `PROVENANCE` with the current commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)