### PR TITLE
chore(looker): re-vendor converter — LookML literal masking (mcp#120)

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -165,6 +165,23 @@ jobs:
         run: |
           if [ -z "${RANGE_BASE:-}" ]; then echo "no diff range to check — skipping"; exit 0; fi
           bash tools/check-converter-provenance.sh "$RANGE_BASE" "$RANGE_HEAD"
+      - name: Converter-freshness guard (vendored-bundle staleness by age)
+        # Standing gate, NOT diff-scoped (unlike the pairing guard above, this
+        # runs every time regardless of RANGE_BASE): a merge to
+        # sigma-data-model-mcp changes nothing for any operator until someone
+        # runs tools/vendor-converters.sh and commits the regenerated bundle,
+        # and pre-existing drift nobody re-vendored in a long time has no diff
+        # to catch it on. CI cannot assume network access to that private repo,
+        # so this grades staleness by the AGE of each PROVENANCE.json's own
+        # source_commit_date (default threshold 14d, CONVERTER_STALENESS_DAYS)
+        # rather than asking upstream what's new — see the header comment in
+        # tools/check-converter-provenance.sh for the full trade-off. cognos-to-sigma
+        # vendors its own converter/*.ts in-skill (no source_repo/source_commit
+        # by design) and is reported explicitly as not-applicable, not flagged
+        # stale; its own freshness gate is tools/check-cognos-bundle.rb below.
+        # A STALE verdict that carries local_patches gets a note pointing at
+        # porting those patches upstream first, never "just re-vendor blind".
+        run: bash tools/check-converter-provenance.sh --freshness "$RANGE_HEAD"
       - name: Plugin-version-bump guard (release-hygiene diff gate)
         # #486: a change under plugins/<name>/** must move that plugin's
         # plugin.json "version" (strict semver) so `claude plugin update` sees a
@@ -194,7 +211,12 @@ jobs:
         # Proves the diff-pairing guard fails unpaired bundle changes, passes
         # paired ones, and schema-pins local_patches entries — plus the
         # string-pin on the real tableau PROVENANCE.json (synthetic fixture
-        # names only).
+        # names only). Also proves the --freshness staleness-by-age gate
+        # (Part E) fails a 40d-stale fixture and passes the same fixture
+        # dated today, reports an in-skill/cognos-shaped entry explicitly
+        # rather than silently, and surfaces the local_patches
+        # don't-re-vendor-blind note; plus --online's soft-pass when no local
+        # checkout is present (Part F).
         run: bash tools/test-converter-provenance.sh
       - name: Plugin-version-bump guard self-test (fixture repos, creds-free)
         # Proves the version-bump gate fails an unbumped plugin change, passes a

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/converter/PROVENANCE.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/converter/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "867c669",
-  "source_commit_date": "2026-06-22",
+  "source_commit": "2f8c6cd",
+  "source_commit_date": "2026-07-31",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "lookml.mjs",
   "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/converter/lookml.mjs
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/converter/lookml.mjs
@@ -1,6 +1,25 @@
-// ../../../Users/tjwells/sigma-data-model-mcp/build/sigma-ids.js
+// ../mcp-fresh/build/sigma-ids.js
 var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 var _usedIds = /* @__PURE__ */ new Set();
+var _idCounter = 0;
+function encodeBase62(n, len) {
+  let x = n, s = "";
+  while (x > 0) {
+    s = SIGMA_CHARS[x % 62] + s;
+    x = Math.floor(x / 62);
+  }
+  return s.padStart(len, SIGMA_CHARS[0]);
+}
+function fnv1a32(s) {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+var NS_MODULUS = 62 ** 4;
+var NS_BLOCK = 1e6;
 var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "a",
   "an",
@@ -24,23 +43,31 @@ var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "via",
   "per"
 ]);
-function resetIds() {
+function resetIds(seed) {
   _usedIds.clear();
+  _idCounter = seed == null ? 0 : fnv1a32(seed) % NS_MODULUS * NS_BLOCK;
+}
+function clampId(id, max = 64) {
+  if (id.length <= max)
+    return id;
+  const suffix = "~" + encodeBase62(fnv1a32(id) % 62 ** 6, 6);
+  return id.slice(0, max - suffix.length) + suffix;
 }
 function sigmaShortId(len = 10) {
   let id;
   do {
-    id = Array.from({ length: len }, () => SIGMA_CHARS[Math.floor(Math.random() * SIGMA_CHARS.length)]).join("");
+    id = encodeBase62(++_idCounter, len);
   } while (_usedIds.has(id));
   _usedIds.add(id);
   return id;
 }
-function sigmaInodeId(identifier) {
-  return `inode-${sigmaShortId(22)}/${identifier.toUpperCase()}`;
+function sigmaInodeId(identifier, casing = "upper") {
+  const phys = casing === "lower" ? identifier.toLowerCase() : identifier.toUpperCase();
+  return clampId(`inode-${sigmaShortId(22)}/${phys}`);
 }
 function sigmaDisplayName(s) {
   const normalized = (s || "").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
-  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
+  const words = normalized.toLowerCase().split(/[_\s/-]+/).filter(Boolean);
   return words.map((w, i) => i === 0 || !SIGMA_LOWERCASE_WORDS.has(w) ? w.charAt(0).toUpperCase() + w.slice(1) : w).join(" ");
 }
 var DATA_MODEL_SCHEMA_SUMMARY = `
@@ -103,7 +130,47 @@ function makeRlsSecurity(opts) {
   };
 }
 
-// ../../../Users/tjwells/sigma-data-model-mcp/build/formulas.js
+// ../mcp-fresh/build/formulas.js
+function stripOuterParens(s) {
+  s = s.trim();
+  while (s.length > 1 && s.startsWith("(") && s.endsWith(")")) {
+    let depth = 0, quote = "", inBracket = false, wraps = true;
+    for (let i = 0; i < s.length; i++) {
+      const c = s[i];
+      if (inBracket) {
+        if (c === "]")
+          inBracket = false;
+        continue;
+      }
+      if (quote) {
+        if (c === quote)
+          quote = "";
+        continue;
+      }
+      if (c === "[") {
+        inBracket = true;
+        continue;
+      }
+      if (c === "'" || c === '"') {
+        quote = c;
+        continue;
+      }
+      if (c === "(")
+        depth++;
+      else if (c === ")") {
+        depth--;
+        if (depth === 0 && i < s.length - 1) {
+          wraps = false;
+          break;
+        }
+      }
+    }
+    if (!wraps || depth !== 0)
+      break;
+    s = s.slice(1, -1).trim();
+  }
+  return s;
+}
 function lookColRef(identifier) {
   return `[${sigmaDisplayName(identifier)}]`;
 }
@@ -181,73 +248,371 @@ var LOOK_FUNC_MAP = {
   "TO_NUMBER": "ToNumber",
   "TO_VARCHAR": "Text"
 };
-function lookConvertCase(expr) {
-  const body = expr.replace(/^CASE\s*/i, "").replace(/\s*END\s*$/i, "").trim();
-  const branches = [];
-  const parts = body.split(/\bWHEN\b/i).filter(Boolean);
-  let elseVal = null;
-  for (const part of parts) {
-    const elseMatch = part.match(/^([\s\S]+?)\s+THEN\s+([\s\S]+?)(?:\s+ELSE\s+([\s\S]+))?$/i);
-    if (!elseMatch) {
-      const e = part.match(/\bELSE\s+([\s\S]+)$/i);
-      if (e && !elseVal)
-        elseVal = e[1].trim();
+var _CASE_KW_RE = /^(CASE|WHEN|THEN|ELSE|END)\b/i;
+function _scanCase(s, pos) {
+  const markers = [];
+  let caseDepth = 1, parenDepth = 0, i = pos;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === "[") {
+      const close = s.indexOf("]", i + 1);
+      i = close === -1 ? s.length : close + 1;
       continue;
     }
-    const cond = elseMatch[1].trim();
-    let val = elseMatch[2].trim();
-    const elseInVal = val.match(/^([\s\S]+?)\s+ELSE\s+([\s\S]+)$/i);
-    if (elseInVal) {
-      val = elseInVal[1].trim();
-      if (!elseVal)
-        elseVal = elseInVal[2].trim();
+    if (c === "(") {
+      parenDepth++;
+      i++;
+      continue;
     }
-    branches.push({ cond, val });
+    if (c === ")") {
+      parenDepth--;
+      i++;
+      continue;
+    }
+    if (/[A-Za-z]/.test(c) && (i === 0 || !/[A-Za-z0-9_]/.test(s[i - 1]))) {
+      const m = _CASE_KW_RE.exec(s.slice(i));
+      if (m) {
+        const kw = m[1].toUpperCase(), start = i, end = i + m[1].length;
+        if (kw === "CASE") {
+          caseDepth++;
+        } else if (kw === "END") {
+          caseDepth--;
+          if (caseDepth === 0)
+            return { endStart: start, endIndex: end, markers };
+        } else if (caseDepth === 1 && parenDepth === 0) {
+          markers.push({ type: kw, start, end });
+        }
+        i = end;
+        continue;
+      }
+    }
+    i++;
   }
-  const topElse = body.match(/\bELSE\s+([\s\S]+)$/i);
-  if (topElse && !elseVal)
-    elseVal = topElse[1].trim();
+  return { endStart: -1, endIndex: -1, markers };
+}
+function _isBalanced(s) {
+  let paren = 0, bracket = 0, inStr = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (c === "\\") {
+        i++;
+        continue;
+      }
+      if (c === '"')
+        inStr = false;
+      continue;
+    }
+    if (c === '"') {
+      inStr = true;
+      continue;
+    }
+    if (c === "(")
+      paren++;
+    else if (c === ")") {
+      paren--;
+      if (paren < 0)
+        return false;
+    } else if (c === "[")
+      bracket++;
+    else if (c === "]") {
+      bracket--;
+      if (bracket < 0)
+        return false;
+    }
+  }
+  return paren === 0 && bracket === 0 && !inStr;
+}
+var _NESTED_CASE_UNMASK_RE = /(\d+)/g;
+function _convertNestedCases(s, lits, onUnparseable = "abort", cdArgs = []) {
+  const blocks = [];
+  let out = "", last = 0, i = 0;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === "[") {
+      const close = s.indexOf("]", i + 1);
+      i = close === -1 ? s.length : close + 1;
+      continue;
+    }
+    if (/[A-Za-z]/.test(c) && (i === 0 || !/[A-Za-z0-9_]/.test(s[i - 1])) && /^CASE\b/i.test(s.slice(i))) {
+      const caseStart = i;
+      const scan = _scanCase(s, i + 4);
+      if (scan.endIndex === -1) {
+        if (onUnparseable === "abort")
+          return null;
+        break;
+      }
+      const rawSpan = _restoreRawCountDistinct(_restoreRawLiterals(s.slice(caseStart, scan.endIndex), lits), cdArgs);
+      const converted = lookConvertCase(rawSpan);
+      if (converted === null) {
+        if (onUnparseable === "abort")
+          return null;
+        i = scan.endIndex;
+        continue;
+      }
+      out += s.slice(last, caseStart) + `${blocks.push(converted) - 1}`;
+      last = scan.endIndex;
+      i = scan.endIndex;
+      continue;
+    }
+    i++;
+  }
+  return { text: out + s.slice(last), blocks };
+}
+function _spliceNestedCases(s, blocks) {
+  return s.replace(_NESTED_CASE_UNMASK_RE, (_m, i) => blocks[Number(i)] ?? _m);
+}
+function lookConvertCase(expr) {
+  const trimmed = expr.trim();
+  const head = /^CASE\b/i.exec(trimmed);
+  if (!head)
+    return null;
+  const { masked, lits } = _maskLiterals(trimmed);
+  const scan = _scanCase(masked, head[0].length);
+  if (scan.endIndex === -1)
+    return null;
+  if (masked.slice(scan.endIndex).trim() !== "")
+    return null;
+  const m = scan.markers;
+  const firstMarkerStart = m.length ? m[0].start : scan.endStart;
+  if (masked.slice(head[0].length, firstMarkerStart).trim() !== "")
+    return null;
+  const branches = [];
+  let elseVal = null;
+  let idx = 0;
+  while (true) {
+    if (idx >= m.length || m[idx].type !== "WHEN")
+      return null;
+    const whenTok = m[idx++];
+    if (idx >= m.length || m[idx].type !== "THEN")
+      return null;
+    const thenTok = m[idx++];
+    const condText = masked.slice(whenTok.end, thenTok.start);
+    let valEnd, sawElse = false;
+    if (idx < m.length && m[idx].type === "WHEN") {
+      valEnd = m[idx].start;
+    } else if (idx < m.length && m[idx].type === "ELSE") {
+      valEnd = m[idx].start;
+      sawElse = true;
+    } else if (idx === m.length) {
+      valEnd = scan.endStart;
+    } else {
+      return null;
+    }
+    branches.push({ cond: condText, val: masked.slice(thenTok.end, valEnd) });
+    if (sawElse) {
+      const elseTok = m[idx++];
+      if (idx !== m.length)
+        return null;
+      elseVal = masked.slice(elseTok.end, scan.endStart);
+      break;
+    }
+    if (idx === m.length)
+      break;
+  }
   if (branches.length === 0)
     return null;
-  const convertVal = (v) => {
-    v = v.trim();
-    if (/^'[^']*'$/.test(v))
+  const convertLeaf = (maskedChunk, allowNumber) => {
+    const v = maskedChunk.trim();
+    if (allowNumber && /^-?\d+(\.\d+)?$/.test(v))
       return v;
-    if (/^-?\d+(\.\d+)?$/.test(v))
-      return v;
-    return lookConvertExpression(v);
+    const stripped = stripOuterParens(v);
+    const nc = _convertNestedCases(stripped, lits);
+    if (nc === null)
+      return null;
+    const raw = _restoreRawLiterals(nc.text, lits);
+    const converted = lookConvertExpression(raw);
+    const spliced = _spliceNestedCases(converted, nc.blocks);
+    if (!spliced.trim())
+      return null;
+    return spliced;
   };
-  let result = elseVal ? convertVal(elseVal) : "null";
+  let result = elseVal !== null ? convertLeaf(elseVal, true) : "null";
+  if (result === null)
+    return null;
   for (let i = branches.length - 1; i >= 0; i--) {
-    const sigmaCond = lookConvertExpression(branches[i].cond);
-    const sigmaVal = convertVal(branches[i].val);
+    const sigmaCond = convertLeaf(branches[i].cond, false);
+    const sigmaVal = convertLeaf(branches[i].val, true);
+    if (sigmaCond === null || sigmaVal === null)
+      return null;
     result = `If(${sigmaCond}, ${sigmaVal}, ${result})`;
   }
+  if (!_isBalanced(result))
+    return null;
   return result;
 }
 function lookConvertMathExpr(expr) {
   expr = expr.replace(/NULLIF\s*\(([A-Z_][A-Z0-9_]*)\s*,\s*([^)]+)\)/gi, (_, col, val) => `If(${lookColRef(col)} = ${val.trim()}, null, ${lookColRef(col)})`);
   return lookConvertExpression(expr);
 }
+var _LIT_RE = /'(?:[^']|'')*'/g;
+function _maskLiterals(s) {
+  const lits = [];
+  let out = "";
+  let i = 0;
+  while (i < s.length) {
+    if (s[i] === "[") {
+      const close = s.indexOf("]", i + 1);
+      if (close !== -1) {
+        out += s.slice(i, close + 1);
+        i = close + 1;
+        continue;
+      }
+    }
+    if (s[i] === "'") {
+      _LIT_RE.lastIndex = i;
+      const m = _LIT_RE.exec(s);
+      if (m && m.index === i) {
+        out += `\0${lits.push(m[0]) - 1}`;
+        i += m[0].length;
+        continue;
+      }
+    }
+    out += s[i];
+    i++;
+  }
+  return { masked: out, lits };
+}
+function _unmaskLiterals(s, lits) {
+  return s.replace(/\u0000(\d+)\u0001/g, (_m, i) => {
+    const inner = lits[Number(i)].slice(1, -1).replace(/''/g, "'").replace(/"/g, '\\"');
+    return `"${inner}"`;
+  });
+}
+function _restoreRawLiterals(s, lits) {
+  return s.replace(/\u0000(\d+)\u0001/g, (_m, i) => lits[Number(i)] ?? _m);
+}
+function _restoreRawCountDistinct(s, args) {
+  return s.replace(/\x02(\d+)\x03/g, (_m, i) => `COUNT(DISTINCT ${args[Number(i)] ?? ""})`);
+}
+function _maskCountDistinct(s) {
+  const args = [];
+  const re = /\bCOUNT\s*\(\s*DISTINCT\s+/gi;
+  let out = "", last = 0, m;
+  while ((m = re.exec(s)) !== null) {
+    const argStart = m.index + m[0].length;
+    let depth = 1, quote = "", i = argStart;
+    for (; i < s.length; i++) {
+      const c = s[i];
+      if (quote) {
+        if (c === quote)
+          quote = "";
+        continue;
+      }
+      if (c === "'" || c === '"') {
+        quote = c;
+        continue;
+      }
+      if (c === "[") {
+        const cl = s.indexOf("]", i + 1);
+        if (cl !== -1) {
+          i = cl;
+          continue;
+        }
+      }
+      if (c === "(")
+        depth++;
+      else if (c === ")") {
+        depth--;
+        if (depth === 0)
+          break;
+      }
+    }
+    if (depth !== 0)
+      break;
+    out += s.slice(last, m.index) + `${args.push(s.slice(argStart, i).trim()) - 1}`;
+    last = i + 1;
+    re.lastIndex = last;
+  }
+  return { masked: out + s.slice(last), args };
+}
+function hasResidualCaseKeyword(s) {
+  const masked = s.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\[[^\]]*\]/g, " ");
+  return /\b(?:CASE|WHEN|THEN|END)\b/i.test(masked);
+}
+function hasResidualInfixOperator(s) {
+  const masked = s.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\[[^\]]*\]/g, " ");
+  return /\b(?:LIKE|BETWEEN)\b/i.test(masked);
+}
+function _unmaskCountDistinct(s, args) {
+  return s.replace(/(\d+)/g, (_m, i) => {
+    const raw = stripOuterParens(args[Number(i)]);
+    const viaRules = lookSqlToSigmaRules(raw);
+    const converted = viaRules ?? lookConvertExpression(raw);
+    if (viaRules === null && hasResidualCaseKeyword(converted)) {
+      return `COUNT(DISTINCT ${raw})`;
+    }
+    return `CountDistinct(${converted})`;
+  });
+}
+var _SQL_KEYWORD_RE = /^(?:AND|OR|NOT|IN|IS|NULL|CASE|WHEN|THEN|ELSE|END|BETWEEN|LIKE|AS|ON|BY|DISTINCT|TRUE|FALSE|OVER|GROUP|EXISTS)$/i;
+function _naiveTitleCase(fn) {
+  return fn.charAt(0).toUpperCase() + fn.slice(1).toLowerCase();
+}
+var _BRACKET_UNMASK_RE = /\x0E(\d+)\x0F/g;
+function _bracketSpanFinalText(rawSpan) {
+  const inner = rawSpan.slice(1, -1);
+  if (/^[A-Z_][A-Z0-9_]*$/.test(inner) && !_SQL_KEYWORD_RE.test(inner)) {
+    return lookColRef(inner);
+  }
+  return rawSpan;
+}
+function _maskBrackets(s) {
+  const spans = [];
+  let out = "", i = 0;
+  while (i < s.length) {
+    if (s[i] === "[") {
+      const close = s.indexOf("]", i + 1);
+      if (close !== -1) {
+        const finalText = _bracketSpanFinalText(s.slice(i, close + 1));
+        out += `${spans.push(finalText) - 1}`;
+        i = close + 1;
+        continue;
+      }
+    }
+    out += s[i];
+    i++;
+  }
+  return { masked: out, spans };
+}
+function _unmaskBrackets(s, spans) {
+  return s.replace(_BRACKET_UNMASK_RE, (_m, i) => spans[Number(i)] ?? _m);
+}
 function lookConvertExpression(expr) {
+  const cd = _maskCountDistinct(expr);
+  const { masked, lits } = _maskLiterals(cd.masked);
+  expr = masked;
+  const ec = _convertNestedCases(expr, lits, "leave-raw", cd.args);
+  expr = ec.text;
   expr = expr.replace(/\b([A-Z_][A-Z0-9_]*)\s*(?=\()/gi, (match, fn) => {
     const upper = fn.toUpperCase();
-    return LOOK_FUNC_MAP[upper] || fn.charAt(0).toUpperCase() + fn.slice(1).toLowerCase();
+    if (_SQL_KEYWORD_RE.test(upper))
+      return match;
+    const mapped = LOOK_FUNC_MAP[upper];
+    if (mapped)
+      return mapped.endsWith("()") ? mapped.slice(0, -2) : mapped;
+    return _naiveTitleCase(fn);
   });
   expr = expr.replace(/(\[[^\]]+\]|[\w\]\)]+(?:\([^)]*\))?)\s+IN\s*\(([^)]+)\)/gi, (_, lhs, list) => {
     return `In(${lhs}, ${list})`;
   });
-  expr = expr.replace(/\b([A-Z_][A-Z0-9_]*)\b(?!\s*\()/g, (match) => {
-    if (/^(AND|OR|NOT|NULL|IS|IN|BETWEEN|LIKE|THEN|ELSE|END|WHEN|CASE|TRUE|FALSE)$/i.test(match))
-      return match;
-    if (/^\d+$/.test(match))
-      return match;
-    return lookColRef(match);
-  });
-  return expr.trim();
+  {
+    const { masked: bracketMasked, spans } = _maskBrackets(expr);
+    expr = bracketMasked.replace(/\b([A-Z_][A-Z0-9_]*)\b(?!\s*\()/g, (match) => {
+      if (_SQL_KEYWORD_RE.test(match))
+        return match;
+      if (/^\d+$/.test(match))
+        return match;
+      return lookColRef(match);
+    });
+    expr = _unmaskBrackets(expr, spans);
+  }
+  expr = _spliceNestedCases(expr, ec.blocks);
+  return _unmaskCountDistinct(_unmaskLiterals(expr, lits), cd.args).trim();
 }
 function lookSqlToSigmaRules(sql) {
   let expr = sql.replace(/\$\{TABLE\}\./gi, "").replace(/\$\{[^.}]+\.([^}]+)\}/g, (_, f) => f.toUpperCase()).replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, n) => n.toUpperCase()).replace(/[\r\n]+\s*/g, " ").trim();
+  expr = stripOuterParens(expr);
   {
     const m = expr.match(/^([A-Z_][A-Z0-9_]*)\s*=\s*(\d+)$/i);
     if (m)
@@ -357,7 +722,7 @@ function lookSigmaMetric(measureType, colName) {
   return map[(measureType || "").toLowerCase()] || `CountIf(IsNotNull([${dn}]))`;
 }
 
-// ../../../Users/tjwells/sigma-data-model-mcp/build/lookml.js
+// ../mcp-fresh/build/lookml.js
 function lookmlNamedFormat(name) {
   const n = name.trim().toLowerCase();
   const CUR = { usd: "$", gbp: "\xA3", eur: "\u20AC", cad: "$", aud: "$" };
@@ -778,6 +1143,19 @@ ${c.sql}
     }
   }
   return body;
+}
+function maskFormulaStringLiterals(formula) {
+  let marker = "@@LIT@@";
+  while (formula.includes(marker))
+    marker += "@";
+  const literals = [];
+  const masked = formula.replace(/"(?:[^"\\]|\\.)*"/g, (lit) => {
+    const idx = literals.push(lit) - 1;
+    return `${marker}${idx}${marker}`;
+  });
+  const escapedMarker = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const unmaskRe = new RegExp(`${escapedMarker}(\\d+)${escapedMarker}`, "g");
+  return { masked, unmask: (s) => s.replace(unmaskRe, (_m, i) => literals[Number(i)]) };
 }
 function lookExtractPath(view, sqlTableNameMap) {
   let raw = (view.sql_table_name || view.from || "").trim().replace(/`/g, "");
@@ -1572,7 +1950,7 @@ function lookConvertView(viewName, view, connectionId, warnings, sqlTableNameMap
         let viaRules = null;
         if (hasCase && !hasRawFn && !hasConcatOp && !hasCast) {
           viaRules = lookSqlToSigmaRules(expr.replace(/--[^\n]*/g, ""));
-          if (viaRules && /\b(CASE|WHEN|THEN)\b|\|\||::\s*\w/i.test(viaRules))
+          if (viaRules && (/\b(CASE|WHEN|THEN)\b|\|\||::\s*\w/i.test(viaRules) || hasResidualInfixOperator(viaRules)))
             viaRules = null;
         }
         if (viaRules) {
@@ -1839,9 +2217,15 @@ function convertLookMLToSigma(files, options = {}) {
       let relType = "N:1";
       if (j.rel === "one_to_one")
         relType = "1:1";
+      else if (j.rel === "one_to_many")
+        relType = "1:N";
+      else if (j.rel === "many_to_one")
+        relType = "N:1";
       else if (j.rel === "many_to_many") {
         relType = "N:1";
         warnings.push(`\u26A0 Relationship "${j.alias}": LookML relationship is many_to_many, which Sigma does not support natively. Mapped to the closest type (N:1) \u2014 verify cardinality and introduce a bridge/junction table if the join can fan out on both sides (otherwise aggregates may double-count).`);
+      } else {
+        warnings.push(`\u26A0 Relationship "${j.alias}": unrecognized LookML relationship "${j.rel}" \u2014 defaulted to N:1 (many-to-one); verify the cardinality.`);
       }
       const srcEl = srcRes.element;
       if (!srcEl.relationships)
@@ -1959,7 +2343,7 @@ function convertLookMLToSigma(files, options = {}) {
         keep.push(c);
         continue;
       }
-      const refs = c.formula.match(/\[([^\]\/]+)\]/g) || [];
+      const refs = maskFormulaStringLiterals(c.formula).masked.match(/\[([^\]\/]+)\]/g) || [];
       const hasCross = refs.some((ref) => {
         const n = ref.replace(/^\[|\]$/g, "");
         return !/^(true|false|null)$/i.test(n) && !localNames.has(n.toUpperCase());
@@ -2017,10 +2401,12 @@ function convertLookMLToSigma(files, options = {}) {
     }
     for (const c of calcs) {
       if (c.formula && Object.keys(relatedNameMap).length) {
-        c.formula = c.formula.replace(/\[([^\]\/]+)\]/g, (match, refName) => {
+        const { masked, unmask } = maskFormulaStringLiterals(c.formula);
+        const rewrittenMasked = masked.replace(/\[([^\]\/]+)\]/g, (match, refName) => {
           const rewritten = relatedNameMap[refName];
           return rewritten ? `[${rewritten}]` : match;
         });
+        c.formula = unmask(rewrittenMasked);
       }
       de.columns.push(c);
       de.order.push(c.id);
@@ -2129,5 +2515,6 @@ function buildDerivedElements(elements) {
 }
 export {
   convertLookMLToSigma,
+  maskFormulaStringLiterals,
   parseLookML
 };

--- a/tools/check-converter-provenance.sh
+++ b/tools/check-converter-provenance.sh
@@ -3,6 +3,8 @@
 # (the standing vendoring rule made mechanical, 2026-07-18).
 #
 #   bash tools/check-converter-provenance.sh <BASE> <HEAD>
+#   bash tools/check-converter-provenance.sh --freshness [REF]
+#   bash tools/check-converter-provenance.sh --online <sigma-data-model-mcp checkout>
 #
 # Fails (exit 1) when the BASE..HEAD range:
 #   1) changes a vendored converter bundle (plugins/**/converter/*.mjs) without
@@ -18,14 +20,195 @@
 # Callers resolve the range (hygiene.yml derives it from the CI event); the
 # check itself is range-parameterized so tools/test-converter-provenance.sh
 # can drive it against throwaway fixture repos offline.
+#
+# --freshness [REF] (default REF=HEAD) — STANDING gate, state-based rather
+# than diff-based: a merge to sigma-data-model-mcp changes nothing for any
+# operator until someone runs tools/vendor-converters.sh and commits the
+# regenerated bundle, and nothing else in this repo notices when that hasn't
+# happened. Pass 1/2 above only look at what changed in a push/PR range, so a
+# bundle nobody has touched in months (pre-existing drift, not a regression in
+# this diff) sails through clean forever. --freshness instead re-reads every
+# plugins/**/converter/PROVENANCE.json at REF on EVERY run, independent of
+# what changed, and flags any vendored (source_repo-bearing) entry whose
+# source_commit_date is more than CONVERTER_STALENESS_DAYS (default 14) old.
+#
+#   Design trade-off (deliberate): CI cannot assume network access to the
+#   private twells89/sigma-data-model-mcp repo, so this cannot ask upstream
+#   "is there anything new" — the honest options were (a) a recorded
+#   expected-latest-commit ledger a human bumps by hand, (b) an online mode
+#   that soft-passes when unreachable, or (c) grading staleness by the AGE of
+#   the recorded source_commit_date. Chosen: (c) as the default/CI-wired
+#   gate, with (b) available locally (see --online below) for a human who
+#   does have a checkout. Age needs no separate file to keep in sync (the
+#   date is already written by vendor-converters.sh on every re-vendor) and
+#   it catches BOTH failure modes from the same signal: a merge that missed
+#   its follow-up vendor, and pre-existing drift nobody flagged. The honest
+#   cost: age is a proxy, not proof — a converter whose upstream genuinely
+#   hasn't changed in 14 days false-positives as "stale" (a human glance,
+#   confirms nothing to do, no code changes needed); conversely a bundle
+#   re-vendored yesterday against an upstream that merged something an hour
+#   later won't be flagged until the window elapses. That is the accepted
+#   latency of an offline check — --online below trades the "always
+#   available" property back for a real comparison when a checkout exists.
+#
+#   cognos-to-sigma is not a false-flagged case: its PROVENANCE.json has no
+#   source_repo/source_commit at all by design (converter/cli.ts is vendored
+#   IN this repo, not from sigma-data-model-mcp — see tools/check-cognos-bundle.rb,
+#   which is the freshness gate for THAT vendoring path). --freshness detects
+#   this shape (no "source_repo" key, same test check-converter-provenance's
+#   diff-pairing pass already uses) and reports it explicitly as
+#   "in-skill, not applicable" rather than silently omitting the plugin or
+#   miscounting its absent source_commit as staleness.
+#
+#   A STALE verdict also never implies "just re-vendor blindly": when the
+#   flagged PROVENANCE.json carries a non-empty local_patches array (e.g.
+#   tableau-to-sigma today), the report appends a note pointing at those
+#   entries / _upstream_and_revendor_tasks instead — a naive re-vendor
+#   overwrites PROVENANCE.json wholesale and drops any patch not yet landed
+#   upstream (see TASK 3 in that file).
+#
+# --online <checkout> — OPTIONAL, NOT wired into CI (needs a local
+# sigma-data-model-mcp clone + network to fetch it current). Compares each
+# vendored plugin's recorded source_commit against the checkout's actual HEAD
+# and reports whether the module's own src file changed since. Soft-passes
+# (exit 0, warning only) when the checkout path is missing/not a git repo —
+# this mode exists for a human doing a manual audit, not as a hard gate.
 set -uo pipefail
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 missing — provenance guard cannot run"; exit 1; }
+
+# --freshness [REF] — standing staleness report, independent of any diff
+# range (see header comment for the design/trade-off). Enumerates every
+# plugins/**/converter/PROVENANCE.json at REF, classifies each as vendored
+# (source_repo present) or in-skill (cognos-style — no source_repo), and for
+# vendored entries flags source_commit_date older than CONVERTER_STALENESS_DAYS.
+if [ "${1:-}" = "--freshness" ]; then
+  REF="${2:-HEAD}"
+  STALE_DAYS="${CONVERTER_STALENESS_DAYS:-14}"
+  files="$(git ls-tree -r --name-only "$REF" -- plugins 2>/dev/null | grep -E '^plugins/.+/converter/PROVENANCE\.json$' | sort || true)"
+  [ -n "$files" ] || { echo "no plugins/**/converter/PROVENANCE.json found at $REF"; exit 1; }
+  printf '%s\n' "$files" | python3 -c "
+import json, sys, datetime
+ref = sys.argv[1]
+stale_days = int(sys.argv[2])
+paths = [l.strip() for l in sys.stdin if l.strip()]
+today = datetime.date.today()
+fail = False
+print('%-24s %-12s %-12s %-6s  %s' % ('PLUGIN', 'SOURCE_COMMIT', 'PINNED', 'AGE_D', 'STATUS'))
+for p in paths:
+    plugin = p.split('/')[1]
+    raw = __import__('subprocess').run(['git', 'show', '%s:%s' % (ref, p)], capture_output=True, text=True)
+    if raw.returncode != 0:
+        print('::error file=%s::cannot read PROVENANCE.json at %s' % (p, ref))
+        fail = True
+        continue
+    try:
+        d = json.loads(raw.stdout)
+    except Exception as exc:
+        print('::error file=%s::not valid JSON (%s) — freshness cannot be assessed' % (p, exc))
+        fail = True
+        continue
+    if 'source_repo' not in d:
+        # in-skill converter (cognos-style): vendors converter/*.ts IN this
+        # repo, never from sigma-data-model-mcp. NONE/absent source_commit is
+        # legitimate here — reported explicitly, not silently skipped, and
+        # not counted as stale. Its own freshness gate is check-cognos-bundle.rb.
+        print('%-24s %-12s %-12s %-6s  %s' % (plugin, 'n/a', 'n/a', 'n/a',
+              'OK (in-skill converter, not vendored from sigma-data-model-mcp — '
+              'see tools/check-cognos-bundle.rb)'))
+        continue
+    commit = d.get('source_commit')
+    date_str = d.get('source_commit_date')
+    if not commit or not date_str:
+        print('::error file=%s::vendored converter (source_repo present) missing source_commit/source_commit_date — re-vendor via tools/vendor-converters.sh <sigma-data-model-mcp checkout> to record real provenance' % p)
+        fail = True
+        continue
+    try:
+        pinned = datetime.date.fromisoformat(date_str)
+    except ValueError:
+        print('::error file=%s::source_commit_date %r is not ISO YYYY-MM-DD' % (p, date_str))
+        fail = True
+        continue
+    age = (today - pinned).days
+    mod = (d.get('vendored_modules') or '').split(',')[0].strip()
+    mod = mod[:-4] if mod.endswith('.mjs') else (mod or '<module>')
+    if age > stale_days:
+        note = ''
+        lp = d.get('local_patches')
+        if isinstance(lp, list) and lp:
+            note = (' NOTE: local_patches has %d entr%s recorded — a naive re-vendor overwrites '
+                     'this file and drops any not yet landed upstream; port each open entry '
+                     'upstream first (see local_patches / _upstream_and_revendor_tasks in this '
+                     'file), then re-vendor — do not just re-vendor blind.'
+                     % (len(lp), 'y' if len(lp) == 1 else 'ies'))
+        print('::error file=%s::STALE — %s pinned at %s (%s, %dd old, exceeds %dd) — run: tools/vendor-converters.sh <sigma-data-model-mcp checkout> %s%s' % (p, plugin, commit, date_str, age, stale_days, mod, note))
+        fail = True
+    else:
+        print('%-24s %-12s %-12s %-6d  %s' % (plugin, commit, date_str, age, 'OK — within %dd freshness window' % stale_days))
+sys.exit(1 if fail else 0)
+" "$REF" "$STALE_DAYS"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "converter-freshness guard FAILED (a bundle is stale, or its provenance is unreadable/incomplete)."
+  else
+    echo "converter-freshness guard OK ($REF, threshold ${STALE_DAYS}d)"
+  fi
+  exit $rc
+fi
+
+# --online <checkout> — optional, human-driven, NOT wired into CI (needs a
+# local sigma-data-model-mcp clone; soft-passes when it's not there so it can
+# never become a silent hard requirement). Compares each vendored plugin's
+# recorded source_commit against the checkout's actual HEAD and reports
+# whether the module's own src/<mod>.ts changed since that commit.
+if [ "${1:-}" = "--online" ]; then
+  CHECKOUT="${2:?usage: check-converter-provenance.sh --online <sigma-data-model-mcp checkout>}"
+  if [ ! -d "$CHECKOUT/.git" ]; then
+    echo "WARN: $CHECKOUT is not a git checkout — --online cannot compare; soft-passing (offline --freshness is the hard gate)"
+    exit 0
+  fi
+  UP_HEAD="$(git -C "$CHECKOUT" rev-parse --short HEAD 2>/dev/null)" || {
+    echo "WARN: could not resolve HEAD in $CHECKOUT — soft-passing"
+    exit 0
+  }
+  files="$(git ls-tree -r --name-only HEAD -- plugins 2>/dev/null | grep -E '^plugins/.+/converter/PROVENANCE\.json$' | sort || true)"
+  fail=0
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    d="$(git show "HEAD:$p" 2>/dev/null)"
+    kind="$(printf '%s' "$d" | python3 -c 'import json,sys
+try: d=json.load(sys.stdin)
+except Exception: d={}
+print("in-skill" if "source_repo" not in d else "vendored")')"
+    [ "$kind" = "vendored" ] || continue
+    commit="$(printf '%s' "$d" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("source_commit") or "")')"
+    mod="$(printf '%s' "$d" | python3 -c 'import json,sys; m=(json.load(sys.stdin).get("vendored_modules") or "").split(",")[0].strip(); print(m[:-4] if m.endswith(".mjs") else m)')"
+    [ -n "$commit" ] || continue
+    srcfile="src/$mod.ts"
+    if ! git -C "$CHECKOUT" cat-file -e "$UP_HEAD:$srcfile" 2>/dev/null; then
+      echo "  ? $p: $srcfile not found at $CHECKOUT HEAD ($UP_HEAD) — skipping live compare for this module"
+      continue
+    fi
+    if ! git -C "$CHECKOUT" cat-file -e "$commit" 2>/dev/null; then
+      echo "  ? $p: recorded source_commit $commit not found in $CHECKOUT — cannot compute upstream delta"
+      continue
+    fi
+    behind="$(git -C "$CHECKOUT" rev-list --count "$commit..$UP_HEAD" -- "$srcfile" 2>/dev/null || echo '?')"
+    if [ "$behind" != "0" ] && [ "$behind" != "?" ]; then
+      echo "  BEHIND $p: pinned $commit, upstream $UP_HEAD is $behind commit(s) ahead on $srcfile — re-vendor"
+      fail=1
+    else
+      echo "  OK     $p: pinned $commit matches upstream $srcfile as of $UP_HEAD"
+    fi
+  done < <(printf '%s\n' "$files")
+  [ "$fail" -eq 0 ] && echo "converter --online check: no live drift found vs $CHECKOUT ($UP_HEAD)" || echo "converter --online check: live drift found vs $CHECKOUT ($UP_HEAD) — see BEHIND lines above"
+  exit $fail
+fi
 
 BASE="${1:?usage: check-converter-provenance.sh <BASE> <HEAD>}"
 HEAD="${2:?usage: check-converter-provenance.sh <BASE> <HEAD>}"
 
-# The schema pin needs a JSON parser; a missing runtime must fail the gate
-# loudly, never skip it green.
-command -v python3 >/dev/null 2>&1 || { echo "python3 missing — provenance schema pin cannot run"; exit 1; }
+# (python3 already checked above — the schema pin below needs it too.)
 
 # An unresolvable range must fail, not read as an empty (green) change list.
 changed="$(git diff --name-only "$BASE" "$HEAD")" || { echo "git diff $BASE..$HEAD failed — cannot check provenance pairing"; exit 1; }

--- a/tools/test-converter-provenance.sh
+++ b/tools/test-converter-provenance.sh
@@ -16,6 +16,18 @@
 #   Part D — string-pin: the real tableau converter PROVENANCE.json records
 #            the d8a049a in-place patch with the commit/summary/upstream_pr
 #            entry schema and carries the upstream-and-re-vendor task block
+#   Part E — --freshness (staleness-by-age gate, 2026-07-31): a vendored
+#            PROVENANCE.json whose source_commit_date is older than
+#            CONVERTER_STALENESS_DAYS fails naming the module + re-vendor
+#            command; the same fixture with today's date passes; a
+#            source_repo entry missing source_commit/source_commit_date
+#            fails; a stale entry carrying local_patches gets the
+#            do-not-re-vendor-blind note; an in-skill (cognos-shaped, no
+#            source_repo) entry is reported explicitly as not-applicable,
+#            never silently dropped or miscounted as stale
+#   Part F — --online soft-pass: with no local sigma-data-model-mcp checkout
+#            present, --online exits 0 with a warning rather than failing —
+#            it is a human-driven convenience, never a hard CI requirement
 #
 # All fixture names are synthetic (toolx) — no field-derived identifiers.
 # Runs standalone:  bash tools/test-converter-provenance.sh
@@ -161,6 +173,88 @@ for t in "TASK 1 —" "TASK 2 —" "TASK 3 —" "TASK 4 —"; do
 done
 grep -q "scripts/dev/vendor-converter.sh" "$REAL"
 check $? "TASK 3 names the second (skill-local) regenerator"
+
+echo "Part E — --freshness: staleness-by-age, in-skill shape, missing keys, local_patches note"
+new_repo "$TMP/freshness"
+TOOLX="plugins/toolx-to-sigma/skills/toolx-to-sigma/converter"
+TOOLY="plugins/tooly-to-sigma/skills/tooly-to-sigma/converter"
+mkdir -p "$TOOLX" "$TOOLY"
+OLD_DATE="$(python3 -c 'import datetime; print((datetime.date.today()-datetime.timedelta(days=40)).isoformat())')"
+TODAY_DATE="$(python3 -c 'import datetime; print(datetime.date.today().isoformat())')"
+
+cat > "$TOOLX/PROVENANCE.json" <<EOF
+{
+  "source_repo": "example/fixture-converters",
+  "source_commit": "aaaaaaa",
+  "source_commit_date": "$OLD_DATE",
+  "vendored_modules": "toolx.mjs"
+}
+EOF
+# tooly stands in for the cognos shape: in-skill converter, no source_repo,
+# so it has no source_commit at all by design — must be reported explicitly,
+# not silently skipped and not counted as stale.
+cat > "$TOOLY/PROVENANCE.json" <<'EOF'
+{
+  "source": "in-skill converter/cli.ts",
+  "vendored_modules": "cli.mjs",
+  "source_sha256": "deadbeef"
+}
+EOF
+E0="$(commit_all base)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E0" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "40d-old source_commit_date fails freshness (got $RC)"
+grep -q "STALE" "$TMP/out"; check $? "failure says STALE"
+grep -q "vendor-converters.sh <sigma-data-model-mcp checkout> toolx" "$TMP/out"
+check $? "failure names the re-vendor command with the correct module"
+grep -q "in-skill converter, not vendored from sigma-data-model-mcp" "$TMP/out"
+check $? "cognos-shaped (no source_repo) entry reported explicitly as not-applicable"
+! grep -q "tooly-to-sigma.*STALE\|STALE.*tooly-to-sigma" "$TMP/out"
+check $? "cognos-shaped entry is never counted as stale"
+
+sed -i.bak "s/$OLD_DATE/$TODAY_DATE/" "$TOOLX/PROVENANCE.json" && rm -f "$TOOLX/PROVENANCE.json.bak"
+E1="$(commit_all fresh)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E1" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 0 ]; check $? "today's source_commit_date passes freshness (got $RC)"
+grep -q "guard OK" "$TMP/out"; check $? "passing state reports guard OK"
+
+cat > "$TOOLX/PROVENANCE.json" <<'EOF'
+{
+  "source_repo": "example/fixture-converters",
+  "vendored_modules": "toolx.mjs"
+}
+EOF
+E2="$(commit_all missing-commit)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E2" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "vendored entry missing source_commit/source_commit_date fails (got $RC)"
+grep -q "missing source_commit/source_commit_date" "$TMP/out"; check $? "failure names the missing keys"
+
+cat > "$TOOLX/PROVENANCE.json" <<EOF
+{
+  "source_repo": "example/fixture-converters",
+  "source_commit": "bbbbbbb",
+  "source_commit_date": "$OLD_DATE",
+  "vendored_modules": "toolx.mjs",
+  "local_patches": [
+    { "commit": "1111111", "summary": "fixture patch", "upstream_pr": null }
+  ]
+}
+EOF
+E3="$(commit_all stale-with-patches)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E3" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "stale entry with local_patches still fails (got $RC)"
+grep -q "local_patches has 1 entry recorded" "$TMP/out"; check $? "failure surfaces the local_patches count"
+grep -q "do not just re-vendor blind" "$TMP/out"; check $? "failure points at the correct remediation (patch upstream, don't blind re-vendor)"
+
+echo '{ not json' > "$TOOLX/PROVENANCE.json"
+E4="$(commit_all bad-json)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E4" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "malformed JSON fails freshness (got $RC)"
+grep -q "not valid JSON" "$TMP/out"; check $? "failure says the file no longer parses"
+
+echo "Part F — --online soft-pass with no local checkout"
+bash "$GUARD" --online "$TMP/no-such-checkout-dir" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 0 ]; check $? "--online soft-passes when the checkout path doesn't exist (got $RC)"
+grep -q "soft-passing" "$TMP/out"; check $? "soft-pass explains why (no checkout to compare against)"
 
 echo
 if [ "$fails" -gt 0 ]; then


### PR DESCRIPTION
Bundle was pinned at `867c669`, so this picks up **more than today's fixes**.

**mcp#120** stops the LookML cross-element calc-column pass from reading string-literal text as
live syntax. `lookml.ts` had **never been audited** for this defect class — it was the one
acknowledged unknown — and turned out to be **exposed and dangerous**: a quoted label
containing a bracketed name had that name read as a live column reference, silently relocating
or, where no derived element existed, **dropping** a fully self-contained column. A second
instance corrupted literal text inside a genuinely cross-element formula. Both demonstrated
live before any code changed.

`dbt.ts` was found to contain byte-identical copy-pasted vulnerable code, which is how the
class spread; it has no plugin bundle, so it reaches users only via the hosted MCP and CLI.

**mcp#121 does not apply here.** `lookml.ts` carries its own local copy of
`buildDerivedElements` rather than the shared one, so `hidden` is correctly **absent** from
this bundle — not a failed vendoring. That local copy is recorded as an unpatched follow-up
upstream.

Marker: `maskFormulaStringLiterals` 0→4.

Built from a `build/` tree verified **behaviourally** in the same session via the powerbi
bundle. See the powerbi PR: `vendor-converters.sh` bundles from `build/`, not `src/`, and
vendors a stale `build/` silently while still stamping `PROVENANCE` with the current commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)