### PR TITLE
tools: a bundle pinned by an OPEN local_patches entry warns instead of failing

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -165,6 +165,23 @@ jobs:
         run: |
           if [ -z "${RANGE_BASE:-}" ]; then echo "no diff range to check — skipping"; exit 0; fi
           bash tools/check-converter-provenance.sh "$RANGE_BASE" "$RANGE_HEAD"
+      - name: Converter-freshness guard (vendored-bundle staleness by age)
+        # Standing gate, NOT diff-scoped (unlike the pairing guard above, this
+        # runs every time regardless of RANGE_BASE): a merge to
+        # sigma-data-model-mcp changes nothing for any operator until someone
+        # runs tools/vendor-converters.sh and commits the regenerated bundle,
+        # and pre-existing drift nobody re-vendored in a long time has no diff
+        # to catch it on. CI cannot assume network access to that private repo,
+        # so this grades staleness by the AGE of each PROVENANCE.json's own
+        # source_commit_date (default threshold 14d, CONVERTER_STALENESS_DAYS)
+        # rather than asking upstream what's new — see the header comment in
+        # tools/check-converter-provenance.sh for the full trade-off. cognos-to-sigma
+        # vendors its own converter/*.ts in-skill (no source_repo/source_commit
+        # by design) and is reported explicitly as not-applicable, not flagged
+        # stale; its own freshness gate is tools/check-cognos-bundle.rb below.
+        # A STALE verdict that carries local_patches gets a note pointing at
+        # porting those patches upstream first, never "just re-vendor blind".
+        run: bash tools/check-converter-provenance.sh --freshness "$RANGE_HEAD"
       - name: Plugin-version-bump guard (release-hygiene diff gate)
         # #486: a change under plugins/<name>/** must move that plugin's
         # plugin.json "version" (strict semver) so `claude plugin update` sees a
@@ -194,7 +211,12 @@ jobs:
         # Proves the diff-pairing guard fails unpaired bundle changes, passes
         # paired ones, and schema-pins local_patches entries — plus the
         # string-pin on the real tableau PROVENANCE.json (synthetic fixture
-        # names only).
+        # names only). Also proves the --freshness staleness-by-age gate
+        # (Part E) fails a 40d-stale fixture and passes the same fixture
+        # dated today, reports an in-skill/cognos-shaped entry explicitly
+        # rather than silently, and surfaces the local_patches
+        # don't-re-vendor-blind note; plus --online's soft-pass when no local
+        # checkout is present (Part F).
         run: bash tools/test-converter-provenance.sh
       - name: Plugin-version-bump guard self-test (fixture repos, creds-free)
         # Proves the version-bump gate fails an unbumped plugin change, passes a

--- a/tools/check-converter-provenance.sh
+++ b/tools/check-converter-provenance.sh
@@ -133,16 +133,35 @@ for p in paths:
     mod = (d.get('vendored_modules') or '').split(',')[0].strip()
     mod = mod[:-4] if mod.endswith('.mjs') else (mod or '<module>')
     if age > stale_days:
-        note = ''
+        # A bundle carrying an OPEN local_patches entry (not yet landed upstream) is
+        # pinned ON PURPOSE — re-vendoring drops the patch. Hard-failing it demanded
+        # exactly the action the note warns against. Measured live on quicksight, whose
+        # UNDOCUMENTED native window-fn lowering was destroyed by a re-vendor:
+        # rank/denseRank/percentileRank/percentOfTotal all fell to Null and broke
+        # scripts/test-window-native.rb. So warn, don't block, and name what actually
+        # unblocks it — porting the entry upstream.
+        #
+        # The gate keeps its teeth: stale with NO open entry still hard-fails, which is
+        # the case it exists for (a bundle nobody remembered to refresh). "Open" means an
+        # entry not describing itself as SUPERSEDED; a superseded entry has landed
+        # upstream and no longer pins anything, so a re-vendor is safe and wanted.
         lp = d.get('local_patches')
-        if isinstance(lp, list) and lp:
-            note = (' NOTE: local_patches has %d entr%s recorded — a naive re-vendor overwrites '
-                     'this file and drops any not yet landed upstream; port each open entry '
-                     'upstream first (see local_patches / _upstream_and_revendor_tasks in this '
-                     'file), then re-vendor — do not just re-vendor blind.'
-                     % (len(lp), 'y' if len(lp) == 1 else 'ies'))
-        print('::error file=%s::STALE — %s pinned at %s (%s, %dd old, exceeds %dd) — run: tools/vendor-converters.sh <sigma-data-model-mcp checkout> %s%s' % (p, plugin, commit, date_str, age, stale_days, mod, note))
-        fail = True
+        open_lp = [x for x in (lp or []) if isinstance(x, dict)
+                   and 'SUPERSEDED' not in str(x.get('summary', '')).upper()]
+        if open_lp:
+            print('::warning file=%s::STALE BUT PINNED — %s at %s (%s, %dd old, exceeds %dd) '
+                  'with %d OPEN local_patches entr%s. Do NOT re-vendor blind: it would drop '
+                  'patches not yet landed upstream. Port each open entry upstream, retire it '
+                  'here, then re-vendor. Not failing the build — the pin is deliberate.'
+                  % (p, plugin, commit, date_str, age, stale_days,
+                     len(open_lp), 'y' if len(open_lp) == 1 else 'ies'))
+        else:
+            note = ''
+            if isinstance(lp, list) and lp:
+                note = (' NOTE: local_patches entries are all SUPERSEDED (landed upstream), so a '
+                        're-vendor is safe here and should also retire them.')
+            print('::error file=%s::STALE — %s pinned at %s (%s, %dd old, exceeds %dd) — run: tools/vendor-converters.sh <sigma-data-model-mcp checkout> %s%s' % (p, plugin, commit, date_str, age, stale_days, mod, note))
+            fail = True
     else:
         print('%-24s %-12s %-12s %-6d  %s' % (plugin, commit, date_str, age, 'OK — within %dd freshness window' % stale_days))
 sys.exit(1 if fail else 0)

--- a/tools/check-converter-provenance.sh
+++ b/tools/check-converter-provenance.sh
@@ -3,6 +3,8 @@
 # (the standing vendoring rule made mechanical, 2026-07-18).
 #
 #   bash tools/check-converter-provenance.sh <BASE> <HEAD>
+#   bash tools/check-converter-provenance.sh --freshness [REF]
+#   bash tools/check-converter-provenance.sh --online <sigma-data-model-mcp checkout>
 #
 # Fails (exit 1) when the BASE..HEAD range:
 #   1) changes a vendored converter bundle (plugins/**/converter/*.mjs) without
@@ -18,14 +20,195 @@
 # Callers resolve the range (hygiene.yml derives it from the CI event); the
 # check itself is range-parameterized so tools/test-converter-provenance.sh
 # can drive it against throwaway fixture repos offline.
+#
+# --freshness [REF] (default REF=HEAD) — STANDING gate, state-based rather
+# than diff-based: a merge to sigma-data-model-mcp changes nothing for any
+# operator until someone runs tools/vendor-converters.sh and commits the
+# regenerated bundle, and nothing else in this repo notices when that hasn't
+# happened. Pass 1/2 above only look at what changed in a push/PR range, so a
+# bundle nobody has touched in months (pre-existing drift, not a regression in
+# this diff) sails through clean forever. --freshness instead re-reads every
+# plugins/**/converter/PROVENANCE.json at REF on EVERY run, independent of
+# what changed, and flags any vendored (source_repo-bearing) entry whose
+# source_commit_date is more than CONVERTER_STALENESS_DAYS (default 14) old.
+#
+#   Design trade-off (deliberate): CI cannot assume network access to the
+#   private twells89/sigma-data-model-mcp repo, so this cannot ask upstream
+#   "is there anything new" — the honest options were (a) a recorded
+#   expected-latest-commit ledger a human bumps by hand, (b) an online mode
+#   that soft-passes when unreachable, or (c) grading staleness by the AGE of
+#   the recorded source_commit_date. Chosen: (c) as the default/CI-wired
+#   gate, with (b) available locally (see --online below) for a human who
+#   does have a checkout. Age needs no separate file to keep in sync (the
+#   date is already written by vendor-converters.sh on every re-vendor) and
+#   it catches BOTH failure modes from the same signal: a merge that missed
+#   its follow-up vendor, and pre-existing drift nobody flagged. The honest
+#   cost: age is a proxy, not proof — a converter whose upstream genuinely
+#   hasn't changed in 14 days false-positives as "stale" (a human glance,
+#   confirms nothing to do, no code changes needed); conversely a bundle
+#   re-vendored yesterday against an upstream that merged something an hour
+#   later won't be flagged until the window elapses. That is the accepted
+#   latency of an offline check — --online below trades the "always
+#   available" property back for a real comparison when a checkout exists.
+#
+#   cognos-to-sigma is not a false-flagged case: its PROVENANCE.json has no
+#   source_repo/source_commit at all by design (converter/cli.ts is vendored
+#   IN this repo, not from sigma-data-model-mcp — see tools/check-cognos-bundle.rb,
+#   which is the freshness gate for THAT vendoring path). --freshness detects
+#   this shape (no "source_repo" key, same test check-converter-provenance's
+#   diff-pairing pass already uses) and reports it explicitly as
+#   "in-skill, not applicable" rather than silently omitting the plugin or
+#   miscounting its absent source_commit as staleness.
+#
+#   A STALE verdict also never implies "just re-vendor blindly": when the
+#   flagged PROVENANCE.json carries a non-empty local_patches array (e.g.
+#   tableau-to-sigma today), the report appends a note pointing at those
+#   entries / _upstream_and_revendor_tasks instead — a naive re-vendor
+#   overwrites PROVENANCE.json wholesale and drops any patch not yet landed
+#   upstream (see TASK 3 in that file).
+#
+# --online <checkout> — OPTIONAL, NOT wired into CI (needs a local
+# sigma-data-model-mcp clone + network to fetch it current). Compares each
+# vendored plugin's recorded source_commit against the checkout's actual HEAD
+# and reports whether the module's own src file changed since. Soft-passes
+# (exit 0, warning only) when the checkout path is missing/not a git repo —
+# this mode exists for a human doing a manual audit, not as a hard gate.
 set -uo pipefail
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 missing — provenance guard cannot run"; exit 1; }
+
+# --freshness [REF] — standing staleness report, independent of any diff
+# range (see header comment for the design/trade-off). Enumerates every
+# plugins/**/converter/PROVENANCE.json at REF, classifies each as vendored
+# (source_repo present) or in-skill (cognos-style — no source_repo), and for
+# vendored entries flags source_commit_date older than CONVERTER_STALENESS_DAYS.
+if [ "${1:-}" = "--freshness" ]; then
+  REF="${2:-HEAD}"
+  STALE_DAYS="${CONVERTER_STALENESS_DAYS:-14}"
+  files="$(git ls-tree -r --name-only "$REF" -- plugins 2>/dev/null | grep -E '^plugins/.+/converter/PROVENANCE\.json$' | sort || true)"
+  [ -n "$files" ] || { echo "no plugins/**/converter/PROVENANCE.json found at $REF"; exit 1; }
+  printf '%s\n' "$files" | python3 -c "
+import json, sys, datetime
+ref = sys.argv[1]
+stale_days = int(sys.argv[2])
+paths = [l.strip() for l in sys.stdin if l.strip()]
+today = datetime.date.today()
+fail = False
+print('%-24s %-12s %-12s %-6s  %s' % ('PLUGIN', 'SOURCE_COMMIT', 'PINNED', 'AGE_D', 'STATUS'))
+for p in paths:
+    plugin = p.split('/')[1]
+    raw = __import__('subprocess').run(['git', 'show', '%s:%s' % (ref, p)], capture_output=True, text=True)
+    if raw.returncode != 0:
+        print('::error file=%s::cannot read PROVENANCE.json at %s' % (p, ref))
+        fail = True
+        continue
+    try:
+        d = json.loads(raw.stdout)
+    except Exception as exc:
+        print('::error file=%s::not valid JSON (%s) — freshness cannot be assessed' % (p, exc))
+        fail = True
+        continue
+    if 'source_repo' not in d:
+        # in-skill converter (cognos-style): vendors converter/*.ts IN this
+        # repo, never from sigma-data-model-mcp. NONE/absent source_commit is
+        # legitimate here — reported explicitly, not silently skipped, and
+        # not counted as stale. Its own freshness gate is check-cognos-bundle.rb.
+        print('%-24s %-12s %-12s %-6s  %s' % (plugin, 'n/a', 'n/a', 'n/a',
+              'OK (in-skill converter, not vendored from sigma-data-model-mcp — '
+              'see tools/check-cognos-bundle.rb)'))
+        continue
+    commit = d.get('source_commit')
+    date_str = d.get('source_commit_date')
+    if not commit or not date_str:
+        print('::error file=%s::vendored converter (source_repo present) missing source_commit/source_commit_date — re-vendor via tools/vendor-converters.sh <sigma-data-model-mcp checkout> to record real provenance' % p)
+        fail = True
+        continue
+    try:
+        pinned = datetime.date.fromisoformat(date_str)
+    except ValueError:
+        print('::error file=%s::source_commit_date %r is not ISO YYYY-MM-DD' % (p, date_str))
+        fail = True
+        continue
+    age = (today - pinned).days
+    mod = (d.get('vendored_modules') or '').split(',')[0].strip()
+    mod = mod[:-4] if mod.endswith('.mjs') else (mod or '<module>')
+    if age > stale_days:
+        note = ''
+        lp = d.get('local_patches')
+        if isinstance(lp, list) and lp:
+            note = (' NOTE: local_patches has %d entr%s recorded — a naive re-vendor overwrites '
+                     'this file and drops any not yet landed upstream; port each open entry '
+                     'upstream first (see local_patches / _upstream_and_revendor_tasks in this '
+                     'file), then re-vendor — do not just re-vendor blind.'
+                     % (len(lp), 'y' if len(lp) == 1 else 'ies'))
+        print('::error file=%s::STALE — %s pinned at %s (%s, %dd old, exceeds %dd) — run: tools/vendor-converters.sh <sigma-data-model-mcp checkout> %s%s' % (p, plugin, commit, date_str, age, stale_days, mod, note))
+        fail = True
+    else:
+        print('%-24s %-12s %-12s %-6d  %s' % (plugin, commit, date_str, age, 'OK — within %dd freshness window' % stale_days))
+sys.exit(1 if fail else 0)
+" "$REF" "$STALE_DAYS"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "converter-freshness guard FAILED (a bundle is stale, or its provenance is unreadable/incomplete)."
+  else
+    echo "converter-freshness guard OK ($REF, threshold ${STALE_DAYS}d)"
+  fi
+  exit $rc
+fi
+
+# --online <checkout> — optional, human-driven, NOT wired into CI (needs a
+# local sigma-data-model-mcp clone; soft-passes when it's not there so it can
+# never become a silent hard requirement). Compares each vendored plugin's
+# recorded source_commit against the checkout's actual HEAD and reports
+# whether the module's own src/<mod>.ts changed since that commit.
+if [ "${1:-}" = "--online" ]; then
+  CHECKOUT="${2:?usage: check-converter-provenance.sh --online <sigma-data-model-mcp checkout>}"
+  if [ ! -d "$CHECKOUT/.git" ]; then
+    echo "WARN: $CHECKOUT is not a git checkout — --online cannot compare; soft-passing (offline --freshness is the hard gate)"
+    exit 0
+  fi
+  UP_HEAD="$(git -C "$CHECKOUT" rev-parse --short HEAD 2>/dev/null)" || {
+    echo "WARN: could not resolve HEAD in $CHECKOUT — soft-passing"
+    exit 0
+  }
+  files="$(git ls-tree -r --name-only HEAD -- plugins 2>/dev/null | grep -E '^plugins/.+/converter/PROVENANCE\.json$' | sort || true)"
+  fail=0
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    d="$(git show "HEAD:$p" 2>/dev/null)"
+    kind="$(printf '%s' "$d" | python3 -c 'import json,sys
+try: d=json.load(sys.stdin)
+except Exception: d={}
+print("in-skill" if "source_repo" not in d else "vendored")')"
+    [ "$kind" = "vendored" ] || continue
+    commit="$(printf '%s' "$d" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("source_commit") or "")')"
+    mod="$(printf '%s' "$d" | python3 -c 'import json,sys; m=(json.load(sys.stdin).get("vendored_modules") or "").split(",")[0].strip(); print(m[:-4] if m.endswith(".mjs") else m)')"
+    [ -n "$commit" ] || continue
+    srcfile="src/$mod.ts"
+    if ! git -C "$CHECKOUT" cat-file -e "$UP_HEAD:$srcfile" 2>/dev/null; then
+      echo "  ? $p: $srcfile not found at $CHECKOUT HEAD ($UP_HEAD) — skipping live compare for this module"
+      continue
+    fi
+    if ! git -C "$CHECKOUT" cat-file -e "$commit" 2>/dev/null; then
+      echo "  ? $p: recorded source_commit $commit not found in $CHECKOUT — cannot compute upstream delta"
+      continue
+    fi
+    behind="$(git -C "$CHECKOUT" rev-list --count "$commit..$UP_HEAD" -- "$srcfile" 2>/dev/null || echo '?')"
+    if [ "$behind" != "0" ] && [ "$behind" != "?" ]; then
+      echo "  BEHIND $p: pinned $commit, upstream $UP_HEAD is $behind commit(s) ahead on $srcfile — re-vendor"
+      fail=1
+    else
+      echo "  OK     $p: pinned $commit matches upstream $srcfile as of $UP_HEAD"
+    fi
+  done < <(printf '%s\n' "$files")
+  [ "$fail" -eq 0 ] && echo "converter --online check: no live drift found vs $CHECKOUT ($UP_HEAD)" || echo "converter --online check: live drift found vs $CHECKOUT ($UP_HEAD) — see BEHIND lines above"
+  exit $fail
+fi
 
 BASE="${1:?usage: check-converter-provenance.sh <BASE> <HEAD>}"
 HEAD="${2:?usage: check-converter-provenance.sh <BASE> <HEAD>}"
 
-# The schema pin needs a JSON parser; a missing runtime must fail the gate
-# loudly, never skip it green.
-command -v python3 >/dev/null 2>&1 || { echo "python3 missing — provenance schema pin cannot run"; exit 1; }
+# (python3 already checked above — the schema pin below needs it too.)
 
 # An unresolvable range must fail, not read as an empty (green) change list.
 changed="$(git diff --name-only "$BASE" "$HEAD")" || { echo "git diff $BASE..$HEAD failed — cannot check provenance pairing"; exit 1; }

--- a/tools/test-converter-provenance.sh
+++ b/tools/test-converter-provenance.sh
@@ -16,6 +16,18 @@
 #   Part D — string-pin: the real tableau converter PROVENANCE.json records
 #            the d8a049a in-place patch with the commit/summary/upstream_pr
 #            entry schema and carries the upstream-and-re-vendor task block
+#   Part E — --freshness (staleness-by-age gate, 2026-07-31): a vendored
+#            PROVENANCE.json whose source_commit_date is older than
+#            CONVERTER_STALENESS_DAYS fails naming the module + re-vendor
+#            command; the same fixture with today's date passes; a
+#            source_repo entry missing source_commit/source_commit_date
+#            fails; a stale entry carrying local_patches gets the
+#            do-not-re-vendor-blind note; an in-skill (cognos-shaped, no
+#            source_repo) entry is reported explicitly as not-applicable,
+#            never silently dropped or miscounted as stale
+#   Part F — --online soft-pass: with no local sigma-data-model-mcp checkout
+#            present, --online exits 0 with a warning rather than failing —
+#            it is a human-driven convenience, never a hard CI requirement
 #
 # All fixture names are synthetic (toolx) — no field-derived identifiers.
 # Runs standalone:  bash tools/test-converter-provenance.sh
@@ -161,6 +173,88 @@ for t in "TASK 1 —" "TASK 2 —" "TASK 3 —" "TASK 4 —"; do
 done
 grep -q "scripts/dev/vendor-converter.sh" "$REAL"
 check $? "TASK 3 names the second (skill-local) regenerator"
+
+echo "Part E — --freshness: staleness-by-age, in-skill shape, missing keys, local_patches note"
+new_repo "$TMP/freshness"
+TOOLX="plugins/toolx-to-sigma/skills/toolx-to-sigma/converter"
+TOOLY="plugins/tooly-to-sigma/skills/tooly-to-sigma/converter"
+mkdir -p "$TOOLX" "$TOOLY"
+OLD_DATE="$(python3 -c 'import datetime; print((datetime.date.today()-datetime.timedelta(days=40)).isoformat())')"
+TODAY_DATE="$(python3 -c 'import datetime; print(datetime.date.today().isoformat())')"
+
+cat > "$TOOLX/PROVENANCE.json" <<EOF
+{
+  "source_repo": "example/fixture-converters",
+  "source_commit": "aaaaaaa",
+  "source_commit_date": "$OLD_DATE",
+  "vendored_modules": "toolx.mjs"
+}
+EOF
+# tooly stands in for the cognos shape: in-skill converter, no source_repo,
+# so it has no source_commit at all by design — must be reported explicitly,
+# not silently skipped and not counted as stale.
+cat > "$TOOLY/PROVENANCE.json" <<'EOF'
+{
+  "source": "in-skill converter/cli.ts",
+  "vendored_modules": "cli.mjs",
+  "source_sha256": "deadbeef"
+}
+EOF
+E0="$(commit_all base)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E0" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "40d-old source_commit_date fails freshness (got $RC)"
+grep -q "STALE" "$TMP/out"; check $? "failure says STALE"
+grep -q "vendor-converters.sh <sigma-data-model-mcp checkout> toolx" "$TMP/out"
+check $? "failure names the re-vendor command with the correct module"
+grep -q "in-skill converter, not vendored from sigma-data-model-mcp" "$TMP/out"
+check $? "cognos-shaped (no source_repo) entry reported explicitly as not-applicable"
+! grep -q "tooly-to-sigma.*STALE\|STALE.*tooly-to-sigma" "$TMP/out"
+check $? "cognos-shaped entry is never counted as stale"
+
+sed -i.bak "s/$OLD_DATE/$TODAY_DATE/" "$TOOLX/PROVENANCE.json" && rm -f "$TOOLX/PROVENANCE.json.bak"
+E1="$(commit_all fresh)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E1" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 0 ]; check $? "today's source_commit_date passes freshness (got $RC)"
+grep -q "guard OK" "$TMP/out"; check $? "passing state reports guard OK"
+
+cat > "$TOOLX/PROVENANCE.json" <<'EOF'
+{
+  "source_repo": "example/fixture-converters",
+  "vendored_modules": "toolx.mjs"
+}
+EOF
+E2="$(commit_all missing-commit)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E2" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "vendored entry missing source_commit/source_commit_date fails (got $RC)"
+grep -q "missing source_commit/source_commit_date" "$TMP/out"; check $? "failure names the missing keys"
+
+cat > "$TOOLX/PROVENANCE.json" <<EOF
+{
+  "source_repo": "example/fixture-converters",
+  "source_commit": "bbbbbbb",
+  "source_commit_date": "$OLD_DATE",
+  "vendored_modules": "toolx.mjs",
+  "local_patches": [
+    { "commit": "1111111", "summary": "fixture patch", "upstream_pr": null }
+  ]
+}
+EOF
+E3="$(commit_all stale-with-patches)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E3" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "stale entry with local_patches still fails (got $RC)"
+grep -q "local_patches has 1 entry recorded" "$TMP/out"; check $? "failure surfaces the local_patches count"
+grep -q "do not just re-vendor blind" "$TMP/out"; check $? "failure points at the correct remediation (patch upstream, don't blind re-vendor)"
+
+echo '{ not json' > "$TOOLX/PROVENANCE.json"
+E4="$(commit_all bad-json)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E4" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "malformed JSON fails freshness (got $RC)"
+grep -q "not valid JSON" "$TMP/out"; check $? "failure says the file no longer parses"
+
+echo "Part F — --online soft-pass with no local checkout"
+bash "$GUARD" --online "$TMP/no-such-checkout-dir" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 0 ]; check $? "--online soft-passes when the checkout path doesn't exist (got $RC)"
+grep -q "soft-passing" "$TMP/out"; check $? "soft-pass explains why (no checkout to compare against)"
 
 echo
 if [ "$fails" -gt 0 ]; then

--- a/tools/test-converter-provenance.sh
+++ b/tools/test-converter-provenance.sh
@@ -241,9 +241,32 @@ cat > "$TOOLX/PROVENANCE.json" <<EOF
 EOF
 E3="$(commit_all stale-with-patches)"
 CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E3" >"$TMP/out" 2>&1; RC=$?
-[ "$RC" -eq 1 ]; check $? "stale entry with local_patches still fails (got $RC)"
-grep -q "local_patches has 1 entry recorded" "$TMP/out"; check $? "failure surfaces the local_patches count"
-grep -q "do not just re-vendor blind" "$TMP/out"; check $? "failure points at the correct remediation (patch upstream, don't blind re-vendor)"
+# CONTRACT CHANGED (2026-07-31): a bundle held back by an OPEN local_patches entry is
+# pinned deliberately, so it WARNS rather than blocking. The old assertion here demanded
+# a hard failure while the guard's own message said "do not re-vendor blind" — it failed
+# you for not taking the action it warned against. Found the hard way: re-vendoring
+# quicksight-to-sigma destroyed an undocumented native window-fn lowering and broke
+# scripts/test-window-native.rb.
+[ "$RC" -eq 0 ]; check $? "stale entry with an OPEN local_patches entry WARNS, not fails (got $RC)"
+grep -q "STALE BUT PINNED" "$TMP/out"; check $? "warning is labelled as a deliberate pin"
+grep -q "1 OPEN local_patches entry" "$TMP/out"; check $? "warning surfaces the open-entry count"
+grep -q "Port each open entry upstream" "$TMP/out"; check $? "warning names the real remedy (port upstream, then re-vendor)"
+grep -q "^::warning" "$TMP/out"; check $? "emitted as ::warning, not ::error"
+
+# Teeth: a patch marked SUPERSEDED has landed upstream and no longer pins anything, so
+# the same staleness MUST still hard-fail. Without this, marking every entry superseded
+# would silently disarm the gate.
+python3 - "$TOOLX/PROVENANCE.json" <<'PYEOF'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d['local_patches'] = [{"commit": "1111111", "summary": "SUPERSEDED — folded upstream", "upstream_pr": "#1"}]
+json.dump(d, open(p, 'w'), indent=2)
+PYEOF
+E3b="$(commit_all stale-with-superseded-patches)"
+CONVERTER_STALENESS_DAYS=14 bash "$GUARD" --freshness "$E3b" >"$TMP/out" 2>&1; RC=$?
+[ "$RC" -eq 1 ]; check $? "stale entry whose local_patches are ALL superseded still FAILS (got $RC)"
+grep -q "all SUPERSEDED" "$TMP/out"; check $? "failure explains a re-vendor is safe here and should retire them"
 
 echo '{ not json' > "$TOOLX/PROVENANCE.json"
 E4="$(commit_all bad-json)"


### PR DESCRIPTION
## The incoherence

The converter-freshness gate hard-failed a stale bundle while its own message said
*"do not just re-vendor blind"* — because that bundle carries patches not yet landed
upstream. **It failed you for not taking the action it warned against**, and offered no
path to green.

## Found the hard way, not reasoned

Re-vendoring `quicksight-to-sigma` (stale at `867c669`, 39 days) **destroyed a feature**:
unpartitioned `rank` / `denseRank` / `percentileRank` / `percentOfTotal` all fell to `Null`,
breaking `scripts/test-window-native.rb`.

Investigated instead of adjusting the test — and upstream `src/quicksight.ts` lists those
functions in its *cannot-be-lowered* set, with `git log -S denseRank` showing a single
commit, the original converter. **The native window lowering exists only in the vendored
bundle**, as an undocumented hand-patch with no `local_patches` ledger to warn anyone.

So that bundle's staleness was *protecting* a real feature, and the gate's advice would
have deleted it.

## The change

A stale bundle with an **OPEN** `local_patches` entry now emits `::warning` and names the
real remedy — port the entry upstream, retire it, then re-vendor.

**Teeth preserved, proven both ways:**
- stale with **no** `local_patches` → still hard-fails (the case the gate exists for)
- stale whose entries are **all SUPERSEDED** → still hard-fails, because a superseded patch
  has landed and no longer pins anything. Without this, marking every entry superseded
  would silently disarm the gate.

Three existing assertions encoded the old contract and are replaced; six new ones were
negative-proved against the old guard (all six fail), and the old assertions fail against
the new guard. `tools/test-converter-provenance.sh` is ALL PASS.

## Disclosure

This unblocks re-vendor work of mine that the gate was holding. The merits stand
independently — a gate demanding an action it simultaneously warns against is broken
regardless of who it inconveniences — but it is a gate change made by the same author whose
PR it unblocks, so it deserves a reviewer's eye rather than a rubber stamp.

## Follow-up

`quicksight`'s undocumented patch is now recorded in a `local_patches` ledger (separate PR).
The mapping should be ported upstream to `src/quicksight.ts`, then the entry retired and the
bundle re-vendored cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)