### PR TITLE
test(tableau): filter-id regression pin + exit-29 gates.md fix (zjkw)

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/gates.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/gates.md
@@ -96,6 +96,7 @@ Exits 0 only when ALL pass. Full prose per gate: `refs/script-map.md` +
 | 26 | 19 agg semantics | `agg-semantics.json` unresolved additive-over-preagg / countd-as-sum / preagg-ratio (`audit-agg-semantics.rb --how <reaggregated\|n/a\|faithful-to-source>`); no skip flag |
 | 27 | 20 semantic edits | `semantic-edits.json` unproven or `match:false` (`probe-equivalence.rb`); NO waiver — revert or redesign |
 | 28 | 21 chart-kind parity | live element family ≠ verified `png-read.json` kind; substitutions recorded as `kind_waivers` at read time |
+| 29 | 8e layout arrangement | `--require-arrangement` set + `layout-arrangement.json` missing/malformed after a layout build, or violations present; WARN-only without the flag |
 | 30 | 4b layout ran | run-state shows the layout phase never entered |
 | 31 | 7c controls census | source control never built, undeclared in `control-scope.json` and unnamed in `controls-waivers.json`; no skip flag |
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-filter-id.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-filter-id.rb
@@ -1,0 +1,221 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-element-filter-id.rb — REGRESSION PIN for beads-sigma-zjkw's M4 claim
+# ("element-filter id omitted at 4 emission sites: null-dim exclusion, 2x
+# native top-n, keep-list"). Re-verification on 2026-07-31 found the claim is
+# FALSE on current code: commit 147e09b4 (2026-06-08, 7 weeks before the bead
+# was filed) already added a centralized backfill in
+# build-charts-from-signals.rb —
+#   el_filters.each_with_index { |nf, i| nf['id'] = "flt-#{el_id}-#{i}" }
+# — run over the SAME array object every element-filter emission site
+# (including the null-dim-exclusion and native-top-n paths) pushes into. Live
+# round-trip evidence: the /v2/workbooks/.../spec API rejects a filters[]
+# entry with no id, so this guarantee matters — this test exists to keep it
+# true, not to fix a live bug.
+#
+# Behaviorally exercises the ACTUAL build-charts-from-signals.rb (not the
+# backfill line in isolation) across four independent emission paths on one
+# dashboard, mirroring the fixture-building pattern of
+# test-topn-filter-emission.rb / test-native-topn-quickfilter.rb /
+# test-exclude-filter-emission.rb (synthetic .twb, empty view CSVs → built
+# from .twb signals, neutral fixture names):
+#
+#   1. null-dim exclusion   — a plain bar chart, NO Tableau quick filter at
+#                              all (build-charts-from-signals.rb ~5465)
+#   2. native top-n         — literal-N `groupfilter end='top' count='10'`
+#                              (~5916)
+#   3. parameter-driven top-n keep-list — count driven by a workbook
+#                              parameter, Rank()+keep-column idiom (~6017)
+#   4. plain categorical list quick-filter — a `groupfilter function='union'`
+#                              inclusive member filter (the `when 'list'` arm)
+#
+# Deterministic + offline + creds-free.
+# Usage:  ruby scripts/test-element-filter-id.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+def ws(name, filter_xml = '')
+  <<~XML
+    <worksheet name='#{name}'>
+      <table>
+        <view>
+          <datasource-dependencies datasource='federated.x' />
+          #{filter_xml}
+        </view>
+        <rows>[federated.x].[sum:TOTALREV:qk]</rows>
+        <cols>[federated.x].[none:REGION:nk]</cols>
+        <pane><mark class='Bar' /></pane>
+      </table>
+    </worksheet>
+  XML
+end
+
+LIST_FILTER = <<~XML
+  <filter class='categorical' column='[federated.x].[none:REGION:nk]'>
+    <groupfilter function='union' user:ui-enumeration='inclusive'>
+      <groupfilter function='member' level='[none:REGION:nk]' member='&quot;Region A&quot;' />
+    </groupfilter>
+  </filter>
+XML
+
+TOPN_FILTER = <<~XML
+  <filter class='categorical' column='[federated.x].[none:REGION:nk]'>
+    <groupfilter function='end' end='top' count='10' units='records'>
+      <groupfilter function='order' direction='DESC' expression='SUM([TOTALREV])'>
+        <groupfilter function='level-members' level='[none:REGION:nk]' />
+      </groupfilter>
+    </groupfilter>
+  </filter>
+XML
+
+PARAM_TOPN_FILTER = <<~XML
+  <filter class='categorical' column='[federated.x].[none:REGION:nk]'>
+    <groupfilter function='end' end='top' count='[Parameters].[Parameter 7]' units='records'>
+      <groupfilter function='order' direction='DESC' expression='SUM([TOTALREV])'>
+        <groupfilter function='level-members' level='[none:REGION:nk]' />
+      </groupfilter>
+    </groupfilter>
+  </filter>
+XML
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+    <datasources>
+      <datasource caption='Params' name='Parameters'>
+        <column param-domain-type='any' caption='Top Region Count' name='[Parameter 7]' datatype='integer' value='5' />
+      </datasource>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Region' name='[REGION]' datatype='string' role='dimension' />
+        <column caption='Total Revenue' name='[TOTALREV]' datatype='real' role='measure' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      #{ws('Null Excl Chart')}
+      #{ws('List Filter Chart', LIST_FILTER)}
+      #{ws('Native TopN Chart', TOPN_FILTER)}
+      #{ws('Param TopN Chart', PARAM_TOPN_FILTER)}
+    </worksheets>
+    <dashboards>
+      <dashboard name='Dash'>
+        <zones>
+          <zone id='1' name='Null Excl Chart' x='0' y='0' w='25000' h='100000' />
+          <zone id='2' name='List Filter Chart' x='25000' y='0' w='25000' h='100000' />
+          <zone id='3' name='Native TopN Chart' x='50000' y='0' w='25000' h='100000' />
+          <zone id='4' name='Param TopN Chart' x='75000' y='0' w='25000' h='100000' />
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Region$'                    => { 'id' => 'm-region', 'name' => 'Region' },
+  '(?i)^TOTALREV$|^Total Revenue$'  => { 'id' => 'm-rev',    'name' => 'Total Revenue' }
+}
+
+meta = nil
+build_out = nil
+build_log = ''
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [
+               { 'id' => 'v1', 'name' => 'Null Excl Chart' },
+               { 'id' => 'v2', 'name' => 'List Filter Chart' },
+               { 'id' => 'v3', 'name' => 'Native TopN Chart' },
+               { 'id' => 'v4', 'name' => 'Param TopN Chart' }
+             ] }))
+  Dir.mkdir(File.join(d, 'views'))
+  %w[v1 v2 v3 v4].each { |v| File.write(File.join(d, 'views', "#{v}.csv"), '') } # empty → build from .twb signals
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  meta = JSON.parse(File.read(lay.sub(/\.json$/, '-meta.json')))
+  out = File.join(d, 'specs.json')
+  build_log = IO.popen(['ruby', BUILD, '--tableau-dir', d, '--layout', lay,
+                        '--meta', lay.sub(/\.json$/, '-meta.json'), '--master-map', mm,
+                        '--master-element-id', 'master', '--skip-dashboard-read', 'unit-test',
+                        '--auto-controls', '--title', 'Dash', '--out', out],
+                       err: %i[child out], &:read)
+  build_log = build_log.to_s.force_encoding('UTF-8')
+  build_out = JSON.parse(File.read(out)) if File.exist?(out)
+end
+
+els = build_out ? (build_out.is_a?(Array) ? build_out : (build_out['elements'] || (build_out['pages'] || []).flat_map { |p| p['elements'] || [] })) : []
+
+def find_el(els, name)
+  els.find { |e| e['name'].to_s.casecmp?(name) }
+end
+
+def filter_ids_valid_and_unique?(el, fails, label)
+  filters = el ? (el['filters'] || []) : []
+  ok = filters.all? { |f| f['id'].is_a?(String) && !f['id'].strip.empty? }
+  check(ok, "#{label}: every filters[] entry has a non-empty id (got #{filters.map { |f| f['id'] }.inspect})", fails)
+  ids = filters.map { |f| f['id'] }
+  check(ids.uniq.size == ids.size, "#{label}: filter ids are unique within the element (got #{ids.inspect})", fails)
+  filters
+end
+
+# ---- Path 1: null-dim exclusion (no Tableau quick filter at all) -----------
+null_excl_el = find_el(els, 'Null Excl Chart')
+check(!null_excl_el.nil?, 'null-dim-exclusion tile built', fails)
+nef = filter_ids_valid_and_unique?(null_excl_el, fails, 'null-dim-exclusion tile')
+check(nef.any? { |f| f['columnId'].to_s.start_with?('nn-') },
+      "null-dim-exclusion path actually fired (expected an nn-* IsNotNull filter, got #{nef.inspect})", fails)
+
+# ---- Path 2: plain categorical list quick-filter ---------------------------
+list_el = find_el(els, 'List Filter Chart')
+check(!list_el.nil?, 'plain list-filter tile built', fails)
+lf = filter_ids_valid_and_unique?(list_el, fails, 'list-filter tile')
+check(lf.any? { |f| f['kind'] == 'list' && f['mode'] == 'include' && f['values'] == ['Region A'] },
+      "plain categorical list filter actually fired (got #{lf.inspect})", fails)
+
+# ---- Path 3: native top-n (literal N) ---------------------------------------
+topn_el = find_el(els, 'Native TopN Chart')
+check(!topn_el.nil?, 'native top-n tile built', fails)
+tf = filter_ids_valid_and_unique?(topn_el, fails, 'native top-n tile')
+check(tf.any? { |f| f['kind'] == 'top-n' && f['rowCount'] == 10 },
+      "native top-n path actually fired (got #{tf.inspect})", fails)
+
+# ---- Path 4: parameter-driven top-n keep-list -------------------------------
+param_el = find_el(els, 'Param TopN Chart')
+check(!param_el.nil?, 'parameter-driven top-n tile built', fails)
+pf = filter_ids_valid_and_unique?(param_el, fails, 'parameter-driven top-n tile')
+check(pf.any? { |f| f['kind'] == 'list' && f['mode'] == 'include' && f['values'] == ['keep'] },
+      "parameter-driven top-n keep-list filter actually fired (got #{pf.inspect})", fails)
+
+# ---- Global sweep: EVERY element's filters[] (any kind, any path) carries a
+# non-empty id unique within that element — the pin this test exists for.
+all_ok = els.all? do |e|
+  filters = e['filters'] || []
+  ids = filters.map { |f| f['id'] }
+  ids.all? { |i| i.is_a?(String) && !i.strip.empty? } && ids.uniq.size == ids.size
+end
+check(all_ok, "every built element's filters[] entries all carry a non-empty, element-unique id (build log tail on failure below)", fails)
+
+puts
+if fails.empty?
+  puts 'test-element-filter-id: ALL PASS — null-dim-exclusion, native top-n, parameter-driven top-n keep-list, ' \
+       'and plain categorical list filters all emit a non-empty, element-unique id on every filters[] entry'
+  exit 0
+else
+  puts "test-element-filter-id: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build log (tail) ---"
+  puts build_log.to_s.lines.last(30).join
+  exit 1
+end


### PR DESCRIPTION
## Update 2026-08-03 — rebased, scope reduced to 2 small items

This PR originally carried 4 changes. Two are now handled elsewhere:

1. ~~Doc fix — `phase-5-workbook.md`'s filter-shape example~~ — **superseded**. Someone independently fixed this exact doc gap on `main` already, with a better version than mine (it also documents that Sigma's spec endpoint hard-`400`s without `id`, resolving the "hard rejection vs. silent drop" question this PR originally left open).
2. ~~Real fix — join-cardinality resolution surfacing~~ — **merged already**, via #597 (cherry-picked from this PR's commit, verified byte-identical, live-validated end-to-end against a real warehouse + gate 16 probe).

What's left, both re-verified GREEN against current `main` post-rebase:

3. **`refs/gates.md`'s exit-29 row.** An E9 diet pass moved the whole exit-code table out of `SKILL.md` (where this PR originally patched it) into `refs/gates.md`, carrying the same gap with it — exit 29 (gate 8e, layout-arrangement parity) still existed in code but not in the table. Re-applied the same fix at its new location.
4. **Regression test — `test-element-filter-id.rb`.** Re-verification (see `beads-sigma-zjkw`'s 2026-07-31 note) found the M4 claim ("element-filter `id` omitted at 4 `build-charts-from-signals.rb` emission sites") is **not reproducible** — commit `147e09b4` (2026-06-08, seven weeks before the bead was filed) already added a centralized `id` backfill covering all four cited sites. This test pins that behavior as a durable regression guard: drives the actual builder across 4 independent filter-emission paths (null-dim exclusion, native top-n, parameter-driven top-n keep-list, plain categorical list) and asserts every `filters[]` entry carries a non-empty, element-unique `id`.

No behavior changes in this PR — one doc fix, one test.