### PR TITLE
domo-to-sigma: pre-flight DM columns against the real warehouse schema (bead m655)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-domo-dm-column-preflight.md
+++ b/docs/superpowers/plans/2026-07-31-domo-dm-column-preflight.md
@@ -1,0 +1,1143 @@
+# Domo DM Column Pre-flight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Before `build-dm.rb` posts a Sigma DM spec, proactively check every mapped Domo
+dataset's columns against the real warehouse table's schema (a live Sigma catalog lookup),
+report every unresolved gap by name, and auto-*suggest* (never auto-apply) a derivation
+formula when a known pattern matches — turning today's opaque `POST /v2/dataModels/spec`
+400 into a clear pre-flight message.
+
+**Architecture:** A new standalone script, `scripts/preflight-columns.rb`, fits the pipeline
+the same way `domo-discover.rb` does — reads already-written discovery files, makes one live
+Sigma catalog call per mapped dataset, and writes `discovery/column-preflight.json` for the
+next stage to consume offline. `build-dm.rb` gains a hard gate requiring that report to be
+clean before it builds `dm-spec.json`, waivable the same way its existing doctor-gate already
+is. `migrate-domo.rb`'s live orchestration gains a matching phase so the turnkey path doesn't
+break. See `docs/superpowers/specs/2026-07-31-domo-dm-column-preflight-design.md` for the
+full design and rationale (approved).
+
+**Tech Stack:** Ruby, stdlib only (`net/http`, `json`) — no gems. Reuses this plugin's
+existing `scripts/lib/sigma_rest.rb` (`Sigma.request`, `Sigma.list_entries` — already
+vendored/shared, NOT modified by this plan) for all live Sigma REST calls. Tests are plain
+Ruby assertion scripts (`ruby test/test-*.rb`), aggregated by `test/run-all.sh` (glob-based —
+no registration needed for new files).
+
+## Global Constraints
+
+- Work happens in worktree `~/wt-domo-m655`, branch `fix/domo-dm-column-preflight`, forked
+  from `origin/main` at `afa4cd27` (post-Track-C-merge). Stage explicitly (`git add <exact
+  paths>`), never `-A`/`-a`. **Never run `git stash`/`git stash pop` in this repo** — `.git`
+  is shared across many concurrent worktrees; stash refs are repo-wide, not per-worktree.
+- All test/build commands run from
+  `plugins/domo-to-sigma/skills/domo-to-sigma/` (cd there first). Full suite:
+  `bash test/run-all.sh` from that directory.
+- **Never auto-apply a derivation.** `suggest_derivation` only ever proposes a
+  `columnOverrides` entry for a human to review (approved design decision — see spec). It is
+  never written into `dataset-map.json` automatically by any code in this plan.
+- **Never guess when ambiguous.** Zero or 2+ candidate warehouse columns for a derivation
+  pattern → no suggestion; the column stays a reported gap for a human. This mirrors this
+  file's existing "never invents a table name, never defaults geometry to 0" conventions.
+- **No shared-lib extraction in this PR.** `scripts/lib/sigma_rest.rb` is a shared/vendored
+  file (`shared/manifest.json` lists it under multiple plugins) — it is **read, never
+  modified** by this plan. The new warehouse-column-fetch orchestration is domo-local for
+  now (see spec's Non-goals); a follow-up bead promotes it to `shared/` later.
+- Version bump required: `plugins/domo-to-sigma/.claude-plugin/plugin.json` is currently
+  `0.8.2` (post-Track-C) — this plan bumps it to `0.9.0` (new capability, not a patch-level
+  bug fix, per this repo's semver-bump gate).
+- `--offline` mode in `migrate-domo.rb` (`run_offline!`, a separate function from the live
+  path `run_live!` this plan touches) stages `dm-spec.json`/`dm-ids.json` directly from the
+  fixture and never invokes `build-dm.rb` at all — this plan's changes to the live path
+  (`run_live!`) do not affect `--offline` and must not be tested through it.
+
+---
+
+## File Structure
+
+- **Create** `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb` —
+  pure logic: name normalization, the missing-column diff, the one derivation pattern
+  (YYYYMMDD integer key → date), and the per-dataset report-entry builder. No network, no
+  filesystem — fully unit-testable offline.
+- **Create** `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb` — the
+  CLI: one network seam (`fetch_warehouse_columns`, table→inodeId lookup + paginated columns
+  fetch) and one orchestration function (`run_preflight`, injectable fetcher) wired to a thin
+  `if $PROGRAM_NAME == __FILE__` block, matching `build-dm.rb`'s own
+  testable-function-plus-thin-CLI-wrapper convention.
+- **Create** `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb` —
+  unit tests for Task 1's pure functions.
+- **Create** `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb` —
+  unit tests for Task 2 (`fetch_warehouse_columns`'s 404/error handling with stubbed
+  requester/lister; `run_preflight`'s orchestration with a stubbed whole-function fetcher).
+- **Modify**
+  `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb:351-377` (right after the
+  `dataset-map.json` existence/autofill block resolves, before `elements = used.map` builds
+  anything — NOT right after the doctor-gate, which would incorrectly also gate the C3
+  reuse-shortcut path that exits before building anything new) — add the column-preflight
+  gate.
+- **Modify** `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb` — add gate
+  tests (missing report aborts; unresolved report aborts and names the gap; clean report
+  proceeds; `SIGMA_SKIP_COLUMN_PREFLIGHT` waives it).
+- **Modify** `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb:565-587`
+  (`run_live!`, the build-dm section) — add a `preflight-columns` phase before `build-dm`,
+  only once `dataset-map.json` exists, respecting the same waiver.
+- **Modify** `plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md` — document the new script
+  in the Scripts table and Phase 3 section (the Track C final review's lesson: SKILL.md is
+  the program the agent executes — keep it in sync with what actually ships).
+- **Modify** `plugins/domo-to-sigma/.claude-plugin/plugin.json` — `0.8.2` → `0.9.0`.
+
+---
+
+### Task 1: Pure diff + suggestion logic (`scripts/lib/column_preflight.rb`)
+
+**Files:**
+- Create: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb`
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb`
+
+**Interfaces:**
+- Produces (consumed by Task 2): `ColumnPreflight.diff_columns(schema_cols, warehouse_cols,
+  excluded, overrides)` → `{'missing'=>[names], 'resolved_by_exclude'=>[names],
+  'resolved_by_override'=>[names]}`. `ColumnPreflight.suggest_derivation(missing_col_name,
+  domo_type, warehouse_cols)` → suggestion Hash or `nil`.
+  `ColumnPreflight.build_report_entry(table, schema_cols, warehouse_cols, excluded,
+  overrides)` → the full per-dataset report entry Hash (the exact
+  `discovery/column-preflight.json` per-dataset shape).
+  All `schema_cols`/`warehouse_cols` entries are `{'name'=>..., 'type'=>...}` Hashes
+  (String keys, matching this codebase's JSON-parsed convention throughout).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb`:
+
+```ruby
+#!/usr/bin/env ruby
+# Offline: ColumnPreflight's pure diff/suggestion logic (bead m655, Track "DM
+# column pre-flight"). No network, no filesystem — see
+# docs/superpowers/specs/2026-07-31-domo-dm-column-preflight-design.md.
+#   ruby test/test-column-preflight.rb
+require_relative '../scripts/lib/column_preflight'
+include ColumnPreflight
+
+$failures = 0
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+def eq(actual, expected, msg)
+  if actual == expected
+    puts "  ok: #{msg}"
+  else
+    $failures += 1
+    puts "  FAIL: #{msg}\n        expected #{expected.inspect}\n        got      #{actual.inspect}"
+  end
+end
+
+puts '== normalize_name: uppercases and strips non-alphanumerics =='
+eq(normalize_name('Order Date'), 'ORDERDATE', 'spaces stripped, uppercased')
+eq(normalize_name('ORDER_DATE_KEY'), 'ORDERDATEKEY', 'underscores stripped')
+eq(normalize_name(''), '', 'empty string stays empty')
+
+puts '== diff_columns: a column present in the warehouse is never "missing" =='
+schema = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DATE', 'type' => 'DATE' }]
+warehouse = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DATE', 'type' => 'DATE' }]
+diff = diff_columns(schema, warehouse, [], {})
+eq(diff['missing'], [], 'both columns resolve — nothing missing')
+
+puts '== diff_columns: a column absent from the warehouse is "missing" unless excluded/overridden =='
+warehouse2 = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }]
+diff2 = diff_columns(schema, warehouse2, [], {})
+eq(diff2['missing'], ['ORDER_DATE'], 'ORDER_DATE absent from warehouse -> missing')
+eq(diff2['resolved_by_exclude'], [], 'nothing excluded')
+eq(diff2['resolved_by_override'], [], 'nothing overridden')
+
+puts '== diff_columns: excludeColumns removes a gap from "missing" -> "resolved_by_exclude" =='
+diff3 = diff_columns(schema, warehouse2, ['ORDER_DATE'], {})
+eq(diff3['missing'], [], 'excluded column is not "missing"')
+eq(diff3['resolved_by_exclude'], ['ORDER_DATE'], 'excluded column is reported as resolved_by_exclude')
+
+puts '== diff_columns: columnOverrides removes a gap from "missing" -> "resolved_by_override" =='
+diff4 = diff_columns(schema, warehouse2, [], { 'ORDER_DATE' => { 'formula' => 'MakeDate(...)' } })
+eq(diff4['missing'], [], 'overridden column is not "missing"')
+eq(diff4['resolved_by_override'], ['ORDER_DATE'], 'overridden column is reported as resolved_by_override')
+
+puts '== diff_columns: case-insensitive matching against warehouse column names =='
+warehouse_lower = [{ 'name' => 'order_id', 'type' => 'LONG' }, { 'name' => 'order_date', 'type' => 'DATE' }]
+diff5 = diff_columns(schema, warehouse_lower, [], {})
+eq(diff5['missing'], [], 'lowercase warehouse names still match Domo\'s uppercase-ish names')
+
+puts '== suggest_derivation: exactly one numeric candidate whose name starts with the missing column\'s normalized name -> suggestion =='
+warehouse3 = [{ 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' }, { 'name' => 'CUSTOMER_ID', 'type' => 'LONG' }]
+s = suggest_derivation('ORDER_DATE', 'DATE', warehouse3)
+ok(s, 'a suggestion is returned')
+eq(s['pattern'], 'yyyymmdd_integer_key', 'suggested pattern name')
+eq(s['candidate_source_column'], 'ORDER_DATE_KEY', 'candidate is the one matching numeric column')
+ok(s['suggested_formula'].include?('MakeDate') && s['suggested_formula'].include?('ORDER_DATE_KEY'),
+   "suggested_formula references MakeDate and the candidate column, got #{s['suggested_formula'].inspect}")
+
+puts '== suggest_derivation: non-date Domo type -> no suggestion, even with a perfect candidate =='
+eq(suggest_derivation('ORDER_DATE', 'LONG', warehouse3), nil, 'only DATE/DATETIME Domo columns trigger this pattern')
+
+puts '== suggest_derivation: zero candidates -> no suggestion =='
+warehouse_none = [{ 'name' => 'CUSTOMER_ID', 'type' => 'LONG' }]
+eq(suggest_derivation('ORDER_DATE', 'DATE', warehouse_none), nil, 'no numeric column with a matching name prefix -> nil, never guess')
+
+puts '== suggest_derivation: two ambiguous candidates -> no suggestion (never guess) =='
+warehouse_ambiguous = [
+  { 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' },
+  { 'name' => 'ORDER_DATE_ID', 'type' => 'LONG' },
+]
+eq(suggest_derivation('ORDER_DATE', 'DATE', warehouse_ambiguous), nil,
+   'two plausible numeric candidates is ambiguous -> nil, never pick one arbitrarily')
+
+puts '== suggest_derivation: a matching-name candidate that is NOT numeric-typed is not a candidate =='
+warehouse_nonnumeric = [{ 'name' => 'ORDER_DATE_KEY', 'type' => 'VARCHAR' }]
+eq(suggest_derivation('ORDER_DATE', 'DATE', warehouse_nonnumeric), nil,
+   'a text-typed column with a matching name is not treated as a YYYYMMDD integer key')
+
+puts '== build_report_entry: combines diff + suggestion into the full report shape =='
+entry = build_report_entry('ORDER_FACT', schema, warehouse3, [], {})
+eq(entry['table'], 'ORDER_FACT', 'table name carried through')
+eq(entry['missing'], ['ORDER_DATE'], 'ORDER_DATE is missing (not in warehouse3)')
+eq(entry['resolved_by_exclude'], [], 'nothing excluded')
+eq(entry['resolved_by_override'], [], 'nothing overridden')
+ok(entry['suggested_overrides']['ORDER_DATE'], 'a suggestion is present for the missing ORDER_DATE column')
+eq(entry['suggested_overrides']['ORDER_DATE']['candidate_source_column'], 'ORDER_DATE_KEY',
+   'the suggestion names the correct candidate column')
+
+puts '== build_report_entry: a missing column with no derivable pattern gets no suggested_overrides entry =='
+entry2 = build_report_entry('ORDER_FACT', schema, warehouse_none, [], {})
+eq(entry2['missing'], ['ORDER_DATE'], 'still missing')
+eq(entry2['suggested_overrides'], {}, 'no suggestion when there is no derivable candidate')
+
+puts
+if $failures.zero?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{$failures} FAILURE(S)"
+  exit 1
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && ruby test/test-column-preflight.rb`
+Expected: FAIL — `scripts/lib/column_preflight.rb` doesn't exist yet
+(`cannot load such file`).
+
+- [ ] **Step 3: Implement `column_preflight.rb`**
+
+Create `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb`:
+
+```ruby
+# frozen_string_literal: true
+#
+# Pure logic for the domo DM column pre-flight check (bead m655): diffing a
+# Domo dataset's schema columns against a warehouse table's REAL columns
+# against what discovery/dataset-map.json's excludeColumns/columnOverrides
+# already resolve, and — for anything still unresolved — checking one
+# extensible derivation-pattern registry for an auto-*suggestion* (never an
+# auto-applied fix; see docs/superpowers/specs/2026-07-31-domo-dm-column-
+# preflight-design.md). No HTTP, no filesystem — the live warehouse-column
+# fetch is scripts/preflight-columns.rb's sole network seam; everything here
+# is pure and offline-testable (test/test-column-preflight.rb), matching
+# build-dm.rb's own derive_map_entry/autofill_dataset_map split.
+module ColumnPreflight
+  module_function
+
+  # Uppercase, strip every non-alphanumeric character — loose comparison
+  # between a missing Domo column's name and a candidate warehouse column's
+  # name (e.g. "Order Date" vs "ORDER_DATE_KEY" both normalize with a shared
+  # "ORDERDATE" prefix).
+  def normalize_name(name)
+    name.to_s.upcase.gsub(/[^A-Z0-9]/, '')
+  end
+
+  # schema_cols: Domo's discovery/datasets.json schema.columns[] ({'name','type'}).
+  # warehouse_cols: [{'name','type'}] as fetched live for the mapped table.
+  # excluded: Array of upcased column names already in dataset-map's excludeColumns.
+  # overrides: Hash of upcased column name => columnOverrides entry (already
+  #            resolved by a human in dataset-map.json).
+  #
+  # Returns { 'missing' => [names], 'resolved_by_exclude' => [names],
+  #           'resolved_by_override' => [names] } — 'missing' is every Domo
+  # column absent from warehouse_cols that isn't already excluded or overridden.
+  # Matching against warehouse_cols is case-insensitive (warehouse catalogs
+  # commonly return lowercase names for some connectors — Postgres, BigQuery —
+  # while Domo's own names may be any case).
+  def diff_columns(schema_cols, warehouse_cols, excluded, overrides)
+    warehouse_names = Array(warehouse_cols).map { |c| c['name'].to_s.upcase }.to_set
+    missing = []
+    resolved_by_exclude = []
+    resolved_by_override = []
+    Array(schema_cols).each do |c|
+      raw = (c['name'] || c['id']).to_s
+      next if raw.empty?
+      up = raw.upcase
+      next if warehouse_names.include?(up)
+      if excluded.include?(up)
+        resolved_by_exclude << raw
+      elsif overrides.key?(up)
+        resolved_by_override << raw
+      else
+        missing << raw
+      end
+    end
+    { 'missing' => missing, 'resolved_by_exclude' => resolved_by_exclude,
+      'resolved_by_override' => resolved_by_override }
+  end
+
+  # Warehouse column types treated as "numeric" for the derivation pattern
+  # below — a YYYYMMDD surrogate key is always an integer/number type, never
+  # text. Deliberately conservative (no VARCHAR/TEXT) — a text column matching
+  # the name pattern is NOT a YYYYMMDD key candidate.
+  NUMERIC_TYPES = %w[LONG DECIMAL DOUBLE INTEGER NUMBER BIGINT NUMERIC FLOAT SMALLINT TINYINT].freeze
+
+  def numeric_warehouse_column?(col)
+    NUMERIC_TYPES.include?(col['type'].to_s.upcase)
+  end
+
+  # The one derivation pattern shipped in this PR (see design doc — the
+  # registry is shaped so a second pattern is additive, but only one exists
+  # today; YAGNI). Triggers when a missing column's Domo type is DATE/DATETIME
+  # and warehouse_cols has EXACTLY ONE numeric-typed column whose normalized
+  # name starts with the missing column's own normalized name. Zero or 2+
+  # candidates -> nil (ambiguous or no match) — never guess.
+  #
+  # missing_col_name: the raw Domo column name (e.g. "Order Date").
+  # domo_type: the Domo column's raw type string (e.g. "DATE").
+  # warehouse_cols: same shape as diff_columns's second argument.
+  #
+  # Returns nil, or { 'pattern' => 'yyyymmdd_integer_key',
+  #   'candidate_source_column' => name, 'suggested_formula' => formula }.
+  def suggest_derivation(missing_col_name, domo_type, warehouse_cols)
+    return nil unless %w[DATE DATETIME].include?(domo_type.to_s.upcase)
+    target = normalize_name(missing_col_name)
+    return nil if target.empty?
+    candidates = Array(warehouse_cols).select do |c|
+      numeric_warehouse_column?(c) && normalize_name(c['name']).start_with?(target)
+    end
+    return nil unless candidates.size == 1
+    source = candidates.first['name']
+    {
+      'pattern' => 'yyyymmdd_integer_key',
+      'candidate_source_column' => source,
+      'suggested_formula' =>
+        "MakeDate(Floor([#{source}]/10000), Floor(Mod([#{source}],10000)/100), Mod([#{source}],100))",
+    }
+  end
+
+  # Builds one discovery/column-preflight.json entry for a single dataset.
+  # `table` is the mapped warehouse table name (dataset-map.json's own
+  # `table` value) — carried through purely for the report's readability.
+  def build_report_entry(table, schema_cols, warehouse_cols, excluded, overrides)
+    diff = diff_columns(schema_cols, warehouse_cols, excluded, overrides)
+    domo_type_by_name = Array(schema_cols).each_with_object({}) do |c, h|
+      h[(c['name'] || c['id']).to_s] = c['type']
+    end
+    suggestions = {}
+    diff['missing'].each do |name|
+      s = suggest_derivation(name, domo_type_by_name[name], warehouse_cols)
+      suggestions[name] = s if s
+    end
+    {
+      'table' => table,
+      'missing' => diff['missing'],
+      'resolved_by_exclude' => diff['resolved_by_exclude'],
+      'resolved_by_override' => diff['resolved_by_override'],
+      'suggested_overrides' => suggestions,
+    }
+  end
+end
+```
+
+Note: `to_set` requires `require 'set'` — Ruby 3.2+ autoloads `Set` core-wide, but this
+codebase's other files (`column_census.rb`) explicitly `require 'set'` for clarity across
+Ruby versions; add `require 'set'` at the top of `column_preflight.rb` for the same reason.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && ruby test/test-column-preflight.rb`
+Expected: `ALL PASS`
+
+- [ ] **Step 5: Run the full existing suite to check for regressions**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && bash test/run-all.sh`
+Expected: `== ALL SUITES PASS ==` (this task adds a new, self-contained file — nothing
+existing should move).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb
+git commit -m "domo: pure column pre-flight diff + derivation-suggestion logic (bead m655)"
+```
+
+---
+
+### Task 2: `scripts/preflight-columns.rb` — live warehouse-column fetch + orchestration
+
+**Files:**
+- Create: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb`
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb`
+
+**Interfaces:**
+- Consumes: `ColumnPreflight.build_report_entry(table, schema_cols, warehouse_cols, excluded,
+  overrides)` (Task 1).
+- Produces (consumed by Task 3 and Task 4, indirectly via the file it writes):
+  `fetch_warehouse_columns(connection_id, path, requester:, lister:)` →
+  `{'columns'=>[{'name','type'}], 'inode_id'=>...}` or `{'error'=>message}` (never raises).
+  `run_preflight(datasets, ds_map, used, fetcher:)` → `[report, any_missing]` where `report`
+  is the exact `discovery/column-preflight.json` Hash (keyed by dataset id) and
+  `any_missing` is a Boolean. The CLI's `discovery/column-preflight.json` — exit 0 (clean) /
+  exit 1 (unresolved columns or a fetch error somewhere).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb`:
+
+```ruby
+#!/usr/bin/env ruby
+# Offline: preflight-columns.rb's network seam (fetch_warehouse_columns) and
+# orchestration (run_preflight) — bead m655. No live Sigma call; requester/
+# lister and fetcher are injected stubs throughout (mirrors build-dm.rb's own
+# fetcher: seam for autofill_dataset_map).
+#   ruby test/test-preflight-columns.rb
+require 'json'
+require_relative '../scripts/preflight-columns'
+
+$failures = 0
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+def eq(actual, expected, msg)
+  if actual == expected
+    puts "  ok: #{msg}"
+  else
+    $failures += 1
+    puts "  FAIL: #{msg}\n        expected #{expected.inspect}\n        got      #{actual.inspect}"
+  end
+end
+
+puts '== fetch_warehouse_columns: happy path — lookup then paginated columns list =='
+stub_requester = ->(method, path, body: nil) do
+  eq(method, :post, 'lookup uses POST')
+  eq(path, '/v2/connection/conn-1/lookup', 'lookup path names the connection')
+  eq(JSON.parse(body), { 'path' => %w[DB SCH ORDER_FACT] }, 'lookup body carries the fully-qualified path')
+  { 'inodeId' => 'inode-1', 'kind' => 'table' }
+end
+stub_lister = ->(path) do
+  eq(path, '/v2/connections/tables/inode-1/columns', 'columns fetched at the resolved inodeId')
+  [{ 'name' => 'ORDER_ID', 'type' => { 'type' => 'LONG' } }, { 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' }]
+end
+result = fetch_warehouse_columns('conn-1', %w[DB SCH ORDER_FACT], requester: stub_requester, lister: stub_lister)
+ok(!result['error'], "no error on the happy path, got #{result['error'].inspect}")
+eq(result['columns'], [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' }],
+   'nested {type:{type:...}} shape is flattened to a plain type string')
+eq(result['inode_id'], 'inode-1', 'inode_id carried through')
+
+puts '== fetch_warehouse_columns: lookup 404 -> a distinct, actionable error (not a generic failure) =='
+requester_404 = ->(*_a, **_kw) { raise Sigma::Error, 'POST /v2/connection/conn-2/lookup -> 404 Not Found' }
+result_404 = fetch_warehouse_columns('conn-2', %w[DB SCH MISSING_TABLE], requester: requester_404, lister: ->(_p) { [] })
+ok(result_404['error'], 'a 404 lookup produces an error result, not an exception')
+ok(result_404['error'].include?('sync'), "the 404 message names the sync-then-retry fix, got #{result_404['error'].inspect}")
+
+puts '== fetch_warehouse_columns: a non-404 Sigma error is reported distinctly from a 404 =='
+requester_500 = ->(*_a, **_kw) { raise Sigma::Error, 'POST /v2/connection/conn-3/lookup -> 500 Internal Server Error' }
+result_500 = fetch_warehouse_columns('conn-3', %w[DB SCH TABLE], requester: requester_500, lister: ->(_p) { [] })
+ok(result_500['error'], 'a 500 also produces an error result, not an exception')
+ok(!result_500['error'].include?('sync'), 'a non-404 error does NOT get the 404-specific sync guidance')
+
+puts '== fetch_warehouse_columns: lookup resolving to a non-table kind is an error =='
+requester_view = ->(*_a, **_kw) { { 'inodeId' => 'inode-9', 'kind' => 'view' } }
+result_view = fetch_warehouse_columns('conn-4', %w[DB SCH V], requester: requester_view, lister: ->(_p) { [] })
+ok(result_view['error'], 'a non-table lookup result is an error')
+ok(result_view['error'].include?('view'), "error names the unexpected kind, got #{result_view['error'].inspect}")
+
+puts '== run_preflight: a dataset whose warehouse table has every Domo column -> clean =='
+datasets = [{ 'id' => 'ds-1', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } }]
+ds_map = { 'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' } }
+clean_fetcher = ->(_conn, _path) { { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } }
+report, any_missing = run_preflight(datasets, ds_map, %w[ds-1], fetcher: clean_fetcher)
+eq(any_missing, false, 'no unresolved columns -> any_missing is false')
+eq(report['ds-1']['missing'], [], 'ds-1 report shows nothing missing')
+
+puts '== run_preflight: a dataset with a genuinely missing column -> any_missing true, named in the report =='
+gap_fetcher = ->(_conn, _path) { { 'columns' => [] } }
+report2, any_missing2 = run_preflight(datasets, ds_map, %w[ds-1], fetcher: gap_fetcher)
+eq(any_missing2, true, 'a missing column -> any_missing is true')
+eq(report2['ds-1']['missing'], ['ORDER_ID'], 'the report names the specific missing column')
+
+puts '== run_preflight: a fetch error is reported and counts as any_missing =='
+error_fetcher = ->(_conn, _path) { { 'error' => 'table not found in Sigma catalog' } }
+report3, any_missing3 = run_preflight(datasets, ds_map, %w[ds-1], fetcher: error_fetcher)
+eq(any_missing3, true, 'a fetch error also makes any_missing true (nothing was actually checked)')
+eq(report3['ds-1']['error'], 'table not found in Sigma catalog', 'the fetch error is carried into the report')
+
+puts '== run_preflight: a dataset-map entry with a placeholder sentinel table is skipped, not attempted =='
+ds_map_sentinel = { 'ds-1' => { 'connectionId' => '', 'database' => nil, 'schema' => nil, 'table' => nil, '_source' => 'domo-landed-data' } }
+never_called = ->(*_a) { raise 'must not attempt a live fetch for an unresolved dataset-map entry' }
+report4, any_missing4 = run_preflight(datasets, ds_map_sentinel, %w[ds-1], fetcher: never_called)
+eq(report4, {}, 'nothing reported for a dataset with no resolved connection/table yet')
+eq(any_missing4, false, 'an unresolved (not-yet-mapped) dataset does not block the pre-flight — build-dm.rb\'s own existing warnings cover it')
+
+puts '== run_preflight: excludeColumns/columnOverrides already in dataset-map.json are honored =='
+ds_map_resolved = { 'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT',
+                                'excludeColumns' => ['ORDER_ID'] } }
+report5, any_missing5 = run_preflight(datasets, ds_map_resolved, %w[ds-1], fetcher: gap_fetcher)
+eq(any_missing5, false, 'the only gap is excluded -> clean')
+eq(report5['ds-1']['resolved_by_exclude'], ['ORDER_ID'], 'the exclusion is reported, not silently applied')
+
+puts
+if $failures.zero?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{$failures} FAILURE(S)"
+  exit 1
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && ruby test/test-preflight-columns.rb`
+Expected: FAIL — `scripts/preflight-columns.rb` doesn't exist yet.
+
+- [ ] **Step 3: Implement `preflight-columns.rb`**
+
+Create `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb`:
+
+```ruby
+#!/usr/bin/env ruby
+# Phase 2.9 — DM column pre-flight (bead m655). Checks every mapped dataset's
+# Domo columns against the REAL warehouse table's schema (a live Sigma
+# catalog lookup) before build-dm.rb (Phase 3) ever constructs dm-spec.json.
+# Never auto-applies a fix — see docs/superpowers/specs/2026-07-31-domo-dm-
+# column-preflight-design.md for the full design and rationale.
+#
+#   ruby scripts/preflight-columns.rb        # → discovery/column-preflight.json
+#     exit 0 = every used dataset's Domo columns are covered (present in the
+#              warehouse table, or already excludeColumns/columnOverrides'd
+#              in dataset-map.json)
+#     exit 1 = at least one dataset still has an unresolved column, or a live
+#              fetch error — see the report for names + any auto-suggested
+#              columnOverrides
+#
+# Requires SIGMA_BASE_URL + a Sigma bearer token (SIGMA_API_TOKEN, or
+# SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET for scripts/lib/sigma_rest.rb to
+# self-mint) — same credential story as put-layout.rb and post-and-readback.rb.
+# Skips (does not attempt a live call for) any dataset whose dataset-map.json
+# entry isn't fully resolved yet (no connectionId/table, or a
+# domo-stream-config-query-only / domo-landed-data _source) — build-dm.rb's
+# own existing warnings already cover those.
+
+require 'json'
+require 'fileutils'
+require_relative 'lib/column_preflight'
+require_relative 'lib/sigma_rest'
+include ColumnPreflight
+
+OUT = ENV['DOMO_DISCOVERY_DIR'] || File.expand_path('../discovery', __dir__)
+
+SENTINEL_SOURCES = %w[domo-stream-config-query-only domo-landed-data].freeze
+
+# Network seam: connection_id + [db,schema,table] -> {'columns'=>[...],
+# 'inode_id'=>...} or {'error'=>message} — NEVER raises, so run_preflight can
+# degrade one dataset at a time instead of aborting the whole run.
+# `requester`/`lister` are injected (default: the real Sigma.request /
+# Sigma.list_entries) so test/test-preflight-columns.rb can stub Sigma
+# entirely, mirroring build-dm.rb's fetcher: seam for autofill_dataset_map.
+def fetch_warehouse_columns(connection_id, path, requester: Sigma.method(:request), lister: Sigma.method(:list_entries))
+  # 1. Resolve the table to an inodeId. NOT GET /v2/connections/{conn}/tables
+  #    — that endpoint does not exist (feedback_sigma_columns_api_endpoint).
+  lookup = requester.call(:post, "/v2/connection/#{connection_id}/lookup",
+                          body: JSON.generate('path' => path))
+  inode = lookup.is_a?(Hash) ? lookup['inodeId'] : nil
+  return { 'error' => "lookup returned no inodeId: #{lookup.inspect}" } unless inode
+  unless lookup['kind'] == 'table'
+    return { 'error' => "#{path.join('.')} resolved to a #{lookup['kind']}, not a table" }
+  end
+
+  # 2. List columns at /v2/connections/tables/<inodeId>/columns — connectionId
+  #    is NOT in this path. Paginated; Sigma.list_entries follows nextPage to
+  #    exhaustion (server default page size is 50 — an unpaginated read would
+  #    silently truncate a wide table).
+  entries = lister.call("/v2/connections/tables/#{inode}/columns")
+  cols = entries.map do |c|
+    t = c['type']
+    t = t['type'] if t.is_a?(Hash) && t['type'] # type may arrive nested
+    { 'name' => c['name'], 'type' => t.to_s }
+  end
+  { 'columns' => cols, 'inode_id' => inode }
+rescue Sigma::Error => e
+  if e.message =~ /\b404\b/
+    { 'error' => "table #{path.join('.')} not found in Sigma's catalog for connection " \
+                 "#{connection_id} — sync it first: POST /v2/connections/#{connection_id}/sync " \
+                 "with body {\"path\": #{JSON.generate(path)}}, then re-run." }
+  else
+    { 'error' => "Sigma error resolving #{path.join('.')}: #{e.message.lines.first.to_s.strip}" }
+  end
+end
+
+# Runs the full pre-flight over every used dataset. Pure orchestration —
+# `fetcher` is the sole network seam (default: fetch_warehouse_columns above),
+# so this is fully unit-testable offline (test/test-preflight-columns.rb
+# stubs it as a whole function, bypassing Sigma entirely).
+#
+# datasets: discovery/datasets.json, parsed ([{'id','schema'=>{'columns'=>[...]}}]).
+# ds_map:   discovery/dataset-map.json, parsed ({datasetId => {...}}).
+# used:     dataset ids actually in scope (cards.json datasetIds, or every
+#           discovered dataset if cards.json is empty/absent — mirrors
+#           build-dm.rb's own `used` derivation).
+#
+# Returns [report, any_missing] — report is the exact discovery/
+# column-preflight.json shape (Hash keyed by dataset id, only datasets that
+# were actually checked or errored); any_missing is a Boolean (true if any
+# checked dataset still has an unresolved column, or a fetch error occurred).
+def run_preflight(datasets, ds_map, used, fetcher: method(:fetch_warehouse_columns))
+  ds_by_id = datasets.each_with_object({}) { |d, h| h[d['id']] = d }
+  report = {}
+  any_missing = false
+  used.each do |id|
+    entry = ds_map[id]
+    ds = ds_by_id[id]
+    next unless entry && ds
+    next if entry['connectionId'].to_s.strip.empty? || entry['table'].to_s.strip.empty? ||
+            SENTINEL_SOURCES.include?(entry['_source'])
+    schema_cols = ds.dig('schema', 'columns')
+    next unless schema_cols.is_a?(Array) # build-dm.rb's own ArgumentError already covers this
+
+    path = [entry['database'], entry['schema'], entry['table']].compact
+    fetched = fetcher.call(entry['connectionId'], path)
+    if fetched['error']
+      report[id] = { 'table' => entry['table'], 'error' => fetched['error'] }
+      any_missing = true
+      next
+    end
+
+    excluded  = Array(entry['excludeColumns']).map { |s| s.to_s.upcase }
+    overrides = (entry['columnOverrides'] || {}).each_with_object({}) { |(k, v), h| h[k.to_s.upcase] = v }
+    entry_report = build_report_entry(entry['table'], schema_cols, fetched['columns'], excluded, overrides)
+    report[id] = entry_report
+    any_missing ||= !entry_report['missing'].empty?
+  end
+  [report, any_missing]
+end
+
+if $PROGRAM_NAME == __FILE__
+  datasets = JSON.parse(File.read(File.join(OUT, 'datasets.json'))) rescue []
+  map_path = File.join(OUT, 'dataset-map.json')
+  unless File.exist?(map_path)
+    abort "  preflight-columns.rb: no discovery/dataset-map.json — run build-dm.rb once first " \
+          '(it writes dataset-map.template.json for you to fill in), then re-run this.'
+  end
+  ds_map = JSON.parse(File.read(map_path))
+  cards  = JSON.parse(File.read(File.join(OUT, 'cards.json'))) rescue []
+  used = cards.map { |c| c['datasetId'] }.compact.uniq
+  used = datasets.map { |d| d['id'] }.compact if used.empty?
+
+  report, any_missing = run_preflight(datasets, ds_map, used)
+
+  FileUtils.mkdir_p(OUT)
+  File.write(File.join(OUT, 'column-preflight.json'), JSON.pretty_generate(report))
+  if any_missing
+    warn "\n  preflight-columns.rb: unresolved column(s) or fetch error(s) — see " \
+         'discovery/column-preflight.json for names + any auto-suggested columnOverrides. ' \
+         'Resolve via excludeColumns/columnOverrides in dataset-map.json (or fix the named ' \
+         'connection/table issue), then re-run.'
+    exit 1
+  else
+    warn "  preflight-columns.rb: clean — every used dataset's Domo columns are covered."
+    exit 0
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && ruby test/test-preflight-columns.rb`
+Expected: `ALL PASS`
+
+- [ ] **Step 5: Run the full existing suite to check for regressions**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && bash test/run-all.sh`
+Expected: `== ALL SUITES PASS ==`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb
+git commit -m "domo: preflight-columns.rb — live warehouse-column fetch + orchestration (bead m655)"
+```
+
+---
+
+### Task 3: `build-dm.rb` gate
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb:351-377` (after the
+  `dataset-map.json` block, before `elements = used.map` — see Step 3 for exactly why)
+- Test: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb`
+
+**Interfaces:**
+- Consumes: `discovery/column-preflight.json` (Task 2's output shape) — read directly as
+  JSON, no function call across files needed.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/test-build-dm.rb`, add (this file already does
+`require_relative '../scripts/build-dm'` at the top — the gate lives inside the
+`if $PROGRAM_NAME == __FILE__` block, so these tests exercise it via subprocess, matching
+`test/test-build-domo-layout.rb`'s established `IO.popen` pattern for this exact situation —
+a main-block behavior that isn't a bare function call):
+
+```ruby
+puts '== column-preflight gate: build-dm.rb aborts when discovery/column-preflight.json is missing =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok(!$?.success?, 'build-dm.rb fails when column-preflight.json is absent')
+  ok(out.include?('preflight-columns.rb'), "the failure names the script to run first, got:\n#{out}")
+end
+
+puts '== column-preflight gate: build-dm.rb aborts when the report shows unresolved columns =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  File.write(File.join(dir, 'column-preflight.json'), JSON.generate(
+    'ds-1' => { 'table' => 'ORDER_FACT', 'missing' => ['ORDER_ID'], 'resolved_by_exclude' => [],
+                'resolved_by_override' => [], 'suggested_overrides' => {} }
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok(!$?.success?, 'build-dm.rb fails when column-preflight.json reports a missing column')
+  ok(out.include?('ORDER_ID'), "the failure names the specific unresolved column, got:\n#{out}")
+end
+
+puts '== column-preflight gate: a clean report lets build-dm.rb proceed =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  File.write(File.join(dir, 'column-preflight.json'), JSON.generate(
+    'ds-1' => { 'table' => 'ORDER_FACT', 'missing' => [], 'resolved_by_exclude' => [],
+                'resolved_by_override' => [], 'suggested_overrides' => {} }
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok($?.success?, "build-dm.rb succeeds when column-preflight.json is clean, got:\n#{out unless $?.success?}")
+  ok(File.exist?(File.join(dir, 'dm-spec.json')), 'dm-spec.json was written')
+end
+
+puts '== column-preflight gate: SIGMA_SKIP_COLUMN_PREFLIGHT waives it, same as the doctor-gate convention =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  # deliberately no column-preflight.json at all
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1',
+          'SIGMA_SKIP_COLUMN_PREFLIGHT' => 'unit test waiver' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok($?.success?, "build-dm.rb succeeds when the gate is waived, got:\n#{out unless $?.success?}")
+  ok(out.include?('WAIVED'), "the waiver is loudly logged, not silent, got:\n#{out}")
+end
+
+puts '== column-preflight gate: the C3 reuse-shortcut path is NEVER gated (nothing new is being built) =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  # No datasets.json/cards.json/dataset-map.json/column-preflight.json at all —
+  # a confirmed auto-pick must short-circuit before any of that is read.
+  File.write(File.join(dir, 'dm-match.json'), JSON.generate(
+    'recommended_dm_id' => 'dm-existing-123', 'auto_picked' => true
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok($?.success?, "build-dm.rb succeeds via the reuse shortcut with NO column-preflight.json present, got:\n#{out unless $?.success?}")
+  ok(File.exist?(File.join(dir, 'dm-reuse.json')), 'dm-reuse.json was written (the reuse path actually ran)')
+  ok(!out.include?('column-preflight'), "the reuse shortcut never even mentions the pre-flight gate, got:\n#{out}")
+end
+```
+
+`test/test-build-dm.rb` currently has neither an `ok` helper (only `eq`) nor `SKILL_ROOT`/
+`Dir.mktmpdir`/`IO.popen` — add all of them. Replace the file's current top:
+
+```ruby
+#!/usr/bin/env ruby
+# Unit tests for build-dm.rb helpers (display_name, build_element). No network.
+#   ruby test/test-build-dm.rb
+
+require_relative '../scripts/build-dm'
+
+$failures = 0
+def eq(a, b, m) if a == b then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}\n    exp #{b.inspect}\n    got #{a.inspect}" end end
+```
+
+with:
+
+```ruby
+#!/usr/bin/env ruby
+# Unit tests for build-dm.rb helpers (display_name, build_element). No network.
+#   ruby test/test-build-dm.rb
+
+require_relative '../scripts/build-dm'
+require 'tmpdir'
+
+SKILL_ROOT = File.expand_path('..', __dir__)
+
+$failures = 0
+def eq(a, b, m) if a == b then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}\n    exp #{b.inspect}\n    got #{a.inspect}" end end
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+```
+
+(`test/test-build-domo-layout.rb` defines its own equivalent `SKILL`/`SCRIPTS` constants
+under different names — each test file runs in its own separate `ruby` invocation via
+`test/run-all.sh`, so there is no top-level-constant collision between files, only within
+one file, which this change avoids by introducing `SKILL_ROOT` once at the top.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && ruby test/test-build-dm.rb`
+Expected: FAIL — `build-dm.rb` doesn't check for `column-preflight.json` yet, so the first
+three new tests fail (build-dm.rb currently succeeds where it should now abort); the fourth
+(waiver) is vacuously true today but for the wrong reason (no gate exists yet to waive); the
+fifth (reuse-shortcut) already passes today since the reuse path doesn't yet touch anything
+new — it stays green throughout and exists to catch a future regression.
+
+- [ ] **Step 3: Add the gate to `build-dm.rb`**
+
+**Placement matters here.** The gate must run AFTER the C3 reuse-shortcut check (a
+confirmed auto-pick reuses an existing DM and `exit 0`s before ever building anything new —
+nothing to pre-flight in that path) and AFTER `dataset-map.json` is confirmed to exist (its
+own `else` branch already `exit 2`s with "fill in the template" when it's missing — the
+column-preflight message only makes sense once a human is past that step). The correct
+insertion point is right after the `dataset-map.json` `if/else` block closes, before the
+`# Projection Beast Modes grouped by dataset` comment.
+
+In `scripts/build-dm.rb`, replace:
+
+```ruby
+    warn "  No discovery/dataset-map.json. Wrote dataset-map.template.json — auto-filled what Domo's"
+    warn '  stream config can tell us per DataSet (see "_source"/"_note" per entry). Fill in the'
+    warn '  remaining connectionId (always a human) and resolve any flagged entries, rename to'
+    warn '  dataset-map.json, re-run.'
+    exit 2
+  end
+
+  # Projection Beast Modes grouped by dataset (only these become DM calc columns).
+  proj_by_ds = Hash.new { |h, k| h[k] = [] }
+```
+
+with:
+
+```ruby
+    warn "  No discovery/dataset-map.json. Wrote dataset-map.template.json — auto-filled what Domo's"
+    warn '  stream config can tell us per DataSet (see "_source"/"_note" per entry). Fill in the'
+    warn '  remaining connectionId (always a human) and resolve any flagged entries, rename to'
+    warn '  dataset-map.json, re-run.'
+    exit 2
+  end
+
+  # Column pre-flight gate (bead m655): refuse to build a DM spec until every
+  # used dataset's Domo columns are confirmed resolvable against the mapped
+  # warehouse table (or already excludeColumns/columnOverrides'd) — see
+  # docs/superpowers/specs/2026-07-31-domo-dm-column-preflight-design.md and
+  # scripts/preflight-columns.rb. Runs here (after dataset-map.json is
+  # confirmed to exist, before elements are built) — NOT before the C3
+  # reuse-shortcut above, which exits before building anything new and has
+  # nothing to pre-flight. Waivable the same way the doctor-gate above is:
+  # name a reason.
+  preflight_path = File.join(OUT, 'column-preflight.json')
+  preflight_skip = ENV['SIGMA_SKIP_COLUMN_PREFLIGHT'].to_s.strip
+  if preflight_skip.empty?
+    unless File.exist?(preflight_path)
+      abort "  build-dm.rb aborted: discovery/column-preflight.json not found — run " \
+            'scripts/preflight-columns.rb first (checks Domo dataset columns against the ' \
+            'real warehouse table before this build). Waive with ' \
+            'SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" ruby scripts/build-dm.rb'
+    end
+    preflight_report = JSON.parse(File.read(preflight_path)) rescue {}
+    unresolved = preflight_report.select { |_, v| !(v['missing'] || []).empty? || v['error'] }
+    unless unresolved.empty?
+      warn "  build-dm.rb aborted: #{unresolved.size} dataset(s) still have unresolved columns " \
+           '(see discovery/column-preflight.json for names + any auto-suggested columnOverrides):'
+      unresolved.each do |id, v|
+        detail = v['error'] || (v['missing'] || []).join(', ')
+        warn "    #{id} (#{v['table']}): #{detail}"
+      end
+      abort '  Resolve via excludeColumns/columnOverrides in dataset-map.json, then re-run ' \
+            'scripts/preflight-columns.rb.'
+    end
+  else
+    warn "  ⚠ column pre-flight gate WAIVED (SIGMA_SKIP_COLUMN_PREFLIGHT=#{preflight_skip.inspect}) — " \
+         'unresolved columns may still 400 at DM POST time.'
+  end
+
+  # Projection Beast Modes grouped by dataset (only these become DM calc columns).
+  proj_by_ds = Hash.new { |h, k| h[k] = [] }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && ruby test/test-build-dm.rb`
+Expected: `ALL PASS`
+
+- [ ] **Step 5: Run the full existing suite to check for regressions**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && bash test/run-all.sh`
+Expected: `== ALL SUITES PASS ==` — in particular, confirm every OTHER existing
+`test-build-dm.rb` scenario (and any other test that shells out to `build-dm.rb`, e.g.
+inside `test-migrate-domo.rb`'s offline fixture path — that path never calls `build-dm.rb`
+at all per this plan's Global Constraints, so it should be unaffected, but confirm the run
+still shows `ALL SUITES PASS` regardless) still passes with the new gate in place.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb
+git commit -m "domo: build-dm.rb refuses to build a DM spec until column pre-flight is clean (bead m655)"
+```
+
+---
+
+### Task 4: Wire into `migrate-domo.rb`, document in SKILL.md, bump version
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb:565-587`
+  (inside `run_live!`)
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md`
+- Modify: `plugins/domo-to-sigma/.claude-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: `run_script!`, `fail_phase!`, `skip_phase!`, `done_phase!`, `hr` (all pre-existing
+  in `migrate-domo.rb`, unchanged signatures).
+- Produces: nothing further downstream — this is the closing task.
+
+**Why this task exists (read before touching anything):** `migrate-domo.rb`'s live path
+(`run_live!`) calls `build-dm.rb` directly today, with no phase for
+`preflight-columns.rb` at all. Task 3's gate means every `migrate-domo.rb` live run would
+now fail at `build-dm.rb` (missing `column-preflight.json`) unless this task wires the new
+phase in — this is a required integration, not an optional nice-to-have. `--offline` mode
+(`run_offline!`, a completely separate function) stages `dm-spec.json`/`dm-ids.json` directly
+from the fixture and never calls `build-dm.rb` at all, so it is unaffected by this task and
+must not be used to test it.
+
+- [ ] **Step 1: Wire the phase into `migrate-domo.rb`'s live path**
+
+In `scripts/migrate-domo.rb`, replace:
+
+```ruby
+  hr('build-dm (implicit prerequisite of build-workbook-spec)')
+  dm_spec_path = File.join(DISCOVERY, 'dm-spec.json')
+  if !opts[:force] && File.exist?(dm_spec_path)
+    log 'discovery/dm-spec.json already present — skip (idempotent; pass --force to rebuild)'
+    skip_phase!('build-dm', 'already built (idempotent skip)')
+  else
+    # --folder-id must reach build-dm too, not just build-workbook-spec: the DM
+    # spec itself needs a folderId or POST /v2/dataModels/spec 400s with
+    # "Expecting UUID at 0.folderId" (live-validated 2026-07-30).
+    dm_args = ['build-dm.rb']
+    dm_args += ['--folder-id', opts[:folder_id]] if opts[:folder_id]
+    ok, code, _out = run_script!(*dm_args)
+    if !ok && File.exist?(File.join(DISCOVERY, 'dataset-map.template.json')) && !File.exist?(File.join(DISCOVERY, 'dataset-map.json'))
+      fail_phase!('build-dm', 'wrote discovery/dataset-map.template.json — fill in the warehouse mapping for ' \
+                              'each DataSet as discovery/dataset-map.json and re-run')
+    end
+    fail_phase!('build-dm', "build-dm.rb exited #{code}") unless ok
+    done_phase!('build-dm')
+  end
+```
+
+with:
+
+```ruby
+  hr('build-dm (implicit prerequisite of build-workbook-spec)')
+  dm_spec_path = File.join(DISCOVERY, 'dm-spec.json')
+  if !opts[:force] && File.exist?(dm_spec_path)
+    log 'discovery/dm-spec.json already present — skip (idempotent; pass --force to rebuild)'
+    skip_phase!('build-dm', 'already built (idempotent skip)')
+  else
+    # Column pre-flight (bead m655): only meaningful once dataset-map.json is
+    # human-resolved — the FIRST build-dm.rb attempt below (no dataset-map.json
+    # yet) writes dataset-map.template.json and fails, same as before this
+    # bead; there is nothing to pre-flight until a human finishes that file.
+    map_path = File.join(DISCOVERY, 'dataset-map.json')
+    if File.exist?(map_path)
+      hr('preflight-columns (Domo columns vs the real warehouse schema)')
+      preflight_path = File.join(DISCOVERY, 'column-preflight.json')
+      if !opts[:force] && File.exist?(preflight_path)
+        skip_phase!('preflight-columns', 'already checked (idempotent skip)')
+      else
+        pf_ok, pf_code, _pf_out = run_script!('preflight-columns.rb')
+        if !pf_ok
+          skip_env = ENV['SIGMA_SKIP_COLUMN_PREFLIGHT'].to_s.strip
+          if skip_env.empty?
+            fail_phase!('preflight-columns',
+                        "preflight-columns.rb exited #{pf_code} — unresolved column(s) or a fetch error " \
+                        'found; see discovery/column-preflight.json for names + any auto-suggested ' \
+                        'columnOverrides, resolve via excludeColumns/columnOverrides in dataset-map.json, ' \
+                        'then re-run (or set SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" to waive, same as ' \
+                        "build-dm.rb's gate)")
+          else
+            skip_phase!('preflight-columns',
+                        "unresolved columns found but WAIVED via SIGMA_SKIP_COLUMN_PREFLIGHT=#{skip_env.inspect}")
+          end
+        else
+          done_phase!('preflight-columns')
+        end
+      end
+    end
+
+    # --folder-id must reach build-dm too, not just build-workbook-spec: the DM
+    # spec itself needs a folderId or POST /v2/dataModels/spec 400s with
+    # "Expecting UUID at 0.folderId" (live-validated 2026-07-30).
+    dm_args = ['build-dm.rb']
+    dm_args += ['--folder-id', opts[:folder_id]] if opts[:folder_id]
+    ok, code, _out = run_script!(*dm_args)
+    if !ok && File.exist?(File.join(DISCOVERY, 'dataset-map.template.json')) && !File.exist?(File.join(DISCOVERY, 'dataset-map.json'))
+      fail_phase!('build-dm', 'wrote discovery/dataset-map.template.json — fill in the warehouse mapping for ' \
+                              'each DataSet as discovery/dataset-map.json and re-run')
+    end
+    fail_phase!('build-dm', "build-dm.rb exited #{code}") unless ok
+    done_phase!('build-dm')
+  end
+```
+
+- [ ] **Step 2: Verify by careful reading — note the honest test-coverage limit**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && ruby -c scripts/migrate-domo.rb`
+Expected: `Syntax OK`
+
+This integration point has **no existing automated test to extend**: `test/test-migrate-domo.rb`
+only exercises `--offline` mode (`run_offline!`), which stages `dm-spec.json`/`dm-ids.json`
+directly and never reaches `build-dm.rb`, `post-and-readback.rb`, or (now)
+`preflight-columns.rb` — by design, since `--offline` is documented as needing no live
+credentials. The live path (`run_live!`) this task touches has no automated coverage today,
+for this phase or any of its neighbors. Do not write a test that fakes this — it would not
+prove anything real. Instead:
+- Confirm by inspection that the new block mirrors the exact structure of the existing
+  `dataset-map.template.json` special-case immediately below it (same `fail_phase!`/
+  `skip_phase!`/`done_phase!` calls, same idempotency-via-existing-output-file pattern).
+- Confirm `run_script!` passes environment variables through to the subprocess by default
+  (`Open3.capture2e(BASE_ENV, ...)` merges `BASE_ENV` on top of the inherited process
+  environment — it does not clear it — so `SIGMA_SKIP_COLUMN_PREFLIGHT`,
+  `SIGMA_API_TOKEN`, etc. all reach `preflight-columns.rb`'s subprocess the same way they
+  already reach `build-dm.rb`'s and `post-and-readback.rb`'s).
+- Recommend, in the PR description, a live smoke-test (`ruby scripts/migrate-domo.rb` against
+  a real Domo/Sigma pair) before this ships as a customer-facing capability — matching how
+  the Track B/C sessions validated their own live-only paths.
+
+- [ ] **Step 3: Run the full existing offline suite to confirm no regression**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && bash test/run-all.sh`
+Expected: `== ALL SUITES PASS ==` — `test-migrate-domo.rb`'s `--offline` assertions must be
+completely unaffected (per Step 2's reasoning); this run is the confirmation.
+
+- [ ] **Step 4: Document in SKILL.md**
+
+In `SKILL.md`, in the Scripts table, add a row immediately after the `find-or-pick-dm.rb`
+row and before the `build-dm.rb` row:
+
+```markdown
+| `scripts/preflight-columns.rb` | 2.9 | Check every mapped dataset's Domo columns against the REAL warehouse table schema (live Sigma catalog lookup); reports gaps + auto-suggests (never auto-applies) a derivation formula for a known pattern |
+```
+
+Then, in the "## Phase 3 — Data model" section, change:
+
+```markdown
+## Phase 3 — Data model
+
+`ruby scripts/build-dm.rb` → one DM element per DataSet (flat table) + calc
+columns from translated Beast Modes. No star schema unless a DataFlow join is in
+scope (out of scope for v1 — DataSets are treated as opaque source tables).
+```
+
+to:
+
+```markdown
+## Phase 3 — Data model
+
+`ruby scripts/build-dm.rb` → one DM element per DataSet (flat table) + calc
+columns from translated Beast Modes. No star schema unless a DataFlow join is in
+scope (out of scope for v1 — DataSets are treated as opaque source tables).
+
+**Pre-flight (Phase 2.9, runs automatically via `migrate-domo.rb`):**
+`ruby scripts/preflight-columns.rb` checks every mapped dataset's Domo columns against the
+real warehouse table's schema before `build-dm.rb` will proceed — a Domo DataSet routinely
+carries columns (derived/computed, or a drifted landed copy) that the mapped warehouse table
+doesn't have, which otherwise only surfaces as an opaque `POST /v2/dataModels/spec` 400. Any
+gap is reported by name in `discovery/column-preflight.json`, with an auto-*suggested* (never
+auto-applied) `columnOverrides` entry when a known derivable pattern matches (e.g. a YYYYMMDD
+integer date key). Resolve via `excludeColumns`/`columnOverrides` in `dataset-map.json`, then
+re-run. Waivable like the doctor-gate: `SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>"`.
+```
+
+- [ ] **Step 5: Bump the plugin version**
+
+In `plugins/domo-to-sigma/.claude-plugin/plugin.json`, change `"version": "0.8.2"` to
+`"version": "0.9.0"`.
+
+- [ ] **Step 6: Run the full suite one last time**
+
+Run: `cd plugins/domo-to-sigma/skills/domo-to-sigma && bash test/run-all.sh`
+Expected: `== ALL SUITES PASS ==`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md \
+        plugins/domo-to-sigma/.claude-plugin/plugin.json
+git commit -m "domo: wire preflight-columns into migrate-domo.rb, document it, close out bead m655 (0.8.2 -> 0.9.0)"
+```
+
+---
+
+## After all tasks: open the PR
+
+```bash
+git push -u origin fix/domo-dm-column-preflight
+gh pr create --title "domo-to-sigma: pre-flight DM columns against the real warehouse schema (bead m655)" --body "$(cat <<'EOF'
+## Summary
+- Adds `scripts/preflight-columns.rb`: checks every mapped Domo dataset's columns against
+  the REAL warehouse table schema (live Sigma catalog lookup) before `build-dm.rb` ever
+  posts a DM spec — closes bead `beads-sigma-m655`.
+- `build-dm.rb` now refuses to build until the report is clean (waivable via
+  `SIGMA_SKIP_COLUMN_PREFLIGHT`, matching the existing doctor-gate convention).
+- Auto-*suggests* (never auto-applies) a derivation formula for one known pattern (YYYYMMDD
+  integer date key -> `MakeDate(...)`) — a human always approves before it's live in
+  `dataset-map.json`.
+- Wires the new phase into `migrate-domo.rb`'s live path so the turnkey orchestrator doesn't
+  break; `--offline` mode is unaffected (it never calls `build-dm.rb` at all).
+- No shared-lib extraction in this PR (domo-local adaptation of `tableau-to-sigma`'s
+  proven warehouse-column-fetch pattern) — see the design doc's Non-goals; a follow-up bead
+  will promote it to `shared/`.
+- 0.8.2 -> 0.9.0.
+
+## Test plan
+- [ ] `bash test/run-all.sh` (from `plugins/domo-to-sigma/skills/domo-to-sigma/`) — all
+      suites pass, including 3 new/changed test files.
+- [ ] Reviewer confirms `migrate-domo.rb`'s new phase mirrors the existing
+      `dataset-map.template.json` special-case pattern exactly (no automated test exists for
+      the live orchestration path — `--offline` mode legitimately bypasses `build-dm.rb`
+      entirely, documented in the plan).
+- [ ] A live smoke-test (`migrate-domo.rb` against a real Domo/Sigma pair) is recommended
+      before this ships as a customer-facing capability.
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-07-31-domo-dm-column-preflight-design.md
+++ b/docs/superpowers/specs/2026-07-31-domo-dm-column-preflight-design.md
@@ -1,0 +1,208 @@
+# Domo DM column pre-flight — Design
+
+**Status:** approved, ready for implementation planning.
+**Bead:** `beads-sigma-m655` — "domo build-dm: no pre-flight validation that Domo dataset
+columns exist in the mapped warehouse table."
+
+## Problem
+
+`build-dm.rb` emits one Sigma DM column per Domo DataSet column, as a bare warehouse-table
+reference (`[TABLE/Column]`). A Domo DataSet routinely carries columns that do not exist in
+the warehouse table it's mapped to — Domo-side derived/computed columns, or a landed copy
+that has drifted from its source. Nothing checks this today. The only signal is an opaque
+`POST /v2/dataModels/spec` 400 at build-workbook time:
+
+```
+Cannot resolve columns on table '<id>': dependency not found:
+formula reference 'order_fact/order date'
+```
+
+`build-dm.rb` already has a mechanism for a human to *resolve* a known gap
+(`excludeColumns` to drop a Domo-only column, `columnOverrides[<COL>].formula` to derive one
+from a column that does exist), built live during the Track B session (bead `m655`'s own
+prior investigation). What's missing is the **pre-flight check itself**: proactively
+detecting the gap against the real warehouse schema before POST, instead of the operator
+discovering it by hand after a live 400.
+
+The bead's suggested tool, `mcp__sigma-data-model__validate_dm_columns`, does not fit this
+gap: it fetches a *saved* data model's columns and flags any with `type.type === "error"` —
+a post-hoc check for a DM that already exists. The failure this bead describes is a
+synchronous 400 at POST time; there is no DM yet for that tool to inspect.
+
+## Goals
+
+1. Before `build-dm.rb` ever constructs `dm-spec.json`, check every mapped dataset's Domo
+   columns against the *actual* warehouse table's real columns (a live Sigma catalog
+   lookup), not an assumption.
+2. Report every unresolved column as a named, visible fidelity gap — never a silent drop,
+   never an opaque POST-time 400 as the first signal.
+3. Where a missing column matches a known derivable pattern (starting with exactly one:
+   a YYYYMMDD-style integer date-key), auto-*suggest* the fix as a ready-to-review
+   `columnOverrides` entry — never auto-*apply* it. A human always approves before it's
+   live in `dataset-map.json`.
+4. Ship at full production quality (offline-testable, clearly documented, no hardcoded
+   customer/company specifics) — but scoped to the `domo-to-sigma` plugin for this PR
+   (see Non-goals).
+
+## Non-goals (this PR)
+
+- **No shared-lib extraction.** `tableau-to-sigma` already has an identical
+  warehouse-column-fetch pattern (`discover-columns.rb` /
+  `discover-warehouse-columns.rb`, `POST /v2/connection/{id}/lookup` →
+  `GET /v2/connections/tables/{inodeId}/columns`). This PR writes a domo-local adaptation
+  of that same pattern, deliberately with a clean, non-domo-coupled interface so it's a
+  trivial lift later — but the actual `shared/` promotion is a separate follow-up bead
+  (this repo's governance rule is "one PR = one plugin, or an isolated shared-lib change,"
+  never both).
+- **No live-data value sampling.** The derivation-pattern matcher works on column
+  *names and types* only (from the Sigma catalog lookup), never a live `SELECT` against
+  warehouse data. A future pattern could add value-sampling if a name/type heuristic proves
+  insufficient, but that's a materially bigger scope (warehouse query access, not just
+  schema introspection) and isn't needed for the one pattern in scope here.
+- **No general-purpose fuzzy schema matcher.** Exactly one derivation pattern ships now
+  (YYYYMMDD integer key → date). The registry is shaped so a second pattern is additive,
+  but nothing beyond the first is implemented or speculatively designed here (YAGNI).
+
+## Architecture
+
+### New script: `scripts/preflight-columns.rb`
+
+Fits the existing pipeline the same way `domo-discover.rb` does — a standalone step reading
+already-written discovery files and writing a new one for the next stage to consume offline,
+not a live call embedded inside `build-dm.rb` itself.
+
+**Reads:**
+- `discovery/datasets.json` — Domo schema per dataset (`schema.columns[]`).
+- `discovery/dataset-map.json` — resolved `connectionId`/`database`/`schema`/`table`, plus
+  any `excludeColumns`/`columnOverrides` a human already wrote.
+
+**Skips gracefully** (no live call attempted) any dataset whose `dataset-map.json` entry
+isn't fully resolved — a `<CONNECTION_ID>`/`<TABLE:...>` sentinel, or a
+`domo-stream-config-query-only` / `domo-landed-data` `_source` (per `build-dm.rb`'s existing
+classification, reused here rather than re-derived). There's nothing in the warehouse to
+check against until a human finishes that entry.
+
+**For every dataset with a real connection + table:**
+
+1. **Resolve table → `inodeId`:** `POST /v2/connection/{connectionId}/lookup` with body
+   `{"path": [database, schema, table]}`. A 404 means the table exists in the warehouse but
+   isn't indexed in Sigma's catalog yet — report this distinctly (mirroring
+   `discover-columns.rb`'s sync-then-retry guidance:
+   `POST /v2/connections/{id}/sync` with body `{"path": [...]}`, then retry), not as a
+   generic failure.
+2. **Fetch real columns:** `GET /v2/connections/tables/{inodeId}/columns`, paginated via
+   this plugin's existing `Sigma.list_entries` (`scripts/lib/sigma_rest.rb`) — no new HTTP
+   client needed, only the orchestration on top of what's already there.
+3. Both calls run through a bounded-timeout, injected-connection pattern (matching
+   `discover-columns.rb`'s `SIGMA_HTTP_TIMEOUT`, default 90s) — a cold warehouse or a very
+   wide view must fail loud, not hang indefinitely.
+
+This fetch is the **one** network seam, matching `build-dm.rb`'s own `fetcher:` pattern for
+`fetch_stream_config` — everything downstream is pure, offline-testable functions.
+
+**Diff logic (pure function):** `schema_cols` (Domo) minus `excludeColumns` minus anything
+already named in `columnOverrides`, compared by name against the fetched real warehouse
+columns → `missing`. Non-empty `missing` on any dataset is what makes the whole script
+exit 1 (see Data flow below).
+
+**Suggestion logic (pure function, extensible registry):** an array of pattern-matchers,
+exactly one entry for this PR:
+
+- **Pattern: YYYYMMDD integer date key.** Triggers when a missing column's Sigma format
+  (via `build-dm.rb`'s existing `type_format`) is `datetime`-like, and the fetched warehouse
+  columns contain **exactly one** numeric-typed column whose name — normalized
+  (uppercased, separators stripped) — starts with the missing column's own normalized name
+  (e.g. missing `ORDER_DATE` → candidate `ORDER_DATE_KEY`). Zero or multiple candidates
+  (ambiguous) → no suggestion; it stays a reported gap for a human. Exactly one candidate →
+  suggest a `MakeDate(...)` integer-arithmetic formula (per bead `9777`'s
+  `MakeDate(y,m,d)`, not the deprecated 3-arg `Date(y,m,d)` — exact Sigma function/arity to
+  be confirmed against the formula-conversion skill during implementation; the
+  architecturally important part is *which column* gets suggested, since a human reviews
+  the exact formula text before it's ever applied).
+
+**Writes:** `discovery/column-preflight.json`, one report entry per dataset:
+
+```json
+{
+  "<datasetId>": {
+    "table": "ORDER_FACT",
+    "missing": ["ORDER_DATE"],
+    "resolved_by_exclude": [],
+    "resolved_by_override": [],
+    "suggested_overrides": {
+      "ORDER_DATE": {
+        "pattern": "yyyymmdd_integer_key",
+        "candidate_source_column": "ORDER_DATE_KEY",
+        "suggested_formula": "MakeDate(Floor([ORDER_DATE_KEY]/10000), Floor(Mod([ORDER_DATE_KEY],10000)/100), Mod([ORDER_DATE_KEY],100))"
+      }
+    }
+  }
+}
+```
+
+A dataset with an empty `missing` array is clean. `resolved_by_exclude` /
+`resolved_by_override` are informational confirmation that the human's existing
+`dataset-map.json` entries actually correspond to a real gap (if a `columnOverrides` entry
+names a column that was never actually missing, that's a *Minor* note in the report, not a
+blocker).
+
+### `build-dm.rb` gate
+
+At the top of the main block, alongside the existing environment doctor-gate, `build-dm.rb`
+now requires `discovery/column-preflight.json` to exist and to show zero `missing` across
+every dataset in `used` — same "fail loud, name the exact fix" convention as the existing
+`schema.columns` and `folderId` checks in this same file. Missing the report file entirely
+gets the same treatment as a missing `dataset-map.json` today: a clear message naming the
+script to run first.
+
+Waivable the same way the doctor-gate already is, not a new mechanism:
+`SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>"`.
+
+## Data flow
+
+```
+domo-discover.rb          (existing)
+  → discovery/datasets.json, discovery/dataset-map[.template].json
+
+preflight-columns.rb       (NEW)
+  reads:  datasets.json, dataset-map.json
+  calls:  Sigma lookup + columns (live, one network seam)
+  writes: discovery/column-preflight.json
+  exit 0 = clean; exit 1 = unresolved columns remain (report names them + any suggestions)
+
+build-dm.rb                (gate added)
+  requires: discovery/column-preflight.json present, zero `missing`
+  (SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" waives it)
+  → discovery/dm-spec.json (unchanged downstream shape)
+```
+
+## Error handling
+
+- **Sentinel/unresolved `dataset-map.json` entries:** skipped, not attempted — already
+  reported by `build-dm.rb`'s own existing `missing`/`needs_review` warnings; the pre-flight
+  report doesn't duplicate that, it only covers datasets ready for a real check.
+- **404 on lookup (table not yet in Sigma's catalog):** distinct message with the sync
+  command, not folded into a generic failure.
+- **Timeout (cold warehouse / wide view):** bounded (`SIGMA_HTTP_TIMEOUT`, default 90s),
+  fails loud with a clear retry/escape-hatch message — never hangs indefinitely.
+- **Ambiguous derivation match (0 or 2+ candidates):** no suggestion emitted; the column
+  stays a reported gap. Never guess when there's more than one plausible answer.
+- **A `columnOverrides` entry that turns out not to correspond to any real gap:** reported
+  as a Minor informational note, not a build blocker.
+
+## Testing
+
+Matches this file's existing style — `test/test-build-dm.rb` already stubs `fetcher:` for
+`autofill_dataset_map` with zero network/credentials. The new diff and suggestion functions
+get the same treatment: pure functions, unit-tested with hand-built and fixture-captured
+warehouse-column-list inputs (a small anonymized fixture under
+`test/fixtures/`, matching the existing `domo-live-raw/` convention), no live Sigma call
+required to test the logic. A live smoke-test against a real connection is a verification
+step during implementation (not part of the automated suite, which stays fully offline).
+
+## Follow-up (explicitly out of scope here)
+
+File a new bead once this lands: promote the warehouse-column-fetch logic (table→inodeId
+lookup + paginated columns list) to `shared/`, and wire `tableau-to-sigma` to consume the
+same shared copy instead of its own standalone script — this PR's domo-local version is
+written cleanly enough that the lift should be mechanical.

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
   "version": "0.9.0",
-  "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
+  "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",
   "keywords": ["domo", "beast-mode", "sigma", "migration", "bi", "converter", "assessment"],

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -113,6 +113,7 @@ grid is only 6 wide, so widths scale ×4).
 | `scripts/domo-capture-visuals.rb` | 1b | Render per-card PNG + full-page PDF, normalize card geometry → layout JSON (design-fidelity reference) |
 | `scripts/convert-beast-modes.rb` | 2 | Beast Mode → Sigma: Domo-specific normalize + classify + POST-lint around `convert_sql_to_sigma_formula` |
 | `scripts/find-or-pick-dm.rb` *(vendored)* | 2.5 | Score existing Sigma data models against a signature and recommend reuse (non-destructive) |
+| `scripts/preflight-columns.rb` | 2.9 | Check every mapped dataset's Domo columns against the REAL warehouse table schema (live Sigma catalog lookup); reports gaps + auto-suggests (never auto-applies) a derivation formula for a known pattern |
 | `scripts/build-dm.rb` | 3 | DataSet schema + projection calc columns → Sigma DM spec (clean display names); honors a Phase-2.5 reuse decision |
 | `post-and-readback.rb` *(vendored)* | 4 | POST DM/WB + capture server element IDs / column labels |
 | `scripts/build-workbook.rb` | 5 | Cards → Sigma chart/table/KPI element specs (`chart-specs.json`) + controls |
@@ -350,6 +351,16 @@ metrics before committing to reuse.
 `ruby scripts/build-dm.rb` → one DM element per DataSet (flat table) + calc
 columns from translated Beast Modes. No star schema unless a DataFlow join is in
 scope (out of scope for v1 — DataSets are treated as opaque source tables).
+
+**Pre-flight (Phase 2.9, runs automatically via `migrate-domo.rb`):**
+`ruby scripts/preflight-columns.rb` checks every mapped dataset's Domo columns against the
+real warehouse table's schema before `build-dm.rb` will proceed — a Domo DataSet routinely
+carries columns (derived/computed, or a drifted landed copy) that the mapped warehouse table
+doesn't have, which otherwise only surfaces as an opaque `POST /v2/dataModels/spec` 400. Any
+gap is reported by name in `discovery/column-preflight.json`, with an auto-*suggested* (never
+auto-applied) `columnOverrides` entry when a known derivable pattern matches (e.g. a YYYYMMDD
+integer date key). Resolve via `excludeColumns`/`columnOverrides` in `dataset-map.json`, then
+re-run. Waivable like the doctor-gate: `SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>"`.
 
 ---
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -362,6 +362,11 @@ auto-applied) `columnOverrides` entry when a known derivable pattern matches (e.
 integer date key). Resolve via `excludeColumns`/`columnOverrides` in `dataset-map.json`, then
 re-run. Waivable like the doctor-gate: `SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>"`.
 
+Note the one accepted gap: a human-authored `columnOverrides` entry is trusted as "resolved" as
+soon as it's present — the formula it contains is NOT independently re-checked against the
+warehouse, so an override that itself references a column the warehouse doesn't have will still
+only surface as an opaque error at DM POST time, same as before this pre-flight existed.
+
 ---
 
 ## Phases 4–6 — turnkey (one command)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb
@@ -376,6 +376,41 @@ if $PROGRAM_NAME == __FILE__
     exit 2
   end
 
+  # Column pre-flight gate (bead m655): refuse to build a DM spec until every
+  # used dataset's Domo columns are confirmed resolvable against the mapped
+  # warehouse table (or already excludeColumns/columnOverrides'd) — see
+  # docs/superpowers/specs/2026-07-31-domo-dm-column-preflight-design.md and
+  # scripts/preflight-columns.rb. Runs here (after dataset-map.json is
+  # confirmed to exist, before elements are built) — NOT before the C3
+  # reuse-shortcut above, which exits before building anything new and has
+  # nothing to pre-flight. Waivable the same way the doctor-gate above is:
+  # name a reason.
+  preflight_path = File.join(OUT, 'column-preflight.json')
+  preflight_skip = ENV['SIGMA_SKIP_COLUMN_PREFLIGHT'].to_s.strip
+  if preflight_skip.empty?
+    unless File.exist?(preflight_path)
+      abort "  build-dm.rb aborted: discovery/column-preflight.json not found — run " \
+            'scripts/preflight-columns.rb first (checks Domo dataset columns against the ' \
+            'real warehouse table before this build). Waive with ' \
+            'SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" ruby scripts/build-dm.rb'
+    end
+    preflight_report = JSON.parse(File.read(preflight_path)) rescue {}
+    unresolved = preflight_report.select { |_, v| !(v['missing'] || []).empty? || v['error'] }
+    unless unresolved.empty?
+      warn "  build-dm.rb aborted: #{unresolved.size} dataset(s) still have unresolved columns " \
+           '(see discovery/column-preflight.json for names + any auto-suggested columnOverrides):'
+      unresolved.each do |id, v|
+        detail = v['error'] || (v['missing'] || []).join(', ')
+        warn "    #{id} (#{v['table']}): #{detail}"
+      end
+      abort '  Resolve via excludeColumns/columnOverrides in dataset-map.json, then re-run ' \
+            'scripts/preflight-columns.rb.'
+    end
+  else
+    warn "  ⚠ column pre-flight gate WAIVED (SIGMA_SKIP_COLUMN_PREFLIGHT=#{preflight_skip.inspect}) — " \
+         'unresolved columns may still 400 at DM POST time.'
+  end
+
   # Projection Beast Modes grouped by dataset (only these become DM calc columns).
   proj_by_ds = Hash.new { |h, k| h[k] = [] }
   formulas.each do |f|

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb
@@ -37,6 +37,7 @@ require 'json'
 require 'fileutils'
 require_relative 'lib/domo_sigma_util'
 require_relative 'lib/domo_rest'   # auto-fill's thin network seam — see fetch_stream_config
+require_relative 'lib/column_preflight' # shared SENTINEL_SOURCES — see the "needs review" warning below
 include DomoSigma   # display_name, rand_id, inode_id — shared with build-workbook.rb
 
 OUT = ENV['DOMO_DISCOVERY_DIR'] || File.expand_path('../discovery', __dir__)
@@ -394,6 +395,11 @@ if $PROGRAM_NAME == __FILE__
             'real warehouse table before this build). Waive with ' \
             'SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" ruby scripts/build-dm.rb'
     end
+    if File.mtime(preflight_path) < File.mtime(map_path)
+      abort "  build-dm.rb aborted: discovery/column-preflight.json predates discovery/dataset-map.json " \
+            '(the mapping changed since the last pre-flight check) — re-run ' \
+            'scripts/preflight-columns.rb to regenerate it, then re-run this.'
+    end
     preflight_report = begin
       JSON.parse(File.read(preflight_path))
     rescue JSON::ParserError => e
@@ -462,7 +468,7 @@ if $PROGRAM_NAME == __FILE__
   warn "  wrote #{File.join(OUT, 'dm-spec.json')} (#{elements.size} element(s))"
   missing = ds_map.select { |_, v| v['connectionId'].to_s.empty? }.keys
   warn "  ⚠ #{missing.size} dataset(s) have no connectionId — fill dataset-map.json: #{missing.join(', ')}" unless missing.empty?
-  needs_review = ds_map.select { |_, v| %w[domo-stream-config-query-only domo-landed-data].include?(v['_source']) }.keys
+  needs_review = ds_map.select { |_, v| ColumnPreflight::SENTINEL_SOURCES.include?(v['_source']) }.keys
   unless needs_review.empty?
     warn "  ⚠ #{needs_review.size} dataset(s) need human review before this DM is posted (query-only " \
          'stream or no warehouse source at all — see "_source"/"_note" in dataset-map.json, and the ' \

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-dm.rb
@@ -394,7 +394,16 @@ if $PROGRAM_NAME == __FILE__
             'real warehouse table before this build). Waive with ' \
             'SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" ruby scripts/build-dm.rb'
     end
-    preflight_report = JSON.parse(File.read(preflight_path)) rescue {}
+    preflight_report = begin
+      JSON.parse(File.read(preflight_path))
+    rescue JSON::ParserError => e
+      abort "  build-dm.rb aborted: discovery/column-preflight.json exists but failed to parse " \
+            "(#{e.message}) — re-run scripts/preflight-columns.rb to regenerate it."
+    end
+    unless preflight_report.is_a?(Hash)
+      abort "  build-dm.rb aborted: discovery/column-preflight.json did not parse to a Hash " \
+            "(got #{preflight_report.class}) — re-run scripts/preflight-columns.rb to regenerate it."
+    end
     unresolved = preflight_report.select { |_, v| !(v['missing'] || []).empty? || v['error'] }
     unless unresolved.empty?
       warn "  build-dm.rb aborted: #{unresolved.size} dataset(s) still have unresolved columns " \

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'set'
+require_relative 'domo_sigma_util'
 
 #
 # Pure logic for the domo DM column pre-flight check (bead m655): diffing a
@@ -13,6 +14,14 @@ require 'set'
 # is pure and offline-testable (test/test-column-preflight.rb), matching
 # build-dm.rb's own derive_map_entry/autofill_dataset_map split.
 module ColumnPreflight
+  # A dataset-map.json entry flagged with one of these `_source` values (see
+  # build-dm.rb's derive_map_entry) has no real warehouse table to check yet —
+  # a query-only stream, or landed data with no connector at all. Shared here
+  # (not just preflight-columns.rb's own concern) so build-dm.rb's "needs
+  # human review" warning and preflight-columns.rb's/run_preflight's skip
+  # condition can never drift apart into two different lists.
+  SENTINEL_SOURCES = %w[domo-stream-config-query-only domo-landed-data].freeze
+
   module_function
 
   # Uppercase, strip every non-alphanumeric character — loose comparison
@@ -36,7 +45,17 @@ module ColumnPreflight
   # commonly return lowercase names for some connectors — Postgres, BigQuery —
   # while Domo's own names may be any case).
   def diff_columns(schema_cols, warehouse_cols, excluded, overrides)
-    warehouse_names = Array(warehouse_cols).map { |c| c['name'].to_s.upcase }.to_set
+    # Warehouse-existence is checked on the SAME transform build_element
+    # actually emits into the formula reference ([table/display_name(raw)] —
+    # see build-dm.rb) — not the raw Domo name and not the raw warehouse
+    # catalog name. Two differently-styled Domo names for the same column
+    # (e.g. "order_date" and "Order Date") must both resolve identically here,
+    # since build_element emits the identical reference for both.
+    # excludeColumns/columnOverrides matching stays on the RAW Domo name
+    # (unchanged) — those are human-authored keys, not a warehouse-existence
+    # check.
+    warehouse_display_names = Array(warehouse_cols)
+      .map { |c| DomoSigma.display_name(c['name'].to_s).upcase }.to_set
     missing = []
     resolved_by_exclude = []
     resolved_by_override = []
@@ -44,7 +63,7 @@ module ColumnPreflight
       raw = (c['name'] || c['id']).to_s
       next if raw.empty?
       up = raw.upcase
-      next if warehouse_names.include?(up)
+      next if warehouse_display_names.include?(DomoSigma.display_name(raw).upcase)
       if excluded.include?(up)
         resolved_by_exclude << raw
       elsif overrides.key?(up)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+require 'set'
+
+#
+# Pure logic for the domo DM column pre-flight check (bead m655): diffing a
+# Domo dataset's schema columns against a warehouse table's REAL columns
+# against what discovery/dataset-map.json's excludeColumns/columnOverrides
+# already resolve, and — for anything still unresolved — checking one
+# extensible derivation-pattern registry for an auto-*suggestion* (never an
+# auto-applied fix; see docs/superpowers/specs/2026-07-31-domo-dm-column-
+# preflight-design.md). No HTTP, no filesystem — the live warehouse-column
+# fetch is scripts/preflight-columns.rb's sole network seam; everything here
+# is pure and offline-testable (test/test-column-preflight.rb), matching
+# build-dm.rb's own derive_map_entry/autofill_dataset_map split.
+module ColumnPreflight
+  module_function
+
+  # Uppercase, strip every non-alphanumeric character — loose comparison
+  # between a missing Domo column's name and a candidate warehouse column's
+  # name (e.g. "Order Date" vs "ORDER_DATE_KEY" both normalize with a shared
+  # "ORDERDATE" prefix).
+  def normalize_name(name)
+    name.to_s.upcase.gsub(/[^A-Z0-9]/, '')
+  end
+
+  # schema_cols: Domo's discovery/datasets.json schema.columns[] ({'name','type'}).
+  # warehouse_cols: [{'name','type'}] as fetched live for the mapped table.
+  # excluded: Array of upcased column names already in dataset-map's excludeColumns.
+  # overrides: Hash of upcased column name => columnOverrides entry (already
+  #            resolved by a human in dataset-map.json).
+  #
+  # Returns { 'missing' => [names], 'resolved_by_exclude' => [names],
+  #           'resolved_by_override' => [names] } — 'missing' is every Domo
+  # column absent from warehouse_cols that isn't already excluded or overridden.
+  # Matching against warehouse_cols is case-insensitive (warehouse catalogs
+  # commonly return lowercase names for some connectors — Postgres, BigQuery —
+  # while Domo's own names may be any case).
+  def diff_columns(schema_cols, warehouse_cols, excluded, overrides)
+    warehouse_names = Array(warehouse_cols).map { |c| c['name'].to_s.upcase }.to_set
+    missing = []
+    resolved_by_exclude = []
+    resolved_by_override = []
+    Array(schema_cols).each do |c|
+      raw = (c['name'] || c['id']).to_s
+      next if raw.empty?
+      up = raw.upcase
+      next if warehouse_names.include?(up)
+      if excluded.include?(up)
+        resolved_by_exclude << raw
+      elsif overrides.key?(up)
+        resolved_by_override << raw
+      else
+        missing << raw
+      end
+    end
+    { 'missing' => missing, 'resolved_by_exclude' => resolved_by_exclude,
+      'resolved_by_override' => resolved_by_override }
+  end
+
+  # Warehouse column types treated as "numeric" for the derivation pattern
+  # below — a YYYYMMDD surrogate key is always an integer/number type, never
+  # text. Deliberately conservative (no VARCHAR/TEXT) — a text column matching
+  # the name pattern is NOT a YYYYMMDD key candidate.
+  NUMERIC_TYPES = %w[LONG DECIMAL DOUBLE INTEGER NUMBER BIGINT NUMERIC FLOAT SMALLINT TINYINT].freeze
+
+  def numeric_warehouse_column?(col)
+    NUMERIC_TYPES.include?(col['type'].to_s.upcase)
+  end
+
+  # The one derivation pattern shipped in this PR (see design doc — the
+  # registry is shaped so a second pattern is additive, but only one exists
+  # today; YAGNI). Triggers when a missing column's Domo type is DATE/DATETIME
+  # and warehouse_cols has EXACTLY ONE numeric-typed column whose normalized
+  # name starts with the missing column's own normalized name. Zero or 2+
+  # candidates -> nil (ambiguous or no match) — never guess.
+  #
+  # missing_col_name: the raw Domo column name (e.g. "Order Date").
+  # domo_type: the Domo column's raw type string (e.g. "DATE").
+  # warehouse_cols: same shape as diff_columns's second argument.
+  #
+  # Returns nil, or { 'pattern' => 'yyyymmdd_integer_key',
+  #   'candidate_source_column' => name, 'suggested_formula' => formula }.
+  def suggest_derivation(missing_col_name, domo_type, warehouse_cols)
+    return nil unless %w[DATE DATETIME].include?(domo_type.to_s.upcase)
+    target = normalize_name(missing_col_name)
+    return nil if target.empty?
+    candidates = Array(warehouse_cols).select do |c|
+      numeric_warehouse_column?(c) && normalize_name(c['name']).start_with?(target)
+    end
+    return nil unless candidates.size == 1
+    source = candidates.first['name']
+    {
+      'pattern' => 'yyyymmdd_integer_key',
+      'candidate_source_column' => source,
+      'suggested_formula' =>
+        "MakeDate(Floor([#{source}]/10000), Floor(Mod([#{source}],10000)/100), Mod([#{source}],100))",
+    }
+  end
+
+  # Builds one discovery/column-preflight.json entry for a single dataset.
+  # `table` is the mapped warehouse table name (dataset-map.json's own
+  # `table` value) — carried through purely for the report's readability.
+  def build_report_entry(table, schema_cols, warehouse_cols, excluded, overrides)
+    diff = diff_columns(schema_cols, warehouse_cols, excluded, overrides)
+    domo_type_by_name = Array(schema_cols).each_with_object({}) do |c, h|
+      h[(c['name'] || c['id']).to_s] = c['type']
+    end
+    suggestions = {}
+    diff['missing'].each do |name|
+      s = suggest_derivation(name, domo_type_by_name[name], warehouse_cols)
+      suggestions[name] = s if s
+    end
+    {
+      'table' => table,
+      'missing' => diff['missing'],
+      'resolved_by_exclude' => diff['resolved_by_exclude'],
+      'resolved_by_override' => diff['resolved_by_override'],
+      'suggested_overrides' => suggestions,
+    }
+  end
+end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -572,6 +572,37 @@ def run_live!(opts)
     log 'discovery/dm-spec.json already present — skip (idempotent; pass --force to rebuild)'
     skip_phase!('build-dm', 'already built (idempotent skip)')
   else
+    # Column pre-flight (bead m655): only meaningful once dataset-map.json is
+    # human-resolved — the FIRST build-dm.rb attempt below (no dataset-map.json
+    # yet) writes dataset-map.template.json and fails, same as before this
+    # bead; there is nothing to pre-flight until a human finishes that file.
+    map_path = File.join(DISCOVERY, 'dataset-map.json')
+    if File.exist?(map_path)
+      hr('preflight-columns (Domo columns vs the real warehouse schema)')
+      preflight_path = File.join(DISCOVERY, 'column-preflight.json')
+      if !opts[:force] && File.exist?(preflight_path)
+        skip_phase!('preflight-columns', 'already checked (idempotent skip)')
+      else
+        pf_ok, pf_code, _pf_out = run_script!('preflight-columns.rb')
+        if !pf_ok
+          skip_env = ENV['SIGMA_SKIP_COLUMN_PREFLIGHT'].to_s.strip
+          if skip_env.empty?
+            fail_phase!('preflight-columns',
+                        "preflight-columns.rb exited #{pf_code} — unresolved column(s) or a fetch error " \
+                        'found; see discovery/column-preflight.json for names + any auto-suggested ' \
+                        'columnOverrides, resolve via excludeColumns/columnOverrides in dataset-map.json, ' \
+                        'then re-run (or set SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" to waive, same as ' \
+                        "build-dm.rb's gate)")
+          else
+            skip_phase!('preflight-columns',
+                        "unresolved columns found but WAIVED via SIGMA_SKIP_COLUMN_PREFLIGHT=#{skip_env.inspect}")
+          end
+        else
+          done_phase!('preflight-columns')
+        end
+      end
+    end
+
     # --folder-id must reach build-dm too, not just build-workbook-spec: the DM
     # spec itself needs a folderId or POST /v2/dataModels/spec 400s with
     # "Expecting UUID at 0.folderId" (live-validated 2026-07-30).

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -579,27 +579,31 @@ def run_live!(opts)
     map_path = File.join(DISCOVERY, 'dataset-map.json')
     if File.exist?(map_path)
       hr('preflight-columns (Domo columns vs the real warehouse schema)')
-      preflight_path = File.join(DISCOVERY, 'column-preflight.json')
-      if !opts[:force] && File.exist?(preflight_path)
-        skip_phase!('preflight-columns', 'already checked (idempotent skip)')
-      else
-        pf_ok, pf_code, _pf_out = run_script!('preflight-columns.rb')
-        if !pf_ok
-          skip_env = ENV['SIGMA_SKIP_COLUMN_PREFLIGHT'].to_s.strip
-          if skip_env.empty?
-            fail_phase!('preflight-columns',
-                        "preflight-columns.rb exited #{pf_code} — unresolved column(s) or a fetch error " \
-                        'found; see discovery/column-preflight.json for names + any auto-suggested ' \
-                        'columnOverrides, resolve via excludeColumns/columnOverrides in dataset-map.json, ' \
-                        'then re-run (or set SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" to waive, same as ' \
-                        "build-dm.rb's gate)")
-          else
-            skip_phase!('preflight-columns',
-                        "unresolved columns found but WAIVED via SIGMA_SKIP_COLUMN_PREFLIGHT=#{skip_env.inspect}")
-          end
+      # Unlike other idempotent phases in this file, this one is NOT skipped
+      # just because its output file already exists: dataset-map.json is
+      # human-editable between runs (a newly-resolved connectionId, a fix via
+      # excludeColumns/columnOverrides), and a stale column-preflight.json
+      # would either silently re-admit a gap that was never actually
+      # re-checked, or permanently deadlock the fix-and-re-run loop (the
+      # operator's fix is never validated). The live check itself is cheap
+      # (a couple of Sigma API calls per dataset), so always re-running it
+      # here is the safe default.
+      pf_ok, pf_code, _pf_out = run_script!('preflight-columns.rb')
+      skip_env = ENV['SIGMA_SKIP_COLUMN_PREFLIGHT'].to_s.strip
+      if !pf_ok
+        if skip_env.empty?
+          fail_phase!('preflight-columns',
+                      "preflight-columns.rb exited #{pf_code} — unresolved column(s) or a fetch error " \
+                      'found; see discovery/column-preflight.json for names + any auto-suggested ' \
+                      'columnOverrides, resolve via excludeColumns/columnOverrides in dataset-map.json, ' \
+                      'then re-run (or set SIGMA_SKIP_COLUMN_PREFLIGHT="<reason>" to waive, same as ' \
+                      "build-dm.rb's gate)")
         else
-          done_phase!('preflight-columns')
+          skip_phase!('preflight-columns',
+                      "unresolved columns found but WAIVED via SIGMA_SKIP_COLUMN_PREFLIGHT=#{skip_env.inspect}")
         end
+      else
+        done_phase!('preflight-columns')
       end
     end
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb
@@ -1,0 +1,143 @@
+#!/usr/bin/env ruby
+# Phase 2.9 — DM column pre-flight (bead m655). Checks every mapped dataset's
+# Domo columns against the REAL warehouse table's schema (a live Sigma
+# catalog lookup) before build-dm.rb (Phase 3) ever constructs dm-spec.json.
+# Never auto-applies a fix — see docs/superpowers/specs/2026-07-31-domo-dm-
+# column-preflight-design.md for the full design and rationale.
+#
+#   ruby scripts/preflight-columns.rb        # → discovery/column-preflight.json
+#     exit 0 = every used dataset's Domo columns are covered (present in the
+#              warehouse table, or already excludeColumns/columnOverrides'd
+#              in dataset-map.json)
+#     exit 1 = at least one dataset still has an unresolved column, or a live
+#              fetch error — see the report for names + any auto-suggested
+#              columnOverrides
+#
+# Requires SIGMA_BASE_URL + a Sigma bearer token (SIGMA_API_TOKEN, or
+# SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET for scripts/lib/sigma_rest.rb to
+# self-mint) — same credential story as put-layout.rb and post-and-readback.rb.
+# Skips (does not attempt a live call for) any dataset whose dataset-map.json
+# entry isn't fully resolved yet (no connectionId/table, or a
+# domo-stream-config-query-only / domo-landed-data _source) — build-dm.rb's
+# own existing warnings already cover those.
+
+require 'json'
+require 'fileutils'
+require_relative 'lib/column_preflight'
+require_relative 'lib/sigma_rest'
+include ColumnPreflight
+
+OUT = ENV['DOMO_DISCOVERY_DIR'] || File.expand_path('../discovery', __dir__)
+
+SENTINEL_SOURCES = %w[domo-stream-config-query-only domo-landed-data].freeze
+
+# Network seam: connection_id + [db,schema,table] -> {'columns'=>[...],
+# 'inode_id'=>...} or {'error'=>message} — NEVER raises, so run_preflight can
+# degrade one dataset at a time instead of aborting the whole run.
+# `requester`/`lister` are injected (default: the real Sigma.request /
+# Sigma.list_entries) so test/test-preflight-columns.rb can stub Sigma
+# entirely, mirroring build-dm.rb's fetcher: seam for autofill_dataset_map.
+def fetch_warehouse_columns(connection_id, path, requester: Sigma.method(:request), lister: Sigma.method(:list_entries))
+  # 1. Resolve the table to an inodeId. NOT GET /v2/connections/{conn}/tables
+  #    — that endpoint does not exist (feedback_sigma_columns_api_endpoint).
+  lookup = requester.call(:post, "/v2/connection/#{connection_id}/lookup",
+                          body: JSON.generate('path' => path))
+  inode = lookup.is_a?(Hash) ? lookup['inodeId'] : nil
+  return { 'error' => "lookup returned no inodeId: #{lookup.inspect}" } unless inode
+  unless lookup['kind'] == 'table'
+    return { 'error' => "#{path.join('.')} resolved to a #{lookup['kind']}, not a table" }
+  end
+
+  # 2. List columns at /v2/connections/tables/<inodeId>/columns — connectionId
+  #    is NOT in this path. Paginated; Sigma.list_entries follows nextPage to
+  #    exhaustion (server default page size is 50 — an unpaginated read would
+  #    silently truncate a wide table).
+  entries = lister.call("/v2/connections/tables/#{inode}/columns")
+  cols = entries.map do |c|
+    t = c['type']
+    t = t['type'] if t.is_a?(Hash) && t['type'] # type may arrive nested
+    { 'name' => c['name'], 'type' => t.to_s }
+  end
+  { 'columns' => cols, 'inode_id' => inode }
+rescue Sigma::Error => e
+  if e.message =~ /\b404\b/
+    { 'error' => "table #{path.join('.')} not found in Sigma's catalog for connection " \
+                 "#{connection_id} — sync it first: POST /v2/connections/#{connection_id}/sync " \
+                 "with body {\"path\": #{JSON.generate(path)}}, then re-run." }
+  else
+    { 'error' => "Sigma error resolving #{path.join('.')}: #{e.message.lines.first.to_s.strip}" }
+  end
+end
+
+# Runs the full pre-flight over every used dataset. Pure orchestration —
+# `fetcher` is the sole network seam (default: fetch_warehouse_columns above),
+# so this is fully unit-testable offline (test/test-preflight-columns.rb
+# stubs it as a whole function, bypassing Sigma entirely).
+#
+# datasets: discovery/datasets.json, parsed ([{'id','schema'=>{'columns'=>[...]}}]).
+# ds_map:   discovery/dataset-map.json, parsed ({datasetId => {...}}).
+# used:     dataset ids actually in scope (cards.json datasetIds, or every
+#           discovered dataset if cards.json is empty/absent — mirrors
+#           build-dm.rb's own `used` derivation).
+#
+# Returns [report, any_missing] — report is the exact discovery/
+# column-preflight.json shape (Hash keyed by dataset id, only datasets that
+# were actually checked or errored); any_missing is a Boolean (true if any
+# checked dataset still has an unresolved column, or a fetch error occurred).
+def run_preflight(datasets, ds_map, used, fetcher: method(:fetch_warehouse_columns))
+  ds_by_id = datasets.each_with_object({}) { |d, h| h[d['id']] = d }
+  report = {}
+  any_missing = false
+  used.each do |id|
+    entry = ds_map[id]
+    ds = ds_by_id[id]
+    next unless entry && ds
+    next if entry['connectionId'].to_s.strip.empty? || entry['table'].to_s.strip.empty? ||
+            SENTINEL_SOURCES.include?(entry['_source'])
+    schema_cols = ds.dig('schema', 'columns')
+    next unless schema_cols.is_a?(Array) # build-dm.rb's own ArgumentError already covers this
+
+    path = [entry['database'], entry['schema'], entry['table']].compact
+    fetched = fetcher.call(entry['connectionId'], path)
+    if fetched['error']
+      report[id] = { 'table' => entry['table'], 'error' => fetched['error'] }
+      any_missing = true
+      next
+    end
+
+    excluded  = Array(entry['excludeColumns']).map { |s| s.to_s.upcase }
+    overrides = (entry['columnOverrides'] || {}).each_with_object({}) { |(k, v), h| h[k.to_s.upcase] = v }
+    entry_report = build_report_entry(entry['table'], schema_cols, fetched['columns'], excluded, overrides)
+    report[id] = entry_report
+    any_missing ||= !entry_report['missing'].empty?
+  end
+  [report, any_missing]
+end
+
+if $PROGRAM_NAME == __FILE__
+  datasets = JSON.parse(File.read(File.join(OUT, 'datasets.json'))) rescue []
+  map_path = File.join(OUT, 'dataset-map.json')
+  unless File.exist?(map_path)
+    abort "  preflight-columns.rb: no discovery/dataset-map.json — run build-dm.rb once first " \
+          '(it writes dataset-map.template.json for you to fill in), then re-run this.'
+  end
+  ds_map = JSON.parse(File.read(map_path))
+  cards  = JSON.parse(File.read(File.join(OUT, 'cards.json'))) rescue []
+  used = cards.map { |c| c['datasetId'] }.compact.uniq
+  used = datasets.map { |d| d['id'] }.compact if used.empty?
+
+  report, any_missing = run_preflight(datasets, ds_map, used)
+
+  FileUtils.mkdir_p(OUT)
+  File.write(File.join(OUT, 'column-preflight.json'), JSON.pretty_generate(report))
+  if any_missing
+    warn "\n  preflight-columns.rb: unresolved column(s) or fetch error(s) — see " \
+         'discovery/column-preflight.json for names + any auto-suggested columnOverrides. ' \
+         'Resolve via excludeColumns/columnOverrides in dataset-map.json (or fix the named ' \
+         'connection/table issue), then re-run.'
+    exit 1
+  else
+    warn "  preflight-columns.rb: clean — every used dataset's Domo columns are covered."
+    exit 0
+  end
+end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb
@@ -33,7 +33,13 @@ SENTINEL_SOURCES = %w[domo-stream-config-query-only domo-landed-data].freeze
 
 # Network seam: connection_id + [db,schema,table] -> {'columns'=>[...],
 # 'inode_id'=>...} or {'error'=>message} — NEVER raises, so run_preflight can
-# degrade one dataset at a time instead of aborting the whole run.
+# degrade one dataset at a time instead of aborting the whole run. Covers not
+# just Sigma::Error (a non-2xx HTTP response) but every other realistic live-
+# call failure mode: malformed JSON (JSON::ParserError), a slow/cold catalog
+# lookup (Net::OpenTimeout/Net::ReadTimeout/Timeout::Error), and DNS/connection
+# failures (SocketError/Errno::ECONNREFUSED) — matching the rescue set already
+# used elsewhere in this plugin (scripts/verify-anchors.rb) and by Tableau's
+# sibling scripts/discover-columns.rb.
 # `requester`/`lister` are injected (default: the real Sigma.request /
 # Sigma.list_entries) so test/test-preflight-columns.rb can stub Sigma
 # entirely, mirroring build-dm.rb's fetcher: seam for autofill_dataset_map.
@@ -60,13 +66,26 @@ def fetch_warehouse_columns(connection_id, path, requester: Sigma.method(:reques
   end
   { 'columns' => cols, 'inode_id' => inode }
 rescue Sigma::Error => e
-  if e.message =~ /\b404\b/
+  # Match only the status-code position on the FIRST line (sigma_rest.rb's
+  # request raises "#{METHOD} #{path} -> #{code} #{message}\n#{body}") — not
+  # anywhere in the full message+body. A bare /\b404\b/ over the whole string
+  # would false-positive on a genuine 500/401/403 whose JSON error body
+  # happens to contain a stray "404" token (a nested error code, a referenced
+  # upstream status, an unrelated ID) and mislabel it with the 404-specific
+  # "sync it first" guidance instead of the real error.
+  if e.message.lines.first.to_s =~ /-> 404\b/
     { 'error' => "table #{path.join('.')} not found in Sigma's catalog for connection " \
                  "#{connection_id} — sync it first: POST /v2/connections/#{connection_id}/sync " \
                  "with body {\"path\": #{JSON.generate(path)}}, then re-run." }
   else
     { 'error' => "Sigma error resolving #{path.join('.')}: #{e.message.lines.first.to_s.strip}" }
   end
+rescue JSON::ParserError => e
+  { 'error' => "Sigma returned malformed JSON resolving #{path.join('.')}: #{e.message}" }
+rescue Net::OpenTimeout, Net::ReadTimeout, Timeout::Error => e
+  { 'error' => "timeout resolving #{path.join('.')} (#{e.class}) — the warehouse catalog lookup did not return in time" }
+rescue SocketError, Errno::ECONNREFUSED => e
+  { 'error' => "network error resolving #{path.join('.')}: #{e.class}: #{e.message}" }
 end
 
 # Runs the full pre-flight over every used dataset. Pure orchestration —

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/preflight-columns.rb
@@ -23,13 +23,13 @@
 
 require 'json'
 require 'fileutils'
+require 'uri'
+require 'net/http'
 require_relative 'lib/column_preflight'
 require_relative 'lib/sigma_rest'
 include ColumnPreflight
 
 OUT = ENV['DOMO_DISCOVERY_DIR'] || File.expand_path('../discovery', __dir__)
-
-SENTINEL_SOURCES = %w[domo-stream-config-query-only domo-landed-data].freeze
 
 # Network seam: connection_id + [db,schema,table] -> {'columns'=>[...],
 # 'inode_id'=>...} or {'error'=>message} — NEVER raises, so run_preflight can
@@ -43,7 +43,31 @@ SENTINEL_SOURCES = %w[domo-stream-config-query-only domo-landed-data].freeze
 # `requester`/`lister` are injected (default: the real Sigma.request /
 # Sigma.list_entries) so test/test-preflight-columns.rb can stub Sigma
 # entirely, mirroring build-dm.rb's fetcher: seam for autofill_dataset_map.
-def fetch_warehouse_columns(connection_id, path, requester: Sigma.method(:request), lister: Sigma.method(:list_entries))
+def fetch_warehouse_columns(connection_id, path, requester: nil, lister: nil)
+  # Bound every live call — a cold warehouse or a very wide view can otherwise
+  # leave a catalog lookup blocked with no client-side cap (the "migration
+  # stuck for hours" hang Tableau's sibling discover-columns.rb guards
+  # against the same way). Only applies to the REAL default requester/lister
+  # — tests inject their own stubs directly and bypass this entirely. Compute
+  # timeout/uri lazily, ONLY when a default is actually needed: every existing
+  # test passes its own requester:/lister: stubs and must keep working with no
+  # SIGMA_BASE_URL set at all (Sigma.base_url raises when it's unset).
+  if requester.nil? || lister.nil?
+    timeout = (ENV['SIGMA_HTTP_TIMEOUT'] || '90').to_i
+    uri = URI(Sigma.base_url)
+  end
+  requester ||= lambda do |method, p, body: nil|
+    Net::HTTP.start(uri.host, uri.port, use_ssl: true,
+                    open_timeout: [timeout, 30].min, read_timeout: timeout) do |http|
+      Sigma.request(method, p, body: body, http: http)
+    end
+  end
+  lister ||= lambda do |p|
+    Net::HTTP.start(uri.host, uri.port, use_ssl: true,
+                    open_timeout: [timeout, 30].min, read_timeout: timeout) do |http|
+      Sigma.list_entries(p, http: http)
+    end
+  end
   # 1. Resolve the table to an inodeId. NOT GET /v2/connections/{conn}/tables
   #    — that endpoint does not exist (feedback_sigma_columns_api_endpoint).
   lookup = requester.call(:post, "/v2/connection/#{connection_id}/lookup",
@@ -112,7 +136,7 @@ def run_preflight(datasets, ds_map, used, fetcher: method(:fetch_warehouse_colum
     ds = ds_by_id[id]
     next unless entry && ds
     next if entry['connectionId'].to_s.strip.empty? || entry['table'].to_s.strip.empty? ||
-            SENTINEL_SOURCES.include?(entry['_source'])
+            ColumnPreflight::SENTINEL_SOURCES.include?(entry['_source'])
     schema_cols = ds.dig('schema', 'columns')
     next unless schema_cols.is_a?(Array) # build-dm.rb's own ArgumentError already covers this
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb
@@ -132,7 +132,8 @@ Dir.mktmpdir('build-dm-gate') do |dir|
   File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
     'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
   ))
-  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1',
+          'SIGMA_SKIP_DOCTOR_GATE' => 'unit test: environment not under test' }
   out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
   ok(!$?.success?, 'build-dm.rb fails when column-preflight.json is absent')
   ok(out.include?('preflight-columns.rb'), "the failure names the script to run first, got:\n#{out}")
@@ -148,7 +149,8 @@ Dir.mktmpdir('build-dm-gate') do |dir|
     'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
   ))
   File.write(File.join(dir, 'column-preflight.json'), '{not valid json')
-  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1',
+          'SIGMA_SKIP_DOCTOR_GATE' => 'unit test: environment not under test' }
   out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
   ok(!$?.success?, 'build-dm.rb fails when column-preflight.json fails to parse (never a silent pass)')
   ok(out.include?('column-preflight.json'), "the failure names column-preflight.json, got:\n#{out}")
@@ -168,7 +170,8 @@ Dir.mktmpdir('build-dm-gate') do |dir|
     'ds-1' => { 'table' => 'ORDER_FACT', 'missing' => ['ORDER_ID'], 'resolved_by_exclude' => [],
                 'resolved_by_override' => [], 'suggested_overrides' => {} }
   ))
-  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1',
+          'SIGMA_SKIP_DOCTOR_GATE' => 'unit test: environment not under test' }
   out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
   ok(!$?.success?, 'build-dm.rb fails when column-preflight.json reports a missing column')
   ok(out.include?('ORDER_ID'), "the failure names the specific unresolved column, got:\n#{out}")
@@ -187,7 +190,8 @@ Dir.mktmpdir('build-dm-gate') do |dir|
     'ds-1' => { 'table' => 'ORDER_FACT', 'missing' => [], 'resolved_by_exclude' => [],
                 'resolved_by_override' => [], 'suggested_overrides' => {} }
   ))
-  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1',
+          'SIGMA_SKIP_DOCTOR_GATE' => 'unit test: environment not under test' }
   out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
   ok($?.success?, "build-dm.rb succeeds when column-preflight.json is clean, got:\n#{out unless $?.success?}")
   ok(File.exist?(File.join(dir, 'dm-spec.json')), 'dm-spec.json was written')
@@ -204,7 +208,8 @@ Dir.mktmpdir('build-dm-gate') do |dir|
   ))
   # deliberately no column-preflight.json at all
   env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1',
-          'SIGMA_SKIP_COLUMN_PREFLIGHT' => 'unit test waiver' }
+          'SIGMA_SKIP_COLUMN_PREFLIGHT' => 'unit test waiver',
+          'SIGMA_SKIP_DOCTOR_GATE' => 'unit test: environment not under test' }
   out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
   ok($?.success?, "build-dm.rb succeeds when the gate is waived, got:\n#{out unless $?.success?}")
   ok(out.include?('WAIVED'), "the waiver is loudly logged, not silent, got:\n#{out}")
@@ -217,11 +222,34 @@ Dir.mktmpdir('build-dm-gate') do |dir|
   File.write(File.join(dir, 'dm-match.json'), JSON.generate(
     'recommended_dm_id' => 'dm-existing-123', 'auto_picked' => true
   ))
-  env = { 'DOMO_DISCOVERY_DIR' => dir }
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_SKIP_DOCTOR_GATE' => 'unit test: environment not under test' }
   out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
   ok($?.success?, "build-dm.rb succeeds via the reuse shortcut with NO column-preflight.json present, got:\n#{out unless $?.success?}")
   ok(File.exist?(File.join(dir, 'dm-reuse.json')), 'dm-reuse.json was written (the reuse path actually ran)')
   ok(!out.include?('column-preflight'), "the reuse shortcut never even mentions the pre-flight gate, got:\n#{out}")
+end
+
+puts '== column-preflight gate: a report older than dataset-map.json is stale — aborts, never silently trusted =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  preflight_path = File.join(dir, 'column-preflight.json')
+  File.write(preflight_path, JSON.generate(
+    'ds-1' => { 'table' => 'ORDER_FACT', 'missing' => [], 'resolved_by_exclude' => [],
+                'resolved_by_override' => [], 'suggested_overrides' => {} }
+  ))
+  old = Time.now - 3600
+  File.utime(old, old, preflight_path) # explicitly backdate the "clean" report
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1', 'SIGMA_SKIP_DOCTOR_GATE' => 'unit test' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok(!$?.success?, "build-dm.rb fails when column-preflight.json predates dataset-map.json, got:\n#{out unless $?.success?}")
+  ok(out.include?('predates') && out.include?('preflight-columns.rb'),
+     "the failure explains the report is stale and names the fix, got:\n#{out}")
 end
 
 puts

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb
@@ -138,6 +138,23 @@ Dir.mktmpdir('build-dm-gate') do |dir|
   ok(out.include?('preflight-columns.rb'), "the failure names the script to run first, got:\n#{out}")
 end
 
+puts '== column-preflight gate: a corrupted (unparsable) column-preflight.json is a LOUD failure, never a silent pass =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  File.write(File.join(dir, 'column-preflight.json'), '{not valid json')
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok(!$?.success?, 'build-dm.rb fails when column-preflight.json fails to parse (never a silent pass)')
+  ok(out.include?('column-preflight.json'), "the failure names column-preflight.json, got:\n#{out}")
+  ok(out.include?('preflight-columns.rb'), "the failure names the script to re-run, got:\n#{out}")
+end
+
 puts '== column-preflight gate: build-dm.rb aborts when the report shows unresolved columns =='
 Dir.mktmpdir('build-dm-gate') do |dir|
   File.write(File.join(dir, 'datasets.json'), JSON.generate([

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-dm.rb
@@ -3,9 +3,13 @@
 #   ruby test/test-build-dm.rb
 
 require_relative '../scripts/build-dm'
+require 'tmpdir'
+
+SKILL_ROOT = File.expand_path('..', __dir__)
 
 $failures = 0
 def eq(a, b, m) if a == b then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}\n    exp #{b.inspect}\n    got #{a.inspect}" end end
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
 
 puts "== display_name (fixes raw snake_case labels) =="
 eq(display_name('order_date'), 'Order Date', 'snake_case → Title Case')
@@ -118,6 +122,90 @@ el_query  = build_element(ds, entry_query,  [])
 el_landed = build_element(ds, entry_landed, [])
 eq(el_query['source']['path'].last,  '<TABLE:QUERY_ONLY_NEEDS_HUMAN>',        'query-only entry -> unmistakable sentinel, not a guessed table')
 eq(el_landed['source']['path'].last, '<TABLE:LANDED_DATA_NO_WAREHOUSE_SOURCE>', 'landed-data entry -> unmistakable sentinel, not the DataSet display name')
+
+puts '== column-preflight gate: build-dm.rb aborts when discovery/column-preflight.json is missing =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok(!$?.success?, 'build-dm.rb fails when column-preflight.json is absent')
+  ok(out.include?('preflight-columns.rb'), "the failure names the script to run first, got:\n#{out}")
+end
+
+puts '== column-preflight gate: build-dm.rb aborts when the report shows unresolved columns =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  File.write(File.join(dir, 'column-preflight.json'), JSON.generate(
+    'ds-1' => { 'table' => 'ORDER_FACT', 'missing' => ['ORDER_ID'], 'resolved_by_exclude' => [],
+                'resolved_by_override' => [], 'suggested_overrides' => {} }
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok(!$?.success?, 'build-dm.rb fails when column-preflight.json reports a missing column')
+  ok(out.include?('ORDER_ID'), "the failure names the specific unresolved column, got:\n#{out}")
+end
+
+puts '== column-preflight gate: a clean report lets build-dm.rb proceed =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  File.write(File.join(dir, 'column-preflight.json'), JSON.generate(
+    'ds-1' => { 'table' => 'ORDER_FACT', 'missing' => [], 'resolved_by_exclude' => [],
+                'resolved_by_override' => [], 'suggested_overrides' => {} }
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok($?.success?, "build-dm.rb succeeds when column-preflight.json is clean, got:\n#{out unless $?.success?}")
+  ok(File.exist?(File.join(dir, 'dm-spec.json')), 'dm-spec.json was written')
+end
+
+puts '== column-preflight gate: SIGMA_SKIP_COLUMN_PREFLIGHT waives it, same as the doctor-gate convention =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  File.write(File.join(dir, 'datasets.json'), JSON.generate([
+    { 'id' => 'ds-1', 'name' => 'Orders', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } },
+  ]))
+  File.write(File.join(dir, 'cards.json'), JSON.generate([{ 'datasetId' => 'ds-1' }]))
+  File.write(File.join(dir, 'dataset-map.json'), JSON.generate(
+    'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' }
+  ))
+  # deliberately no column-preflight.json at all
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_FOLDER_ID' => 'folder-1',
+          'SIGMA_SKIP_COLUMN_PREFLIGHT' => 'unit test waiver' }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok($?.success?, "build-dm.rb succeeds when the gate is waived, got:\n#{out unless $?.success?}")
+  ok(out.include?('WAIVED'), "the waiver is loudly logged, not silent, got:\n#{out}")
+end
+
+puts '== column-preflight gate: the C3 reuse-shortcut path is NEVER gated (nothing new is being built) =='
+Dir.mktmpdir('build-dm-gate') do |dir|
+  # No datasets.json/cards.json/dataset-map.json/column-preflight.json at all —
+  # a confirmed auto-pick must short-circuit before any of that is read.
+  File.write(File.join(dir, 'dm-match.json'), JSON.generate(
+    'recommended_dm_id' => 'dm-existing-123', 'auto_picked' => true
+  ))
+  env = { 'DOMO_DISCOVERY_DIR' => dir }
+  out = IO.popen(env, ['ruby', File.join(SKILL_ROOT, 'scripts', 'build-dm.rb')], err: [:child, :out], &:read)
+  ok($?.success?, "build-dm.rb succeeds via the reuse shortcut with NO column-preflight.json present, got:\n#{out unless $?.success?}")
+  ok(File.exist?(File.join(dir, 'dm-reuse.json')), 'dm-reuse.json was written (the reuse path actually ran)')
+  ok(!out.include?('column-preflight'), "the reuse shortcut never even mentions the pre-flight gate, got:\n#{out}")
+end
 
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# Offline: ColumnPreflight's pure diff/suggestion logic (bead m655, Track "DM
+# column pre-flight"). No network, no filesystem — see
+# docs/superpowers/specs/2026-07-31-domo-dm-column-preflight-design.md.
+#   ruby test/test-column-preflight.rb
+require_relative '../scripts/lib/column_preflight'
+include ColumnPreflight
+
+$failures = 0
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+def eq(actual, expected, msg)
+  if actual == expected
+    puts "  ok: #{msg}"
+  else
+    $failures += 1
+    puts "  FAIL: #{msg}\n        expected #{expected.inspect}\n        got      #{actual.inspect}"
+  end
+end
+
+puts '== normalize_name: uppercases and strips non-alphanumerics =='
+eq(normalize_name('Order Date'), 'ORDERDATE', 'spaces stripped, uppercased')
+eq(normalize_name('ORDER_DATE_KEY'), 'ORDERDATEKEY', 'underscores stripped')
+eq(normalize_name(''), '', 'empty string stays empty')
+
+puts '== diff_columns: a column present in the warehouse is never "missing" =='
+schema = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DATE', 'type' => 'DATE' }]
+warehouse = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DATE', 'type' => 'DATE' }]
+diff = diff_columns(schema, warehouse, [], {})
+eq(diff['missing'], [], 'both columns resolve — nothing missing')
+
+puts '== diff_columns: a column absent from the warehouse is "missing" unless excluded/overridden =='
+warehouse2 = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }]
+diff2 = diff_columns(schema, warehouse2, [], {})
+eq(diff2['missing'], ['ORDER_DATE'], 'ORDER_DATE absent from warehouse -> missing')
+eq(diff2['resolved_by_exclude'], [], 'nothing excluded')
+eq(diff2['resolved_by_override'], [], 'nothing overridden')
+
+puts '== diff_columns: excludeColumns removes a gap from "missing" -> "resolved_by_exclude" =='
+diff3 = diff_columns(schema, warehouse2, ['ORDER_DATE'], {})
+eq(diff3['missing'], [], 'excluded column is not "missing"')
+eq(diff3['resolved_by_exclude'], ['ORDER_DATE'], 'excluded column is reported as resolved_by_exclude')
+
+puts '== diff_columns: columnOverrides removes a gap from "missing" -> "resolved_by_override" =='
+diff4 = diff_columns(schema, warehouse2, [], { 'ORDER_DATE' => { 'formula' => 'MakeDate(...)' } })
+eq(diff4['missing'], [], 'overridden column is not "missing"')
+eq(diff4['resolved_by_override'], ['ORDER_DATE'], 'overridden column is reported as resolved_by_override')
+
+puts '== diff_columns: case-insensitive matching against warehouse column names =='
+warehouse_lower = [{ 'name' => 'order_id', 'type' => 'LONG' }, { 'name' => 'order_date', 'type' => 'DATE' }]
+diff5 = diff_columns(schema, warehouse_lower, [], {})
+eq(diff5['missing'], [], 'lowercase warehouse names still match Domo\'s uppercase-ish names')
+
+puts '== suggest_derivation: exactly one numeric candidate whose name starts with the missing column\'s normalized name -> suggestion =='
+warehouse3 = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' }, { 'name' => 'CUSTOMER_ID', 'type' => 'LONG' }]
+s = suggest_derivation('ORDER_DATE', 'DATE', warehouse3)
+ok(s, 'a suggestion is returned')
+eq(s['pattern'], 'yyyymmdd_integer_key', 'suggested pattern name')
+eq(s['candidate_source_column'], 'ORDER_DATE_KEY', 'candidate is the one matching numeric column')
+ok(s['suggested_formula'].include?('MakeDate') && s['suggested_formula'].include?('ORDER_DATE_KEY'),
+   "suggested_formula references MakeDate and the candidate column, got #{s['suggested_formula'].inspect}")
+
+puts '== suggest_derivation: non-date Domo type -> no suggestion, even with a perfect candidate =='
+eq(suggest_derivation('ORDER_DATE', 'LONG', warehouse3), nil, 'only DATE/DATETIME Domo columns trigger this pattern')
+
+puts '== suggest_derivation: zero candidates -> no suggestion =='
+warehouse_none = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'CUSTOMER_ID', 'type' => 'LONG' }]
+eq(suggest_derivation('ORDER_DATE', 'DATE', warehouse_none), nil, 'no numeric column with a matching name prefix -> nil, never guess')
+
+puts '== suggest_derivation: two ambiguous candidates -> no suggestion (never guess) =='
+warehouse_ambiguous = [
+  { 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' },
+  { 'name' => 'ORDER_DATE_ID', 'type' => 'LONG' },
+]
+eq(suggest_derivation('ORDER_DATE', 'DATE', warehouse_ambiguous), nil,
+   'two plausible numeric candidates is ambiguous -> nil, never pick one arbitrarily')
+
+puts '== suggest_derivation: a matching-name candidate that is NOT numeric-typed is not a candidate =='
+warehouse_nonnumeric = [{ 'name' => 'ORDER_DATE_KEY', 'type' => 'VARCHAR' }]
+eq(suggest_derivation('ORDER_DATE', 'DATE', warehouse_nonnumeric), nil,
+   'a text-typed column with a matching name is not treated as a YYYYMMDD integer key')
+
+puts '== build_report_entry: combines diff + suggestion into the full report shape =='
+entry = build_report_entry('ORDER_FACT', schema, warehouse3, [], {})
+eq(entry['table'], 'ORDER_FACT', 'table name carried through')
+eq(entry['missing'], ['ORDER_DATE'], 'ORDER_DATE is missing (not in warehouse3)')
+eq(entry['resolved_by_exclude'], [], 'nothing excluded')
+eq(entry['resolved_by_override'], [], 'nothing overridden')
+ok(entry['suggested_overrides']['ORDER_DATE'], 'a suggestion is present for the missing ORDER_DATE column')
+eq(entry['suggested_overrides']['ORDER_DATE']['candidate_source_column'], 'ORDER_DATE_KEY',
+   'the suggestion names the correct candidate column')
+
+puts '== build_report_entry: a missing column with no derivable pattern gets no suggested_overrides entry =='
+entry2 = build_report_entry('ORDER_FACT', schema, warehouse_none, [], {})
+eq(entry2['missing'], ['ORDER_DATE'], 'still missing')
+eq(entry2['suggested_overrides'], {}, 'no suggestion when there is no derivable candidate')
+
+puts
+if $failures.zero?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{$failures} FAILURE(S)"
+  exit 1
+end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb
@@ -50,6 +50,15 @@ warehouse_lower = [{ 'name' => 'order_id', 'type' => 'LONG' }, { 'name' => 'orde
 diff5 = diff_columns(schema, warehouse_lower, [], {})
 eq(diff5['missing'], [], 'lowercase warehouse names still match Domo\'s uppercase-ish names')
 
+puts '== diff_columns: differently-styled Domo names for the same column both resolve against the warehouse (display_name-matched, not raw-matched) =='
+schema_spaced = [{ 'name' => 'Order Date', 'type' => 'DATE' }]
+warehouse_raw = [{ 'name' => 'ORDER_DATE', 'type' => 'DATE' }]
+diff_spaced = diff_columns(schema_spaced, warehouse_raw, [], {})
+eq(diff_spaced['missing'], [], '"Order Date" (spaced) matches warehouse "ORDER_DATE" via the same display_name transform build_element emits')
+schema_snake = [{ 'name' => 'order_date', 'type' => 'DATE' }]
+diff_snake = diff_columns(schema_snake, warehouse_raw, [], {})
+eq(diff_snake['missing'], [], '"order_date" (snake_case) matches the same warehouse column too — both Domo naming styles resolve identically')
+
 puts '== suggest_derivation: exactly one numeric candidate whose name starts with the missing column\'s normalized name -> suggestion =='
 warehouse3 = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' }, { 'name' => 'CUSTOMER_ID', 'type' => 'LONG' }]
 s = suggest_derivation('ORDER_DATE', 'DATE', warehouse3)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-e2e.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-e2e.rb
@@ -21,7 +21,8 @@ Dir.mktmpdir('domo-e2e') do |dir|
   # build LOGIC, not the environment, so waive it explicitly — keeps the suite
   # hermetic on a machine (e.g. CI) that never ran the doctor.
   env = { 'DOMO_DISCOVERY_DIR' => dir,
-          'SIGMA_SKIP_DOCTOR_GATE' => 'e2e: environment not under test' }
+          'SIGMA_SKIP_DOCTOR_GATE' => 'e2e: environment not under test',
+          'SIGMA_SKIP_COLUMN_PREFLIGHT' => 'e2e: build LOGIC under test, not the live warehouse check' }
   w = ->(name, obj) { File.write(File.join(dir, name), JSON.generate(obj)) }
   run = ->(script, *args) { system(env, 'ruby', File.join(SCRIPTS, script), *args, out: File::NULL, err: File::NULL) }
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-pdp-detect.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-pdp-detect.rb
@@ -32,7 +32,8 @@ Dir.mktmpdir('domo-pdp') do |dir|
   # (connectionId/database/schema/table/name), NOT a nested path array.
   w.('dataset-map.json', { 'ds1' => { 'connectionId' => 'inode-CONN', 'database' => 'DB',
                                        'schema' => 'SCH', 'table' => 'ORDERS', 'name' => 'Orders' } })
-  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_SKIP_DOCTOR_GATE' => 'test' }
+  env = { 'DOMO_DISCOVERY_DIR' => dir, 'SIGMA_SKIP_DOCTOR_GATE' => 'test',
+          'SIGMA_SKIP_COLUMN_PREFLIGHT' => 'test: pdp detection under test, not column pre-flight' }
   system(env, 'ruby', File.expand_path('../scripts/build-dm.rb', __dir__), out: File::NULL, err: File::NULL)
   ok(File.exist?(File.join(dir, 'rls-todo.json')), 'rls-todo.json written for PDP dataset')
   todo = JSON.parse(File.read(File.join(dir, 'rls-todo.json')))

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb
@@ -47,6 +47,20 @@ result_500 = fetch_warehouse_columns('conn-3', %w[DB SCH TABLE], requester: requ
 ok(result_500['error'], 'a 500 also produces an error result, not an exception')
 ok(!result_500['error'].include?('sync'), 'a non-404 error does NOT get the 404-specific sync guidance')
 
+puts '== fetch_warehouse_columns: a stray "404" in a 500 error BODY must not false-positive as a 404 (Finding 1 regression) =='
+requester_500_with_404_in_body = ->(*_a, **_kw) do
+  raise Sigma::Error, "POST /v2/connection/conn-5/lookup -> 500 Internal Server Error\n{\"error\":\"upstream call to service X returned 404\",\"code\":\"E404\"}"
+end
+result_500_body404 = fetch_warehouse_columns('conn-5', %w[DB SCH TABLE], requester: requester_500_with_404_in_body, lister: ->(_p) { [] })
+ok(result_500_body404['error'], 'a 500 whose body mentions 404 still produces an error result, not an exception')
+ok(!result_500_body404['error'].include?('sync'),
+   "a 404 token in the BODY (not the status line) must NOT trigger the 404-specific sync guidance, got #{result_500_body404['error'].inspect}")
+
+puts '== fetch_warehouse_columns: a network-level exception (timeout) is caught, not propagated (Finding 2 regression) =='
+requester_timeout = ->(*_a, **_kw) { raise Net::ReadTimeout, 'execution expired' }
+result_timeout = fetch_warehouse_columns('conn-6', %w[DB SCH TABLE], requester: requester_timeout, lister: ->(_p) { [] })
+ok(result_timeout.is_a?(Hash) && result_timeout['error'], 'a Net::ReadTimeout is caught and returned as an error Hash, not raised')
+
 puts '== fetch_warehouse_columns: lookup resolving to a non-table kind is an error =='
 requester_view = ->(*_a, **_kw) { { 'inodeId' => 'inode-9', 'kind' => 'view' } }
 result_view = fetch_warehouse_columns('conn-4', %w[DB SCH V], requester: requester_view, lister: ->(_p) { [] })

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+# Offline: preflight-columns.rb's network seam (fetch_warehouse_columns) and
+# orchestration (run_preflight) — bead m655. No live Sigma call; requester/
+# lister and fetcher are injected stubs throughout (mirrors build-dm.rb's own
+# fetcher: seam for autofill_dataset_map).
+#   ruby test/test-preflight-columns.rb
+require 'json'
+require_relative '../scripts/preflight-columns'
+
+$failures = 0
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+def eq(actual, expected, msg)
+  if actual == expected
+    puts "  ok: #{msg}"
+  else
+    $failures += 1
+    puts "  FAIL: #{msg}\n        expected #{expected.inspect}\n        got      #{actual.inspect}"
+  end
+end
+
+puts '== fetch_warehouse_columns: happy path — lookup then paginated columns list =='
+stub_requester = ->(method, path, body: nil) do
+  eq(method, :post, 'lookup uses POST')
+  eq(path, '/v2/connection/conn-1/lookup', 'lookup path names the connection')
+  eq(JSON.parse(body), { 'path' => %w[DB SCH ORDER_FACT] }, 'lookup body carries the fully-qualified path')
+  { 'inodeId' => 'inode-1', 'kind' => 'table' }
+end
+stub_lister = ->(path) do
+  eq(path, '/v2/connections/tables/inode-1/columns', 'columns fetched at the resolved inodeId')
+  [{ 'name' => 'ORDER_ID', 'type' => { 'type' => 'LONG' } }, { 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' }]
+end
+result = fetch_warehouse_columns('conn-1', %w[DB SCH ORDER_FACT], requester: stub_requester, lister: stub_lister)
+ok(!result['error'], "no error on the happy path, got #{result['error'].inspect}")
+eq(result['columns'], [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DATE_KEY', 'type' => 'INTEGER' }],
+   'nested {type:{type:...}} shape is flattened to a plain type string')
+eq(result['inode_id'], 'inode-1', 'inode_id carried through')
+
+puts '== fetch_warehouse_columns: lookup 404 -> a distinct, actionable error (not a generic failure) =='
+requester_404 = ->(*_a, **_kw) { raise Sigma::Error, 'POST /v2/connection/conn-2/lookup -> 404 Not Found' }
+result_404 = fetch_warehouse_columns('conn-2', %w[DB SCH MISSING_TABLE], requester: requester_404, lister: ->(_p) { [] })
+ok(result_404['error'], 'a 404 lookup produces an error result, not an exception')
+ok(result_404['error'].include?('sync'), "the 404 message names the sync-then-retry fix, got #{result_404['error'].inspect}")
+
+puts '== fetch_warehouse_columns: a non-404 Sigma error is reported distinctly from a 404 =='
+requester_500 = ->(*_a, **_kw) { raise Sigma::Error, 'POST /v2/connection/conn-3/lookup -> 500 Internal Server Error' }
+result_500 = fetch_warehouse_columns('conn-3', %w[DB SCH TABLE], requester: requester_500, lister: ->(_p) { [] })
+ok(result_500['error'], 'a 500 also produces an error result, not an exception')
+ok(!result_500['error'].include?('sync'), 'a non-404 error does NOT get the 404-specific sync guidance')
+
+puts '== fetch_warehouse_columns: lookup resolving to a non-table kind is an error =='
+requester_view = ->(*_a, **_kw) { { 'inodeId' => 'inode-9', 'kind' => 'view' } }
+result_view = fetch_warehouse_columns('conn-4', %w[DB SCH V], requester: requester_view, lister: ->(_p) { [] })
+ok(result_view['error'], 'a non-table lookup result is an error')
+ok(result_view['error'].include?('view'), "error names the unexpected kind, got #{result_view['error'].inspect}")
+
+puts '== run_preflight: a dataset whose warehouse table has every Domo column -> clean =='
+datasets = [{ 'id' => 'ds-1', 'schema' => { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } }]
+ds_map = { 'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT' } }
+clean_fetcher = ->(_conn, _path) { { 'columns' => [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }] } }
+report, any_missing = run_preflight(datasets, ds_map, %w[ds-1], fetcher: clean_fetcher)
+eq(any_missing, false, 'no unresolved columns -> any_missing is false')
+eq(report['ds-1']['missing'], [], 'ds-1 report shows nothing missing')
+
+puts '== run_preflight: a dataset with a genuinely missing column -> any_missing true, named in the report =='
+gap_fetcher = ->(_conn, _path) { { 'columns' => [] } }
+report2, any_missing2 = run_preflight(datasets, ds_map, %w[ds-1], fetcher: gap_fetcher)
+eq(any_missing2, true, 'a missing column -> any_missing is true')
+eq(report2['ds-1']['missing'], ['ORDER_ID'], 'the report names the specific missing column')
+
+puts '== run_preflight: a fetch error is reported and counts as any_missing =='
+error_fetcher = ->(_conn, _path) { { 'error' => 'table not found in Sigma catalog' } }
+report3, any_missing3 = run_preflight(datasets, ds_map, %w[ds-1], fetcher: error_fetcher)
+eq(any_missing3, true, 'a fetch error also makes any_missing true (nothing was actually checked)')
+eq(report3['ds-1']['error'], 'table not found in Sigma catalog', 'the fetch error is carried into the report')
+
+puts '== run_preflight: a dataset-map entry with a placeholder sentinel table is skipped, not attempted =='
+ds_map_sentinel = { 'ds-1' => { 'connectionId' => '', 'database' => nil, 'schema' => nil, 'table' => nil, '_source' => 'domo-landed-data' } }
+never_called = ->(*_a) { raise 'must not attempt a live fetch for an unresolved dataset-map entry' }
+report4, any_missing4 = run_preflight(datasets, ds_map_sentinel, %w[ds-1], fetcher: never_called)
+eq(report4, {}, 'nothing reported for a dataset with no resolved connection/table yet')
+eq(any_missing4, false, 'an unresolved (not-yet-mapped) dataset does not block the pre-flight — build-dm.rb\'s own existing warnings cover it')
+
+puts '== run_preflight: excludeColumns/columnOverrides already in dataset-map.json are honored =='
+ds_map_resolved = { 'ds-1' => { 'connectionId' => 'conn-1', 'database' => 'DB', 'schema' => 'SCH', 'table' => 'ORDER_FACT',
+                                'excludeColumns' => ['ORDER_ID'] } }
+report5, any_missing5 = run_preflight(datasets, ds_map_resolved, %w[ds-1], fetcher: gap_fetcher)
+eq(any_missing5, false, 'the only gap is excluded -> clean')
+eq(report5['ds-1']['resolved_by_exclude'], ['ORDER_ID'], 'the exclusion is reported, not silently applied')
+
+puts
+if $failures.zero?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{$failures} FAILURE(S)"
+  exit 1
+end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-preflight-columns.rb
@@ -101,6 +101,25 @@ report5, any_missing5 = run_preflight(datasets, ds_map_resolved, %w[ds-1], fetch
 eq(any_missing5, false, 'the only gap is excluded -> clean')
 eq(report5['ds-1']['resolved_by_exclude'], ['ORDER_ID'], 'the exclusion is reported, not silently applied')
 
+puts '== fetch_warehouse_columns: honors SIGMA_HTTP_TIMEOUT for the real (non-stubbed) network path =='
+captured_timeouts = []
+Net::HTTP.define_singleton_method(:start) do |*args, **kwargs, &blk|
+  captured_timeouts << kwargs
+  # Return a minimal fake result so the block completes without a real connection.
+  blk.call(Object.new.tap { |o| o.define_singleton_method(:request) { |*_a| raise Sigma::Error, 'stub: no real request' } })
+end
+begin
+  ENV['SIGMA_HTTP_TIMEOUT'] = '45'
+  ENV['SIGMA_BASE_URL'] ||= 'https://example.sigmacomputing.com'
+  fetch_warehouse_columns('conn-timeout-test', %w[DB SCH T]) # requester/lister both nil -> real path
+rescue StandardError
+  # Expected — the stub raises past the lookup; we only care about the captured timeout kwargs.
+ensure
+  ENV.delete('SIGMA_HTTP_TIMEOUT')
+end
+ok(captured_timeouts.any? { |kw| kw[:read_timeout] == 45 }, "SIGMA_HTTP_TIMEOUT=45 was actually used as read_timeout, got #{captured_timeouts.inspect}")
+ok(captured_timeouts.any? { |kw| kw[:open_timeout] == 30 }, "open_timeout is capped at 30 even though read_timeout is 45, got #{captured_timeouts.inspect}")
+
 puts
 if $failures.zero?
   puts 'ALL PASS'


### PR DESCRIPTION
## What & why

`beads-sigma-m655`: `build-dm.rb` used to emit a Sigma DM column for every Domo dataset column as a bare warehouse-table reference, with no check that the column actually exists in the mapped warehouse table. A Domo DataSet routinely carries columns the mapped warehouse table doesn't have (derived/computed columns, or a landed copy that drifted from its source) — the only signal was an opaque `POST /v2/dataModels/spec` 400 at build time.

This adds a live pre-flight check (`scripts/preflight-columns.rb`): resolves each mapped table to a Sigma catalog `inodeId`, fetches its real columns (reusing the same live-validated endpoint pattern already proven in `tableau-to-sigma/scripts/discover-columns.rb`), diffs against the Domo dataset's columns, and writes `discovery/column-preflight.json`. `build-dm.rb` now refuses to proceed unless that report is clean (waivable via `SIGMA_SKIP_COLUMN_PREFLIGHT`, matching the existing doctor-gate convention). When a missing column matches one known derivable pattern (a YYYYMMDD integer date key), the tool auto-*suggests* — never auto-applies — a `MakeDate(...)` formula for a human to review and approve. `migrate-domo.rb` (the turnkey orchestrator) is wired to run this automatically.

No shared-lib extraction in this PR (see the design doc's Non-goals) — the warehouse-column-fetch logic is a domo-local adaptation of Tableau's proven pattern, written cleanly enough to lift later. A follow-up bead should promote it to `shared/` and wire Tableau to the same copy.

Design doc: `docs/superpowers/specs/2026-07-31-domo-dm-column-preflight-design.md`
Plan: `docs/superpowers/plans/2026-07-31-domo-dm-column-preflight.md`

0.8.2 -> 0.9.0.

### Notable things a final whole-branch review caught (fixed before this PR)
- A stale `discovery/column-preflight.json` could silently satisfy the new gate (a dataset resolved *after* the report was generated was never re-checked) and could permanently deadlock `migrate-domo.rb`'s fix-and-re-run loop — fixed by no longer treating "file exists" as "still valid" in the orchestrator, plus a staleness check in `build-dm.rb` as a safety net for standalone invocations.
- `diff_columns` compared raw Domo column names against raw warehouse names, but `build_element` actually emits `display_name`-transformed references — so two differently-styled Domo names for the same column (e.g. `"order_date"` vs `"Order Date"`) got inconsistent verdicts, and "fixing" a false positive via `excludeColumns` could have silently dropped a column that actually resolves fine. Both sides now compare on the same `display_name` transform `build_element` uses.
- The design's bounded-timeout requirement (`SIGMA_HTTP_TIMEOUT`, matching Tableau's sibling script) had been dropped during implementation — now implemented via the existing injectable `http:` seam on the shared (unmodified) `sigma_rest.rb`.

## Scope

- Plugin(s) touched: `domo-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green (`OK: 601 shared-file copies all match canonical`; `scripts/lib/sigma_rest.rb` — a shared file — is read-only in this PR, confirmed untouched)
- [x] `ruby tools/lint-skills.rb` — green (`OK: 11 converter SKILL.md files document all mandatory gates`)
- [x] `./corpus/run-corpus.sh --check` — green (20/20 cases pass); no domo corpus case exists to reconvert, and this change doesn't touch `build-workbook`/`build-dm` output shape for any existing corpus case
- [x] Phase numbers unchanged (no new skill added; the new script is documented as Phase 2.9 in SKILL.md's scripts table, a sub-step of Phase 3)
- [x] No unrelated working-tree changes swept in (`git status` clean)
- [x] Bumped `domo-to-sigma`'s `plugin.json`: 0.8.2 → 0.9.0

## Test plan

- [x] `bash test/run-all.sh` (from `plugins/domo-to-sigma/skills/domo-to-sigma/`) — all 21 suites pass
- [x] Every finding from 3 task reviews + fix rounds + a final whole-branch review was independently re-verified (not just re-read) by a fresh reviewer agent each time — including hand-derived logic re-checks, fresh scratch-script reproductions of each bug before/after its fix, and a real subprocess re-run of the full suite at every step
- [ ] No live Domo/Sigma smoke test was run in this environment (no credentials available in this session) — recommended before this ships as a customer-facing capability. Every network call shape matches Tableau's already live-verified equivalent exactly.

Built with Claude Code (Sonnet 5, subagent-driven-development workflow — design doc + plan + 4 tasks each with independent task review and fix rounds where needed, plus a final whole-branch review with one fix wave covering 1 Critical + 3 Important cross-task findings). Full ledger of findings/rulings lived at `.superpowers/sdd/2026-07-31-domo-dm-column-preflight/` (workspace deleted post-merge per that workflow's convention; git history is the record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)