### PR TITLE
domo-to-sigma: vendor SQL-formula converter off the live MCP (Track E)

### DIFF
--- a/docs/superpowers/plans/2026-08-03-domo-sql-formula-vendoring.md
+++ b/docs/superpowers/plans/2026-08-03-domo-sql-formula-vendoring.md
@@ -1,0 +1,1134 @@
+# Domo SQL-Formula Vendoring (Track E) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `domo-to-sigma`'s live-MCP dependency for Beast Mode SQL → Sigma
+formula translation by vendoring the already-tested `sigma-data-model-mcp` functions
+into a committed, self-contained `converter/sql.mjs` bundle, and rewiring
+`convert-beast-modes.rb` to call it via one local `node` invocation instead of an
+agent relaying `convert_sql_to_sigma_formula` calls by hand.
+
+**Architecture:** A third flavor of `tools/vendor-converters.sh`'s existing
+bundle-from-mcp pattern — same ongoing "canonical source stays upstream, re-vendor
+periodically" relationship as tableau/lookml/thoughtspot/qlik/powerbi/quicksight, but
+a custom entry module (`build/formulas.js`, a shared SQL-formula toolkit, not a
+top-level converter) and a custom export sanity-check (5 named functions, not the
+generic `convert*ToSigma` regex). `convert-beast-modes.rb` gains a `--convert` mode
+that resolves the converter via the same 3-tier ladder `powerbi-to-sigma` already
+uses (vendored bundle default → `--mcp-dir`/`DOMO_MCP_DIR` dev override → exit-10
+manual-MCP-call last resort), writes a small ephemeral `node` shim (mirroring
+`migrate-powerbi.rb`'s `_convert.mjs` pattern) that replicates `tools.ts`'s existing
+per-formula orchestration verbatim, and merges results back into the pending file.
+
+**Tech Stack:** Ruby (2.6, no endless method defs), Node.js (ESM, no TypeScript at
+runtime — only the vendored `.mjs`), esbuild (bundler), bash 3.2-portable shell.
+
+**Design doc:** `docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md`
+(read this first for full rationale — this plan implements it task-by-task).
+
+## Global Constraints
+
+- No changes to `sigma-data-model-mcp` (any repo/branch) — vendoring only reads its
+  `origin/main` via a fresh clone, never modifies it.
+- No new CI freshness gate for the domo bundle (matches the 6 mainline vendor-from-mcp
+  converters, which have none — `PROVENANCE.json` is informational only).
+- No Ruby port of `hasResidualCaseKeyword`/`hasResidualInfixOperator` regex logic —
+  the vendored JS functions are called directly instead.
+- `discovery/formula-overrides.json` override-eligibility is unchanged: it only fills
+  a `sigmaFormula` that is missing/blank, never one that is present but
+  `converted: false` (that widening is explicit non-goal / future follow-up).
+- Ruby throughout this repo targets **Ruby 2.6** — no endless method defs (`def f = ...`).
+- `tools/vendor-converters.sh` targets **macOS bash 3.2** — no associative arrays.
+- Stage git commits with explicit file paths — never `git add -A` (shared working
+  tree, other sessions may have uncommitted WIP).
+- Any change under `plugins/domo-to-sigma/**` requires a strict-semver bump of
+  `plugins/domo-to-sigma/.claude-plugin/plugin.json`'s `version` (currently `0.9.0`)
+  or a `Skip-Version-Bump: <reason>` commit trailer — enforced by CI
+  (`tools/check-plugin-version-bump.sh`).
+- Work happens in a dedicated git worktree off current `origin/main`, never the
+  shared `~/sigma-migration-skills` working directory. Commit frequently; never
+  commit onto a branch name that has already been squash-merged into `main`.
+
+---
+
+### Task 1: Vendor the SQL-formula converter into `converter/sql.mjs`
+
+**Files:**
+- Modify: `tools/vendor-converters.sh`
+- Create (generated artifact, committed): `plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs`
+- Create (generated artifact, committed): `plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `converter/sql.mjs`, a self-contained ESM module exporting (at least)
+  `lookSqlToSigmaRules(sql: string): string | null`,
+  `lookConvertExpression(sql: string): string`,
+  `hasResidualCaseKeyword(s: string): boolean`,
+  `hasResidualInfixOperator(s: string): boolean`,
+  `lookUnknownFunctions(sql: string): string[]` — Task 2 and Task 3 both import
+  from this exact path (`plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs`).
+
+- [ ] **Step 1: Add the `domo` case to `skill_for()`**
+
+Edit `tools/vendor-converters.sh`. Find:
+
+```bash
+    cognos|cognos-report) echo cognos-to-sigma ;;
+    *) echo "" ;;
+```
+
+Replace with:
+
+```bash
+    cognos|cognos-report) echo cognos-to-sigma ;;
+    domo) echo domo-to-sigma ;;
+    *) echo "" ;;
+```
+
+- [ ] **Step 2: Add `domo` to the default `WANT` list**
+
+Find:
+
+```bash
+WANT=("$@"); [ ${#WANT[@]} -eq 0 ] && WANT=(tableau lookml thoughtspot qlik powerbi quicksight cognos)
+```
+
+Replace with:
+
+```bash
+WANT=("$@"); [ ${#WANT[@]} -eq 0 ] && WANT=(tableau lookml thoughtspot qlik powerbi quicksight cognos domo)
+```
+
+- [ ] **Step 3: Add the domo special-case branch**
+
+Find the end of the cognos branch (the line reading `ruby "$ROOT/tools/check-cognos-bundle.rb" --write` followed by `continue` and `fi`):
+
+```bash
+    ruby "$ROOT/tools/check-cognos-bundle.rb" --write
+    continue
+  fi
+
+  entry="$SRC/build/$mod.js"
+```
+
+Replace with (inserting the new branch between the cognos branch and the generic path):
+
+```bash
+    ruby "$ROOT/tools/check-cognos-bundle.rb" --write
+    continue
+  fi
+
+  # Domo is a third flavor: same ongoing vendor-from-mcp relationship as the
+  # mainline 6 (canonical source stays upstream, re-vendor periodically — domo
+  # inherits future accuracy fixes the same way they do), but its source module
+  # doesn't follow the convert<Tool>ToSigma naming convention. It vendors
+  # formulas.ts, a shared low-level SQL-formula toolkit already used internally
+  # by lookml/dbt/snowflake/tableau's own converters — not a top-level
+  # converter — so the entry file and the export sanity-check are both custom.
+  if [ "$mod" = "domo" ]; then
+    entry="$SRC/build/formulas.js"
+    out="$dest/sql.mjs"
+    [ -f "$entry" ] || { echo "FATAL: $entry missing (build the converter repo first)"; exit 1; }
+    "$ESBUILD" "$entry" --bundle --format=esm --platform=node --outfile="$out" >/dev/null
+    node --input-type=module -e "
+      import * as m from '$out';
+      const need = ['lookSqlToSigmaRules','lookConvertExpression','hasResidualCaseKeyword','hasResidualInfixOperator','lookUnknownFunctions'];
+      const missing = need.filter(k => typeof m[k] !== 'function');
+      if (missing.length) { console.error('FATAL: $out missing exports: ' + missing.join(', ')); process.exit(1); }
+    "
+    echo "✓ $skill/converter/sql.mjs  ($(du -h "$out" | cut -f1))  [vendored from formulas.ts, custom export check]"
+    case "$STAMPED_DIRS" in *"|$dest|"*) : ;; *) STAMPED_DIRS="$STAMPED_DIRS|$dest|" ;; esac
+    continue
+  fi
+
+  entry="$SRC/build/$mod.js"
+```
+
+- [ ] **Step 4: Verify the script's bash-3.2 portability didn't regress**
+
+Run: `bash -n tools/vendor-converters.sh`
+Expected: no output, exit 0 (syntax check only — confirms no bash-4+ constructs like
+associative arrays were introduced).
+
+- [ ] **Step 5: Clone `sigma-data-model-mcp` fresh into scratch space and build it**
+
+Do NOT use `~/sigma-data-model-mcp` (it's on a dirty branch with ~20 untracked
+scratch files per this effort's own convention — never touch it). Clone fresh:
+
+```bash
+rm -rf /tmp/sigma-data-model-mcp-vendor
+git clone https://github.com/twells89/sigma-data-model-mcp.git /tmp/sigma-data-model-mcp-vendor
+cd /tmp/sigma-data-model-mcp-vendor
+git checkout main
+npm ci
+npm run build
+ls build/formulas.js   # confirm it exists before proceeding
+```
+
+Expected: `build/formulas.js` exists; `npm run build` exits 0.
+
+- [ ] **Step 6: Run the vendoring script against the fresh clone**
+
+From the `sigma-migration-skills` worktree root:
+
+```bash
+bash tools/vendor-converters.sh /tmp/sigma-data-model-mcp-vendor domo
+```
+
+Expected output: a line `✓ domo-to-sigma/converter/sql.mjs  (NN K)  [vendored from
+formulas.ts, custom export check]` and no `FATAL` lines. Confirm the files exist:
+
+```bash
+ls -la plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs
+cat plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
+```
+
+Expected: `PROVENANCE.json` contains `"source_repo": "twells89/sigma-data-model-mcp"`,
+a `source_commit` matching `git -C /tmp/sigma-data-model-mcp-vendor rev-parse --short HEAD`,
+and `"vendored_modules": "sql.mjs"`.
+
+- [ ] **Step 7: Smoke-test the bundle directly**
+
+```bash
+node --input-type=module -e "
+  import * as m from './plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs';
+  console.log(m.lookSqlToSigmaRules('SUM(\`Net Revenue\`)'));
+  console.log(m.hasResidualCaseKeyword('If(1,2,3)'));
+  console.log(m.hasResidualCaseKeyword('CASE WHEN x THEN 1 END'));
+"
+```
+
+Expected: three lines of output — a Sigma-formula string for the first (something
+like `Sum([Net Revenue])`), `false` for the second, `true` for the third. If any
+line errors or prints `undefined`, the bundle is broken — do not proceed to commit.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tools/vendor-converters.sh \
+        plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs \
+        plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
+git commit -m "domo-to-sigma: vendor SQL-formula converter as converter/sql.mjs (Track E, 1/4)"
+```
+
+---
+
+### Task 2: Rewire `convert-beast-modes.rb` with a `--convert` mode + 3-tier resolution
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb`
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 for its own tests (uses a hand-authored fake stub
+  module so this task's tests are fast/deterministic and don't depend on upstream
+  translation accuracy — that's Task 3's job against the real bundle). In practice,
+  by the time this task runs, Task 1's real `converter/sql.mjs` already exists in
+  the repo and this is what a live run will actually use.
+- Produces: `resolve_sql_converter(mcp_dir, vendored)` (Ruby function, returns
+  `[conv_path_or_nil, dev_module_or_nil, desc_or_nil]`), the `--convert` CLI flag,
+  the `--converter-out PATH` CLI flag, the `--mcp-dir DIR` CLI flag. Task 4's
+  `migrate-domo.rb` wiring calls `convert-beast-modes.rb --convert` and depends on
+  its exit codes (0 = success, 10 = tier-3 gate, nonzero-other = hard failure) and
+  on `discovery/formulas.pending.json` gaining `converted`/`warnings`/`note` keys
+  per entry after this mode runs.
+
+- [ ] **Step 1: Add `require 'open3'` and `require 'tmpdir'`**
+
+Edit `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb`.
+Find:
+
+```ruby
+require 'json'
+require 'optparse'
+```
+
+Replace with:
+
+```ruby
+require 'json'
+require 'optparse'
+require 'open3'
+require 'tmpdir'
+```
+
+- [ ] **Step 2: Add the vendored-path constant and `resolve_sql_converter`**
+
+Find:
+
+```ruby
+OUT = ENV['DOMO_DISCOVERY_DIR'] || File.expand_path('../discovery', __dir__)
+```
+
+Replace with:
+
+```ruby
+OUT = ENV['DOMO_DISCOVERY_DIR'] || File.expand_path('../discovery', __dir__)
+
+# Track E — the vendored SQL-formula converter (tools/vendor-converters.sh domo).
+VENDORED_SQL = File.expand_path('../converter/sql.mjs', __dir__)
+
+# Converter resolution, same 3-tier ladder as powerbi-to-sigma's
+# migrate-powerbi.rb#resolve_converter: the vendored bundle is the DEFAULT (byte-
+# identical output on any machine); a local sigma-data-model-mcp build is used
+# ONLY when explicitly opted into via --mcp-dir/DOMO_MCP_DIR — no silent ~/…
+# auto-discovery (that's the "works in my checkout, differs for the customer"
+# footgun powerbi's own comment names). If neither resolves, the caller's
+# --convert branch takes the last-resort exit-10 path. Returns
+# [conv_module_path_or_nil, dev_build_dir_or_nil, description_or_nil].
+def resolve_sql_converter(mcp_dir, vendored)
+  dev_module = (mcp_dir && File.exist?(File.join(mcp_dir, 'build', 'formulas.js'))) ?
+    File.join(mcp_dir, 'build', 'formulas.js') : nil
+  conv = dev_module || (File.exist?(vendored) ? vendored : nil)
+  desc =
+    if conv && conv == vendored
+      prov = File.join(File.dirname(vendored), 'PROVENANCE.json')
+      commit = (JSON.parse(File.read(prov))['source_commit'] rescue nil)
+      "VENDORED converter/sql.mjs#{commit ? " (pinned #{commit})" : ''} — no data egress"
+    elsif conv
+      "DEV BUILD #{conv} (explicit opt-in via --mcp-dir/DOMO_MCP_DIR)"
+    end
+  [conv, dev_module, desc]
+end
+```
+
+- [ ] **Step 3: Write the failing test for `resolve_sql_converter`**
+
+Append to `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb`,
+just before the final `puts` / `if $failures.zero?` block:
+
+```ruby
+# ---------------------------------------------------------------------------
+# resolve_sql_converter — Track E's 3-tier resolution (vendored default,
+# --mcp-dir/DOMO_MCP_DIR dev override, nil when neither resolves).
+# ---------------------------------------------------------------------------
+
+puts '== resolve_sql_converter: vendored bundle wins when no mcp_dir given =='
+Dir.mktmpdir('resolve-sql-conv') do |dir|
+  vendored = File.join(dir, 'sql.mjs')
+  File.write(vendored, '// fake bundle')
+  File.write(File.join(dir, 'PROVENANCE.json'), JSON.generate({ 'source_commit' => 'abc1234' }))
+  conv, dev_dir, desc = resolve_sql_converter(nil, vendored)
+  ok(conv == vendored, 'resolves to the vendored path')
+  ok(dev_dir.nil?, 'no dev build dir reported')
+  ok(desc.include?('VENDORED') && desc.include?('abc1234'), 'description names VENDORED + pinned commit')
+end
+
+puts '== resolve_sql_converter: --mcp-dir wins over vendored when both present =='
+Dir.mktmpdir('resolve-sql-conv-dev') do |dir|
+  vendored = File.join(dir, 'sql.mjs')
+  File.write(vendored, '// fake bundle')
+  mcp_dir = File.join(dir, 'mcp')
+  FileUtils.mkdir_p(File.join(mcp_dir, 'build'))
+  File.write(File.join(mcp_dir, 'build', 'formulas.js'), '// fake dev build')
+  conv, dev_dir, desc = resolve_sql_converter(mcp_dir, vendored)
+  ok(conv == File.join(mcp_dir, 'build', 'formulas.js'), 'resolves to the dev build, not vendored')
+  ok(dev_dir == mcp_dir, 'dev build dir reported')
+  ok(desc.include?('DEV BUILD') && desc.include?('explicit opt-in'), 'description names DEV BUILD + opt-in')
+end
+
+puts '== resolve_sql_converter: nil when neither vendored nor --mcp-dir resolve =='
+Dir.mktmpdir('resolve-sql-conv-none') do |dir|
+  conv, dev_dir, desc = resolve_sql_converter(nil, File.join(dir, 'does-not-exist.mjs'))
+  ok(conv.nil?, 'no converter resolves')
+  ok(dev_dir.nil?, 'no dev dir')
+  ok(desc.nil?, 'no description when nothing resolves')
+end
+```
+
+Also add `require 'fileutils'` near the top of the test file (needed for
+`FileUtils.mkdir_p` above). Find:
+
+```ruby
+require_relative '../scripts/convert-beast-modes'
+require 'json'
+require 'tmpdir'
+```
+
+Replace with:
+
+```ruby
+require_relative '../scripts/convert-beast-modes'
+require 'json'
+require 'tmpdir'
+require 'fileutils'
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb`
+Expected: FAIL — `undefined method 'resolve_sql_converter'` (or similar NameError),
+since Step 2's code hasn't been added to the running file yet if you're doing TDD
+strictly. (If Step 2 was already applied, this test should PASS immediately —
+either order is fine as long as you confirm the assertions are meaningful by
+temporarily breaking one, e.g. swap `conv == vendored` to `conv == 'wrong'` and
+confirm it reports FAIL, then revert.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb`
+Expected: `ALL PASS`, exit 0.
+
+- [ ] **Step 6: Add the `--convert`, `--mcp-dir`, `--converter-out` CLI options**
+
+Find:
+
+```ruby
+opts = {}
+OptionParser.new do |o|
+  o.on('--lint') { opts[:lint] = true }
+  o.on('--in PATH')  { |v| opts[:in] = v }
+  o.on('--out PATH') { |v| opts[:out] = v }
+  o.on('--overrides PATH') { |v| opts[:overrides] = v }
+end.parse!(ARGV)
+```
+
+Replace with:
+
+```ruby
+opts = {}
+OptionParser.new do |o|
+  o.on('--lint') { opts[:lint] = true }
+  o.on('--convert') { opts[:convert] = true }
+  o.on('--in PATH')  { |v| opts[:in] = v }
+  o.on('--out PATH') { |v| opts[:out] = v }
+  o.on('--overrides PATH') { |v| opts[:overrides] = v }
+  # Track E 3-tier resolution: --mcp-dir/DOMO_MCP_DIR (tier 2, explicit dev
+  # opt-in) and --converter-out (tier 3 resume — an agent-produced JSON array
+  # of [{id, sigmaFormula, converted, warnings, note?}] filled by hand via the
+  # manual convert_sql_to_sigma_formula MCP call the exit-10 path prints).
+  o.on('--mcp-dir DIR') { |v| opts[:mcp_dir] = File.expand_path(v) }
+  o.on('--converter-out PATH') { |v| opts[:converter_out] = v }
+end.parse!(ARGV)
+```
+
+- [ ] **Step 7: Add the `--convert` branch**
+
+Find:
+
+```ruby
+if opts[:lint]
+  # ---- Validate a filled pending file → formulas.json --------------------
+```
+
+Replace with:
+
+```ruby
+if opts[:convert]
+  # ---- Track E: run the SQL-formula converter over the whole pending file,
+  # one node invocation, no agent/MCP call in the loop ----------------------
+  path = opts[:in] || File.join(OUT, 'formulas.pending.json')
+  pending = JSON.parse(File.read(path))
+
+  if opts[:converter_out]
+    # Tier 3 resume: an agent already ran convert_sql_to_sigma_formula by hand
+    # per the exit-10 instructions below and saved [{id, sigmaFormula,
+    # converted, warnings, note?}] to this file. Merge by id; never clobber
+    # fields this tier doesn't supply.
+    filled = JSON.parse(File.read(opts[:converter_out]))
+    by_id = {}
+    filled.each { |e| by_id[e['id']] = e }
+    pending.each do |e|
+      src = by_id[e['id']]
+      next unless src
+      e['sigmaFormula'] = src['sigmaFormula']
+      e['converted']    = src['converted']
+      e['warnings']     = src['warnings']
+      e['note']         = src['note'] if src['note']
+    end
+    out = opts[:out] || path
+    File.write(out, JSON.pretty_generate(pending))
+    warn "  filled #{filled.size} formula(s) from --converter-out #{opts[:converter_out]}"
+    exit 0
+  end
+
+  conv, _dev_dir, desc = resolve_sql_converter(opts[:mcp_dir] || ENV['DOMO_MCP_DIR'], VENDORED_SQL)
+  if conv.nil?
+    warn '  vendored converter (converter/sql.mjs) missing and no local sigma-data-model-mcp ' \
+         'build (--mcp-dir / DOMO_MCP_DIR).'
+    warn ''
+    warn '  >>> GATE: for EACH entry in discovery/formulas.pending.json, call'
+    warn '      convert_sql_to_sigma_formula(sql: normalizedSql), collect the result as'
+    warn '      {id, sigmaFormula, converted, warnings, note?}, write the whole array to a'
+    warn '      JSON file, then re-run:'
+    warn '        ruby scripts/convert-beast-modes.rb --convert --converter-out <that file>'
+    warn '      No formulas were translated.'
+    exit 10
+  end
+  warn "  converter: #{desc}"
+
+  import_specifier =
+    (Gem.win_platform? && conv.to_s.match?(/\A[A-Za-z]:/)) ? 'file:///' + conv.gsub('\\', '/') : conv
+
+  Dir.mktmpdir('domo-convert') do |dir|
+    in_path  = File.join(dir, 'pending.json')
+    res_path = File.join(dir, 'results.json')
+    File.write(in_path, JSON.generate(pending))
+
+    runner = File.join(dir, 'run.mjs')
+    File.write(runner, <<~JS)
+      import { readFileSync, writeFileSync } from 'node:fs';
+      import { lookSqlToSigmaRules, lookConvertExpression, hasResidualCaseKeyword, hasResidualInfixOperator, lookUnknownFunctions } from #{import_specifier.to_json};
+      const pending = JSON.parse(readFileSync(#{in_path.to_json}, 'utf8'));
+      // Same per-formula orchestration as sigma-data-model-mcp's src/tools.ts
+      // convert_sql_to_sigma_formula tool handler — try the rule engine first,
+      // fall back to the total mechanical converter, then check for residual
+      // untranslated SQL syntax the same way the live tool already does.
+      const NOTE = 'Could not fully translate — output still contains raw SQL syntax Sigma has no equivalent for (CASE/WHEN/THEN, or an infix LIKE/BETWEEN), do not use as-is';
+      const out = pending.map((entry) => {
+        const sql = entry.normalizedSql;
+        const warnings = lookUnknownFunctions(sql).map(fn => `${fn}() has no Sigma mapping — emitted as-is; verify it exists in Sigma.`);
+        let sigmaFormula = lookSqlToSigmaRules(sql);
+        if (sigmaFormula == null) sigmaFormula = lookConvertExpression(sql);
+        const converted = !hasResidualCaseKeyword(sigmaFormula) && !hasResidualInfixOperator(sigmaFormula);
+        const result = { ...entry, sigmaFormula, converted, warnings };
+        if (!converted) result.note = NOTE;
+        return result;
+      });
+      writeFileSync(#{res_path.to_json}, JSON.stringify(out));
+    JS
+
+    _stdout, stderr, status = Open3.capture3('node', runner)
+    abort "FATAL: converter failed:\n#{stderr}" unless status.success?
+    pending = JSON.parse(File.read(res_path))
+  end
+
+  out = opts[:out] || path
+  File.write(out, JSON.pretty_generate(pending))
+  unreliable = pending.count { |e| e['converted'] == false }
+  if unreliable.positive?
+    warn "  wrote #{out} (#{pending.size} formulas; #{unreliable} flagged converted:false — review before --lint)"
+  else
+    warn "  wrote #{out} (#{pending.size} formulas, all converted:true)"
+  end
+elsif opts[:lint]
+  # ---- Validate a filled pending file → formulas.json --------------------
+```
+
+- [ ] **Step 8: Add the `converted:false` visibility warning to `resolve_entry`**
+
+Find:
+
+```ruby
+  errs, lint_warns = lint_formula(sigma, entry['class'])
+  resolved = entry.merge('sigmaFormula' => sigma, 'lintErrors' => errs, 'lintWarnings' => lint_warns)
+  if used_override
+    resolved['_source'] = 'formula-override'
+    resolved['note'] = override['note'] if override['note']
+    warnings << "#{entry['name'] || entry['id']}: sigmaFormula supplied by " \
+      "discovery/formula-overrides.json (hand-authored) — automated conversion " \
+      "(convert_sql_to_sigma_formula) did not produce a usable formula for this " \
+      "Beast Mode; verify by hand. CASE WHEN / COUNT(DISTINCT) / double-bracketed " \
+      "ALL-CAPS refs are fixed (sigma-data-model-mcp PR #115, #116) so this is NOT " \
+      "that historical 74%-fail case — check refs/live-validation-2026-07-30.md " \
+      "and this script's still-open gaps (WEEKDAY→DAYOFWEEK, CEILING/FLOOR " \
+      "aggregates, untranslatable infix LIKE) for what actually still needs a " \
+      "hand-authored formula."
+  end
+  [resolved, warnings]
+```
+
+Replace with:
+
+```ruby
+  errs, lint_warns = lint_formula(sigma, entry['class'])
+  resolved = entry.merge('sigmaFormula' => sigma, 'lintErrors' => errs, 'lintWarnings' => lint_warns)
+  if used_override
+    resolved['_source'] = 'formula-override'
+    resolved['note'] = override['note'] if override['note']
+    warnings << "#{entry['name'] || entry['id']}: sigmaFormula supplied by " \
+      "discovery/formula-overrides.json (hand-authored) — automated conversion " \
+      "(convert_sql_to_sigma_formula) did not produce a usable formula for this " \
+      "Beast Mode; verify by hand. CASE WHEN / COUNT(DISTINCT) / double-bracketed " \
+      "ALL-CAPS refs are fixed (sigma-data-model-mcp PR #115, #116) so this is NOT " \
+      "that historical 74%-fail case — check refs/live-validation-2026-07-30.md " \
+      "and this script's still-open gaps (WEEKDAY→DAYOFWEEK, CEILING/FLOOR " \
+      "aggregates, untranslatable infix LIKE) for what actually still needs a " \
+      "hand-authored formula."
+  elsif entry['converted'] == false
+    # Track E: --convert already computed a REAL converted flag (via the
+    # vendored hasResidualCaseKeyword/hasResidualInfixOperator) — surface it
+    # loudly here rather than letting a "flagged unreliable but still has SOME
+    # string in sigmaFormula" entry ride through --lint silently. Does NOT
+    # change override-eligibility (still fills-missing-only, unchanged) — this
+    # is visibility only.
+    warnings << "#{entry['name'] || entry['id']}: automated conversion flagged this formula as " \
+      "converted:false (still contains raw CASE/WHEN/THEN or an infix LIKE/BETWEEN Sigma has no " \
+      "equivalent for) — review before shipping; consider a discovery/formula-overrides.json entry."
+  end
+  [resolved, warnings]
+```
+
+- [ ] **Step 9: Update the normalize-mode "next step" instructions**
+
+Find:
+
+```ruby
+  warn "  wrote #{out} (#{pending.size} Beast Modes to translate)"
+  warn "\n  Next (Phase 2): for each entry call convert_sql_to_sigma_formula(sql: normalizedSql),"
+  warn "  write the result into `sigmaFormula`, apply preWarning overrides (CEILING/FLOOR/window/LOD),"
+  warn "  then: ruby scripts/convert-beast-modes.rb --lint"
+```
+
+Replace with:
+
+```ruby
+  warn "  wrote #{out} (#{pending.size} Beast Modes to translate)"
+  warn "\n  Next (Phase 2): ruby scripts/convert-beast-modes.rb --convert   # local node, no MCP call"
+  warn "  then:            ruby scripts/convert-beast-modes.rb --lint"
+```
+
+- [ ] **Step 10: Write a fake-stub CLI test for `--convert`'s plumbing**
+
+Append to `test-convert-beast-modes.rb`, after the `resolve_sql_converter` tests
+added in Step 3:
+
+```ruby
+# ---------------------------------------------------------------------------
+# --convert CLI mode — plumbing test against a hand-authored FAKE stub module
+# (deterministic, no dependency on the real vendored bundle's translation
+# accuracy — that's covered separately by test-convert-beast-modes-fixtures.rb
+# against the real converter/sql.mjs). Exercises: shim generation, node
+# invocation, result merge, and the converted:false marking.
+# ---------------------------------------------------------------------------
+
+puts '== CLI --convert: dev-build tier (--mcp-dir) runs the fake stub end-to-end =='
+node_present = begin
+  _o, _e, st = Open3.capture3('node', '--version')
+  st.success?
+rescue Errno::ENOENT
+  false
+end
+
+if node_present
+  Dir.mktmpdir('convert-mode-fake-stub') do |dir|
+    mcp_dir = File.join(dir, 'fake-mcp')
+    FileUtils.mkdir_p(File.join(mcp_dir, 'build'))
+    File.write(File.join(mcp_dir, 'build', 'formulas.js'), <<~JS)
+      export function lookSqlToSigmaRules(sql) {
+        return sql.startsWith('FAIL_RULES') ? null : `RULES(${sql})`;
+      }
+      export function lookConvertExpression(sql) { return `EXPR(${sql})`; }
+      export function hasResidualCaseKeyword(s) { return s.includes('BADCASE'); }
+      export function hasResidualInfixOperator(s) { return s.includes('BADINFIX'); }
+      export function lookUnknownFunctions(sql) { return sql.includes('UNKNOWNFN') ? ['UNKNOWNFN'] : []; }
+    JS
+
+    pending_path = File.join(dir, 'formulas.pending.json')
+    out_path     = File.join(dir, 'formulas.pending.json') # in place
+    File.write(pending_path, JSON.generate([
+      { 'id' => 'calculation_clean-1', 'name' => 'Clean One', 'normalizedSql' => 'SUM([x])', 'sigmaFormula' => nil },
+      { 'id' => 'calculation_fallback-1', 'name' => 'Fallback One', 'normalizedSql' => 'FAIL_RULES SUM([x])', 'sigmaFormula' => nil },
+      { 'id' => 'calculation_badcase-1', 'name' => 'Bad Case One', 'normalizedSql' => 'BADCASE([x])', 'sigmaFormula' => nil },
+      { 'id' => 'calculation_unknownfn-1', 'name' => 'Unknown Fn One', 'normalizedSql' => 'UNKNOWNFN([x])', 'sigmaFormula' => nil },
+    ]))
+
+    cmd = ['ruby', SCRIPT, '--convert', '--mcp-dir', mcp_dir, '--in', pending_path, '--out', out_path]
+    output = IO.popen(cmd, err: [:child, :out], &:read)
+    ok($?.success?, "--convert exits 0 against a fake dev-build stub\n#{output unless $?.success?}")
+    ok(output.include?('DEV BUILD') && output.include?('explicit opt-in'), 'stderr names the DEV BUILD tier')
+
+    result = JSON.parse(File.read(out_path))
+    by_id = {}
+    result.each { |e| by_id[e['id']] = e }
+
+    ok(by_id['calculation_clean-1']['sigmaFormula'] == 'RULES(SUM([x]))', 'rule-engine path used when it returns non-null')
+    ok(by_id['calculation_clean-1']['converted'] == true, 'clean formula marked converted:true')
+
+    ok(by_id['calculation_fallback-1']['sigmaFormula'] == 'EXPR(FAIL_RULES SUM([x]))', 'falls back to lookConvertExpression when rules return null')
+
+    ok(by_id['calculation_badcase-1']['sigmaFormula'] == 'RULES(BADCASE([x]))', 'residual-flagged formula is still emitted, never dropped')
+    ok(by_id['calculation_badcase-1']['converted'] == false, 'residual CASE keyword marks converted:false')
+    ok(by_id['calculation_badcase-1']['note'].to_s.include?('Could not fully translate'), 'converted:false entry carries a note')
+
+    ok(by_id['calculation_unknownfn-1']['warnings'].any? { |w| w.include?('UNKNOWNFN') }, 'lookUnknownFunctions warning surfaced per entry')
+  end
+
+  puts '== CLI --convert: --converter-out tier-3 resume merges by id =='
+  Dir.mktmpdir('convert-mode-tier3') do |dir|
+    pending_path = File.join(dir, 'formulas.pending.json')
+    conv_out     = File.join(dir, 'manual-mcp-results.json')
+    File.write(pending_path, JSON.generate([
+      { 'id' => 'calculation_manual-1', 'name' => 'Manual One', 'normalizedSql' => 'SUM([x])', 'sigmaFormula' => nil },
+    ]))
+    File.write(conv_out, JSON.generate([
+      { 'id' => 'calculation_manual-1', 'sigmaFormula' => 'Sum([x])', 'converted' => true, 'warnings' => [] },
+    ]))
+    cmd = ['ruby', SCRIPT, '--convert', '--converter-out', conv_out, '--in', pending_path, '--out', pending_path]
+    output = IO.popen(cmd, err: [:child, :out], &:read)
+    ok($?.success?, "--converter-out resume exits 0\n#{output unless $?.success?}")
+    result = JSON.parse(File.read(pending_path))
+    ok(result.first['sigmaFormula'] == 'Sum([x])', 'manual MCP result merged into the pending file by id')
+  end
+else
+  puts '== CLI --convert: SKIPPED (node not on PATH) =='
+end
+```
+
+The `--convert` CLI's tier-3 exit-10 gate fires exactly when
+`resolve_sql_converter` returns `nil` for its first element — Step 3's
+`resolve_sql_converter: nil when neither vendored nor --mcp-dir resolve` test
+already asserts that condition directly, so no separate CLI-level exit-10 test
+is added here (it would just be re-testing the same branch through an extra
+process-spawn layer for no new coverage).
+
+- [ ] **Step 11: Run the full test file to verify it fails, then passes**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb`
+Expected (before Step 6-9's implementation is in place): FAIL — CLI invocation
+errors on the unrecognized `--convert` flag. After Step 6-9 are applied: `ALL PASS`,
+exit 0.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+git commit -m "domo-to-sigma: add --convert mode + 3-tier converter resolution (Track E, 2/4)"
+```
+
+---
+
+### Task 3: Real-bundle accuracy fixture test
+
+**Files:**
+- Create: `plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb`
+
+**Interfaces:**
+- Consumes: Task 1's `converter/sql.mjs` (must exist on disk — this test aborts
+  loudly if it's missing, per the tableau-exemplar pattern).
+- Produces: nothing consumed by later tasks — this is a leaf test file.
+
+- [ ] **Step 1: Write the fixture test file**
+
+```ruby
+#!/usr/bin/env ruby
+# Accuracy fixture suite for the vendored converter/sql.mjs (Track E). Offline +
+# deterministic. Pattern copied from tableau-to-sigma's test-converter-fixtures.rb
+# (the exemplar this skill's own design doc cites): a symbol-count guard runs
+# UNCONDITIONALLY so a re-vendor that drops/renames a needed export hard-aborts
+# rather than silently skipping every fixture; if `node` is present, fixtures run
+# for real against the bundle; if absent, SKIPPED loudly, never a silent pass.
+#
+#   ruby test/test-convert-beast-modes-fixtures.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+
+VENDORED = File.expand_path('../converter/sql.mjs', __dir__)
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# ---------------------------------------------------------------------------
+# Representative Beast Mode SQL snippets (post-normalize_bm — backticks already
+# rewritten to [brackets], matching what --convert actually feeds the bundle).
+# Deliberately NOT the mcp's own 74-item corpus — that stays upstream-only; a
+# domo-side dependency on it would reintroduce exactly the coupling Track E
+# removes. :expect_converted false marks a formula this converter is KNOWN not
+# to fully translate (still an honest, present sigmaFormula) — never asserted
+# as a bug, just locked so a future upstream fix is noticed via NOTE below.
+# ---------------------------------------------------------------------------
+FIXTURES = [
+  { id: 'D-1', sql: 'SUM([Net Revenue])',                        expect: 'Sum([Net Revenue])' },
+  { id: 'D-2', sql: 'COUNT(DISTINCT [Order Id])',                 expect: 'CountDistinct([Order Id])' },
+  { id: 'D-3', sql: 'AVG([Order Total])',                         expect: 'Avg([Order Total])' },
+  { id: 'D-4', sql: 'SUM([Gross Profit]) / SUM([Net Revenue])',   expect: 'Sum([Gross Profit]) / Sum([Net Revenue])' },
+  { id: 'D-5', sql: "CASE WHEN [Status] = 'Active' THEN 1 ELSE 0 END",
+    expect: 'If([Status] = "Active", 1, 0)' },
+  { id: 'D-6', sql: 'MAX([Order Date])',                          expect: 'Max([Order Date])' },
+  { id: 'D-7', sql: 'MIN([Order Date])',                          expect: 'Min([Order Date])' },
+  { id: 'D-8', sql: 'ROUND([Margin Pct], 2)',                     expect: 'Round([Margin Pct], 2)' },
+  { id: 'D-9', sql: "DATEDIFF('day', [Order Date], [Ship Date])", expect: 'DateDiff("day", [Order Date], [Ship Date])' },
+  { id: 'D-10', sql: 'COALESCE([Discount], 0)',                   expect: 'Coalesce([Discount], 0)' },
+]
+# NOTE (converted:false expected): the vendored converter has no Sigma mapping
+# for LIKE/BETWEEN — this is intentional, not a bug (see design doc's Error
+# Handling section). Locks the honesty signal itself, not a translation.
+RESIDUAL_FIXTURES = [
+  { id: 'D-R1', sql: "LOWER([Country]) LIKE 'usa'" },
+  { id: 'D-R2', sql: '[Order Total] BETWEEN 100 AND 500' },
+]
+
+puts 'Accuracy fixtures — vendored converter/sql.mjs'
+abort "FATAL: vendored converter missing at #{VENDORED} — run tools/vendor-converters.sh <mcp-clone> domo" \
+  unless File.exist?(VENDORED)
+bundle = File.read(VENDORED, encoding: 'utf-8')
+
+# Symbol-count guard — UNCONDITIONAL, runs even without node. A re-vendor that
+# drops or renames any of these 5 exports must hard-abort, never silently skip
+# every fixture below.
+NEEDED = %w[lookSqlToSigmaRules lookConvertExpression hasResidualCaseKeyword hasResidualInfixOperator lookUnknownFunctions]
+missing = NEEDED.reject { |name| bundle.match?(/\b#{Regexp.escape(name)}\b/) }
+abort "converter fixture harness: converter/sql.mjs is missing expected export(s): #{missing.join(', ')} " \
+      '— the re-vendor dropped/renamed a needed function; update test-convert-beast-modes-fixtures.rb ' \
+      'or investigate the upstream change.' unless missing.empty?
+
+node_present = begin
+  _o, _e, st = Open3.capture3('node', '--version')
+  st.success?
+rescue Errno::ENOENT
+  false
+end
+
+if node_present
+  Dir.mktmpdir('domo-conv-fixtures') do |dir|
+    fx_path  = File.join(dir, 'fixtures.json')
+    res_path = File.join(dir, 'results.json')
+    all_fixtures = FIXTURES + RESIDUAL_FIXTURES
+    File.write(fx_path, JSON.generate(all_fixtures.map { |x| { 'id' => x[:id], 'sql' => x[:sql] } }))
+
+    import_specifier = Gem.win_platform? && VENDORED.match?(/\A[A-Za-z]:/) ? 'file:///' + VENDORED.gsub('\\', '/') : VENDORED
+    runner = File.join(dir, 'run.mjs')
+    File.write(runner, <<~JS)
+      import { readFileSync, writeFileSync } from 'node:fs';
+      import { lookSqlToSigmaRules, lookConvertExpression, hasResidualCaseKeyword, hasResidualInfixOperator } from #{import_specifier.to_json};
+      const fixtures = JSON.parse(readFileSync(#{fx_path.to_json}, 'utf8'));
+      const out = fixtures.map(({ id, sql }) => {
+        let sigmaFormula = lookSqlToSigmaRules(sql);
+        if (sigmaFormula == null) sigmaFormula = lookConvertExpression(sql);
+        const converted = !hasResidualCaseKeyword(sigmaFormula) && !hasResidualInfixOperator(sigmaFormula);
+        return { id, sigmaFormula, converted };
+      });
+      writeFileSync(#{res_path.to_json}, JSON.stringify(out));
+    JS
+
+    _o, e, st = Open3.capture3('node', runner)
+    if !st.success?
+      warn "FAIL — node fixture runner failed:\n#{e}"
+      exit 1
+    end
+
+    rows = JSON.parse(File.read(res_path, encoding: 'utf-8'))
+    by_id = {}
+    rows.each { |r| by_id[r['id']] = r }
+
+    FIXTURES.each do |fx|
+      r = by_id[fx[:id]]
+      check(r && r['sigmaFormula'] == fx[:expect] && r['converted'] == true,
+            "#{fx[:id]}  #{fx[:sql].inspect} → #{fx[:expect].inspect} (converted:true)", fails)
+    end
+
+    RESIDUAL_FIXTURES.each do |fx|
+      r = by_id[fx[:id]]
+      check(r && !r['sigmaFormula'].to_s.empty? && r['converted'] == false,
+            "#{fx[:id]}  #{fx[:sql].inspect} → present-but-converted:false (honest residual-LIKE/BETWEEN signal)", fails)
+    end
+  end
+else
+  warn '  WARN  node not found on PATH — accuracy fixtures SKIPPED ' \
+       "(#{FIXTURES.size + RESIDUAL_FIXTURES.size} fixtures unexercised). " \
+       'Install node (doctor.sh enforces it for the converter path) to run them.'
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end
+```
+
+- [ ] **Step 2: Run it and confirm the expected outcome**
+
+Run: `ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb`
+Expected: `ALL PASS`, exit 0 (assuming Task 1's bundle is present and `node` is on
+PATH). If any `D-*` fixture FAILs, that's a real, measured translation gap in the
+vendored converter for that SQL shape — do not silently loosen the assertion;
+either the fixture's expected string is wrong (fix the fixture) or the converter
+genuinely doesn't handle that shape yet (document it as a known gap in
+`refs/beast-mode-to-sigma.md`, matching how CEILING/FLOOR/WEEKDAY gaps are already
+documented there).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
+git commit -m "domo-to-sigma: add converter/sql.mjs accuracy fixture suite (Track E, 3/4)"
+```
+
+---
+
+### Task 4: Wire `migrate-domo.rb`, update docs, bump plugin version, final verification
+
+**Files:**
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb:372-397`
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md:322-328`
+- Modify: `plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md:1-30,243-253`
+- Modify: `plugins/domo-to-sigma/.claude-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: Task 2's `convert-beast-modes.rb --convert` (exit codes 0/10/other,
+  and that it fills `sigmaFormula`/`converted`/`warnings`/`note` per pending entry).
+- Produces: nothing consumed by later tasks — this is the final integration task.
+
+- [ ] **Step 1: Wire `migrate-domo.rb`'s `phase_convert_beast_modes!`**
+
+Find (`plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb`, the body
+of `phase_convert_beast_modes!` after the normalize step):
+
+```ruby
+  ok, code, _out = run_script!('convert-beast-modes.rb')
+  fail_phase!('convert-beast-modes', "normalize step exited #{code}") unless ok
+
+  pending_path = File.join(DISCOVERY, 'formulas.pending.json')
+  pending = begin
+    JSON.parse(File.read(pending_path))
+  rescue StandardError
+    []
+  end
+  unresolved = pending.count { |e| e['sigmaFormula'].nil? || e['sigmaFormula'].to_s.strip.empty? }
+  if unresolved.positive?
+    log "NOTE: #{unresolved} Beast Mode(s) still lack a sigmaFormula — normally filled by calling " \
+        'convert_sql_to_sigma_formula per pending entry (see the script header) before --lint. ' \
+        'Running --lint now anyway: unresolved entries are DROPPED from formulas.json (never shipped ' \
+        'silently as-is), so this phase is only fully complete once formulas.pending.json is filled in ' \
+        'and re-linted.'
+  end
+
+  ok, code, _out = run_script!('convert-beast-modes.rb', '--lint')
+  fail_phase!('convert-beast-modes', "--lint step exited #{code}") unless ok
+
+  if unresolved.positive?
+    done_phase!('convert-beast-modes', "#{unresolved} Beast Mode(s) unresolved — see discovery/formulas.pending.json")
+  else
+    done_phase!('convert-beast-modes')
+  end
+end
+```
+
+Replace with:
+
+```ruby
+  ok, code, _out = run_script!('convert-beast-modes.rb')
+  fail_phase!('convert-beast-modes', "normalize step exited #{code}") unless ok
+
+  ok, code, _out = run_script!('convert-beast-modes.rb', '--convert')
+  if !ok && code == 10
+    fail_phase!('convert-beast-modes',
+                'no vendored converter/sql.mjs and no --mcp-dir/DOMO_MCP_DIR — re-run ' \
+                "'ruby scripts/convert-beast-modes.rb --convert' directly to see the manual " \
+                'convert_sql_to_sigma_formula + --converter-out fallback instructions')
+  end
+  fail_phase!('convert-beast-modes', "--convert step exited #{code}") unless ok
+
+  pending_path = File.join(DISCOVERY, 'formulas.pending.json')
+  pending = begin
+    JSON.parse(File.read(pending_path))
+  rescue StandardError
+    []
+  end
+  unresolved = pending.count { |e| e['sigmaFormula'].nil? || e['sigmaFormula'].to_s.strip.empty? }
+  unreliable = pending.count { |e| e['converted'] == false }
+  if unresolved.positive?
+    log "NOTE: #{unresolved} Beast Mode(s) still lack a sigmaFormula after --convert — unexpected " \
+        '(lookConvertExpression is a total fallback that never returns nil); check ' \
+        "convert-beast-modes.rb --convert's stderr output above."
+  end
+  if unreliable.positive?
+    log "NOTE: #{unreliable} Beast Mode(s) flagged converted:false by --convert — has a sigmaFormula " \
+        '(never silently dropped) but still contains untranslated CASE/WHEN/THEN or an infix ' \
+        'LIKE/BETWEEN; review before shipping (discovery/formula-overrides.json can supply a ' \
+        'hand-authored replacement).'
+  end
+
+  ok, code, _out = run_script!('convert-beast-modes.rb', '--lint')
+  fail_phase!('convert-beast-modes', "--lint step exited #{code}") unless ok
+
+  if unresolved.positive? || unreliable.positive?
+    done_phase!('convert-beast-modes',
+                "#{unresolved} unresolved, #{unreliable} unreliable (converted:false) — see " \
+                'discovery/formulas.pending.json')
+  else
+    done_phase!('convert-beast-modes')
+  end
+end
+```
+
+- [ ] **Step 2: Update `SKILL.md`'s Phase 2 section**
+
+Find (`plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md`, around line 322):
+
+```markdown
+## Phase 2 — Translate Beast Modes
+
+`ruby scripts/convert-beast-modes.rb` → feeds each Beast Mode SQL string through
+`convert_sql_to_sigma_formula`. Apply the normalizations in
+`refs/beast-mode-to-sigma.md` FIRST (strip backticks, `WEEKDAY`→`DAYOFWEEK`,
+flag aggregate `CEILING`/`FLOOR`, reject unsupported `SQRT`/`CONVERT_TZ`).
+Outputs `discovery/formulas.json` (Beast Mode id → Sigma formula).
+```
+
+Replace with:
+
+```markdown
+## Phase 2 — Translate Beast Modes
+
+Three scripted steps, no agent/MCP call in the loop (`migrate-domo.rb` runs all
+three automatically):
+```bash
+ruby scripts/convert-beast-modes.rb            # normalize → discovery/formulas.pending.json
+ruby scripts/convert-beast-modes.rb --convert  # vendored converter/sql.mjs fills sigmaFormula/converted/warnings, locally via node
+ruby scripts/convert-beast-modes.rb --lint     # validate → discovery/formulas.json
+```
+`--convert` resolves the converter via a 3-tier ladder: the vendored bundle
+(default, no MCP/network), a local `sigma-data-model-mcp` build via
+`--mcp-dir`/`DOMO_MCP_DIR` (explicit dev opt-in only), or — last resort, bundle
+and `node` both absent — exit 10 with the manual `convert_sql_to_sigma_formula`
++ `--converter-out` fallback instructions. Applies the normalizations in
+`refs/beast-mode-to-sigma.md` FIRST (strip backticks, `WEEKDAY`→`DAYOFWEEK`,
+flag aggregate `CEILING`/`FLOOR`, reject unsupported `SQRT`/`CONVERT_TZ`).
+Outputs `discovery/formulas.json` (Beast Mode id → Sigma formula).
+```
+
+- [ ] **Step 3: Update `refs/beast-mode-to-sigma.md`'s intro section**
+
+Find (around line 1-22):
+
+```markdown
+# Beast Mode → Sigma formula mapping
+
+Beast Mode is **MySQL-dialect SQL**. The primary translation path is the existing
+`mcp__sigma-data-model__convert_sql_to_sigma_formula` tool — feed it the Beast
+Mode string and it emits a Sigma formula. This doc is the **pre-processing +
+verification layer**: normalizations to apply first, the function-by-function map
+to sanity-check the converter's output, and the gotchas that the generic SQL
+converter won't know are Domo-specific.
+
+Source of truth: Domo "Beast Mode Functions Reference Guide" (captured 2026-06-02).
+
+---
+
+## Translation is delegated — this ref is the Domo-specific wrapper
+
+The actual SQL→Sigma translation runs through the
+`mcp__sigma-data-model__convert_sql_to_sigma_formula` MCP tool — it is the
+**single source of truth** and already handles `CASE WHEN`, `IN` lists,
+`DATEDIFF`, arithmetic, and `snake_case` → `[Title Case]` column references.
+Don't re-implement those. This ref is the **Domo-specific PRE-normalization +
+POST-lint** layer that `scripts/convert-beast-modes.rb` implements around that
+call.
+```
+
+Replace with:
+
+```markdown
+# Beast Mode → Sigma formula mapping
+
+Beast Mode is **MySQL-dialect SQL**. The primary translation path is the vendored
+`converter/sql.mjs` (`scripts/convert-beast-modes.rb --convert`, running locally
+via `node` — no MCP call, no network; see Track E,
+`docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md`). This
+doc is the **pre-processing + verification layer**: normalizations to apply
+first, the function-by-function map to sanity-check the converter's output, and
+the gotchas that the generic SQL converter won't know are Domo-specific.
+
+Source of truth: Domo "Beast Mode Functions Reference Guide" (captured 2026-06-02).
+
+---
+
+## Translation is delegated — this ref is the Domo-specific wrapper
+
+The actual SQL→Sigma translation runs through the vendored `converter/sql.mjs`
+(`lookSqlToSigmaRules`/`lookConvertExpression`, re-vendored periodically from
+`sigma-data-model-mcp`'s `src/formulas.ts` — same functions the
+`convert_sql_to_sigma_formula` MCP tool itself calls) — it is the **single
+source of truth** and already handles `CASE WHEN`, `IN` lists, `DATEDIFF`,
+arithmetic, and `snake_case` → `[Title Case]` column references. Don't
+re-implement those. This ref is the **Domo-specific PRE-normalization +
+POST-lint** layer that `scripts/convert-beast-modes.rb` implements around that
+call.
+```
+
+- [ ] **Step 4: Update `refs/beast-mode-to-sigma.md`'s "Translation workflow" section**
+
+Find (around line 243-253):
+
+```markdown
+## Translation workflow (per Beast Mode)
+
+1. Normalize (backticks, WEEKDAY, unsupported, aggregate CEILING/FLOOR, context).
+2. Call `convert_sql_to_sigma_formula` with the normalized string.
+3. Cross-check the result against the tables above; apply the Domo-specific
+   gotchas the generic SQL converter misses (CEILING/FLOOR aggregates, `IN`→`or`,
+   `DATEDIFF` arg order, format-specifier translation).
+4. Validate the column posts without an error type (`diagnose_sigma_save_error`
+   if it fails; remember `*Over` window-function limits per
+   `feedback_sigma_window_functions`).
+```
+
+Replace with:
+
+```markdown
+## Translation workflow (per Beast Mode)
+
+1. Normalize (backticks, WEEKDAY, unsupported, aggregate CEILING/FLOOR, context).
+2. `ruby scripts/convert-beast-modes.rb --convert` runs the vendored
+   `converter/sql.mjs` against every normalized string in one local `node`
+   invocation (no MCP call).
+3. Cross-check the result against the tables above; apply the Domo-specific
+   gotchas the generic SQL converter misses (CEILING/FLOOR aggregates, `IN`→`or`,
+   `DATEDIFF` arg order, format-specifier translation).
+4. Validate the column posts without an error type (`diagnose_sigma_save_error`
+   if it fails; remember `*Over` window-function limits per
+   `feedback_sigma_window_functions`).
+```
+
+- [ ] **Step 5: Bump the plugin version**
+
+Read `plugins/domo-to-sigma/.claude-plugin/plugin.json`, find the `"version"`
+field (currently `"0.9.0"`), bump it to `"0.10.0"` (minor — new capability/behavior
+change, no breaking interface change to anything external).
+
+- [ ] **Step 6: Run the full domo test suite**
+
+```bash
+ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+ruby plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
+bash plugins/domo-to-sigma/skills/domo-to-sigma/test/run-all.sh   # if present — run domo's full offline suite
+```
+
+Expected: `ALL PASS` / exit 0 on every suite; no new failures relative to the
+pre-existing baseline (this repo's convention is "no NEW failures," not
+necessarily zero across the whole monorepo — see the Environment section of
+`project_domo_live_validation` memory for known pre-existing unrelated failures
+elsewhere in the tree).
+
+- [ ] **Step 7: Run the repo-wide gates**
+
+```bash
+ruby tools/check-shared.rb
+ruby tools/vendor-converters.sh --help 2>/dev/null; bash -n tools/vendor-converters.sh
+ruby tools/check-plugin-version-bump.sh "$(git merge-base origin/main HEAD)" HEAD
+```
+
+Expected: all exit 0. (These also run as pre-commit hooks in this repo per prior
+sessions' experience — if a commit in this task fails a hygiene/lint gate, fix
+and recommit rather than bypassing with `--no-verify`.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb \
+        plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md \
+        plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md \
+        plugins/domo-to-sigma/.claude-plugin/plugin.json
+git commit -m "domo-to-sigma: wire --convert into migrate-domo.rb, update docs, bump 0.9.0→0.10.0 (Track E, 4/4)"
+```
+
+---
+
+## After this plan: live E2E validation (not part of this plan's task list)
+
+Once all 4 tasks are implemented, reviewed, and merged via PR, re-run the same bar
+Tracks A/B/C already established against a real Domo instance: `migrate-domo.rb`
+end-to-end on a live page, `assert-phase6-ran.rb` exit 0, honest waiver-budget
+tracking, orphan cleanup. This is a separate live-credentialed session step (see
+the design doc's "Live E2E validation" section), not an offline-testable task —
+intentionally excluded from this plan's task list per the brainstorming design.

--- a/docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md
+++ b/docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md
@@ -113,11 +113,25 @@ cleanly.
   PROVENANCE.json block (source_repo/source_commit/source_commit_date/bundler/
   vendored_modules) writes for domo too, unmodified — this is the standard
   vendor-from-mcp provenance shape, not a bespoke one.
-- **No CI freshness gate.** Checked: `check-cognos-bundle.rb` only exists because
-  cognos's canonical source lives *inside* this repo (CI can hash it without cloning
-  anything). The 6 mainline vendor-from-mcp converters have no CI freshness gate at all
-  — `PROVENANCE.json` is informational, refreshed by a human running the script
-  periodically. Domo matches that; no new tooling.
+- **No NEW CI freshness gate needed — correction, one already exists and applies.**
+  Originally checked (incorrectly) as: `check-cognos-bundle.rb` only exists because
+  cognos's canonical source lives *inside* this repo, and the 6 mainline vendor-from-mcp
+  converters have no CI freshness gate at all. **That premise was wrong.**
+  `tools/check-converter-provenance.sh --freshness` IS a standing CI gate (wired in
+  `.github/workflows/hygiene.yml`), and it already applies to every vendored
+  (`source_repo`-bearing) `PROVENANCE.json` in the repo — domo's included, the moment
+  domo has one. The gate derives its `--freshness` remediation command and its
+  (non-CI, human-run) `--online` upstream-diff source file from `PROVENANCE.json`,
+  assuming a mainline-converter shape where the module basename doubles as both the
+  vendor-converters.sh arg and the upstream `src/<mod>.ts` file — true for the 6
+  mainline converters, false for domo (vendor arg is `domo`, upstream source is
+  `src/formulas.ts`, not `src/sql.ts`). Fixed by recording two explicit fields in
+  domo's `PROVENANCE.json` — `source_file: "src/formulas.ts"` and `vendor_arg: "domo"`
+  — which `check-converter-provenance.sh` now prefers when present, falling back to
+  the mainline-converter inference otherwise (see the vendor-converters.sh /
+  check-converter-provenance.sh diffs). No new gate was built; the existing one just
+  needed domo's `PROVENANCE.json` to carry data accurate enough for its existing
+  remediation/online-check logic to work.
 
 ### 2. `converter/sql.mjs` (new, vendored artifact)
 
@@ -218,14 +232,22 @@ MCP results — proving the rewire is behavior-preserving (or better, via the ne
 
 - **No upstream `sigma-data-model-mcp` change of any kind.** Both prior docs assumed
   one was needed (a CLI, or a reason to avoid depending on main); neither holds.
-- **No new CI freshness gate.** Matches the 6 mainline converters' (lack of) precedent.
+- **No new CI freshness gate needed.** Correction (see the vendor-converters.sh /
+  `converter/sql.mjs` section above): the standing `check-converter-provenance.sh
+  --freshness` gate already covers every vendored `PROVENANCE.json`, domo included —
+  it was never true that the 6 mainline converters had no freshness gate. Domo just
+  needed accurate `source_file`/`vendor_arg` fields for that existing gate's
+  remediation/online-check logic to point at the right things.
 - **No Ruby port of the residual-CASE/infix-operator regexes.** The vendored JS
   functions supply this directly and more reliably.
-- **No change to override-eligibility semantics** (`formula-overrides.json` still only
-  fills a missing `sigmaFormula`, never overrides a `converted:false`-but-present one).
-  Widening this is a legitimate future improvement given the new real `converted` signal,
-  but it's separate scope from removing the MCP dependency — flag as a candidate
-  follow-up bead, not built here.
+- ~~No change to override-eligibility semantics~~ **Superseded 2026-08-03 (final review
+  fix wave):** the follow-up flagged here was built in the same branch. Confirmed
+  decision: `formula-overrides.json` now also supersedes a pending entry flagged
+  `converted: false` (still-broken machine output), not just a blank `sigmaFormula` —
+  because `--convert`'s `lookConvertExpression` fallback is total (always produces
+  SOME `sigmaFormula`), so "blank" alone had become nearly unreachable in the
+  orchestrated pipeline. It still never overrides a `converted: true` (or legacy,
+  no-`converted`-key) entry. See `resolve_entry` in `scripts/convert-beast-modes.rb`.
 - **No change to `mcp__sigma-mcp-v2__query`** (live parity verification) — out of scope
   per the original 2026-07-31 scope decision, unaffected by any of the above.
 

--- a/docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md
+++ b/docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md
@@ -1,0 +1,251 @@
+# Design — vendor `domo-to-sigma`'s SQL-formula conversion off the live MCP
+
+**Date:** 2026-08-03. **Status:** approved, ready for implementation plan.
+**Bead:** `beads-sigma-qu59`. **Supersedes:** the Track E section of
+`docs/handoff/2026-07-31-domo-to-gold.md` (upstream-CLI-prerequisite plan) and the
+"port-and-own" architecture agreed in `docs/handoff/2026-08-03-domo-to-gold-track-e-reconciled.md`
+— both superseded by facts discovered while writing this doc (see "Why this differs
+from both prior write-ups" below). Read this doc as the current source of truth for
+Track E; the two prior docs are historical context only.
+
+## Problem
+
+`domo-to-sigma` is the only converter plugin with no `converter/` bundle — its formula
+translation step (Beast Mode SQL → Sigma formula) depends on a live agent calling the
+`convert_sql_to_sigma_formula` MCP tool once per formula, by hand, in the middle of
+`convert-beast-modes.rb`'s otherwise-scripted pipeline. This is slow, not offline
+testable, and puts an agent in a loop that every other converter has already removed.
+
+## Why this differs from both prior write-ups
+
+Two designs existed before this session, and disagreed with each other; this session
+re-verified the facts both were built on and found **both were wrong on their load
+bearing claim**, in opposite directions:
+
+- The 2026-07-31 design doc's Track E section wanted an **upstream mcp-repo PR**
+  (`src/formula-cli.ts`) as a prerequisite, on the theory that domo needed a new CLI
+  surface to batch-call the converter.
+- The 2026-08-03 reconciliation doc rejected that (correctly — no upstream PR needed)
+  but for the **wrong reason**: it believed `hasResidualCaseKeyword`,
+  `hasResidualInfixOperator`, `lookUnknownFunctions`, and the real
+  `{sigmaFormula, converted, warnings, note}` return shape only existed on an unmerged
+  branch (`origin/fix/sql-formula-beastmode`), and picked "port and own" (copy the TS
+  into `sigma-migration-skills` permanently, cognos-style, zero ongoing mcp relationship)
+  partly to avoid depending on that instability.
+
+**Verified directly against `sigma-data-model-mcp` on 2026-08-03:**
+
+- `hasResidualCaseKeyword`, `hasResidualInfixOperator`, `lookUnknownFunctions` are all
+  exported on `origin/main` (`src/formulas.ts`), merged via PR #115 on **2026-07-31** —
+  three days before the reconciliation doc was written, not stuck on an unmerged branch.
+- `src/tools.ts`'s live `convert_sql_to_sigma_formula` tool already computes `converted`
+  for real (`!hasResidualCaseKeyword(result) && !hasResidualInfixOperator(result)`) — it
+  is not hardcoded `true`.
+- The 74-entry `src/sql.beastmode.corpus.json` + its test file are on `main`.
+- `origin/fix/sql-formula-beastmode` is actually **behind** main by 7 commits (and ahead
+  by 27 unrelated ones) — a stale, abandoned branch, not a source of newer unmerged work.
+- `src/formulas.ts` has had 4 more merged fixes in the 3 days before this doc (#115,
+  #116, #118, #120) — this shared converter is under active, frequent improvement.
+
+Given main is genuinely stable and tested, freezing a "port and own" copy today would
+mean manually re-deriving every future fix by hand forever, with real drift risk — the
+exact failure mode Track A already fixed once (the pre-#115 converter silently
+corrupting 74% of real Beast Modes). The standard **vendor-from-mcp** pattern (used by
+tableau/lookml/thoughtspot/qlik/powerbi/quicksight) avoids that: bundle from `main`,
+re-vendor periodically, inherit future accuracy fixes automatically, same as every
+sibling. TJ confirmed this reversal on 2026-08-03 once the corrected facts were in hand.
+
+A second, independent simplification fell out of checking how the existing
+vendor-from-mcp converters actually call their bundles: `powerbi-to-sigma`'s
+`migrate-powerbi.rb` (:612-643) writes a small ephemeral `node` shim per run that
+imports the vendored function by name and does a little glue logic (default options,
+result-unwrapping) **locally**, not upstream. Domo can do the same — vendor the
+already-exported, already-tested formula functions directly, and keep the thin
+per-formula orchestration (which function to try first, how to build the result object)
+as a local shim, not an upstream CLI. **Net result: zero changes to `sigma-data-model-mcp`
+at all**, for either of the two originally-proposed reasons.
+
+## Decision
+
+Vendor the 5 needed functions from `sigma-data-model-mcp`'s `src/formulas.ts` (compiled
+to `build/formulas.js`) into a self-contained `converter/sql.mjs`, the same way the 6
+mainline converters vendor their `.mjs` bundles — but as a **third flavor** of
+`tools/vendor-converters.sh`, because `formulas.ts` doesn't fit either existing flavor:
+
+| | canonical source | re-vendor relationship | entry module | export check |
+|---|---|---|---|---|
+| tableau/lookml/qlik/powerbi/quicksight/thoughtspot | upstream mcp | yes, periodic | `build/$mod.js` (1:1 with `$mod`) | regex `/^convert.*ToSigma$/` |
+| cognos | in-skill TS | none (owns it) | in-skill `converter/cli.ts` | n/a (own build) |
+| **domo (new)** | **upstream mcp** | **yes, periodic** | **`build/formulas.js`** (name mismatch — shared low-level toolkit, not a top-level converter) | **custom: assert 5 named functions present** |
+
+`formulas.ts`'s own header confirms it's already a shared toolkit, not a
+domo/tableau-specific file: *"SQL → Sigma formula conversion utilities. Used by LookML,
+Snowflake, dbt, and Tableau converters."* 2118 lines, one clean import
+(`sigmaDisplayName` from `sigma-ids.ts`, a small pure helper — free in the bundle, no
+further work needed for the `format_sigma_display_name` MCP-tool dependency the
+2026-07-31 doc had also flagged). No side effects, no filesystem/network — bundles
+cleanly.
+
+## Components
+
+### 1. `tools/vendor-converters.sh`
+
+- Add `domo) echo domo-to-sigma ;;` to `skill_for()`.
+- Add `domo` to the default `WANT` list (so a no-args run refreshes all 8 skills, not 7).
+- New branch, same shape/position as the existing cognos special case:
+  ```bash
+  if [ "$mod" = "domo" ]; then
+    entry="$SRC/build/formulas.js"
+    out="$dest/sql.mjs"
+    "$ESBUILD" "$entry" --bundle --format=esm --platform=node --outfile="$out" >/dev/null
+    node --input-type=module -e "
+      import * as m from '$out';
+      const need = ['lookSqlToSigmaRules','lookConvertExpression','hasResidualCaseKeyword','hasResidualInfixOperator','lookUnknownFunctions'];
+      const missing = need.filter(k => typeof m[k] !== 'function');
+      if (missing.length) { console.error('FATAL: $out missing exports: ' + missing.join(', ')); process.exit(1); }
+    "
+    echo "✓ $skill/converter/sql.mjs  ($(du -h "$out" | cut -f1))  [vendored from formulas.ts, custom export check]"
+    case "$STAMPED_DIRS" in *"|$dest|"*) : ;; *) STAMPED_DIRS="$STAMPED_DIRS|$dest|" ;; esac
+    continue
+  fi
+  ```
+- Unlike cognos, domo's `dest` **is** added to `STAMPED_DIRS`, so the existing generic
+  PROVENANCE.json block (source_repo/source_commit/source_commit_date/bundler/
+  vendored_modules) writes for domo too, unmodified — this is the standard
+  vendor-from-mcp provenance shape, not a bespoke one.
+- **No CI freshness gate.** Checked: `check-cognos-bundle.rb` only exists because
+  cognos's canonical source lives *inside* this repo (CI can hash it without cloning
+  anything). The 6 mainline vendor-from-mcp converters have no CI freshness gate at all
+  — `PROVENANCE.json` is informational, refreshed by a human running the script
+  periodically. Domo matches that; no new tooling.
+
+### 2. `converter/sql.mjs` (new, vendored artifact)
+
+Self-contained ESM bundle exporting (at minimum) `lookSqlToSigmaRules`,
+`lookConvertExpression`, `hasResidualCaseKeyword`, `hasResidualInfixOperator`,
+`lookUnknownFunctions` (esbuild keeps all named exports of the bundled entry module, so
+the other ~25 `formulas.ts` exports ride along unused — accepted, matches how every
+other vendored bundle already carries some dead code for its consumer; not worth a
+second entry point for). Committed to git, `PROVENANCE.json` alongside it.
+
+### 3. `convert-beast-modes.rb` rewire
+
+Phase 2 changes from "agent calls MCP once per formula, writes `sigmaFormula` by hand"
+to one `node` invocation over the whole `formulas.pending.json`, mirroring
+`migrate-powerbi.rb`'s `_convert.mjs` shim pattern:
+
+1. Resolve the converter module via the same 3-tier ladder `powerbi-to-sigma` uses
+   (`resolve_converter`, ported/adapted):
+   - **Tier 1 (default):** vendored `converter/sql.mjs`.
+   - **Tier 2 (dev override):** `--mcp-dir DIR` / `DOMO_MCP_DIR` env — a local
+     `sigma-data-model-mcp` checkout's `build/formulas.js`, explicit opt-in only, no
+     silent auto-discovery.
+   - **Tier 3 (last resort):** both absent → print the exact
+     `convert_sql_to_sigma_formula` MCP-call instructions per pending formula (today's
+     existing fallback text, kept verbatim) and `exit 10`; resume via
+     `--converter-out <file>` once an agent has filled it by hand. Keeps a manual
+     escape hatch without making MCP load-bearing for the default path.
+2. Write a tiny ephemeral ESM shim to a tmp/work file (same technique as
+   `migrate-powerbi.rb:624`) that:
+   - imports the 5 functions from the resolved module,
+   - reads `formulas.pending.json`,
+   - for each entry, replicates `tools.ts`'s existing per-formula logic verbatim:
+     `result = lookSqlToSigmaRules(normalizedSql)`; if null, fall back to
+     `lookConvertExpression(normalizedSql)`; `converted = !hasResidualCaseKeyword(x) &&
+     !hasResidualInfixOperator(x)`; `warnings = lookUnknownFunctions(normalizedSql).map(...)`;
+     `note` set on the same "could not fully translate" text `tools.ts` already uses
+     when `!converted`,
+   - writes the whole array back out with `sigmaFormula`/`converted`/`warnings`/`note`
+     merged into each entry.
+3. Run via `Open3.capture3('node', shim)`; abort loudly on non-zero exit (matches
+   `migrate-powerbi.rb:642-643`).
+4. `--lint` mode is unchanged in structure — it still reads the (now pre-filled)
+   pending file, still applies `discovery/formula-overrides.json` only where
+   `sigmaFormula` is still missing (override-eligibility rule **unchanged** — see
+   Non-goals), still calls `lint_formula`, still writes `formulas.json`.
+5. **New:** `--lint` also emits a loud warning for any entry with `converted: false`
+   even though `sigmaFormula` is present — naming the Beast Mode, so a human notices an
+   honest "didn't fully translate" signal instead of it silently riding through as if it
+   were clean. This does not change exit-code/error behavior, only visibility.
+
+### 4. `lint_formula` (Ruby) — unchanged
+
+The reconciliation doc's plan to port `hasResidualCaseKeyword`/`hasResidualInfixOperator`
+as Ruby regexes is dropped — moot, since the vendored JS shim now computes the real
+`converted` per entry directly, more accurately than a re-derived Ruby regex could
+(exact same masking logic the tested upstream functions already use). `lint_formula`
+keeps its existing, different, still-load-bearing checks: raw `IN(...)` (no `IsIn` in
+Sigma), `And()/Or()/Not()` used as function calls (silently nulls rows), unbalanced
+brackets/parens. No new Ruby regex logic in this track.
+
+### 5. Testing
+
+Follow `tableau-to-sigma`'s `test-converter-fixtures.rb` exactly (the exemplar cited in
+the reconciliation doc, confirmed still the right pattern): a symbol-count guard scans
+the bundle text for the 5 expected function names so a rebuild that silently
+renames/minifies one is never a silent skip; if `node` is present, copy the bundle to a
+tmpdir, write fixture inputs to JSON + a tiny node ESM runner, run via
+`Open3.capture3('node', runner)`, assert each fixture's exact output; if `node` is
+absent, skip loudly, never silently pass. New file
+`test/test-convert-beast-modes-fixtures.rb`, 10-20 hand-picked representative Beast
+Mode SQL snippets (not the mcp's own 74-item corpus — that stays upstream-only, correctly
+per the reconciliation doc, since depending on it would reintroduce exactly the coupling
+this track removes). Existing `test/test-convert-beast-modes.rb` (Ruby-only
+normalize/lint/override unit tests) is unaffected and stays as-is.
+
+### 6. Docs
+
+`SKILL.md`, `QUICKSTART.md`, `refs/beast-mode-to-sigma.md`, `refs/card-to-element.md`:
+remove the "Phase 2 — skill calls `convert_sql_to_sigma_formula` per entry" instruction
+block; document the one-shot `node` call, the 3-tier resolution ladder, and the
+`--converter-out` escape hatch (mirroring how `powerbi-to-sigma`'s own docs describe its
+ladder — `SKILL.md:183`, `QUICKSTART.md:55`, cited in the original design doc as the
+exemplar to read first).
+
+### 7. Live E2E validation (post-merge, this session's actual ask)
+
+Once the above is implemented, offline-tested, and merged: re-run the exact bar Tracks
+A/B/C already established (`docs/handoff/2026-07-31-domo-to-gold-track-b-done.md`) —
+`migrate-domo.rb` end-to-end against a real Domo page/tier with real credentials,
+`assert-phase6-ran.rb` exit 0, honest waiver-budget tracking (not silently passing
+anything), orphan cleanup of any Sigma objects created during the run. The specific
+thing this validates that Tracks A/B/C didn't: the **same formula translations** now
+come from the vendored bundle with **zero MCP tool calls**, not an agent hand-relaying
+MCP results — proving the rewire is behavior-preserving (or better, via the new
+`converted:false` visibility) on real Beast Modes, not just the offline fixture set.
+
+## Non-goals (explicit, to stop scope creep)
+
+- **No upstream `sigma-data-model-mcp` change of any kind.** Both prior docs assumed
+  one was needed (a CLI, or a reason to avoid depending on main); neither holds.
+- **No new CI freshness gate.** Matches the 6 mainline converters' (lack of) precedent.
+- **No Ruby port of the residual-CASE/infix-operator regexes.** The vendored JS
+  functions supply this directly and more reliably.
+- **No change to override-eligibility semantics** (`formula-overrides.json` still only
+  fills a missing `sigmaFormula`, never overrides a `converted:false`-but-present one).
+  Widening this is a legitimate future improvement given the new real `converted` signal,
+  but it's separate scope from removing the MCP dependency — flag as a candidate
+  follow-up bead, not built here.
+- **No change to `mcp__sigma-mcp-v2__query`** (live parity verification) — out of scope
+  per the original 2026-07-31 scope decision, unaffected by any of the above.
+
+## Error handling
+
+- Bundle present, `node` present → normal path, no behavior surprises for an operator.
+- Bundle missing, `--mcp-dir`/`DOMO_MCP_DIR` present and valid → dev-build path, printed
+  loudly (`DEV BUILD ... (explicit opt-in)`), matching powerbi's own wording convention.
+- Both absent → `exit 10` with the exact per-formula MCP-call text + `--converter-out`
+  resume instructions (today's existing fallback text is already this shape; kept, not
+  rewritten).
+- `node` invocation throws (malformed pending JSON, etc.) → abort loudly with stderr,
+  matching `migrate-powerbi.rb:643`'s `abort "FATAL: converter failed:\n#{c_err}#{_c_out}"`.
+- A formula that neither `lookSqlToSigmaRules` nor `lookConvertExpression` can resolve
+  usefully still gets a `sigmaFormula` string (per `tools.ts`'s existing contract — the
+  fallback never returns null) with `converted: false` and a `note` — never silently
+  dropped, never silently claimed clean. This is unchanged from today's MCP-tool
+  behavior, just now computed locally.
+
+## Plugin version
+
+`domo-to-sigma` is at `0.9.0` (bead `m655`'s merge, #591). This PR bumps from there per
+this repo's plugin-version-bump-gate convention.

--- a/docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md
+++ b/docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md
@@ -105,14 +105,21 @@ cleanly.
       if (missing.length) { console.error('FATAL: $out missing exports: ' + missing.join(', ')); process.exit(1); }
     "
     echo "✓ $skill/converter/sql.mjs  ($(du -h "$out" | cut -f1))  [vendored from formulas.ts, custom export check]"
-    case "$STAMPED_DIRS" in *"|$dest|"*) : ;; *) STAMPED_DIRS="$STAMPED_DIRS|$dest|" ;; esac
     continue
   fi
   ```
-- Unlike cognos, domo's `dest` **is** added to `STAMPED_DIRS`, so the existing generic
+- ~~Unlike cognos, domo's `dest` **is** added to `STAMPED_DIRS`, so the existing generic
   PROVENANCE.json block (source_repo/source_commit/source_commit_date/bundler/
   vendored_modules) writes for domo too, unmodified — this is the standard
-  vendor-from-mcp provenance shape, not a bespoke one.
+  vendor-from-mcp provenance shape, not a bespoke one.~~ **Superseded 2026-08-03 (final
+  review fix wave):** domo's `dest` is deliberately **not** added to `STAMPED_DIRS`.
+  The generic block's derivation (vendor-arg == module basename == upstream source
+  basename) is exactly the assumption domo's third flavor breaks — see the
+  `source_file`/`vendor_arg` fix directly below. Domo's branch writes its own complete
+  `PROVENANCE.json` immediately (same `source_repo`/`source_commit`/`source_commit_date`
+  /`bundler`/`vendored_modules` fields as the generic shape, plus the two new ones), so
+  the shared post-loop block never touches it. The illustrated snippet above is updated
+  accordingly (the `STAMPED_DIRS` line is removed from it).
 - **No NEW CI freshness gate needed — correction, one already exists and applies.**
   Originally checked (incorrectly) as: `check-cognos-bundle.rb` only exists because
   cognos's canonical source lives *inside* this repo, and the 6 mainline vendor-from-mcp

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -54,8 +54,9 @@ card→element map.
 ## The one big idea
 
 **Beast Mode is MySQL-dialect SQL.** Domo's calc-field language routes through the
-existing `mcp__sigma-data-model__convert_sql_to_sigma_formula` tool — no bespoke
-parser like Power BI's DAX.
+vendored `converter/sql.mjs` (`scripts/convert-beast-modes.rb --convert`,
+running locally via `node` — no MCP call, no network) — no bespoke parser
+like Power BI's DAX.
 
 > ✅ **UPDATED 2026-07-30 — the historical "NOT nearly free" finding is
 > RESOLVED, with a calibrated result, not a swing to "it just works."** A live
@@ -115,7 +116,7 @@ grid is only 6 wide, so widths scale ×4).
 | `scripts/lib/domo_rest.rb` | prereq | Domo REST wrapper (public + private), auto token refresh |
 | `scripts/domo-discover.rb` | 1 | Enumerate DataSets, pages, cards; pull schemas + (private) card defs + Beast Modes |
 | `scripts/domo-capture-visuals.rb` | 1b | Render per-card PNG + full-page PDF, normalize card geometry → layout JSON (design-fidelity reference) |
-| `scripts/convert-beast-modes.rb` | 2 | Beast Mode → Sigma: Domo-specific normalize + classify + POST-lint around `convert_sql_to_sigma_formula` |
+| `scripts/convert-beast-modes.rb` | 2 | Beast Mode → Sigma: Domo-specific normalize + classify + POST-lint around the vendored `converter/sql.mjs` (`--convert`) |
 | `scripts/find-or-pick-dm.rb` *(vendored)* | 2.5 | Score existing Sigma data models against a signature and recommend reuse (non-destructive) |
 | `scripts/preflight-columns.rb` | 2.9 | Check every mapped dataset's Domo columns against the REAL warehouse table schema (live Sigma catalog lookup); reports gaps + auto-suggests (never auto-applies) a derivation formula for a known pattern |
 | `scripts/build-dm.rb` | 3 | DataSet schema + projection calc columns → Sigma DM spec (clean display names); honors a Phase-2.5 reuse decision |

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -332,7 +332,7 @@ ruby scripts/convert-beast-modes.rb --lint     # validate → discovery/formulas
 `--convert` resolves the converter via a 3-tier ladder: the vendored bundle
 (default, no MCP/network), a local `sigma-data-model-mcp` build via
 `--mcp-dir`/`DOMO_MCP_DIR` (explicit dev opt-in only), or — last resort, bundle
-and `node` both absent — exit 10 with the manual `convert_sql_to_sigma_formula`
+or `node` absent — exit 10 with the manual `convert_sql_to_sigma_formula`
 + `--converter-out` fallback instructions. Applies the normalizations in
 `refs/beast-mode-to-sigma.md` FIRST (strip backticks, `WEEKDAY`→`DAYOFWEEK`,
 flag aggregate `CEILING`/`FLOOR`, reject unsupported `SQRT`/`CONVERT_TZ`).

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -321,8 +321,18 @@ Geometry preference order used by Phase 5d, highest first:
 
 ## Phase 2 — Translate Beast Modes
 
-`ruby scripts/convert-beast-modes.rb` → feeds each Beast Mode SQL string through
-`convert_sql_to_sigma_formula`. Apply the normalizations in
+Three scripted steps, no agent/MCP call in the loop (`migrate-domo.rb` runs all
+three automatically):
+```bash
+ruby scripts/convert-beast-modes.rb            # normalize → discovery/formulas.pending.json
+ruby scripts/convert-beast-modes.rb --convert  # vendored converter/sql.mjs fills sigmaFormula/converted/warnings, locally via node
+ruby scripts/convert-beast-modes.rb --lint     # validate → discovery/formulas.json
+```
+`--convert` resolves the converter via a 3-tier ladder: the vendored bundle
+(default, no MCP/network), a local `sigma-data-model-mcp` build via
+`--mcp-dir`/`DOMO_MCP_DIR` (explicit dev opt-in only), or — last resort, bundle
+and `node` both absent — exit 10 with the manual `convert_sql_to_sigma_formula`
++ `--converter-out` fallback instructions. Applies the normalizations in
 `refs/beast-mode-to-sigma.md` FIRST (strip backticks, `WEEKDAY`→`DAYOFWEEK`,
 flag aggregate `CEILING`/`FLOOR`, reject unsupported `SQRT`/`CONVERT_TZ`).
 Outputs `discovery/formulas.json` (Beast Mode id → Sigma formula).

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
@@ -4,5 +4,7 @@
   "source_commit_date": "2026-07-31",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "sql.mjs",
+  "source_file": "src/formulas.ts",
+  "vendor_arg": "domo",
   "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."
 }

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
@@ -1,0 +1,8 @@
+{
+  "source_repo": "twells89/sigma-data-model-mcp",
+  "source_commit": "2f8c6cd",
+  "source_commit_date": "2026-07-31",
+  "bundler": "esbuild --bundle --format=esm --platform=node",
+  "vendored_modules": "sql.mjs",
+  "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."
+}

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs
@@ -1,0 +1,1475 @@
+// ../../../private/tmp/sigma-data-model-mcp-vendor/build/sigma-ids.js
+var NS_MODULUS = 62 ** 4;
+var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "but",
+  "or",
+  "for",
+  "nor",
+  "so",
+  "yet",
+  "at",
+  "by",
+  "in",
+  "of",
+  "on",
+  "to",
+  "up",
+  "as",
+  "into",
+  "via",
+  "per"
+]);
+function sigmaDisplayName(s) {
+  const normalized = (s || "").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
+  const words = normalized.toLowerCase().split(/[_\s/-]+/).filter(Boolean);
+  return words.map((w, i) => i === 0 || !SIGMA_LOWERCASE_WORDS.has(w) ? w.charAt(0).toUpperCase() + w.slice(1) : w).join(" ");
+}
+var DATA_MODEL_SCHEMA_SUMMARY = `
+Sigma Data Model JSON top-level structure:
+{
+  "name": "Model Name",
+  "pages": [{ "id": "pageId", "name": "Page 1", "elements": [...] }]
+}
+
+Element types: warehouse-table, custom-sql (kind:"sql"), join, union, control.
+Columns: { "id": "inode-xxx/COL", "formula": "[TABLE/Display Name]" }
+Calculated columns: { "id": "shortId", "formula": "[Price] - [Cost]", "name": "Profit" }
+Metrics: { "id": "shortId", "formula": "Sum([Revenue])", "name": "Total Revenue" }
+Relationships: { "id": "shortId", "targetElementId": "...", "keys": [{ "sourceColumnId": "...", "targetColumnId": "..." }] }
+
+Cross-element Reference (accessing related dimension columns via relationships):
+  [SOURCE_TABLE/REL_NAME/Column Display Name]
+  REL_NAME is the relationship's "name" field (= target table name uppercase by convention).
+  Example: DateDiff("day", [ORDER_FACT/PROMO_DIM/Start Date], [ORDER_FACT/PROMO_DIM/End Date])
+  \u26A0 The dash-link form [SRC/FK_COL - link/Field] does NOT work via the API \u2014 use REL_NAME.
+
+Conditional Aggregate Syntax:
+  CountIf(condition) \u2014 condition only, NO field argument
+  SumIf(field, condition) \u2014 FIELD FIRST, condition second
+  AvgIf/MaxIf/MinIf/CountDistinctIf \u2014 all FIELD FIRST
+  For booleans: always use [Column] = True, never bare [Column]
+
+Groupings (for LOD / different aggregation levels):
+  "groupings": [{ "id": "gId", "groupBy": ["colId1"], "calculations": ["calcId1"] }]
+  Array order = nesting hierarchy. Use child elements for LOD patterns.
+`.trim();
+
+// ../../../private/tmp/sigma-data-model-mcp-vendor/build/formulas.js
+function decodeXmlEntities(s) {
+  if (!s || s.indexOf("&") === -1)
+    return s;
+  return s.replace(/&#x([0-9a-fA-F]+);/g, (_m, h) => String.fromCodePoint(parseInt(h, 16))).replace(/&#(\d+);/g, (_m, d) => String.fromCodePoint(parseInt(d, 10))).replace(/&quot;/g, '"').replace(/&apos;/g, "'").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+}
+function stripLineComments(s) {
+  if (!s || s.indexOf("//") === -1)
+    return s;
+  let out = "", inS = false, inD = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inS) {
+      out += c;
+      if (c === "'")
+        inS = false;
+      continue;
+    }
+    if (inD) {
+      out += c;
+      if (c === '"')
+        inD = false;
+      continue;
+    }
+    if (c === "'") {
+      inS = true;
+      out += c;
+      continue;
+    }
+    if (c === '"') {
+      inD = true;
+      out += c;
+      continue;
+    }
+    if (c === "/" && s[i + 1] === "/") {
+      while (i < s.length && s[i] !== "\n")
+        i++;
+      if (i < s.length)
+        out += "\n";
+      continue;
+    }
+    out += c;
+  }
+  return out;
+}
+function tableauInToSigma(formula) {
+  const re = /(\[[^\]]+\]|[A-Za-z_][\w]*)\s+(not\s+)?in\s*\(/gi;
+  let f = formula, guard = 0;
+  for (let m = re.exec(f); m && guard < 200; m = re.exec(f), guard++) {
+    const operand = m[1];
+    const isNot = !!m[2];
+    const open = m.index + m[0].length - 1;
+    let depth = 0, close = -1;
+    for (let i = open; i < f.length; i++) {
+      if (f[i] === "(")
+        depth++;
+      else if (f[i] === ")") {
+        depth--;
+        if (depth === 0) {
+          close = i;
+          break;
+        }
+      }
+    }
+    if (close === -1)
+      break;
+    const inner = f.slice(open + 1, close);
+    const parts = [];
+    let buf = "", d = 0, sq = false, dq = false;
+    for (const ch of inner) {
+      if (sq) {
+        buf += ch;
+        if (ch === "'")
+          sq = false;
+        continue;
+      }
+      if (dq) {
+        buf += ch;
+        if (ch === '"')
+          dq = false;
+        continue;
+      }
+      if (ch === "'") {
+        sq = true;
+        buf += ch;
+        continue;
+      }
+      if (ch === '"') {
+        dq = true;
+        buf += ch;
+        continue;
+      }
+      if (ch === "(") {
+        d++;
+        buf += ch;
+        continue;
+      }
+      if (ch === ")") {
+        d--;
+        buf += ch;
+        continue;
+      }
+      if (ch === "," && d === 0) {
+        parts.push(buf.trim());
+        buf = "";
+        continue;
+      }
+      buf += ch;
+    }
+    if (buf.trim())
+      parts.push(buf.trim());
+    if (!parts.length)
+      continue;
+    const op = isNot ? "<>" : "=";
+    const join = isNot ? " and " : " or ";
+    const chain = "(" + parts.map((p) => `${operand} ${op} ${p}`).join(join) + ")";
+    f = f.slice(0, m.index) + chain + f.slice(close + 1);
+    re.lastIndex = m.index + chain.length;
+  }
+  return f;
+}
+var _TEXT_FN_RE = /(?:Coalesce|Concat|Text|Left|Right|Mid|Substring|Substr|Upper|Lower|Trim|Replace|MonthName|WeekdayName|DateName|Proper)$/i;
+function stripOuterParens(s) {
+  s = s.trim();
+  while (s.length > 1 && s.startsWith("(") && s.endsWith(")")) {
+    let depth = 0, quote = "", inBracket = false, wraps = true;
+    for (let i = 0; i < s.length; i++) {
+      const c = s[i];
+      if (inBracket) {
+        if (c === "]")
+          inBracket = false;
+        continue;
+      }
+      if (quote) {
+        if (c === quote)
+          quote = "";
+        continue;
+      }
+      if (c === "[") {
+        inBracket = true;
+        continue;
+      }
+      if (c === "'" || c === '"') {
+        quote = c;
+        continue;
+      }
+      if (c === "(")
+        depth++;
+      else if (c === ")") {
+        depth--;
+        if (depth === 0 && i < s.length - 1) {
+          wraps = false;
+          break;
+        }
+      }
+    }
+    if (!wraps || depth !== 0)
+      break;
+    s = s.slice(1, -1).trim();
+  }
+  return s;
+}
+function _isTextOperand(op, isTextRef) {
+  let s = stripOuterParens(op.trim());
+  if (!s)
+    return false;
+  if (/^"(?:[^"\\]|\\.)*"$/.test(s) || /^'(?:[^'\\]|\\.)*'$/.test(s))
+    return true;
+  const ref = s.match(/^\[([^\]\/]+)\]$/);
+  if (ref)
+    return isTextRef ? isTextRef(ref[1]) : false;
+  const fn = s.match(/^([A-Za-z_]+)\s*\(.*\)$/s);
+  if (fn && _TEXT_FN_RE.test(fn[1]))
+    return true;
+  return false;
+}
+function tableauTextConcatToSigma(formula, isTextRef) {
+  if (!formula || formula.indexOf("+") === -1)
+    return formula;
+  const grab = (s, i, dir) => {
+    let j = i;
+    while (j >= 0 && j < s.length && /\s/.test(s[j]))
+      j += dir;
+    if (j < 0 || j >= s.length)
+      return "";
+    const close = dir < 0 ? s[j] : "";
+    if (dir < 0 && (close === ")" || close === "]")) {
+      const open = close === ")" ? "(" : "[", cl = close;
+      let depth = 0, k2 = j;
+      for (; k2 >= 0; k2--) {
+        if (s[k2] === cl)
+          depth++;
+        else if (s[k2] === open) {
+          depth--;
+          if (depth === 0)
+            break;
+        }
+      }
+      let f2 = k2;
+      while (f2 - 1 >= 0 && /[A-Za-z0-9_]/.test(s[f2 - 1]))
+        f2--;
+      return s.slice(f2, j + 1);
+    }
+    if (dir > 0 && (s[j] === "(" || s[j] === "[")) {
+      const open = s[j], cl = open === "(" ? ")" : "]";
+      let depth = 0, k2 = j;
+      for (; k2 < s.length; k2++) {
+        if (s[k2] === open)
+          depth++;
+        else if (s[k2] === cl) {
+          depth--;
+          if (depth === 0)
+            break;
+        }
+      }
+      return s.slice(j, k2 + 1);
+    }
+    if (s[j] === '"' || s[j] === "'") {
+      const q = s[j];
+      let k2 = j + dir;
+      while (k2 >= 0 && k2 < s.length && s[k2] !== q)
+        k2 += dir;
+      return dir < 0 ? s.slice(k2, j + 1) : s.slice(j, k2 + 1);
+    }
+    let k = j;
+    while (k >= 0 && k < s.length && /[A-Za-z0-9_.]/.test(s[k]))
+      k += dir;
+    return dir < 0 ? s.slice(k + 1, j + 1) : s.slice(j, k);
+  };
+  let f = formula, changed = true, guard = 0;
+  while (changed && guard++ < 500) {
+    changed = false;
+    for (let i = 0; i < f.length; i++) {
+      if (f[i] !== "+")
+        continue;
+      const left = grab(f, i - 1, -1), right = grab(f, i + 1, 1);
+      if (_isTextOperand(left, isTextRef) || _isTextOperand(right, isTextRef)) {
+        f = f.slice(0, i) + "&" + f.slice(i + 1);
+        changed = true;
+        break;
+      }
+    }
+  }
+  return f;
+}
+function tableauParamSwitchToSigma(formula, controlId, warnings) {
+  const f = decodeXmlEntities(stripLineComments(formula)).trim();
+  const head = f.match(/^case\s+\[Parameters?\]\s*\.\s*\[([^\]]+)\]\s+([\s\S]*?)\s*end\s*$/i);
+  if (!head)
+    return null;
+  const paramName = head[1];
+  const { masked: body, lits } = _maskTableauLiterals(head[2]);
+  const cases = [];
+  const pairRe = new RegExp(`\\bwhen\\s+${_TABLEAU_SENTINEL_SRC}\\s+then\\s+([\\s\\S]*?)(?=\\s*\\bwhen\\b|\\s*\\belse\\b|$)`, "gi");
+  let m;
+  while (m = pairRe.exec(body)) {
+    const whenVal = _tabLitInner(lits, m[1]);
+    const thenRaw = _restoreRawTableauLiterals(m[2], lits).trim();
+    const thenSig = tableauFormulaToSigma(thenRaw, warnings);
+    cases.push({ when: whenVal, then: thenSig });
+  }
+  if (!cases.length)
+    return null;
+  const elseM = body.match(/\belse\s+([\s\S]*?)$/i);
+  const elseExpr = elseM ? tableauFormulaToSigma(_restoreRawTableauLiterals(elseM[1], lits).trim(), warnings) : null;
+  const parts = cases.map((c) => `"${c.when}", ${c.then}`).join(", ");
+  const switchFormula = `Switch([${controlId}], ${parts}${elseExpr ? `, ${elseExpr}` : ""})`;
+  return { paramName, controlId, cases, elseExpr, switchFormula };
+}
+function lookColRef(identifier) {
+  return `[${sigmaDisplayName(identifier)}]`;
+}
+var UNSUPPORTED_SIGMA_SQL = [
+  { pattern: /\bFLATTEN\s*\(/i, name: "FLATTEN" },
+  { pattern: /\bLATERAL\b/i, name: "LATERAL" },
+  { pattern: /\bQUALIFY\b/i, name: "QUALIFY" },
+  { pattern: /\bPIVOT\s*\(/i, name: "PIVOT" },
+  { pattern: /\bUNPIVOT\s*\(/i, name: "UNPIVOT" },
+  { pattern: /\bGENERATOR\s*\(/i, name: "GENERATOR" },
+  { pattern: /\bTABLESAMPLE\b/i, name: "TABLESAMPLE" },
+  { pattern: /\bOBJECT_CONSTRUCT\s*\(/i, name: "OBJECT_CONSTRUCT" },
+  { pattern: /\bARRAY_CONSTRUCT\s*\(/i, name: "ARRAY_CONSTRUCT" }
+];
+function detectUnsupportedSigmaFunction(formula) {
+  for (const { pattern, name } of UNSUPPORTED_SIGMA_SQL) {
+    if (pattern.test(formula))
+      return name;
+  }
+  return null;
+}
+function lookIsComplexSql(sql) {
+  if (!sql)
+    return false;
+  const cleaned = sql.replace(/\$\{TABLE\}\./gi, "").replace(/\$\{[^}]+\}/g, "X").trim();
+  if (/^(?:CAST|SAFE_CAST|TRY_CAST)\s*\(\s*"?[A-Za-z_][A-Za-z0-9_]*"?\s+AS\s+\w[\w_]*\s*\)$/i.test(cleaned))
+    return false;
+  if (/^[A-Za-z_][A-Za-z0-9_]*\s*\(/.test(cleaned))
+    return true;
+  if (/^CASE\b/i.test(cleaned))
+    return true;
+  if (/\bIN\s*\(/i.test(cleaned))
+    return true;
+  if (cleaned.includes("||"))
+    return true;
+  if (/[=<>!+\-*\/%]/.test(cleaned.replace(/'[^']*'/g, "")))
+    return true;
+  return false;
+}
+var LOOK_FUNC_MAP = {
+  "MONTH": "Month",
+  "YEAR": "Year",
+  "DAY": "Day",
+  "HOUR": "Hour",
+  "MINUTE": "Minute",
+  "SECOND": "Second",
+  "QUARTER": "Quarter",
+  "WEEK": "WeekOfYear",
+  "WEEKDAY": "Weekday",
+  "DATE_TRUNC": "DateTrunc",
+  "DATEADD": "DateAdd",
+  "DATEDIFF": "DateDiff",
+  "COALESCE": "Coalesce",
+  "NVL": "Coalesce",
+  "NULLIF": "Nullif",
+  "ROUND": "Round",
+  "FLOOR": "Floor",
+  "CEILING": "Ceiling",
+  "ABS": "Abs",
+  "UPPER": "Upper",
+  "LOWER": "Lower",
+  "TRIM": "Trim",
+  "LENGTH": "Length",
+  "SUBSTR": "Substring",
+  "SUBSTRING": "Substring",
+  "CONCAT": "Concat",
+  "CURRENT_DATE": "Today()",
+  "GETDATE": "Now()",
+  "IFF": "If",
+  "IIF": "If",
+  "DECODE": "Switch",
+  "ISNULL": "IsNull",
+  "IFNULL": "Coalesce",
+  "TO_DATE": "ToDate",
+  "TO_NUMBER": "ToNumber",
+  "TO_VARCHAR": "Text"
+};
+var _CASE_KW_RE = /^(CASE|WHEN|THEN|ELSE|END)\b/i;
+function _scanCase(s, pos) {
+  const markers = [];
+  let caseDepth = 1, parenDepth = 0, i = pos;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === "[") {
+      const close = s.indexOf("]", i + 1);
+      i = close === -1 ? s.length : close + 1;
+      continue;
+    }
+    if (c === "(") {
+      parenDepth++;
+      i++;
+      continue;
+    }
+    if (c === ")") {
+      parenDepth--;
+      i++;
+      continue;
+    }
+    if (/[A-Za-z]/.test(c) && (i === 0 || !/[A-Za-z0-9_]/.test(s[i - 1]))) {
+      const m = _CASE_KW_RE.exec(s.slice(i));
+      if (m) {
+        const kw = m[1].toUpperCase(), start = i, end = i + m[1].length;
+        if (kw === "CASE") {
+          caseDepth++;
+        } else if (kw === "END") {
+          caseDepth--;
+          if (caseDepth === 0)
+            return { endStart: start, endIndex: end, markers };
+        } else if (caseDepth === 1 && parenDepth === 0) {
+          markers.push({ type: kw, start, end });
+        }
+        i = end;
+        continue;
+      }
+    }
+    i++;
+  }
+  return { endStart: -1, endIndex: -1, markers };
+}
+function _isBalanced(s) {
+  let paren = 0, bracket = 0, inStr = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (c === "\\") {
+        i++;
+        continue;
+      }
+      if (c === '"')
+        inStr = false;
+      continue;
+    }
+    if (c === '"') {
+      inStr = true;
+      continue;
+    }
+    if (c === "(")
+      paren++;
+    else if (c === ")") {
+      paren--;
+      if (paren < 0)
+        return false;
+    } else if (c === "[")
+      bracket++;
+    else if (c === "]") {
+      bracket--;
+      if (bracket < 0)
+        return false;
+    }
+  }
+  return paren === 0 && bracket === 0 && !inStr;
+}
+var _NESTED_CASE_UNMASK_RE = /(\d+)/g;
+function _convertNestedCases(s, lits, onUnparseable = "abort", cdArgs = []) {
+  const blocks = [];
+  let out = "", last = 0, i = 0;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === "[") {
+      const close = s.indexOf("]", i + 1);
+      i = close === -1 ? s.length : close + 1;
+      continue;
+    }
+    if (/[A-Za-z]/.test(c) && (i === 0 || !/[A-Za-z0-9_]/.test(s[i - 1])) && /^CASE\b/i.test(s.slice(i))) {
+      const caseStart = i;
+      const scan = _scanCase(s, i + 4);
+      if (scan.endIndex === -1) {
+        if (onUnparseable === "abort")
+          return null;
+        break;
+      }
+      const rawSpan = _restoreRawCountDistinct(_restoreRawLiterals(s.slice(caseStart, scan.endIndex), lits), cdArgs);
+      const converted = lookConvertCase(rawSpan);
+      if (converted === null) {
+        if (onUnparseable === "abort")
+          return null;
+        i = scan.endIndex;
+        continue;
+      }
+      out += s.slice(last, caseStart) + `${blocks.push(converted) - 1}`;
+      last = scan.endIndex;
+      i = scan.endIndex;
+      continue;
+    }
+    i++;
+  }
+  return { text: out + s.slice(last), blocks };
+}
+function _spliceNestedCases(s, blocks) {
+  return s.replace(_NESTED_CASE_UNMASK_RE, (_m, i) => blocks[Number(i)] ?? _m);
+}
+function lookConvertCase(expr) {
+  const trimmed = expr.trim();
+  const head = /^CASE\b/i.exec(trimmed);
+  if (!head)
+    return null;
+  const { masked, lits } = _maskLiterals(trimmed);
+  const scan = _scanCase(masked, head[0].length);
+  if (scan.endIndex === -1)
+    return null;
+  if (masked.slice(scan.endIndex).trim() !== "")
+    return null;
+  const m = scan.markers;
+  const firstMarkerStart = m.length ? m[0].start : scan.endStart;
+  if (masked.slice(head[0].length, firstMarkerStart).trim() !== "")
+    return null;
+  const branches = [];
+  let elseVal = null;
+  let idx = 0;
+  while (true) {
+    if (idx >= m.length || m[idx].type !== "WHEN")
+      return null;
+    const whenTok = m[idx++];
+    if (idx >= m.length || m[idx].type !== "THEN")
+      return null;
+    const thenTok = m[idx++];
+    const condText = masked.slice(whenTok.end, thenTok.start);
+    let valEnd, sawElse = false;
+    if (idx < m.length && m[idx].type === "WHEN") {
+      valEnd = m[idx].start;
+    } else if (idx < m.length && m[idx].type === "ELSE") {
+      valEnd = m[idx].start;
+      sawElse = true;
+    } else if (idx === m.length) {
+      valEnd = scan.endStart;
+    } else {
+      return null;
+    }
+    branches.push({ cond: condText, val: masked.slice(thenTok.end, valEnd) });
+    if (sawElse) {
+      const elseTok = m[idx++];
+      if (idx !== m.length)
+        return null;
+      elseVal = masked.slice(elseTok.end, scan.endStart);
+      break;
+    }
+    if (idx === m.length)
+      break;
+  }
+  if (branches.length === 0)
+    return null;
+  const convertLeaf = (maskedChunk, allowNumber) => {
+    const v = maskedChunk.trim();
+    if (allowNumber && /^-?\d+(\.\d+)?$/.test(v))
+      return v;
+    const stripped = stripOuterParens(v);
+    const nc = _convertNestedCases(stripped, lits);
+    if (nc === null)
+      return null;
+    const raw = _restoreRawLiterals(nc.text, lits);
+    const converted = lookConvertExpression(raw);
+    const spliced = _spliceNestedCases(converted, nc.blocks);
+    if (!spliced.trim())
+      return null;
+    return spliced;
+  };
+  let result = elseVal !== null ? convertLeaf(elseVal, true) : "null";
+  if (result === null)
+    return null;
+  for (let i = branches.length - 1; i >= 0; i--) {
+    const sigmaCond = convertLeaf(branches[i].cond, false);
+    const sigmaVal = convertLeaf(branches[i].val, true);
+    if (sigmaCond === null || sigmaVal === null)
+      return null;
+    result = `If(${sigmaCond}, ${sigmaVal}, ${result})`;
+  }
+  if (!_isBalanced(result))
+    return null;
+  return result;
+}
+function lookConvertMathExpr(expr) {
+  expr = expr.replace(/NULLIF\s*\(([A-Z_][A-Z0-9_]*)\s*,\s*([^)]+)\)/gi, (_, col, val) => `If(${lookColRef(col)} = ${val.trim()}, null, ${lookColRef(col)})`);
+  return lookConvertExpression(expr);
+}
+var _LIT_RE = /'(?:[^']|'')*'/g;
+function _maskLiterals(s) {
+  const lits = [];
+  let out = "";
+  let i = 0;
+  while (i < s.length) {
+    if (s[i] === "[") {
+      const close = s.indexOf("]", i + 1);
+      if (close !== -1) {
+        out += s.slice(i, close + 1);
+        i = close + 1;
+        continue;
+      }
+    }
+    if (s[i] === "'") {
+      _LIT_RE.lastIndex = i;
+      const m = _LIT_RE.exec(s);
+      if (m && m.index === i) {
+        out += `\0${lits.push(m[0]) - 1}`;
+        i += m[0].length;
+        continue;
+      }
+    }
+    out += s[i];
+    i++;
+  }
+  return { masked: out, lits };
+}
+function _unmaskLiterals(s, lits) {
+  return s.replace(/\u0000(\d+)\u0001/g, (_m, i) => {
+    const inner = lits[Number(i)].slice(1, -1).replace(/''/g, "'").replace(/"/g, '\\"');
+    return `"${inner}"`;
+  });
+}
+function _restoreRawLiterals(s, lits) {
+  return s.replace(/\u0000(\d+)\u0001/g, (_m, i) => lits[Number(i)] ?? _m);
+}
+function _restoreRawCountDistinct(s, args) {
+  return s.replace(/\x02(\d+)\x03/g, (_m, i) => `COUNT(DISTINCT ${args[Number(i)] ?? ""})`);
+}
+function _maskCountDistinct(s) {
+  const args = [];
+  const re = /\bCOUNT\s*\(\s*DISTINCT\s+/gi;
+  let out = "", last = 0, m;
+  while ((m = re.exec(s)) !== null) {
+    const argStart = m.index + m[0].length;
+    let depth = 1, quote = "", i = argStart;
+    for (; i < s.length; i++) {
+      const c = s[i];
+      if (quote) {
+        if (c === quote)
+          quote = "";
+        continue;
+      }
+      if (c === "'" || c === '"') {
+        quote = c;
+        continue;
+      }
+      if (c === "[") {
+        const cl = s.indexOf("]", i + 1);
+        if (cl !== -1) {
+          i = cl;
+          continue;
+        }
+      }
+      if (c === "(")
+        depth++;
+      else if (c === ")") {
+        depth--;
+        if (depth === 0)
+          break;
+      }
+    }
+    if (depth !== 0)
+      break;
+    out += s.slice(last, m.index) + `${args.push(s.slice(argStart, i).trim()) - 1}`;
+    last = i + 1;
+    re.lastIndex = last;
+  }
+  return { masked: out + s.slice(last), args };
+}
+function hasResidualCaseKeyword(s) {
+  const masked = s.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\[[^\]]*\]/g, " ");
+  return /\b(?:CASE|WHEN|THEN|END)\b/i.test(masked);
+}
+function hasResidualInfixOperator(s) {
+  const masked = s.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\[[^\]]*\]/g, " ");
+  return /\b(?:LIKE|BETWEEN)\b/i.test(masked);
+}
+function _unmaskCountDistinct(s, args) {
+  return s.replace(/(\d+)/g, (_m, i) => {
+    const raw = stripOuterParens(args[Number(i)]);
+    const viaRules = lookSqlToSigmaRules(raw);
+    const converted = viaRules ?? lookConvertExpression(raw);
+    if (viaRules === null && hasResidualCaseKeyword(converted)) {
+      return `COUNT(DISTINCT ${raw})`;
+    }
+    return `CountDistinct(${converted})`;
+  });
+}
+var _SQL_KEYWORD_RE = /^(?:AND|OR|NOT|IN|IS|NULL|CASE|WHEN|THEN|ELSE|END|BETWEEN|LIKE|AS|ON|BY|DISTINCT|TRUE|FALSE|OVER|GROUP|EXISTS)$/i;
+function _naiveTitleCase(fn) {
+  return fn.charAt(0).toUpperCase() + fn.slice(1).toLowerCase();
+}
+var _BRACKET_UNMASK_RE = /\x0E(\d+)\x0F/g;
+function _bracketSpanFinalText(rawSpan) {
+  const inner = rawSpan.slice(1, -1);
+  if (/^[A-Z_][A-Z0-9_]*$/.test(inner) && !_SQL_KEYWORD_RE.test(inner)) {
+    return lookColRef(inner);
+  }
+  return rawSpan;
+}
+function _maskBrackets(s) {
+  const spans = [];
+  let out = "", i = 0;
+  while (i < s.length) {
+    if (s[i] === "[") {
+      const close = s.indexOf("]", i + 1);
+      if (close !== -1) {
+        const finalText = _bracketSpanFinalText(s.slice(i, close + 1));
+        out += `${spans.push(finalText) - 1}`;
+        i = close + 1;
+        continue;
+      }
+    }
+    out += s[i];
+    i++;
+  }
+  return { masked: out, spans };
+}
+function _unmaskBrackets(s, spans) {
+  return s.replace(_BRACKET_UNMASK_RE, (_m, i) => spans[Number(i)] ?? _m);
+}
+function lookConvertExpression(expr) {
+  const cd = _maskCountDistinct(expr);
+  const { masked, lits } = _maskLiterals(cd.masked);
+  expr = masked;
+  const ec = _convertNestedCases(expr, lits, "leave-raw", cd.args);
+  expr = ec.text;
+  expr = expr.replace(/\b([A-Z_][A-Z0-9_]*)\s*(?=\()/gi, (match, fn) => {
+    const upper = fn.toUpperCase();
+    if (_SQL_KEYWORD_RE.test(upper))
+      return match;
+    const mapped = LOOK_FUNC_MAP[upper];
+    if (mapped)
+      return mapped.endsWith("()") ? mapped.slice(0, -2) : mapped;
+    return _naiveTitleCase(fn);
+  });
+  expr = expr.replace(/(\[[^\]]+\]|[\w\]\)]+(?:\([^)]*\))?)\s+IN\s*\(([^)]+)\)/gi, (_, lhs, list) => {
+    return `In(${lhs}, ${list})`;
+  });
+  {
+    const { masked: bracketMasked, spans } = _maskBrackets(expr);
+    expr = bracketMasked.replace(/\b([A-Z_][A-Z0-9_]*)\b(?!\s*\()/g, (match) => {
+      if (_SQL_KEYWORD_RE.test(match))
+        return match;
+      if (/^\d+$/.test(match))
+        return match;
+      return lookColRef(match);
+    });
+    expr = _unmaskBrackets(expr, spans);
+  }
+  expr = _spliceNestedCases(expr, ec.blocks);
+  return _unmaskCountDistinct(_unmaskLiterals(expr, lits), cd.args).trim();
+}
+var _SUPPLEMENTAL_SIGMA_NAMES = [
+  "Count",
+  // resources.ts formula-syntax reference: "Count([Col])"
+  "Rank",
+  // qlik.test.ts: Rank(Sum([Sales Amount]), "desc")
+  "Lag",
+  // qlik.test.ts: Lag(Sum([Sales Amount]), 1)
+  "Lead"
+  // qlik.test.ts: Lead(Sum([Sales Amount]), 1)
+];
+var _sigmaPassthroughCache = null;
+function _sigmaPassthrough() {
+  if (_sigmaPassthroughCache)
+    return _sigmaPassthroughCache;
+  const names = /* @__PURE__ */ new Set();
+  for (const raw of [...Object.values(LOOK_FUNC_MAP), ...Object.values(TABLEAU_FUNC_MAP), ..._SUPPLEMENTAL_SIGMA_NAMES]) {
+    const stripped = raw.endsWith("()") ? raw.slice(0, -2) : raw;
+    if (_naiveTitleCase(stripped) === stripped)
+      names.add(stripped.toUpperCase());
+  }
+  _sigmaPassthroughCache = names;
+  return names;
+}
+function lookUnknownFunctions(sql) {
+  const { masked } = _maskLiterals(sql);
+  const passthrough = _sigmaPassthrough();
+  const seen = /* @__PURE__ */ new Set();
+  for (const m of masked.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)\s*(?=\()/g)) {
+    const upper = m[1].toUpperCase();
+    if (_SQL_KEYWORD_RE.test(upper))
+      continue;
+    if (LOOK_FUNC_MAP[upper] || passthrough.has(upper))
+      continue;
+    seen.add(upper);
+  }
+  return [...seen];
+}
+function lookSqlToSigmaRules(sql) {
+  let expr = sql.replace(/\$\{TABLE\}\./gi, "").replace(/\$\{[^.}]+\.([^}]+)\}/g, (_, f) => f.toUpperCase()).replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, n) => n.toUpperCase()).replace(/[\r\n]+\s*/g, " ").trim();
+  expr = stripOuterParens(expr);
+  {
+    const m = expr.match(/^([A-Z_][A-Z0-9_]*)\s*=\s*(\d+)$/i);
+    if (m)
+      return `${lookColRef(m[1])} = ${m[2]}`;
+  }
+  {
+    const m = expr.match(/^([A-Z_][A-Z0-9_]*)\s+IN\s*\(([^)]+)\)$/i);
+    if (m) {
+      const col = lookColRef(m[1]);
+      const vals = m[2].split(",").map((v) => {
+        v = v.trim();
+        if (/^'[^']*'$/.test(v))
+          return `"${v.slice(1, -1)}"`;
+        return v;
+      });
+      return `In(${col}, ${vals.join(", ")})`;
+    }
+  }
+  {
+    const m = expr.match(/^(\[[^\]]+\])\s*(>=|<=|!=|<>|>|<|=)\s*(-?\d+(?:\.\d+)?)$/i);
+    if (m)
+      return `${m[1]} ${m[2] === "<>" ? "!=" : m[2]} ${m[3]}`;
+  }
+  {
+    const m = expr.match(/^(\[[^\]]+\])\s+IN\s*\(([^)]+)\)$/i);
+    if (m) {
+      const vals = m[2].split(",").map((v) => {
+        v = v.trim();
+        if (/^'[^']*'$/.test(v))
+          return `"${v.slice(1, -1)}"`;
+        return v;
+      });
+      return `In(${m[1]}, ${vals.join(", ")})`;
+    }
+  }
+  if (/^ROUND\s*\(/i.test(expr)) {
+    const inner = expr.replace(/^ROUND\s*\(/i, "").replace(/\)\s*$/, "");
+    const lastComma = inner.lastIndexOf(",");
+    if (lastComma >= 0) {
+      const mathExpr = inner.slice(0, lastComma).trim();
+      const decimals = inner.slice(lastComma + 1).trim();
+      const converted = lookConvertMathExpr(mathExpr);
+      return `Round(${converted}, ${decimals})`;
+    }
+  }
+  {
+    const m = expr.match(/^DATEDIFF\s*\(\s*'([^']+)'\s*,\s*([A-Z_][A-Z0-9_]*)\s*,\s*([A-Z_][A-Z0-9_]*)\s*\)$/i);
+    if (m)
+      return `DateDiff("${m[1]}", ${lookColRef(m[2])}, ${lookColRef(m[3])})`;
+  }
+  if (/^CASE\b/i.test(expr)) {
+    return lookConvertCase(expr);
+  }
+  if (/^[A-Z_][A-Z0-9_]*\s*[+\-*\/]/.test(expr) || /NULLIF/i.test(expr)) {
+    return lookConvertMathExpr(expr);
+  }
+  if (expr.includes("||")) {
+    const parts = expr.split("||").map((p) => {
+      p = p.trim();
+      if (/^'[^']*'$/.test(p))
+        return `"${p.slice(1, -1)}"`;
+      if (/^\[[^\]]+\]$/.test(p))
+        return `Text(${p})`;
+      if (/^[A-Z_][A-Z0-9_]*$/i.test(p))
+        return `Text(${lookColRef(p)})`;
+      return null;
+    });
+    if (parts.length > 1 && parts.every((p) => p !== null))
+      return `Concat(${parts.join(", ")})`;
+  }
+  return null;
+}
+var TABLEAU_FUNC_MAP = {
+  "AVG": "Avg",
+  "MAX": "Max",
+  "MIN": "Min",
+  "MEDIAN": "Median",
+  "SUM": "Sum",
+  "ABS": "Abs",
+  "CEILING": "Ceiling",
+  "FLOOR": "Floor",
+  "ROUND": "Round",
+  "SQRT": "Sqrt",
+  "POWER": "Power",
+  // scalar math (verified resolve in Sigma 2026-06-15; Tableau LOG default base 10 == Sigma Log default base 10)
+  "LN": "Ln",
+  "LOG": "Log",
+  "EXP": "Exp",
+  "MOD": "Mod",
+  "SIGN": "Sign",
+  "PI": "Pi",
+  // trig + angle conversion — same names/arg-order in Sigma (live-verified 2026-07-10, bead tt3z.3)
+  "SIN": "Sin",
+  "COS": "Cos",
+  "TAN": "Tan",
+  "COT": "Cot",
+  "ASIN": "Asin",
+  "ACOS": "Acos",
+  "ATAN": "Atan",
+  "ATAN2": "Atan2",
+  "DEGREES": "Degrees",
+  "RADIANS": "Radians",
+  // PROPER (title-case) — live-verified Sigma Proper() (bead tt3z.3)
+  "PROPER": "Proper",
+  "STR": "Text",
+  "INT": "Int",
+  "FLOAT": "Number",
+  "LEN": "Len",
+  "UPPER": "Upper",
+  "LOWER": "Lower",
+  "TRIM": "Trim",
+  "LTRIM": "Ltrim",
+  "RTRIM": "Rtrim",
+  "LEFT": "Left",
+  "RIGHT": "Right",
+  "MID": "Mid",
+  "REPLACE": "Replace",
+  "CONTAINS": "Contains",
+  "STARTSWITH": "StartsWith",
+  "ENDSWITH": "EndsWith",
+  "FIND": "Find",
+  "TODAY": "Today",
+  "NOW": "Now",
+  "YEAR": "Year",
+  "MONTH": "Month",
+  "DAY": "Day",
+  "HOUR": "Hour",
+  "MINUTE": "Minute",
+  "SECOND": "Second",
+  // NOTE: no 'WEEK' entry — Sigma has no Week() function; WEEK(date) is rewritten
+  // to DatePart("week", date) below (verified via docs + live query 2026-07-10).
+  "QUARTER": "Quarter",
+  "DATE": "Date",
+  "DATETIME": "Datetime",
+  "MAKEDATE": "MakeDate",
+  // regex (same arg order as Tableau)
+  "REGEXP_EXTRACT": "RegexpExtract",
+  "REGEXP_REPLACE": "RegexpReplace",
+  "REGEXP_MATCH": "RegexpMatch",
+  // statistical aggregates (sample variants direct; STDEVP handled above)
+  "STDEV": "StdDev",
+  "VAR": "Variance",
+  "VARP": "VariancePop",
+  "PERCENTILE": "PercentileCont",
+  "CORR": "Corr",
+  // string split — both 1-indexed, negatives count from the right
+  "SPLIT": "SplitPart"
+};
+var SIGMA_CHART_ONLY_WINDOW_RE = /\b(?:Cumulative(?:Sum|Avg|Min|Max|Count)|Moving(?:Sum|Avg|Min|Max|Count|StdDev)|RankDense|RankPercentile|Rank|PercentOfTotal|RowNumber|Lag|Lead)\s*\(/;
+var TABLEAU_TABLE_CALC_TOKEN_RE = /\b(?:WINDOW_[A-Z]+|RUNNING_[A-Z]+|LOOKUP|PREVIOUS_VALUE|RANK(?:_[A-Z]+)?|INDEX|SIZE|TOTAL|FIRST|LAST)\s*\(/;
+var TABLEAU_TABLE_CALC_TOKEN_CI_RE = /\b(?:WINDOW_[A-Za-z]+|RUNNING_[A-Za-z]+|PREVIOUS_VALUE)\s*\(/i;
+var TABLEAU_LOD_LEFTOVER_RE = /\{\s*(?:FIXED|INCLUDE|EXCLUDE)\b/i;
+function formulaHasUntranslatableFragment(f) {
+  if (!f)
+    return false;
+  if (TABLEAU_LOD_LEFTOVER_RE.test(f) || TABLEAU_TABLE_CALC_TOKEN_RE.test(f) || TABLEAU_TABLE_CALC_TOKEN_CI_RE.test(f) || /\/\*\s*(?:LOD|table calc|no Sigma equivalent)/.test(f))
+    return true;
+  const masked = f.replace(/"[^"]*"|'[^']*'|\[[^\]]*\]/g, " ");
+  return /\b(?:then|end|when)\b/i.test(masked);
+}
+var _TC_AGG_MAP = {
+  SUM: "Sum",
+  AVG: "Avg",
+  MIN: "Min",
+  MAX: "Max",
+  COUNT: "Count",
+  COUNTD: "CountDistinct",
+  MEDIAN: "Median",
+  STDEV: "StdDev",
+  VAR: "Variance"
+};
+var _TC_COL = "(\\[[^\\]]+\\]|[A-Za-z_][A-Za-z0-9_]*)";
+var _TC_AGG = "(SUM|AVG|MIN|MAX|COUNT|COUNTD|MEDIAN|STDEV|VAR)";
+var _TC_AGG_EXPR = `${_TC_AGG}\\s*\\(\\s*${_TC_COL}\\s*\\)`;
+function _tcCol(raw) {
+  const name = raw.replace(/^\[|\]$/g, "");
+  if (/^[A-Z][A-Z0-9_]{2,}$/.test(name))
+    return "[" + sigmaDisplayName(name) + "]";
+  return "[" + name + "]";
+}
+function _tcAgg(aggFunc, colRaw) {
+  const fn = _TC_AGG_MAP[aggFunc.toUpperCase()] || "Sum";
+  return `${fn}(${_tcCol(colRaw)})`;
+}
+function _tcSameRef(a, b) {
+  const norm = (s) => s.replace(/^\[|\]$/g, "").replace(/[^A-Za-z0-9_]/g, "_").toUpperCase();
+  return norm(a) === norm(b);
+}
+function tableauWindowUntranslatable(formula) {
+  const m = (formula || "").match(/\b(WINDOW_MEDIAN|WINDOW_PERCENTILE|WINDOW_CORR|WINDOW_COVARP?|WINDOW_VARP?|WINDOW_STDEVP|PREVIOUS_VALUE|SIZE)\s*\(/i);
+  return m ? m[1].toUpperCase() : null;
+}
+function tableauWindowToSigmaChart(formula) {
+  const f = (formula || "").trim();
+  if (!f || tableauWindowUntranslatable(f))
+    return null;
+  let m;
+  m = f.match(new RegExp(`^${_TC_AGG_EXPR}\\s*\\/\\s*(?:TOTAL|WINDOW_SUM)\\s*\\(\\s*${_TC_AGG_EXPR}\\s*\\)$`, "i"));
+  if (m && m[1].toUpperCase() === m[3].toUpperCase() && _tcSameRef(m[2], m[4])) {
+    return { formula: `PercentOfTotal(${_tcAgg(m[1], m[2])}, "grand_total")`, kind: "percent-of-total" };
+  }
+  m = f.match(new RegExp(`^RUNNING_SUM\\s*\\(\\s*${_TC_AGG_EXPR}\\s*\\)\\s*\\/\\s*(?:TOTAL|WINDOW_SUM)\\s*\\(\\s*${_TC_AGG_EXPR}\\s*\\)$`, "i"));
+  if (m && m[1].toUpperCase() === m[3].toUpperCase() && _tcSameRef(m[2], m[4])) {
+    return { formula: `CumulativeSum(PercentOfTotal(${_tcAgg(m[1], m[2])}, "grand_total"))`, kind: "cumulative" };
+  }
+  m = f.match(new RegExp(`^RUNNING_(SUM|AVG|MIN|MAX|COUNT)\\s*\\(\\s*${_TC_AGG_EXPR}\\s*\\)$`, "i"));
+  if (m) {
+    const fn = "Cumulative" + m[1].charAt(0).toUpperCase() + m[1].slice(1).toLowerCase();
+    return { formula: `${fn}(${_tcAgg(m[2], m[3])})`, kind: "cumulative" };
+  }
+  m = f.match(new RegExp(`^RUNNING_(SUM|AVG|MIN|MAX|COUNT)\\s*\\(\\s*${_TC_COL}\\s*\\)$`, "i"));
+  if (m) {
+    const fn = "Cumulative" + m[1].charAt(0).toUpperCase() + m[1].slice(1).toLowerCase();
+    return { formula: `${fn}(${_tcAgg(m[1], m[2])})`, kind: "cumulative" };
+  }
+  m = f.match(new RegExp(`^WINDOW_(SUM|AVG|MIN|MAX|STDEV)\\s*\\(\\s*${_TC_AGG_EXPR}\\s*,\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*\\)$`, "i"));
+  if (m) {
+    const back = parseInt(m[4], 10);
+    const fwd = parseInt(m[5], 10);
+    if (back <= 0 && fwd >= 0) {
+      const movMap = {
+        SUM: "MovingSum",
+        AVG: "MovingAvg",
+        MIN: "MovingMin",
+        MAX: "MovingMax",
+        STDEV: "MovingStdDev"
+      };
+      const fn = movMap[m[1].toUpperCase()];
+      const args = fwd === 0 ? `${-back}` : `${-back}, ${fwd}`;
+      return { formula: `${fn}(${_tcAgg(m[2], m[3])}, ${args})`, kind: "moving" };
+    }
+    return null;
+  }
+  m = f.match(new RegExp(`^(RANK|RANK_DENSE|RANK_PERCENTILE|RANK_UNIQUE)\\s*\\(\\s*${_TC_AGG_EXPR}\\s*(?:,\\s*['"]?(asc|desc)['"]?\\s*)?\\)$`, "i"));
+  if (m) {
+    const fnMap = {
+      RANK: "Rank",
+      RANK_DENSE: "RankDense",
+      RANK_PERCENTILE: "RankPercentile",
+      RANK_UNIQUE: "Rank"
+    };
+    const fn = fnMap[m[1].toUpperCase()];
+    const dir = (m[4] || "desc").toLowerCase();
+    const unique = m[1].toUpperCase() === "RANK_UNIQUE";
+    return {
+      formula: `${fn}(${_tcAgg(m[2], m[3])}, "${dir}")`,
+      kind: "rank",
+      ...unique ? { verify: true, note: "RANK_UNIQUE breaks ties arbitrarily; Sigma Rank assigns equal ranks to ties \u2014 verify against Tableau." } : {}
+    };
+  }
+  if (/^INDEX\s*\(\s*\)$/i.test(f))
+    return { formula: "RowNumber()", kind: "index" };
+  m = f.match(new RegExp(`^LOOKUP\\s*\\(\\s*${_TC_AGG_EXPR}\\s*,\\s*(-?\\d+)\\s*\\)$`, "i"));
+  if (m) {
+    const off = parseInt(m[3], 10);
+    const agg = _tcAgg(m[1], m[2]);
+    if (off === 0)
+      return { formula: agg, kind: "lag", note: "LOOKUP(expr, 0) is the identity \u2014 no window function needed." };
+    return off < 0 ? { formula: `Lag(${agg}, ${-off})`, kind: "lag" } : { formula: `Lead(${agg}, ${off})`, kind: "lead" };
+  }
+  return null;
+}
+var _TAB_BLOCK_KW_RE = /^(IF|CASE|ELSEIF|THEN|ELSE|WHEN|END)\b/i;
+function _scanTableauBlock(s, pos) {
+  const markers = [];
+  let blockDepth = 1, i = pos;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === "[") {
+      const close = s.indexOf("]", i + 1);
+      i = close === -1 ? s.length : close + 1;
+      continue;
+    }
+    if (/[A-Za-z]/.test(c) && (i === 0 || !/[A-Za-z0-9_]/.test(s[i - 1]))) {
+      const m = _TAB_BLOCK_KW_RE.exec(s.slice(i));
+      if (m) {
+        const kw = m[1].toUpperCase(), start = i, end = i + m[1].length;
+        if (kw === "IF" || kw === "CASE") {
+          blockDepth++;
+        } else if (kw === "END") {
+          blockDepth--;
+          if (blockDepth === 0)
+            return { endStart: start, endIndex: end, markers };
+        } else if (blockDepth === 1) {
+          markers.push({ type: kw, start, end });
+        }
+        i = end;
+        continue;
+      }
+    }
+    i++;
+  }
+  return { endStart: -1, endIndex: -1, markers };
+}
+function _convertIfBody(inner, markers, innerOffset, lits) {
+  const rel = markers.map((mk) => ({ type: mk.type, start: mk.start - innerOffset, end: mk.end - innerOffset }));
+  const elseMarker = rel.find((mk) => mk.type === "ELSE");
+  const chainEnd = elseMarker ? elseMarker.start : inner.length;
+  const elseVal = elseMarker ? _tableauRecurse(inner.slice(elseMarker.end).trim(), lits) : "null";
+  const chain = rel.filter((mk) => mk.type === "THEN" || mk.type === "ELSEIF");
+  const clauses = [];
+  let condStart = 0;
+  for (let k = 0; k < chain.length; k += 2) {
+    const thenMk = chain[k];
+    if (!thenMk || thenMk.type !== "THEN")
+      break;
+    const cond = inner.slice(condStart, thenMk.start).trim();
+    const nextMk = chain[k + 1];
+    const valEnd = nextMk ? nextMk.start : chainEnd;
+    const val = inner.slice(thenMk.end, valEnd).trim();
+    clauses.push({ cond, val });
+    condStart = nextMk ? nextMk.end : valEnd;
+  }
+  let result = elseVal;
+  for (let k = clauses.length - 1; k >= 0; k--) {
+    result = "If(" + _tableauRecurse(clauses[k].cond, lits) + ", " + _tableauRecurse(clauses[k].val, lits) + ", " + result + ")";
+  }
+  return result;
+}
+function _convertCaseBody(inner, markers, innerOffset, lits) {
+  const rel = markers.map((mk) => ({ type: mk.type, start: mk.start - innerOffset, end: mk.end - innerOffset }));
+  const elseMarker = rel.find((mk) => mk.type === "ELSE");
+  const chainEnd = elseMarker ? elseMarker.start : inner.length;
+  const elseVal = elseMarker ? _tableauRecurse(inner.slice(elseMarker.end).trim(), lits) : "null";
+  const chain = rel.filter((mk) => mk.type === "WHEN" || mk.type === "THEN");
+  const firstWhen = chain.find((mk) => mk.type === "WHEN");
+  const field = firstWhen ? _tableauRecurse(inner.slice(0, firstWhen.start).trim(), lits) : "[?]";
+  const clauses = [];
+  for (let k = 0; k < chain.length; k += 2) {
+    const whenMk = chain[k];
+    const thenMk = chain[k + 1];
+    if (!whenMk || whenMk.type !== "WHEN" || !thenMk || thenMk.type !== "THEN")
+      break;
+    const nextWhenMk = chain[k + 2];
+    const cond = inner.slice(whenMk.end, thenMk.start).trim();
+    const valEnd = nextWhenMk ? nextWhenMk.start : chainEnd;
+    const val = inner.slice(thenMk.end, valEnd).trim();
+    clauses.push({ cond, val });
+  }
+  let result = elseVal;
+  for (let k = clauses.length - 1; k >= 0; k--) {
+    result = "If(" + field + " = " + _tableauRecurse(clauses[k].cond, lits) + ", " + _tableauRecurse(clauses[k].val, lits) + ", " + result + ")";
+  }
+  return result;
+}
+function tableauControlToSigma(f, lits) {
+  let out = "", last = 0, i = 0;
+  while (i < f.length) {
+    const c = f[i];
+    if (c === "[") {
+      const close = f.indexOf("]", i + 1);
+      i = close === -1 ? f.length : close + 1;
+      continue;
+    }
+    if (/[A-Za-z]/.test(c) && (i === 0 || !/[A-Za-z0-9_]/.test(f[i - 1]))) {
+      const isIf = /^IF\b/i.test(f.slice(i));
+      const isCase = !isIf && /^CASE\b/i.test(f.slice(i));
+      if (isIf || isCase) {
+        const blockStart = i;
+        const bodyStart = i + (isIf ? 2 : 4);
+        const scan = _scanTableauBlock(f, bodyStart);
+        if (scan.endIndex === -1) {
+          i++;
+          continue;
+        }
+        const inner = f.slice(bodyStart, scan.endStart);
+        const converted = isIf ? _convertIfBody(inner, scan.markers, bodyStart, lits) : _convertCaseBody(inner, scan.markers, bodyStart, lits);
+        out += f.slice(last, blockStart) + converted;
+        last = scan.endIndex;
+        i = scan.endIndex;
+        continue;
+      }
+    }
+    i++;
+  }
+  return out + f.slice(last);
+}
+var _TABLEAU_LIT_SQ_RE = /'(?:[^'\\]|\\.)*'/g;
+var _TABLEAU_LIT_DQ_RE = /"(?:[^"\\]|\\.)*"/g;
+var _TABLEAU_SENTINEL_SRC = "\0(\\d+)";
+var _TABLEAU_SENTINEL_RE = /\u0000(\d+)\u0001/g;
+function _maskTableauLiterals(s, lits = []) {
+  let out = "";
+  let i = 0;
+  while (i < s.length) {
+    if (s[i] === "[") {
+      const close = s.indexOf("]", i + 1);
+      if (close !== -1) {
+        out += s.slice(i, close + 1);
+        i = close + 1;
+        continue;
+      }
+    }
+    if (s[i] === "'" || s[i] === '"') {
+      const re = s[i] === "'" ? _TABLEAU_LIT_SQ_RE : _TABLEAU_LIT_DQ_RE;
+      re.lastIndex = i;
+      const m = re.exec(s);
+      if (m && m.index === i) {
+        out += `\0${lits.push(m[0]) - 1}`;
+        i += m[0].length;
+        continue;
+      }
+    }
+    out += s[i];
+    i++;
+  }
+  return { masked: out, lits };
+}
+function _restoreRawTableauLiterals(s, lits) {
+  return s.replace(_TABLEAU_SENTINEL_RE, (_m, i) => lits[Number(i)] ?? _m);
+}
+function _tabLitInner(lits, idxStr) {
+  const raw = lits[Number(idxStr)];
+  return raw === void 0 ? "" : raw.slice(1, -1).replace(/\\(.)/g, "$1");
+}
+function _tabEscapeForSigma(inner) {
+  return inner.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+function _unmaskTableauLiterals(s, lits) {
+  return s.replace(_TABLEAU_SENTINEL_RE, (_m, i) => `"${_tabEscapeForSigma(_tabLitInner(lits, i))}"`);
+}
+function _tableauRecurse(maskedSlice, lits) {
+  const raw = _restoreRawTableauLiterals(maskedSlice, lits);
+  const converted = tableauFormulaToSigma(raw);
+  const { masked } = _maskTableauLiterals(converted, lits);
+  return masked;
+}
+function tableauFormulaToSigma(formula, warnings) {
+  if (!formula || !formula.trim())
+    return "";
+  const raw0 = stripLineComments(decodeXmlEntities(formula)).trim();
+  const { masked, lits } = _maskTableauLiterals(raw0);
+  let f = masked;
+  if (/^\s*\{/.test(f)) {
+    if (warnings)
+      warnings.push("\u26A0 LOD expression not converted: " + raw0.slice(0, 60));
+    return "/* LOD: " + raw0.replace(/\/\*/g, "").replace(/\*\//g, "") + " */";
+  }
+  {
+    const winChart = tableauWindowToSigmaChart(raw0);
+    if (winChart) {
+      if (warnings)
+        warnings.push(`\u2139 Table calc \u2192 ${winChart.formula} \u2014 CHART/grouped-element context ONLY: place in a grouped workbook element (group by the viz dimensions); window functions silently error in data-model calc columns and workbook master calc columns.` + (winChart.note ? " " + winChart.note : ""));
+      return winChart.formula;
+    }
+    const untrans = tableauWindowUntranslatable(raw0);
+    if (untrans) {
+      if (warnings)
+        warnings.push(`\u26A0 Table calculation NOT converted \u2014 ${untrans}() has no Sigma equivalent. Untranslated fragment: ${raw0.slice(0, 120)}`);
+      return "/* table calc: " + raw0.replace(/\/\*/g, "").replace(/\*\//g, "") + " */";
+    }
+    if (/^(WINDOW_|RUNNING_|FIRST\(|LAST\(|INDEX\(|RANK\b|RANK_|LOOKUP\(|TOTAL\s*\()/i.test(raw0)) {
+      const gt = raw0.match(/^WINDOW_SUM\s*\(\s*(SUM|COUNT|AVG|MIN|MAX)\s*\(\s*(\[[^\]]+\])\s*\)\s*\)$/i);
+      if (gt) {
+        const aggMap = { SUM: "Sum", COUNT: "Count", AVG: "Avg", MIN: "Min", MAX: "Max" };
+        return "GrandTotal(" + (aggMap[gt[1].toUpperCase()] || gt[1]) + "(" + gt[2] + "))";
+      }
+      if (warnings)
+        warnings.push(`\u26A0 Table calculation not converted. Untranslated fragment: ${raw0.slice(0, 120)}`);
+      return "/* table calc: " + raw0.replace(/\/\*/g, "").replace(/\*\//g, "") + " */";
+    }
+  }
+  if (/\bCOVARP?\s*\(/i.test(f)) {
+    if (warnings)
+      warnings.push(`\u26A0 COVAR/COVARP has no Sigma equivalent \u2014 not converted. Fragment: ${raw0.slice(0, 120)}`);
+    return "/* no Sigma equivalent: " + raw0.replace(/\/\*/g, "").replace(/\*\//g, "") + " */";
+  }
+  f = f.replace(/\bZN\s*\(([^)]+)\)/gi, "Coalesce($1, 0)");
+  f = f.replace(/\bIFNULL\s*\(/gi, "Coalesce(").replace(/\bIFERROR\s*\(/gi, "Coalesce(");
+  f = f.replace(/\bISNULL\s*\(/gi, "IsNull(");
+  f = f.replace(/\bCOUNT\s*\(([^)]+)\)/gi, (m, arg) => "CountIf(IsNotNull(" + arg.trim() + "))");
+  f = f.replace(/\bCOUNTD\s*\(/gi, "CountDistinct(");
+  f = f.replace(/\bATTR\s*\(([^)]+)\)/gi, "$1");
+  f = tableauInToSigma(f);
+  f = tableauControlToSigma(f, lits);
+  f = f.replace(/\bIIF\s*\(/gi, "If(");
+  f = f.replace(new RegExp(`\\bDATEPART\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*,\\s*([^)]+)\\)`, "gi"), (m, litIdx, dateArg) => {
+    const part = _tabLitInner(lits, litIdx);
+    if (!/^\w+$/.test(part))
+      return m;
+    if (part.toLowerCase() === "week")
+      return 'DatePart("week", ' + dateArg.trim() + ")";
+    const partMap = {
+      year: "Year",
+      month: "Month",
+      day: "Day",
+      hour: "Hour",
+      minute: "Minute",
+      second: "Second",
+      quarter: "Quarter",
+      dayofweek: "DayOfWeek",
+      weekday: "DayOfWeek"
+    };
+    const fn = partMap[part.toLowerCase()];
+    return fn ? fn + "(" + dateArg.trim() + ")" : m;
+  });
+  f = f.replace(new RegExp(`\\bDATENAME\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*,\\s*([^,)]+)(?:,[^)]*)?\\)`, "gi"), (m, litIdx, dateArg) => {
+    const part = _tabLitInner(lits, litIdx);
+    if (!/^\w+$/.test(part))
+      return m;
+    const arg = dateArg.trim();
+    switch (part.toLowerCase()) {
+      case "month":
+        return "MonthName(" + arg + ")";
+      case "weekday":
+      case "dayofweek":
+        return "WeekdayName(" + arg + ")";
+      case "year":
+        return "Text(Year(" + arg + "))";
+      case "quarter":
+        return "Text(Quarter(" + arg + "))";
+      case "day":
+        return "Text(Day(" + arg + "))";
+      case "week":
+        return "Text(Week(" + arg + "))";
+      case "hour":
+        return "Text(Hour(" + arg + "))";
+      case "minute":
+        return "Text(Minute(" + arg + "))";
+      case "second":
+        return "Text(Second(" + arg + "))";
+      default:
+        return m;
+    }
+  });
+  f = f.replace(new RegExp(`\\bDATETRUNC\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*,`, "gi"), (_m, litIdx) => `DateTrunc("${_tabEscapeForSigma(_tabLitInner(lits, litIdx))}",`);
+  f = f.replace(new RegExp(`,\\s*${_TABLEAU_SENTINEL_SRC}\\s*\\)`, "gi"), (m, litIdx) => {
+    const val = _tabLitInner(lits, litIdx);
+    return /^(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/i.test(val) ? ")" : m;
+  });
+  f = f.replace(new RegExp(`\\bDATEADD\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*,`, "gi"), (_m, litIdx) => `DateAdd("${_tabEscapeForSigma(_tabLitInner(lits, litIdx))}",`);
+  f = f.replace(new RegExp(`\\bDATEDIFF\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*,`, "gi"), (_m, litIdx) => `DateDiff("${_tabEscapeForSigma(_tabLitInner(lits, litIdx))}",`);
+  f = f.replace(/\bWEEK\s*\(\s*([^()]*(?:\([^()]*\)[^()]*)*)\)/gi, 'DatePart("week", $1)');
+  f = f.replace(/\bSTDEVP\s*\(([^()]+(?:\([^()]*\)[^()]*)*)\)/gi, "Sqrt(VariancePop($1))");
+  f = f.replace(new RegExp(`\\bDATEPARSE\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*,\\s*([^()]+(?:\\([^()]*\\)[^()]*)*)\\)`, "gi"), (_m, litIdx, str) => {
+    const fmtRaw = _tabLitInner(lits, litIdx);
+    const sf = fmtRaw.replace(/yyyy/g, "%Y").replace(/yy/g, "%y").replace(/MMMM/g, "%B").replace(/MMM/g, "%b").replace(/MM/g, "%m").replace(/dd/g, "%d").replace(/HH/g, "%H").replace(/hh/g, "%I").replace(/mm/g, "%M").replace(/ss/g, "%S");
+    if (warnings)
+      warnings.push("\u26A0 DATEPARSE format translated to strftime tokens \u2014 verify the pattern resolves on your warehouse.");
+    return `DateParse(${str.trim()}, "${sf}")`;
+  });
+  f = f.replace(/\bUSERNAME\s*\(\s*\)/gi, "CurrentUserEmail()");
+  f = f.replace(new RegExp(`\\bISMEMBEROF\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*\\)`, "gi"), (_m, litIdx) => `CurrentUserInTeam("${_tabEscapeForSigma(_tabLitInner(lits, litIdx))}")`);
+  f = f.replace(new RegExp(`\\bUSERATTRIBUTE\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*\\)`, "gi"), (_m, litIdx) => `CurrentUserAttributeText("${_tabEscapeForSigma(_tabLitInner(lits, litIdx))}")`);
+  f = f.replace(new RegExp(`\\bISUSERNAME\\s*\\(\\s*${_TABLEAU_SENTINEL_SRC}\\s*\\)`, "gi"), (_m, litIdx) => `(CurrentUserEmail() = "${_tabEscapeForSigma(_tabLitInner(lits, litIdx))}")`);
+  f = f.replace(/\bSQUARE\s*\(\s*([^()]*(?:\([^()]*\)[^()]*)*)\)/gi, "Power($1, 2)");
+  f = f.replace(/\bSPACE\s*\(\s*([^()]*(?:\([^()]*\)[^()]*)*)\)/gi, 'Repeat(" ", $1)');
+  for (const [tab, sig] of Object.entries(TABLEAU_FUNC_MAP)) {
+    f = f.replace(new RegExp("\\b" + tab + "\\s*\\(", "gi"), sig + "(");
+  }
+  f = f.replace(/\bNOT\b/g, "Not").replace(/\bAND\b/g, "and").replace(/\bOR\b/g, "or");
+  f = f.replace(/\bTRUE\b/gi, "True").replace(/\bFALSE\b/gi, "False").replace(/\bNULL\b/gi, "null");
+  f = f.replace(/\[([A-Z][A-Z0-9_]{2,})\]/g, (match, colName) => {
+    if (colName === colName.toLowerCase() || colName.includes(" "))
+      return match;
+    return "[" + sigmaDisplayName(colName) + "]";
+  });
+  f = _unmaskTableauLiterals(f, lits);
+  f = tableauTextConcatToSigma(f);
+  if (warnings && TABLEAU_TABLE_CALC_TOKEN_RE.test(f)) {
+    warnings.push(`\u26A0 Table-calc function embedded in a larger expression \u2014 NOT translated in place. Untranslated fragment: ${f.slice(0, 120)}`);
+  }
+  if (warnings) {
+    const masked2 = f.replace(/"[^"]*"/g, '""').replace(/\[[^\]]*\]/g, "[]");
+    const unmapped = /* @__PURE__ */ new Set();
+    const scan = /\b([A-Z][A-Z0-9_]+)\s*\(/g;
+    let mm;
+    while ((mm = scan.exec(masked2)) !== null) {
+      const fn = mm[1];
+      if (TABLEAU_TABLE_CALC_TOKEN_RE.test(fn + "("))
+        continue;
+      unmapped.add(fn);
+    }
+    if (unmapped.size) {
+      warnings.push(`\u26A0 Unmapped Tableau function(s) passed through unconverted: ${[...unmapped].join(", ")} \u2014 no validated Sigma equivalent yet. Rewrite manually; left as-is they error at query time.`);
+    }
+  }
+  return f.trim();
+}
+function tableauIsAggregate(formula) {
+  return /\b(SUM|AVG|COUNT|COUNTD|MAX|MIN|MEDIAN|STDEV|STDEVP|VAR|VARP|PERCENTILE|CORR|ATTR)\s*\(/i.test(formula);
+}
+function tableauFormulaIsRls(formula) {
+  return /\b(USERNAME|FULLNAME|USERDOMAIN|ISMEMBEROF|ISUSERNAME|USERATTRIBUTE)\s*\(/i.test(formula || "");
+}
+function lookStripSql(sql) {
+  if (!sql)
+    return "";
+  sql = sql.replace(/\$\{TABLE\}\./gi, "").trim();
+  sql = sql.replace(/\$\{[^.}]+\.([^}]+)\}/g, "$1");
+  sql = sql.replace(/`/g, "");
+  sql = sql.replace(/\[([A-Za-z_][A-Za-z0-9_\s]*)\]/g, "$1");
+  sql = sql.replace(/::\w[\w_]*/g, "");
+  const castMatch = sql.match(/^(?:SAFE_CAST|TRY_CAST|CAST)\s*\(\s*("?[A-Za-z_][A-Za-z0-9_]*"?)\s+AS\s+\w[\w_]*\s*\)$/i);
+  if (castMatch)
+    sql = castMatch[1];
+  sql = sql.replace(/"/g, "").trim();
+  const m = sql.match(/^([A-Za-z_][A-Za-z0-9_]*)/);
+  return m ? m[1] : sql;
+}
+function lookSigmaType(lkType) {
+  const map = {
+    string: "text",
+    number: "number",
+    yesno: "boolean",
+    date: "datetime",
+    time: "datetime",
+    datetime: "datetime",
+    zipcode: "text",
+    tier: "text",
+    location: "text",
+    distance: "number",
+    duration: "number",
+    count: "number"
+  };
+  return map[(lkType || "").toLowerCase()] || "text";
+}
+function lookSigmaMetric(measureType, colName) {
+  const dn = sigmaDisplayName(colName);
+  const map = {
+    sum: `Sum([${dn}])`,
+    count: `CountIf(IsNotNull([${dn}]))`,
+    count_distinct: `CountDistinct([${dn}])`,
+    average: `Avg([${dn}])`,
+    max: `Max([${dn}])`,
+    min: `Min([${dn}])`,
+    list: `ListAgg([${dn}])`,
+    sum_distinct: `Sum(Distinct [${dn}])`,
+    average_distinct: `Avg(Distinct [${dn}])`,
+    median: `Median([${dn}])`,
+    number: `[${dn}]`,
+    yesno: `CountIf([${dn}])`
+  };
+  return map[(measureType || "").toLowerCase()] || `CountIf(IsNotNull([${dn}]))`;
+}
+export {
+  SIGMA_CHART_ONLY_WINDOW_RE,
+  TABLEAU_LOD_LEFTOVER_RE,
+  TABLEAU_TABLE_CALC_TOKEN_CI_RE,
+  TABLEAU_TABLE_CALC_TOKEN_RE,
+  _SQL_KEYWORD_RE,
+  decodeXmlEntities,
+  detectUnsupportedSigmaFunction,
+  formulaHasUntranslatableFragment,
+  hasResidualCaseKeyword,
+  hasResidualInfixOperator,
+  lookColRef,
+  lookConvertCase,
+  lookConvertExpression,
+  lookConvertMathExpr,
+  lookIsComplexSql,
+  lookSigmaMetric,
+  lookSigmaType,
+  lookSqlToSigmaRules,
+  lookStripSql,
+  lookUnknownFunctions,
+  stripLineComments,
+  stripOuterParens,
+  tableauFormulaIsRls,
+  tableauFormulaToSigma,
+  tableauInToSigma,
+  tableauIsAggregate,
+  tableauParamSwitchToSigma,
+  tableauTextConcatToSigma,
+  tableauWindowToSigmaChart,
+  tableauWindowUntranslatable
+};

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md
@@ -1,11 +1,12 @@
 # Beast Mode → Sigma formula mapping
 
-Beast Mode is **MySQL-dialect SQL**. The primary translation path is the existing
-`mcp__sigma-data-model__convert_sql_to_sigma_formula` tool — feed it the Beast
-Mode string and it emits a Sigma formula. This doc is the **pre-processing +
-verification layer**: normalizations to apply first, the function-by-function map
-to sanity-check the converter's output, and the gotchas that the generic SQL
-converter won't know are Domo-specific.
+Beast Mode is **MySQL-dialect SQL**. The primary translation path is the vendored
+`converter/sql.mjs` (`scripts/convert-beast-modes.rb --convert`, running locally
+via `node` — no MCP call, no network; see Track E,
+`docs/superpowers/specs/2026-08-03-domo-sql-formula-vendoring-design.md`). This
+doc is the **pre-processing + verification layer**: normalizations to apply
+first, the function-by-function map to sanity-check the converter's output, and
+the gotchas that the generic SQL converter won't know are Domo-specific.
 
 Source of truth: Domo "Beast Mode Functions Reference Guide" (captured 2026-06-02).
 
@@ -13,11 +14,13 @@ Source of truth: Domo "Beast Mode Functions Reference Guide" (captured 2026-06-0
 
 ## Translation is delegated — this ref is the Domo-specific wrapper
 
-The actual SQL→Sigma translation runs through the
-`mcp__sigma-data-model__convert_sql_to_sigma_formula` MCP tool — it is the
-**single source of truth** and already handles `CASE WHEN`, `IN` lists,
-`DATEDIFF`, arithmetic, and `snake_case` → `[Title Case]` column references.
-Don't re-implement those. This ref is the **Domo-specific PRE-normalization +
+The actual SQL→Sigma translation runs through the vendored `converter/sql.mjs`
+(`lookSqlToSigmaRules`/`lookConvertExpression`, re-vendored periodically from
+`sigma-data-model-mcp`'s `src/formulas.ts` — same functions the
+`convert_sql_to_sigma_formula` MCP tool itself calls) — it is the **single
+source of truth** and already handles `CASE WHEN`, `IN` lists, `DATEDIFF`,
+arithmetic, and `snake_case` → `[Title Case]` column references. Don't
+re-implement those. This ref is the **Domo-specific PRE-normalization +
 POST-lint** layer that `scripts/convert-beast-modes.rb` implements around that
 call.
 
@@ -243,7 +246,9 @@ string** (`"day"`, `"month"`, `"year"`, …) and use **format tokens** (`YYYY`,
 ## Translation workflow (per Beast Mode)
 
 1. Normalize (backticks, WEEKDAY, unsupported, aggregate CEILING/FLOOR, context).
-2. Call `convert_sql_to_sigma_formula` with the normalized string.
+2. `ruby scripts/convert-beast-modes.rb --convert` runs the vendored
+   `converter/sql.mjs` against every normalized string in one local `node`
+   invocation (no MCP call).
 3. Cross-check the result against the tables above; apply the Domo-specific
    gotchas the generic SQL converter misses (CEILING/FLOOR aggregates, `IN`→`or`,
    `DATEDIFF` arg order, format-specifier translation).

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -311,17 +311,27 @@ if opts[:convert]
     filled = JSON.parse(File.read(opts[:converter_out]))
     by_id = {}
     filled.each { |e| by_id[e['id']] = e }
+    applied_ids = []
     pending.each do |e|
       src = by_id[e['id']]
       next unless src
+      applied_ids << e['id']
       e['sigmaFormula'] = src['sigmaFormula']
       e['converted']    = src['converted']
       e['warnings']     = src['warnings']
-      e['note']         = src['note'] if src['note']
+      # Always overwrite — nil when src has no note — so a formula that is
+      # NOW cleanly converted never carries forward a stale "could not fully
+      # translate" note from a prior run's pending entry.
+      e['note']         = src['note']
+    end
+    unmatched_ids = by_id.keys - applied_ids
+    unmatched_ids.each do |id|
+      warn "  ⚠ --converter-out id '#{id}' matches no Beast Mode in #{path} — typo'd id? (ignored)"
     end
     out = opts[:out] || path
     File.write(out, JSON.pretty_generate(pending))
-    warn "  filled #{filled.size} formula(s) from --converter-out #{opts[:converter_out]}"
+    warn "  filled #{applied_ids.size}/#{filled.size} formula(s) from --converter-out " \
+         "#{opts[:converter_out]}#{unmatched_ids.empty? ? '' : " (#{unmatched_ids.size} unmatched — see warnings above)"}"
     exit 0
   end
 
@@ -365,7 +375,10 @@ if opts[:convert]
         if (sigmaFormula == null) sigmaFormula = lookConvertExpression(sql);
         const converted = !hasResidualCaseKeyword(sigmaFormula) && !hasResidualInfixOperator(sigmaFormula);
         const result = { ...entry, sigmaFormula, converted, warnings };
-        if (!converted) result.note = NOTE;
+        // entry may carry a stale `note` from a prior run (e.g. re-running
+        // --convert after the bundle improves, or after a hand-edit to
+        // normalizedSql) — never let it survive onto a now-clean result.
+        if (!converted) { result.note = NOTE; } else { delete result.note; }
         return result;
       });
       writeFileSync(#{res_path.to_json}, JSON.stringify(out));

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -1,11 +1,18 @@
 #!/usr/bin/env ruby
 # Phase 2 — Beast Mode (MySQL SQL) → Sigma formula.
 #
-# Beast Mode is MySQL-dialect SQL, so the actual translation is delegated to the
-# ONE source of truth: the `convert_sql_to_sigma_formula` MCP tool (which already
-# handles CASE WHEN, IN lists, DATEDIFF, arithmetic, and SNAKE_CASE → [Title
-# Case] column refs). This script does NOT reimplement translation. It adds the
-# two layers the generic SQL converter can't know about:
+# Beast Mode is MySQL-dialect SQL. The actual translation runs LOCALLY via the
+# vendored converter/sql.mjs bundle (esbuild-bundled from sigma-data-model-mcp's
+# src/formulas.ts by `tools/vendor-converters.sh <checkout> domo` — see
+# converter/PROVENANCE.json for the pinned source commit), invoked through
+# `node`. No MCP call and no network in the automated path — see
+# resolve_sql_converter's 3-tier ladder below: the vendored bundle is the
+# default; --mcp-dir/DOMO_MCP_DIR is an explicit local-dev opt-in; a manual
+# convert_sql_to_sigma_formula MCP call + --converter-out is the tier-3 last
+# resort, reached only via the exit-10 GATE when neither of the first two
+# resolves (e.g. no vendored bundle and no dev checkout, or `node` missing).
+# This script does NOT reimplement translation itself. It adds the two layers
+# the generic SQL converter can't know about:
 #
 #   PRE  — Domo-specific normalization (backtick identifiers → [Col], WEEKDAY →
 #          DAYOFWEEK, flag unsupported fns, flag the CEILING/FLOOR-are-aggregates
@@ -14,11 +21,12 @@
 #          Not() function-call forms that silently null, window-fn workbook-master
 #          limits) — see refs/beast-mode-to-sigma.md + feedback_sigma_window_functions.
 #
-# Two-step flow (the skill's Phase 2 orchestrates the middle step):
-#   ruby scripts/convert-beast-modes.rb          # normalize → discovery/formulas.pending.json
-#   # → skill calls convert_sql_to_sigma_formula(sql: normalizedSql) per entry,
-#   #   writes the result into `sigmaFormula`, applies preWarning overrides.
-#   ruby scripts/convert-beast-modes.rb --lint   # validate filled pending → discovery/formulas.json
+# Three-step flow (SKILL.md's Phase 2 runs all three; no agent/MCP call in the
+# middle step unless the exit-10 GATE fires):
+#   ruby scripts/convert-beast-modes.rb            # normalize → discovery/formulas.pending.json
+#   ruby scripts/convert-beast-modes.rb --convert  # local node + vendored converter/sql.mjs —
+#                                                   #   fills sigmaFormula + converted (true/false) in place
+#   ruby scripts/convert-beast-modes.rb --lint     # validate filled pending → discovery/formulas.json
 #
 # HAND-AUTHORED ESCAPE HATCH — discovery/formula-overrides.json
 #
@@ -49,6 +57,11 @@
 # is simply no longer load-bearing for the CASE WHEN / COUNT(DISTINCT) /
 # double-bracketing defect class.
 #
+# Track E (2026-08-03): this translation now runs vendored/local (see the
+# 3-tier ladder above) instead of a live MCP call, so the PR #115/#116 fixes
+# above are inherited automatically on each `tools/vendor-converters.sh domo`
+# re-vendor — nothing in this script's own logic needed to change for that.
+#
 # discovery/formula-overrides.json is an OPERATOR-authored sidecar (same
 # convention as discovery/kpi-overrides.json / dataset-map.json — this script
 # only ever READS it, so re-running normalize or --lint never clobbers it).
@@ -73,8 +86,17 @@
 # plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/formulas.md.
 #
 # Rules (enforced in resolve_entry / unmatched_override_keys below):
-#   - An override only SUPPLIES a MISSING sigmaFormula — it never silently
-#     replaces one convert_sql_to_sigma_formula already filled in.
+#   - An override SUPPLIES a MISSING sigmaFormula, OR SUPERSEDES one that
+#     --convert filled in but flagged converted:false (still-broken machine
+#     output) — widened 2026-08-03: --convert's mechanical fallback
+#     (lookConvertExpression) is total and always produces SOME sigmaFormula,
+#     so "missing" alone had become nearly unreachable in the orchestrated
+#     pipeline. It never silently replaces a formula that converted CLEANLY
+#     (converted:true, or a legacy entry with no `converted` key at all —
+#     unaffected by this widening). When an override IS applied, the emitted
+#     entry's `converted` is forced to `true` and any stale converted:false
+#     "could not fully translate" note is cleared first — a human-authored
+#     formula must never carry forward the discarded automated attempt's note.
 #   - Every use is still POST-linted by lint_formula (raw IN(, And()/Or()/
 #     Not() as calls, unbalanced brackets) — a hand-authored typo is a hard
 #     lintError in formulas.json, never a silent pass.
@@ -222,21 +244,30 @@ end
 # no sigmaFormula (no override applied) — the caller drops it, exactly
 # today's honest-drop behaviour (refs/live-validation-2026-07-30.md).
 #
-# An override only SUPPLIES a sigmaFormula that is missing; it never silently
-# clobbers one convert_sql_to_sigma_formula already filled in (if it matches
-# an already-resolved entry, that's a no-op override — warned, not applied).
+# An override SUPPLIES a sigmaFormula that is missing, OR SUPERSEDES one
+# --convert already filled in but flagged converted:false (still-broken
+# machine output) — widened 2026-08-03 because --convert's
+# lookConvertExpression fallback is total (always produces SOME sigmaFormula,
+# even a bad one), so "missing" alone had become nearly unreachable in the
+# orchestrated pipeline (there is no interposition point to hand-clear a
+# sigmaFormula between --convert and --lint in the automated flow). It never
+# silently clobbers a formula that converted CLEANLY — converted:true, or a
+# legacy entry with no `converted` key at all (entry['converted'] != false is
+# true for nil, so already_resolved's truth value is unchanged for those) — a
+# no-op override there is still warned, not applied.
 def resolve_entry(entry, overrides)
   warnings = []
   sigma = entry['sigmaFormula']
-  already_resolved = !(sigma.nil? || sigma.to_s.strip.empty?)
+  already_resolved = !(sigma.nil? || sigma.to_s.strip.empty?) && entry['converted'] != false
   override = find_override(entry, overrides)
   used_override = false
 
   if override && !override['sigmaFormula'].to_s.strip.empty?
     if already_resolved
       warnings << "formula-overrides.json has an entry for " \
-        "#{entry['name'] || entry['id']} but it already has a sigmaFormula — " \
-        "override NOT applied (clear the pending entry's sigmaFormula to force it)."
+        "#{entry['name'] || entry['id']} but it already has a sigmaFormula that " \
+        "converted cleanly (converted:true) — override NOT applied (an override " \
+        "only supersedes a missing or converted:false result)."
     else
       sigma = override['sigmaFormula']
       used_override = true
@@ -249,26 +280,35 @@ def resolve_entry(entry, overrides)
   resolved = entry.merge('sigmaFormula' => sigma, 'lintErrors' => errs, 'lintWarnings' => lint_warns)
   if used_override
     resolved['_source'] = 'formula-override'
+    # Human-authored, trusted — clear any stale automated converted:false +
+    # its "could not fully translate" note (which would otherwise describe
+    # formula content no longer even present in sigmaFormula) before applying
+    # the override's own note, if any.
+    resolved['converted'] = true
+    resolved.delete('note')
     resolved['note'] = override['note'] if override['note']
     warnings << "#{entry['name'] || entry['id']}: sigmaFormula supplied by " \
       "discovery/formula-overrides.json (hand-authored) — automated conversion " \
-      "(convert_sql_to_sigma_formula) did not produce a usable formula for this " \
-      "Beast Mode; verify by hand. CASE WHEN / COUNT(DISTINCT) / double-bracketed " \
-      "ALL-CAPS refs are fixed (sigma-data-model-mcp PR #115, #116) so this is NOT " \
-      "that historical 74%-fail case — check refs/live-validation-2026-07-30.md " \
-      "and this script's still-open gaps (WEEKDAY→DAYOFWEEK, CEILING/FLOOR " \
-      "aggregates, untranslatable infix LIKE) for what actually still needs a " \
-      "hand-authored formula."
+      "did not produce a fully reliable formula for this Beast Mode (missing, or " \
+      "flagged converted:false); verify by hand. CASE WHEN / COUNT(DISTINCT) / " \
+      "double-bracketed ALL-CAPS refs are fixed (sigma-data-model-mcp PR #115, " \
+      "#116) so this is NOT that historical 74%-fail case — check " \
+      "refs/live-validation-2026-07-30.md and this script's still-open gaps " \
+      "(WEEKDAY→DAYOFWEEK, CEILING/FLOOR aggregates, untranslatable infix LIKE) " \
+      "for what actually still needs a hand-authored formula."
   elsif entry['converted'] == false
     # Track E: --convert already computed a REAL converted flag (via the
     # vendored hasResidualCaseKeyword/hasResidualInfixOperator) — surface it
     # loudly here rather than letting a "flagged unreliable but still has SOME
-    # string in sigmaFormula" entry ride through --lint silently. Does NOT
-    # change override-eligibility (still fills-missing-only, unchanged) — this
-    # is visibility only.
+    # string in sigmaFormula" entry ride through --lint silently. No override
+    # was applied above (none exists for this id/name, or its sigmaFormula is
+    # blank) — per the widened eligibility rule, a discovery/formula-
+    # overrides.json entry for this id/name WOULD supersede this
+    # converted:false result, so suggest adding one.
     warnings << "#{entry['name'] || entry['id']}: automated conversion flagged this formula as " \
       "converted:false (still contains raw CASE/WHEN/THEN or an infix LIKE/BETWEEN Sigma has no " \
-      "equivalent for) — review before shipping; consider a discovery/formula-overrides.json entry."
+      "equivalent for) — review before shipping; a discovery/formula-overrides.json entry WILL " \
+      "supersede this converted:false result."
   end
   [resolved, warnings]
 end
@@ -412,7 +452,8 @@ if opts[:convert]
   if unreliable.positive?
     warn "  wrote #{out} (#{pending.size} formulas; #{unreliable} flagged converted:false — review before --lint)"
   else
-    warn "  wrote #{out} (#{pending.size} formulas, all converted:true)"
+    warn "  wrote #{out} (#{pending.size} formulas — no residual CASE/infix syntax detected in any of " \
+         "them; not a full validity guarantee)"
   end
 elsif opts[:lint]
   # ---- Validate a filled pending file → formulas.json --------------------

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -87,8 +87,36 @@
 
 require 'json'
 require 'optparse'
+require 'open3'
+require 'tmpdir'
 
 OUT = ENV['DOMO_DISCOVERY_DIR'] || File.expand_path('../discovery', __dir__)
+
+# Track E — the vendored SQL-formula converter (tools/vendor-converters.sh domo).
+VENDORED_SQL = File.expand_path('../converter/sql.mjs', __dir__)
+
+# Converter resolution, same 3-tier ladder as powerbi-to-sigma's
+# migrate-powerbi.rb#resolve_converter: the vendored bundle is the DEFAULT (byte-
+# identical output on any machine); a local sigma-data-model-mcp build is used
+# ONLY when explicitly opted into via --mcp-dir/DOMO_MCP_DIR — no silent ~/…
+# auto-discovery (that's the "works in my checkout, differs for the customer"
+# footgun powerbi's own comment names). If neither resolves, the caller's
+# --convert branch takes the last-resort exit-10 path. Returns
+# [conv_module_path_or_nil, dev_build_dir_or_nil, description_or_nil].
+def resolve_sql_converter(mcp_dir, vendored)
+  dev_module = (mcp_dir && File.exist?(File.join(mcp_dir, 'build', 'formulas.js'))) ?
+    File.join(mcp_dir, 'build', 'formulas.js') : nil
+  conv = dev_module || (File.exist?(vendored) ? vendored : nil)
+  desc =
+    if conv && conv == vendored
+      prov = File.join(File.dirname(vendored), 'PROVENANCE.json')
+      commit = (JSON.parse(File.read(prov))['source_commit'] rescue nil)
+      "VENDORED converter/sql.mjs#{commit ? " (pinned #{commit})" : ''} — no data egress"
+    elsif conv
+      "DEV BUILD #{conv} (explicit opt-in via --mcp-dir/DOMO_MCP_DIR)"
+    end
+  [conv, dev_module, desc]
+end
 
 # Removed from Beast Mode / unsupported in Sigma — warn if seen.
 UNSUPPORTED = %w[SQRT CONVERT_TZ MICROSECOND WEEKDAY].freeze
@@ -231,6 +259,16 @@ def resolve_entry(entry, overrides)
       "and this script's still-open gaps (WEEKDAY→DAYOFWEEK, CEILING/FLOOR " \
       "aggregates, untranslatable infix LIKE) for what actually still needs a " \
       "hand-authored formula."
+  elsif entry['converted'] == false
+    # Track E: --convert already computed a REAL converted flag (via the
+    # vendored hasResidualCaseKeyword/hasResidualInfixOperator) — surface it
+    # loudly here rather than letting a "flagged unreliable but still has SOME
+    # string in sigmaFormula" entry ride through --lint silently. Does NOT
+    # change override-eligibility (still fills-missing-only, unchanged) — this
+    # is visibility only.
+    warnings << "#{entry['name'] || entry['id']}: automated conversion flagged this formula as " \
+      "converted:false (still contains raw CASE/WHEN/THEN or an infix LIKE/BETWEEN Sigma has no " \
+      "equivalent for) — review before shipping; consider a discovery/formula-overrides.json entry."
   end
   [resolved, warnings]
 end
@@ -247,12 +285,106 @@ if run_main
 opts = {}
 OptionParser.new do |o|
   o.on('--lint') { opts[:lint] = true }
+  o.on('--convert') { opts[:convert] = true }
   o.on('--in PATH')  { |v| opts[:in] = v }
   o.on('--out PATH') { |v| opts[:out] = v }
   o.on('--overrides PATH') { |v| opts[:overrides] = v }
+  # Track E 3-tier resolution: --mcp-dir/DOMO_MCP_DIR (tier 2, explicit dev
+  # opt-in) and --converter-out (tier 3 resume — an agent-produced JSON array
+  # of [{id, sigmaFormula, converted, warnings, note?}] filled by hand via the
+  # manual convert_sql_to_sigma_formula MCP call the exit-10 path prints).
+  o.on('--mcp-dir DIR') { |v| opts[:mcp_dir] = File.expand_path(v) }
+  o.on('--converter-out PATH') { |v| opts[:converter_out] = v }
 end.parse!(ARGV)
 
-if opts[:lint]
+if opts[:convert]
+  # ---- Track E: run the SQL-formula converter over the whole pending file,
+  # one node invocation, no agent/MCP call in the loop ----------------------
+  path = opts[:in] || File.join(OUT, 'formulas.pending.json')
+  pending = JSON.parse(File.read(path))
+
+  if opts[:converter_out]
+    # Tier 3 resume: an agent already ran convert_sql_to_sigma_formula by hand
+    # per the exit-10 instructions below and saved [{id, sigmaFormula,
+    # converted, warnings, note?}] to this file. Merge by id; never clobber
+    # fields this tier doesn't supply.
+    filled = JSON.parse(File.read(opts[:converter_out]))
+    by_id = {}
+    filled.each { |e| by_id[e['id']] = e }
+    pending.each do |e|
+      src = by_id[e['id']]
+      next unless src
+      e['sigmaFormula'] = src['sigmaFormula']
+      e['converted']    = src['converted']
+      e['warnings']     = src['warnings']
+      e['note']         = src['note'] if src['note']
+    end
+    out = opts[:out] || path
+    File.write(out, JSON.pretty_generate(pending))
+    warn "  filled #{filled.size} formula(s) from --converter-out #{opts[:converter_out]}"
+    exit 0
+  end
+
+  conv, _dev_dir, desc = resolve_sql_converter(opts[:mcp_dir] || ENV['DOMO_MCP_DIR'], VENDORED_SQL)
+  if conv.nil?
+    warn '  vendored converter (converter/sql.mjs) missing and no local sigma-data-model-mcp ' \
+         'build (--mcp-dir / DOMO_MCP_DIR).'
+    warn ''
+    warn '  >>> GATE: for EACH entry in discovery/formulas.pending.json, call'
+    warn '      convert_sql_to_sigma_formula(sql: normalizedSql), collect the result as'
+    warn '      {id, sigmaFormula, converted, warnings, note?}, write the whole array to a'
+    warn '      JSON file, then re-run:'
+    warn '        ruby scripts/convert-beast-modes.rb --convert --converter-out <that file>'
+    warn '      No formulas were translated.'
+    exit 10
+  end
+  warn "  converter: #{desc}"
+
+  import_specifier =
+    (Gem.win_platform? && conv.to_s.match?(/\A[A-Za-z]:/)) ? 'file:///' + conv.gsub('\\', '/') : conv
+
+  Dir.mktmpdir('domo-convert') do |dir|
+    in_path  = File.join(dir, 'pending.json')
+    res_path = File.join(dir, 'results.json')
+    File.write(in_path, JSON.generate(pending))
+
+    runner = File.join(dir, 'run.mjs')
+    File.write(runner, <<~JS)
+      import { readFileSync, writeFileSync } from 'node:fs';
+      import { lookSqlToSigmaRules, lookConvertExpression, hasResidualCaseKeyword, hasResidualInfixOperator, lookUnknownFunctions } from #{import_specifier.to_json};
+      const pending = JSON.parse(readFileSync(#{in_path.to_json}, 'utf8'));
+      // Same per-formula orchestration as sigma-data-model-mcp's src/tools.ts
+      // convert_sql_to_sigma_formula tool handler — try the rule engine first,
+      // fall back to the total mechanical converter, then check for residual
+      // untranslated SQL syntax the same way the live tool already does.
+      const NOTE = 'Could not fully translate — output still contains raw SQL syntax Sigma has no equivalent for (CASE/WHEN/THEN, or an infix LIKE/BETWEEN), do not use as-is';
+      const out = pending.map((entry) => {
+        const sql = entry.normalizedSql;
+        const warnings = lookUnknownFunctions(sql).map(fn => `${fn}() has no Sigma mapping — emitted as-is; verify it exists in Sigma.`);
+        let sigmaFormula = lookSqlToSigmaRules(sql);
+        if (sigmaFormula == null) sigmaFormula = lookConvertExpression(sql);
+        const converted = !hasResidualCaseKeyword(sigmaFormula) && !hasResidualInfixOperator(sigmaFormula);
+        const result = { ...entry, sigmaFormula, converted, warnings };
+        if (!converted) result.note = NOTE;
+        return result;
+      });
+      writeFileSync(#{res_path.to_json}, JSON.stringify(out));
+    JS
+
+    _stdout, stderr, status = Open3.capture3('node', runner)
+    abort "FATAL: converter failed:\n#{stderr}" unless status.success?
+    pending = JSON.parse(File.read(res_path))
+  end
+
+  out = opts[:out] || path
+  File.write(out, JSON.pretty_generate(pending))
+  unreliable = pending.count { |e| e['converted'] == false }
+  if unreliable.positive?
+    warn "  wrote #{out} (#{pending.size} formulas; #{unreliable} flagged converted:false — review before --lint)"
+  else
+    warn "  wrote #{out} (#{pending.size} formulas, all converted:true)"
+  end
+elsif opts[:lint]
   # ---- Validate a filled pending file → formulas.json --------------------
   path = opts[:in] || File.join(OUT, 'formulas.pending.json')
   pending = JSON.parse(File.read(path))
@@ -312,8 +444,7 @@ else
   require 'fileutils'; FileUtils.mkdir_p(OUT)
   File.write(out, JSON.pretty_generate(pending))
   warn "  wrote #{out} (#{pending.size} Beast Modes to translate)"
-  warn "\n  Next (Phase 2): for each entry call convert_sql_to_sigma_formula(sql: normalizedSql),"
-  warn "  write the result into `sigmaFormula`, apply preWarning overrides (CEILING/FLOOR/window/LOD),"
-  warn "  then: ruby scripts/convert-beast-modes.rb --lint"
+  warn "\n  Next (Phase 2): ruby scripts/convert-beast-modes.rb --convert   # local node, no MCP call"
+  warn "  then:            ruby scripts/convert-beast-modes.rb --lint"
 end
 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -336,9 +336,26 @@ if opts[:convert]
   end
 
   conv, _dev_dir, desc = resolve_sql_converter(opts[:mcp_dir] || ENV['DOMO_MCP_DIR'], VENDORED_SQL)
-  if conv.nil?
-    warn '  vendored converter (converter/sql.mjs) missing and no local sigma-data-model-mcp ' \
-         'build (--mcp-dir / DOMO_MCP_DIR).'
+  # resolve_sql_converter only checks FILE EXISTENCE of the bundle/dev build —
+  # it never confirms `node` itself is invokable. A resolved `conv` with no
+  # `node` on PATH (e.g. this script run directly, bypassing doctor.sh's usual
+  # node-prerequisite gate) must NOT fall through to the raw Open3::ENOENT
+  # crash below; it gets the same clean instructional exit-10 as a missing
+  # bundle.
+  node_available = conv && begin
+    _o, _e, st = Open3.capture3('node', '--version')
+    st.success?
+  rescue Errno::ENOENT
+    false
+  end
+  if conv.nil? || !node_available
+    if conv.nil?
+      warn '  vendored converter (converter/sql.mjs) missing and no local sigma-data-model-mcp ' \
+           'build (--mcp-dir / DOMO_MCP_DIR).'
+    else
+      warn "  converter: #{desc}"
+      warn '  but `node` is not on PATH — required to run it locally (doctor.sh normally gates on this).'
+    end
     warn ''
     warn '  >>> GATE: for EACH entry in discovery/formulas.pending.json, call'
     warn '      convert_sql_to_sigma_formula(sql: normalizedSql), collect the result as'

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -372,6 +372,15 @@ def phase_convert_beast_modes!(opts)
   ok, code, _out = run_script!('convert-beast-modes.rb')
   fail_phase!('convert-beast-modes', "normalize step exited #{code}") unless ok
 
+  ok, code, _out = run_script!('convert-beast-modes.rb', '--convert')
+  if !ok && code == 10
+    fail_phase!('convert-beast-modes',
+                'no vendored converter/sql.mjs and no --mcp-dir/DOMO_MCP_DIR — re-run ' \
+                "'ruby scripts/convert-beast-modes.rb --convert' directly to see the manual " \
+                'convert_sql_to_sigma_formula + --converter-out fallback instructions')
+  end
+  fail_phase!('convert-beast-modes', "--convert step exited #{code}") unless ok
+
   pending_path = File.join(DISCOVERY, 'formulas.pending.json')
   pending = begin
     JSON.parse(File.read(pending_path))
@@ -379,19 +388,26 @@ def phase_convert_beast_modes!(opts)
     []
   end
   unresolved = pending.count { |e| e['sigmaFormula'].nil? || e['sigmaFormula'].to_s.strip.empty? }
+  unreliable = pending.count { |e| e['converted'] == false }
   if unresolved.positive?
-    log "NOTE: #{unresolved} Beast Mode(s) still lack a sigmaFormula — normally filled by calling " \
-        'convert_sql_to_sigma_formula per pending entry (see the script header) before --lint. ' \
-        'Running --lint now anyway: unresolved entries are DROPPED from formulas.json (never shipped ' \
-        'silently as-is), so this phase is only fully complete once formulas.pending.json is filled in ' \
-        'and re-linted.'
+    log "NOTE: #{unresolved} Beast Mode(s) still lack a sigmaFormula after --convert — unexpected " \
+        '(lookConvertExpression is a total fallback that never returns nil); check ' \
+        "convert-beast-modes.rb --convert's stderr output above."
+  end
+  if unreliable.positive?
+    log "NOTE: #{unreliable} Beast Mode(s) flagged converted:false by --convert — has a sigmaFormula " \
+        '(never silently dropped) but still contains untranslated CASE/WHEN/THEN or an infix ' \
+        'LIKE/BETWEEN; review before shipping (discovery/formula-overrides.json can supply a ' \
+        'hand-authored replacement).'
   end
 
   ok, code, _out = run_script!('convert-beast-modes.rb', '--lint')
   fail_phase!('convert-beast-modes', "--lint step exited #{code}") unless ok
 
-  if unresolved.positive?
-    done_phase!('convert-beast-modes', "#{unresolved} Beast Mode(s) unresolved — see discovery/formulas.pending.json")
+  if unresolved.positive? || unreliable.positive?
+    done_phase!('convert-beast-modes',
+                "#{unresolved} unresolved, #{unreliable} unreliable (converted:false) — see " \
+                'discovery/formulas.pending.json')
   else
     done_phase!('convert-beast-modes')
   end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -409,7 +409,8 @@ def phase_convert_beast_modes!(opts)
                 "#{unresolved} unresolved, #{unreliable} unreliable (converted:false) — see " \
                 'discovery/formulas.pending.json')
   else
-    done_phase!('convert-beast-modes')
+    done_phase!('convert-beast-modes',
+                'no residual CASE/infix syntax detected — not a full validity guarantee')
   end
 end
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/beast-modes.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/fixtures/domo-estate/beast-modes.json
@@ -1,0 +1,8 @@
+[
+  { "id": "calculation_e2e-1", "name": "Total Net Revenue", "scope": "dataset", "class": null,
+    "sql": "SUM(`Net Revenue`)" },
+  { "id": "calculation_e2e-2", "name": "Gross Margin Pct", "scope": "dataset", "class": null,
+    "sql": "CASE WHEN SUM(`Net Revenue`) = 0 THEN 0 ELSE SUM(`Gross Profit`)/SUM(`Net Revenue`) END" },
+  { "id": "calculation_e2e-3", "name": "US Customers", "scope": "dataset", "class": null,
+    "sql": "LOWER(`Country`) LIKE 'usa'" }
+]

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
@@ -1,0 +1,131 @@
+#!/usr/bin/env ruby
+# Accuracy fixture suite for the vendored converter/sql.mjs (Track E). Offline +
+# deterministic. Pattern copied from tableau-to-sigma's test-converter-fixtures.rb
+# (the exemplar this skill's own design doc cites): a symbol-count guard runs
+# UNCONDITIONALLY so a re-vendor that drops/renames a needed export hard-aborts
+# rather than silently skipping every fixture; if `node` is present, fixtures run
+# for real against the bundle; if absent, SKIPPED loudly, never a silent pass.
+#
+#   ruby test/test-convert-beast-modes-fixtures.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+
+VENDORED = File.expand_path('../converter/sql.mjs', __dir__)
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# ---------------------------------------------------------------------------
+# Representative Beast Mode SQL snippets (post-normalize_bm — backticks already
+# rewritten to [brackets], matching what --convert actually feeds the bundle).
+# Deliberately NOT the mcp's own 74-item corpus — that stays upstream-only; a
+# domo-side dependency on it would reintroduce exactly the coupling Track E
+# removes. :expect_converted false marks a formula this converter is KNOWN not
+# to fully translate (still an honest, present sigmaFormula) — never asserted
+# as a bug, just locked so a future upstream fix is noticed via NOTE below.
+# ---------------------------------------------------------------------------
+FIXTURES = [
+  { id: 'D-1', sql: 'SUM([Net Revenue])',                        expect: 'Sum([Net Revenue])' },
+  { id: 'D-2', sql: 'COUNT(DISTINCT [Order Id])',                 expect: 'CountDistinct([Order Id])' },
+  { id: 'D-3', sql: 'AVG([Order Total])',                         expect: 'Avg([Order Total])' },
+  { id: 'D-4', sql: 'SUM([Gross Profit]) / SUM([Net Revenue])',   expect: 'Sum([Gross Profit]) / Sum([Net Revenue])' },
+  { id: 'D-5', sql: "CASE WHEN [Status] = 'Active' THEN 1 ELSE 0 END",
+    expect: 'If([Status] = "Active", 1, 0)' },
+  { id: 'D-6', sql: 'MAX([Order Date])',                          expect: 'Max([Order Date])' },
+  { id: 'D-7', sql: 'MIN([Order Date])',                          expect: 'Min([Order Date])' },
+  { id: 'D-8', sql: 'ROUND([Margin Pct], 2)',                     expect: 'Round([Margin Pct], 2)' },
+  { id: 'D-9', sql: "DATEDIFF('day', [Order Date], [Ship Date])", expect: 'DateDiff("day", [Order Date], [Ship Date])' },
+  { id: 'D-10', sql: 'COALESCE([Discount], 0)',                   expect: 'Coalesce([Discount], 0)' },
+]
+# NOTE (converted:false expected): the vendored converter has no Sigma mapping
+# for LIKE/BETWEEN — this is intentional, not a bug (see design doc's Error
+# Handling section). Locks the honesty signal itself, not a translation.
+RESIDUAL_FIXTURES = [
+  { id: 'D-R1', sql: "LOWER([Country]) LIKE 'usa'" },
+  { id: 'D-R2', sql: '[Order Total] BETWEEN 100 AND 500' },
+]
+
+puts 'Accuracy fixtures — vendored converter/sql.mjs'
+abort "FATAL: vendored converter missing at #{VENDORED} — run tools/vendor-converters.sh <mcp-clone> domo" \
+  unless File.exist?(VENDORED)
+bundle = File.read(VENDORED, encoding: 'utf-8')
+
+# Symbol-count guard — UNCONDITIONAL, runs even without node. A re-vendor that
+# drops or renames any of these 5 exports must hard-abort, never silently skip
+# every fixture below.
+NEEDED = %w[lookSqlToSigmaRules lookConvertExpression hasResidualCaseKeyword hasResidualInfixOperator lookUnknownFunctions]
+missing = NEEDED.reject { |name| bundle.match?(/\b#{Regexp.escape(name)}\b/) }
+abort "converter fixture harness: converter/sql.mjs is missing expected export(s): #{missing.join(', ')} " \
+      '— the re-vendor dropped/renamed a needed function; update test-convert-beast-modes-fixtures.rb ' \
+      'or investigate the upstream change.' unless missing.empty?
+
+node_present = begin
+  _o, _e, st = Open3.capture3('node', '--version')
+  st.success?
+rescue Errno::ENOENT
+  false
+end
+
+if node_present
+  Dir.mktmpdir('domo-conv-fixtures') do |dir|
+    fx_path  = File.join(dir, 'fixtures.json')
+    res_path = File.join(dir, 'results.json')
+    all_fixtures = FIXTURES + RESIDUAL_FIXTURES
+    File.write(fx_path, JSON.generate(all_fixtures.map { |x| { 'id' => x[:id], 'sql' => x[:sql] } }))
+
+    import_specifier = Gem.win_platform? && VENDORED.match?(/\A[A-Za-z]:/) ? 'file:///' + VENDORED.gsub('\\', '/') : VENDORED
+    runner = File.join(dir, 'run.mjs')
+    File.write(runner, <<~JS)
+      import { readFileSync, writeFileSync } from 'node:fs';
+      import { lookSqlToSigmaRules, lookConvertExpression, hasResidualCaseKeyword, hasResidualInfixOperator } from #{import_specifier.to_json};
+      const fixtures = JSON.parse(readFileSync(#{fx_path.to_json}, 'utf8'));
+      const out = fixtures.map(({ id, sql }) => {
+        let sigmaFormula = lookSqlToSigmaRules(sql);
+        if (sigmaFormula == null) sigmaFormula = lookConvertExpression(sql);
+        const converted = !hasResidualCaseKeyword(sigmaFormula) && !hasResidualInfixOperator(sigmaFormula);
+        return { id, sigmaFormula, converted };
+      });
+      writeFileSync(#{res_path.to_json}, JSON.stringify(out));
+    JS
+
+    _o, e, st = Open3.capture3('node', runner)
+    if !st.success?
+      warn "FAIL — node fixture runner failed:\n#{e}"
+      exit 1
+    end
+
+    rows = JSON.parse(File.read(res_path, encoding: 'utf-8'))
+    by_id = {}
+    rows.each { |r| by_id[r['id']] = r }
+
+    FIXTURES.each do |fx|
+      r = by_id[fx[:id]]
+      check(r && r['sigmaFormula'] == fx[:expect] && r['converted'] == true,
+            "#{fx[:id]}  #{fx[:sql].inspect} → #{fx[:expect].inspect} (converted:true)", fails)
+    end
+
+    RESIDUAL_FIXTURES.each do |fx|
+      r = by_id[fx[:id]]
+      check(r && !r['sigmaFormula'].to_s.empty? && r['converted'] == false,
+            "#{fx[:id]}  #{fx[:sql].inspect} → present-but-converted:false (honest residual-LIKE/BETWEEN signal)", fails)
+    end
+  end
+else
+  warn '  WARN  node not found on PATH — accuracy fixtures SKIPPED ' \
+       "(#{FIXTURES.size + RESIDUAL_FIXTURES.size} fixtures unexercised). " \
+       'Install node (doctor.sh enforces it for the converter path) to run them.'
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
@@ -121,7 +121,14 @@ else
 end
 
 puts
-if fails.empty?
+if !node_present
+  # Zero fixtures ran — 'fails' is empty by construction, not because anything
+  # was verified. Never print the bare "ALL PASS" string here: a CI consumer
+  # that only checks the final line or exit code must not read a
+  # zero-coverage run as a clean, fully-exercised pass.
+  puts "SKIPPED — 0/#{FIXTURES.size + RESIDUAL_FIXTURES.size} fixtures exercised (node absent). This is NOT a verified pass."
+  exit 0
+elsif fails.empty?
   puts 'ALL PASS'
   exit 0
 else

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -8,6 +8,8 @@ require_relative '../scripts/convert-beast-modes'
 require 'json'
 require 'tmpdir'
 require 'fileutils'
+require 'open3'
+require 'rbconfig'
 
 SCRIPT = File.expand_path('../scripts/convert-beast-modes.rb', __dir__)
 
@@ -361,6 +363,52 @@ if node_present
   end
 else
   puts '== CLI --convert: SKIPPED (node not on PATH) =='
+end
+
+# ---------------------------------------------------------------------------
+# Review fix (Track E, 4/4): resolve_sql_converter only checks FILE EXISTENCE
+# of the bundle/dev build — it never confirmed `node` itself is invokable. A
+# resolved `conv` with no `node` on PATH used to fall straight into
+# Open3.capture3('node', runner), which raises an uncaught Errno::ENOENT — a
+# raw Ruby backtrace instead of the documented clean exit-10 fallback. This
+# test runs the REAL script (not a stub of the check) with a scrubbed PATH
+# that genuinely cannot resolve `node`, and proves it exits 10 with the same
+# GATE instructions a missing bundle gets — never a crash.
+#
+# `ruby` itself is invoked by RbConfig.ruby's ABSOLUTE path (not a bare 'ruby'
+# looked up on PATH), so only node's resolvability changes here. PATH is
+# trimmed to real coreutils dirs only (verified: neither nvm's nor Homebrew's
+# node lives under /usr/bin or /bin) with unsetenv_others — same idiom as
+# powerbi-to-sigma's test-bootstrap.rb "scrubbed environment" runs.
+# ---------------------------------------------------------------------------
+puts '== CLI --convert: resolved converter but `node` unavailable on PATH -> clean exit 10, never a raw crash =='
+Dir.mktmpdir('convert-mode-node-absent') do |dir|
+  mcp_dir = File.join(dir, 'fake-mcp')
+  FileUtils.mkdir_p(File.join(mcp_dir, 'build'))
+  File.write(File.join(mcp_dir, 'build', 'formulas.js'), <<~JS)
+    export function lookSqlToSigmaRules(sql) { return `RULES(${sql})`; }
+    export function lookConvertExpression(sql) { return `EXPR(${sql})`; }
+    export function hasResidualCaseKeyword(s) { return false; }
+    export function hasResidualInfixOperator(s) { return false; }
+    export function lookUnknownFunctions(sql) { return []; }
+  JS
+
+  pending_path = File.join(dir, 'formulas.pending.json')
+  before = JSON.generate([
+    { 'id' => 'calculation_x', 'name' => 'X', 'normalizedSql' => 'SUM([x])', 'sigmaFormula' => nil },
+  ])
+  File.write(pending_path, before)
+
+  env = { 'PATH' => '/usr/bin:/bin' }
+  cmd = [RbConfig.ruby, SCRIPT, '--convert', '--mcp-dir', mcp_dir, '--in', pending_path, '--out', pending_path]
+  out, status = Open3.capture2e(env, *cmd, unsetenv_others: true)
+
+  ok(status.exitstatus == 10, "resolved converter + node absent from PATH -> exit 10 (gate), not a crash\n#{out}")
+  ok(out.include?('GATE'), 'still prints the same GATE instructional fallback a missing bundle gets')
+  ok(out.downcase.include?('node'), 'names node as the specific reason (distinct from the missing-bundle message)')
+  ok(!out.include?('Errno::ENOENT') && !out.include?("#{SCRIPT}:"),
+     'no raw Ruby exception/backtrace leaks to the user (the bug this test guards against)')
+  ok(File.read(pending_path) == before, 'no formulas were translated — pending file is untouched by the aborted attempt')
 end
 
 puts

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -7,6 +7,7 @@
 require_relative '../scripts/convert-beast-modes'
 require 'json'
 require 'tmpdir'
+require 'fileutils'
 
 SCRIPT = File.expand_path('../scripts/convert-beast-modes.rb', __dir__)
 
@@ -207,6 +208,126 @@ Dir.mktmpdir('convert-beast-modes-no-overrides') do |dir|
   final = JSON.parse(File.read(out_path))
   ok(final.empty?, 'with no override and no sigmaFormula, the entry is still honestly dropped')
   ok(output.include?('Untranslated Metric'), 'the unresolved Beast Mode is still named in the drop warning')
+end
+
+# ---------------------------------------------------------------------------
+# resolve_sql_converter — Track E's 3-tier resolution (vendored default,
+# --mcp-dir/DOMO_MCP_DIR dev override, nil when neither resolves).
+# ---------------------------------------------------------------------------
+
+puts '== resolve_sql_converter: vendored bundle wins when no mcp_dir given =='
+Dir.mktmpdir('resolve-sql-conv') do |dir|
+  vendored = File.join(dir, 'sql.mjs')
+  File.write(vendored, '// fake bundle')
+  File.write(File.join(dir, 'PROVENANCE.json'), JSON.generate({ 'source_commit' => 'abc1234' }))
+  conv, dev_dir, desc = resolve_sql_converter(nil, vendored)
+  ok(conv == vendored, 'resolves to the vendored path')
+  ok(dev_dir.nil?, 'no dev build dir reported')
+  ok(desc.include?('VENDORED') && desc.include?('abc1234'), 'description names VENDORED + pinned commit')
+end
+
+puts '== resolve_sql_converter: --mcp-dir wins over vendored when both present =='
+Dir.mktmpdir('resolve-sql-conv-dev') do |dir|
+  vendored = File.join(dir, 'sql.mjs')
+  File.write(vendored, '// fake bundle')
+  mcp_dir = File.join(dir, 'mcp')
+  FileUtils.mkdir_p(File.join(mcp_dir, 'build'))
+  File.write(File.join(mcp_dir, 'build', 'formulas.js'), '// fake dev build')
+  conv, dev_dir, desc = resolve_sql_converter(mcp_dir, vendored)
+  ok(conv == File.join(mcp_dir, 'build', 'formulas.js'), 'resolves to the dev build, not vendored')
+  # resolve_sql_converter's 2nd tuple element is `dev_module` (the full resolved
+  # path), per the function's own doc comment and Step 7's usage — not the bare
+  # --mcp-dir. Same value as `conv` in this tier, since dev_module wins.
+  ok(dev_dir == File.join(mcp_dir, 'build', 'formulas.js'), 'dev build module path reported')
+  ok(desc.include?('DEV BUILD') && desc.include?('explicit opt-in'), 'description names DEV BUILD + opt-in')
+end
+
+puts '== resolve_sql_converter: nil when neither vendored nor --mcp-dir resolve =='
+Dir.mktmpdir('resolve-sql-conv-none') do |dir|
+  conv, dev_dir, desc = resolve_sql_converter(nil, File.join(dir, 'does-not-exist.mjs'))
+  ok(conv.nil?, 'no converter resolves')
+  ok(dev_dir.nil?, 'no dev dir')
+  ok(desc.nil?, 'no description when nothing resolves')
+end
+
+# ---------------------------------------------------------------------------
+# --convert CLI mode — plumbing test against a hand-authored FAKE stub module
+# (deterministic, no dependency on the real vendored bundle's translation
+# accuracy — that's covered separately by test-convert-beast-modes-fixtures.rb
+# against the real converter/sql.mjs). Exercises: shim generation, node
+# invocation, result merge, and the converted:false marking.
+# ---------------------------------------------------------------------------
+
+puts '== CLI --convert: dev-build tier (--mcp-dir) runs the fake stub end-to-end =='
+node_present = begin
+  _o, _e, st = Open3.capture3('node', '--version')
+  st.success?
+rescue Errno::ENOENT
+  false
+end
+
+if node_present
+  Dir.mktmpdir('convert-mode-fake-stub') do |dir|
+    mcp_dir = File.join(dir, 'fake-mcp')
+    FileUtils.mkdir_p(File.join(mcp_dir, 'build'))
+    File.write(File.join(mcp_dir, 'build', 'formulas.js'), <<~JS)
+      export function lookSqlToSigmaRules(sql) {
+        return sql.startsWith('FAIL_RULES') ? null : `RULES(${sql})`;
+      }
+      export function lookConvertExpression(sql) { return `EXPR(${sql})`; }
+      export function hasResidualCaseKeyword(s) { return s.includes('BADCASE'); }
+      export function hasResidualInfixOperator(s) { return s.includes('BADINFIX'); }
+      export function lookUnknownFunctions(sql) { return sql.includes('UNKNOWNFN') ? ['UNKNOWNFN'] : []; }
+    JS
+
+    pending_path = File.join(dir, 'formulas.pending.json')
+    out_path     = File.join(dir, 'formulas.pending.json') # in place
+    File.write(pending_path, JSON.generate([
+      { 'id' => 'calculation_clean-1', 'name' => 'Clean One', 'normalizedSql' => 'SUM([x])', 'sigmaFormula' => nil },
+      { 'id' => 'calculation_fallback-1', 'name' => 'Fallback One', 'normalizedSql' => 'FAIL_RULES SUM([x])', 'sigmaFormula' => nil },
+      { 'id' => 'calculation_badcase-1', 'name' => 'Bad Case One', 'normalizedSql' => 'BADCASE([x])', 'sigmaFormula' => nil },
+      { 'id' => 'calculation_unknownfn-1', 'name' => 'Unknown Fn One', 'normalizedSql' => 'UNKNOWNFN([x])', 'sigmaFormula' => nil },
+    ]))
+
+    cmd = ['ruby', SCRIPT, '--convert', '--mcp-dir', mcp_dir, '--in', pending_path, '--out', out_path]
+    output = IO.popen(cmd, err: [:child, :out], &:read)
+    ok($?.success?, "--convert exits 0 against a fake dev-build stub\n#{output unless $?.success?}")
+    ok(output.include?('DEV BUILD') && output.include?('explicit opt-in'), 'stderr names the DEV BUILD tier')
+
+    result = JSON.parse(File.read(out_path))
+    by_id = {}
+    result.each { |e| by_id[e['id']] = e }
+
+    ok(by_id['calculation_clean-1']['sigmaFormula'] == 'RULES(SUM([x]))', 'rule-engine path used when it returns non-null')
+    ok(by_id['calculation_clean-1']['converted'] == true, 'clean formula marked converted:true')
+
+    ok(by_id['calculation_fallback-1']['sigmaFormula'] == 'EXPR(FAIL_RULES SUM([x]))', 'falls back to lookConvertExpression when rules return null')
+
+    ok(by_id['calculation_badcase-1']['sigmaFormula'] == 'RULES(BADCASE([x]))', 'residual-flagged formula is still emitted, never dropped')
+    ok(by_id['calculation_badcase-1']['converted'] == false, 'residual CASE keyword marks converted:false')
+    ok(by_id['calculation_badcase-1']['note'].to_s.include?('Could not fully translate'), 'converted:false entry carries a note')
+
+    ok(by_id['calculation_unknownfn-1']['warnings'].any? { |w| w.include?('UNKNOWNFN') }, 'lookUnknownFunctions warning surfaced per entry')
+  end
+
+  puts '== CLI --convert: --converter-out tier-3 resume merges by id =='
+  Dir.mktmpdir('convert-mode-tier3') do |dir|
+    pending_path = File.join(dir, 'formulas.pending.json')
+    conv_out     = File.join(dir, 'manual-mcp-results.json')
+    File.write(pending_path, JSON.generate([
+      { 'id' => 'calculation_manual-1', 'name' => 'Manual One', 'normalizedSql' => 'SUM([x])', 'sigmaFormula' => nil },
+    ]))
+    File.write(conv_out, JSON.generate([
+      { 'id' => 'calculation_manual-1', 'sigmaFormula' => 'Sum([x])', 'converted' => true, 'warnings' => [] },
+    ]))
+    cmd = ['ruby', SCRIPT, '--convert', '--converter-out', conv_out, '--in', pending_path, '--out', pending_path]
+    output = IO.popen(cmd, err: [:child, :out], &:read)
+    ok($?.success?, "--converter-out resume exits 0\n#{output unless $?.success?}")
+    result = JSON.parse(File.read(pending_path))
+    ok(result.first['sigmaFormula'] == 'Sum([x])', 'manual MCP result merged into the pending file by id')
+  end
+else
+  puts '== CLI --convert: SKIPPED (node not on PATH) =='
 end
 
 puts

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -287,6 +287,13 @@ if node_present
       { 'id' => 'calculation_fallback-1', 'name' => 'Fallback One', 'normalizedSql' => 'FAIL_RULES SUM([x])', 'sigmaFormula' => nil },
       { 'id' => 'calculation_badcase-1', 'name' => 'Bad Case One', 'normalizedSql' => 'BADCASE([x])', 'sigmaFormula' => nil },
       { 'id' => 'calculation_unknownfn-1', 'name' => 'Unknown Fn One', 'normalizedSql' => 'UNKNOWNFN([x])', 'sigmaFormula' => nil },
+      # Re-run scenario: this entry already carries a stale converted:false +
+      # note from a PRIOR --convert run (e.g. before the bundle improved, or
+      # before normalizedSql was hand-edited to drop the offending syntax).
+      # Its normalizedSql is now clean — the note must NOT survive.
+      { 'id' => 'calculation_stale-note-1', 'name' => 'Stale Note One', 'normalizedSql' => 'SUM([y])',
+        'sigmaFormula' => 'RULES(OLD BAD SQL)', 'converted' => false,
+        'note' => 'STALE: a prior run flagged this as not fully translated' },
     ]))
 
     cmd = ['ruby', SCRIPT, '--convert', '--mcp-dir', mcp_dir, '--in', pending_path, '--out', out_path]
@@ -308,6 +315,10 @@ if node_present
     ok(by_id['calculation_badcase-1']['note'].to_s.include?('Could not fully translate'), 'converted:false entry carries a note')
 
     ok(by_id['calculation_unknownfn-1']['warnings'].any? { |w| w.include?('UNKNOWNFN') }, 'lookUnknownFunctions warning surfaced per entry')
+
+    stale = by_id['calculation_stale-note-1']
+    ok(stale['converted'] == true, 'stale-note entry re-processed to converted:true on re-run (clean sql, fresh compute)')
+    ok(stale['note'].nil?, 'stale converted:false note does NOT survive onto a now-clean converted:true result')
   end
 
   puts '== CLI --convert: --converter-out tier-3 resume merges by id =='
@@ -316,15 +327,37 @@ if node_present
     conv_out     = File.join(dir, 'manual-mcp-results.json')
     File.write(pending_path, JSON.generate([
       { 'id' => 'calculation_manual-1', 'name' => 'Manual One', 'normalizedSql' => 'SUM([x])', 'sigmaFormula' => nil },
+      # This entry already carries a stale converted:false + note from a prior
+      # run; the manual-mcp-results.json entry for it below has NO `note` key
+      # (the agent's hand-run convert_sql_to_sigma_formula call cleanly
+      # translated it this time) — the stale note must be cleared, not kept.
+      { 'id' => 'calculation_manual-stale-note', 'name' => 'Manual Stale Note', 'normalizedSql' => 'SUM([y])',
+        'sigmaFormula' => 'Old([y])', 'converted' => false, 'note' => 'STALE: previously flagged not fully translated' },
     ]))
     File.write(conv_out, JSON.generate([
       { 'id' => 'calculation_manual-1', 'sigmaFormula' => 'Sum([x])', 'converted' => true, 'warnings' => [] },
+      { 'id' => 'calculation_manual-stale-note', 'sigmaFormula' => 'Sum([y])', 'converted' => true, 'warnings' => [] },
+      # Typo'd / stale id present in the supplied file but matching NO pending
+      # entry — must warn loudly (mirrors unmatched_override_keys), never
+      # silently no-op.
+      { 'id' => 'calculation_typo-does-not-exist', 'sigmaFormula' => 'Sum([z])', 'converted' => true, 'warnings' => [] },
     ]))
     cmd = ['ruby', SCRIPT, '--convert', '--converter-out', conv_out, '--in', pending_path, '--out', pending_path]
     output = IO.popen(cmd, err: [:child, :out], &:read)
     ok($?.success?, "--converter-out resume exits 0\n#{output unless $?.success?}")
     result = JSON.parse(File.read(pending_path))
-    ok(result.first['sigmaFormula'] == 'Sum([x])', 'manual MCP result merged into the pending file by id')
+    by_id2 = {}
+    result.each { |e| by_id2[e['id']] = e }
+
+    ok(by_id2['calculation_manual-1']['sigmaFormula'] == 'Sum([x])', 'manual MCP result merged into the pending file by id')
+
+    ok(by_id2['calculation_manual-stale-note']['sigmaFormula'] == 'Sum([y])', 'manual result merged for the stale-note entry too')
+    ok(by_id2['calculation_manual-stale-note']['converted'] == true, 'stale-note entry updated to converted:true via --converter-out')
+    ok(by_id2['calculation_manual-stale-note']['note'].nil?, 'stale note cleared by --converter-out merge when src has no note')
+
+    ok(output.include?('calculation_typo-does-not-exist'), 'stderr names the --converter-out id that matched no pending entry')
+    ok(output.downcase.include?('unmatched') || output.downcase.include?('no beast mode'),
+       'stderr flags the unmatched id as such, not just a bare mention')
   end
 else
   puts '== CLI --convert: SKIPPED (node not on PATH) =='

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -138,6 +138,48 @@ ok(resolved_filled['sigmaFormula'] == 'Sum([Net Revenue])', 'auto-translated for
 ok(!resolved_filled.key?('_source'), 'no formula-override attribution when the override was not actually used')
 ok(warns_filled.any? { |w| w.include?('NOT applied') }, 'still warns that the override existed but was ignored (not a silent no-op)')
 
+puts '== resolve_entry: override is still NOT applied when the entry is converted:true (fully resolved), same as legacy no-converted-key shape =='
+pending_true = { 'id' => 'calculation_true-1', 'name' => 'Cleanly Converted', 'class' => nil,
+                 'sigmaFormula' => 'Sum([Net Revenue])', 'converted' => true }
+overrides_true = { 'calculation_true-1' => { 'sigmaFormula' => 'Avg([Net Revenue])' } }
+resolved_true, warns_true = resolve_entry(pending_true, overrides_true)
+ok(resolved_true['sigmaFormula'] == 'Sum([Net Revenue])', 'converted:true formula wins; override is not applied over a cleanly-converted entry')
+ok(!resolved_true.key?('_source'), 'no formula-override attribution when converted:true blocked the override')
+ok(warns_true.any? { |w| w.include?('NOT applied') && w.include?('converted:true') },
+   'the NOT-applied warning names converted:true as the reason (widened-rule wording)')
+
+# ---------------------------------------------------------------------------
+# Fix 2 (final review): widen override eligibility to also supersede a
+# converted:false formula, not just a blank one — --convert's
+# lookConvertExpression fallback is total, so a truly blank sigmaFormula is
+# now nearly unreachable in the orchestrated pipeline; converted:false is the
+# realistic "this needs an override" signal an operator actually hits.
+# ---------------------------------------------------------------------------
+
+puts '== resolve_entry: override DOES supersede a formula flagged converted:false (the widened rule) =='
+pending_unreliable = { 'id' => 'calculation_unreliable-1', 'name' => 'Unreliable Auto', 'class' => nil,
+                       'sigmaFormula' => 'Lower([Country]) LIKE "usa"', 'converted' => false,
+                       'note' => 'Could not fully translate — output still contains raw SQL syntax Sigma has no equivalent for (CASE/WHEN/THEN, or an infix LIKE/BETWEEN), do not use as-is' }
+overrides_unreliable = { 'calculation_unreliable-1' => { 'sigmaFormula' => 'Lower([Country]) = "usa"',
+                                                          'note' => 'hand-authored: LIKE has no Sigma equivalent for an exact match here' } }
+resolved_unreliable, warns_unreliable = resolve_entry(pending_unreliable, overrides_unreliable)
+ok(!resolved_unreliable.nil?, 'override supersedes a converted:false entry → entry is NOT dropped')
+ok(resolved_unreliable['sigmaFormula'] == 'Lower([Country]) = "usa"', 'sigmaFormula came from the override, not the automated converted:false result')
+ok(resolved_unreliable['converted'] == true, 'overridden entry is marked converted:true (human-authored, trusted) — the stale converted:false is cleared')
+ok(resolved_unreliable['note'] == 'hand-authored: LIKE has no Sigma equivalent for an exact match here',
+   'the emitted note is the override\'s own note — the stale automated "could not fully translate" note does NOT survive')
+ok(resolved_unreliable['_source'] == 'formula-override', 'attributed with _source: formula-override')
+ok(warns_unreliable.any? { |w| w.include?('Unreliable Auto') }, 'using the override on a converted:false entry still warns, naming the Beast Mode')
+
+puts '== resolve_entry: a converted:false entry with NO matching override still keeps its (unreliable) formula, unchanged =='
+pending_unreliable_no_ov = { 'id' => 'calculation_unreliable-2', 'name' => 'Unreliable No Override', 'class' => nil,
+                             'sigmaFormula' => 'Lower([Country]) LIKE "usa"', 'converted' => false }
+resolved_no_ov, warns_no_ov = resolve_entry(pending_unreliable_no_ov, {})
+ok(!resolved_no_ov.nil?, 'no override available → converted:false entry is still emitted (never silently dropped)')
+ok(resolved_no_ov['sigmaFormula'] == 'Lower([Country]) LIKE "usa"', 'the unreliable automated formula is left untouched when no override matches')
+ok(resolved_no_ov['converted'] == false, 'converted stays false — nothing forces it to true without an applied override')
+ok(warns_no_ov.any? { |w| w.include?('converted:false') }, 'still warns that this formula was flagged converted:false and an override would supersede it')
+
 puts '== resolve_entry: no override + no sigmaFormula → still dropped (unchanged honest-drop behaviour) =='
 pending_none = { 'id' => 'calculation_none-1', 'name' => 'Untranslatable', 'class' => nil, 'sigmaFormula' => nil }
 resolved_none, warns_none = resolve_entry(pending_none, {})

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -13,6 +13,7 @@
 
 require 'json'
 require 'tmpdir'
+require 'open3'
 
 SKILL   = File.expand_path('..', __dir__)
 SCRIPTS = File.join(SKILL, 'scripts')
@@ -43,7 +44,26 @@ ok(cards.any? { |c| c['summaryNumber'] && !Array(c['groupBy']).empty? },
    'sanity: fixture cards.json includes a non-Rule-0 card (real grouping) that ALSO carries a summaryNumber (bead 08sf)')
 ok(File.exist?(File.join(FIXTURE, 'dm-spec.json')), 'sanity: fixture stages dm-spec.json (build-dm.rb pre-post shape) for the ds-dim sub-master')
 ok(File.exist?(File.join(FIXTURE, 'dm-ids.json')), 'sanity: fixture stages dm-ids.json (synthesized post-and-readback) for the ds-dim sub-master')
+ok(File.exist?(File.join(FIXTURE, 'beast-modes.json')), 'sanity: fixture stages beast-modes.json so migrate-domo.rb\'s convert-beast-modes phase is actually exercised, not SKIPped')
 
+# Track E: the fixture's discovery/beast-modes.json (see test/fixtures/domo-estate/
+# beast-modes.json) drives migrate-domo.rb's convert-beast-modes phase through its
+# real --convert step, which shells out to `node` against the vendored
+# converter/sql.mjs (same as test-convert-beast-modes.rb / -fixtures.rb). Gate the
+# whole node-dependent pipeline run the same way those suites gate their node-only
+# assertions — a loud, honest SKIP (never a silent pass) when `node` is not on
+# PATH, rather than letting the entire offline pipeline hard-fail at the
+# convert-beast-modes phase (fail-fast semantics mean nothing downstream of that
+# phase — build-workbook, layout, etc. — would run either, so there is no useful
+# partial-assertion split here; the whole run is the unit that depends on node).
+node_present = begin
+  _o, _e, st = Open3.capture3('node', '--version')
+  st.success?
+rescue Errno::ENOENT
+  false
+end
+
+if node_present
 Dir.mktmpdir('migrate-domo-e2e') do |out_dir|
   cmd = ['ruby', File.join(SCRIPTS, 'migrate-domo.rb'), '--offline', FIXTURE, '--out', out_dir]
   output = IO.popen(cmd, err: [:child, :out], &:read)
@@ -62,6 +82,42 @@ Dir.mktmpdir('migrate-domo-e2e') do |out_dir|
   missing = required_phases.reject { |p| run_state['phases'].key?(p) }
   ok(missing.empty?, "run-state.json accounts for every phase in the chain (missing: #{missing.join(', ')})")
   eq(run_state['mode'], 'offline', 'run-state.json records mode=offline')
+
+  # ---- Track E: convert-beast-modes is actually exercised now that the -----
+  # fixture carries discovery/beast-modes.json (previously this phase was
+  # ALWAYS skip_phase!'d in this suite — no fixture ever supplied one).
+  ok(!output.include?('SKIP convert-beast-modes'),
+     'convert-beast-modes phase actually runs (no longer prints the SKIP convert-beast-modes line)')
+  eq(run_state['phases']['convert-beast-modes']['status'], 'done',
+     "run-state.json shows convert-beast-modes as done, not skip — #{run_state['phases']['convert-beast-modes'].inspect}")
+
+  formulas_path = File.join(out_dir, 'discovery', 'formulas.json')
+  ok(File.exist?(formulas_path), 'wrote discovery/formulas.json (the --convert + --lint steps ran for real, via node)')
+  if File.exist?(formulas_path)
+    formulas = JSON.parse(File.read(formulas_path))
+    eq(formulas.size, 3, 'all 3 fixture Beast Modes made it into formulas.json (none silently dropped)')
+    by_name = {}
+    formulas.each { |f| by_name[f['name']] = f }
+
+    revenue = by_name['Total Net Revenue']
+    ok(revenue && revenue['converted'] == true && revenue['sigmaFormula'] == 'Sum([Net Revenue])',
+       "Total Net Revenue (plain SUM) converts cleanly to Sum([Net Revenue]) — got #{revenue.inspect}")
+
+    margin = by_name['Gross Margin Pct']
+    ok(margin && margin['converted'] == true && margin['sigmaFormula'].to_s.start_with?('If('),
+       "Gross Margin Pct (CASE WHEN) converts cleanly to an If(...) (converted:true) — got #{margin.inspect}")
+
+    # Deliberately LIKE-shaped (design's known residual-operator case, same as
+    # test-convert-beast-modes-fixtures.rb's D-R1) — exercises converted:false.
+    us_customers = by_name['US Customers']
+    ok(us_customers && us_customers['converted'] == false,
+       "US Customers (LIKE) is honestly flagged converted:false, not silently marked clean — got #{us_customers.inspect}")
+    ok(us_customers && !us_customers['sigmaFormula'].to_s.strip.empty?,
+       'US Customers still carries a present (if unreliable) sigmaFormula — never silently dropped')
+
+    ok(formulas.all? { |f| Array(f['lintErrors']).empty? },
+       'none of the 3 fixture Beast Modes trip a lint ERROR')
+  end
 
   # ---- (a) layout-2d.flag == 'grid' (NOT 'stack') ------------------------
   flag_path = File.join(out_dir, 'layout-2d.flag')
@@ -167,6 +223,17 @@ Dir.mktmpdir('migrate-domo-e2e') do |out_dir|
   forced_state = JSON.parse(File.read(run_state_path))
   ok(built_phases.all? { |p| forced_state['phases'][p]['status'] == 'done' }, '--force rebuilds every phase (status done, not skip)')
   eq(File.read(flag_path).strip, 'grid', '--force re-run recomputes the same grid flag')
+end
+else
+  # Loud, honest skip — never a silent pass (same idiom as
+  # test-convert-beast-modes-fixtures.rb / test-convert-beast-modes.rb's
+  # node-gated sections). Zero assertions from the block above ran; do not
+  # print ALL PASS as if they had.
+  puts '  SKIPPED — 0 migrate-domo.rb --offline pipeline assertions exercised (`node` not on PATH). ' \
+       'test/fixtures/domo-estate/beast-modes.json now drives the convert-beast-modes phase\'s --convert ' \
+       'step, which requires node to run the vendored converter/sql.mjs (same as doctor.sh\'s hard node ' \
+       'requirement for this skill). Install node (see scripts/bootstrap.sh) to exercise this suite for real. ' \
+       'This is NOT a verified pass.'
 end
 
 # ---- fail-fast: a fixture missing cards.json aborts loudly, non-zero ------

--- a/tools/check-converter-provenance.sh
+++ b/tools/check-converter-provenance.sh
@@ -130,8 +130,19 @@ for p in paths:
         fail = True
         continue
     age = (today - pinned).days
-    mod = (d.get('vendored_modules') or '').split(',')[0].strip()
-    mod = mod[:-4] if mod.endswith('.mjs') else (mod or '<module>')
+    # vendor_arg (when present) is the RECORDED tools/vendor-converters.sh arg
+    # for this plugin — needed because domo's module basename ("sql") is NOT
+    # its vendor arg ("domo"); vendored_modules alone would suggest running
+    # `tools/vendor-converters.sh <checkout> sql`, a silent no-op (not a
+    # registered converter). Falls back to the vendored_modules-derived guess
+    # for the mainline 6, which have no vendor_arg field and where the guess
+    # is correct (module basename == vendor arg == upstream src file basename).
+    vendor_arg = d.get('vendor_arg')
+    if vendor_arg:
+        mod = vendor_arg
+    else:
+        mod = (d.get('vendored_modules') or '').split(',')[0].strip()
+        mod = mod[:-4] if mod.endswith('.mjs') else (mod or '<module>')
     if age > stale_days:
         # A bundle carrying an OPEN local_patches entry (not yet landed upstream) is
         # pinned ON PURPOSE — re-vendoring drops the patch. Hard-failing it demanded
@@ -202,8 +213,14 @@ print("in-skill" if "source_repo" not in d else "vendored")')"
     [ "$kind" = "vendored" ] || continue
     commit="$(printf '%s' "$d" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("source_commit") or "")')"
     mod="$(printf '%s' "$d" | python3 -c 'import json,sys; m=(json.load(sys.stdin).get("vendored_modules") or "").split(",")[0].strip(); print(m[:-4] if m.endswith(".mjs") else m)')"
+    # source_file (when present) is the RECORDED upstream path — needed
+    # because domo vendors src/formulas.ts, not src/sql.ts (module basename
+    # "sql" is unrelated to its real upstream source file). Falls back to the
+    # src/<mod>.ts guess for the mainline 6, which have no source_file field
+    # and where the guess is correct.
+    recorded_srcfile="$(printf '%s' "$d" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("source_file") or "")')"
     [ -n "$commit" ] || continue
-    srcfile="src/$mod.ts"
+    srcfile="${recorded_srcfile:-src/$mod.ts}"
     if ! git -C "$CHECKOUT" cat-file -e "$UP_HEAD:$srcfile" 2>/dev/null; then
       echo "  ? $p: $srcfile not found at $CHECKOUT HEAD ($UP_HEAD) — skipping live compare for this module"
       continue

--- a/tools/check-converter-provenance.sh
+++ b/tools/check-converter-provenance.sh
@@ -133,10 +133,14 @@ for p in paths:
     # vendor_arg (when present) is the RECORDED tools/vendor-converters.sh arg
     # for this plugin — needed because domo's module basename ("sql") is NOT
     # its vendor arg ("domo"); vendored_modules alone would suggest running
-    # `tools/vendor-converters.sh <checkout> sql`, a silent no-op (not a
-    # registered converter). Falls back to the vendored_modules-derived guess
-    # for the mainline 6, which have no vendor_arg field and where the guess
-    # is correct (module basename == vendor arg == upstream src file basename).
+    # tools/vendor-converters.sh with the arg "sql", a silent no-op (not a
+    # registered converter). NOTE: this comment intentionally avoids backticks
+    # — this whole block is embedded in a bash python3 -c "..." DOUBLE-quoted
+    # string, where a backtick pair triggers bash command substitution before
+    # python ever sees the text (a real bug this exact comment tripped over).
+    # Falls back to the vendored_modules-derived guess for the mainline 6,
+    # which have no vendor_arg field and where the guess is correct (module
+    # basename == vendor arg == upstream src file basename).
     vendor_arg = d.get('vendor_arg')
     if vendor_arg:
         mod = vendor_arg

--- a/tools/vendor-converters.sh
+++ b/tools/vendor-converters.sh
@@ -98,7 +98,26 @@ for mod in "${WANT[@]}"; do
       if (missing.length) { console.error('FATAL: $out missing exports: ' + missing.join(', ')); process.exit(1); }
     "
     echo "✓ $skill/converter/sql.mjs  ($(du -h "$out" | cut -f1))  [vendored from formulas.ts, custom export check]"
-    case "$STAMPED_DIRS" in *"|$dest|"*) : ;; *) STAMPED_DIRS="$STAMPED_DIRS|$dest|" ;; esac
+    # Domo is NOT added to STAMPED_DIRS: the shared post-loop block below
+    # writes a PROVENANCE.json shape that assumes vendored_modules' basename
+    # doubles as both the vendor-converters.sh arg AND the upstream src/<mod>.ts
+    # file — true for the mainline 6, false for domo (arg is "domo", upstream
+    # source is src/formulas.ts, not src/sql.ts). Write domo's own complete
+    # PROVENANCE.json here instead, with the two extra fields
+    # tools/check-converter-provenance.sh needs to get both right.
+    cat > "$dest/PROVENANCE.json" <<EOF
+{
+  "source_repo": "twells89/sigma-data-model-mcp",
+  "source_commit": "$SHA",
+  "source_commit_date": "$DATE",
+  "bundler": "esbuild --bundle --format=esm --platform=node",
+  "vendored_modules": "sql.mjs",
+  "source_file": "src/formulas.ts",
+  "vendor_arg": "domo",
+  "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."
+}
+EOF
+    echo "✓ $skill/converter/PROVENANCE.json  [domo's own — source_file=src/formulas.ts, vendor_arg=domo]"
     continue
   fi
 
@@ -116,11 +135,16 @@ for mod in "${WANT[@]}"; do
   case "$STAMPED_DIRS" in *"|$dest|"*) : ;; *) STAMPED_DIRS="$STAMPED_DIRS|$dest|" ;; esac
 done
 
-# one PROVENANCE.json per touched skill converter dir
-echo "$STAMPED_DIRS" | tr '|' '\n' | grep -v '^$' | sort -u | while read -r dest; do
-  [ -d "$dest" ] || continue
-  mods=$(ls "$dest"/*.mjs 2>/dev/null | xargs -n1 basename | paste -sd, -)
-  cat > "$dest/PROVENANCE.json" <<EOF
+# one PROVENANCE.json per touched skill converter dir (generic shape — domo
+# is deliberately never added to STAMPED_DIRS; it writes its own complete
+# PROVENANCE.json above, right after its bundle is built). A domo-only run
+# leaves STAMPED_DIRS empty — guard the pipeline so `grep -v '^$'` finding no
+# lines (exit 1) doesn't abort the script under `set -euo pipefail`.
+if [ -n "$STAMPED_DIRS" ]; then
+  echo "$STAMPED_DIRS" | tr '|' '\n' | grep -v '^$' | sort -u | while read -r dest; do
+    [ -d "$dest" ] || continue
+    mods=$(ls "$dest"/*.mjs 2>/dev/null | xargs -n1 basename | paste -sd, -)
+    cat > "$dest/PROVENANCE.json" <<EOF
 {
   "source_repo": "twells89/sigma-data-model-mcp",
   "source_commit": "$SHA",
@@ -130,6 +154,7 @@ echo "$STAMPED_DIRS" | tr '|' '\n' | grep -v '^$' | sort -u | while read -r dest
   "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."
 }
 EOF
-done
+  done
+fi
 
 echo "Done — source $SHA ($DATE). Commit the converter/ diffs."

--- a/tools/vendor-converters.sh
+++ b/tools/vendor-converters.sh
@@ -34,11 +34,12 @@ skill_for() {
     powerbi) echo powerbi-to-sigma ;;
     quicksight) echo quicksight-to-sigma ;;
     cognos|cognos-report) echo cognos-to-sigma ;;
+    domo) echo domo-to-sigma ;;
     *) echo "" ;;
   esac
 }
 
-WANT=("$@"); [ ${#WANT[@]} -eq 0 ] && WANT=(tableau lookml thoughtspot qlik powerbi quicksight cognos)
+WANT=("$@"); [ ${#WANT[@]} -eq 0 ] && WANT=(tableau lookml thoughtspot qlik powerbi quicksight cognos domo)
 
 [ -d "$SRC" ] || { echo "FATAL: converter source not found: $SRC"; exit 1; }
 ESBUILD="$SRC/node_modules/.bin/esbuild"
@@ -75,6 +76,29 @@ for mod in "${WANT[@]}"; do
     # source_sha256 here (single owner: tools/check-cognos-bundle.rb) is what lets the
     # freshness gate detect a converter/*.ts edit that skipped this re-bundle.
     ruby "$ROOT/tools/check-cognos-bundle.rb" --write
+    continue
+  fi
+
+  # Domo is a third flavor: same ongoing vendor-from-mcp relationship as the
+  # mainline 6 (canonical source stays upstream, re-vendor periodically — domo
+  # inherits future accuracy fixes the same way they do), but its source module
+  # doesn't follow the convert<Tool>ToSigma naming convention. It vendors
+  # formulas.ts, a shared low-level SQL-formula toolkit already used internally
+  # by lookml/dbt/snowflake/tableau's own converters — not a top-level
+  # converter — so the entry file and the export sanity-check are both custom.
+  if [ "$mod" = "domo" ]; then
+    entry="$SRC/build/formulas.js"
+    out="$dest/sql.mjs"
+    [ -f "$entry" ] || { echo "FATAL: $entry missing (build the converter repo first)"; exit 1; }
+    "$ESBUILD" "$entry" --bundle --format=esm --platform=node --outfile="$out" >/dev/null
+    node --input-type=module -e "
+      import * as m from '$out';
+      const need = ['lookSqlToSigmaRules','lookConvertExpression','hasResidualCaseKeyword','hasResidualInfixOperator','lookUnknownFunctions'];
+      const missing = need.filter(k => typeof m[k] !== 'function');
+      if (missing.length) { console.error('FATAL: $out missing exports: ' + missing.join(', ')); process.exit(1); }
+    "
+    echo "✓ $skill/converter/sql.mjs  ($(du -h "$out" | cut -f1))  [vendored from formulas.ts, custom export check]"
+    case "$STAMPED_DIRS" in *"|$dest|"*) : ;; *) STAMPED_DIRS="$STAMPED_DIRS|$dest|" ;; esac
     continue
   fi
 


### PR DESCRIPTION
## Summary

Removes `domo-to-sigma`'s live-MCP dependency for Beast Mode SQL → Sigma formula
translation — it was the only converter plugin without a `converter/` bundle,
relying on an agent hand-relaying `convert_sql_to_sigma_formula` MCP calls one
formula at a time in the middle of an otherwise-scripted pipeline.

**Design correction (the reason this took real investigation, not just a build):**
two prior design write-ups for this track disagreed with each other, and both
turned out to be wrong on their load-bearing claim, in opposite directions. This
PR's design doc re-verified the facts directly against `sigma-data-model-mcp` and
found: no upstream mcp-repo change is needed for either originally-proposed reason,
and the standard **vendor-from-mcp** pattern (matching
tableau/lookml/thoughtspot/qlik/powerbi/quicksight) is correct — not "port and own,"
which would freeze translation quality and require manually re-deriving every future
upstream fix (and `formulas.ts` has had 4 merged fixes in the 3 days before this
doc alone).

**What shipped:**
- `converter/sql.mjs` — a new committed, self-contained bundle vendoring 5 functions
  from `sigma-data-model-mcp`'s `src/formulas.ts`, via a new "third flavor" of
  `tools/vendor-converters.sh` (vendor-from-mcp relationship, but a custom entry
  module + custom export check, since `formulas.ts` is a shared low-level toolkit,
  not a top-level converter).
- `convert-beast-modes.rb --convert` — a new CLI mode replacing the agent-relay step
  with one local `node` invocation, with a 3-tier resolution ladder (vendored bundle
  default → `--mcp-dir`/`DOMO_MCP_DIR` dev override → exit-10 last-resort manual
  fallback), matching `powerbi-to-sigma`'s existing pattern.
- An offline accuracy fixture suite testing the real vendored bundle against 12
  representative Beast Mode SQL shapes.
- `migrate-domo.rb` wired to run `--convert` automatically; docs updated; plugin
  version bumped `0.9.1 → 0.10.1`.
- `discovery/formula-overrides.json`'s override eligibility widened to also
  supersede a `converted:false` result (not just a blank one) — the automated
  fallback converter is total (always produces *some* formula), so "blank" alone
  had become nearly unreachable in the orchestrated pipeline.
- Two incidental bugs found and fixed in shared tooling along the way: a
  `set -euo pipefail` abort on a domo-only (or cognos-only) `vendor-converters.sh`
  run, and a stray error line in `check-converter-provenance.sh` from a backtick
  inside an embedded Python comment.

Built via `brainstorming` → `writing-plans` → `subagent-driven-development`: 4 tasks,
each independently implemented and reviewed (with fix rounds where needed), plus a
final whole-branch review on the most capable model, plus one combined fix wave
covering all 7 of its findings, plus a scoped re-review of that wave that
independently re-executed every fix rather than trusting the report.

**Live E2E validation (this session, 2026-08-03):** ran the real pipeline against
`thomas-dev-1107913.domo.com`'s "Orders Overview" (Tier 1) page, real credentials,
zero mocks. Confirmed directly in the log: `converter: VENDORED converter/sql.mjs
(pinned 2f8c6cd) — no data egress` — the new local converter path runs with **zero
MCP calls**, exactly as designed. Real parity (live Domo SQL vs. live Sigma query):
**100% (8/8 elements)**. 5/5 source anchors matched. 39/39 data-model columns clean
(no `type=error`) — including a hand-fixed `ORDER_DATE` derivation after finding a
real, pre-existing (non-Track-E) bug in `preflight-columns.rb`'s auto-suggested
formula (used the raw warehouse column name instead of Sigma's display-name form;
not fixed in this PR, filed separately). Visual render read directly against the
source: composition/shape/category-order match exactly; the only divergences are
the same pre-existing, already-documented gaps from the 2026-07-30/31 Track A/B
validations (Domo's abbreviated K-format numbers vs. Sigma's raw decimals;
continuously-growing live warehouse drift) — not introduced by this change.
`assert-phase6-ran.rb`'s formal GREEN exit was blocked by a separate, newly-found
gate-tooling gap (its anchors-oracle fallback hard-requires a Tableau-only
per-tile visual-verify manifest domo has no generator for) — filed as
`beads-sigma-co6m`, not a Track E defect.

## Test plan
- [x] Full domo-to-sigma test suite (`test/run-all.sh`) — all suites pass
- [x] New accuracy fixture suite (`test-convert-beast-modes-fixtures.rb`) — 12/12
      fixtures pass against the real vendored bundle
- [x] `migrate-domo.rb`'s offline e2e test now actually exercises the `--convert`
      phase (previously silently skipped for lack of a fixture)
- [x] `tools/check-shared.rb`, `bash -n tools/vendor-converters.sh`,
      `tools/check-converter-provenance.sh --freshness`, plugin-version-bump gate —
      all pass
- [x] Live E2E validation against a real Domo instance (see above) — zero MCP
      calls confirmed, 100% real parity, visual match confirmed
- [x] TJ review