### PR TITLE
fix(shared): a SKIPped gate-3 column audit is recorded and caps at YELLOW (ruzs)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex → Sigma",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Migrate Hex projects to Sigma — SQL cells, single-value/METRIC cells, and EXPLORE charts → Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/degradation_ledger.rb
@@ -48,7 +48,9 @@
 #                       assert-phase6-ran on every run), minus the POLICY
 #                       exclusions (--skip-telemetry-gate; --skip-visual-
 #                       comparison under the sanctioned /verifier/i split) and
-#                       minus flags reclassified below.
+#                       minus flags reclassified below; plus column-scan.json
+#                       skipped-* statuses (gate 3/7's runtime auto-skips —
+#                       ruzs: an unaudited workbook must never keep GREEN).
 #   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
 #                       waivers, stale-skill, degraded fast path, and the
 #                       PR-14 `skip-flag-waived` records every closed --skip-*
@@ -116,6 +118,7 @@ module DegradationLedger
     entries = []
     entries.concat(scope_cuts(workdir))
     entries.concat(quality_waivers(workdir))
+    entries.concat(column_scan_skips(workdir))
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
@@ -251,6 +254,24 @@ module DegradationLedger
       out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
     end
     out
+  end
+
+  # Gate 3/7's runtime auto-skips (ruzs): column-scan.json is stamped by
+  # assert-phase6-ran at audit time — complete-clean is positive evidence and
+  # derives nothing; a skipped-* status means the live column audit NEVER
+  # verified the workbook, which is the same degradation class as an operator
+  # --skip-column-check (quality-waiver → verdict at most YELLOW). Kept
+  # separate from the census: these skips are runtime conditions, not flags,
+  # so they must not depend on the waiver census having been stamped.
+  def column_scan_skips(wd)
+    scan = read_json(wd, 'column-scan.json')
+    return [] unless scan.is_a?(Hash) && scan['status'].to_s.start_with?('skipped-')
+    reason = scan['reason'].to_s
+    reason = scan['status'].to_s if reason.empty?
+    detail = scan['columns_read'] ? " (#{scan['columns_read']} column(s) read before the stop)" : ''
+    [entry('quality-waiver', 'gate-3-column-scan',
+           "live column type=error audit #{scan['status']}: #{reason}#{detail}",
+           'column-scan.json')]
   end
 
   def recorded_escapes(wd)

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/degradation_ledger.rb
@@ -48,7 +48,9 @@
 #                       assert-phase6-ran on every run), minus the POLICY
 #                       exclusions (--skip-telemetry-gate; --skip-visual-
 #                       comparison under the sanctioned /verifier/i split) and
-#                       minus flags reclassified below.
+#                       minus flags reclassified below; plus column-scan.json
+#                       skipped-* statuses (gate 3/7's runtime auto-skips —
+#                       ruzs: an unaudited workbook must never keep GREEN).
 #   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
 #                       waivers, stale-skill, degraded fast path, and the
 #                       PR-14 `skip-flag-waived` records every closed --skip-*
@@ -116,6 +118,7 @@ module DegradationLedger
     entries = []
     entries.concat(scope_cuts(workdir))
     entries.concat(quality_waivers(workdir))
+    entries.concat(column_scan_skips(workdir))
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
@@ -251,6 +254,24 @@ module DegradationLedger
       out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
     end
     out
+  end
+
+  # Gate 3/7's runtime auto-skips (ruzs): column-scan.json is stamped by
+  # assert-phase6-ran at audit time — complete-clean is positive evidence and
+  # derives nothing; a skipped-* status means the live column audit NEVER
+  # verified the workbook, which is the same degradation class as an operator
+  # --skip-column-check (quality-waiver → verdict at most YELLOW). Kept
+  # separate from the census: these skips are runtime conditions, not flags,
+  # so they must not depend on the waiver census having been stamped.
+  def column_scan_skips(wd)
+    scan = read_json(wd, 'column-scan.json')
+    return [] unless scan.is_a?(Hash) && scan['status'].to_s.start_with?('skipped-')
+    reason = scan['reason'].to_s
+    reason = scan['status'].to_s if reason.empty?
+    detail = scan['columns_read'] ? " (#{scan['columns_read']} column(s) read before the stop)" : ''
+    [entry('quality-waiver', 'gate-3-column-scan',
+           "live column type=error audit #{scan['status']}: #{reason}#{detail}",
+           'column-scan.json')]
   end
 
   def recorded_escapes(wd)

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/degradation_ledger.rb
@@ -48,7 +48,9 @@
 #                       assert-phase6-ran on every run), minus the POLICY
 #                       exclusions (--skip-telemetry-gate; --skip-visual-
 #                       comparison under the sanctioned /verifier/i split) and
-#                       minus flags reclassified below.
+#                       minus flags reclassified below; plus column-scan.json
+#                       skipped-* statuses (gate 3/7's runtime auto-skips —
+#                       ruzs: an unaudited workbook must never keep GREEN).
 #   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
 #                       waivers, stale-skill, degraded fast path, and the
 #                       PR-14 `skip-flag-waived` records every closed --skip-*
@@ -116,6 +118,7 @@ module DegradationLedger
     entries = []
     entries.concat(scope_cuts(workdir))
     entries.concat(quality_waivers(workdir))
+    entries.concat(column_scan_skips(workdir))
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
@@ -251,6 +254,24 @@ module DegradationLedger
       out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
     end
     out
+  end
+
+  # Gate 3/7's runtime auto-skips (ruzs): column-scan.json is stamped by
+  # assert-phase6-ran at audit time — complete-clean is positive evidence and
+  # derives nothing; a skipped-* status means the live column audit NEVER
+  # verified the workbook, which is the same degradation class as an operator
+  # --skip-column-check (quality-waiver → verdict at most YELLOW). Kept
+  # separate from the census: these skips are runtime conditions, not flags,
+  # so they must not depend on the waiver census having been stamped.
+  def column_scan_skips(wd)
+    scan = read_json(wd, 'column-scan.json')
+    return [] unless scan.is_a?(Hash) && scan['status'].to_s.start_with?('skipped-')
+    reason = scan['reason'].to_s
+    reason = scan['status'].to_s if reason.empty?
+    detail = scan['columns_read'] ? " (#{scan['columns_read']} column(s) read before the stop)" : ''
+    [entry('quality-waiver', 'gate-3-column-scan',
+           "live column type=error audit #{scan['status']}: #{reason}#{detail}",
+           'column-scan.json')]
   end
 
   def recorded_escapes(wd)

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/degradation_ledger.rb
@@ -48,7 +48,9 @@
 #                       assert-phase6-ran on every run), minus the POLICY
 #                       exclusions (--skip-telemetry-gate; --skip-visual-
 #                       comparison under the sanctioned /verifier/i split) and
-#                       minus flags reclassified below.
+#                       minus flags reclassified below; plus column-scan.json
+#                       skipped-* statuses (gate 3/7's runtime auto-skips —
+#                       ruzs: an unaudited workbook must never keep GREEN).
 #   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
 #                       waivers, stale-skill, degraded fast path, and the
 #                       PR-14 `skip-flag-waived` records every closed --skip-*
@@ -116,6 +118,7 @@ module DegradationLedger
     entries = []
     entries.concat(scope_cuts(workdir))
     entries.concat(quality_waivers(workdir))
+    entries.concat(column_scan_skips(workdir))
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
@@ -251,6 +254,24 @@ module DegradationLedger
       out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
     end
     out
+  end
+
+  # Gate 3/7's runtime auto-skips (ruzs): column-scan.json is stamped by
+  # assert-phase6-ran at audit time — complete-clean is positive evidence and
+  # derives nothing; a skipped-* status means the live column audit NEVER
+  # verified the workbook, which is the same degradation class as an operator
+  # --skip-column-check (quality-waiver → verdict at most YELLOW). Kept
+  # separate from the census: these skips are runtime conditions, not flags,
+  # so they must not depend on the waiver census having been stamped.
+  def column_scan_skips(wd)
+    scan = read_json(wd, 'column-scan.json')
+    return [] unless scan.is_a?(Hash) && scan['status'].to_s.start_with?('skipped-')
+    reason = scan['reason'].to_s
+    reason = scan['status'].to_s if reason.empty?
+    detail = scan['columns_read'] ? " (#{scan['columns_read']} column(s) read before the stop)" : ''
+    [entry('quality-waiver', 'gate-3-column-scan',
+           "live column type=error audit #{scan['status']}: #{reason}#{detail}",
+           'column-scan.json')]
   end
 
   def recorded_escapes(wd)

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/degradation_ledger.rb
@@ -48,7 +48,9 @@
 #                       assert-phase6-ran on every run), minus the POLICY
 #                       exclusions (--skip-telemetry-gate; --skip-visual-
 #                       comparison under the sanctioned /verifier/i split) and
-#                       minus flags reclassified below.
+#                       minus flags reclassified below; plus column-scan.json
+#                       skipped-* statuses (gate 3/7's runtime auto-skips —
+#                       ruzs: an unaudited workbook must never keep GREEN).
 #   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
 #                       waivers, stale-skill, degraded fast path, and the
 #                       PR-14 `skip-flag-waived` records every closed --skip-*
@@ -116,6 +118,7 @@ module DegradationLedger
     entries = []
     entries.concat(scope_cuts(workdir))
     entries.concat(quality_waivers(workdir))
+    entries.concat(column_scan_skips(workdir))
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
@@ -251,6 +254,24 @@ module DegradationLedger
       out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
     end
     out
+  end
+
+  # Gate 3/7's runtime auto-skips (ruzs): column-scan.json is stamped by
+  # assert-phase6-ran at audit time — complete-clean is positive evidence and
+  # derives nothing; a skipped-* status means the live column audit NEVER
+  # verified the workbook, which is the same degradation class as an operator
+  # --skip-column-check (quality-waiver → verdict at most YELLOW). Kept
+  # separate from the census: these skips are runtime conditions, not flags,
+  # so they must not depend on the waiver census having been stamped.
+  def column_scan_skips(wd)
+    scan = read_json(wd, 'column-scan.json')
+    return [] unless scan.is_a?(Hash) && scan['status'].to_s.start_with?('skipped-')
+    reason = scan['reason'].to_s
+    reason = scan['status'].to_s if reason.empty?
+    detail = scan['columns_read'] ? " (#{scan['columns_read']} column(s) read before the stop)" : ''
+    [entry('quality-waiver', 'gate-3-column-scan',
+           "live column type=error audit #{scan['status']}: #{reason}#{detail}",
+           'column-scan.json')]
   end
 
   def recorded_escapes(wd)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-assert-phase6-gates.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-assert-phase6-gates.rb
@@ -1446,17 +1446,24 @@ end
 # regardless of the waiver budget; the success marker records the verdict.
 # =============================================================================
 
-# clean baseline → VERDICT: GREEN, empty ledger written, verdict stamped.
+# clean OFFLINE baseline → VERDICT: YELLOW, never GREEN (ruzs): this harness
+# resolves no workbook id, so gate 3/7's live column audit auto-skips — and a
+# workbook whose live columns were never audited must not claim GREEN. The
+# skip is recorded (column-scan.json → exactly one quality-waiver ledger
+# entry). GREEN-with-a-completed-audit is pinned by the canonical
+# test-assert-phase6.rb stub-server scenario, not here.
 Dir.mktmpdir do |dir|
   base_workdir(dir)
   out, _err, st = run_gate(dir)
-  check(st.success? && out.include?('VERDICT: GREEN'), 'clean run → VERDICT: GREEN on the final line', fails)
+  check(st.success? && out.include?('VERDICT: YELLOW'),
+        'clean offline run → VERDICT: YELLOW (unaudited live columns forfeit GREEN)', fails)
   led = JSON.parse(File.read(File.join(dir, 'degradation-ledger.json')))
-  check(led['entries'] == [], 'clean run writes an EMPTY degradation-ledger.json (presence proves derivation ran)', fails)
+  check(led['entries'].length == 1 && led['entries'].first['item'] == 'gate-3-column-scan',
+        'the ONLY ledger entry is the recorded gate-3 auto-skip (quality-waiver)', fails)
   succ = JSON.parse(File.read(File.join(dir, 'phase6-success.json')))
-  check(succ['verdict'] == 'GREEN', 'the DONE marker records the GREEN verdict string', fails)
+  check(succ['verdict'] == 'YELLOW', 'the DONE marker records the YELLOW verdict string', fails)
   pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
-  check(pf['verdict'] == 'GREEN', 'parity-final.json carries the verdict beside the census', fails)
+  check(pf['verdict'] == 'YELLOW', 'parity-final.json carries the verdict beside the census', fails)
 end
 
 # 1 within-budget quality waiver → gates pass, but GREEN is forfeited: YELLOW.
@@ -1486,8 +1493,10 @@ Dir.mktmpdir do |dir|
         'the ledger is written even on the budget-fail path', fails)
 end
 
-# 1 dropped tile (coverage.json) + 0 waivers → PARTIAL: a scope cut caps the
-# verdict even on a run that spends NO waiver budget.
+# 1 dropped tile (coverage.json) + 0 waivers → PARTIAL+YELLOW on this offline
+# harness: the scope cut caps at PARTIAL even with NO waiver budget spent, and
+# the recorded gate-3 auto-skip (unaudited live columns, ruzs) notes YELLOW
+# beside it. PARTIAL stays the dominant verdict.
 Dir.mktmpdir do |dir|
   base_workdir(dir)
   File.write(File.join(dir, 'coverage.json'), JSON.pretty_generate(
@@ -1495,13 +1504,13 @@ Dir.mktmpdir do |dir|
     'unresolved' => [{ 'visual' => 'Region Map', 'severity' => 'dropped', 'detail' => 'no basemap support' }]))
   out, _err, st = run_gate(dir)
   check(st.success?, "dropped tile with 0 waivers still passes the gates (got #{st.exitstatus})", fails)
-  check(out.include?('VERDICT: PARTIAL') && !out.include?('VERDICT: PARTIAL+YELLOW'),
-        '1 dropped tile + 0 waivers → VERDICT: PARTIAL (not YELLOW)', fails)
+  check(out.include?('VERDICT: PARTIAL+YELLOW'),
+        '1 dropped tile + unaudited columns → VERDICT: PARTIAL+YELLOW (scope cut dominant)', fails)
   check(out.include?('[scope-cut]') && out.include?('Region Map'),
         'the scope cut prints inline, named', fails)
   check(out.include?('SUBSET of the source'), 'PARTIAL explains the scope-cut meaning', fails)
   succ = JSON.parse(File.read(File.join(dir, 'phase6-success.json')))
-  check(succ['verdict'] == 'PARTIAL', 'the DONE marker records PARTIAL', fails)
+  check(succ['verdict'] == 'PARTIAL+YELLOW', 'the DONE marker records PARTIAL+YELLOW', fails)
 end
 
 # scope cut + within-budget waiver → both co-occur: PARTIAL+YELLOW, exit 0.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-degradation-ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-degradation-ledger.rb
@@ -246,6 +246,40 @@ Dir.mktmpdir do |wd|
         'report_lines renders one line per entry with its class', fails)
 end
 
+# ---- quality-waiver: gate-3 column scan skipped at runtime (ruzs) ------------
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'column-scan.json'), JSON.pretty_generate(
+    'gate' => 'gate 3/7 live column type=error scan',
+    'status' => 'skipped-incomplete', 'columns_read' => 37, 'http' => '500',
+    'reason' => 'live column scan did not complete'))
+  entries = DegradationLedger.derive(wd)
+  qw = entries.select { |e| e['class'] == 'quality-waiver' }
+  check(qw.length == 1, "skipped-incomplete column scan → 1 quality-waiver (got #{qw.length})", fails)
+  check(items(qw) == ['gate-3-column-scan'], 'the entry is named gate-3-column-scan', fails)
+  check(DegradationLedger.verdict(entries) == 'YELLOW',
+        'a run whose live column audit did not complete caps at YELLOW', fails)
+end
+
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'column-scan.json'), JSON.pretty_generate(
+    'gate' => 'gate 3/7 live column type=error scan',
+    'status' => 'skipped-no-workbook-id',
+    'reason' => 'no workbook ID resolvable'))
+  entries = DegradationLedger.derive(wd)
+  check(classes(entries) == ['quality-waiver'], 'no-workbook-id skip derives a quality-waiver', fails)
+  check(DegradationLedger.verdict(entries) == 'YELLOW', 'no-workbook-id skip → YELLOW', fails)
+end
+
+# ---- a COMPLETE clean scan is positive evidence, not a degradation -----------
+Dir.mktmpdir do |wd|
+  File.write(File.join(wd, 'column-scan.json'), JSON.pretty_generate(
+    'gate' => 'gate 3/7 live column type=error scan',
+    'status' => 'complete-clean', 'columns_read' => 118))
+  entries = DegradationLedger.derive(wd)
+  check(entries == [], 'complete-clean column scan derives no entry', fails)
+  check(DegradationLedger.verdict(entries) == 'GREEN', 'complete-clean keeps GREEN reachable', fails)
+end
+
 puts
 if fails.empty?
   puts 'ALL PASS — degradation ledger derivation (every artifact class) + verdict matrix'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-evidence-gates.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-evidence-gates.rb
@@ -77,7 +77,10 @@ Dir.mktmpdir do |dir|
   entries = ledger(dir)
   summary = entries.find { |e| e['gate'] == 'phase6-gates' }
   check(!summary.nil?, 'terminal run-summary entry appended')
-  check(summary && summary['verdict'] == 'GREEN' && summary['evidence_kind'] == 'gate-summary',
+  # ruzs: this offline harness resolves no workbook id, so gate 3/7's live
+  # column audit auto-skips and is RECORDED — an unaudited run is YELLOW, not
+  # GREEN. The summary MECHANISM (entry shape, keying) is what this pins.
+  check(summary && summary['verdict'] == 'YELLOW' && summary['evidence_kind'] == 'gate-summary',
         "summary carries the PR-14 verdict (got #{summary && summary['verdict']})")
   check(summary && summary['evidence_key'] =~ /\Awb:.*@v/ && summary['at'] =~ /Z\z/,
         'summary is version-keyed and timestamped')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wave2-verdict-gates.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wave2-verdict-gates.rb
@@ -17,7 +17,10 @@
 #
 # Runs the real script per scenario in a scratch workdir with no SIGMA_* env,
 # so live gates SKIP and the file-based gates are exercised (the
-# test-assert-phase6-gates.rb harness pattern).
+# test-assert-phase6-gates.rb harness pattern). EXCEPTION (ruzs): the W2.3
+# verdict-labeling scenarios run AUDITED via run_gate_audited — a local stub
+# serves gate 3/7 a complete clean /columns page, because GREEN is only
+# mintable over a finished live column audit now.
 #
 # Usage:  ruby scripts/test-wave2-verdict-gates.rb
 require 'json'
@@ -306,11 +309,46 @@ def run_verify(dir, *args)
   [out, err, st]
 end
 
+# ruzs: GREEN now requires gate 3/7's live column audit to have COMPLETED —
+# the silent-skip free pass is gone, so the verdict scenarios below need an
+# honestly AUDITED clean run. One local stub Sigma serves /columns a complete
+# clean page; every other path (the shared live-spec fetch for gates 4/6/7/7b)
+# gets 404 and keeps those gates' existing no-spec behavior. verify-complete
+# needs no stub: it re-derives offline from the recorded column-scan.json.
+require 'socket'
+AUDIT_STUB = TCPServer.new('127.0.0.1', 0)
+AUDIT_PORT = AUDIT_STUB.addr[1]
+Thread.new do
+  loop do
+    c = AUDIT_STUB.accept
+    req = c.gets.to_s
+    while (l = c.gets) && l != "\r\n"; end
+    if req.include?('/columns')
+      body = JSON.generate('entries' => [{ 'columnId' => 'c1', 'label' => 'A',
+                                           'type' => { 'type' => 'number' } }])
+      c.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+              "Content-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n#{body}")
+    else
+      c.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+    end
+    c.close
+  end
+rescue StandardError
+  nil
+end
+
+def run_gate_audited(dir, *args)
+  File.write(File.join(dir, 'wb-ids.json'), JSON.generate('workbookId' => 'wb-audited'))
+  env = { 'SIGMA_BASE_URL' => "http://127.0.0.1:#{AUDIT_PORT}", 'SIGMA_API_TOKEN' => 'stub' }
+  out, err, st = Open3.capture3(env, RbConfig.ruby, SCRIPT, '--workdir', dir, *args)
+  [out, err, st]
+end
+
 # D1+D2: Tier-S self-attested GREEN → labeled everywhere; verify-complete DONE.
 Dir.mktmpdir do |dir|
   base_workdir(dir)
   File.write(File.join(dir, 'migrate-state.json'), JSON.generate(TIER_S_STATE))
-  out, _err, st = run_gate(dir)
+  out, _err, st = run_gate_audited(dir)
   check(st.success?, "Tier-S factory green → exit 0 (got #{st.exitstatus})", fails)
   check(out.include?("VERDICT: #{FACTORY_LABEL}"), 'RESULT line carries the labeled verdict', fails)
   check(!out.match?(/VERDICT: GREEN \(degradation ledger empty/), 'bare-GREEN result line is unmintable on the factory path', fails)
@@ -340,7 +378,7 @@ Dir.mktmpdir do |dir|
   base_workdir(dir)
   File.write(File.join(dir, 'migrate-state.json'),
              JSON.generate('tier' => 'M', 'tier_basis' => 'auto-predicate'))
-  out, _err, st = run_gate(dir)
+  out, _err, st = run_gate_audited(dir)
   check(st.success? && out.include?('VERDICT: GREEN (degradation ledger empty'),
         'Tier-M self-attested keeps the bare GREEN line (no label)', fails)
   pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
@@ -352,7 +390,7 @@ end
 Dir.mktmpdir do |dir|
   base_workdir(dir, parity_extra: { 'visual_notes' => 'VERIFIER: source vs render compared tile-by-tile' })
   File.write(File.join(dir, 'migrate-state.json'), JSON.generate(TIER_S_STATE))
-  out, _err, st = run_gate(dir)
+  out, _err, st = run_gate_audited(dir)
   check(st.success? && out.include?('VERDICT: GREEN (degradation ledger empty'),
         'Tier-S countersigned run keeps the bare GREEN', fails)
   pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
@@ -363,7 +401,7 @@ end
 # D6 no-false-trip: tierless workdir → shipped strings byte-identical.
 Dir.mktmpdir do |dir|
   base_workdir(dir)
-  out, _err, st = run_gate(dir)
+  out, _err, st = run_gate_audited(dir)
   check(st.success? && out.include?('VERDICT: GREEN (degradation ledger empty'),
         'tierless run keeps the shipped GREEN line', fails)
   vout, _verr, vst = run_verify(dir)
@@ -374,7 +412,7 @@ end
 # D7 anti-fabrication: the label WITHOUT a factory basis is equally exit 6.
 Dir.mktmpdir do |dir|
   base_workdir(dir)
-  run_gate(dir) # stamps bare GREEN (tierless)
+  run_gate_audited(dir) # stamps bare GREEN (tierless)
   pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
   pf['verdict'] = FACTORY_LABEL
   File.write(File.join(dir, 'parity-final.json'), JSON.pretty_generate(pf))
@@ -391,19 +429,19 @@ Dir.mktmpdir do |dir|
   base_workdir(dir)
   File.write(File.join(dir, 'migrate-state.json'), JSON.generate(TIER_S_STATE))
   File.write(File.join(dir, 'verification-result.json'), '') # zero-byte touch
-  out, _err, st = run_gate(dir)
+  out, _err, st = run_gate_audited(dir)
   pf = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
   check(st.success? && pf['verdict'] == FACTORY_LABEL && pf['verdict_by'] == 'builder-self-attested',
         'zero-byte verification-result.json is not countersignature evidence (label + self-attested kept)', fails)
   check(out.include?("VERDICT: #{FACTORY_LABEL}"), 'touch-file run still prints the labeled verdict', fails)
   File.write(File.join(dir, 'verification-result.json'), JSON.generate('note' => 'no verdict field'))
-  _out2, _err2, st2 = run_gate(dir)
+  _out2, _err2, st2 = run_gate_audited(dir)
   pf2 = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
   check(st2.success? && pf2['verdict_by'] == 'builder-self-attested',
         'verdict-less verification-result.json is not evidence either', fails)
   File.write(File.join(dir, 'verification-result.json'),
              JSON.generate('verdict' => 'GREEN', 'notes' => 'VERIFIER: tile-by-tile'))
-  _out3, _err3, st3 = run_gate(dir)
+  _out3, _err3, st3 = run_gate_audited(dir)
   pf3 = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
   check(st3.success? && pf3['verdict'] == 'GREEN' && pf3['verdict_by'] == 'verifier',
         'a valid verifier deliverable still countersigns (bare GREEN + verifier)', fails)
@@ -415,7 +453,7 @@ end
 Dir.mktmpdir do |dir|
   base_workdir(dir)
   File.write(File.join(dir, 'migrate-state.json'), JSON.generate(TIER_S_STATE))
-  run_gate(dir) # stamps the labeled factory verdict
+  run_gate_audited(dir) # stamps the labeled factory verdict
   %w[parity-final.json phase6-success.json].each do |f|
     j = JSON.parse(File.read(File.join(dir, f)))
     j['verdict'] = 'GREEN'

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/degradation_ledger.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/degradation_ledger.rb
@@ -48,7 +48,9 @@
 #                       assert-phase6-ran on every run), minus the POLICY
 #                       exclusions (--skip-telemetry-gate; --skip-visual-
 #                       comparison under the sanctioned /verifier/i split) and
-#                       minus flags reclassified below.
+#                       minus flags reclassified below; plus column-scan.json
+#                       skipped-* statuses (gate 3/7's runtime auto-skips —
+#                       ruzs: an unaudited workbook must never keep GREEN).
 #   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
 #                       waivers, stale-skill, degraded fast path, and the
 #                       PR-14 `skip-flag-waived` records every closed --skip-*
@@ -116,6 +118,7 @@ module DegradationLedger
     entries = []
     entries.concat(scope_cuts(workdir))
     entries.concat(quality_waivers(workdir))
+    entries.concat(column_scan_skips(workdir))
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
@@ -251,6 +254,24 @@ module DegradationLedger
       out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
     end
     out
+  end
+
+  # Gate 3/7's runtime auto-skips (ruzs): column-scan.json is stamped by
+  # assert-phase6-ran at audit time — complete-clean is positive evidence and
+  # derives nothing; a skipped-* status means the live column audit NEVER
+  # verified the workbook, which is the same degradation class as an operator
+  # --skip-column-check (quality-waiver → verdict at most YELLOW). Kept
+  # separate from the census: these skips are runtime conditions, not flags,
+  # so they must not depend on the waiver census having been stamped.
+  def column_scan_skips(wd)
+    scan = read_json(wd, 'column-scan.json')
+    return [] unless scan.is_a?(Hash) && scan['status'].to_s.start_with?('skipped-')
+    reason = scan['reason'].to_s
+    reason = scan['status'].to_s if reason.empty?
+    detail = scan['columns_read'] ? " (#{scan['columns_read']} column(s) read before the stop)" : ''
+    [entry('quality-waiver', 'gate-3-column-scan',
+           "live column type=error audit #{scan['status']}: #{reason}#{detail}",
+           'column-scan.json')]
   end
 
   def recorded_escapes(wd)

--- a/shared/lib/degradation_ledger.rb
+++ b/shared/lib/degradation_ledger.rb
@@ -48,7 +48,9 @@
 #                       assert-phase6-ran on every run), minus the POLICY
 #                       exclusions (--skip-telemetry-gate; --skip-visual-
 #                       comparison under the sanctioned /verifier/i split) and
-#                       minus flags reclassified below.
+#                       minus flags reclassified below; plus column-scan.json
+#                       skipped-* statuses (gate 3/7's runtime auto-skips —
+#                       ruzs: an unaudited workbook must never keep GREEN).
 #   recorded-escape   — offramps.jsonl escape kinds (cred/doctor/tableau gate
 #                       waivers, stale-skill, degraded fast path, and the
 #                       PR-14 `skip-flag-waived` records every closed --skip-*
@@ -116,6 +118,7 @@ module DegradationLedger
     entries = []
     entries.concat(scope_cuts(workdir))
     entries.concat(quality_waivers(workdir))
+    entries.concat(column_scan_skips(workdir))
     entries.concat(recorded_escapes(workdir))
     entries.concat(fidelity_residuals(workdir))
     entries.concat(resolution_waived(workdir))
@@ -251,6 +254,24 @@ module DegradationLedger
       out << entry('quality-waiver', flag, reason, 'parity-final.json waivers')
     end
     out
+  end
+
+  # Gate 3/7's runtime auto-skips (ruzs): column-scan.json is stamped by
+  # assert-phase6-ran at audit time — complete-clean is positive evidence and
+  # derives nothing; a skipped-* status means the live column audit NEVER
+  # verified the workbook, which is the same degradation class as an operator
+  # --skip-column-check (quality-waiver → verdict at most YELLOW). Kept
+  # separate from the census: these skips are runtime conditions, not flags,
+  # so they must not depend on the waiver census having been stamped.
+  def column_scan_skips(wd)
+    scan = read_json(wd, 'column-scan.json')
+    return [] unless scan.is_a?(Hash) && scan['status'].to_s.start_with?('skipped-')
+    reason = scan['reason'].to_s
+    reason = scan['status'].to_s if reason.empty?
+    detail = scan['columns_read'] ? " (#{scan['columns_read']} column(s) read before the stop)" : ''
+    [entry('quality-waiver', 'gate-3-column-scan',
+           "live column type=error audit #{scan['status']}: #{reason}#{detail}",
+           'column-scan.json')]
   end
 
   def recorded_escapes(wd)

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -1343,8 +1343,24 @@ unless opts[:skip_column]
     end
   end
 
+  # ruzs: a runtime SKIP of this audit must be RECORDED, never a free pass —
+  # column-scan.json is derived into the degradation ledger (quality-waiver →
+  # verdict at most YELLOW). complete-clean is the positive evidence that
+  # keeps GREEN reachable. Written best-effort: bookkeeping must not sink the
+  # gate run, and the hard-fail paths (creds, error columns) exit 5 anyway.
+  record_column_scan = lambda do |h|
+    File.write(File.join(opts[:tab], 'column-scan.json'),
+               JSON.pretty_generate({ 'gate' => 'gate 3/7 live column type=error scan' }.merge(h)))
+  rescue StandardError
+    nil
+  end
+
   if wb_id.nil? || wb_id.empty?
     puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts '       Recorded to column-scan.json — joins the degradation ledger as a'
+    puts '       quality-waiver: an unaudited workbook caps the verdict at YELLOW.'
+    record_column_scan.call('status' => 'skipped-no-workbook-id',
+                            'reason' => 'no workbook ID resolvable (no --workbook-id and no wb-ids.json)')
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
@@ -1411,8 +1427,15 @@ unless opts[:skip_column]
              "(#{cols.length} column(s) read; HTTP #{res&.code}) — cannot verify."
         warn '       No type=error column was found in what WAS read, but an incomplete'
         warn '       scan does not prove the workbook clean. Re-run this gate.'
+        warn '       Recorded to column-scan.json — joins the degradation ledger as a'
+        warn '       quality-waiver: an unverified scan caps the verdict at YELLOW.'
+        record_column_scan.call('status' => 'skipped-incomplete',
+                                'columns_read' => cols.length,
+                                'http' => res&.code,
+                                'reason' => "live column scan of #{wb_id} did not complete")
       else
         puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+        record_column_scan.call('status' => 'complete-clean', 'columns_read' => cols.length)
       end
     end
   end

--- a/shared/scripts/test-assert-phase6.rb
+++ b/shared/scripts/test-assert-phase6.rb
@@ -311,6 +311,100 @@ scenario('3 budget-counted waivers (column+layout+orphan), 1 policy-excluded (vi
          HAPPY_FLAGS + ['--skip-orphan-check', 'budget test: deliberately exceed the cap of 2'])
 
 puts
+puts '== gate 3 (ruzs: silent SKIP paths are RECORDED, never a free pass) =='
+# A [SKIP] in gate 3/7 that leaves no artifact lets a workbook whose live
+# columns were never audited reach GREEN ("gates => all-pass" survives).
+# Ratified remedy: the skip is recorded to column-scan.json, which the
+# degradation ledger derives into a quality-waiver — capping the verdict at
+# YELLOW — rather than a hard exit (a transient outage must not hard-block).
+Dir.mktmpdir('domo-p6') do |dir|
+  write_good_fixtures(dir)
+  File.delete(File.join(dir, 'wb-ids.json')) # no workbook id resolvable at all
+  run_gate(dir, '--skip-layout-check', 'no wb id for gate 4 either',
+           '--skip-visual-comparison', 'verifier: pre-verified')
+  scan = (JSON.parse(File.read(File.join(dir, 'column-scan.json'))) rescue nil)
+  eq(scan.is_a?(Hash), true, 'no-wb-id skip writes column-scan.json')
+  eq(scan && scan['status'], 'skipped-no-workbook-id',
+     'column-scan.json records status=skipped-no-workbook-id')
+  ledger = (JSON.parse(File.read(File.join(dir, 'degradation-ledger.json'))) rescue nil)
+  entry = ledger && Array(ledger['entries']).find { |e| e['item'] == 'gate-3-column-scan' }
+  eq(!entry.nil?, true, 'the skip lands in the degradation ledger as gate-3-column-scan')
+  eq(entry && entry['class'], 'quality-waiver', 'ledger entry class is quality-waiver (caps at YELLOW)')
+end
+
+require 'socket'
+Dir.mktmpdir('domo-p6') do |dir|
+  write_good_fixtures(dir)
+  # Stub Sigma: first /columns page promises a nextPage, then the server 500s
+  # every later request — the mid-scan transient the ruzs bead describes.
+  server = TCPServer.new('127.0.0.1', 0)
+  port = server.addr[1]
+  th = Thread.new do
+    first = true
+    loop do
+      client = server.accept
+      while (l = client.gets) && l != "\r\n"; end
+      if first
+        first = false
+        body = JSON.generate('entries' => [{ 'columnId' => 'c1', 'label' => 'A',
+                                             'type' => { 'type' => 'number' } }],
+                             'nextPage' => 'p2')
+        client.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+                     "Content-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n#{body}")
+      else
+        client.write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+      end
+      client.close
+    end
+  rescue StandardError
+    nil
+  end
+  env = { 'SIGMA_BASE_URL' => "http://127.0.0.1:#{port}", 'SIGMA_API_TOKEN' => 'stub-token' }
+  system(env, 'ruby', GATE, '--workdir', dir,
+         '--skip-layout-check', 'stub server serves only gate 3',
+         '--skip-visual-comparison', 'verifier: pre-verified',
+         out: File::NULL, err: File::NULL)
+  server.close rescue nil
+  th.kill
+  scan = (JSON.parse(File.read(File.join(dir, 'column-scan.json'))) rescue nil)
+  eq(scan.is_a?(Hash), true, 'incomplete scan writes column-scan.json')
+  eq(scan && scan['status'], 'skipped-incomplete', 'column-scan.json records status=skipped-incomplete')
+  eq(scan && scan['columns_read'], 1, 'the partial read count is recorded (1 column seen)')
+end
+
+# The clean COMPLETE scan must stay a free pass: complete-clean is recorded as
+# positive evidence and derives NO ledger entry (GREEN stays reachable).
+Dir.mktmpdir('domo-p6') do |dir|
+  write_good_fixtures(dir)
+  server = TCPServer.new('127.0.0.1', 0)
+  port = server.addr[1]
+  th = Thread.new do
+    loop do
+      client = server.accept
+      while (l = client.gets) && l != "\r\n"; end
+      body = JSON.generate('entries' => [{ 'columnId' => 'c1', 'label' => 'A',
+                                           'type' => { 'type' => 'number' } }])
+      client.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+                   "Content-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n#{body}")
+      client.close
+    end
+  rescue StandardError
+    nil
+  end
+  env = { 'SIGMA_BASE_URL' => "http://127.0.0.1:#{port}", 'SIGMA_API_TOKEN' => 'stub-token' }
+  system(env, 'ruby', GATE, '--workdir', dir,
+         '--skip-layout-check', 'stub server serves only gate 3',
+         '--skip-visual-comparison', 'verifier: pre-verified',
+         out: File::NULL, err: File::NULL)
+  server.close rescue nil
+  th.kill
+  scan = (JSON.parse(File.read(File.join(dir, 'column-scan.json'))) rescue nil)
+  eq(scan && scan['status'], 'complete-clean', 'a full clean scan records complete-clean')
+  ledger = (JSON.parse(File.read(File.join(dir, 'degradation-ledger.json'))) rescue nil)
+  entry = ledger && Array(ledger['entries']).find { |e| e['item'] == 'gate-3-column-scan' }
+  eq(entry, nil, 'complete-clean derives NO ledger entry (GREEN stays reachable)')
+end
+
 if $failures.zero? then puts 'ALL PASS'; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end
 
 # NOTE on coverage boundaries NOT tested above (documented, not faked):


### PR DESCRIPTION
Closes bead `ruzs` (your handoff §5): a `[SKIP]` in gate 3/7's live column type=error audit never reached the degradation ledger, so `'gates' => 'all-pass'` survived and a workbook whose live columns were **never audited** could be declared GREEN. Worse than filed: the no-workbook-id skip runs *before* the credential fail-closed check, so a run missing `wb-ids.json` skipped the audit entirely, credential-less.

**Remedy** — per the ratified policy call (record a degradation capping at YELLOW, not a bare `exit 5`; a transient outage must not hard-block): the gate stamps `<workdir>/column-scan.json` in every audit outcome — `complete-clean` (+`columns_read`), `skipped-no-workbook-id`, or `skipped-incomplete` (+`columns_read`, `http`) — and `DegradationLedger.derive()` turns any `skipped-*` status into a `quality-waiver` entry (`gate-3-column-scan`), the same class an operator `--skip-column-check` lands in. Any such entry caps the verdict at YELLOW; `complete-clean` derives nothing, so **GREEN is only mintable over a finished audit**. `verify-complete.rb` re-derives through the same lib — the offline anti-"0 waivers" cross-check stays consistent for free.

**Tests** (13 new assertions, all watched failing first): canonical `test-assert-phase6.rb` gains three scenarios — the no-wb-id skip writes the artifact and lands in the ledger; a stub Sigma that 500s mid-scan yields `skipped-incomplete` with the partial read count; a stub serving one full clean page yields `complete-clean` and no entry. `test-degradation-ledger.rb` pins the derivation + verdict matrix for all three statuses.

**Doctrine ripple, worth your eye in review:** three offline harnesses were themselves minting GREEN through this hole (no resolvable workbook id → silent skip → empty ledger). The gates suite's "clean baseline → GREEN" and the evidence-gates summary scenario now pin YELLOW-with-exactly-the-recorded-skip; the W2.3 verdict-labeling scenarios (`test-wave2-verdict-gates.rb`), where GREEN is the point, now run **audited** against a local stub serving a clean `/columns` page — so factory-label coverage is preserved over an honest audit instead of the bug.

**Disclosed follow-up (not fixed here, same class):** gates 4/6/7/7b share the wb-id resolution and still skip silently when no id resolves. Scoped out to keep this the `ruzs` fix; happy to take it as a sibling PR if you want the whole class closed.

SHARED atomic commit: canonical `assert-phase6-ran.rb` + `degradation_ledger.rb`, sync-shared fan-out (8 gate twins, 6 ledger twins), patch bumps for all 8 touched plugins. Local: check-shared 634/634, closure, hygiene, version gate, full tableau glob (0 fails), all twin assert-phase6 suites + verify-complete green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
