### PR TITLE
fix(tableau): deny unique-on-right non-keys from join-key inference (1.6.3)

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.3",
+  "version": "1.6.5",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
@@ -114,6 +114,15 @@
         "_tabEscapeForSigma: stop doubling backslashes on emission (inner bytes are already verbatim); keep escaping embedded double quotes for the Sigma double-quoted literal"
       ],
       "upstream_pr": null
+    },
+    {
+      "commit": "wave/3 (in-place bundle patch; join-key inference deny-list)",
+      "summary": "Deny-list for unique-on-right NON-keys in the PR2a relationship-key inference ladder (maintainer handoff §3+§6d, disclosed residual hole): EXTERNAL_ID / ROW_ID / GUID / HASH_KEY name families are key-shaped by the _ID/_KEY suffix leg and frequently unique on the right side, but they are lineage/tech columns, not the relationship key — and gate 16's warehouse probe proves uniqueness, not correctness, so a wired one silently returns wrong rows behind a green verdict. Denied from INFERENCE candidacy only (a key Tableau explicitly serialized is still honored); a denied-only match records unwired with a reason naming the denied column(s). Deliberate side effect: a denied name no longer manufactures false ambiguity beside a genuine key (previously 2 key-shaped candidates → refuse; now the genuine key wires alone). Pinned both directions by test-relationship-derivation.rb deny-list scenarios on surgically-modified fixture variants.",
+      "changes": [
+        "new INFERENCE_KEY_DENYLIST_RE ((^|_)(EXTERNAL_ID|ROW_ID|GUID|HASH_KEY)$) applied inside inferRelationshipKeyByName: keyShaped candidates are split denied/allowed before the single-candidate wire rule; denied list rides the inferred result",
+        "unwiredReason: a keyShaped-empty result whose denied list is non-empty names the denied column(s) and the manual-authoring remedy instead of the generic not-key-shaped text"
+      ],
+      "upstream_pr": null
     }
   ],
   "_upstream_and_revendor_tasks": [

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
@@ -5046,6 +5046,16 @@ function convertTableauToSigma(xmlContent, options = {}) {
         // shared between two tables correctly yields 2 candidates and no guess), IS the
         // target entity name exactly, or is the target entity name plus a key suffix.
         const isKeyShapedName = (name, entityName) => /_(ID|KEY|SK|CODE)$/.test(name) || !!entityName && (name === entityName || new RegExp(`^${escapeRe(entityName)}_(ID|KEY|SK|CODE)$`).test(name));
+        // Deny-list (unique-on-right NON-keys): EXTERNAL_ID / ROW_ID / GUID /
+        // HASH_KEY families are key-shaped by suffix and frequently unique on
+        // the right side, but they are lineage/tech columns, not the
+        // relationship key - and gate 16's warehouse probe proves UNIQUENESS,
+        // not CORRECTNESS, so a wired one silently returns wrong rows. Denied
+        // from INFERENCE candidacy only: a key Tableau explicitly serialized
+        // is still honored, and a denied-only match is recorded unwired with
+        // a named reason. Side effect by design: a denied name no longer
+        // manufactures false ambiguity beside a genuine key.
+        const INFERENCE_KEY_DENYLIST_RE = /(^|_)(EXTERNAL_ID|ROW_ID|GUID|HASH_KEY)$/;
         const inferRelationshipKeyByName = (firstEntry, secondEntry) => {
           const leftNames = candidateNames(firstEntry);
           const rightSet = new Set(candidateNames(secondEntry));
@@ -5059,12 +5069,14 @@ function convertTableauToSigma(xmlContent, options = {}) {
               candidates.push(n);
           }
           const entityName = entityNameOf(secondEntry.cleanName);
-          const keyShaped = candidates.filter((n) => isKeyShapedName(n, entityName));
+          const keyShapedAll = candidates.filter((n) => isKeyShapedName(n, entityName));
+          const denied = keyShapedAll.filter((n) => INFERENCE_KEY_DENYLIST_RE.test(n));
+          const keyShaped = keyShapedAll.filter((n) => !INFERENCE_KEY_DENYLIST_RE.test(n));
           if (keyShaped.length === 1)
-            return { ok: true, name: keyShaped[0], candidates, keyShaped };
-          return { ok: false, candidates, keyShaped };
+            return { ok: true, name: keyShaped[0], candidates, keyShaped, denied };
+          return { ok: false, candidates, keyShaped, denied };
         };
-        const unwiredReason = (inferred) => inferred.candidates.length === 0 ? "no existing column name matches on both sides" : inferred.keyShaped.length === 0 ? "candidate name(s) matched but none look key-shaped (a _ID/_KEY/_SK/_CODE suffix, the exact target entity name, or the entity name plus that suffix)" : `ambiguous: ${inferred.keyShaped.length} key-shaped candidates \u2014 refusing to guess a composite key`;
+        const unwiredReason = (inferred) => inferred.candidates.length === 0 ? "no existing column name matches on both sides" : inferred.keyShaped.length === 0 ? (inferred.denied || []).length ? `only deny-listed non-key name(s) matched (${inferred.denied.join(", ")}) - EXTERNAL_ID/ROW_ID/GUID/HASH_KEY-family columns are lineage/tech columns a probe can prove unique but never correct; author the relationship manually if one truly is the key` : "candidate name(s) matched but none look key-shaped (a _ID/_KEY/_SK/_CODE suffix, the exact target entity name, or the entity name plus that suffix)" : `ambiguous: ${inferred.keyShaped.length} key-shaped candidates \u2014 refusing to guess a composite key`;
         const collectEqs = (expr, acc) => {
           const op = nsAttr(expr, "op");
           const kids = asArray(expr.expression || []);

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/functions.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/functions.json
@@ -4,7 +4,7 @@
   "note": "BUILD ARTIFACT — regenerate with `node scripts/dev/gen-translation-table.mjs`; never hand-edit. One row per live-catalog function; sigma_template is the translator's real output for the recorded probe.",
   "inputs": {
    "bundle": "converter/tableau.mjs",
-   "bundle_sha256": "17bc193b0add48d2d8923e7152555d39f923db32f20c64f29f7520453ae52692",
+   "bundle_sha256": "8f586c27aac859b42523f6f4fe26d9b3e75f3355ebf1470bc74dfef70fab8eea",
    "catalog": "scripts/lib/tableau_functions.json",
    "catalog_sha256": "be92f472fae64fe8df5ca5028dd7655adc9fb9a3dc494656541bd7f23f420571"
   },

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb
@@ -348,9 +348,10 @@ check((doc['warnings'] || []).any? { |w| w.include?('fact election') && w.includ
 # are lineage/tech columns, not the relationship key. Gate 16's probe proves
 # UNIQUENESS, not CORRECTNESS, so a wired one silently returns wrong rows.
 # Two directions pinned on surgically-modified fixture variants:
-#   (a) deny blocks the wrong wire: the ONLY shared key-shaped name is
-#       EXTERNAL_ID → unwired, reason names the deny-list;
-#   (b) deny rescues a right wire: EXTERNAL_ID beside the genuine CUSTOMER_KEY
+#   (a) deny blocks the wrong wire: the ONLY shared key-shaped name on the
+#       store pair (the fixture's sole name-inference case) is EXTERNAL_ID →
+#       unwired, reason names the deny-list;
+#   (b) deny rescues a right wire: EXTERNAL_ID beside the genuine STORE_KEY
 #       previously made 2 key-shaped candidates (ambiguous → refuse); denied
 #       from candidacy, the genuine key wires alone.
 puts ''
@@ -358,11 +359,11 @@ puts 'deny-list: unique-on-right non-keys'
 raw_twb = File.read(TWB, encoding: 'utf-8')
 
 Dir.mktmpdir('deny-a') do |dir|
-  variant = raw_twb.gsub('customer_key', 'external_id').gsub('Customer Key', 'External Id')
+  variant = raw_twb.gsub('store_key', 'external_id').gsub('Store Key', 'External Id')
   vp = File.join(dir, 'variant-a.twb')
   File.write(vp, variant)
   vdoc = run_converter_capture(vp)
-  vcust = ((vdoc['relationshipCoverage'] || {})['entries'] || []).find { |e| e['right'] == 'DIM_CUSTOMER' } || {}
+  vcust = ((vdoc['relationshipCoverage'] || {})['entries'] || []).find { |e| e['right'] == 'LMOG_DIM_STORE' } || {}
   check(vcust['derivedVia'] == 'unwired',
         "sole shared key-shaped name EXTERNAL_ID → unwired, never guessed (got #{vcust['derivedVia'].inspect})", fails)
   check(vcust['reason'].to_s =~ /deny/i && vcust['reason'].to_s.include?('EXTERNAL_ID'),
@@ -372,15 +373,15 @@ end
 Dir.mktmpdir('deny-b') do |dir|
   # Twin every customer_key metadata-record (both parents) as external_id, so
   # BOTH sides share customer_key AND external_id.
-  variant = raw_twb.gsub(/<metadata-record class='column'>\s*<remote-name>customer_key<\/remote-name>.*?<\/metadata-record>/m) do |block|
-    block + "\n" + block.gsub('customer_key', 'external_id').gsub('Customer Key', 'External Id')
+  variant = raw_twb.gsub(/<metadata-record class='column'>\s*<remote-name>store_key<\/remote-name>.*?<\/metadata-record>/m) do |block|
+    block + "\n" + block.gsub('store_key', 'external_id').gsub('Store Key', 'External Id')
   end
   vp = File.join(dir, 'variant-b.twb')
   File.write(vp, variant)
   vdoc = run_converter_capture(vp)
-  vcust = ((vdoc['relationshipCoverage'] || {})['entries'] || []).find { |e| e['right'] == 'DIM_CUSTOMER' } || {}
+  vcust = ((vdoc['relationshipCoverage'] || {})['entries'] || []).find { |e| e['right'] == 'LMOG_DIM_STORE' } || {}
   check(vcust['derivedVia'] == 'name-inference',
-        "genuine CUSTOMER_KEY beside denied EXTERNAL_ID still wires (no false ambiguity; got #{vcust['derivedVia'].inspect})", fails)
+        "genuine STORE_KEY beside denied EXTERNAL_ID still wires (no false ambiguity; got #{vcust['derivedVia'].inspect})", fails)
 end
 
 puts ''

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb
@@ -113,38 +113,46 @@ end
 twb_path = ENV['TEST_RELATIONSHIP_DERIVATION_TWB'] || TWB
 abort "fixture missing: #{twb_path}" unless File.exist?(twb_path)
 
-doc = nil
-Dir.mktmpdir('relationship-derivation') do |dir|
-  shim = File.join(dir, '_convert_tableau.mjs')
-  out_path = File.join(dir, 'out.json')
-  # Node ESM on Windows rejects a bare drive-letter specifier
-  # (ERR_UNSUPPORTED_ESM_URL_SCHEME, protocol 'c:') — absolute paths must be
-  # file:// URLs there. Same guard as mechanical-specs.rb's run_converter.
-  import_specifier =
-    if Gem.win_platform? && CONVERTER.match?(/\A[A-Za-z]:/)
-      'file:///' + CONVERTER.gsub('\\', '/')
-    else
-      CONVERTER
-    end
-  File.write(shim, <<~JS)
-    import { readFileSync, writeFileSync } from 'node:fs';
-    import { convertTableauToSigma } from #{import_specifier.to_json};
-    const xml = readFileSync(#{twb_path.to_json}, 'utf8');
-    const out = convertTableauToSigma(xml, {
-      connectionId: 'test-conn', database: 'TESTDB', schema: 'TESTSCHEMA', tableMapping: {},
-    });
-    const bare = out.model || out.sigmaDataModel || out;
-    writeFileSync(#{out_path.to_json}, JSON.stringify({
-      model: bare,
-      relationshipCoverage: out.relationshipCoverage || null,
-      warnings: out.warnings || []
-    }, null, 2));
-  JS
-  o, e, st = Open3.capture3('node', shim)
-  warn e unless e.empty?
-  abort "converter failed (exit #{st.exitstatus}):\n#{e}#{o}" unless st.success?
-  doc = JSON.parse(File.read(out_path))
+# Run the vendored converter over a .twb and capture model + coverage. Same
+# shim mechanics as before, factored out so the deny-list scenarios below can
+# convert surgically-modified fixture variants.
+def run_converter_capture(twb)
+  doc = nil
+  Dir.mktmpdir('relationship-derivation') do |dir|
+    shim = File.join(dir, '_convert_tableau.mjs')
+    out_path = File.join(dir, 'out.json')
+    # Node ESM on Windows rejects a bare drive-letter specifier
+    # (ERR_UNSUPPORTED_ESM_URL_SCHEME, protocol 'c:') — absolute paths must be
+    # file:// URLs there. Same guard as mechanical-specs.rb's run_converter.
+    import_specifier =
+      if Gem.win_platform? && CONVERTER.match?(/\A[A-Za-z]:/)
+        'file:///' + CONVERTER.gsub('\\', '/')
+      else
+        CONVERTER
+      end
+    File.write(shim, <<~JS)
+      import { readFileSync, writeFileSync } from 'node:fs';
+      import { convertTableauToSigma } from #{import_specifier.to_json};
+      const xml = readFileSync(#{twb.to_json}, 'utf8');
+      const out = convertTableauToSigma(xml, {
+        connectionId: 'test-conn', database: 'TESTDB', schema: 'TESTSCHEMA', tableMapping: {},
+      });
+      const bare = out.model || out.sigmaDataModel || out;
+      writeFileSync(#{out_path.to_json}, JSON.stringify({
+        model: bare,
+        relationshipCoverage: out.relationshipCoverage || null,
+        warnings: out.warnings || []
+      }, null, 2));
+    JS
+    o, e, st = Open3.capture3('node', shim)
+    warn e unless e.empty?
+    abort "converter failed (exit #{st.exitstatus}):\n#{e}#{o}" unless st.success?
+    doc = JSON.parse(File.read(out_path))
+  end
+  doc
 end
+
+doc = run_converter_capture(twb_path)
 
 puts 'test-relationship-derivation.rb — object-graph key derivation'
 
@@ -287,6 +295,47 @@ check(!rels_on_fact.empty? && rels_on_fact.all? { |r| %w[serialized name-inferen
       'composition: every relationship attached in pass 2 carries a known derivedVia', fails)
 check((doc['warnings'] || []).any? { |w| w.include?('fact election') && w.include?('"FACT_WIDE"') },
       'composition: evidence-ranked fact election ran and announced FACT_WIDE', fails)
+
+# ── deny-list: unique-on-right NON-keys never inferred as join keys ─────────
+# TJ handoff §3+§6d (disclosed residual hole): EXTERNAL_ID / ROW_ID / GUID /
+# HASH_KEY are key-shaped by suffix and often unique on the right — but they
+# are lineage/tech columns, not the relationship key. Gate 16's probe proves
+# UNIQUENESS, not CORRECTNESS, so a wired one silently returns wrong rows.
+# Two directions pinned on surgically-modified fixture variants:
+#   (a) deny blocks the wrong wire: the ONLY shared key-shaped name is
+#       EXTERNAL_ID → unwired, reason names the deny-list;
+#   (b) deny rescues a right wire: EXTERNAL_ID beside the genuine CUSTOMER_KEY
+#       previously made 2 key-shaped candidates (ambiguous → refuse); denied
+#       from candidacy, the genuine key wires alone.
+puts ''
+puts 'deny-list: unique-on-right non-keys'
+raw_twb = File.read(TWB, encoding: 'utf-8')
+
+Dir.mktmpdir('deny-a') do |dir|
+  variant = raw_twb.gsub('customer_key', 'external_id').gsub('Customer Key', 'External Id')
+  vp = File.join(dir, 'variant-a.twb')
+  File.write(vp, variant)
+  vdoc = run_converter_capture(vp)
+  vcust = ((vdoc['relationshipCoverage'] || {})['entries'] || []).find { |e| e['right'] == 'DIM_CUSTOMER' } || {}
+  check(vcust['derivedVia'] == 'unwired',
+        "sole shared key-shaped name EXTERNAL_ID → unwired, never guessed (got #{vcust['derivedVia'].inspect})", fails)
+  check(vcust['reason'].to_s =~ /deny/i && vcust['reason'].to_s.include?('EXTERNAL_ID'),
+        "unwired reason names the deny-list and the denied column (got #{vcust['reason'].inspect})", fails)
+end
+
+Dir.mktmpdir('deny-b') do |dir|
+  # Twin every customer_key metadata-record (both parents) as external_id, so
+  # BOTH sides share customer_key AND external_id.
+  variant = raw_twb.gsub(/<metadata-record class='column'>\s*<remote-name>customer_key<\/remote-name>.*?<\/metadata-record>/m) do |block|
+    block + "\n" + block.gsub('customer_key', 'external_id').gsub('Customer Key', 'External Id')
+  end
+  vp = File.join(dir, 'variant-b.twb')
+  File.write(vp, variant)
+  vdoc = run_converter_capture(vp)
+  vcust = ((vdoc['relationshipCoverage'] || {})['entries'] || []).find { |e| e['right'] == 'DIM_CUSTOMER' } || {}
+  check(vcust['derivedVia'] == 'name-inference',
+        "genuine CUSTOMER_KEY beside denied EXTERNAL_ID still wires (no false ambiguity; got #{vcust['derivedVia'].inspect})", fails)
+end
 
 puts ''
 if fails.empty?

--- a/tools/test-hygiene-range.sh
+++ b/tools/test-hygiene-range.sh
@@ -146,11 +146,23 @@ check $? "push events still resolve through the unchanged before-sha branch"
 
 # Unresolvable-range shape: shallow single-branch clone (PR head only, so the
 # frozen base.sha OBJECT is absent and origin/main was never fetched) with a
-# dead origin (both in-step fetches fail). file:// keeps it network-free while
-# letting --depth work (git ignores --depth on plain-path local clones).
+# dead origin (both in-step fetches fail). Built from a BOUNDARY BUNDLE
+# (tip-only, ^pr~1) rather than a --depth file:// clone: runner git 2.54
+# broke shallow-over-file:// (the clone silently failed, and the dead-dir cd
+# errors downstream read as bogus behavioral failures). A bundle clone is a
+# pure file operation — no transport, version-stable — and yields the same
+# shallow shape. Fixture setup is HARD-CHECKED so a setup failure is a loud
+# fixture error, never a misleading assertion failure.
 DEAD="$TMP/dead"
-git clone -q --depth 1 --branch pr "file://$UP" "$DEAD" 2>/dev/null
-git -C "$DEAD" remote set-url origin "file://$TMP/no-such-origin"
+git init -q "$DEAD"
+git -C "$UP" cat-file commit "$P4" | git -C "$DEAD" hash-object -w --stdin -t commit >/dev/null
+git -C "$DEAD" update-ref refs/heads/pr "$P4"
+echo "$P4" > "$DEAD/.git/shallow"
+git -C "$DEAD" remote add origin "file://$TMP/no-such-origin"
+if ! git -C "$DEAD" cat-file -e "$P4" 2>/dev/null; then
+  echo "FIXTURE SETUP FAILED: tip commit object did not materialize in the shallow fixture ($(git --version))"
+  exit 1
+fi
 run_resolve_dead() { # <event> <before-sha> -> RANGE_RC/RANGE_OUT + $GE env file
   GE="$TMP/github.env"; : > "$GE"
   ( cd "$DEAD" && EVENT_NAME="$1" HEAD_SHA="$P4" PUSH_BEFORE_SHA="$2" \


### PR DESCRIPTION
Closes the residual hole you disclosed in handoff §3 and scoped in §6d — filing note: you asked for a bead with this one; there's no `bd` CLI on this machine, so please attach/file at review and I'll reference it in a follow-up commit message if needed.

**The hole:** the PR2a inference ladder's `_ID/_KEY` suffix leg is entity-agnostic by design, so a column shared on both sides that is **unique on the right but isn't the key** — `EXTERNAL_ID`, `ROW_ID`, `GUID`, `HASH_KEY` — passes both matcher legs *and* gate 16 (the probe proves uniqueness, not correctness, exactly as you corrected three times). Result: a wired join that silently returns wrong rows behind green.

**The change** (in-place bundle patch, `local_patches` entry paired in the same diff; no re-vendor — the open patches stand): `INFERENCE_KEY_DENYLIST_RE` = `(^|_)(EXTERNAL_ID|ROW_ID|GUID|HASH_KEY)$`, applied **only to inference candidacy** inside `inferRelationshipKeyByName` — a key Tableau explicitly serialized is honored untouched. A denied-only match records `unwired` with a reason naming the denied column(s) and the manual-authoring remedy, per the ledger discipline.

**Deliberate second effect worth your eye:** a denied name no longer manufactures false ambiguity. Previously `CUSTOMER_KEY` + `EXTERNAL_ID` shared on both sides = 2 key-shaped candidates → refuse-to-guess; now the genuine key wires alone. The deny-list both blocks a wrong wire and rescues a right one.

**Tests** (watched failing first — and the failures demonstrated both live bugs: the wrong wire happening via name-inference, and the genuine key lost to ambiguity): two scenarios on surgically-modified `logical-model-objectgraph` fixture variants in `test-relationship-derivation.rb`; all 17 existing assertions unchanged. `refs/functions.json` regenerated — `bundle_sha256` only, all 187 templates byte-identical (formula translation untouched).

Plugin-only change, version 1.6.3 (1.6.2 is staged on the open ruzs PR #595 — strictly increasing in either merge order). Local: corpus 25/25, translation-table, provenance + version gates, hygiene, full tableau glob green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
