### PR TITLE
tableau: live M1 regression fix (beads-sigma-tzly) + genuine logical-model-objectgraph fixture (beads-sigma-ovy4)

### DIFF
--- a/corpus/tableau/logical-model-objectgraph/MANIFEST.md
+++ b/corpus/tableau/logical-model-objectgraph/MANIFEST.md
@@ -2,110 +2,379 @@
 
 ## Provenance — READ THIS FIRST
 
-**`workbook-content.twb` in this directory is HAND-AUTHORED / DERIVED. It was
-NOT produced by Tableau Desktop or Tableau Server, and no `.twb` in this
-directory should ever be mistaken for real Tableau output.**
+**`workbook-content.twb` in this directory is now GENUINE Tableau Server
+output.** It was published live to a real Tableau Cloud site (a
+`class='snowflake'` federated datasource, a real object-graph relationships
+model, a worksheet, and a dashboard) via the REST API
+(`POST /api/3.22/sites/{site}/workbooks?overwrite=true`, multipart/mixed,
+`connectionCredentials` embedding), then downloaded back
+(`GET /sites/{site}/workbooks/{id}/content`) — the file in this directory is
+that downloaded, Tableau-Server-processed XML, not the hand-typed upload.
 
-It was built by generating XML that follows the *shape* of a genuine 2020.2+
-Tableau logical (relationship / object-graph) datasource — modeled directly
-on the real, Tableau-published structure already pinned in
-`corpus/tableau/orders-overview/workbook-content.twb` (its `<connection
-class='federated'>` + `<relation type='collection'>` + `<metadata-records>` +
-sibling `<object-graph><objects>/<relationships>` shape, with
-`first-end-point`/`second-end-point` object-id references) — not by
-authoring against the XSD from scratch, and not invented. The differences
-from a literal copy are deliberate: this fixture trims the table set to one
-fact and three dimensions, renames everything to plain, obviously-synthetic
-identifiers (`FACT_WIDE`, `DIM_CUSTOMER`, `DIM_PRODUCT`, `DIM_DATE`,
-`DIM_STORE`), and widens the fact table to 63 columns so the two
-serialized-physical-key wired join keys land past metadata-record ordinal 50
-(see below). No customer or prospect data, identifiers, or names appear
-anywhere in it.
+This replaces the PREVIOUS state of this fixture, which was hand-authored/
+derived XML that only looked like real Tableau output (see git history for
+that version and its own provenance note). That version's own MANIFEST said a
+follow-up would replace it with genuine served output once available offline
+— this is that follow-up.
 
-**A follow-up replaces this fixture with genuine published Tableau output**
-(publish a real logical-model workbook from Tableau Server/Cloud and pull its
-`.twb` back down) once one is available offline. Until then, this is a
-structural stand-in whose only job is to drive the three branches of the
-relationship-derivation ladder in `converter/tableau.mjs` (PR2a) and prove
-`test-relationship-derivation.rb` (the Task 2 contract test) goes green.
+**Identifiers neutralized for repo hygiene.** The live build used a real
+Snowflake account/schema/connection already used by several other live
+fixtures in this repo, and a dedicated scratch service role/user created for
+this Tableau connection specifically. Per `tools/hygiene-patterns.txt` (this
+repo's hard no-test-org-identifiers rule, enforced by `tools/hygiene-sweep.sh`
+on every commit), the served `.twb`'s connection `server`/`dbname`/`schema`
+attributes were replaced with neutral placeholders
+(`example.snowflakecomputing.com` / `ANALYTICS` / `PUBLIC`, matching this
+corpus's existing placeholder convention) before vendoring. This is a
+post-download string substitution on 2 attributes and every `[SCHEMA].[TABLE]`
+path — the object-graph, metadata-records, relationships, worksheet, and
+dashboard structure Tableau actually produced are otherwise byte-for-byte
+untouched. Real environment specifics (which account, which connection ID,
+which live-verified evidence) are not repeated in this file for the same
+reason; they were reported to the requester directly and are recorded on
+`beads-sigma-tzly`'s note.
+
+### What changed from the hand-authored version, and why (live finding)
+
+The hand-authored fixture modeled Tableau's "auto-matched, no serialized key"
+case (`FACT_WIDE → DIM_CUSTOMER`, now `LMOG_FACT_WIDE → LMOG_DIM_CUSTOMER`) by
+omitting `<expression>` from that `<relationship>` entirely — an assumption
+about what genuine Tableau output looks like that was **never verified
+against real Tableau** until this task.
+
+**It's wrong.** Publishing that exact shape to a real Tableau Server returns:
+
+```
+HTTP 400011: There was a problem publishing the file '...'..
+(0x2805CF18 : com.tableausoftware.domain.exception.NativeException:
+The relationship/expression tag is missing or invalid)
+```
+
+Real Tableau Server requires every `<object-graph><relationships><relationship>`
+to carry some `<expression>` — a relationship with none does not survive
+publish. This fixture's `LMOG_FACT_WIDE → LMOG_DIM_CUSTOMER` relationship was
+changed to a plain serialized physical-equality expression
+(`CUSTOMER_KEY = CUSTOMER_KEY`) to publish successfully.
+
+**Consequence for the derivation ladder this fixture exercises:** case 1
+(`LMOG_DIM_CUSTOMER`) no longer exercises the name-inference rung — it is now
+`derivedVia: "serialized"`, the same rung as the plain-key case. The
+name-inference rung (a relationship whose *serialized* expression is present
+but not usable as a *physical* key — e.g. wrapped in `IFNULL`/`DATETRUNC` —
+so the converter falls back to matching column names) is now exercised
+**solely** by case 4 (`LMOG_DIM_STORE`, unchanged: `IFNULL([STORE_KEY],-1) =
+[STORE_KEY]`). This is a genuine, live-verified correction to the original
+fixture's design, not a downgrade of coverage — the ladder's other 3 rungs
+(serialized, mixed/partial, unwired-but-recorded) are all still exercised, and
+the STORE case alone is sufficient to prove name-inference recovery (see
+`test-relationship-derivation.rb`'s test 7, repointed from
+`LMOG_DIM_CUSTOMER` to `LMOG_DIM_STORE` accordingly).
+
+**One further live-only implication:** a relationship this repo's own
+`converter/tableau.mjs` treats as "no serialized key at all" (the ladder's
+name-inference-from-nothing rung, as originally imagined) may not be
+constructible via a genuinely Tableau-Server-processed `.twb` at all — every
+relationship Tableau will actually publish carries an expression. If a real
+prospect's Tableau workbook truly has zero-condition auto-matched
+relationships reaching Sigma's converter, they most likely arrived there via
+some path other than a hand-typed `.twb` upload (e.g. Tableau Desktop's own
+internal auto-match UI may serialize an empty-but-present `<expression>`
+rather than omitting the tag, which would still trigger the same ladder rung
+in the converter — this was not verified either way; flagging as an open
+question, not a claim).
 
 ## The shape (what this fixture exercises)
 
-One fact (`FACT_WIDE`, 63 columns) related to four dimensions, each forcing
-a different rung of the derivation ladder:
+One fact (`LMOG_FACT_WIDE`, 64 columns) related to five dimensions:
 
-1. **`FACT_WIDE` → `DIM_CUSTOMER` (auto-matched).** The `<relationship>` has
-   **no serialized `<expression>` at all** — the shape Tableau emits when it
-   auto-matches logical relationships by column name at query time. The only
-   shared, key-shaped column name between the two sides is `CUSTOMER_KEY`
-   (metadata-record ordinal **54** on `FACT_WIDE`), so the name-inference
-   rung fires and wires it. Expected: `derivedVia: "name-inference"`, not
-   partial.
-2. **`FACT_WIDE` → `DIM_PRODUCT` (mixed physical + computed).** The
+1. **`LMOG_FACT_WIDE` → `LMOG_DIM_CUSTOMER` (plain serialized physical key).**
+   `CUSTOMER_KEY = CUSTOMER_KEY` (metadata-record ordinal **54** on
+   `LMOG_FACT_WIDE`). Expected: `derivedVia: "serialized"`, not partial.
+2. **`LMOG_FACT_WIDE` → `LMOG_DIM_PRODUCT` (mixed physical + computed).** The
    `<expression op='AND'>` ANDs together one physical equality
    (`PRODUCT_KEY = PRODUCT_KEY`, metadata-record ordinal **57** on
-   `FACT_WIDE`) with one purely-computed condition
+   `LMOG_FACT_WIDE`) with one purely-computed condition
    (`DATETRUNC('month',[ORDER_TS]) = [EFFECTIVE_MONTH]`). The physical half
    wires; the computed half is dropped. Expected: `derivedVia: "serialized"`,
    `partial: true`, `droppedConditions: 1`.
-3. **`FACT_WIDE` → `DIM_DATE` (computed-only, inference fails).** The sole
-   condition is `DATETRUNC('day',[ORDER_TS]) = [CALENDAR_KEY]` — no physical
-   column on either side. `FACT_WIDE` and `DIM_DATE` deliberately share **no**
-   column name (the dimension's own key, `CALENDAR_KEY`, is never duplicated
+3. **`LMOG_FACT_WIDE` → `LMOG_DIM_DATE` (computed-only, inference fails).**
+   The sole condition is `DATETRUNC('day',[ORDER_TS]) = [CALENDAR_KEY]` — no
+   physical column on either side. `LMOG_FACT_WIDE` and `LMOG_DIM_DATE`
+   deliberately share **no** column name (`CALENDAR_KEY` is never duplicated
    on the fact), so the name-inference fallback also fails. Expected:
    recorded in the ledger, `derivedVia: "unwired"`, never silently dropped
    from the report.
-4. **`FACT_WIDE` → `DIM_STORE` (computed-only, inference SUCCEEDS —
-   regression fixture for the 2026-07-30 fix-wave, Important finding 2).**
-   The sole condition is `IFNULL([STORE_KEY],-1) = [STORE_KEY]` — computed on
-   its left operand, so (like case 3) no physical pair survives. Unlike case
-   3, `FACT_WIDE` and `DIM_STORE` DO share a key-shaped column name
-   (`STORE_KEY`, metadata-record ordinal **62** on `FACT_WIDE`), so
-   name-inference fires and wires it — but a computed condition Tableau
-   required (the `IFNULL` null-coalescing) was dropped, making the wired join
-   WIDER than Tableau's. Before this fix, a successful inference here
-   recorded `derivedVia: "name-inference"` with no `partial` /
-   `droppedConditions` and no dropped-condition warning, so a wider-than-
-   Tableau join looked clean everywhere. Expected now: `derivedVia:
-   "name-inference"`, `partial: true`, `droppedConditions: 1`, plus a
-   dropped-condition warning identical in spirit to the one the
-   fully-serialized/mixed-key case (2, `DIM_PRODUCT`) already got.
+4. **`LMOG_FACT_WIDE` → `LMOG_DIM_STORE` (computed-only, inference SUCCEEDS —
+   this fixture's sole remaining name-inference case; see the live-finding
+   note above).** The sole condition is `IFNULL([STORE_KEY],-1) =
+   [STORE_KEY]` — computed on its left operand, so no physical pair survives.
+   `LMOG_FACT_WIDE` and `LMOG_DIM_STORE` DO share a key-shaped column name
+   (`STORE_KEY`, metadata-record ordinal **62** on `LMOG_FACT_WIDE`), so
+   name-inference fires and wires it — but the `IFNULL` null-coalescing
+   Tableau required is dropped, making the wired join WIDER than Tableau's.
+   Expected: `derivedVia: "name-inference"`, `partial: true`,
+   `droppedConditions: 1`, plus a dropped-condition warning.
+5. **`LMOG_FACT_WIDE` → `LMOG_DIM_REGION` (plain serialized physical key —
+   NEW, added for this live pass, orthogonal to the derivation ladder above).**
+   `REGION_KEY = REGION_KEY` (metadata-record ordinal **63** on
+   `LMOG_FACT_WIDE`). Structurally identical to case 1 — what makes this case
+   different is **`LMOG_DIM_REGION` is deliberately NON-UNIQUE on
+   `REGION_KEY`** in the live warehouse table backing it (one key value
+   duplicated across 2 rows). This is invisible to the offline converter (it
+   only sees a clean serialized key) and exists specifically to exercise
+   gate 16's live join-cardinality probe (`probe-join-keys.rb`) — see the
+   live validation section below.
 
-**Ordinal placement / pagination coverage.** `FACT_WIDE` carries 63
-metadata-record columns (ordinals 0–62); `CUSTOMER_KEY` sits at ordinal 54
-and `PRODUCT_KEY` at ordinal 57 — both past the 50-column boundary that the
-columns-endpoint pagination fix (#565, `fix(tableau): paginate every
-columns-endpoint read`) addressed. `test-relationship-derivation.rb` and
-this directory's `checks.sh` only exercise the converter's in-process
-`.twb`-parsing path (no Sigma REST calls), so the ordinal placement does not
-by itself invoke the paginated `/columns` reader — that reader only comes
-into play once this data model is actually posted to Sigma and read back
-live. Placing the keys past ordinal 50 here is a forward-looking property of
-the fixture (so a future live/E2E pass over this same `.twb` is a real test
-of that pagination fix, not an accident of a narrow table), not a claim that
-this offline test exercises the paginated reader today.
+**Ordinal placement / pagination coverage.** `LMOG_FACT_WIDE` carries 64
+metadata-record columns (ordinals 0–63); `CUSTOMER_KEY` sits at ordinal 54,
+`PRODUCT_KEY` at 57, `STORE_KEY` at 62, and `REGION_KEY` at 63 — all past the
+50-column boundary that the columns-endpoint pagination fix (#565,
+`fix(tableau): paginate every columns-endpoint read`) addressed.
+`test-relationship-derivation.rb` and this directory's `checks.sh` only
+exercise the converter's in-process `.twb`-parsing path (no Sigma REST
+calls), so the ordinal placement does not by itself invoke the paginated
+`/columns` reader in an offline run — **that reader was exercised live, for
+real, against the real warehouse table backing this fixture, and it found a
+regression.** See "Live validation" below.
+
+## Live validation (2026-08) — what was actually run, what passed, what didn't
+
+This section documents the E2E live pass this fixture was built for: real
+Snowflake tables, a real Tableau Server publish/download round-trip, the real
+`converter/tableau.mjs` against the real served `.twb`, and a real gate-16
+probe against the real warehouse. Unrounded, as measured.
+
+### M1 — column-discovery pagination: LIVE REGRESSION FOUND AND FIXED
+
+`discover-columns.rb` against the real 64-column warehouse table backing
+`LMOG_FACT_WIDE` initially returned **50 of 64 columns** — silently truncated,
+missing `CUSTOMER_KEY`/`PRODUCT_KEY`/`STORE_KEY`/`REGION_KEY` entirely. This
+is exactly the bug class bead `beads-sigma-tzly` was originally filed for and
+PR #565 (merged, tableau-to-sigma 1.3.5) was believed to have fixed
+end-to-end. It hadn't, for this specific endpoint:
+
+```
+GET .../columns?limit=1000              -> 50 entries, nextPageToken: 50
+GET .../columns?limit=1000&page=50      -> 50 entries AGAIN (page 1 repeats —
+                                            `page` is silently ignored server-side)
+GET .../columns?limit=1000&pageToken=50 -> 14 entries, nextPageToken: null
+```
+
+`Sigma.list_entries` (`shared/lib/sigma_rest.rb`) — what `discover-columns.rb`
+and `discover-warehouse-columns.rb` were routed through by PR #565 — follows
+a `nextPage` response field / `page` request param. The real
+`/v2/connections/tables/<inode>/columns` endpoint never sends `nextPage` at
+all; it sends `nextPageToken` and expects `pageToken`. `list_entries`'s
+termination check fires after page 1 every time against this endpoint, so
+the fix "worked" by every existing offline test (which stub the assumed
+shape) while remaining silently broken live.
+
+**Fixed** (this branch, plugin-local — see `scripts/lib/
+warehouse_columns_pagination.rb`; bead reopened as `beads-sigma-tzly`, back
+to P0). Re-verified live after the fix: `discover-columns.rb` against the
+same real table now returns **all 64 columns**, with the four join keys at
+their correct 0-based indices **54, 57, 62, 63**. Full plugin test suite
+re-run: `PASS=196 FAIL=0`.
+
+### M2/M3 — relationship derivation ladder: LIVE, against the genuinely served `.twb`
+
+Running the real `converter/tableau.mjs` against this fixture's real,
+Tableau-Server-served `.twb` (the exact file in this directory) produces
+(rendered as plain text here, not a ```json fence, so it is not mistaken by
+`corpus_check.py`'s manifest parser for the Expectations block at the bottom
+of this file — that parser takes the FIRST ```json fenced block it finds):
+
+```
+{
+  "serialized": 5,
+  "wired": 4,
+  "entries": [
+    { "left": "LMOG_FACT_WIDE", "right": "LMOG_DIM_CUSTOMER", "derivedVia": "serialized", "keyCount": 1 },
+    { "left": "LMOG_FACT_WIDE", "right": "LMOG_DIM_PRODUCT", "derivedVia": "serialized", "keyCount": 1, "partial": true, "droppedConditions": 1 },
+    { "left": "LMOG_FACT_WIDE", "right": "LMOG_DIM_DATE", "derivedVia": "unwired", "reason": "no existing column name matches on both sides", "candidates": [] },
+    { "left": "LMOG_FACT_WIDE", "right": "LMOG_DIM_STORE", "derivedVia": "name-inference", "keyCount": 1, "partial": true, "droppedConditions": 1 },
+    { "left": "LMOG_FACT_WIDE", "right": "LMOG_DIM_REGION", "derivedVia": "serialized", "keyCount": 1 }
+  ]
+}
+```
+
+This matches `relationship-coverage.expected.json` byte-for-byte (regenerated
+per the recipe below against the real served `.twb`) and is pinned by
+`checks.sh` and `test-relationship-derivation.rb` (both updated for the new
+table names, the 5th relationship, and the case-1 correction above; both
+GREEN — see `checks.sh`'s own output for the exact pass lines).
+
+Deriving the join-plan ledger (`scripts/lib/join_plan.rb`, the same module
+`migrate-tableau.rb` calls during a real DM build) against this same real
+`.twb` + the converter's real DM output produces one `federated-join` entry
+per wired relationship (`LMOG_DIM_CUSTOMER`, `LMOG_DIM_PRODUCT`,
+`LMOG_DIM_STORE`, `LMOG_DIM_REGION` — `LMOG_DIM_DATE` correctly absent, since
+it never wired), each carrying `derived_via` and, for the partial cases,
+`partial`/`dropped_conditions` — proof the DM-build path (not just the raw
+converter) carries this fixture's ladder result through to what gate 16
+actually probes.
+
+### Gate 16 + PR #590 resolution surfacing: LIVE, against the real warehouse
+
+`scripts/probe-join-keys.rb`, run against the join-plan ledger above with a
+live Sigma connection, against the REAL warehouse tables:
+
+```
+==================== JOIN-CARDINALITY FATAL ====================
+entry #3 (federated-join): LMOG_FACT_WIDE -> LMOG_DIM_REGION on (REGION_KEY)
+  right side NOT unique at the key grain: 6 row(s) over 5 distinct key(s)
+  sample duplicate keys:
+    REGION_KEY=3  -> 2 rows
+================================================================
+probe-join-keys: 1 unresolved non-unique entr(y/ies) — the final gate (exit 23) will refuse GREEN.
+  UNIQUE  #0 federated-join: LMOG_DIM_CUSTOMER unique on (CUSTOMER_KEY) — 20 row(s), 20 key(s)
+  UNIQUE  #1 federated-join: LMOG_DIM_PRODUCT unique on (PRODUCT_KEY) — 15 row(s), 15 key(s)
+  UNIQUE  #2 federated-join: LMOG_DIM_STORE unique on (STORE_KEY) — 10 row(s), 10 key(s)
+  NON-UNIQUE  #3 federated-join: LMOG_DIM_REGION on (REGION_KEY) — 6 row(s) over 5 key(s)
+```
+
+Deliberately built that way: `LMOG_DIM_REGION` has 6 rows over 5 distinct
+`REGION_KEY` values (one duplicated), and gate 16 caught it live, correctly,
+against the real table — exactly the "field failure: target at a finer grain
+than the key" class this gate exists to stop, and exactly the case this
+fixture's 5th relationship was added to prove live (the offline converter
+alone cannot see this — it only sees a clean serialized key; see case 5
+above).
+
+Resolved per the sanctioned remedy: a pre-aggregated helper query
+(`SELECT REGION_KEY, MIN(REGION_NAME) AS REGION_NAME FROM <table> GROUP BY
+REGION_KEY`) was verified live to be unique at the `REGION_KEY` grain (5
+rows/5 keys), then the resolution was recorded:
+
+```
+ruby scripts/probe-join-keys.rb --workdir <W> --resolve 3 --how preaggregated \
+  --reason "LMOG_DIM_REGION non-unique on REGION_KEY (6 rows/5 keys, REGION_KEY=3
+  duplicated x2, live-verified 2026-08-03). Resolved via a pre-aggregated helper:
+  SELECT REGION_KEY, MIN(REGION_NAME) AS REGION_NAME FROM <table> GROUP BY
+  REGION_KEY, grouped to the REGION_KEY grain. Re-probed against that helper
+  live: 5 rows/5 keys, unique — confirmed before recording this resolution."
+```
+
+`scripts/lib/join_plan_resolutions.rb` (PR #590 / bead `beads-sigma-zjkw`, not
+yet merged to `main` at the time of this fixture — cherry-picked onto this
+branch to exercise it) then correctly surfaces that resolution. Running
+`migrate-tableau.rb`'s exact end-of-run block (reproduced standalone here
+since the full orchestrator run could not be completed — see "Known,
+unresolved limitation" below) against the resolved ledger prints:
+
+```
+============== JOIN-CARDINALITY RESOLUTIONS (gate 16) ==============
+   1 gate-16 join-cardinality resolution(s) recorded in join-plan.json (each added or accepted a helper element / arbitrary-match risk to fix a non-unique join target):
+
+   - LMOG_FACT_WIDE -> LMOG_DIM_REGION (federated-join, preaggregated): LMOG_DIM_REGION non-unique on REGION_KEY (6 rows/5 keys, REGION_KEY=3 duplicated x2, live-verified 2026-08-03). Resolved via a pre-aggregated helper: SELECT REGION_KEY, MIN(REGION_NAME) AS REGION_NAME FROM <table> GROUP BY REGION_KEY, grouped to the REGION_KEY grain. Re-probed against that helper live: 5 rows/5 keys, unique — confirmed before recording this resolution.
+======================================================================
+```
+
+And `assert-phase6-ran.rb`'s gate 16 logic itself (reproduced standalone
+against the same resolved ledger, same reason as above), exits 0:
+
+```
+[OK] gate 16: join-cardinality ledger resolved — 3 unique, 1 resolved of 4 (join-plan.json)
+exit code: 0
+```
+
+### Known, unresolved limitation: published-workbook rendering
+
+**This is a real gap, not softened.** The Tableau workbook was published
+successfully (HTTP 201) to a real Tableau Server/Cloud site, with a real
+embedded live Snowflake connection (`embedPassword: true`, confirmed
+authenticating live — Snowflake's own query history shows the embedded
+service credential successfully running `USE WAREHOUSE`/`USE DATABASE`/a
+catalog-probe query). **But every render of that published workbook comes
+back genuinely empty**: `GET /views/{id}/data` returns HTTP 200 with a
+**0-byte CSV**; `GET /views/{id}/image` returns HTTP 200 with a **2x2 pixel
+PNG**. The actual per-view `SELECT` against the warehouse tables is **never
+issued at all** — Snowflake's query history shows the connection-test query
+repeating, never the real one, on both the main fixture workbook and an
+isolated single-table diagnostic workbook built specifically to narrow this
+down.
+
+Four hypotheses were tested; three were ruled out, one is suspected but not
+confirmed:
+
+1. Cross-table join complexity in the worksheet — ruled out (a single-table-
+   only worksheet, no dimension fields at all, also renders empty).
+2. Worksheet structural shape (missing `<column-instance>` mappings) — this
+   WAS the real fix for a separate, genuine publish-time 400
+   ("no visual representation in the workbook"), cloned from a real,
+   confirmed-rendering workbook's exact XML shape on the same site — but does
+   not explain the empty render.
+3. Missing `<panes>/<mark>/<encodings>` — added back in combination with #2 —
+   still empty.
+4. **(Suspected, not confirmed.)** Every workbook found on the test site that
+   *does* render live data goes through a Tableau Virtual Connection
+   (`class='publishedConnection'`) or `sqlproxy` layer — never a bare embedded
+   `class='snowflake'` connection with inline credentials, which is what this
+   fixture's workbook uses. The site may filter/restrict direct ad-hoc DB
+   connections from actually serving queries even though publish-time
+   validation and lightweight connection tests succeed. Not confirmed by any
+   site-settings flag; would need either building a Virtual Connection or
+   switching to an embedded-Hyper-extract-based workbook to test properly —
+   both explicitly out of scope for this fixture (a separate investigation).
+
+**Consequence:** `migrate-tableau.rb`'s Phase 1d gate (`assert-dashboard-read.rb`,
+which requires a real PNG render of the source dashboard) is **NOT exercised
+by this fixture** and should be treated as still-unvalidated against a
+genuinely live-published, directly-embedded-connection Tableau workbook. The
+M2/M3 and gate-16 evidence above was gathered by driving the converter and
+`probe-join-keys.rb`/`join_plan_resolutions.rb` directly against the real
+served `.twb` and the real warehouse — not by completing a full
+`migrate-tableau.rb` orchestrator run, which cannot get past Phase 1d against
+this specific published workbook. A full orchestrated run against this
+fixture (or a workbook built via a Virtual Connection / extract, once that
+investigation happens) remains an open follow-up.
+
+### Live infrastructure left behind (not cleaned up — a deliberate later decision)
+
+- **Snowflake**: 6 real tables (`LMOG_FACT_WIDE` + 5 dimensions, matching the
+  shape above) in a pre-existing scratch schema in this repo's shared sandbox
+  Snowflake account (the same account/schema several of this repo's other
+  live fixtures already use — not named literally here per the hygiene-sweep
+  policy above). A dedicated scratch role and password-auth service user were
+  created specifically for the Tableau connection (least-privilege: `USAGE`
+  on the warehouse/database/schema, `SELECT` on only these 6 tables).
+- **Tableau**: 2 published workbooks on the test site's default project,
+  both named to be unambiguous scratch content safe to delete
+  ("LMOG Live Fixture -- scratch, safe to delete" and
+  "LMOG Diagnostic Test - safe to delete").
+- None of this was deleted as part of this task. Cleanup is a separate,
+  deliberate decision for whoever owns that environment.
 
 ## Artifacts
 
 | File | What it is |
 |---|---|
-| `workbook-content.twb` | The hand-authored/derived workbook XML (see Provenance above) |
-| `relationship-coverage.expected.json` | PINNED `relationshipCoverage` object emitted by `converter/tableau.mjs` for this fixture (4 serialized, 3 wired, 1 recorded-unwired). This is the converter's RAW, camelCase JS output (`derivedVia`, `keyCount`, `droppedConditions`), checked by `checks.sh` below — it is a different artifact from, and predates, `scripts/emit-relationship-coverage.rb`'s snake_case `relationship-coverage.json` (`derived_via`, `key_count`, `dropped_conditions`), which that script writes to a run's `<workdir>` for PR2b's gate 22 to consume. Same values, same entries, deliberately different key casing for two different consumers — do not assume this file pins the emitter's output. |
-| `checks.sh` | Executable expectations, run by `run-corpus.sh --check` |
+| `workbook-content.twb` | Genuine Tableau-Server-served workbook XML (identifiers neutralized per repo hygiene policy — see Provenance above) |
+| `relationship-coverage.expected.json` | PINNED `relationshipCoverage` object emitted by `converter/tableau.mjs` for this fixture (5 serialized, 4 wired, 1 recorded-unwired). This is the converter's RAW, camelCase JS output (`derivedVia`, `keyCount`, `droppedConditions`), checked by `checks.sh` below — it is a different artifact from, and predates, `scripts/emit-relationship-coverage.rb`'s snake_case `relationship-coverage.json` (`derived_via`, `key_count`, `dropped_conditions`), which that script writes to a run's `<workdir>` for PR2b's gate 22 to consume. Same values, same entries, deliberately different key casing for two different consumers — do not assume this file pins the emitter's output. |
+| `checks.sh` | Executable expectations, run by `run-corpus.sh --check`. Offline/converter-only — see the note at the top of that file for exactly what it does and does not prove; the live warehouse/gate-16 evidence above is NOT re-derivable offline and is documented here instead. |
 
 ## Expected behaviors (encoded in checks.sh)
 
 1. Running `convertTableauToSigma` over `workbook-content.twb` (connectionId
    `test-conn`, database `TESTDB`, schema `TESTSCHEMA`) produces a
    `relationshipCoverage` object that matches
-   `relationship-coverage.expected.json` byte-for-byte: `serialized: 4`,
-   `wired: 3`, and the four per-relationship entries described above keyed
-   by target (`DIM_CUSTOMER`, `DIM_PRODUCT`, `DIM_DATE`, `DIM_STORE`).
-2. `CUSTOMER_KEY` and `PRODUCT_KEY` — the two columns actually wired as join
-   keys — have metadata-record `<ordinal>` values past 50 on `FACT_WIDE`.
+   `relationship-coverage.expected.json` byte-for-byte: `serialized: 5`,
+   `wired: 4`, and the five per-relationship entries described above keyed
+   by target (`LMOG_DIM_CUSTOMER`, `LMOG_DIM_PRODUCT`, `LMOG_DIM_DATE`,
+   `LMOG_DIM_STORE`, `LMOG_DIM_REGION`).
+2. `CUSTOMER_KEY`, `PRODUCT_KEY`, `STORE_KEY`, and `REGION_KEY` — the four
+   columns actually wired as join keys — have metadata-record `<ordinal>`
+   values past 50 on `LMOG_FACT_WIDE`.
 3. `plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb`
-   (Task 2's contract test) passes at its default (no `TEST_RELATIONSHIP_DERIVATION_TWB`
-   override) path against this exact fixture.
+   (Task 2's contract test, updated for this fixture's real table names and
+   the case-1 live correction) passes at its default (no
+   `TEST_RELATIONSHIP_DERIVATION_TWB` override) path against this exact
+   fixture.
+4. **Not encoded here (live-only, cannot be exercised offline):** M1
+   pagination against a real warehouse table, and gate 16's join-cardinality
+   probe + resolution surfacing against a real non-unique warehouse table.
+   Both are documented with real, unrounded evidence in the "Live
+   validation" section above instead of being faked as an offline check.
 
 ## Converter
 

--- a/corpus/tableau/logical-model-objectgraph/checks.sh
+++ b/corpus/tableau/logical-model-objectgraph/checks.sh
@@ -2,17 +2,28 @@
 # logical-model-objectgraph — executable expectations (offline, creds-free).
 # Run by corpus/run-corpus.sh --check after corpus_check.py passes.
 #
+# This fixture's workbook-content.twb is GENUINE Tableau Server output (see
+# MANIFEST.md's Provenance section) — published to a real Tableau site with a
+# real Snowflake connection, then downloaded back. These checks are still
+# offline/creds-free: they run the converter and the skill's own contract test
+# against the vendored, already-served .twb; they do NOT re-publish or re-probe
+# the live warehouse (that live-only evidence — M1 pagination, gate 16 —
+# lives in MANIFEST.md's live validation section, not here, since it needs a
+# live Sigma connection + warehouse this offline check suite deliberately does
+# not have).
+#
 #   1. converter/tableau.mjs's object-graph relationship-derivation ladder
-#      (PR2a) on this HAND-AUTHORED/DERIVED .twb (see MANIFEST.md) produces
-#      EXACTLY the pinned relationshipCoverage ledger: 4 serialized
-#      relationships, 3 wired (auto-match name-inference + mixed
-#      serialized/partial + computed-only-but-name-inferred/partial), 1
+#      (PR2a) on this genuinely-served .twb produces EXACTLY the pinned
+#      relationshipCoverage ledger: 5 serialized relationships, 4 wired (plain
+#      physical key + mixed serialized/partial + computed-only-but-
+#      name-inferred/partial + a 5th plain physical key), 1
 #      recorded-but-unwired (computed-only, no shared key-shaped name) —
 #      never silently dropped from the report.
-#   2. The two WIRED join-key columns (CUSTOMER_KEY, PRODUCT_KEY) on
-#      FACT_WIDE sit past metadata-record ordinal 50 (54 and 57 of 62) — see
-#      MANIFEST.md's "Ordinal placement" note for what this does and does not
-#      prove offline.
+#   2. The four WIRED join-key columns (CUSTOMER_KEY, PRODUCT_KEY, STORE_KEY,
+#      REGION_KEY) on FACT_WIDE sit past metadata-record ordinal 50 (54, 57,
+#      62, 63 of 64) — see MANIFEST.md's "Ordinal placement" note for what
+#      this does and does not prove offline (the live M1 pagination proof
+#      against the real warehouse table is documented there, not here).
 #   3. plugins/tableau-to-sigma/skills/tableau-to-sigma's own
 #      test-relationship-derivation.rb (the Task 2 contract test) passes
 #      against this fixture at its default (no-override) path.
@@ -76,19 +87,20 @@ JS
 node "$TMP/_convert.mjs" 2>"$TMP/convert.err" || { note "FAIL: converter invocation failed"; sed -n '1,20p' "$TMP/convert.err"; fail=1; }
 
 if [ -f "$TMP/coverage.json" ] && cmp -s <(tr -d "\r" < "$TMP/coverage.json") <(tr -d "\r" < "$CASE_DIR/relationship-coverage.expected.json"); then
-  note "ok: relationshipCoverage matches relationship-coverage.expected.json (4 serialized, 3 wired, DIM_DATE recorded unwired)"
+  note "ok: relationshipCoverage matches relationship-coverage.expected.json (5 serialized, 4 wired, DIM_DATE recorded unwired)"
 else
   note "FAIL: relationshipCoverage drifted from relationship-coverage.expected.json:"
   diff <(tr -d "\r" < "$CASE_DIR/relationship-coverage.expected.json") <(tr -d "\r" < "$TMP/coverage.json") 2>/dev/null | head -40
   fail=1
 fi
 
-# -- 2. the two wired join keys sit past metadata-record ordinal 50 ----------
+# -- 2. the four wired join keys sit past metadata-record ordinal 50 ---------
 ruby -e '
   raw = File.read(ARGV[0], encoding: "utf-8")
   records = raw.scan(%r{<metadata-record\b[^>]*>.*?</metadata-record>}m)
   bad = []
-  { "CUSTOMER_KEY" => "Customer Key", "PRODUCT_KEY" => "Product Key" }.each do |key, caption|
+  { "CUSTOMER_KEY" => "Customer Key", "PRODUCT_KEY" => "Product Key",
+    "STORE_KEY" => "Store Key", "REGION_KEY" => "Region Key" }.each do |key, caption|
     rec = records.find { |r| r.include?("<caption>#{caption}</caption>") }
     unless rec
       bad << "#{key}: metadata-record with caption #{caption.inspect} not found"
@@ -103,7 +115,7 @@ ruby -e '
   end
   abort bad.join("; ") unless bad.empty?
 ' "$CASE_DIR/workbook-content.twb" \
-  && note "ok: CUSTOMER_KEY and PRODUCT_KEY metadata-records sit past ordinal 50 on the 62-column FACT_WIDE" \
+  && note "ok: CUSTOMER_KEY, PRODUCT_KEY, STORE_KEY, and REGION_KEY metadata-records sit past ordinal 50 on the 64-column FACT_WIDE" \
   || { note "FAIL: join-key ordinal placement check"; fail=1; }
 
 # -- 3. the skill's own contract test passes against this fixture directly ---

--- a/corpus/tableau/logical-model-objectgraph/relationship-coverage.expected.json
+++ b/corpus/tableau/logical-model-objectgraph/relationship-coverage.expected.json
@@ -1,35 +1,41 @@
 {
-  "serialized": 4,
-  "wired": 3,
+  "serialized": 5,
+  "wired": 4,
   "entries": [
     {
-      "left": "FACT_WIDE",
-      "right": "DIM_CUSTOMER",
-      "derivedVia": "name-inference",
+      "left": "LMOG_FACT_WIDE",
+      "right": "LMOG_DIM_CUSTOMER",
+      "derivedVia": "serialized",
       "keyCount": 1
     },
     {
-      "left": "FACT_WIDE",
-      "right": "DIM_PRODUCT",
+      "left": "LMOG_FACT_WIDE",
+      "right": "LMOG_DIM_PRODUCT",
       "derivedVia": "serialized",
       "keyCount": 1,
       "partial": true,
       "droppedConditions": 1
     },
     {
-      "left": "FACT_WIDE",
-      "right": "DIM_DATE",
+      "left": "LMOG_FACT_WIDE",
+      "right": "LMOG_DIM_DATE",
       "derivedVia": "unwired",
       "reason": "no existing column name matches on both sides",
       "candidates": []
     },
     {
-      "left": "FACT_WIDE",
-      "right": "DIM_STORE",
+      "left": "LMOG_FACT_WIDE",
+      "right": "LMOG_DIM_STORE",
       "derivedVia": "name-inference",
       "keyCount": 1,
       "partial": true,
       "droppedConditions": 1
+    },
+    {
+      "left": "LMOG_FACT_WIDE",
+      "right": "LMOG_DIM_REGION",
+      "derivedVia": "serialized",
+      "keyCount": 1
     }
   ]
 }

--- a/corpus/tableau/logical-model-objectgraph/workbook-content.twb
+++ b/corpus/tableau/logical-model-objectgraph/workbook-content.twb
@@ -1,984 +1,1019 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<!-- HAND-AUTHORED / DERIVED fixture for the tableau-to-sigma converter's
-     test-relationship-derivation.rb contract test. This file was NOT
-     produced by Tableau Desktop or Tableau Server — see MANIFEST.md for
-     provenance, what it is standing in for, and the follow-up that
-     replaces it with a genuinely published .twb. -->
+<!-- build 20262.26.0716.1805                               -->
 <workbook locale='en_US' original-version='18.1' source-build='2026.1.5 (20261.26.0512.1609)' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <preferences>
+    <preference name='ui.encoding.shelf.height' value='24' />
+  </preferences>
   <datasources>
-    <datasource caption='Logical Model Object Graph Fixture' inline='true' name='federated.objgraph01' version='18.1'>
+    <datasource caption='Logical Model Object Graph Live Fixture' inline='true' name='federated.lmog01' version='18.1'>
       <connection class='federated'>
         <named-connections>
-          <named-connection caption='snowflake' name='snowflake.objgraph01'>
-            <connection class='snowflake' dbname='ANALYTICS' schema='PUBLIC' server='example.snowflakecomputing.com' warehouse='WH_XS' />
+          <named-connection caption='snowflake' name='snowflake.lmog01'>
+            <connection class='snowflake' dbname='ANALYTICS' role='LMOG_TABLEAU_ROLE' schema='PUBLIC' server='example.snowflakecomputing.com' username='LMOG_TABLEAU_SVC' warehouse='SIGMA_WH' />
           </named-connection>
         </named-connections>
         <relation type='collection'>
-          <relation connection='snowflake.objgraph01' name='FACT_WIDE' table='[FACT_WIDE]' type='table' />
-          <relation connection='snowflake.objgraph01' name='DIM_CUSTOMER' table='[DIM_CUSTOMER]' type='table' />
-          <relation connection='snowflake.objgraph01' name='DIM_PRODUCT' table='[DIM_PRODUCT]' type='table' />
-          <relation connection='snowflake.objgraph01' name='DIM_DATE' table='[DIM_DATE]' type='table' />
-          <relation connection='snowflake.objgraph01' name='DIM_STORE' table='[DIM_STORE]' type='table' />
+          <relation connection='snowflake.lmog01' name='LMOG_FACT_WIDE' table='[PUBLIC].[LMOG_FACT_WIDE]' type='table' />
+          <relation connection='snowflake.lmog01' name='LMOG_DIM_CUSTOMER' table='[PUBLIC].[LMOG_DIM_CUSTOMER]' type='table' />
+          <relation connection='snowflake.lmog01' name='LMOG_DIM_PRODUCT' table='[PUBLIC].[LMOG_DIM_PRODUCT]' type='table' />
+          <relation connection='snowflake.lmog01' name='LMOG_DIM_DATE' table='[PUBLIC].[LMOG_DIM_DATE]' type='table' />
+          <relation connection='snowflake.lmog01' name='LMOG_DIM_STORE' table='[PUBLIC].[LMOG_DIM_STORE]' type='table' />
+          <relation connection='snowflake.lmog01' name='LMOG_DIM_REGION' table='[PUBLIC].[LMOG_DIM_REGION]' type='table' />
         </relation>
         <metadata-records>
-<metadata-record class='column'>
-  <remote-name>order_id</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[order_id]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>order_id</remote-alias>
-  <ordinal>0</ordinal>
-  <caption>Order Id</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>order_line_no</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[order_line_no]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>order_line_no</remote-alias>
-  <ordinal>1</ordinal>
-  <caption>Order Line No</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>amount</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[amount]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>amount</remote-alias>
-  <ordinal>2</ordinal>
-  <caption>Amount</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>quantity</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[quantity]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>quantity</remote-alias>
-  <ordinal>3</ordinal>
-  <caption>Quantity</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>unit_price</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[unit_price]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>unit_price</remote-alias>
-  <ordinal>4</ordinal>
-  <caption>Unit Price</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>discount_pct</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[discount_pct]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>discount_pct</remote-alias>
-  <ordinal>5</ordinal>
-  <caption>Discount Pct</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>tax_amount</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[tax_amount]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>tax_amount</remote-alias>
-  <ordinal>6</ordinal>
-  <caption>Tax Amount</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>ship_mode</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[ship_mode]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>ship_mode</remote-alias>
-  <ordinal>7</ordinal>
-  <caption>Ship Mode</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>ship_cost</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[ship_cost]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>ship_cost</remote-alias>
-  <ordinal>8</ordinal>
-  <caption>Ship Cost</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>store_number</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[store_number]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>store_number</remote-alias>
-  <ordinal>9</ordinal>
-  <caption>Store Number</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>channel</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[channel]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>channel</remote-alias>
-  <ordinal>10</ordinal>
-  <caption>Channel</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>currency_code</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[currency_code]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>currency_code</remote-alias>
-  <ordinal>11</ordinal>
-  <caption>Currency Code</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>fx_rate</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[fx_rate]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>fx_rate</remote-alias>
-  <ordinal>12</ordinal>
-  <caption>Fx Rate</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>cost_amount</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[cost_amount]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>cost_amount</remote-alias>
-  <ordinal>13</ordinal>
-  <caption>Cost Amount</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>margin_amount</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[margin_amount]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>margin_amount</remote-alias>
-  <ordinal>14</ordinal>
-  <caption>Margin Amount</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>return_flag</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[return_flag]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>return_flag</remote-alias>
-  <ordinal>15</ordinal>
-  <caption>Return Flag</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>promo_applied</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[promo_applied]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>promo_applied</remote-alias>
-  <ordinal>16</ordinal>
-  <caption>Promo Applied</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>loyalty_points</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[loyalty_points]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>loyalty_points</remote-alias>
-  <ordinal>17</ordinal>
-  <caption>Loyalty Points</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>payment_method</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[payment_method]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>payment_method</remote-alias>
-  <ordinal>18</ordinal>
-  <caption>Payment Method</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>order_status</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[order_status]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>order_status</remote-alias>
-  <ordinal>19</ordinal>
-  <caption>Order Status</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>fulfillment_center</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[fulfillment_center]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>fulfillment_center</remote-alias>
-  <ordinal>20</ordinal>
-  <caption>Fulfillment Center</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>warehouse_zone</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[warehouse_zone]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>warehouse_zone</remote-alias>
-  <ordinal>21</ordinal>
-  <caption>Warehouse Zone</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>backorder_flag</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[backorder_flag]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>backorder_flag</remote-alias>
-  <ordinal>22</ordinal>
-  <caption>Backorder Flag</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>gift_wrap_flag</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[gift_wrap_flag]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>gift_wrap_flag</remote-alias>
-  <ordinal>23</ordinal>
-  <caption>Gift Wrap Flag</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>sales_rep_id</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[sales_rep_id]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>sales_rep_id</remote-alias>
-  <ordinal>24</ordinal>
-  <caption>Sales Rep Id</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>territory_code</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[territory_code]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>territory_code</remote-alias>
-  <ordinal>25</ordinal>
-  <caption>Territory Code</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>weight_kg</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[weight_kg]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>weight_kg</remote-alias>
-  <ordinal>26</ordinal>
-  <caption>Weight Kg</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>volume_m3</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[volume_m3]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>volume_m3</remote-alias>
-  <ordinal>27</ordinal>
-  <caption>Volume M3</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>package_count</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[package_count]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>package_count</remote-alias>
-  <ordinal>28</ordinal>
-  <caption>Package Count</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>carrier_code</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[carrier_code]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>carrier_code</remote-alias>
-  <ordinal>29</ordinal>
-  <caption>Carrier Code</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>tracking_number</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[tracking_number]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>tracking_number</remote-alias>
-  <ordinal>30</ordinal>
-  <caption>Tracking Number</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>invoice_number</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[invoice_number]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>invoice_number</remote-alias>
-  <ordinal>31</ordinal>
-  <caption>Invoice Number</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>po_number</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[po_number]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>po_number</remote-alias>
-  <ordinal>32</ordinal>
-  <caption>Po Number</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>batch_id</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[batch_id]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>batch_id</remote-alias>
-  <ordinal>33</ordinal>
-  <caption>Batch Id</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>source_system</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[source_system]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>source_system</remote-alias>
-  <ordinal>34</ordinal>
-  <caption>Source System</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>load_timestamp</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[load_timestamp]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>load_timestamp</remote-alias>
-  <ordinal>35</ordinal>
-  <caption>Load Timestamp</caption>
-  <local-type>datetime</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>data_quality_score</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[data_quality_score]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>data_quality_score</remote-alias>
-  <ordinal>36</ordinal>
-  <caption>Data Quality Score</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>audit_flag</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[audit_flag]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>audit_flag</remote-alias>
-  <ordinal>37</ordinal>
-  <caption>Audit Flag</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>revision_number</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[revision_number]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>revision_number</remote-alias>
-  <ordinal>38</ordinal>
-  <caption>Revision Number</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>line_total</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[line_total]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>line_total</remote-alias>
-  <ordinal>39</ordinal>
-  <caption>Line Total</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>net_total</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[net_total]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>net_total</remote-alias>
-  <ordinal>40</ordinal>
-  <caption>Net Total</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>gross_total</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[gross_total]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>gross_total</remote-alias>
-  <ordinal>41</ordinal>
-  <caption>Gross Total</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>vat_amount</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[vat_amount]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>vat_amount</remote-alias>
-  <ordinal>42</ordinal>
-  <caption>Vat Amount</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>handling_fee</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[handling_fee]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>handling_fee</remote-alias>
-  <ordinal>43</ordinal>
-  <caption>Handling Fee</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>insurance_fee</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[insurance_fee]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>insurance_fee</remote-alias>
-  <ordinal>44</ordinal>
-  <caption>Insurance Fee</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>surcharge_amount</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[surcharge_amount]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>surcharge_amount</remote-alias>
-  <ordinal>45</ordinal>
-  <caption>Surcharge Amount</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>rebate_amount</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[rebate_amount]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>rebate_amount</remote-alias>
-  <ordinal>46</ordinal>
-  <caption>Rebate Amount</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>commission_amount</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[commission_amount]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>commission_amount</remote-alias>
-  <ordinal>47</ordinal>
-  <caption>Commission Amount</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>settlement_status</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[settlement_status]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>settlement_status</remote-alias>
-  <ordinal>48</ordinal>
-  <caption>Settlement Status</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>reconciled_flag</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[reconciled_flag]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>reconciled_flag</remote-alias>
-  <ordinal>49</ordinal>
-  <caption>Reconciled Flag</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>export_batch</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[export_batch]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>export_batch</remote-alias>
-  <ordinal>50</ordinal>
-  <caption>Export Batch</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>priority_level</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[priority_level]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>priority_level</remote-alias>
-  <ordinal>51</ordinal>
-  <caption>Priority Level</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>service_level</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[service_level]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>service_level</remote-alias>
-  <ordinal>52</ordinal>
-  <caption>Service Level</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>risk_score</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[risk_score]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>risk_score</remote-alias>
-  <ordinal>53</ordinal>
-  <caption>Risk Score</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>customer_key</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[customer_key]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>customer_key</remote-alias>
-  <ordinal>54</ordinal>
-  <caption>Customer Key</caption>
-  <local-type>integer</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>sales_channel_detail</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[sales_channel_detail]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>sales_channel_detail</remote-alias>
-  <ordinal>55</ordinal>
-  <caption>Sales Channel Detail</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>campaign_id</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[campaign_id]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>campaign_id</remote-alias>
-  <ordinal>56</ordinal>
-  <caption>Campaign Id</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>product_key</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[product_key]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>product_key</remote-alias>
-  <ordinal>57</ordinal>
-  <caption>Product Key</caption>
-  <local-type>integer</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>fulfillment_notes</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[fulfillment_notes]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>fulfillment_notes</remote-alias>
-  <ordinal>58</ordinal>
-  <caption>Fulfillment Notes</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>return_reason_code</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[return_reason_code]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>return_reason_code</remote-alias>
-  <ordinal>59</ordinal>
-  <caption>Return Reason Code</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>exchange_rate_source</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[exchange_rate_source]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>exchange_rate_source</remote-alias>
-  <ordinal>60</ordinal>
-  <caption>Exchange Rate Source</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>order_ts</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[order_ts]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>order_ts</remote-alias>
-  <ordinal>61</ordinal>
-  <caption>Order Ts</caption>
-  <local-type>datetime</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>store_key</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[store_key]</local-name>
-  <parent-name>[FACT_WIDE]</parent-name>
-  <remote-alias>store_key</remote-alias>
-  <ordinal>62</ordinal>
-  <caption>Store Key</caption>
-  <local-type>integer</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>customer_key</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[customer_key]</local-name>
-  <parent-name>[DIM_CUSTOMER]</parent-name>
-  <remote-alias>customer_key</remote-alias>
-  <ordinal>0</ordinal>
-  <caption>Customer Key</caption>
-  <local-type>integer</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_CUSTOMER_B1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>customer_name</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[customer_name]</local-name>
-  <parent-name>[DIM_CUSTOMER]</parent-name>
-  <remote-alias>customer_name</remote-alias>
-  <ordinal>1</ordinal>
-  <caption>Customer Name</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_CUSTOMER_B1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>customer_segment</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[customer_segment]</local-name>
-  <parent-name>[DIM_CUSTOMER]</parent-name>
-  <remote-alias>customer_segment</remote-alias>
-  <ordinal>2</ordinal>
-  <caption>Customer Segment</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_CUSTOMER_B1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>region</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[region]</local-name>
-  <parent-name>[DIM_CUSTOMER]</parent-name>
-  <remote-alias>region</remote-alias>
-  <ordinal>3</ordinal>
-  <caption>Region</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_CUSTOMER_B1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>product_key</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[product_key]</local-name>
-  <parent-name>[DIM_PRODUCT]</parent-name>
-  <remote-alias>product_key</remote-alias>
-  <ordinal>0</ordinal>
-  <caption>Product Key</caption>
-  <local-type>integer</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_PRODUCT_C1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>product_name</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[product_name]</local-name>
-  <parent-name>[DIM_PRODUCT]</parent-name>
-  <remote-alias>product_name</remote-alias>
-  <ordinal>1</ordinal>
-  <caption>Product Name</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_PRODUCT_C1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>category</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[category]</local-name>
-  <parent-name>[DIM_PRODUCT]</parent-name>
-  <remote-alias>category</remote-alias>
-  <ordinal>2</ordinal>
-  <caption>Category</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_PRODUCT_C1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>effective_month</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[effective_month]</local-name>
-  <parent-name>[DIM_PRODUCT]</parent-name>
-  <remote-alias>effective_month</remote-alias>
-  <ordinal>3</ordinal>
-  <caption>Effective Month</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_PRODUCT_C1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>calendar_key</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[calendar_key]</local-name>
-  <parent-name>[DIM_DATE]</parent-name>
-  <remote-alias>calendar_key</remote-alias>
-  <ordinal>0</ordinal>
-  <caption>Calendar Key</caption>
-  <local-type>integer</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_DATE_D1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>calendar_date</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[calendar_date]</local-name>
-  <parent-name>[DIM_DATE]</parent-name>
-  <remote-alias>calendar_date</remote-alias>
-  <ordinal>1</ordinal>
-  <caption>Calendar Date</caption>
-  <local-type>date</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_DATE_D1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>month_name</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[month_name]</local-name>
-  <parent-name>[DIM_DATE]</parent-name>
-  <remote-alias>month_name</remote-alias>
-  <ordinal>2</ordinal>
-  <caption>Month Name</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_DATE_D1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>store_key</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[store_key]</local-name>
-  <parent-name>[DIM_STORE]</parent-name>
-  <remote-alias>store_key</remote-alias>
-  <ordinal>0</ordinal>
-  <caption>Store Key</caption>
-  <local-type>integer</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_STORE_E1B2C3D4E5F60718]</object-id>
-</metadata-record>
-<metadata-record class='column'>
-  <remote-name>store_name</remote-name>
-  <remote-type>130</remote-type>
-  <local-name>[store_name]</local-name>
-  <parent-name>[DIM_STORE]</parent-name>
-  <remote-alias>store_name</remote-alias>
-  <ordinal>1</ordinal>
-  <caption>Store Name</caption>
-  <local-type>string</local-type>
-  <contains-null>true</contains-null>
-  <object-id>[DIM_STORE_E1B2C3D4E5F60718]</object-id>
-</metadata-record>
+          <metadata-record class='column'>
+            <remote-name>order_id</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[order_id]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>order_id</remote-alias>
+            <ordinal>0</ordinal>
+            <caption>Order Id</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>order_line_no</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[order_line_no]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>order_line_no</remote-alias>
+            <ordinal>1</ordinal>
+            <caption>Order Line No</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>amount</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[amount]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>amount</remote-alias>
+            <ordinal>2</ordinal>
+            <caption>Amount</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>quantity</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[quantity]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>quantity</remote-alias>
+            <ordinal>3</ordinal>
+            <caption>Quantity</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>unit_price</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[unit_price]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>unit_price</remote-alias>
+            <ordinal>4</ordinal>
+            <caption>Unit Price</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>discount_pct</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[discount_pct]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>discount_pct</remote-alias>
+            <ordinal>5</ordinal>
+            <caption>Discount Pct</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>tax_amount</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[tax_amount]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>tax_amount</remote-alias>
+            <ordinal>6</ordinal>
+            <caption>Tax Amount</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>ship_mode</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[ship_mode]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>ship_mode</remote-alias>
+            <ordinal>7</ordinal>
+            <caption>Ship Mode</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>ship_cost</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[ship_cost]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>ship_cost</remote-alias>
+            <ordinal>8</ordinal>
+            <caption>Ship Cost</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>store_number</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[store_number]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>store_number</remote-alias>
+            <ordinal>9</ordinal>
+            <caption>Store Number</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>channel</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[channel]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>channel</remote-alias>
+            <ordinal>10</ordinal>
+            <caption>Channel</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>currency_code</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[currency_code]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>currency_code</remote-alias>
+            <ordinal>11</ordinal>
+            <caption>Currency Code</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>fx_rate</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[fx_rate]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>fx_rate</remote-alias>
+            <ordinal>12</ordinal>
+            <caption>Fx Rate</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>cost_amount</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[cost_amount]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>cost_amount</remote-alias>
+            <ordinal>13</ordinal>
+            <caption>Cost Amount</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>margin_amount</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[margin_amount]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>margin_amount</remote-alias>
+            <ordinal>14</ordinal>
+            <caption>Margin Amount</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>return_flag</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[return_flag]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>return_flag</remote-alias>
+            <ordinal>15</ordinal>
+            <caption>Return Flag</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>promo_applied</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[promo_applied]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>promo_applied</remote-alias>
+            <ordinal>16</ordinal>
+            <caption>Promo Applied</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>loyalty_points</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[loyalty_points]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>loyalty_points</remote-alias>
+            <ordinal>17</ordinal>
+            <caption>Loyalty Points</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>payment_method</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[payment_method]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>payment_method</remote-alias>
+            <ordinal>18</ordinal>
+            <caption>Payment Method</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>order_status</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[order_status]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>order_status</remote-alias>
+            <ordinal>19</ordinal>
+            <caption>Order Status</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>fulfillment_center</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[fulfillment_center]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>fulfillment_center</remote-alias>
+            <ordinal>20</ordinal>
+            <caption>Fulfillment Center</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>warehouse_zone</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[warehouse_zone]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>warehouse_zone</remote-alias>
+            <ordinal>21</ordinal>
+            <caption>Warehouse Zone</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>backorder_flag</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[backorder_flag]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>backorder_flag</remote-alias>
+            <ordinal>22</ordinal>
+            <caption>Backorder Flag</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>gift_wrap_flag</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[gift_wrap_flag]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>gift_wrap_flag</remote-alias>
+            <ordinal>23</ordinal>
+            <caption>Gift Wrap Flag</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>sales_rep_id</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[sales_rep_id]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>sales_rep_id</remote-alias>
+            <ordinal>24</ordinal>
+            <caption>Sales Rep Id</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>territory_code</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[territory_code]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>territory_code</remote-alias>
+            <ordinal>25</ordinal>
+            <caption>Territory Code</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>weight_kg</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[weight_kg]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>weight_kg</remote-alias>
+            <ordinal>26</ordinal>
+            <caption>Weight Kg</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>volume_m3</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[volume_m3]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>volume_m3</remote-alias>
+            <ordinal>27</ordinal>
+            <caption>Volume M3</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>package_count</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[package_count]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>package_count</remote-alias>
+            <ordinal>28</ordinal>
+            <caption>Package Count</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>carrier_code</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[carrier_code]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>carrier_code</remote-alias>
+            <ordinal>29</ordinal>
+            <caption>Carrier Code</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>tracking_number</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[tracking_number]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>tracking_number</remote-alias>
+            <ordinal>30</ordinal>
+            <caption>Tracking Number</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>invoice_number</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[invoice_number]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>invoice_number</remote-alias>
+            <ordinal>31</ordinal>
+            <caption>Invoice Number</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>po_number</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[po_number]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>po_number</remote-alias>
+            <ordinal>32</ordinal>
+            <caption>Po Number</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>batch_id</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[batch_id]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>batch_id</remote-alias>
+            <ordinal>33</ordinal>
+            <caption>Batch Id</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>source_system</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[source_system]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>source_system</remote-alias>
+            <ordinal>34</ordinal>
+            <caption>Source System</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>load_timestamp</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[load_timestamp]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>load_timestamp</remote-alias>
+            <ordinal>35</ordinal>
+            <caption>Load Timestamp</caption>
+            <local-type>datetime</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>data_quality_score</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[data_quality_score]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>data_quality_score</remote-alias>
+            <ordinal>36</ordinal>
+            <caption>Data Quality Score</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>audit_flag</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[audit_flag]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>audit_flag</remote-alias>
+            <ordinal>37</ordinal>
+            <caption>Audit Flag</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>revision_number</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[revision_number]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>revision_number</remote-alias>
+            <ordinal>38</ordinal>
+            <caption>Revision Number</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>line_total</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[line_total]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>line_total</remote-alias>
+            <ordinal>39</ordinal>
+            <caption>Line Total</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>net_total</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[net_total]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>net_total</remote-alias>
+            <ordinal>40</ordinal>
+            <caption>Net Total</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>gross_total</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[gross_total]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>gross_total</remote-alias>
+            <ordinal>41</ordinal>
+            <caption>Gross Total</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>vat_amount</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[vat_amount]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>vat_amount</remote-alias>
+            <ordinal>42</ordinal>
+            <caption>Vat Amount</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>handling_fee</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[handling_fee]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>handling_fee</remote-alias>
+            <ordinal>43</ordinal>
+            <caption>Handling Fee</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>insurance_fee</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[insurance_fee]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>insurance_fee</remote-alias>
+            <ordinal>44</ordinal>
+            <caption>Insurance Fee</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>surcharge_amount</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[surcharge_amount]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>surcharge_amount</remote-alias>
+            <ordinal>45</ordinal>
+            <caption>Surcharge Amount</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>rebate_amount</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[rebate_amount]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>rebate_amount</remote-alias>
+            <ordinal>46</ordinal>
+            <caption>Rebate Amount</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>commission_amount</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[commission_amount]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>commission_amount</remote-alias>
+            <ordinal>47</ordinal>
+            <caption>Commission Amount</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>settlement_status</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[settlement_status]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>settlement_status</remote-alias>
+            <ordinal>48</ordinal>
+            <caption>Settlement Status</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>reconciled_flag</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[reconciled_flag]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>reconciled_flag</remote-alias>
+            <ordinal>49</ordinal>
+            <caption>Reconciled Flag</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>export_batch</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[export_batch]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>export_batch</remote-alias>
+            <ordinal>50</ordinal>
+            <caption>Export Batch</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>priority_level</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[priority_level]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>priority_level</remote-alias>
+            <ordinal>51</ordinal>
+            <caption>Priority Level</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>service_level</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[service_level]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>service_level</remote-alias>
+            <ordinal>52</ordinal>
+            <caption>Service Level</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>risk_score</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[risk_score]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>risk_score</remote-alias>
+            <ordinal>53</ordinal>
+            <caption>Risk Score</caption>
+            <local-type>real</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>customer_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[customer_key]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>customer_key</remote-alias>
+            <ordinal>54</ordinal>
+            <caption>Customer Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>sales_channel_detail</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[sales_channel_detail]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>sales_channel_detail</remote-alias>
+            <ordinal>55</ordinal>
+            <caption>Sales Channel Detail</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>campaign_id</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[campaign_id]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>campaign_id</remote-alias>
+            <ordinal>56</ordinal>
+            <caption>Campaign Id</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>product_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[product_key]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>product_key</remote-alias>
+            <ordinal>57</ordinal>
+            <caption>Product Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>fulfillment_notes</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[fulfillment_notes]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>fulfillment_notes</remote-alias>
+            <ordinal>58</ordinal>
+            <caption>Fulfillment Notes</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>return_reason_code</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[return_reason_code]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>return_reason_code</remote-alias>
+            <ordinal>59</ordinal>
+            <caption>Return Reason Code</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>exchange_rate_source</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[exchange_rate_source]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>exchange_rate_source</remote-alias>
+            <ordinal>60</ordinal>
+            <caption>Exchange Rate Source</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>order_ts</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[order_ts]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>order_ts</remote-alias>
+            <ordinal>61</ordinal>
+            <caption>Order Ts</caption>
+            <local-type>datetime</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>store_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[store_key]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>store_key</remote-alias>
+            <ordinal>62</ordinal>
+            <caption>Store Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>region_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[region_key]</local-name>
+            <parent-name>[LMOG_FACT_WIDE]</parent-name>
+            <remote-alias>region_key</remote-alias>
+            <ordinal>63</ordinal>
+            <caption>Region Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[FACT_WIDE_A1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>customer_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[customer_key]</local-name>
+            <parent-name>[LMOG_DIM_CUSTOMER]</parent-name>
+            <remote-alias>customer_key</remote-alias>
+            <ordinal>0</ordinal>
+            <caption>Customer Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_CUSTOMER_B1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>customer_name</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[customer_name]</local-name>
+            <parent-name>[LMOG_DIM_CUSTOMER]</parent-name>
+            <remote-alias>customer_name</remote-alias>
+            <ordinal>1</ordinal>
+            <caption>Customer Name</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_CUSTOMER_B1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>customer_segment</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[customer_segment]</local-name>
+            <parent-name>[LMOG_DIM_CUSTOMER]</parent-name>
+            <remote-alias>customer_segment</remote-alias>
+            <ordinal>2</ordinal>
+            <caption>Customer Segment</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_CUSTOMER_B1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>region</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[region]</local-name>
+            <parent-name>[LMOG_DIM_CUSTOMER]</parent-name>
+            <remote-alias>region</remote-alias>
+            <ordinal>3</ordinal>
+            <caption>Region</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_CUSTOMER_B1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>product_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[product_key]</local-name>
+            <parent-name>[LMOG_DIM_PRODUCT]</parent-name>
+            <remote-alias>product_key</remote-alias>
+            <ordinal>0</ordinal>
+            <caption>Product Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_PRODUCT_C1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>product_name</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[product_name]</local-name>
+            <parent-name>[LMOG_DIM_PRODUCT]</parent-name>
+            <remote-alias>product_name</remote-alias>
+            <ordinal>1</ordinal>
+            <caption>Product Name</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_PRODUCT_C1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>category</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[category]</local-name>
+            <parent-name>[LMOG_DIM_PRODUCT]</parent-name>
+            <remote-alias>category</remote-alias>
+            <ordinal>2</ordinal>
+            <caption>Category</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_PRODUCT_C1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>effective_month</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[effective_month]</local-name>
+            <parent-name>[LMOG_DIM_PRODUCT]</parent-name>
+            <remote-alias>effective_month</remote-alias>
+            <ordinal>3</ordinal>
+            <caption>Effective Month</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_PRODUCT_C1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>calendar_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[calendar_key]</local-name>
+            <parent-name>[LMOG_DIM_DATE]</parent-name>
+            <remote-alias>calendar_key</remote-alias>
+            <ordinal>0</ordinal>
+            <caption>Calendar Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_DATE_D1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>calendar_date</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[calendar_date]</local-name>
+            <parent-name>[LMOG_DIM_DATE]</parent-name>
+            <remote-alias>calendar_date</remote-alias>
+            <ordinal>1</ordinal>
+            <caption>Calendar Date</caption>
+            <local-type>date</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_DATE_D1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>month_name</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[month_name]</local-name>
+            <parent-name>[LMOG_DIM_DATE]</parent-name>
+            <remote-alias>month_name</remote-alias>
+            <ordinal>2</ordinal>
+            <caption>Month Name</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_DATE_D1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>store_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[store_key]</local-name>
+            <parent-name>[LMOG_DIM_STORE]</parent-name>
+            <remote-alias>store_key</remote-alias>
+            <ordinal>0</ordinal>
+            <caption>Store Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_STORE_E1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>store_name</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[store_name]</local-name>
+            <parent-name>[LMOG_DIM_STORE]</parent-name>
+            <remote-alias>store_name</remote-alias>
+            <ordinal>1</ordinal>
+            <caption>Store Name</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_STORE_E1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>region_key</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[region_key]</local-name>
+            <parent-name>[LMOG_DIM_REGION]</parent-name>
+            <remote-alias>region_key</remote-alias>
+            <ordinal>0</ordinal>
+            <caption>Region Key</caption>
+            <local-type>integer</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_REGION_F1B2C3D4E5F60718]</object-id>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>region_name</remote-name>
+            <remote-type>130</remote-type>
+            <local-name>[region_name]</local-name>
+            <parent-name>[LMOG_DIM_REGION]</parent-name>
+            <remote-alias>region_name</remote-alias>
+            <ordinal>1</ordinal>
+            <caption>Region Name</caption>
+            <local-type>string</local-type>
+            <contains-null>true</contains-null>
+            <object-id>[DIM_REGION_F1B2C3D4E5F60718]</object-id>
+          </metadata-record>
         </metadata-records>
       </connection>
       <object-graph>
         <objects>
-          <object caption='FACT_WIDE' id='FACT_WIDE_A1B2C3D4E5F60718'>
+          <object caption='LMOG_FACT_WIDE' id='FACT_WIDE_A1B2C3D4E5F60718'>
             <properties context=''>
-              <relation connection='snowflake.objgraph01' name='FACT_WIDE' table='[FACT_WIDE]' type='table' />
+              <relation connection='snowflake.lmog01' name='LMOG_FACT_WIDE' table='[PUBLIC].[LMOG_FACT_WIDE]' type='table' />
             </properties>
           </object>
-          <object caption='DIM_CUSTOMER' id='DIM_CUSTOMER_B1B2C3D4E5F60718'>
+          <object caption='LMOG_DIM_CUSTOMER' id='DIM_CUSTOMER_B1B2C3D4E5F60718'>
             <properties context=''>
-              <relation connection='snowflake.objgraph01' name='DIM_CUSTOMER' table='[DIM_CUSTOMER]' type='table' />
+              <relation connection='snowflake.lmog01' name='LMOG_DIM_CUSTOMER' table='[PUBLIC].[LMOG_DIM_CUSTOMER]' type='table' />
             </properties>
           </object>
-          <object caption='DIM_PRODUCT' id='DIM_PRODUCT_C1B2C3D4E5F60718'>
+          <object caption='LMOG_DIM_PRODUCT' id='DIM_PRODUCT_C1B2C3D4E5F60718'>
             <properties context=''>
-              <relation connection='snowflake.objgraph01' name='DIM_PRODUCT' table='[DIM_PRODUCT]' type='table' />
+              <relation connection='snowflake.lmog01' name='LMOG_DIM_PRODUCT' table='[PUBLIC].[LMOG_DIM_PRODUCT]' type='table' />
             </properties>
           </object>
-          <object caption='DIM_DATE' id='DIM_DATE_D1B2C3D4E5F60718'>
+          <object caption='LMOG_DIM_DATE' id='DIM_DATE_D1B2C3D4E5F60718'>
             <properties context=''>
-              <relation connection='snowflake.objgraph01' name='DIM_DATE' table='[DIM_DATE]' type='table' />
+              <relation connection='snowflake.lmog01' name='LMOG_DIM_DATE' table='[PUBLIC].[LMOG_DIM_DATE]' type='table' />
             </properties>
           </object>
-          <object caption='DIM_STORE' id='DIM_STORE_E1B2C3D4E5F60718'>
+          <object caption='LMOG_DIM_STORE' id='DIM_STORE_E1B2C3D4E5F60718'>
             <properties context=''>
-              <relation connection='snowflake.objgraph01' name='DIM_STORE' table='[DIM_STORE]' type='table' />
+              <relation connection='snowflake.lmog01' name='LMOG_DIM_STORE' table='[PUBLIC].[LMOG_DIM_STORE]' type='table' />
+            </properties>
+          </object>
+          <object caption='LMOG_DIM_REGION' id='DIM_REGION_F1B2C3D4E5F60718'>
+            <properties context=''>
+              <relation connection='snowflake.lmog01' name='LMOG_DIM_REGION' table='[PUBLIC].[LMOG_DIM_REGION]' type='table' />
             </properties>
           </object>
         </objects>
         <relationships>
-          <!-- 1. AUTO-MATCHED: Tableau serialized NO join key at all (the
-               modern-star-schema common case) — no <expression> child here
-               whatsoever. Must be recovered by the name-inference rung of
-               the ladder: FACT_WIDE.CUSTOMER_KEY <-> DIM_CUSTOMER.CUSTOMER_KEY
-               is the only shared key-shaped column name on both sides. -->
           <relationship>
+            <expression op='='>
+              <expression op='[CUSTOMER_KEY]' />
+              <expression op='[CUSTOMER_KEY]' />
+            </expression>
             <first-end-point object-id='FACT_WIDE_A1B2C3D4E5F60718' />
             <second-end-point object-id='DIM_CUSTOMER_B1B2C3D4E5F60718' />
           </relationship>
-          <!-- 2. MIXED: one physical equality (PRODUCT_KEY = PRODUCT_KEY,
-               wired) AND-ed with one purely-computed condition
-               (DATETRUNC('month', ORDER_TS) = EFFECTIVE_MONTH, dropped).
-               Must land as derivedVia=serialized, partial=true,
-               droppedConditions>=1. -->
           <relationship>
             <expression op='AND'>
               <expression op='='>
@@ -986,51 +1021,108 @@
                 <expression op='[PRODUCT_KEY]' />
               </expression>
               <expression op='='>
-                <expression op="DATETRUNC('month',[ORDER_TS])" />
+                <expression op='DATETRUNC(&apos;month&apos;,[ORDER_TS])' />
                 <expression op='[EFFECTIVE_MONTH]' />
               </expression>
             </expression>
             <first-end-point object-id='FACT_WIDE_A1B2C3D4E5F60718' />
             <second-end-point object-id='DIM_PRODUCT_C1B2C3D4E5F60718' />
           </relationship>
-          <!-- 3. COMPUTED-ONLY: the sole condition is a DATETRUNC(...)
-               expression with no physical column to fall back on, and
-               FACT_WIDE/DIM_DATE share no column name at all (deliberately
-               — CALENDAR_KEY only exists on the DIM_DATE side) — so this
-               stays unwired. What matters is that it is RECORDED, not
-               silently dropped from the ledger. -->
           <relationship>
             <expression op='='>
-              <expression op="DATETRUNC('day',[ORDER_TS])" />
+              <expression op='DATETRUNC(&apos;day&apos;,[ORDER_TS])' />
               <expression op='[CALENDAR_KEY]' />
             </expression>
             <first-end-point object-id='FACT_WIDE_A1B2C3D4E5F60718' />
             <second-end-point object-id='DIM_DATE_D1B2C3D4E5F60718' />
           </relationship>
-          <!-- 4. COMPUTED-ONLY, BUT NAME-INFERENCE SUCCEEDS (review fix-wave,
-               2026-07-30, Important finding 2): unlike case 3 above, FACT_WIDE
-               and DIM_STORE DO share a key-shaped column name (STORE_KEY) on
-               both sides, even though the sole serialized condition is
-               computed on its left operand (IFNULL(...) is not a bare
-               physical [STORE_KEY] ref, so it is dropped exactly like case
-               3's DATETRUNC). Before the fix, a successful inference here
-               recorded derivedVia: "name-inference" with NO partial /
-               droppedConditions and no dropped-condition warning — a join
-               strictly WIDER than Tableau's (IFNULL's null-coalescing no
-               longer narrows matches) that looked clean in both the
-               relationship object and the coverage ledger. Expected now:
-               derivedVia: "name-inference", partial: true,
-               droppedConditions: 1, plus the widening warning. -->
           <relationship>
             <expression op='='>
-              <expression op="IFNULL([STORE_KEY],-1)" />
+              <expression op='IFNULL([STORE_KEY],-1)' />
               <expression op='[STORE_KEY]' />
             </expression>
             <first-end-point object-id='FACT_WIDE_A1B2C3D4E5F60718' />
             <second-end-point object-id='DIM_STORE_E1B2C3D4E5F60718' />
           </relationship>
+          <relationship>
+            <expression op='='>
+              <expression op='[REGION_KEY]' />
+              <expression op='[REGION_KEY]' />
+            </expression>
+            <first-end-point object-id='FACT_WIDE_A1B2C3D4E5F60718' />
+            <second-end-point object-id='DIM_REGION_F1B2C3D4E5F60718' />
+          </relationship>
         </relationships>
       </object-graph>
     </datasource>
   </datasources>
+  <worksheets>
+    <worksheet name='LMOG Customer Revenue'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Logical Model Object Graph Live Fixture' name='federated.lmog01' />
+          </datasources>
+          <datasource-dependencies datasource='federated.lmog01'>
+            <column caption='Customer Name' datatype='string' name='[customer_name]' role='dimension' type='nominal' />
+            <column caption='Amount' datatype='real' default-aggregation='Sum' name='[amount]' role='measure' type='quantitative' />
+            <column-instance column='[customer_name]' derivation='None' name='[none:customer_name:nk]' pivot='key' type='nominal' />
+            <column-instance column='[amount]' derivation='Sum' name='[sum:amount:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+        </view>
+        <rows>[federated.lmog01].[none:customer_name:nk]</rows>
+        <cols>[federated.lmog01].[sum:amount:qk]</cols>
+      </table>
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='LMOG Live Fixture Overview'>
+      <style />
+      <size maxheight='800' maxwidth='1000' minheight='800' minwidth='1000' />
+      <zones>
+        <zone h='98000' id='3' type-v2='layout-basic' w='98000' x='1000' y='1000'>
+          <zone h='94000' id='4' name='LMOG Customer Revenue' w='96000' x='2000' y='2000'>
+            <zone-style>
+              <format attr='border-color' value='#000000' />
+              <format attr='border-style' value='none' />
+              <format attr='border-width' value='0' />
+              <format attr='margin' value='4' />
+            </zone-style>
+          </zone>
+        </zone>
+      </zones>
+      <simple-id uuid='{B2B2B2B2-0000-4000-8000-0000000000B2}' />
+    </dashboard>
+  </dashboards>
+  <windows source-height='30'>
+    <window class='worksheet' name='LMOG Customer Revenue'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+      <simple-id uuid='{C3C3C3C3-0000-4000-8000-0000000000C3}' />
+    </window>
+    <window class='dashboard' name='LMOG Live Fixture Overview'>
+      <viewpoints>
+        <viewpoint name='LMOG Customer Revenue'>
+          <zoom type='entire-view' />
+        </viewpoint>
+      </viewpoints>
+      <active id='-1' />
+      <simple-id uuid='{D4D4D4D4-0000-4000-8000-0000000000D4}' />
+    </window>
+  </windows>
 </workbook>

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/discover-columns.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/discover-columns.rb
@@ -35,6 +35,7 @@ require 'json'
 require 'optparse'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
+require 'warehouse_columns_pagination'
 
 opts = {}
 OptionParser.new do |p|
@@ -121,8 +122,17 @@ end
 #    SUPPORT 2026-06-02. Truncation here is not a cosmetic loss: a join key past
 #    ordinal 50 leaves the DM builder no column to point a relationship at, and
 #    fields past the cut read as "not on the table", whose fallback is Custom SQL.
-#    Sigma.list_entries sends limit=1000, follows nextPage (URL-encoded, opaque)
-#    to exhaustion, and stops loudly on a repeated token instead of spinning.
+#
+#    Sends limit=1000 and follows this endpoint's ACTUAL cursor to exhaustion via
+#    WarehouseColumnsPagination (scripts/lib/warehouse_columns_pagination.rb),
+#    not Sigma.list_entries: live verification against this endpoint (2026-08,
+#    the logical-model-objectgraph fixture's real 64-column FACT_WIDE table)
+#    found it returns `nextPageToken`/expects `pageToken`, not the `nextPage`/
+#    `page` shape list_entries assumes — list_entries silently stops after page
+#    1 (50 columns) against this specific endpoint. See that file's header for
+#    the full repro. Built on the same Sigma.request primitive, so 401-refresh
+#    behavior is unchanged, and it stops loudly (not spinning) on a repeated
+#    cursor exactly like Sigma.list_entries does.
 #
 #    The connection is INJECTED so this read keeps this script's
 #    SIGMA_HTTP_TIMEOUT bound — the "migration stuck for hours" guard above —
@@ -137,7 +147,7 @@ entries =
   begin
     Net::HTTP.start(cols_uri.host, cols_uri.port, use_ssl: cols_uri.scheme == 'https',
                     open_timeout: [timeout, 30].min, read_timeout: timeout) do |h|
-      Sigma.list_entries(cols_path, http: h) { pages += 1 }
+      WarehouseColumnsPagination.list(cols_path, http: h) { pages += 1 }
     end
   rescue Net::OpenTimeout, Net::ReadTimeout, Timeout::Error => e
     abort "TIMEOUT after #{timeout}s listing columns for #{opts[:path]} (#{e.class}). " \

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/discover-warehouse-columns.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/discover-warehouse-columns.rb
@@ -18,22 +18,27 @@ abort 'no inodeIds given' if INODES.empty?
 BASE = ENV.fetch('SIGMA_BASE_URL')
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
+require 'warehouse_columns_pagination'
 FileUtils.mkdir_p(OUT_DIR)
 
 # Fans out to N inodes in parallel; Sigma.request handles 401-refresh
 # (single-flight mutex so threads don't all refresh at once).
 #
-# PAGINATED. Sigma.list_entries sends limit=1000 and follows nextPage to
-# exhaustion, and returns the concatenated entries already parsed — it requests
-# accept: application/json, so there is no raw body to JSON.parse and no
-# `entries` key to remember. A bare first-page GET truncated wide tables at the
-# server default of 50.
+# PAGINATED. Sends limit=1000 and follows this endpoint's ACTUAL cursor to
+# exhaustion via WarehouseColumnsPagination (scripts/lib/warehouse_columns_pagination.rb),
+# not Sigma.list_entries — live verification against this exact endpoint
+# (2026-08, logical-model-objectgraph fixture) found it returns
+# `nextPageToken`/expects `pageToken`, not list_entries' assumed `nextPage`/
+# `page` — see that file's header for the full repro. Still built on
+# Sigma.request, so 401-refresh is unchanged, and the returned entries are
+# already parsed the same way list_entries' were. A bare first-page GET
+# truncated wide tables at the server default of 50.
 #
 # Deliberately NO `http:` injection: one thread per inode, so each must open its
 # own connection (the library default). A shared Net::HTTP would be raced.
 threads = INODES.map do |inode|
   Thread.new do
-    cols = Sigma.list_entries("/v2/connections/tables/#{inode}/columns")
+    cols = WarehouseColumnsPagination.list("/v2/connections/tables/#{inode}/columns")
     File.write("#{OUT_DIR}/#{inode}.json", JSON.pretty_generate(cols))
     [inode, cols.size]
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/join_plan_resolutions.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/join_plan_resolutions.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+#
+# JoinPlanResolutions — surfaces gate-16 join-cardinality RESOLUTIONS
+# (probe-join-keys.rb `--resolve <i> --how preaggregated|waived --reason
+# "<...>"`) from <workdir>/join-plan.json into the consolidated end-of-run
+# readout, instead of leaving them recorded but unread.
+#
+# WHY (beads-sigma-zjkw, the real M5 gap): when a join/Lookup target is not
+# unique at the key grain, probe-join-keys.rb lets an operator resolve it by
+# (a) adding a pre-aggregated helper element to the data model at the key
+# grain and repointing the Lookup at it (`--how preaggregated`), or (b)
+# accepting the arbitrary-match risk (`--how waived`) — either way recording
+# a human-written `reason` on the entry's `resolution` key. NOTHING
+# downstream ever read that back out: migrate-tableau.rb's MIGRATION
+# COVERAGE readout is built solely from build-charts' own coverage.json, never
+# from join-plan.json. So a DM-level pre-aggregated helper table — the actual
+# "Custom SQL aggregate table that wasn't in Tableau" a field report
+# described — had a recorded reason that never reached any customer-visible
+# surface. This module closes that gap.
+#
+# Pure + offline + no network — unit-tested in
+# test-join-plan-resolution-surfacing.rb. Plugin-local: NOT vendored to other
+# plugins (only scripts/lib/coverage_gate.rb is shared — see
+# shared/manifest.json).
+require 'json'
+
+module JoinPlanResolutions
+  module_function
+
+  # Read join-plan.json defensively; nil when absent/garbage so callers can
+  # no-op (a run before the ledger existed, or one whose derivation failed,
+  # should never crash the end-of-run readout over this).
+  def load(path)
+    return nil unless path && File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue JSON::ParserError
+    nil
+  end
+
+  # 'how' values probe-join-keys.rb accepts for --resolve (see its --resolve
+  # handling). Anything else on a 'resolution' key (absent, malformed, or an
+  # unrecognized value) is treated as NOT resolved — surfacing it here would
+  # misrepresent a still-blocking entry as explained.
+  RESOLVED_HOW = %w[preaggregated waived].freeze
+
+  # Entries carrying an operator-recorded resolution. Unresolved entries
+  # (unprobed, unique, or non-unique-but-not-yet-resolved) are excluded on
+  # purpose — this surfacing is only for entries that already have a
+  # human-written explanation to show.
+  def resolved_entries(doc)
+    entries = doc.is_a?(Hash) ? Array(doc['entries']) : []
+    entries.select do |e|
+      e.is_a?(Hash) && e['resolution'].is_a?(Hash) && RESOLVED_HOW.include?(e['resolution']['how'].to_s)
+    end
+  end
+
+  # One short line per resolved entry: which relationship, its kind, how it
+  # was resolved, and the recorded reason — the piece of information the
+  # field report needed and never had.
+  def report_lines(doc)
+    resolved_entries(doc).map do |e|
+      res = e['resolution']
+      "   - #{e['left']} -> #{e['right']} (#{e['kind']}, #{res['how']}): #{res['reason']}"
+    end
+  end
+
+  def headline(doc)
+    n = resolved_entries(doc).size
+    "#{n} gate-16 join-cardinality resolution(s) recorded in join-plan.json " \
+      '(each added or accepted a helper element / arbitrary-match risk to fix a non-unique join target):'
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/warehouse_columns_pagination.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/warehouse_columns_pagination.rb
@@ -76,7 +76,8 @@ module WarehouseColumnsPagination
         end
       break if next_cursor.nil? || next_cursor.to_s.empty?
       if seen[next_cursor]
-        warn "#{path}: server repeated cursor #{next_cursor.inspect} — " \
+        cursor_label = cursor_param == 'page' ? 'nextPage token' : 'nextPageToken cursor'
+        warn "#{path}: server repeated #{cursor_label} #{next_cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/warehouse_columns_pagination.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/warehouse_columns_pagination.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+# Plugin-local (NOT shared/lib/sigma_rest.rb) exhaustive pagination for Sigma's
+# warehouse-catalog `/v2/connections/tables/<inodeId>/columns` endpoint.
+#
+# LIVE-VERIFIED 2026-08 (logical-model-objectgraph live fixture build, a real
+# 64-physical-column Snowflake fact table via the same live Sigma connection
+# this repo's other live warehouse fixtures use): this endpoint's actual pagination
+# cursor is `nextPageToken` in the response body / `pageToken` on the request
+# query string — NOT the `nextPage`/`page` convention `Sigma.list_entries`
+# (shared/lib/sigma_rest.rb) assumes. Calling `Sigma.list_entries` against this
+# endpoint makes exactly ONE request: `nextPage` is never present in the
+# response, so `list_entries`'s own termination check (`page = data['nextPage'];
+# break if page.nil?`) fires immediately and it silently returns page 1 only
+# (50 of 64 columns on the live fixture table) — the exact M1 regression this
+# code exists to prevent, reproduced live against real warehouse metadata
+# rather than a synthetic offline fixture. Confirmed against the live endpoint:
+#
+#   GET .../columns?limit=1000              -> 50 entries, nextPageToken: 50
+#   GET .../columns?limit=1000&page=50      -> 50 entries AGAIN (page 1 — `page`
+#                                               is silently ignored server-side)
+#   GET .../columns?limit=1000&pageToken=50 -> 14 entries, nextPageToken: null
+#
+# 50 + 14 = 64, matching the live fact table's real physical column count.
+#
+# Kept plugin-local rather than patching the shared canonical
+# (shared/lib/sigma_rest.rb, vendored byte-identical into 13 plugins per
+# shared/manifest.json) because correcting a live-endpoint pagination
+# contract needs its own dedicated cross-plugin verification pass — out of
+# scope for this fixture task, and a PR touching a shared file cannot also
+# carry plugin-scoped changes under this repo's "PR = 1 plugin OR shared"
+# rule. See corpus/tableau/logical-model-objectgraph/MANIFEST.md's live
+# validation section for the full repro and a pointer to the follow-up this
+# implies for shared/lib/sigma_rest.rb + its other 12 consumers.
+#
+# Built on `Sigma.request` (shared/lib/sigma_rest.rb), not raw Net::HTTP, so
+# every page GET still inherits the shared lib's 401-refresh-and-retry
+# behavior and single auth path — only the pagination LOOP is reimplemented.
+require_relative 'sigma_rest'
+
+module WarehouseColumnsPagination
+  # Exhaustively lists entries at `path` (a GET endpoint returning
+  # { "entries": [...], "nextPage": ... } OR { "entries": [...], "nextPageToken": ... }).
+  # The cursor convention is detected from whichever key the FIRST page's
+  # response actually carries, then that same convention is used for every
+  # subsequent page — so this is correct against either shape, not just the
+  # one this endpoint happens to use today.
+  #
+  # An optional block receives each page's parsed body as it arrives (same
+  # observability seam as Sigma.list_entries — callers use it to announce a
+  # multi-page fetch on stderr without re-implementing the loop). A repeated
+  # cursor stops the loop defensively and warns on stderr rather than
+  # spinning or silently truncating.
+  def self.list(path, http: nil, limit: 1000)
+    entries = []
+    cursor = nil
+    cursor_param = nil
+    seen = {}
+    pages = 0
+    loop do
+      qs = "limit=#{limit}"
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor.to_s)}" if cursor && cursor_param
+      full_path = "#{path}#{path.include?('?') ? '&' : '?'}#{qs}"
+      doc = Sigma.request(:get, full_path, http: http)
+      break unless doc.is_a?(Hash)
+      pages += 1
+      yield doc if block_given?
+      entries.concat(doc['entries'] || [])
+
+      next_cursor =
+        if doc.key?('nextPageToken')
+          cursor_param = 'pageToken'
+          doc['nextPageToken']
+        else
+          cursor_param = 'page'
+          doc['nextPage']
+        end
+      break if next_cursor.nil? || next_cursor.to_s.empty?
+      if seen[next_cursor]
+        warn "#{path}: server repeated cursor #{next_cursor.inspect} — " \
+             "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
+        break
+      end
+
+      seen[next_cursor] = true
+      cursor = next_cursor
+    end
+    entries
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -182,6 +182,7 @@ begin
 rescue LoadError, StandardError
   nil
 end
+require 'join_plan_resolutions' # join-plan.json gate-16 resolutions → consolidated report (beads-sigma-zjkw)
 
 require 'rbconfig'
 # Children (post-and-readback.rb, phase6-parity.rb, …) inherit this marker so
@@ -4662,6 +4663,27 @@ if mechanical
       end
     end
     puts '==========================================================='
+  end
+
+  # JOIN-CARDINALITY RESOLUTIONS — surfaces gate-16's operator-recorded
+  # explanations (beads-sigma-zjkw) for any join-plan.json entry resolved via
+  # `probe-join-keys.rb --resolve <i> --how preaggregated|waived --reason
+  # "<...>"`. Without this, a `preaggregated` resolution's helper element (a
+  # pre-aggregated / Custom-SQL-shaped table added to the DM to fix a
+  # non-unique join target) had a recorded reason that never reached any
+  # customer-visible surface — confirmed root cause of a field report ("it
+  # created a custom SQL aggregate table in a data model that didn't exist in
+  # the Tableau data set"). Same consolidated readout as MIGRATION COVERAGE
+  # above, not a stderr-only warning. Non-blocking; purely informational.
+  jp_doc = JoinPlanResolutions.load(File.join(WORK, 'join-plan.json'))
+  jp_resolved_lines = JoinPlanResolutions.report_lines(jp_doc)
+  unless jp_resolved_lines.empty?
+    puts
+    puts '============== JOIN-CARDINALITY RESOLUTIONS (gate 16) =============='
+    puts "   #{JoinPlanResolutions.headline(jp_doc)}"
+    puts
+    puts jp_resolved_lines.join("\n")
+    puts '======================================================================'
   end
 
   # 3) Assemble the workbook spec (page-data master [+ hidden helpers] + one

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-read-pagination.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-read-pagination.rb
@@ -95,10 +95,17 @@ check(entries.any? { |c| c['name'] == 'COL_54' },
       'a column at ordinal 54 (past the default page size) is discovered', fails)
 
 # 3. WIRING PIN — discover-columns.rb issues its columns read through
-#    Sigma.list_entries and no longer parses a single first-page body.
+#    WarehouseColumnsPagination (NOT Sigma.list_entries — see
+#    lib/warehouse_columns_pagination.rb's header: live verification against
+#    the real /v2/connections/tables/<inode>/columns endpoint, 2026-08 on the
+#    logical-model-objectgraph fixture's real 64-column FACT_WIDE table, found
+#    it paginates via nextPageToken/pageToken, not list_entries' assumed
+#    nextPage/page — list_entries silently stops after page 1 (50 columns)
+#    against this specific endpoint) and no longer parses a single first-page
+#    body.
 src = File.read(File.join(__dir__, 'discover-columns.rb'))
-check(src.include?('Sigma.list_entries'),
-      'discover-columns.rb reads columns via Sigma.list_entries', fails)
+check(src.include?('WarehouseColumnsPagination.list'),
+      'discover-columns.rb reads columns via WarehouseColumnsPagination (live-correct cursor handling)', fails)
 check(!src.match?(/JSON\.parse\(body\)\['entries'\]/),
       'discover-columns.rb no longer reads a bare first-page body', fails)
 check(src.include?('SIGMA_HTTP_TIMEOUT'),
@@ -110,17 +117,47 @@ check(src.include?("not found in Sigma's catalog") && src.include?('/sync'),
 check(src.include?('exit 4'),
       'discover-columns.rb still exits 4 on a catalog miss', fails)
 
-# 4. WIRING PIN — discover-warehouse-columns.rb paginates, and does NOT inject a
-#    shared connection: it runs one thread per inode, so each thread must get its
-#    own Net::HTTP (the http: nil default) or they race on one socket.
+# 4. WIRING PIN — discover-warehouse-columns.rb paginates via the same live-
+#    correct helper, and does NOT inject a shared connection: it runs one
+#    thread per inode, so each thread must get its own Net::HTTP (the http:
+#    nil default) or they race on one socket.
 src = File.read(File.join(__dir__, 'discover-warehouse-columns.rb'))
-check(src.include?('Sigma.list_entries'),
-      'discover-warehouse-columns.rb reads columns via Sigma.list_entries', fails)
+check(src.include?('WarehouseColumnsPagination.list'),
+      'discover-warehouse-columns.rb reads columns via WarehouseColumnsPagination (live-correct cursor handling)', fails)
 check(!src.match?(/body\['entries'\]/),
       'discover-warehouse-columns.rb no longer reads a bare first-page body', fails)
-check(!src.match?(/list_entries\([^)]*http:/),
+check(!src.match?(/WarehouseColumnsPagination\.list\([^)]*http:/),
       'discover-warehouse-columns.rb does NOT inject a shared connection into its thread fan-out',
       fails)
+
+# 5. REGRESSION PIN — WarehouseColumnsPagination follows nextPageToken/pageToken
+#    (the endpoint's REAL shape, live-verified against a real 64-column warehouse fact table),
+#    not just nextPage/page (Sigma.list_entries' assumed shape, which this
+#    endpoint never actually sends). Fixture mirrors the real 64-column
+#    FACT_WIDE table: page 1 = 50 entries + nextPageToken, page 2 = 14 entries
+#    + nextPageToken: nil.
+require_relative 'lib/warehouse_columns_pagination'
+
+def token_paged_table
+  page1 = (1..50).map  { |i| { 'name' => "COL_#{i}",  'type' => { 'type' => 'text' } } }
+  page2 = (51..64).map { |i| { 'name' => "COL_#{i}", 'type' => { 'type' => 'text' } } }
+  [
+    http_res(Net::HTTPOK, 200, JSON.generate('entries' => page1, 'nextPageToken' => 50)),
+    http_res(Net::HTTPOK, 200, JSON.generate('entries' => page2, 'nextPageToken' => nil))
+  ]
+end
+
+reset_state!
+ENV['SIGMA_BASE_URL'] = 'https://sigma.example'
+ENV['SIGMA_API_TOKEN'] = 'tok'
+entries = WarehouseColumnsPagination.list('/v2/connections/tables/inode-1/columns',
+                                          http: FakeHttp.new(token_paged_table))
+check(entries.size == 64,
+      "a 64-column table paginated via nextPageToken returns ALL 64 columns (got #{entries.size})", fails)
+check(entries.any? { |c| c['name'] == 'COL_54' },
+      'a column at ordinal 54 (past the default page size, nextPageToken-paginated) is discovered', fails)
+check(entries.first['name'] == 'COL_1' && entries.last['name'] == 'COL_64',
+      'first and last column both survive nextPageToken pagination', fails)
 
 # 6. WIRING PIN — post-and-readback.rb's column census paginates. The census
 #    drives the error-column quarantine decision, so a truncated read can

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-join-plan-resolution-surfacing.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-join-plan-resolution-surfacing.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-join-plan-resolution-surfacing.rb — unit test for
+# scripts/lib/join_plan_resolutions.rb (beads-sigma-zjkw, the real M5 gap).
+#
+# WHY: probe-join-keys.rb (gate 16) lets an operator resolve a non-unique join
+# by recording {how, reason} on the entry's 'resolution' key in
+# <workdir>/join-plan.json — but nothing downstream ever read it back out.
+# A 'preaggregated' resolution means a helper element (a pre-aggregated /
+# Custom-SQL-shaped table) was added to the data model to fix the grain; with
+# no readback, that helper has no customer-visible explanation anywhere. This
+# is the confirmed root cause of a field report ("it created a custom SQL
+# aggregate table in a data model that didn't exist in the Tableau data set").
+#
+# Pure/offline, no network, no fixtures beyond an inline join-plan.json —
+# same shape convention as test-coverage-gate.rb / test-join-plan.rb.
+# Run: ruby scripts/test-join-plan-resolution-surfacing.rb
+require 'json'
+require 'tmpdir'
+require_relative 'lib/join_plan_resolutions'
+
+$fail = 0
+def ok(name, cond)
+  puts((cond ? '  ok  ' : 'FAIL  ') + name)
+  $fail += 1 unless cond
+end
+
+# One RESOLVED entry (preaggregated, with a human-written reason) and one
+# UNRESOLVED non-unique entry (no resolution recorded yet) — the exact mix a
+# real join-plan.json carries mid-migration.
+DOC = {
+  'generated_at' => '2026-07-31T00:00:00Z',
+  'entries' => [
+    {
+      'kind' => 'lookup-synthesis', 'left' => 'Orders', 'right' => 'Shipments',
+      'keys' => ['Order Id'], 'status' => 'non-unique',
+      'resolution' => { 'how' => 'preaggregated', 'reason' => 'Shipments Preagg by Order Id',
+                         'recorded_at' => '2026-07-31T01:00:00Z' }
+    },
+    {
+      'kind' => 'federated-join', 'left' => 'FACT_WIDE', 'right' => 'DIM_PRODUCT',
+      'keys' => ['PRODUCT_ID'], 'status' => 'non-unique'
+      # no 'resolution' — still blocking, NOT yet explained.
+    }
+  ]
+}.freeze
+
+puts '== resolved_entries: only entries with a recognized resolution =='
+resolved = JoinPlanResolutions.resolved_entries(DOC)
+ok('exactly one resolved entry (the unresolved one is excluded)', resolved.size == 1)
+ok('the resolved entry is the Orders->Shipments one', resolved.first && resolved.first['left'] == 'Orders')
+
+puts "\n== report_lines: names the reason + how for the resolved entry =="
+lines = JoinPlanResolutions.report_lines(DOC)
+joined = lines.join("\n")
+ok('report mentions the left->right relationship', joined.include?('Orders') && joined.include?('Shipments'))
+ok('report names the resolution kind (preaggregated)', joined.include?('preaggregated'))
+ok('report carries the human-written reason verbatim', joined.include?('Shipments Preagg by Order Id'))
+ok('the UNRESOLVED entry (FACT_WIDE/DIM_PRODUCT) is NOT surfaced as if it were fine',
+   !joined.include?('FACT_WIDE') && !joined.include?('DIM_PRODUCT'))
+
+puts "\n== headline names the count =="
+hl = JoinPlanResolutions.headline(DOC)
+ok('headline reports 1 resolution', hl.include?('1'))
+
+puts "\n== waived resolutions are ALSO surfaced (not just preaggregated) =="
+waived_doc = { 'entries' => [
+  { 'kind' => 'federated-join', 'left' => 'A', 'right' => 'B', 'keys' => ['K'], 'status' => 'non-unique',
+    'resolution' => { 'how' => 'waived', 'reason' => 'ops: accepted arbitrary-match risk for this report' } }
+] }
+w_lines = JoinPlanResolutions.report_lines(waived_doc)
+ok('waived resolution surfaced', w_lines.join.include?('waived') && w_lines.join.include?('accepted arbitrary-match risk'))
+
+puts "\n== no resolutions at all -> empty report, no crash =="
+none_doc = { 'entries' => [{ 'kind' => 'federated-join', 'left' => 'X', 'right' => 'Y', 'status' => 'unique' }] }
+ok('report_lines([]) for an all-unique ledger', JoinPlanResolutions.report_lines(none_doc) == [])
+ok('resolved_entries([]) for an all-unique ledger', JoinPlanResolutions.resolved_entries(none_doc) == [])
+
+puts "\n== defensive load: missing/garbage/empty doc never crashes =="
+ok('load(nil) -> nil', JoinPlanResolutions.load(nil).nil?)
+ok('load(missing path) -> nil', JoinPlanResolutions.load('/no/such/join-plan.json').nil?)
+ok('report_lines(nil) -> []', JoinPlanResolutions.report_lines(nil) == [])
+ok('resolved_entries(nil) -> []', JoinPlanResolutions.resolved_entries(nil) == [])
+Dir.mktmpdir do |dir|
+  path = File.join(dir, 'join-plan.json')
+  File.write(path, JSON.pretty_generate(DOC))
+  loaded = JoinPlanResolutions.load(path)
+  ok('load() round-trips a real file', loaded && JoinPlanResolutions.resolved_entries(loaded).size == 1)
+end
+
+# An entry whose 'resolution' key exists but isn't a recognized 'how' (e.g. a
+# future value, or malformed data) must not be treated as resolved — silently
+# accepting an unrecognized how would risk mis-surfacing something as
+# explained when it isn't.
+puts "\n== unrecognized resolution.how is NOT treated as resolved =="
+weird_doc = { 'entries' => [
+  { 'kind' => 'federated-join', 'left' => 'A', 'right' => 'B', 'status' => 'non-unique',
+    'resolution' => { 'how' => 'something-else', 'reason' => 'r' } }
+] }
+ok('unrecognized how excluded from resolved_entries', JoinPlanResolutions.resolved_entries(weird_doc) == [])
+
+puts($fail.zero? ? "\ntest-join-plan-resolution-surfacing: ALL PASS" : "\ntest-join-plan-resolution-surfacing: #{$fail} FAILURE(S)")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb
@@ -311,24 +311,28 @@ check(store_jp && store_jp['probe_keys'] == ['STORE_KEY'],
 #        rung that bypasses orientation, both fail here);
 #      - derivedVia and the partial/droppedConditions census must SURVIVE
 #        pass-2 attachment onto the relationship object itself.
-fact_el = els.find { |e| ((e['source'] || {})['path'] || []).last == 'FACT_WIDE' }
-check(!fact_el.nil?, 'composition: FACT_WIDE element located by warehouse source path', fails)
+#    Table/relationship names below are this fixture's real LMOG_-prefixed
+#    ones (see the header's live-verified correction), and the name-inference
+#    edge checked is LMOG_DIM_STORE (this fixture's sole name-inference case
+#    now — LMOG_DIM_CUSTOMER moved to a plain serialized key; see case 1's
+#    comment above).
+fact_el = els.find { |e| ((e['source'] || {})['path'] || []).last == 'LMOG_FACT_WIDE' }
+check(!fact_el.nil?, 'composition: LMOG_FACT_WIDE element located by warehouse source path', fails)
 rels_on_fact = fact_el ? (fact_el['relationships'] || []) : []
-cust_rel = rels_on_fact.find { |r| r['name'] == 'DIM_CUSTOMER' }
-check(!cust_rel.nil?,
-      'composition: the name-inferred DIM_CUSTOMER edge attaches to the ELECTED fact via pass-2 ' \
+store_pass2_rel = rels_on_fact.find { |r| r['name'] == 'LMOG_DIM_STORE' }
+check(!store_pass2_rel.nil?,
+      'composition: the name-inferred LMOG_DIM_STORE edge attaches to the ELECTED fact via pass-2 ' \
       'orientation (not first-end-point document order)', fails)
-check(cust_rel && cust_rel['derivedVia'] == 'name-inference',
+check(store_pass2_rel && store_pass2_rel['derivedVia'] == 'name-inference',
       "composition: derivedVia survives pass-2 attachment on the element relationship " \
-      "(got #{(cust_rel || {})['derivedVia'].inspect})", fails)
-store_rel = rels_on_fact.find { |r| r['name'] == 'DIM_STORE' }
-check(store_rel && store_rel['partial'] == true && store_rel['droppedConditions'].to_i >= 1,
+      "(got #{(store_pass2_rel || {})['derivedVia'].inspect})", fails)
+check(store_pass2_rel && store_pass2_rel['partial'] == true && store_pass2_rel['droppedConditions'].to_i >= 1,
       'composition: partial/droppedConditions survive pass-2 attachment (wider-than-Tableau join ' \
       'stays visible on the wired relationship object)', fails)
 check(!rels_on_fact.empty? && rels_on_fact.all? { |r| %w[serialized name-inference].include?(r['derivedVia']) },
       'composition: every relationship attached in pass 2 carries a known derivedVia', fails)
-check((doc['warnings'] || []).any? { |w| w.include?('fact election') && w.include?('"FACT_WIDE"') },
-      'composition: evidence-ranked fact election ran and announced FACT_WIDE', fails)
+check((doc['warnings'] || []).any? { |w| w.include?('fact election') && w.include?('"LMOG_FACT_WIDE"') },
+      'composition: evidence-ranked fact election ran and announced LMOG_FACT_WIDE', fails)
 
 puts ''
 if fails.empty?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-derivation.rb
@@ -4,11 +4,23 @@
 # Contract test: object-graph relationships whose join key Tableau did NOT
 # serialize must still be wired, and every derivation must be recorded.
 #
-# WHY: Tableau AUTO-MATCHES relationships by column name at query time and
-# serializes no key. That is how modern star schemas are built, so the converter
-# saw a star and emitted disconnected tables — after which a parity gate with no
-# relationships to satisfy it pushes the run into joined/aggregated Custom SQL.
-# That is the "flattened star schema" a field report described.
+# WHY: Tableau AUTO-MATCHES relationships by column name at query time, and can
+# serialize a relationship whose only usable key is a computed expression Sigma
+# cannot join on physically. That is how modern star schemas are built, so the
+# converter saw a star and emitted disconnected tables — after which a parity
+# gate with no relationships to satisfy it pushes the run into joined/
+# aggregated Custom SQL. That is the "flattened star schema" a field report
+# described.
+#
+# LIVE-VERIFIED CORRECTION (2026-08, logical-model-objectgraph fixture): a
+# relationship with literally NO <expression> at all — this test's original
+# model of "auto-matched, no serialized key" — does not survive a real Tableau
+# Server publish (HTTP 400011, "The relationship/expression tag is missing or
+# invalid"). Every relationship in genuine Tableau output carries SOME
+# expression. The name-inference rung this test exercises is instead reached
+# via a relationship whose serialized expression is present but not a usable
+# PHYSICAL key (e.g. wrapped in IFNULL/DATETRUNC) — see case 4 (LMOG_DIM_STORE)
+# below, now the sole name-inference case in this fixture.
 #
 # Inference is only safe because inferred keys are written into join-plan.json,
 # where gate 16's warehouse uniqueness probe validates them before GREEN. A wrong
@@ -149,34 +161,43 @@ end
 puts 'test-relationship-derivation.rb — object-graph key derivation'
 
 cov = doc['relationshipCoverage'] || {}
-check(cov['serialized'].to_i == 4,
-      "coverage reports all 4 serialized relationships (got #{cov['serialized'].inspect})", fails)
+check(cov['serialized'].to_i == 5,
+      "coverage reports all 5 serialized relationships (got #{cov['serialized'].inspect})", fails)
 entries = cov['entries'] || []
 by_target = entries.each_with_object({}) { |e, h| h[e['right']] = e }
-# The auto-matched, mixed-key, and computed-only-but-name-inferred relationships
-# MUST wire. The computed-only/no-shared-name one may legitimately stay unwired
-# under the conservative rule (no key-shaped name match) — what matters is that
-# it is RECORDED, never silently absent.
-check(cov['wired'].to_i >= 3,
-      "at least the auto-matched, mixed-key, and computed-only-but-name-inferred relationships are WIRED " \
-      "(got #{cov['wired'].inspect}) — fewer means the star still becomes disconnected tables", fails)
-check(entries.length == 4,
-      "all 4 relationships appear in the ledger, wired or not (got #{entries.length})", fails)
+# The plain-physical-key, mixed-key, computed-only-but-name-inferred, and
+# 5th (new, plain physical) relationships MUST wire. The computed-only/
+# no-shared-name one may legitimately stay unwired under the conservative rule
+# (no key-shaped name match) — what matters is that it is RECORDED, never
+# silently absent.
+check(cov['wired'].to_i >= 4,
+      "at least the plain-physical-key, mixed-key, computed-only-but-name-inferred, and 5th relationships " \
+      "are WIRED (got #{cov['wired'].inspect}) — fewer means the star still becomes disconnected tables", fails)
+check(entries.length == 5,
+      "all 5 relationships appear in the ledger, wired or not (got #{entries.length})", fails)
 
 entries = cov['entries'] || []
 by_target = entries.each_with_object({}) { |e, h| h[e['right']] = e }
 
-# 1. AUTO-MATCHED: Tableau serialized no key at all. Must be inferred by name.
-cust = by_target['DIM_CUSTOMER'] || {}
-check(cust['derivedVia'] == 'name-inference',
-      "auto-matched FACT_WIDE->DIM_CUSTOMER is derived by name-inference (got #{cust['derivedVia'].inspect})",
+# 1. PLAIN PHYSICAL KEY (CUSTOMER_KEY = CUSTOMER_KEY). LIVE-VERIFIED CORRECTION
+#    (see header note above): this fixture originally modeled this
+#    relationship with NO serialized expression at all ("auto-matched, no
+#    serialized key"), to exercise name-inference on a relationship Tableau
+#    itself never wrote a key for. Publishing that shape to real Tableau
+#    Server 400s — every relationship needs an expression — so this case is
+#    now a plain serialized physical key instead. It still proves the
+#    baseline "serialized physical key wires cleanly" rung; name-inference is
+#    now exercised solely by case 4 (LMOG_DIM_STORE) below.
+cust = by_target['LMOG_DIM_CUSTOMER'] || {}
+check(cust['derivedVia'] == 'serialized',
+      "plain-physical-key LMOG_FACT_WIDE->LMOG_DIM_CUSTOMER is derived as serialized (got #{cust['derivedVia'].inspect})",
       fails)
-check(cust['partial'] != true, 'auto-matched relationship is not marked partial', fails)
+check(cust['partial'] != true, 'plain-physical-key relationship is not marked partial', fails)
 
 # 2. MIXED keys: physical subset wired, computed condition recorded as dropped.
-prod = by_target['DIM_PRODUCT'] || {}
+prod = by_target['LMOG_DIM_PRODUCT'] || {}
 check(prod['derivedVia'] == 'serialized',
-      "mixed-key FACT_WIDE->DIM_PRODUCT keeps its serialized physical key (got #{prod['derivedVia'].inspect})",
+      "mixed-key LMOG_FACT_WIDE->LMOG_DIM_PRODUCT keeps its serialized physical key (got #{prod['derivedVia'].inspect})",
       fails)
 check(prod['partial'] == true && prod['droppedConditions'].to_i >= 1,
       'mixed-key relationship is marked partial with a dropped-condition count', fails)
@@ -184,26 +205,41 @@ check(prod['partial'] == true && prod['droppedConditions'].to_i >= 1,
 # 3. COMPUTED-ONLY key, inference fails (no shared key-shaped name): no physical
 #    column to join on, so inference by name is the only route. Whatever the
 #    outcome, it must be RECORDED, never silently absent.
-date = by_target['DIM_DATE'] || {}
-check(!date.empty?, 'computed-key FACT_WIDE->DIM_DATE appears in the coverage ledger', fails)
+date = by_target['LMOG_DIM_DATE'] || {}
+check(!date.empty?, 'computed-key LMOG_FACT_WIDE->LMOG_DIM_DATE appears in the coverage ledger', fails)
 check(%w[serialized name-inference unwired].include?(date['derivedVia']),
       "computed-key relationship records a known derivedVia (got #{date['derivedVia'].inspect})", fails)
 
 # 4. COMPUTED-ONLY key, inference SUCCEEDS (review fix-wave, 2026-07-30,
-#    Important finding 2): FACT_WIDE/DIM_STORE's sole condition
-#    (IFNULL([STORE_KEY],-1) = [STORE_KEY]) is computed on its left operand, so
-#    no physical pair survives — but STORE_KEY is a shared key-shaped column
-#    name on both sides, so name-inference wires it. Before the fix this wired
-#    cleanly with no partial/droppedConditions, hiding that the IFNULL
-#    condition Tableau required was dropped (a WIDER-than-Tableau join). The
-#    ledger entry must now say so explicitly, exactly like the mixed-key case.
-store = by_target['DIM_STORE'] || {}
+#    Important finding 2 — this is now the fixture's SOLE name-inference case,
+#    since case 1 above moved to a plain serialized key): FACT_WIDE/DIM_STORE's
+#    sole condition (IFNULL([STORE_KEY],-1) = [STORE_KEY]) is computed on its
+#    left operand, so no physical pair survives — but STORE_KEY is a shared
+#    key-shaped column name on both sides, so name-inference wires it. Before
+#    the fix this wired cleanly with no partial/droppedConditions, hiding that
+#    the IFNULL condition Tableau required was dropped (a WIDER-than-Tableau
+#    join). The ledger entry must now say so explicitly, exactly like the
+#    mixed-key case.
+store = by_target['LMOG_DIM_STORE'] || {}
 check(store['derivedVia'] == 'name-inference',
-      "computed-only-but-name-matched FACT_WIDE->DIM_STORE is derived by name-inference " \
+      "computed-only-but-name-matched LMOG_FACT_WIDE->LMOG_DIM_STORE is derived by name-inference " \
       "(got #{store['derivedVia'].inspect})", fails)
 check(store['partial'] == true && store['droppedConditions'].to_i >= 1,
       'computed-only-but-name-inferred relationship is marked partial with a dropped-condition count ' \
       '(a wider-than-Tableau join must never look clean)', fails)
+
+# 5. NEW (live-fixture addition, orthogonal to the derivation ladder): a plain
+#    serialized physical equality key with no complexity at all. Exists to
+#    exercise gate 16's join-cardinality probe live (LMOG_DIM_REGION is
+#    deliberately non-unique on REGION_KEY in the live warehouse fixture —
+#    see MANIFEST.md's live validation section) — the offline converter
+#    check here only proves the key wires; the non-uniqueness itself is a
+#    live-warehouse-only behavior no offline check can exercise.
+region = by_target['LMOG_DIM_REGION'] || {}
+check(region['derivedVia'] == 'serialized',
+      "plain-physical-key LMOG_FACT_WIDE->LMOG_DIM_REGION is derived as serialized (got #{region['derivedVia'].inspect})",
+      fails)
+check(region['partial'] != true, 'plain-physical-key LMOG_FACT_WIDE->LMOG_DIM_REGION relationship is not marked partial', fails)
 
 # 5. Every wired relationship's keys must trace back to a column NAME the
 #    .twb itself declared — not merely one present in element.columns, which
@@ -243,20 +279,26 @@ check(src.include?('partial'),
       fails)
 
 # 7. BEHAVIORAL pin (not a source grep): JoinPlan.derive must actually RECOVER
-#    the name-inferred FACT_WIDE->DIM_CUSTOMER relationship — the .twb alone
-#    carries no <expression> for it, so this only passes if join_plan.rb reads
-#    the converter's dm-spec relationships (dm_object_graph_index), not merely
-#    if it mentions the string "derived_via" somewhere. This is the check that
-#    pins the recovery branch AND the dm-spec/.twb name-matching together.
+#    the name-inferred LMOG_FACT_WIDE->LMOG_DIM_STORE relationship — the .twb's
+#    sole serialized condition for it (IFNULL([STORE_KEY],-1) = [STORE_KEY]) is
+#    computed, not a bare physical key, so this only passes if join_plan.rb
+#    reads the converter's dm-spec relationships (dm_object_graph_index), not
+#    merely if it mentions the string "derived_via" somewhere. This is the
+#    check that pins the recovery branch AND the dm-spec/.twb name-matching
+#    together. (Pinned against LMOG_DIM_STORE, not LMOG_DIM_CUSTOMER, per the
+#    header's live-verified correction: LMOG_DIM_CUSTOMER now carries a plain
+#    serialized physical key, so it is derived as "serialized", not
+#    "name-inference" — LMOG_DIM_STORE is this fixture's only remaining
+#    name-inference case.)
 jp_entries = JoinPlan.derive(doc['model'], File.read(twb_path, encoding: 'UTF-8'))
-cust_jp = jp_entries.find { |e| e['left'] == 'FACT_WIDE' && e['right'] == 'DIM_CUSTOMER' }
-check(!cust_jp.nil?,
-      'JoinPlan.derive recovers a join-plan.json entry for the name-inferred FACT_WIDE->DIM_CUSTOMER ' \
+store_jp = jp_entries.find { |e| e['left'] == 'LMOG_FACT_WIDE' && e['right'] == 'LMOG_DIM_STORE' }
+check(!store_jp.nil?,
+      'JoinPlan.derive recovers a join-plan.json entry for the name-inferred LMOG_FACT_WIDE->LMOG_DIM_STORE ' \
       'relationship (absent before this task — nothing for gate 16 to probe)', fails)
-check(cust_jp && cust_jp['derived_via'] == 'name-inference',
-      "recovered entry's derived_via is name-inference (got #{(cust_jp || {})['derived_via'].inspect})", fails)
-check(cust_jp && cust_jp['probe_keys'] == ['CUSTOMER_KEY'],
-      "recovered entry's probe_keys resolve to the physical inferred key (got #{(cust_jp || {})['probe_keys'].inspect})",
+check(store_jp && store_jp['derived_via'] == 'name-inference',
+      "recovered entry's derived_via is name-inference (got #{(store_jp || {})['derived_via'].inspect})", fails)
+check(store_jp && store_jp['probe_keys'] == ['STORE_KEY'],
+      "recovered entry's probe_keys resolve to the physical inferred key (got #{(store_jp || {})['probe_keys'].inspect})",
       fails)
 
 # 8. COMPOSITION (wave/2-integration merge of #569 + W2-OM): the derivation


### PR DESCRIPTION
## Summary

Two related pieces, both tableau-to-sigma-only:

1. **Headline finding — `beads-sigma-tzly` regression (reopened P0).** The M1 column-discovery pagination fix (PR #565, merged, tableau-to-sigma 1.3.5) does not actually work against the real warehouse-catalog `/v2/connections/tables/<inode>/columns` endpoint. Live verification against a real 64-column Snowflake table found the endpoint paginates via `nextPageToken`/`pageToken`, never `nextPage`/`page` — the shape `Sigma.list_entries` (shared/lib/sigma_rest.rb) assumes. `list_entries` therefore returns only page 1 (50 of 64 columns) against this specific endpoint, every time, silently. Fixed plugin-locally (`scripts/lib/warehouse_columns_pagination.rb`) — confirmed only `discover-columns.rb`/`discover-warehouse-columns.rb` call this endpoint anywhere in the repo, so this is correctly scoped as a single-plugin fix, not a shared-file change.
2. **`corpus/tableau/logical-model-objectgraph/` fixture replacement (`beads-sigma-ovy4`'s deferred follow-up).** That fixture's `.twb` was hand-authored XML that only looked like real Tableau output (its own MANIFEST said so). It's now the genuine, downloaded-back output of a real Tableau Server publish, over real Snowflake tables, run through the real converter and a real live gate-16 probe.

## What's live-verified (measured, not rounded)

**M1 — pagination**, live, before/after:
```
GET .../columns?limit=1000              -> 50 entries, nextPageToken: 50
GET .../columns?limit=1000&page=50      -> 50 entries AGAIN (page 1 repeats)
GET .../columns?limit=1000&pageToken=50 -> 14 entries, nextPageToken: null
```
After the fix, `discover-columns.rb` against the same real table: **64/64 columns**, join keys at 0-based indices **54, 57, 62, 63**.

**M2/M3 — relationship derivation**, live, against the genuinely served `.twb`:
```
serialized: 5, wired: 4
  LMOG_DIM_CUSTOMER  serialized              (plain physical key)
  LMOG_DIM_PRODUCT   serialized, partial:true, droppedConditions:1 (mixed)
  LMOG_DIM_DATE      unwired                 (recorded, not dropped)
  LMOG_DIM_STORE     name-inference, partial:true, droppedConditions:1
  LMOG_DIM_REGION    serialized              (plain physical key, NEW)
```
One real, live-only correction to the original fixture's design: real Tableau Server rejects an object-graph `<relationship>` with no `<expression>` at all (`HTTP 400011`, *"The relationship/expression tag is missing or invalid"*) — the exact shape the old fixture used for "auto-matched, no serialized key." That case (`LMOG_DIM_CUSTOMER`) is now a plain serialized key; name-inference is now exercised solely by `LMOG_DIM_STORE`. Full detail in `MANIFEST.md`'s Provenance section.

**Gate 16 + PR #590 resolution surfacing**, live, against the real warehouse:
```
NON-UNIQUE  #3 federated-join: LMOG_DIM_REGION on (REGION_KEY) — 6 row(s) over 5 key(s)
  sample duplicate keys: REGION_KEY=3 -> 2 rows
```
Resolved via a pre-aggregated helper (verified unique live: 5/5), then `--resolve 3 --how preaggregated --reason "..."`. `migrate-tableau.rb`'s exact end-of-run block then prints:
```
============== JOIN-CARDINALITY RESOLUTIONS (gate 16) ==============
   1 gate-16 join-cardinality resolution(s) recorded in join-plan.json ...
   - LMOG_FACT_WIDE -> LMOG_DIM_REGION (federated-join, preaggregated): ...
======================================================================
```
And `assert-phase6-ran.rb`'s gate 16 logic itself, run standalone against the resolved ledger: `[OK] gate 16: join-cardinality ledger resolved — 3 unique, 1 resolved of 4 (join-plan.json)`, exit 0.

PR #590 (bead `beads-sigma-zjkw`) was not yet merged to `main` at the time of this work — its 3 commits are cherry-picked onto this branch (`join_plan_resolutions.rb` + the `migrate-tableau.rb` print block + its own regression test) so this surfacing could actually be exercised live. `test-join-plan-resolution-surfacing.rb` (that PR's own test) passes unmodified.

## What's a known, explicitly-unresolved gap — not softened

The published Tableau workbook renders **genuinely empty**: `GET /views/{id}/data` → HTTP 200, 0-byte CSV; `GET /views/{id}/image` → HTTP 200, 2x2 PNG. The real per-view `SELECT` is never issued against the warehouse at all (confirmed via Snowflake's own query history — only the connection-test query ever appears), despite the embedded live Snowflake credential authenticating successfully. Four hypotheses tried; three ruled out (cross-table join complexity, missing `<column-instance>` mappings — which DID fix a separate real publish-time 400 but not this — missing `<panes>/<mark>/<encodings>`); one suspected but not confirmed (this test site may only serve live queries through a Tableau Virtual Connection / `sqlproxy` layer, never a bare embedded `class='snowflake'` connection — every workbook on the site that DOES render goes through one of those). Full writeup, evidence, and the explicit decision to stop pursuing this (a separate investigation, not in scope here) in `MANIFEST.md`.

**Consequence:** `migrate-tableau.rb`'s Phase 1d source-dashboard-read gate is NOT exercised by this fixture and remains unvalidated against a genuinely live-published, directly-embedded-connection Tableau workbook. The M2/M3 and gate-16 evidence above was gathered by driving the converter, `probe-join-keys.rb`, and `join_plan_resolutions.rb` directly against the real served `.twb` and the real warehouse — not via a completed `migrate-tableau.rb` orchestrator run (which cannot get past Phase 1d against this specific published workbook).

## Rebase note

This branch was rebased onto `origin/main` after PR #587 ("Wave 2", tableau-to-sigma 1.4.2 → 1.6.0) landed concurrently and touched several of the same files (`discover-columns.rb`, `lib/join_plan.rb`, `lib/sigma_rest.rb`, `migrate-tableau.rb`, `test-relationship-derivation.rb`). Conflicts resolved keeping both sides (e.g. `discover-columns.rb` keeps Wave 2's `use_ssl`-by-scheme fix and per-page observability counter *and* this branch's `WarehouseColumnsPagination` live-cursor fix; `warehouse_columns_pagination.rb` gained the same optional per-page block Wave 2 added to `Sigma.list_entries` so that feature isn't lost). One post-rebase issue required a follow-up fix commit: Wave 2 independently added a new "composition" test section to `test-relationship-derivation.rb`, hardcoded to the old fixture's table names and to `DIM_CUSTOMER` being the name-inference case — git auto-merged it without conflict (different line ranges), so it only surfaced by actually running the test after rebasing. Repointed to `LMOG_DIM_STORE` (this fixture's real name-inference case).

## Live infrastructure left behind (not cleaned up)

- 6 Snowflake tables (`LMOG_FACT_WIDE` + 5 dimensions) in a pre-existing scratch schema in this repo's shared sandbox Snowflake account, plus a dedicated least-privilege scratch role/service user created for the Tableau connection.
- 2 published Tableau workbooks on the test site's default project, named unambiguously as scratch/safe-to-delete.
- None of this was deleted. Cleanup is a separate, deliberate decision — see `MANIFEST.md`.

## Test plan

- [x] Full `tableau-to-sigma` offline test suite (`scripts/test-*.rb`, excluding the creds-requiring `test-calc-discovery.rb`): PASS after rebase + fixes
- [x] `corpus/run-corpus.sh --check tableau/logical-model-objectgraph`: 1/1 case pass
- [x] `tools/check-shared.rb`: clean
- [x] `tools/check-plugin-version-bump.sh origin/main HEAD`: OK (1.6.1 -> 1.6.2)
- [x] `tools/hygiene-sweep.sh`: clean
- [x] M1 live re-verification post-rebase: 64/64 columns, correct join-key ordinals
- [x] Gate 16 + resolution-surfacing live re-verification post-rebase: unchanged, both print the expected blocks

Refs: `beads-sigma-tzly` (reopened, headline regression), `beads-sigma-ovy4` (this fixture's original bead — closes its explicitly-deferred "live-published fixture" follow-up), `beads-sigma-zjkw` (PR #590, cherry-picked to exercise resolution surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
