### PR TITLE
fix(shared): quote-free doctor.ps1 cred probes — Windows PowerShell false negatives

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-assessment/scripts/doctor.ps1
+++ b/plugins/domo-to-sigma/skills/domo-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/doctor.ps1
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData → Sigma",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.7",
+  "version": "0.2.9",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.1",
+  "version": "1.8.3",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense → Sigma",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma — data model + workbook (indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; columnar layout→24-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.3",
+  "version": "1.6.6",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -145,7 +145,11 @@ if (-not $sigmaCreds) {
 } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
   Ok "Sigma credentials present (live token-mint smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
 } elseif ((Test-Path $sigmaLib) -and (Get-Command ruby -ErrorAction SilentlyContinue)) {
-  & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "sigma_rest"; Timeout.timeout(20) { Sigma.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+  # Quote-free -e payload (portability lint): Windows PowerShell 5.1 native-arg
+  # passing strips embedded double quotes, so the old inline requires reached
+  # Ruby unquoted and died at parse - a guaranteed false cred-probe negative.
+  # Load path and requires ride -I / -r flags instead.
+  & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rsigma_rest -e 'Timeout.timeout(20) { Sigma.refresh_token! }' 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) {
     Ok "Sigma credentials present + live token mint OK"
     $script:SmokeSigma = "pass"
@@ -176,7 +180,9 @@ if ((Test-Path $tabSetup) -and (Test-Path $tabLib)) {
   } elseif ($env:SIGMA_SKIP_CRED_SMOKE) {
     Ok "Tableau credentials present (live PAT signin smoke SKIPPED: SIGMA_SKIP_CRED_SMOKE)"
   } elseif (Get-Command ruby -ErrorAction SilentlyContinue) {
-    & ruby -e '$LOAD_PATH.unshift File.join(ARGV[0], "lib"); require "timeout"; require "tableau_rest"; Timeout.timeout(20) { Tableau.refresh_token! }' $PSScriptRoot 2>$null | Out-Null
+    # Quote-free -e payload - same PS 5.1 native-arg constraint as the Sigma
+    # probe above.
+    & ruby -I (Join-Path $PSScriptRoot 'lib') -rtimeout -rtableau_rest -e 'Timeout.timeout(20) { Tableau.refresh_token! }' 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Ok "Tableau credentials present + live PAT signin OK"
       $script:SmokeTableau = "pass"

--- a/tools/lint-skills.rb
+++ b/tools/lint-skills.rb
@@ -189,6 +189,26 @@ Dir.glob('**/*.sh').sort.each do |f|
   end
 end
 
+# Field-caught (doctor.ps1 cred probes): Windows PowerShell 5.1 does NOT
+# escape embedded double quotes when passing arguments to a native exe — a
+# single-quoted `-e '...'` payload containing "quoted" strings reaches the
+# interpreter with the inner quotes stripped, dies at parse, and (with stderr
+# redirected) reads as a probe failure: a guaranteed false negative on every
+# Windows PowerShell box. CI cannot exercise these paths (creds-free), so
+# this static rule is the only guard. Remedy: keep -e payloads quote-free —
+# hoist load paths to -I and requires to -r flags.
+Dir.glob('**/*.ps1').sort.each do |f|
+  File.readlines(f).each_with_index do |line, i|
+    next if line =~ /\A\s*#/                           # skip PS comments
+    payload = line[/-e\s+'([^']*)'/, 1]
+    next unless payload && payload.include?('"')
+    port_fails << [f, i + 1,
+                   'native -e payload embeds double quotes — Windows PowerShell 5.1 strips them ' \
+                   'in native-arg passing and the payload dies at parse (silent false negative). ' \
+                   'Keep the payload quote-free: hoist load paths to -I and requires to -r.']
+  end
+end
+
 unless warns.empty?
   puts "Tracked baseline gaps (WARN — fix and remove from #{baseline_path}):"
   warns.each { |n, id, desc, r| puts "  ~ #{n}: #{desc}\n      #{r}" }


### PR DESCRIPTION
The Windows field report you forwarded, root-caused and fixed — and no, the wave-2 merge had not touched it: the bug ships on main in the canonical `shared/scripts/doctor.ps1` and all 24 vendored copies.

**Confirmed mechanism, exactly as the report said:** both cred probes pass Ruby a single-quoted `-e` payload with double-quoted inner strings. Windows PowerShell 5.1's native-argument passing doesn't escape embedded double quotes, so Ruby parses bare words → `NameError` before any socket opens → `2>$null` swallows it → `$LASTEXITCODE` ≠ 0 → "live token mint FAILED" regardless of credential validity. False negative for every Windows PowerShell user *with* creds; invisible to the windows CI job because it runs creds-free and never enters the probe branch. (PowerShell 7.3+'s new argument passing doesn't strip them — which is why it's specifically a *Windows PowerShell* report.)

**Fix — quote-free payloads:** load path hoisted to `-I`, requires to `-r`, leaving a `-e` body with zero quote characters (`Timeout.timeout(20) { Sigma.refresh_token! }`) — immune to every PS argument-passing mode, no version-conditional escaping games. Canonical + sync fan-out (23 registered twins) + the same two-line fix applied directly to domo-assessment's unregistered variant. Validated live on this machine: the new `-I/-r` form mints a Sigma token; the Tableau probe is structurally identical (not live-run — PAT single-session lockout).

**Guard:** CI can never exercise this branch, so the portability content-lint (`tools/lint-skills.rb`, beside your #346 base64 rule — same latent-on-macOS class) now fails any `.ps1` native `-e` payload embedding double quotes. Watched failing first: 50 hits before the fix, 0 after, no false trips elsewhere in the tree.

Sweep note: the other eight `ruby -e` sites across doctor/bootstrap are quote-free payloads (`print RUBY_VERSION`) or file-path invocations — unaffected in every PS version. Version bumps for all 12 plugins shipping a doctor copy, staged clear of the other two open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
