### PR TITLE
fix(domo-to-sigma): use Sigma display name in YYYYMMDD-key formula suggestion

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/column_preflight.rb
@@ -86,6 +86,26 @@ module ColumnPreflight
     NUMERIC_TYPES.include?(col['type'].to_s.upcase)
   end
 
+  # Sigma's SERVER auto-names a raw warehouse table column (as returned by
+  # fetch_warehouse_columns / /v2/connections/tables/<inodeId>/columns —
+  # e.g. an unquoted Snowflake identifier, all-caps with underscores) by
+  # Title-Casing every underscore-separated word UNCONDITIONALLY:
+  # ORDER_DATE_KEY -> "Order Date Key", TAX_AMOUNT -> "Tax Amount". Confirmed
+  # LIVE against ~28 real columns on one warehouse table, 2026-08-03.
+  #
+  # This is DELIBERATELY separate from DomoSigma.display_name
+  # (domo_sigma_util.rb), which preserves an all-caps word-segment as-is
+  # (e.g. an "ID"/"URL" acronym) — the right rule for DOMO'S OWN
+  # dataset/calc-field names, but NOT for a raw warehouse identifier Sigma
+  # is auto-labeling fresh, where there is no way to distinguish "a real
+  # acronym" from "just an all-caps word" — Sigma doesn't try, so this
+  # helper doesn't either. Do not merge these two functions: same input
+  # shape, two different correct answers depending on which naming
+  # pipeline produced the name.
+  def warehouse_column_display_name(raw)
+    raw.to_s.split('_').map { |w| w.empty? ? w : w.capitalize }.join(' ')
+  end
+
   # The one derivation pattern shipped in this PR (see design doc — the
   # registry is shaped so a second pattern is additive, but only one exists
   # today; YAGNI). Triggers when a missing column's Domo type is DATE/DATETIME
@@ -108,11 +128,15 @@ module ColumnPreflight
     end
     return nil unless candidates.size == 1
     source = candidates.first['name']
+    # The formula reference must be the column's SIGMA-ASSIGNED display label
+    # (what Sigma auto-names the raw warehouse column), not the raw warehouse
+    # identifier itself — see warehouse_column_display_name above.
+    display = warehouse_column_display_name(source)
     {
       'pattern' => 'yyyymmdd_integer_key',
       'candidate_source_column' => source,
       'suggested_formula' =>
-        "MakeDate(Floor([#{source}]/10000), Floor(Mod([#{source}],10000)/100), Mod([#{source}],100))",
+        "MakeDate(Floor([#{display}]/10000), Floor(Mod([#{display}],10000)/100), Mod([#{display}],100))",
     }
   end
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-column-preflight.rb
@@ -64,9 +64,35 @@ warehouse3 = [{ 'name' => 'ORDER_ID', 'type' => 'LONG' }, { 'name' => 'ORDER_DAT
 s = suggest_derivation('ORDER_DATE', 'DATE', warehouse3)
 ok(s, 'a suggestion is returned')
 eq(s['pattern'], 'yyyymmdd_integer_key', 'suggested pattern name')
-eq(s['candidate_source_column'], 'ORDER_DATE_KEY', 'candidate is the one matching numeric column')
-ok(s['suggested_formula'].include?('MakeDate') && s['suggested_formula'].include?('ORDER_DATE_KEY'),
-   "suggested_formula references MakeDate and the candidate column, got #{s['suggested_formula'].inspect}")
+eq(s['candidate_source_column'], 'ORDER_DATE_KEY', 'candidate is the one matching numeric column (RAW warehouse name)')
+ok(s['suggested_formula'].include?('MakeDate') && s['suggested_formula'].include?('Order Date Key'),
+   "suggested_formula references MakeDate and the candidate column's Sigma DISPLAY name, got #{s['suggested_formula'].inspect}")
+
+puts '== suggest_derivation: suggested_formula brackets the candidate\'s Sigma-auto-assigned DISPLAY name, ' \
+     'NEVER the raw all-caps warehouse identifier (bead beads-sigma-nxft) =='
+# Sigma's server Title-Cases every underscore-separated word of a raw warehouse
+# column UNCONDITIONALLY when auto-naming it (confirmed live, 2026-08-03:
+# ORDER_DATE_KEY -> "Order Date Key") -- a formula referencing [ORDER_DATE_KEY]
+# would not resolve against the real column, which is labeled [Order Date Key].
+s_bug = suggest_derivation('ORDER_DATE', 'DATE', warehouse3)
+ok(s_bug['suggested_formula'].include?('[Order Date Key]'),
+   "suggested_formula must bracket-reference the Title-Cased display name, got #{s_bug['suggested_formula'].inspect}")
+ok(!s_bug['suggested_formula'].include?('[ORDER_DATE_KEY]'),
+   "suggested_formula must NOT bracket-reference the raw all-caps warehouse name, got #{s_bug['suggested_formula'].inspect}")
+
+puts '== suggest_derivation: an already-mixed/Title-Case candidate name is left as-is by Title-Casing (idempotent-ish shape) =='
+# fetch_warehouse_columns reports names exactly as the warehouse catalog returns
+# them (preflight-columns.rb) -- for an unquoted Snowflake identifier that's
+# always all-caps, but guard the mixed-case shape too in case a differently
+# cased connector (or a quoted identifier) is ever the candidate.
+warehouse_mixed = [
+  { 'name' => 'Order_Date_Key', 'type' => 'INTEGER' },
+  { 'name' => 'ORDER_ID', 'type' => 'LONG' },
+]
+s_mixed = suggest_derivation('ORDER_DATE', 'DATE', warehouse_mixed)
+ok(s_mixed, 'a suggestion is returned for the mixed-case candidate')
+eq(s_mixed['suggested_formula'].include?('[Order Date Key]'), true,
+   "mixed-case warehouse name still normalizes to the Title-Cased display form, got #{s_mixed['suggested_formula'].inspect}")
 
 puts '== suggest_derivation: non-date Domo type -> no suggestion, even with a perfect candidate =='
 eq(suggest_derivation('ORDER_DATE', 'LONG', warehouse3), nil, 'only DATE/DATETIME Domo columns trigger this pattern')


### PR DESCRIPTION
## Summary
- `column_preflight.rb`'s `suggest_derivation` was interpolating the raw warehouse
  column name (e.g. `ORDER_DATE_KEY`) into a `[bracket]` formula reference, but
  Sigma's server auto-labels a raw warehouse column by Title-Casing every
  underscore-separated word unconditionally (`ORDER_DATE_KEY` -> `Order Date Key`).
  Confirmed live 2026-08-03 against ~28 real columns on a real Snowflake table
  during Track E's live E2E validation — the suggested override formula
  referenced a column that doesn't exist in the data model, so any operator
  who accepted the auto-suggestion as-is would hit a live `type:error` column.
- Added a new, deliberately separate `warehouse_column_display_name` helper
  (not a reuse of `DomoSigma.display_name`, which preserves all-caps segments —
  correct for Domo's own acronym-bearing names, wrong for Sigma's raw-warehouse
  auto-naming — two different naming pipelines for the same input shape).
- Bumps `domo-to-sigma` 0.10.1 -> 0.10.2 (patch, bug fix).

Bead: `beads-sigma-nxft`.

## Test plan
- [x] New regression test asserts the formula emits `[Order Date Key]`, not
      `[ORDER_DATE_KEY]` — verified genuinely red before the fix, green after
      (both by the implementer and independently reproduced by the reviewer
      against the actual parent commit)
- [x] Full plugin suite (`test/run-all.sh`, 22 suites) — all pass, no regressions
- [x] Independent task review: Approved, no Critical/Important findings (a few
      Minor edge-case/doc-staleness notes, non-blocking)