### PR TITLE
fix(shared): accept a page-level visual verdict when no per-tile manifest exists

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -310,6 +310,7 @@ jobs:
             shared/lib/test_metric_binding.rb
             shared/lib/test_phase_metrics.rb
             shared/scripts/test-intake-triage.rb
+            shared/scripts/test-assert-phase6.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake-triage.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-validate-sigma-formula-cleanup.rb
             # shared/scripts/test-validate-sigma-formula-cleanup.rb is INTENTIONALLY not listed: standalone it

--- a/docs/superpowers/plans/2026-08-03-assert-phase6-visual-verify-fallback.md
+++ b/docs/superpowers/plans/2026-08-03-assert-phase6-visual-verify-fallback.md
@@ -1,0 +1,396 @@
+# assert-phase6-ran.rb Visual-Verify Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `assert-phase6-ran.rb`'s anchors-oracle substitution path accept a
+page-level `record-visual-check.rb` verdict as satisfying its "every visual-verify
+tile confirmed" condition when no Tableau-only per-tile
+`visual-verify/manifest.json` exists — unblocking a clean GREEN exit for the 7
+non-Tableau converters that share this gate script, without changing Tableau's
+own (manifest-bearing) behavior at all.
+
+**Architecture:** One small conditional fallback in the canonical
+`shared/scripts/assert-phase6-ran.rb`'s `_vv_ok` computation, reusing the exact
+`visual_checked`/`screenshot_path`/`visual_verdict`/`agent_vision` fields gate 8b
+already reads from the same already-parsed `parity-final.json`. Propagated
+byte-identical to all 8 sharing plugins via this repo's existing
+`tools/sync-shared.rb` mechanism.
+
+**Tech Stack:** Ruby 2.6 (no endless method defs), this repo's existing
+scenario-based offline test harness (`shared/scripts/test-assert-phase6.rb`).
+
+**Design doc:** `docs/superpowers/specs/2026-08-03-assert-phase6-visual-verify-fallback-design.md`
+(read this first for full rationale — this plan implements it task-by-task).
+
+## Global Constraints
+
+- Edit ONLY `shared/scripts/assert-phase6-ran.rb` (canonical) and
+  `shared/scripts/test-assert-phase6.rb` directly. Every plugin copy of
+  `assert-phase6-ran.rb` must end up byte-identical to the canonical via
+  `tools/sync-shared.rb` — never hand-edit a plugin's copy.
+- This is a **shared-files-only PR** per this repo's governance
+  (`shared-file-governance`): one PR touches either a single plugin or the
+  shared files, never both. No plugin-specific (non-`assert-phase6-ran.rb`)
+  file should be touched.
+- Tableau's own behavior (manifest present → the existing strict per-tile
+  check) must be provably unchanged — a regression test proves this, not just
+  "the diff looks small."
+- A recorded visual verdict only satisfies the fallback when it is genuinely
+  vision-backed: `agent_vision == false` or `visual_verdict == "not-executable"`
+  must still reject the fallback (matching gate 8b's own §D5 doctrine) — this
+  is not a rubber-stamp escape hatch.
+- Ruby 2.6 — no endless method defs (`def f = ...`).
+- Any change under `plugins/<name>/**` requires a strict-semver bump of that
+  plugin's `plugin.json` version (or a `Skip-Version-Bump: <reason>` trailer),
+  enforced by CI. **`main` has been moving fast this session — re-check each
+  plugin's CURRENT version at execution time** (`grep version
+  plugins/<name>/.claude-plugin/plugin.json` against fresh `origin/main`, not
+  any number written into this plan) and bump from whatever that actual value
+  is. A prior PR in this same session hit two consecutive version-bump
+  collisions from concurrent shared-file PRs landing mid-task — rebase onto
+  current `origin/main` and re-bump if this happens again; it is not a sign
+  anything is wrong with this fix.
+- Stage git commits with explicit file paths — never `git add -A`.
+- Work happens in the dedicated worktree `/Users/tjwells/wt-domo-visual-verify-fallback`
+  (branch `fix/assert-phase6-visual-verify-fallback`, already has the design doc
+  committed) — do not create a new worktree.
+
+---
+
+### Task 1: Implement the fallback + regression tests in the canonical file
+
+**Files:**
+- Modify: `shared/scripts/assert-phase6-ran.rb`
+- Modify: `shared/scripts/test-assert-phase6.rb`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: the corrected `_vv_ok` / success-message logic in the canonical
+  file. Task 2 consumes this file's final state as the sync source — Task 2
+  does not touch its logic at all, only propagates + verifies + bumps
+  versions, so Task 1 must be fully correct and tested before Task 2 starts.
+
+- [ ] **Step 1: Write the failing tests first**
+
+Read `shared/scripts/test-assert-phase6.rb` in full first (340 lines) to match
+its established `scenario(name, expected_exit) { |dir| ... }` style exactly —
+look at the existing scenario `'source PNG present, source-anchors.json under
+the 5-anchor floor -> exit 18'` (currently around line 254) as the closest
+precedent for an anchors-oracle-path scenario, and the file's helper functions
+(`write_json`, etc.) for how fixture files get built.
+
+Append these 5 new scenarios (adapt exact helper-call syntax to match what you
+find in the file — the logic below is the source of truth, not the Ruby
+formatting):
+
+```ruby
+scenario('anchors-oracle: no manifest, no recorded visual verdict -> condition (b) incomplete, gate still fails', 18) do |dir|
+  # Set up: anchors-verdict.json passing (a), tiles non-empty (c), coverage ok (d),
+  # parity-final.json with charts_total 0 and NO visual_checked/screenshot_path/
+  # visual_verdict fields at all, NO visual-verify/manifest.json file.
+  # Expect: assert-phase6-ran.rb reports "b) every visual-verify tile confirmed
+  # (incomplete)" and the overall run still fails (does NOT silently pass just
+  # because a fallback path exists) — same exit code the pre-fix "no manifest at
+  # all" case already produced, proving the fallback requires REAL recorded
+  # evidence, not just its own absence-of-a-blocker.
+end
+
+scenario('anchors-oracle: no manifest, page-level visual_verdict=pass recorded -> gate 2 passes via anchors oracle', 0) do |dir|
+  # Same anchors/tiles/coverage setup as above, but parity-final.json carries
+  # visual_verdict: "pass" (and no agent_vision key, or agent_vision: true).
+  # No visual-verify/manifest.json file.
+  # Expect: exit 0, and the printed success line reads "page-level visual
+  # verdict recorded (pass)" — NOT "all N tile(s) image-verified" (that phrasing
+  # is reserved for the real-manifest path) and critically does NOT raise
+  # NoMethodError (this is the regression the fix must not (re)introduce —
+  # assert the process actually completes and prints the PASS line, don't just
+  # check the exit code, since a crash before printing could still coincidentally
+  # look like SOME exit code without this specific assertion).
+end
+
+scenario('anchors-oracle: no manifest, page-level visual_verdict=divergent recorded -> still satisfies condition (b)', 0) do |dir|
+  # Same setup, visual_verdict: "divergent" instead of "pass".
+  # Expect: exit 0 (condition (b) only requires "an agent with vision looked",
+  # not "it passed cleanly" — the divergence itself is priced separately via
+  # the pre-existing visual-divergent waiver-budget mechanism, unchanged by
+  # this fix). Confirm the run's overall waiver census still reflects
+  # visual-divergent being counted (this part of the behavior already exists
+  # pre-fix; this scenario is proving the fallback doesn't accidentally bypass
+  # it, not introducing new waiver logic).
+end
+
+scenario('anchors-oracle: no manifest, agent_vision:false recorded -> condition (b) still incomplete (blind attestation rejected)', 18) do |dir|
+  # Same setup, parity-final.json has visual_verdict: "pass" (or "divergent")
+  # AND agent_vision: false.
+  # Expect: condition (b) is NOT satisfied — the fallback must reject a
+  # recorded verdict that was never actually looked at with vision, matching
+  # gate 8b's own §D5 doctrine. Exit reflects the still-incomplete condition
+  # (same exit code as the "nothing recorded at all" scenario above).
+end
+
+scenario('anchors-oracle: manifest PRESENT and fully verified -> unchanged existing behavior (regression guard)', 0) do |dir|
+  # visual-verify/manifest.json present with every tile visual_verified: true,
+  # parity-final.json has NO visual_checked/screenshot_path/visual_verdict at
+  # all (proving the manifest path doesn't even look at those fields).
+  # Expect: exit 0, success line reads "all N tile(s) image-verified" (the
+  # ORIGINAL, unmodified wording) — proving Tableau's own path is completely
+  # untouched by this fix.
+end
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `ruby shared/scripts/test-assert-phase6.rb`
+Expected: the 5 new scenarios FAIL (the fallback doesn't exist yet — scenarios
+2/3/5 will fail because `_vv_ok` is still hard-`false` without a manifest, or
+because the crash-guard scenario hasn't been exercised yet). Scenario 1 and 4
+may currently PASS by coincidence (since "nothing recorded" and "blind
+attestation" both currently produce `_vv_ok == false` even pre-fix) — if so,
+that's fine, they're regression guards more than red/green proof for THIS
+change; what matters is scenarios 2, 3, and 5 must genuinely fail pre-fix.
+
+- [ ] **Step 3: Implement the `_vv_ok` fallback**
+
+Find, in `shared/scripts/assert-phase6-ran.rb` (currently lines 1132-1133,
+inside the `if total <= 0` anchors-oracle branch that starts around line
+1121 — `summary` is already parsed from `parity-final.json` at line 1110 in
+this same method scope, no new file read needed):
+
+```ruby
+    _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
+    _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
+    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+```
+
+Replace with:
+
+```ruby
+    _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
+    _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
+```
+
+- [ ] **Step 4: Fix the `_vv.size` crash in the success message**
+
+Find (currently lines 1167-1174):
+
+```ruby
+    if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
+           "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
+           "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
+           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
+           "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
+           "#{anchors_tol_note.call(_av)}"
+```
+
+Replace with:
+
+```ruby
+    if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
+      puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
+           "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
+           "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
+           "+ #{_vv_note} + all displayed tiles return data " \
+           "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
+           "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
+           "#{anchors_tol_note.call(_av)}"
+```
+
+- [ ] **Step 5: Add the remediation hint to the failure path**
+
+Find, inside the `else` branch right after (currently around lines 1176-1182,
+the `warn` block starting `"[FAIL] parity-final.json reports charts_total=..."`,
+specifically right after the line printing condition (b)'s status):
+
+```ruby
+      warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+```
+
+Immediately after that line, add (only reachable in this failure branch, so it
+naturally only prints when (b) is part of what's being reported — do not print
+it unconditionally elsewhere):
+
+```ruby
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `ruby shared/scripts/test-assert-phase6.rb`
+Expected: all scenarios PASS, including all 5 new ones. Confirm scenario 2's
+assertion genuinely exercises the success-message print path (not just the
+exit code) so the `_vv.size` crash fix is actually proven, not incidentally
+avoided.
+
+- [ ] **Step 7: Run the full existing offline test suite for this file**
+
+Check whether `shared/scripts/test-assert-phase6.rb` is invoked by a wrapper
+(e.g. `tools/test-*.rb` or a corpus-check script) and run that too if so —
+grep `.github/workflows/*.yml` for `test-assert-phase6` to find the exact
+invocation this repo's CI uses, and run it locally the same way, to catch
+anything the direct `ruby` invocation might not.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add shared/scripts/assert-phase6-ran.rb shared/scripts/test-assert-phase6.rb
+git commit -m "fix(shared): assert-phase6-ran.rb accepts a page-level visual verdict when no per-tile manifest exists
+
+The anchors-oracle substitution path hard-required a Tableau-only
+visual-verify/manifest.json, capping the other 7 converters sharing this
+file below GREEN whenever they hit the charts_total<=0 path (their normal
+case). Falls back to the page-level record-visual-check.rb verdict already
+stamped into parity-final.json (same fields gate 8b reads), rejecting a
+blind/not-executable attestation the same way gate 8b already does. Fixes
+a real NoMethodError the fallback would otherwise expose (_vv.size on nil).
+Tableau's own manifest-bearing path is unchanged (regression-tested).
+
+Bead: beads-sigma-co6m"
+```
+
+(This is Task 1's own commit only — do NOT run `tools/sync-shared.rb` or touch
+any plugin copy yet; that is Task 2's job, done against this task's final,
+reviewed state of the canonical file.)
+
+---
+
+### Task 2: Propagate to all 8 plugins, bump versions, final verification
+
+**Files:**
+- Modify (via sync, not hand-edit): `plugins/{looker-to-sigma,microstrategy-to-sigma,
+  powerbi-to-sigma,quicksight-to-sigma,tableau-to-sigma,thoughtspot-to-sigma,
+  domo-to-sigma,hex-to-sigma}/skills/*/scripts/assert-phase6-ran.rb`
+- Modify: each of the above 8 plugins' `.claude-plugin/plugin.json` (version bump)
+
+**Interfaces:**
+- Consumes: Task 1's final, committed `shared/scripts/assert-phase6-ran.rb` as
+  the sync source. Do not re-derive or hand-edit the fix logic here — this
+  task is propagation + bookkeeping only.
+- Produces: nothing consumed by a later task — this is the final task.
+
+- [ ] **Step 1: Run the sync**
+
+```bash
+ruby tools/sync-shared.rb
+```
+
+Expected: reports syncing `assert-phase6-ran.rb` to all 8 plugin targets
+listed in `shared/manifest.json` (looker-to-sigma, microstrategy-to-sigma,
+powerbi-to-sigma, quicksight-to-sigma, tableau-to-sigma, thoughtspot-to-sigma,
+domo-to-sigma, hex-to-sigma). If it reports "already in sync" for this file,
+STOP and investigate — Task 1's commit should have introduced real drift
+between canonical and the (stale) plugin copies; an unexpected "already in
+sync" means Task 1's commit didn't land where expected.
+
+- [ ] **Step 2: Verify byte-identity**
+
+```bash
+ruby tools/check-shared.rb
+```
+
+Expected: reports all shared-file copies matching canonical (same "OK: NNN
+shared-file copies all match canonical" style output seen elsewhere in this
+repo's history), zero new drift beyond the pre-existing allowlisted
+exceptions this repo already carries (e.g. `tableau-to-sigma/refs/environment.md`
+— unrelated, leave it alone).
+
+- [ ] **Step 3: Bump each of the 8 plugins' version**
+
+For each of the 8 plugin directories, read its CURRENT version fresh (main may
+have moved since this plan was written):
+
+```bash
+for p in looker-to-sigma microstrategy-to-sigma powerbi-to-sigma quicksight-to-sigma tableau-to-sigma thoughtspot-to-sigma domo-to-sigma hex-to-sigma; do
+  grep '"version"' plugins/$p/.claude-plugin/plugin.json
+done
+```
+
+Bump each one's patch version by 1 (strict semver, since this is a bug fix
+with no new user-facing feature) — e.g. if a plugin currently reads `1.2.3`,
+bump to `1.2.4`. Edit each of the 8 `plugin.json` files directly.
+
+- [ ] **Step 4: Run the full local verification sweep**
+
+```bash
+ruby shared/scripts/test-assert-phase6.rb
+ruby tools/check-shared.rb
+bash tools/check-plugin-version-bump.sh "$(git merge-base origin/main HEAD)" HEAD
+bash -n tools/sync-shared.rb 2>/dev/null; ruby -c tools/sync-shared.rb
+```
+
+All must pass/exit 0. If `check-plugin-version-bump.sh` fails because
+`origin/main` moved again mid-task (a real risk this session has already hit
+twice on a different PR) — `git fetch origin main`, rebase, re-check each of
+the 8 versions against the NEW current values, and re-bump only the ones that
+collided. Do not force-bump all 8 blindly if only some collided.
+
+- [ ] **Step 5: Spot-check one non-domo, non-Tableau plugin's copy directly**
+
+Pick one plugin NOT already exercised live this session (e.g.
+`microstrategy-to-sigma` or `hex-to-sigma`) and confirm its
+`scripts/assert-phase6-ran.rb` is byte-identical to
+`shared/scripts/assert-phase6-ran.rb`:
+
+```bash
+diff shared/scripts/assert-phase6-ran.rb plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
+```
+
+Expected: no output (identical).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb \
+        plugins/looker-to-sigma/.claude-plugin/plugin.json \
+        plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb \
+        plugins/microstrategy-to-sigma/.claude-plugin/plugin.json \
+        plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb \
+        plugins/powerbi-to-sigma/.claude-plugin/plugin.json \
+        plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb \
+        plugins/quicksight-to-sigma/.claude-plugin/plugin.json \
+        plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb \
+        plugins/tableau-to-sigma/.claude-plugin/plugin.json \
+        plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb \
+        plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json \
+        plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb \
+        plugins/domo-to-sigma/.claude-plugin/plugin.json \
+        plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb \
+        plugins/hex-to-sigma/.claude-plugin/plugin.json
+git commit -m "chore(shared): propagate assert-phase6-ran.rb visual-verify fallback to all 8 plugins
+
+Mechanical sync via tools/sync-shared.rb from the canonical fixed in the
+previous commit, plus the required per-plugin version bumps."
+```
+
+---
+
+## After this plan
+
+PR against `main` (shared-files-only, per this repo's governance), wait for
+CI (10 checks, matching this session's established convention), squash-merge
+once green. Update bead `beads-sigma-co6m` with the PR link and close it.

--- a/docs/superpowers/specs/2026-08-03-assert-phase6-visual-verify-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-03-assert-phase6-visual-verify-fallback-design.md
@@ -49,9 +49,15 @@ Every converter already CAN produce a page-level visual verdict via
 the source and records `pass` or `divergent` into `parity-final.json`). When no
 `visual-verify/manifest.json` exists at all, accept that recorded page-level
 verdict as satisfying condition (b) for every displayed tile on that page.
-**Manifest-bearing converters (Tableau) are completely unaffected** — this is
-purely a fallback for the "no manifest" case, not a loosening of the existing
-per-tile check.
+**Tableau is unaffected whenever its manifest is a non-empty array** (the
+normal case) — this is purely a fallback for the "no manifest" case, not a
+loosening of the existing per-tile check. The fallback triggers on
+`!(_vv.is_a?(Array) && _vv.any?)`, which also catches a manifest that is
+present but genuinely EMPTY (`[]`) — e.g. `verify-visual-tiles.rb` writing an
+empty array for a zero-tile run. Previously that was a hard fail at condition
+(b); now it is eligible for the page-level fallback too. This is a
+defensible, not a regressive, change: an empty manifest carries zero per-tile
+evidence, informationally identical to no manifest existing at all.
 
 The recorded-verdict signal to reuse is the SAME one gate 8b already reads
 (`shared/scripts/assert-phase6-ran.rb:2181-2187`, reading `parity-final.json`'s

--- a/docs/superpowers/specs/2026-08-03-assert-phase6-visual-verify-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-03-assert-phase6-visual-verify-fallback-design.md
@@ -1,0 +1,205 @@
+# Design — accept a page-level visual verdict when no per-tile manifest exists
+
+**Date:** 2026-08-03. **Status:** approved, ready for implementation plan.
+**Bead:** `beads-sigma-co6m`. **File:** `shared/scripts/assert-phase6-ran.rb` (canonical,
+synced byte-identical to 8 plugins via `shared/manifest.json`).
+
+## Problem
+
+`assert-phase6-ran.rb`'s anchors-oracle substitution path (used whenever
+`parity-final.json` reports `charts_total <= 0` — the normal case for every
+converter that has no Tableau-style exportable view CSVs, i.e. every non-Tableau
+converter that shares this file) requires FOUR conditions to hold before it will
+accept anchors-verdict.json as a substitute for real chart-level parity:
+
+```
+a) verify-anchors.rb pass with EVERY anchor matched
+b) every visual-verify tile confirmed
+c) every displayed tile returns >=1 data row
+d) every displayed tile has anchor coverage or a Phase 1d coverage waiver
+```
+
+Condition (b) is computed at `shared/scripts/assert-phase6-ran.rb:1132-1133`:
+
+```ruby
+_vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
+_vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+```
+
+`<workdir>/visual-verify/manifest.json` is written ONLY by
+`plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-visual-tiles.rb`,
+which compares per-tile `<tile>.tableau.png` vs `<tile>.sigma.png` pairs. Verified
+directly (`find`): no other plugin has an equivalent generator. `shared/manifest.json`
+(lines 355-364) confirms `assert-phase6-ran.rb` is shared byte-identical across
+**8 plugins**: looker, microstrategy, powerbi, quicksight, tableau, thoughtspot,
+domo, hex. So condition (b) can never be satisfied by 7 of the 8 — the moment any
+of them hits the `charts_total<=0` anchors-oracle path (their normal case), they
+are capped below GREEN regardless of how correct the actual migration is.
+
+**Discovered 2026-08-03** during `domo-to-sigma`'s Track E live E2E validation
+(real Domo/Sigma instance, 100% real value-parity via `build-parity-plan.rb` +
+`verify-parity.rb`, 5/5 anchors matched, 39/39 DM columns clean) — every other
+condition held, but (b) blocked a clean gate exit because domo has no
+`verify-visual-tiles.rb` equivalent. Not a domo defect; a shared-file gap.
+
+## Decision
+
+Every converter already CAN produce a page-level visual verdict via
+`record-visual-check.rb` (an agent with vision reads the rendered page against
+the source and records `pass` or `divergent` into `parity-final.json`). When no
+`visual-verify/manifest.json` exists at all, accept that recorded page-level
+verdict as satisfying condition (b) for every displayed tile on that page.
+**Manifest-bearing converters (Tableau) are completely unaffected** — this is
+purely a fallback for the "no manifest" case, not a loosening of the existing
+per-tile check.
+
+The recorded-verdict signal to reuse is the SAME one gate 8b already reads
+(`shared/scripts/assert-phase6-ran.rb:2181-2187`, reading `parity-final.json`'s
+`visual_checked`/`screenshot_path`/`visual_verdict`/`agent_vision` fields, which
+`record-visual-check.rb` stamps):
+
+```ruby
+recorded = s['visual_checked'] || s['screenshot_path'] || s['visual_verdict'].to_s == 'divergent'
+vision_blocked = (s.key?('agent_vision') && s['agent_vision'] == false) ||
+                 s['visual_verdict'].to_s == 'not-executable'
+```
+
+`recorded` alone is not enough — gate 8b's own doctrine (§D5, line 2176-2180) is
+that a verdict recorded without real vision (`agent_vision=false` or
+`visual_verdict="not-executable"`) is a **blind attestation**, never a substitute
+for a real check. The fallback for condition (b) must apply the exact same
+`vision_blocked` exclusion, or it would accept exactly the kind of unverified
+"looks fine" rubber-stamp this whole anchors/visual-verify system exists to
+prevent.
+
+Both `pass` and `divergent` verdicts satisfy condition (b) — `divergent` still
+means an agent with vision genuinely read the render (the ONLY thing condition
+(b) is checking); the imperfection it records is priced separately via the
+existing `visual-divergent` waiver-budget injection (unchanged by this fix).
+
+## Implementation
+
+**1. `_vv_ok` computation** (`shared/scripts/assert-phase6-ran.rb:1132-1133`) —
+`summary` (the parsed `parity-final.json`) is ALREADY loaded in this exact method
+scope at line 1110, so no new file read is needed:
+
+```ruby
+_vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
+if _vv.is_a?(Array) && _vv.any?
+  _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+  _vv_source = :manifest
+else
+  _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                   summary['visual_verdict'].to_s == 'divergent'
+  _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                         summary['visual_verdict'].to_s == 'not-executable'
+  _vv_ok = _page_recorded && !_page_vision_blocked
+  _vv_source = :page_verdict
+end
+```
+
+(`_vv_source` is a new small local used only by step 2 below, to pick the right
+wording — not persisted anywhere.)
+
+**2. Fix a real crash the fallback would otherwise expose** — the existing
+success message (`shared/scripts/assert-phase6-ran.rb:1167-1174`) does
+`"+ all #{_vv.size} tile(s) image-verified ..."`. `_vv` is `nil` in the no-manifest
+case; once the fallback makes `_vv_ok` true without a manifest, this line raises
+`NoMethodError: undefined method 'size' for nil` — a genuine bug the fallback
+would otherwise introduce, not merely a cosmetic gap. Branch the message on
+`_vv_source`:
+
+```ruby
+_vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+  "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
+puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
+     "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
+     "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
+     "+ #{_vv_note} + all displayed tiles return data " \
+     "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
+     "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
+     "#{anchors_tol_note.call(_av)}"
+```
+
+**3. Failure message** (`shared/scripts/assert-phase6-ran.rb:1182`) — currently
+`"b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"`. No
+change needed — stays accurate under the fallback (still prints `ok`/`incomplete`
+based on the same `_vv_ok`), but the FAIL block's remediation text (lines
+1179-1180, "If every worksheet is dashboard-embedded... the anchors oracle can
+stand in") should gain one line naming the new fallback so an operator hitting
+`incomplete` knows `record-visual-check.rb` is the fix, not just "go build a
+Tableau-style manifest":
+
+```
+warn '         (no manifest.json + no recorded page-level visual verdict — run'
+warn '          scripts/record-visual-check.rb to satisfy this condition when your'
+warn "          converter has no visual-verify/manifest.json generator)"
+```
+
+(Placed only in the `_vv_ok` false branch, i.e. only shown when (b) is actually
+the blocking condition — not printed unconditionally.)
+
+## Explicitly out of scope
+
+- **`shared/scripts/assert-phase6-ran.rb:1622-1627`** (gate 5/7's own separate
+  `_vv_ok`-style read of the same manifest, used to credit "unmatched dashboard
+  zones" against visually-verified worksheet NAMES). This is a different
+  mechanism — it needs a per-tile/per-name manifest to do name-level matching,
+  which a single page-level verdict cannot substitute for (there's no way to
+  know WHICH zone a page-level "yes I looked" verdict vouches for). Not
+  currently a live blocker for non-Tableau converters: confirmed via domo's own
+  live run this session, gate 5/7 SKIPs entirely when `parity-final.json` has no
+  `tile_census` — which none of the 7 non-Tableau converters emit today (only
+  Tableau's `build-charts-from-signals.rb --meta` writes one). Leave this path
+  alone; if a future converter starts emitting `tile_census`, it will need its
+  own design pass, not a copy of this fix.
+- **Giving non-Tableau converters their own per-tile `verify-visual-tiles.rb`
+  equivalent.** Considered and explicitly rejected (confirmed with TJ,
+  2026-08-03) as disproportionate — 7 new per-converter scripts, each needing
+  its own per-element render capability, to solve a gap the page-level
+  substitute already closes honestly.
+- **Any change to gate 8b itself** (the page-level visual-comparison gate this
+  fix reuses the recorded-verdict fields from). Gate 8b's own logic, its style
+  checklist requirement, and its `vision_blocked` doctrine are untouched — this
+  fix only reads the SAME already-stamped fields, at an earlier point in the
+  file, for a different gate's condition.
+
+## Testing
+
+`shared/scripts/test-assert-phase6.rb` (340 lines, scenario-based, canonical —
+fanned to the 6 non-Tableau plugins per an earlier session's "assert-phase6
+offline harness promoted to a SHARED canonical" work) has ONE existing
+anchors-oracle scenario (`'source PNG present, source-anchors.json under the
+5-anchor floor -> exit 18'`, line 254) and it does not touch condition (b) at
+all. Add new scenarios:
+
+1. No `visual-verify/manifest.json`, no recorded visual verdict in
+   `parity-final.json` → condition (b) reports `incomplete`, overall gate
+   still fails at exit 18/19 (whatever the surrounding conditions produce) —
+   confirms the fallback does NOT silently pass when nothing was recorded.
+2. No manifest, `parity-final.json` has `visual_verdict: "pass"` recorded (and
+   `agent_vision` true or absent) + all of (a)/(c)/(d) hold → gate 2 passes via
+   the anchors oracle, success message says "page-level visual verdict recorded
+   (pass)", not a crash.
+3. Same as 2 but `visual_verdict: "divergent"` → still satisfies (b) (an agent
+   looked), overall run still gets the pre-existing `visual-divergent`
+   waiver-budget treatment elsewhere (unchanged).
+4. No manifest, `parity-final.json` has `agent_vision: false` recorded → (b)
+   stays `incomplete` (blind attestation correctly rejected, matching gate 8b's
+   own doctrine).
+5. Manifest PRESENT and fully verified → unchanged existing behavior (a
+   regression guard proving Tableau's path is untouched).
+
+Also add: a focused test (or an assertion within scenario 2) proving the
+success-message line no longer raises `NoMethodError` when `_vv` is `nil` — this
+is the concrete regression the fix must not reintroduce.
+
+## Rollout
+
+Edit only `shared/scripts/assert-phase6-ran.rb` (the canonical) +
+`shared/scripts/test-assert-phase6.rb`. Run `ruby tools/sync-shared.rb` (or
+this repo's equivalent propagation step) to fan the byte-identical change to
+all 8 plugin copies, then `ruby tools/check-shared.rb` to confirm canonical ==
+every vendored copy. This is a **shared-files-only PR** per this repo's
+governance (`shared-file-governance`: one PR touches either a single plugin or
+the shared files, never both) — no plugin-specific file changes ride along.

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex → Sigma",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Migrate Hex projects to Sigma — SQL cells, single-value/METRIC cells, and EXPLORE charts → Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -1124,10 +1124,11 @@ else
     # pool is legitimately empty. The numbers are still machine-verified when
     # BOTH hold: (a) anchors-verdict.json passes with EVERY source anchor
     # matched against live element exports, and (b) every empty-export tile is
-    # image-verified (visual-verify manifest all true). Then the anchors
-    # oracle IS the parity evidence — same doctrine as the conditional
-    # --skip-parity-gate acceptance, but deterministic, and it burns no waiver
-    # budget because nothing is skipped.
+    # image-verified (visual-verify manifest all true — or, when no manifest
+    # exists at all, a recorded page-level visual verdict stands in, see
+    # below). Then the anchors oracle IS the parity evidence — same doctrine
+    # as the conditional --skip-parity-gate acceptance, but deterministic, and
+    # it burns no waiver budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
     if _vv.is_a?(Array) && _vv.any?
@@ -1199,7 +1200,7 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
-      unless _vv_ok
+      if _vv_source == :page_verdict && !_vv_ok
         warn '            (no manifest.json + no recorded page-level visual verdict — run'
         warn '             scripts/record-visual-check.rb to satisfy this condition when your'
         warn '             converter has no visual-verify/manifest.json generator)'
@@ -1643,6 +1644,11 @@ else
   # image-verified. Count a zone as matched when its tile carries a confirmed
   # visual-verify entry (the per-tile side-by-side oracle) — deterministic,
   # per-name, and loud below.
+  # NOTE: `_vv_ok` here is a fresh top-level reassignment for an UNRELATED
+  # purpose (an Array of visually-verified worksheet NAMES for gate 5/7's own
+  # name-matching), not the Boolean `_vv_ok`/`_vv_source` computed above for
+  # gate 2's anchors-oracle condition (b) — gate 2's use is fully consumed
+  # before this point, but don't assume shared meaning between the two blocks.
   _vv_ok = begin
     Array(JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))))
       .select { |t| t['visual_verified'] == true }.map { |t| t['worksheet'].to_s }

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -1130,7 +1130,24 @@ else
     # budget because nothing is skipped.
     _av = (JSON.parse(File.read(File.join(opts[:tab], 'anchors-verdict.json'))) rescue nil)
     _vv = (JSON.parse(File.read(File.join(opts[:tab], 'visual-verify', 'manifest.json'))) rescue nil)
-    _vv_ok = _vv.is_a?(Array) && _vv.any? && _vv.all? { |t| t['visual_verified'] == true }
+    if _vv.is_a?(Array) && _vv.any?
+      _vv_ok = _vv.all? { |t| t['visual_verified'] == true }
+      _vv_source = :manifest
+    else
+      # No Tableau-style per-tile visual-verify manifest (the other 7
+      # converters sharing this gate script have no verify-visual-tiles.rb
+      # equivalent) -- fall back to the page-level record-visual-check.rb
+      # verdict already stamped into parity-final.json (same fields gate 8b
+      # reads below: visual_checked/screenshot_path/visual_verdict), as long
+      # as it is genuinely vision-backed, not a blind/not-executable
+      # attestation (same doctrine as gate 8b's own §D5 check).
+      _page_recorded = summary['visual_checked'] || summary['screenshot_path'] ||
+                        summary['visual_verdict'].to_s == 'divergent'
+      _page_vision_blocked = (summary.key?('agent_vision') && summary['agent_vision'] == false) ||
+                             summary['visual_verdict'].to_s == 'not-executable'
+      _vv_ok = _page_recorded && !_page_vision_blocked
+      _vv_source = :page_verdict
+    end
     # W1.1: condition (c) — every DISPLAYED dashboard tile must export >=1 data
     # row. A 2026-07 field-workbook run passed (a) + (b) with all 15 anchors
     # matched, yet every chart rendered "No data": the anchors matched only in the
@@ -1165,10 +1182,12 @@ else
       _n_waived = 0
     end
     if _av && _av['pass'] && _av['checked'].to_i >= 5 && _av['matched'] == _av['checked'] && _vv_ok && _tiles_ok && _cov_ok
+      _vv_note = _vv_source == :manifest ? "all #{_vv.size} tile(s) image-verified" :
+        "page-level visual verdict recorded (#{summary['visual_verdict'] || 'checked'})"
       puts "[PASS] gate 2 (value parity): 0 exportable view CSVs (all worksheets dashboard-embedded) — " \
            "the ANCHORS ORACLE stands in: anchors-verdict.json pass " \
            "(#{_av['matched']}/#{_av['checked']} anchors matched, #{_av['anchors_matched_in_displayed'] || '?'} in displayed tiles) " \
-           "+ all #{_vv.size} tile(s) image-verified + all displayed tiles return data " \
+           "+ #{_vv_note} + all displayed tiles return data " \
            "+ anchor coverage #{_cov['covered']}/#{_cov['displayed']} displayed tile(s)" \
            "#{_n_waived.positive? ? " (#{_n_waived} coverage-waived at Phase 1d)" : ''}." \
            "#{anchors_tol_note.call(_av)}"
@@ -1180,6 +1199,11 @@ else
       warn '       anchors oracle can stand in — ALL FOUR must hold:'
       warn "         a) verify-anchors.rb pass with EVERY anchor matched (#{_av ? "currently #{_av['matched']}/#{_av['checked']}" : 'anchors-verdict.json missing'})"
       warn "         b) every visual-verify tile confirmed (#{_vv_ok ? 'ok' : 'incomplete'})"
+      unless _vv_ok
+        warn '            (no manifest.json + no recorded page-level visual verdict — run'
+        warn '             scripts/record-visual-check.rb to satisfy this condition when your'
+        warn '             converter has no visual-verify/manifest.json generator)'
+      end
       if _tiles_field_present
         empty = (_av['dashboard_tiles_empty'] || [])
         warn "         c) every displayed tile returns >=1 data row (#{_tiles_ok ? 'ok' : "#{empty.length} tile(s) EMPTY: #{empty.map { |t| t['name'] }.first(6).join(', ')}"})"

--- a/shared/scripts/test-assert-phase6.rb
+++ b/shared/scripts/test-assert-phase6.rb
@@ -77,15 +77,19 @@ def write_json(dir, name, obj)
   File.write(File.join(dir, name), JSON.generate(obj))
 end
 
-# Like run_gate, but also captures stdout — needed where a scenario must
-# assert on the exact PRINTED success/failure message, not just the exit
-# code (a crash before the print, or the wrong branch's message, could still
-# coincidentally produce the same exit code without this).
+# Like run_gate, but also captures stdout AND stderr — needed where a
+# scenario must assert on the exact PRINTED success/failure message, not just
+# the exit code (a crash before the print, or the wrong branch's message,
+# could still coincidentally produce the same exit code without this). Every
+# `warn` call in the gate (all of its diagnostic/remediation text, including
+# FAIL-branch hints) goes to stderr, not stdout — callers that only need
+# stdout can still destructure just `code, out = run_gate_capture(...)` and
+# the captured stderr string is simply dropped.
 def run_gate_capture(dir, *extra_args)
   cmd = ['ruby', GATE, '--workdir', dir] + extra_args
   env = { 'SIGMA_BASE_URL' => '', 'SIGMA_API_TOKEN' => '' }
-  out, _err, status = Open3.capture3(env, *cmd)
-  [status.exitstatus, out]
+  out, err, status = Open3.capture3(env, *cmd)
+  [status.exitstatus, out, err]
 end
 
 # A workdir with valid, minimal fixtures for every FILE-DRIVEN gate this
@@ -497,6 +501,34 @@ Dir.mktmpdir('domo-p6') do |dir|
   eq(code, 0, 'anchors-oracle: manifest PRESENT and fully verified -> unchanged existing behavior (regression guard)')
   eq(out.include?('all 2 tile(s) image-verified'), true,
      'success line keeps the ORIGINAL manifest-path wording ("all N tile(s) image-verified") — proves the manifest path is untouched by the fallback')
+end
+
+# Regression guard for the misdirection this fix corrects: a REAL manifest
+# that exists but has a failing tile must never be reported with the
+# no-manifest-at-all remediation hint ("no manifest.json + no recorded
+# page-level visual verdict... run scripts/record-visual-check.rb") — that
+# hint is only correct when NO manifest exists at all (_vv_source ==
+# :page_verdict); here a manifest genuinely exists and one tile failed real
+# per-tile verification, so the fix is verify-visual-tiles.rb, not
+# record-visual-check.rb. Without this guard, a future edit could reintroduce
+# the exact misdirection two prior whole-branch reviews missed.
+Dir.mktmpdir('domo-p6') do |dir|
+  write_good_fixtures(dir)
+  write_json(dir, 'anchors-verdict.json', PASSING_ANCHORS_ORACLE)
+  write_json(dir, 'parity-final.json',
+             'charts_total' => 0, 'charts_pass' => 0, 'status' => 'PASS', 'mode' => 'live')
+  FileUtils.mkdir_p(File.join(dir, 'visual-verify'))
+  write_json(dir, File.join('visual-verify', 'manifest.json'),
+             [{ 'worksheet' => 'Tile A', 'visual_verified' => true },
+              { 'worksheet' => 'Tile B', 'visual_verified' => false }])
+  code, _out, err = run_gate_capture(dir, *HAPPY_FLAGS)
+  eq(code, 2, 'anchors-oracle: manifest PRESENT with a failing tile -> condition (b) incomplete, gate fails')
+  eq(err.include?('every visual-verify tile confirmed (incomplete)'), true,
+     'stderr reports condition (b) as incomplete (the real, manifest-driven failure)')
+  eq(err.include?('no manifest.json'), false,
+     'stderr does NOT print the no-manifest remediation hint when a manifest genuinely exists — the Fix-2 regression guard')
+  eq(err.include?('record-visual-check.rb'), false,
+     'stderr does NOT recommend record-visual-check.rb (the wrong remediation for a manifest-present failure) — re-running verify-visual-tiles.rb is the real fix')
 end
 
 if $failures.zero? then puts 'ALL PASS'; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/shared/scripts/test-assert-phase6.rb
+++ b/shared/scripts/test-assert-phase6.rb
@@ -51,6 +51,7 @@
 require 'json'
 require 'tmpdir'
 require 'fileutils'
+require 'open3'
 
 GATE = File.expand_path('../scripts/assert-phase6-ran.rb', __dir__)
 # Self-identifies the adopting converter from this file's own path (e.g. a
@@ -74,6 +75,17 @@ end
 
 def write_json(dir, name, obj)
   File.write(File.join(dir, name), JSON.generate(obj))
+end
+
+# Like run_gate, but also captures stdout — needed where a scenario must
+# assert on the exact PRINTED success/failure message, not just the exit
+# code (a crash before the print, or the wrong branch's message, could still
+# coincidentally produce the same exit code without this).
+def run_gate_capture(dir, *extra_args)
+  cmd = ['ruby', GATE, '--workdir', dir] + extra_args
+  env = { 'SIGMA_BASE_URL' => '', 'SIGMA_API_TOKEN' => '' }
+  out, _err, status = Open3.capture3(env, *cmd)
+  [status.exitstatus, out]
 end
 
 # A workdir with valid, minimal fixtures for every FILE-DRIVEN gate this
@@ -124,6 +136,16 @@ HAPPY_FLAGS = [
   '--skip-layout-check', 'offline harness: no live Sigma creds (gate 4 needs GET /v2/workbooks/{id}/spec)',
   '--skip-visual-comparison', 'verifier: render pre-verified by a prior session (policy-excluded from the waiver budget)'
 ].freeze
+
+# Conditions (a)+(c)+(d) of the anchors-oracle substitution (charts_total<=0
+# branch) satisfied — every scenario below is only exercising condition (b)
+# (the visual-verify-tile confirmation), so the other three are held constant
+# and passing here.
+PASSING_ANCHORS_ORACLE = {
+  'pass' => true, 'checked' => 5, 'matched' => 5, 'anchors_matched_in_displayed' => 5,
+  'tiles_all_nonempty' => true,
+  'anchor_coverage' => { 'covered' => 3, 'displayed' => 3, 'uncovered' => [] }
+}.freeze
 
 # Build a fresh good workdir, let the block corrupt/add exactly one thing,
 # run the gate with `flags`, and assert the EXACT exit code.
@@ -403,6 +425,78 @@ Dir.mktmpdir('domo-p6') do |dir|
   ledger = (JSON.parse(File.read(File.join(dir, 'degradation-ledger.json'))) rescue nil)
   entry = ledger && Array(ledger['entries']).find { |e| e['item'] == 'gate-3-column-scan' }
   eq(entry, nil, 'complete-clean derives NO ledger entry (GREEN stays reachable)')
+end
+
+puts
+puts '== anchors-oracle SUBSTITUTION (charts_total<=0) fallback: page-level visual verdict when =='
+puts '== no visual-verify/manifest.json exists (Tableau-only artifact; 7 other converters share this file) =='
+# The manifest-only condition (b) capped every non-Tableau converter sharing
+# this canonical file below GREEN whenever they hit the charts_total<=0 path
+# (their NORMAL case for a fully dashboard-embedded workbook) — only
+# Tableau's own skill emits visual-verify/manifest.json. These scenarios
+# exercise the fallback to the page-level record-visual-check.rb verdict
+# already stamped into parity-final.json.
+
+scenario('anchors-oracle: no manifest, no recorded visual verdict -> condition (b) incomplete, gate still fails', 2) do |dir|
+  write_json(dir, 'anchors-verdict.json', PASSING_ANCHORS_ORACLE)
+  write_json(dir, 'parity-final.json',
+             'charts_total' => 0, 'charts_pass' => 0, 'status' => 'PASS', 'mode' => 'live')
+end
+
+scenario('anchors-oracle: no manifest, agent_vision:false recorded -> condition (b) still incomplete (blind attestation rejected)', 2) do |dir|
+  write_json(dir, 'anchors-verdict.json', PASSING_ANCHORS_ORACLE)
+  write_json(dir, 'parity-final.json',
+             'charts_total' => 0, 'charts_pass' => 0, 'status' => 'PASS', 'mode' => 'live',
+             'visual_checked' => true, 'visual_verdict' => 'pass', 'agent_vision' => false)
+end
+
+# scenarios 2 and 5 assert on the exact PRINTED success line (not just the
+# exit code) — a crash before the print, or the wrong branch's wording, could
+# otherwise coincidentally still exit 0.
+Dir.mktmpdir('domo-p6') do |dir|
+  write_good_fixtures(dir)
+  write_json(dir, 'anchors-verdict.json', PASSING_ANCHORS_ORACLE)
+  write_json(dir, 'parity-final.json',
+             'charts_total' => 0, 'charts_pass' => 0, 'status' => 'PASS', 'mode' => 'live',
+             'visual_checked' => true, 'visual_verdict' => 'pass', 'agent_vision' => true)
+  code, out = run_gate_capture(dir, *HAPPY_FLAGS)
+  eq(code, 0, 'anchors-oracle: no manifest, page-level visual_verdict=pass recorded -> gate 2 passes via anchors oracle')
+  eq(out.include?('page-level visual verdict recorded (pass)'), true,
+     'success line names the page-level fallback wording — proves the print path executed, not a coincidental exit 0')
+  eq(out.include?('tile(s) image-verified'), false,
+     'success line does NOT use the manifest-path wording ("all N tile(s) image-verified") when no manifest exists')
+end
+
+Dir.mktmpdir('domo-p6') do |dir|
+  write_good_fixtures(dir)
+  File.delete(File.join(dir, 'wb-ids.json')) # gates 3/4 take the free no-workbook-id SKIP (zero waiver-budget
+                                              # cost) so this scenario's waiver-budget math isolates the
+                                              # visual-divergent census entry (budget is 2; --skip-visual-comparison
+                                              # here is the policy-excluded /verifier/i reason, never budget-counted).
+  write_json(dir, 'anchors-verdict.json', PASSING_ANCHORS_ORACLE)
+  write_json(dir, 'parity-final.json',
+             'charts_total' => 0, 'charts_pass' => 0, 'status' => 'PASS', 'mode' => 'live',
+             'visual_checked' => true, 'visual_verdict' => 'divergent', 'agent_vision' => true)
+  code = run_gate(dir, '--skip-visual-comparison', 'verifier: pre-verified by a prior session')
+  eq(code, 0, 'anchors-oracle: no manifest, page-level visual_verdict=divergent recorded -> still satisfies condition (b)')
+  pf = (JSON.parse(File.read(File.join(dir, 'parity-final.json'))) rescue nil)
+  eq(pf.is_a?(Hash) && Array(pf['waivers']).include?('visual-divergent'), true,
+     "waiver census still counts 'visual-divergent' (pre-existing mechanism; the fallback doesn't bypass it)")
+end
+
+Dir.mktmpdir('domo-p6') do |dir|
+  write_good_fixtures(dir)
+  write_json(dir, 'anchors-verdict.json', PASSING_ANCHORS_ORACLE)
+  write_json(dir, 'parity-final.json',
+             'charts_total' => 0, 'charts_pass' => 0, 'status' => 'PASS', 'mode' => 'live')
+  FileUtils.mkdir_p(File.join(dir, 'visual-verify'))
+  write_json(dir, File.join('visual-verify', 'manifest.json'),
+             [{ 'worksheet' => 'Tile A', 'visual_verified' => true },
+              { 'worksheet' => 'Tile B', 'visual_verified' => true }])
+  code, out = run_gate_capture(dir, *HAPPY_FLAGS)
+  eq(code, 0, 'anchors-oracle: manifest PRESENT and fully verified -> unchanged existing behavior (regression guard)')
+  eq(out.include?('all 2 tile(s) image-verified'), true,
+     'success line keeps the ORIGINAL manifest-path wording ("all N tile(s) image-verified") — proves the manifest path is untouched by the fallback')
 end
 
 if $failures.zero? then puts 'ALL PASS'; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end


### PR DESCRIPTION
## Summary

`assert-phase6-ran.rb`'s anchors-oracle substitution path (used whenever a
workbook has no Tableau-style exportable view CSVs — the normal case for the
other 7 converters sharing this canonical file) hard-required a Tableau-only
per-tile `visual-verify/manifest.json` (written only by
`verify-visual-tiles.rb`, which no other converter has an equivalent of),
capping looker/microstrategy/powerbi/quicksight/thoughtspot/domo/hex below a
clean GREEN gate exit regardless of how correct their actual migration was.

Discovered live 2026-08-03 during `domo-to-sigma`'s Track E validation
(100% real value-parity, 5/5 anchors matched, 39/39 DM columns clean) — every
other condition held, but this one blocked a clean exit.

**Fix:** when no per-tile manifest exists, fall back to the page-level visual
verdict `record-visual-check.rb` already stamps into `parity-final.json` (the
same `visual_checked`/`screenshot_path`/`visual_verdict`/`agent_vision` fields
gate 8b already reads elsewhere in this file), rejecting a blind/
`not-executable` attestation the same way gate 8b's own doctrine already does.
Tableau's own manifest-bearing path is unaffected whenever its manifest is a
non-empty array (the normal case) — regression-tested. Also fixes a real
`NoMethodError` (`_vv.size` on `nil`) the naive version of this fallback would
have introduced.

Built via `brainstorming` → `writing-plans` → `subagent-driven-development`.
Hit and resolved a real plan defect mid-build: this repo's pre-commit hook
enforces canonical/plugin-copy byte-identity on every commit, so the fix and
its propagation had to land in one combined commit rather than two separate
task commits — no hook bypass used. The final whole-branch review (most
capable model) then found 3 more real issues a task-scoped review couldn't
see — the new tests were invisible to CI, the new remediation hint misfired
on Tableau's own failure path, and two doctrine comments were stale — all
fixed in a follow-up wave and independently re-verified.

Bead: `beads-sigma-co6m` (a follow-up for `shared/refs/source-anchors.md`'s
own stale wording, out of scope here since it has 11 sync targets and would
pull in 3 plugins this PR doesn't otherwise touch, is noted on the bead).

## Test plan
- [x] `shared/scripts/test-assert-phase6.rb` — 8 new anchors-oracle fallback
      scenarios + regression guards, all passing; now wired into
      `corpus-check.yml` (previously ran nowhere in CI)
- [x] All 8 plugin copies independently verified byte-identical to canonical
      (`tools/check-shared.rb`, plus direct `diff`/`md5` on every one)
- [x] All 8 plugins' version bumps independently verified as real increases
      from current `origin/main`
- [x] Reproduced the original bug (manifest-present, one tile failing) against
      both the pre-fix and post-fix code to confirm the remediation-hint
      misdirection is genuinely gone
- [x] Full whole-branch review (Opus) + one fix wave + scoped re-review, all
      findings independently re-executed rather than trusted from reports