### PR TITLE
fix(domo-to-sigma): match KPI zone captions to the label build_kpi actually uses (bead wmkf)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-domo-layout.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-domo-layout.rb
@@ -153,6 +153,24 @@ def kind_hint(chart_type)
   'bar-chart'
 end
 
+# Zone caption for a card. KPI-kind cards must match the name build_kpi
+# (build-workbook.rb) will actually give the built Sigma element -- it prefers
+# the card's Summary Number label over the card's own title (Domo lets an
+# author label a tile differently from the card's title; the label is what
+# actually renders ON the KPI). Every zone-building path in this file used the
+# card's title unconditionally, so a KPI whose summaryNumber.label differs
+# from its title (e.g. a card titled "Units Ordered" labeled "Units" on the
+# tile itself) got a zone build-dashboard-layout.rb's name-based matcher could
+# never find, silently dropping it into the generic bottom-band fallback
+# (bead wmkf).
+def zone_caption_for(card, chart_kind)
+  if chart_kind == 'kpi'
+    label = card['summaryNumber'] && card['summaryNumber']['label']
+    return label unless label.to_s.strip.empty?
+  end
+  card['title']
+end
+
 # Build one dashboard's zone tree from its own geometry-bearing cards (already
 # scoped to one page by the caller). `cards` — this page's cards.json records
 # that carry x/y/w/h (Task 1's merge_geometry). `name` — the page title, used
@@ -175,7 +193,7 @@ def build_dashboard(name, cards)
       'w_pct'     => (c['w'].to_f * 100.0 / max_x).round(2),
       'h_pct'     => (c['h'].to_f * 100.0 / max_y).round(2),
       'kind'      => is_filter ? 'filter' : 'chart',
-      'caption'   => c['title'],
+      'caption'   => zone_caption_for(c, kh),
       'chart_kind'=> is_filter ? nil : kh,
       # non-empty so ZoneCensus.plots? counts a data card as a real tile
       'measures'  => is_filter ? [] : ['value'],
@@ -255,7 +273,7 @@ def build_dashboard_with_observed(name, cards, observed, kind_map)
       'w_pct'      => (o['w'].to_f * 100.0).round(2),
       'h_pct'      => (o['h'].to_f * 100.0).round(2),
       'kind'       => is_filter ? 'filter' : 'chart',
-      'caption'    => c['title'],
+      'caption'    => zone_caption_for(c, kh),
       'chart_kind' => is_filter ? nil : kh,
       'measures'   => is_filter ? [] : ['value'],
       'children'   => [],
@@ -811,7 +829,7 @@ def build_dashboard_from_collections(name, cards, kind_map = {})
       row_h = rg['height'] || row.map { |c, _x, _w, _ck, _f| card_height_units(c) }.max
       row.each do |c, x, w, chart_kind, is_filter|
         raw << {
-          'kind' => is_filter ? 'filter' : 'chart', 'id' => c['id'], 'caption' => c['title'],
+          'kind' => is_filter ? 'filter' : 'chart', 'id' => c['id'], 'caption' => zone_caption_for(c, chart_kind),
           'chart_kind' => is_filter ? nil : chart_kind, 'x' => x, 'y' => y, 'w' => w, 'h' => row_h,
           'measures' => is_filter ? [] : ['value'],
         }
@@ -868,7 +886,7 @@ def build_stack_fallback(name, cards)
       'w_pct'      => 100.0,
       'h_pct'      => (100.0 / n).round(2),
       'kind'       => is_filter ? 'filter' : 'chart',
-      'caption'    => c['title'],
+      'caption'    => zone_caption_for(c, kh),
       'chart_kind' => is_filter ? nil : kh,
       'measures'   => is_filter ? [] : ['value'],
       'children'   => [],

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-domo-layout.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-domo-layout.rb
@@ -365,5 +365,64 @@ Dir.mktmpdir('domo-build-layout-observed') do |dir|
   ok(zov2['y_pct'] > zov1['y_pct'], 'the composed remainder (ov2) is placed below the observed region, end to end')
 end
 
+# ===========================================================================
+# bead wmkf: a KPI-kind card's ZONE caption must match the name build_kpi
+# (build-workbook.rb) will actually give the built Sigma element — it prefers
+# the card's Summary Number label over the card's own title (Domo lets an
+# author label a tile differently from the card's own title; the label is
+# what actually renders ON the KPI). Regression for a real live bug: a card
+# titled "Units Ordered" but labeled "Units" on the tile itself produced a
+# zone captioned "Units Ordered", which build-dashboard-layout.rb's NAME-based
+# zone matcher (els_by_name, keyed on the real built element's name "Units")
+# could never match — silently dropping the KPI out of the shared top KPI row
+# and into the generic "no zone matched" bottom-band fallback instead.
+#
+# No card here carries x/y/w/h, '_collection', or a real '_size' token, so
+# every card routes through rung 2a (compose_kind_aware_rows / kpi_rows_for)
+# — the same call site (build-domo-layout.rb's row-tuple `chart_kind`
+# destructure) the real live bug (card id 390868622) was reproduced through.
+# ===========================================================================
+Dir.mktmpdir('domo-build-layout-kpi-caption') do |dir|
+  w = ->(name, obj) { File.write(File.join(dir, name), JSON.generate(obj)) }
+  w.call('cards.json', [
+    { 'id' => 'kpi-label-diff', 'title' => 'Units Ordered', 'chartType' => 'badge_singlevalue',
+      'summaryNumber' => { 'column' => 'QUANTITY_ORDERED', 'aggregation' => 'SUM', 'label' => 'Units' },
+      '_size' => '', '_pageOrder' => 0 },
+    { 'id' => 'kpi-label-same', 'title' => 'Orders', 'chartType' => 'badge_singlevalue',
+      'summaryNumber' => { 'column' => 'ORDER_ID', 'aggregation' => 'COUNT', 'label' => 'Orders' },
+      '_size' => '', '_pageOrder' => 1 },
+    { 'id' => 'kpi-label-blank', 'title' => 'Net Revenue', 'chartType' => 'badge_singlevalue',
+      'summaryNumber' => { 'column' => 'NET_REVENUE', 'aggregation' => 'SUM', 'label' => '' },
+      '_size' => '', '_pageOrder' => 2 },
+    { 'id' => 'kpi-no-summary', 'title' => 'Gross Profit', 'chartType' => 'badge_singlevalue',
+      '_size' => '', '_pageOrder' => 3 },
+  ])
+  w.call('pages.json', [{ 'id' => 'p1', 'title' => 'KPI Caption Page',
+                          'cardIds' => %w[kpi-label-diff kpi-label-same kpi-label-blank kpi-no-summary] }])
+
+  env = { 'DOMO_DISCOVERY_DIR' => dir }
+  out = IO.popen(env, ['ruby', File.join(SCRIPTS, 'build-domo-layout.rb')], err: [:child, :out], &:read)
+  status = $?.success?
+  ok(status, "build-domo-layout.rb exits 0 on a page of KPI cards whose title/summaryNumber.label vary\n#{out unless status}")
+
+  dash = JSON.parse(File.read(File.join(dir, 'dashboard-layout.json'))).find { |d| d['dashboard'] == 'KPI Caption Page' }
+  zones = dash['zones']
+
+  z_diff  = zones.find { |z| z['id'] == 'kpi-label-diff' }
+  z_same  = zones.find { |z| z['id'] == 'kpi-label-same' }
+  z_blank = zones.find { |z| z['id'] == 'kpi-label-blank' }
+  z_none  = zones.find { |z| z['id'] == 'kpi-no-summary' }
+  ok(z_diff && z_same && z_blank && z_none, 'every KPI card in the fixture was placed')
+
+  eq(z_diff['caption'], 'Units',
+     "bead wmkf: a KPI whose summaryNumber.label ('Units') differs from its card title ('Units Ordered') " \
+     'gets a zone captioned with the LABEL — the same name build_kpi actually gives the built Sigma element')
+  eq(z_same['caption'], 'Orders', 'a KPI whose label already matches its title is unaffected (unchanged behavior)')
+  eq(z_blank['caption'], 'Net Revenue',
+     'a KPI with a BLANK summaryNumber.label falls back to the card title, unchanged (regression guard)')
+  eq(z_none['caption'], 'Gross Profit',
+     'a KPI card with no summaryNumber at all falls back to the card title, unchanged (regression guard)')
+end
+
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end


### PR DESCRIPTION
## Summary

A Domo KPI card's layout zone was captioned from the card's `title` (e.g.
"Units Ordered"), but `build-workbook.rb`'s `build_kpi` names the real built
Sigma element from the card's Summary Number `label` when present (e.g.
"Units") — Domo lets an author label a KPI tile differently from the card's
own title, and the label is what actually renders on the tile.
`build-dashboard-layout.rb` matches layout zones to real Sigma elements by
NAME, so this caption/name mismatch silently dropped the tile into a generic
"no zone matched" bottom-band fallback instead of its intended spot in the
shared top KPI row.

Found live 2026-08-03 in a real render during Track E's validation — the
"Units" KPI landed in a separate bottom band while Orders/Net Revenue/Gross
Profit stayed together up top. Matches `beads-sigma-wmkf`, filed 2026-07-30.

**Fix:** a new `zone_caption_for(card, chart_kind)` helper in
`build-domo-layout.rb`, wired into all 4 places in that file that build a
zone dict (a real, duplicated bug, not a single call site) — for `kind ==
'kpi'` cards, prefers the Summary Number label when present and non-blank,
falls back to the card title otherwise (unchanged behavior for every
non-KPI card and for a KPI with no distinct label).

**Verified against real live discovery data**, not synthetic fixtures: the
same discovery capture from the live Track E validation run reproduces the
bug pre-fix (`caption: "Units Ordered"`) and confirms the fix (`caption:
"Units"`, matching the actually-built Sigma element's real name). Running
the full downstream `build-dashboard-layout.rb` against the real posted
workbook's `wb-ids.json` shows the "no Tableau zone" warning drop from 3
unmatched elements to 2 (only the 2 *by-design* companion KPIs from bead
08sf remain, correctly, in the shared bottom band).

## Test plan
- [x] New regression test (4 cases: label≠title, label==title, blank
      label, no summaryNumber) — verified genuinely red before the fix,
      green after
- [x] Independently reproduced against real live discovery data by both the
      implementer and the reviewer (not just synthetic test fixtures)
- [x] Full plugin suite (`test/run-all.sh`, 22 files) — all pass, no
      regressions
- [x] Independent task review: Approved, no Critical/Important findings (2
      Minor defensive-coding nits, non-blocking)