### PR TITLE
fix(domo-to-sigma): narrow raw-IN( lint to genuine SQL infix (bead kn8s)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -199,6 +199,53 @@ end
 
 NEEDS_REVIEW = %w[window lod].freeze
 
+# Is this `IN(`/`in(` occurrence a raw SQL INFIX construct (`x IN (a, b)`,
+# unsupported by Sigma) rather than Sigma's own `In([col], "a", "b")`
+# FUNCTION form (real, documented, must NOT be flagged — see
+# plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/formulas.md)?
+#
+# Shape, not substring: a genuine infix always has a VALUE EXPRESSION
+# directly before the `IN` token (only whitespace between) — a `]`, a
+# closing `)`, a quoted string, or a bare identifier/number. Sigma's
+# function-call form instead sits in a function-NAME position: the very
+# start of the formula, or immediately after `(`, `,`, `and`, or `or` —
+# wherever a function name is syntactically expected.
+#
+# `not` is deliberately NOT treated as its own function-name-position marker
+# here (unlike a natural first reading of that rule): `not` is itself a
+# prefix operator in Sigma, so whatever precedes IT determines the shape —
+# `not In([c], "a")` (legitimate: `not` prefixing a real function call) and
+# `[c] not in (1, 2)` (a genuine, still-unsupported infix `NOT IN`) are
+# lexically identical right at the `in(` token, and only resolvable by
+# looking through the `not` to what's underneath it. So trailing `not`s are
+# stripped and the position underneath is re-checked (recursively, so
+# `not not In(...)` still resolves correctly) rather than treating `not`
+# itself as a free pass.
+def raw_infix_in_position?(prefix)
+  s = prefix.rstrip
+  loop do
+    return false if s.empty? # formula start → function-name position
+    return false if s =~ /(\(|,|\b(?:and|or)\b)\z/i # function-name position
+
+    stripped = s.sub(/\bnot\z/i, '')
+    return true if stripped == s # a real value sits directly before IN/In → infix
+
+    s = stripped.rstrip # strip one trailing "not" and re-check what's under it
+  end
+end
+
+# True if `f` contains at least one genuine infix `IN(`/`in(` occurrence
+# (checked per-occurrence via raw_infix_in_position?, not a single formula-wide
+# substring test — a formula can legitimately mix a real In(...) call with
+# other text elsewhere).
+def contains_raw_infix_in?(f)
+  f.to_s.enum_for(:scan, /\bIN\s*\(/i).each do
+    m = Regexp.last_match
+    return true if raw_infix_in_position?(f[0...m.begin(0)])
+  end
+  false
+end
+
 # Lint a translated Sigma formula for the traps that ship silently-broken output.
 # Returns [errors, warnings].
 def lint_formula(sigma, klass = nil)
@@ -206,9 +253,25 @@ def lint_formula(sigma, klass = nil)
   warnings = []
   f = sigma.to_s
 
-  # IN(...) survived translation → Sigma has no IsIn; it silently blanks the column.
-  if f =~ /\bIN\s*\(/i && f !~ /\bContains\s*\(/i
-    errors << 'Contains a raw IN(...) — Sigma has no IsIn; expand to an OR-chain ([c]=a or [c]=b) or it silently blanks the column (feedback_sigma_formula_isin).'
+  # A raw SQL infix `x IN (a, b)` survived translation → Sigma has no infix
+  # IN/IsIn operator; it silently blanks the column. Sigma's own `In(...)`
+  # FUNCTION form (e.g. `In([Region], "East", "West")`) is real, documented
+  # syntax and must NOT be flagged — see contains_raw_infix_in? /
+  # raw_infix_in_position? above for the shape this distinguishes on.
+  #
+  # (No separate `Contains(` guard here anymore — it used to blanket-suppress
+  # this whole check whenever a formula contained an unrelated Contains(...)
+  # call ANYWHERE, e.g. from a translated LIKE clause, which could mask a
+  # genuine infix-IN bug coexisting in the same formula. `\bIN\s*\(/i` never
+  # actually matches inside the word "Contains(" in the first place — \b
+  # requires "in" to start a fresh token, and "Contains(" doesn't create that
+  # boundary — so the guard was never protecting against a real false
+  # positive; it only ever introduced that false-negative loophole. The
+  # per-occurrence, shape-based check above already excludes legitimate
+  # Contains(...)/In(...) calls on its own, so the guard is both redundant
+  # and actively wrong to keep.)
+  if contains_raw_infix_in?(f)
+    errors << "Contains a raw SQL infix IN (...) — Sigma has no infix IN/IsIn operator; expand to an OR-chain ([c]=a or [c]=b), or rewrite as Sigma's own In([c], a, b) function, or it silently blanks the column (feedback_sigma_formula_isin)."
   end
 
   # And()/Or()/Not() as FUNCTION CALLS silently produce null rows — must be infix.

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -208,7 +208,10 @@ NEEDS_REVIEW = %w[window lod].freeze
 # directly before the `IN` token (only whitespace between) — a `]`, a
 # closing `)`, a quoted string, or a bare identifier/number. Sigma's
 # function-call form instead sits in a function-NAME position: the very
-# start of the formula, or immediately after `(`, `,`, `and`, or `or` —
+# start of the formula, immediately after `(`, `,`, `and`, or `or`, or right
+# after a comparison operator (`=`, `<>`, `!=`, `>`, `<`, `>=`, `<=` — the
+# full set the vendored SQL-formula converter itself recognizes, converter/
+# sql.mjs) used as In(...)'s left-hand operand, e.g. `[a] = In([b], "x")` —
 # wherever a function name is syntactically expected.
 #
 # `not` is deliberately NOT treated as its own function-name-position marker
@@ -218,14 +221,15 @@ NEEDS_REVIEW = %w[window lod].freeze
 # `[c] not in (1, 2)` (a genuine, still-unsupported infix `NOT IN`) are
 # lexically identical right at the `in(` token, and only resolvable by
 # looking through the `not` to what's underneath it. So trailing `not`s are
-# stripped and the position underneath is re-checked (recursively, so
-# `not not In(...)` still resolves correctly) rather than treating `not`
+# stripped and the position underneath is re-checked (iteratively — the
+# `loop do` below walks back through as many chained `not`s as are present,
+# so `not not In(...)` still resolves correctly) rather than treating `not`
 # itself as a free pass.
 def raw_infix_in_position?(prefix)
   s = prefix.rstrip
   loop do
     return false if s.empty? # formula start → function-name position
-    return false if s =~ /(\(|,|\b(?:and|or)\b)\z/i # function-name position
+    return false if s =~ /(?:\(|,|>=|<=|!=|<>|[=<>]|\b(?:and|or)\b)\z/i # function-name position
 
     stripped = s.sub(/\bnot\z/i, '')
     return true if stripped == s # a real value sits directly before IN/In → infix

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -115,6 +115,37 @@ errs, _ = lint_formula('If([Region] IN ("A","B") or Contains([Notes], "foo"), 1,
 ok(errs.any? { |e| e.include?('infix') },
    'a genuine infix IN elsewhere in the formula still flags even when the formula also contains an unrelated Contains(...) call')
 
+# ---------------------------------------------------------------------------
+# review finding: In(...) used as a comparison OPERAND (e.g. `[a] = In(...)`)
+# is ALSO a legitimate function-name position — `=`/`<>`/`!=`/`>`/`<`/`>=`/`<=`
+# are the full comparison-operator set the vendored SQL-formula converter
+# itself recognizes (converter/sql.mjs). Reproduced by the reviewer as
+# wrongly-flagged before this fix; confirmed here as real assertions.
+# ---------------------------------------------------------------------------
+puts '== lint_formula (bead kn8s): In(...) as a comparison operand must NOT flag (review finding) =='
+errs, _ = lint_formula('[IsEast] = In([Region], "East")')
+ok(errs.empty?, 'In(...) right after = is legitimate, not an error')
+errs, _ = lint_formula('[a] <> In([Region], "East")')
+ok(errs.empty?, 'In(...) right after <> is legitimate, not an error')
+errs, _ = lint_formula('If([a] = In([Region],"East"), 1, 0)')
+ok(errs.empty?, 'In(...) right after = inside an If condition is legitimate, not an error')
+errs, _ = lint_formula('[a] != In([Region], "East")')
+ok(errs.empty?, 'In(...) right after != is legitimate, not an error')
+errs, _ = lint_formula('[a] >= In([Region], "East")')
+ok(errs.empty?, 'In(...) right after >= is legitimate, not an error')
+errs, _ = lint_formula('[a] <= In([Region], "East")')
+ok(errs.empty?, 'In(...) right after <= is legitimate, not an error')
+errs, _ = lint_formula('[a] > In([Region], "East")')
+ok(errs.empty?, 'In(...) right after > is legitimate, not an error')
+errs, _ = lint_formula('[a] < In([Region], "East")')
+ok(errs.empty?, 'In(...) right after < is legitimate, not an error')
+# Sanity check: a genuine infix elsewhere in the same formula still flags
+# even when a comparison operator appears nearby — adding these markers
+# must not blanket-suppress real infix detection.
+errs, _ = lint_formula('If([a] = 1 and [Status] IN (1,2), 1, 0)')
+ok(errs.any? { |e| e.include?('infix') },
+   'a genuine infix IN still flags alongside an unrelated comparison operator')
+
 puts "== lint_formula: And()/Or()/Not() function-call warnings =="
 _, w = lint_formula('If(And([a]>1, [b]<2), 1, 0)')
 ok(w.any? { |x| x.include?('infix') }, 'And() function-call warned (use infix)')

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -52,6 +52,69 @@ ok(errs.any? { |e| e.include?('IsIn') }, 'raw IN(...) → error (no IsIn)')
 errs, _ = lint_formula('If([col]="A" or [col]="B", 1, 0)')
 ok(errs.empty?, 'expanded OR-chain passes clean')
 
+# ---------------------------------------------------------------------------
+# bead kn8s — narrow the raw-IN( rule to SHAPE, not the bare substring "IN(".
+# Sigma has a real, documented `In([col], "a", "b")` FUNCTION (see
+# .../sigma-workbooks/reference/specification/formulas.md) that the old
+# `/\bIN\s*\(/i` substring check wrongly flagged as an error, because it can't
+# tell that form apart from a genuine unsupported SQL infix `x IN (a, b)`. The
+# distinguishing shape: a genuine infix always has a VALUE immediately before
+# the IN token (`]`, `)`, a quoted string, or a bare identifier/number);
+# Sigma's function form instead sits in a function-NAME position (formula
+# start, or right after `(` `,` `and` `or`, or a `not` that itself traces back
+# to one of those). Cases below are the ones enumerated by the bead itself,
+# reproduced here as real assertions (not eyeballed) — each false-positive
+# case is confirmed to have been WRONGLY flagged before this fix.
+# ---------------------------------------------------------------------------
+
+puts '== lint_formula (bead kn8s): genuine infix IN(...) still flags — unchanged =='
+errs, _ = lint_formula('If([Region] IN ("East", "West"), 1, 0)')
+ok(errs.any? { |e| e.include?('infix') }, 'infix right after ] (If-wrapped) still an error')
+errs, _ = lint_formula('[Status] IN (1, 2, 3)')
+ok(errs.any? { |e| e.include?('infix') }, 'infix right after ], bare condition, still an error')
+errs, _ = lint_formula('If(Sum([x]) IN (5, 10), 1, 0)')
+ok(errs.any? { |e| e.include?('infix') }, 'infix right after a closing ) (aggregate result) still an error')
+
+puts '== lint_formula (bead kn8s): Sigma In(...) FUNCTION form must NOT be flagged (was the bug) =='
+errs, _ = lint_formula('In([Region], "East", "West")')
+ok(errs.empty?, 'In(...) at the very start of the formula is legitimate Sigma syntax, not an error')
+errs, _ = lint_formula('If(In([Region], "East", "West"), 1, 0)')
+ok(errs.empty?, 'In(...) right after ( is legitimate, not an error')
+errs, _ = lint_formula('In([Region], "East") and In([Status], "Active")')
+ok(errs.empty?, 'In(...) right after `and` is legitimate, not an error')
+errs, _ = lint_formula('Not(In([Region], "East"))')
+ok(errs.empty?, 'In(...) nested right after ( inside Not( is legitimate, not an error')
+errs, _ = lint_formula('If([x] > 0, In([Region], "East"), In([Region], "West"))')
+ok(errs.empty?, 'In(...) right after a , (function argument position) is legitimate, not an error')
+
+puts '== lint_formula (bead kn8s): extra edge cases beyond the bead minimum =='
+# Infix NOT IN must still flag (the old rule caught this too — a naive `not`
+# exemption could regress it if it treated `not` itself as a free pass;
+# instead we look through `not` to what precedes IT).
+errs, _ = lint_formula('[Status] NOT IN (1, 2, 3)')
+ok(errs.any? { |e| e.include?('infix') }, 'genuine infix NOT IN (a value before `not`) still flags')
+errs, _ = lint_formula('If([Status] not in (1,2), 1, 0)')
+ok(errs.any? { |e| e.include?('infix') }, 'lowercase infix "not in" after a value still flags')
+# Bare infix `not` directly negating a real In(...) call (no wrapping parens)
+# must NOT flag — `not` here traces back to a function-name position.
+errs, _ = lint_formula('not In([Region], "East")')
+ok(errs.empty?, 'bare `not In(...)` (infix negation of a function call) is not an error')
+errs, _ = lint_formula('If([x]>0, not In([Region],"East"), 0)')
+ok(errs.empty?, '`not In(...)` right after a , is not an error')
+# No-space and mixed-case variants of the same two shapes.
+errs, _ = lint_formula('[Status]IN(1,2,3)')
+ok(errs.any? { |e| e.include?('infix') }, 'infix with no space before IN( still flags')
+errs, _ = lint_formula('if(in([col], "a","b"), 1, 0)')
+ok(errs.empty?, 'lowercase in(...) function-call form after ( is not an error')
+# A formula that legitimately mixes a real Contains(...) call (e.g. from a
+# translated LIKE clause) with an UNRELATED genuine infix IN elsewhere must
+# still flag — this used to be masked by the old formula-wide `f !~
+# /\bContains\s*\(/i` guard, which is why that guard was removed (see
+# convert-beast-modes.rb for the full rationale).
+errs, _ = lint_formula('If([Region] IN ("A","B") or Contains([Notes], "foo"), 1, 0)')
+ok(errs.any? { |e| e.include?('infix') },
+   'a genuine infix IN elsewhere in the formula still flags even when the formula also contains an unrelated Contains(...) call')
+
 puts "== lint_formula: And()/Or()/Not() function-call warnings =="
 _, w = lint_formula('If(And([a]>1, [b]<2), 1, 0)')
 ok(w.any? { |x| x.include?('infix') }, 'And() function-call warned (use infix)')


### PR DESCRIPTION
## Summary
- The Beast Mode SQL lint for raw infix `IN (...)` was flagging Sigma's own `In(...)` function as if it were untranslated MySQL infix SQL.
- Replaced the naive substring check with a shape-based `raw_infix_in_position?`/`contains_raw_infix_in?` pair that only flags `IN` when it is genuinely in SQL-infix position (not immediately preceded by a function-name-position token: `(`, `,`, `and`/`or`, or — added in review follow-up — any of the 7 comparison operators `=`, `<>`, `!=`, `>`, `<`, `>=`, `<=`), so `In(...)` used as a comparison operand (e.g. `[a] = In(1,2,3)`) is no longer wrongly flagged.
- Genuine raw infix `IN (...)`/`NOT IN (...)` (the actual bug this bead exists to catch) is still flagged correctly.

Bead: `beads-sigma-kn8s`

## Test plan
- [x] `ruby test/test-convert-beast-modes.rb` — new cases for each comparison operator, verified red-before/green-after against the pre-fix commit
- [x] `bash test/run-all.sh` — all suites pass
- [x] Scoped re-review (Sonnet) confirmed gap closure, no regression on genuine infix detection, and independently reproduced red/green test behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)