### PR TITLE
fix(domo-to-sigma): stop rewriting WEEKDAY to a fake fn, flag real numbering mismatch (bead nrml)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -91,12 +91,19 @@ like Power BI's DAX.
 > untranslatable construct still needs the `formula-overrides.json` sidecar —
 > that mechanism is unchanged and still the right escape hatch, it is just no
 > longer load-bearing for CASE WHEN or COUNT(DISTINCT). One more thing to
-> budget for: `convert-beast-modes.rb`'s own `WEEKDAY` → `DAYOFWEEK`
-> normalization step is *counterproductive* — `WEEKDAY(...)` converts cleanly
-> on its own, but this step rewrites it to `DAYOFWEEK(...)` first, which is
-> **not** a real Sigma function (still open; see the note in
-> `scripts/convert-beast-modes.rb`). Full evidence and the exact
-> before/after outputs: `refs/live-validation-2026-07-30.md`.
+> budget for, now FIXED (2026-08-03, bead beads-sigma-nrml):
+> `convert-beast-modes.rb` used to rewrite `WEEKDAY(...)` to `DAYOFWEEK(...)`
+> "for parity," which was *counterproductive* — `WEEKDAY(...)` converts
+> cleanly on its own (Sigma has `Weekday()` by that exact name), but
+> `Dayofweek(...)` is **not** a real Sigma function. That rewrite is gone;
+> `WEEKDAY(...)` now passes through unchanged. But a second, more serious
+> issue surfaced during that fix and is verified against both vendors'
+> docs: MySQL `WEEKDAY()` (0=Monday..6=Sunday) and Sigma `Weekday()`
+> (1=Sunday..7=Saturday) use genuinely different numbering, so a name-clean
+> translation can still be a silent VALUE mismatch. `normalize_bm` now flags
+> this with a warning naming the exact override — `Mod(Weekday([col])+5,7)`
+> — rather than auto-rewriting; see the note in `scripts/convert-beast-modes.rb`.
+> Full evidence and the exact before/after outputs: `refs/live-validation-2026-07-30.md`.
 
 The other work is *extraction* (card defs + Beast Mode text + layout out of Domo)
 and *layout/binding* (cards → Sigma elements on a 24-col grid; note Domo's own card
@@ -334,8 +341,10 @@ ruby scripts/convert-beast-modes.rb --lint     # validate → discovery/formulas
 `--mcp-dir`/`DOMO_MCP_DIR` (explicit dev opt-in only), or — last resort, bundle
 or `node` absent — exit 10 with the manual `convert_sql_to_sigma_formula`
 + `--converter-out` fallback instructions. Applies the normalizations in
-`refs/beast-mode-to-sigma.md` FIRST (strip backticks, `WEEKDAY`→`DAYOFWEEK`,
-flag aggregate `CEILING`/`FLOOR`, reject unsupported `SQRT`/`CONVERT_TZ`).
+`refs/beast-mode-to-sigma.md` FIRST (strip backticks, flag the `WEEKDAY`
+day-numbering mismatch (MySQL vs. Sigma disagree — override to
+`Mod(Weekday([col])+5,7)`), flag aggregate `CEILING`/`FLOOR`, reject
+unsupported `SQRT`/`CONVERT_TZ`).
 Outputs `discovery/formulas.json` (Beast Mode id → Sigma formula).
 
 ---

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md
@@ -69,11 +69,18 @@ Apply these to the raw Beast Mode string first:
 
 1. **Strip backtick / bracket identifier quoting** → Sigma uses `[Column Name]`.
    `` `Sales` `` and `` `Operating Budget` `` → `[Sales]`, `[Operating Budget]`.
-2. **`WEEKDAY` → `DAYOFWEEK`.** Beast Mode silently does this substitution itself;
-   replicate it so behavior matches. (`WEEKDAY` is in the unsupported list.)
+2. **`WEEKDAY` day-numbering mismatch.** Do NOT rewrite the SQL — `WEEKDAY(...)`
+   converts cleanly on its own to Sigma's `Weekday(...)` by name. But MySQL
+   `WEEKDAY()` (0=Monday..6=Sunday) and Sigma `Weekday()` (1=Sunday..7=Saturday)
+   use genuinely different numbering, so a name-clean translation can still be
+   a silent VALUE mismatch. Flag with a warning naming the override:
+   `Mod(Weekday([col])+5,7)` reproduces MySQL's exact numbering from Sigma's
+   `Weekday()` output.
 3. **Reject / flag unsupported functions** (no longer supported in Beast Mode, so
-   they shouldn't appear, but guard anyway): `SQRT`, `CONVERT_TZ`, `MICROSECOND`,
-   `WEEKDAY`. If present, warn — likely a legacy formula.
+   they shouldn't appear, but guard anyway): `SQRT`, `CONVERT_TZ`, `MICROSECOND`.
+   If present, warn — likely a legacy formula. (`WEEKDAY` is excluded from this
+   generic loop — it gets its own targeted day-numbering warning above instead,
+   since it DOES have a real Sigma equivalent and isn't actually unsupported.)
 4. **Flag the aggregate `CEILING` / `FLOOR` trap** — see below. These are NOT math
    rounding in Beast Mode.
 5. **Decide row vs aggregate context.** If a top-level aggregate (`SUM`, `AVG`,
@@ -90,7 +97,7 @@ Apply these to the raw Beast Mode string first:
 | `CEILING(Budget)` | math ceiling | **aggregate**: rounded `MAX` | `Round(Max([Budget]))` |
 | `FLOOR(Budget)` | math floor | **aggregate**: rounded `MIN` | `Round(Min([Budget]))` |
 | `POWER(Values,2)` | per-row power | per-row power, but **sums per series** if multi-series | `Power([Values],2)` (handle series via grouping) |
-| `WEEKDAY(d)` | MySQL WEEKDAY (0=Mon) | replaced with `DAYOFWEEK` (1=Sun) | `Weekday([d])` — mind the 1=Sunday base |
+| `WEEKDAY(d)` | MySQL WEEKDAY (0=Mon..6=Sun) | converts by NAME to `Weekday([d])`, but Sigma's numbering is DIFFERENT (1=Sun..7=Sat) — a silent VALUE mismatch, not just an off-by-one | `Weekday([d])`; override to `Mod(Weekday([d])+5,7)` to preserve MySQL's exact day numbers |
 | `SQRT(x)` | square root | **unsupported** in Beast Mode | use `Power([x], 0.5)` if it appears |
 | Summary Number Beast Mode | a column | must be aggregated to be a summary | maps to a Sigma **KPI** element — see `refs/card-to-element.md` Rule 0 (KPI, never a table) |
 | `SUM(SUM([x]) FIXED (BY [Region]))` | a nested aggregate | **level-of-detail** (LOD) | Sigma **level-of-detail** — do NOT flatten to a plain aggregate; flag for review (see `lod_conditional_inner`) |

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -14,9 +14,11 @@
 # This script does NOT reimplement translation itself. It adds the two layers
 # the generic SQL converter can't know about:
 #
-#   PRE  — Domo-specific normalization (backtick identifiers → [Col], WEEKDAY →
-#          DAYOFWEEK, flag unsupported fns, flag the CEILING/FLOOR-are-aggregates
-#          trap, flag window/LOD Beast Modes) — see refs/beast-mode-to-sigma.md.
+#   PRE  — Domo-specific normalization (backtick identifiers → [Col], flag
+#          unsupported fns, flag the WEEKDAY day-numbering mismatch (MySQL vs.
+#          Sigma disagree on which int means which weekday) and the
+#          CEILING/FLOOR-are-aggregates trap, flag window/LOD Beast Modes) —
+#          see refs/beast-mode-to-sigma.md.
 #   POST — Sigma-specific lint of the returned formula (leftover IN(, And()/Or()/
 #          Not() function-call forms that silently null, window-fn workbook-master
 #          limits) — see refs/beast-mode-to-sigma.md + feedback_sigma_window_functions.
@@ -152,23 +154,40 @@ def normalize_bm(sql, klass = nil)
   # 1. Backtick / bracket MySQL identifier quoting → Sigma [Column Name].
   s = s.gsub(/`([^`]+)`/) { "[#{$1}]" }
 
-  # 2. WEEKDAY → DAYOFWEEK (Beast Mode does this itself; replicate for parity).
+  # 2. WEEKDAY name-matches Sigma's Weekday() but the two use DIFFERENT day
+  #    numbering — not just an off-by-one. Do NOT rewrite the SQL text.
   #
-  # ⚠️ MEASURED 2026-07-30 (bead, not fixed here — see progress ledger for
-  # 2026-07-30-track-a-sql-formula-converter, "LIKELY REAL PRODUCTION BUG"):
-  # this rewrite makes the formula WORSE, not better. `WEEKDAY(...)` passed to
-  # the shared converter comes back clean (`Weekday(...)` — Sigma has it), but
-  # this step rewrites it to `DAYOFWEEK(...)` FIRST, and `Dayofweek(...)` is
-  # NOT a real Sigma function — the converter now warns on it
-  # (lookUnknownFunctions) where the untouched WEEKDAY form would not have
-  # warned at all. Do not "fix" this by just deleting the rewrite without
-  # checking Sigma's WEEKDAY offset (1=Sunday) actually matches Beast Mode's —
-  # that offset question is exactly why this was added "for parity" in the
-  # first place, and is unverified either way. Tracked as its own bead; needs
-  # its own investigation, not a silent revert.
+  # HISTORY (bead beads-sigma-nrml): a prior version of this step rewrote
+  # `WEEKDAY(...)` to `DAYOFWEEK(...)` "for parity" with a substitution Beast
+  # Mode was believed to do itself. That rewrite was itself the bug:
+  # `WEEKDAY(...)` handed to the shared converter comes back clean
+  # (`Weekday(...)` — Sigma has it by that exact name), but the old rewrite
+  # renamed it to `DAYOFWEEK(...)` FIRST, and `Dayofweek(...)` is NOT a real
+  # Sigma function — the converter then warned on it (lookUnknownFunctions)
+  # where the untouched WEEKDAY form would not have warned at all. Fixed:
+  # let `WEEKDAY(...)` pass through unchanged; it converts to `Weekday(...)`
+  # by name with no help needed here.
+  #
+  # But name-matching isn't the whole story. VERIFIED 2026-08-03 against both
+  # vendors' official docs — these are genuinely DIFFERENT numbering
+  # conventions, not just an off-by-one:
+  #   MySQL  WEEKDAY(date):  0=Monday .. 6=Sunday
+  #   Sigma  Weekday(date):  1=Sunday .. 7=Saturday
+  # So a Beast Mode formula that compares the raw WEEKDAY() result to a
+  # literal (e.g. `WEEKDAY(x) = 0` meaning "is Monday") translates to a NAME
+  # match with SILENTLY WRONG values (Sigma's Weekday(x) returns 2 for
+  # Monday, not 0). Same class of trap as the CEILING/FLOOR aggregate trap
+  # below (generic converter succeeds syntactically but gets the SEMANTICS
+  # wrong) — flag for a hand override rather than auto-rewriting the formula.
+  # `Mod(Weekday([col])+5,7)` reproduces MySQL's exact WEEKDAY() numbering
+  # from Sigma's Weekday() output (verified for all 7 days in
+  # test/test-convert-beast-modes.rb).
   if s =~ /\bWEEKDAY\s*\(/i
-    s = s.gsub(/\bWEEKDAY\s*\(/i, 'DAYOFWEEK(')
-    warnings << 'WEEKDAY → DAYOFWEEK (1=Sunday base; verify offset).'
+    warnings << "WEEKDAY() converts to Sigma Weekday() by NAME, but the two use " \
+      "DIFFERENT day numbering (MySQL WEEKDAY: 0=Monday..6=Sunday; Sigma Weekday: " \
+      "1=Sunday..7=Saturday) — override to Mod(Weekday([col])+5,7) to preserve " \
+      "Beast Mode's exact day numbers, or verify downstream logic does not depend " \
+      "on the raw numeric value."
   end
 
   # 3. Unsupported functions.
@@ -361,8 +380,9 @@ def resolve_entry(entry, overrides)
       "double-bracketed ALL-CAPS refs are fixed (sigma-data-model-mcp PR #115, " \
       "#116) so this is NOT that historical 74%-fail case — check " \
       "refs/live-validation-2026-07-30.md and this script's still-open gaps " \
-      "(WEEKDAY→DAYOFWEEK, CEILING/FLOOR aggregates, untranslatable infix LIKE) " \
-      "for what actually still needs a hand-authored formula."
+      "(WEEKDAY day-numbering mismatch — override to Mod(Weekday([col])+5,7) — " \
+      "CEILING/FLOOR aggregates, untranslatable infix LIKE) for what actually " \
+      "still needs a hand-authored formula."
   elsif entry['converted'] == false
     # Track E: --convert already computed a REAL converted flag (via the
     # vendored hasResidualCaseKeyword/hasResidualInfixOperator) — surface it

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -183,11 +183,7 @@ def normalize_bm(sql, klass = nil)
   # from Sigma's Weekday() output (verified for all 7 days in
   # test/test-convert-beast-modes.rb).
   if s =~ /\bWEEKDAY\s*\(/i
-    warnings << "WEEKDAY() converts to Sigma Weekday() by NAME, but the two use " \
-      "DIFFERENT day numbering (MySQL WEEKDAY: 0=Monday..6=Sunday; Sigma Weekday: " \
-      "1=Sunday..7=Saturday) — override to Mod(Weekday([col])+5,7) to preserve " \
-      "Beast Mode's exact day numbers, or verify downstream logic does not depend " \
-      "on the raw numeric value."
+    warnings << 'WEEKDAY() converts to Sigma Weekday() by NAME, but the two use DIFFERENT day numbering (MySQL WEEKDAY: 0=Monday..6=Sunday; Sigma Weekday: 1=Sunday..7=Saturday) — override to Mod(Weekday([col])+5,7) to preserve the original MySQL day numbers, or verify downstream logic does not depend on the raw numeric value.'
   end
 
   # 3. Unsupported functions.
@@ -380,7 +376,7 @@ def resolve_entry(entry, overrides)
       "double-bracketed ALL-CAPS refs are fixed (sigma-data-model-mcp PR #115, " \
       "#116) so this is NOT that historical 74%-fail case — check " \
       "refs/live-validation-2026-07-30.md and this script's still-open gaps " \
-      "(WEEKDAY day-numbering mismatch — override to Mod(Weekday([col])+5,7) — " \
+      "(WEEKDAY day-numbering mismatch [override: Mod(Weekday([col])+5,7)], " \
       "CEILING/FLOOR aggregates, untranslatable infix LIKE) for what actually " \
       "still needs a hand-authored formula."
   elsif entry['converted'] == false

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -25,10 +25,13 @@ ok(n == "CONCAT([StringColumnCity], ', ', [StringColumnState])", 'backticks → 
 n, _ = normalize_bm("SUM(`Operating Budget`)")
 ok(n == 'SUM([Operating Budget])', 'spaced identifier preserved in brackets')
 
-puts "== normalize_bm: WEEKDAY → DAYOFWEEK =="
+puts "== normalize_bm: WEEKDAY passes through unchanged, flagged for override =="
 n, w = normalize_bm('WEEKDAY(`d`)')
-ok(n == 'DAYOFWEEK([d])', 'WEEKDAY rewritten to DAYOFWEEK')
-ok(w.any? { |x| x.include?('WEEKDAY') }, 'WEEKDAY warning emitted')
+ok(n == 'WEEKDAY([d])', 'WEEKDAY left untouched (no DAYOFWEEK rewrite)')
+ok(!n.include?('DAYOFWEEK'), 'DAYOFWEEK never appears in normalized output')
+ok(w.any? { |x| x.include?('WEEKDAY') && x.include?('Weekday') }, 'WEEKDAY warning emitted, names Sigma Weekday()')
+ok(w.any? { |x| x.include?('Mod(Weekday([col])+5,7)') }, 'WEEKDAY warning names the exact override formula')
+ok(w.any? { |x| x.include?('0=Monday') && x.include?('1=Sunday') }, 'WEEKDAY warning documents both numbering conventions')
 
 puts "== normalize_bm: unsupported functions flagged =="
 _, w = normalize_bm('SQRT(`x`)')
@@ -164,12 +167,22 @@ puts "== lint_formula: valid multi-condition If passes =="
 errs, w = lint_formula('If([Status]="Active","Active",[Status]="Pending","Pending","Other")')
 ok(errs.empty?, 'native multi-condition If is clean (no nesting needed)')
 
-puts '== normalize_bm: unsupported + WEEKDAY rewrite =='
+puts '== normalize_bm: unsupported + WEEKDAY override warning =='
 n, w = normalize_bm('WEEKDAY(order_date)')
-ok(n.include?('DAYOFWEEK'), 'WEEKDAY → DAYOFWEEK')
-ok(!w.empty?, 'WEEKDAY rewrite warns')
+ok(n.include?('WEEKDAY'), 'WEEKDAY name preserved unchanged')
+ok(!n.include?('DAYOFWEEK'), 'no DAYOFWEEK rewrite (bare identifier, no backticks)')
+ok(!w.empty?, 'WEEKDAY override warning present')
+ok(!w.any? { |x| x =~ /\bWEEKDAY\b.*unsupported/i }, 'WEEKDAY not double-flagged via the generic UNSUPPORTED loop')
 _, w2 = normalize_bm('SQRT(x)')
 ok(w2.join.match?(/SQRT/i), 'SQRT flagged unsupported')
+
+puts '== normalize_bm: WEEKDAY() day-numbering arithmetic sanity check =='
+# Sanity check the exact override formula this file's warning names —
+# Mod(Weekday([col])+5,7) — reproduces MySQL's WEEKDAY() numbering (0=Monday)
+# from Sigma's Weekday() numbering (1=Sunday), for all 7 days.
+sigma_to_mysql = { 1 => 6, 2 => 0, 3 => 1, 4 => 2, 5 => 3, 6 => 4, 7 => 5 } # Sun..Sat
+all_match = sigma_to_mysql.all? { |sigma_val, mysql_val| (sigma_val + 5) % 7 == mysql_val }
+ok(all_match, 'Mod(Weekday([col])+5,7) matches MySQL WEEKDAY() for all 7 days (Sun..Sat)')
 
 puts '== lint_formula: raw IN + And()/Or() function-call =='
 errs, _ = lint_formula('If([x] IN (1,2), "a", "b")')

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -172,7 +172,7 @@ n, w = normalize_bm('WEEKDAY(order_date)')
 ok(n.include?('WEEKDAY'), 'WEEKDAY name preserved unchanged')
 ok(!n.include?('DAYOFWEEK'), 'no DAYOFWEEK rewrite (bare identifier, no backticks)')
 ok(!w.empty?, 'WEEKDAY override warning present')
-ok(!w.any? { |x| x =~ /\bWEEKDAY\b.*unsupported/i }, 'WEEKDAY not double-flagged via the generic UNSUPPORTED loop')
+ok(!w.any? { |x| x.include?('Unsupported function WEEKDAY') }, 'WEEKDAY not double-flagged via the generic UNSUPPORTED loop')
 _, w2 = normalize_bm('SQRT(x)')
 ok(w2.join.match?(/SQRT/i), 'SQRT flagged unsupported')
 


### PR DESCRIPTION
## Summary
- `normalize_bm` was rewriting SQL `WEEKDAY(...)` to `DAYOFWEEK(...)` "for parity," but `Dayofweek(...)` is not a real Sigma function — the rewrite made the shared converter warn on an unknown function where the untouched `WEEKDAY(...)` form would have passed through cleanly as Sigma's `Weekday(...)`.
- Investigation also surfaced a genuine value-correctness issue (verified against both vendors' docs): Sigma's `Weekday()` uses 1=Sunday..7=Saturday, MySQL's `WEEKDAY()` uses 0=Monday..6=Sunday — different numbering conventions. A clean pass-through alone would produce numerically wrong values.
- Removed the fake-function rewrite; added a warning naming the correct override formula `Mod(Weekday([col])+5,7)`, matching the existing CEILING/FLOOR warning pattern.
- Review follow-up: fixed a dead test assertion (wrong regex ordering meant it could never catch a regression) and two minor wording nits.

Bead: `beads-sigma-nrml`

## Test plan
- [x] `ruby test/test-convert-beast-modes.rb` — WEEKDAY warning/override assertions, dead-assertion fix independently verified red-before/green-after
- [x] `bash test/run-all.sh` — all suites pass
- [x] Scoped re-review (Sonnet) independently reproduced the red/green check and confirmed the override guidance is intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)