### PR TITLE
fix(domo-to-sigma): narrow IN(...) lint + drop wrong WEEKDAY rewrite (beads-sigma-kn8s, beads-sigma-nrml)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -90,13 +90,22 @@ like Power BI's DAX.
 > `sigmaFormula` rather than shipping bad output, a Beast Mode using an
 > untranslatable construct still needs the `formula-overrides.json` sidecar —
 > that mechanism is unchanged and still the right escape hatch, it is just no
-> longer load-bearing for CASE WHEN or COUNT(DISTINCT). One more thing to
-> budget for: `convert-beast-modes.rb`'s own `WEEKDAY` → `DAYOFWEEK`
-> normalization step is *counterproductive* — `WEEKDAY(...)` converts cleanly
-> on its own, but this step rewrites it to `DAYOFWEEK(...)` first, which is
-> **not** a real Sigma function (still open; see the note in
-> `scripts/convert-beast-modes.rb`). Full evidence and the exact
-> before/after outputs: `refs/live-validation-2026-07-30.md`.
+> longer load-bearing for CASE WHEN or COUNT(DISTINCT). Full evidence and the
+> exact before/after outputs: `refs/live-validation-2026-07-30.md`.
+>
+> ✅ **RESOLVED 2026-08-03 (beads-sigma-nrml)**: `convert-beast-modes.rb`'s own
+> `WEEKDAY` → `DAYOFWEEK` normalization step (used by the measurement above)
+> was itself *counterproductive* — `WEEKDAY(...)` converts cleanly to Sigma's
+> real `Weekday()` on its own, but that step rewrote it to `DAYOFWEEK(...)`
+> first, which is **not** a real Sigma function. Fixed by dropping the
+> rewrite entirely: `WEEKDAY(...)` now passes straight through unrewritten.
+> Verified this is not just simpler but fully correct — Domo's own docs claim
+> `WEEKDAY()` is MySQL-native 0=Monday, but that documentation is itself
+> wrong (Domo Community Forum-confirmed): Domo silently executes `WEEKDAY()`
+> as `DAYOFWEEK()` at runtime, so it already returns 1=Sunday..7=Saturday,
+> identical to Sigma's `Weekday()` — no numbering compensation needed. See
+> `refs/beast-mode-to-sigma.md`'s gotchas table and `normalize_bm` step 2 in
+> `scripts/convert-beast-modes.rb`.
 
 The other work is *extraction* (card defs + Beast Mode text + layout out of Domo)
 and *layout/binding* (cards → Sigma elements on a 24-col grid; note Domo's own card
@@ -334,9 +343,11 @@ ruby scripts/convert-beast-modes.rb --lint     # validate → discovery/formulas
 `--mcp-dir`/`DOMO_MCP_DIR` (explicit dev opt-in only), or — last resort, bundle
 or `node` absent — exit 10 with the manual `convert_sql_to_sigma_formula`
 + `--converter-out` fallback instructions. Applies the normalizations in
-`refs/beast-mode-to-sigma.md` FIRST (strip backticks, `WEEKDAY`→`DAYOFWEEK`,
-flag aggregate `CEILING`/`FLOOR`, reject unsupported `SQRT`/`CONVERT_TZ`).
-Outputs `discovery/formulas.json` (Beast Mode id → Sigma formula).
+`refs/beast-mode-to-sigma.md` FIRST (strip backticks, pass `WEEKDAY(...)`
+through unrewritten — it already matches Sigma's `Weekday()` numbering, see
+beads-sigma-nrml above — flag aggregate `CEILING`/`FLOOR`, reject unsupported
+`SQRT`/`CONVERT_TZ`). Outputs `discovery/formulas.json` (Beast Mode id → Sigma
+formula).
 
 ---
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/refs/beast-mode-to-sigma.md
@@ -69,11 +69,27 @@ Apply these to the raw Beast Mode string first:
 
 1. **Strip backtick / bracket identifier quoting** → Sigma uses `[Column Name]`.
    `` `Sales` `` and `` `Operating Budget` `` → `[Sales]`, `[Operating Budget]`.
-2. **`WEEKDAY` → `DAYOFWEEK`.** Beast Mode silently does this substitution itself;
-   replicate it so behavior matches. (`WEEKDAY` is in the unsupported list.)
+2. **`WEEKDAY(...)` — pass through unrewritten.** (beads-sigma-nrml, RESOLVED
+   2026-08-03.) An earlier version of this script rewrote `WEEKDAY` →
+   `DAYOFWEEK` "for parity" — that made things worse: `WEEKDAY(...)` already
+   converts cleanly to Sigma's real `Weekday(...)` function, while
+   `DAYOFWEEK(...)` (the rewritten name) has no Sigma mapping and gets flagged
+   as an unknown function. Domo's own Beast Mode docs claim `WEEKDAY()` is
+   MySQL-native (0=Monday), but that documentation is itself wrong — Domo
+   silently executes a Beast Mode `WEEKDAY()` call as `DAYOFWEEK()` under the
+   hood (Domo Community Forum: "error in documentation of weekday beast mode
+   function" and others — "WEEKDAY and DAYOFWEEK used to display the same
+   value, even though the beast mode editor function description indicated
+   one was 0-start and the other was 1-start"), so it actually returns
+   1=Sunday..7=Saturday in practice — identical to Sigma's `Weekday()`. No
+   numbering compensation is needed; a bare passthrough is correct. (Residual,
+   non-blocking caveat: at least one report ties the returned value to the
+   target instance's first-day-of-week/timezone configuration, which cannot be
+   known at conversion time — spot-check against the real instance.)
 3. **Reject / flag unsupported functions** (no longer supported in Beast Mode, so
-   they shouldn't appear, but guard anyway): `SQRT`, `CONVERT_TZ`, `MICROSECOND`,
-   `WEEKDAY`. If present, warn — likely a legacy formula.
+   they shouldn't appear, but guard anyway): `SQRT`, `CONVERT_TZ`, `MICROSECOND`.
+   If present, warn — likely a legacy formula. (`WEEKDAY` is NOT in this list —
+   it is fully supported; see #2 above.)
 4. **Flag the aggregate `CEILING` / `FLOOR` trap** — see below. These are NOT math
    rounding in Beast Mode.
 5. **Decide row vs aggregate context.** If a top-level aggregate (`SUM`, `AVG`,
@@ -90,7 +106,7 @@ Apply these to the raw Beast Mode string first:
 | `CEILING(Budget)` | math ceiling | **aggregate**: rounded `MAX` | `Round(Max([Budget]))` |
 | `FLOOR(Budget)` | math floor | **aggregate**: rounded `MIN` | `Round(Min([Budget]))` |
 | `POWER(Values,2)` | per-row power | per-row power, but **sums per series** if multi-series | `Power([Values],2)` (handle series via grouping) |
-| `WEEKDAY(d)` | MySQL WEEKDAY (0=Mon) | replaced with `DAYOFWEEK` (1=Sun) | `Weekday([d])` — mind the 1=Sunday base |
+| `WEEKDAY(d)` | MySQL WEEKDAY (0=Mon), per Domo's own (incorrect) docs | Domo silently executes it as `DAYOFWEEK` (1=Sun) — verified, matches Sigma | `Weekday([d])` — passthrough, no rewrite needed |
 | `SQRT(x)` | square root | **unsupported** in Beast Mode | use `Power([x], 0.5)` if it appears |
 | Summary Number Beast Mode | a column | must be aggregated to be a summary | maps to a Sigma **KPI** element — see `refs/card-to-element.md` Rule 0 (KPI, never a table) |
 | `SUM(SUM([x]) FIXED (BY [Region]))` | a nested aggregate | **level-of-detail** (LOD) | Sigma **level-of-detail** — do NOT flatten to a plain aggregate; flag for review (see `lod_conditional_inner`) |
@@ -138,7 +154,7 @@ Apply these to the raw Beast Mode string first:
 | `CASE WHEN c THEN a ELSE b END` | `If(c, a, b)` |
 | `CASE WHEN c1 THEN 1 WHEN c2 THEN 2 END` | **native multi-pair** `If(c1, 1, c2, 2, null)` — no nesting needed |
 | `CASE col WHEN x THEN a WHEN y THEN b END` | `If([col]=x, a, [col]=y, b, null)` |
-| `col IN (v1, v2, ...)` | **`[col]=v1 or [col]=v2 ...`** — Sigma has **no `IsIn`** (see `feedback_sigma_formula_isin`) |
+| `col IN (v1, v2, ...)` | **`[col]=v1 or [col]=v2 ...`**, or Sigma's own **`In([col], v1, v2, ...)`** function — Sigma has no *infix* `IN` (see `feedback_sigma_formula_isin`). `lint_formula` (beads-sigma-kn8s) only flags the raw infix shape; it does not reject a legitimate `In(...)` function call. |
 | `col LIKE '%TX%'` | `Contains([col], "TX")` |
 | `col LIKE 'TX%'` | `StartsWith([col], "TX")` |
 | `col LIKE '%TX'` | `EndsWith([col], "TX")` |
@@ -194,6 +210,7 @@ string** (`"day"`, `"month"`, `"year"`, …) and use **format tokens** (`YYYY`,
 | `DAY(d)` / `DAYOFMONTH(d)` | `Day([d])` |
 | `DAYNAME(d)` | `DateFormat([d], "dddd")` |
 | `DAYOFWEEK(d)` | `Weekday([d])` (1=Sunday) |
+| `WEEKDAY(d)` | `Weekday([d])` (1=Sunday) — passes straight through, no rewrite; see the gotchas table below for why |
 | `DAYOFYEAR(d)` | `DateDiff("day", DateTrunc("year",[d]), [d]) + 1` |
 | `HOUR(d)` / `MINUTE(d)` / `SECOND(d)` | `Hour([d])` / `Minute([d])` / `Second([d])` |
 | `QUARTER(d)` | `Quarter([d])` |

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/convert-beast-modes.rb
@@ -14,12 +14,17 @@
 # This script does NOT reimplement translation itself. It adds the two layers
 # the generic SQL converter can't know about:
 #
-#   PRE  — Domo-specific normalization (backtick identifiers → [Col], WEEKDAY →
-#          DAYOFWEEK, flag unsupported fns, flag the CEILING/FLOOR-are-aggregates
-#          trap, flag window/LOD Beast Modes) — see refs/beast-mode-to-sigma.md.
-#   POST — Sigma-specific lint of the returned formula (leftover IN(, And()/Or()/
-#          Not() function-call forms that silently null, window-fn workbook-master
-#          limits) — see refs/beast-mode-to-sigma.md + feedback_sigma_window_functions.
+#   PRE  — Domo-specific normalization (backtick identifiers → [Col], flag
+#          unsupported fns, flag the CEILING/FLOOR-are-aggregates trap, flag
+#          window/LOD Beast Modes) — see refs/beast-mode-to-sigma.md. WEEKDAY(...)
+#          is deliberately passed through unrewritten (beads-sigma-nrml, see
+#          normalize_bm step 2) — it converts cleanly and its numbering already
+#          matches Sigma's Weekday().
+#   POST — Sigma-specific lint of the returned formula (raw SQL infix IN (...),
+#          And()/Or()/Not() function-call forms that silently null, window-fn
+#          workbook-master limits) — see refs/beast-mode-to-sigma.md +
+#          feedback_sigma_window_functions. Sigma's own In(col, ...) function
+#          call is NOT flagged (beads-sigma-kn8s) — only a raw SQL infix IN is.
 #
 # Three-step flow (SKILL.md's Phase 2 runs all three; no agent/MCP call in the
 # middle step unless the exit-10 GATE fires):
@@ -140,8 +145,10 @@ def resolve_sql_converter(mcp_dir, vendored)
   [conv, dev_module, desc]
 end
 
-# Removed from Beast Mode / unsupported in Sigma — warn if seen.
-UNSUPPORTED = %w[SQRT CONVERT_TZ MICROSECOND WEEKDAY].freeze
+# Removed from Beast Mode / unsupported in Sigma — warn if seen. WEEKDAY is
+# NOT in this list (see normalize_bm step 2) — it is fully supported, both in
+# Beast Mode and in Sigma.
+UNSUPPORTED = %w[SQRT CONVERT_TZ MICROSECOND].freeze
 
 # Convert a raw Beast Mode string toward what convert_sql_to_sigma_formula expects,
 # applying only the Domo-specific deltas. Returns [normalizedSql, warnings].
@@ -152,28 +159,51 @@ def normalize_bm(sql, klass = nil)
   # 1. Backtick / bracket MySQL identifier quoting → Sigma [Column Name].
   s = s.gsub(/`([^`]+)`/) { "[#{$1}]" }
 
-  # 2. WEEKDAY → DAYOFWEEK (Beast Mode does this itself; replicate for parity).
+  # 2. WEEKDAY(...) — beads-sigma-nrml, RESOLVED 2026-08-03: deliberately NO
+  #    rewrite here anymore (the old code rewrote WEEKDAY → DAYOFWEEK "for
+  #    parity"). That rewrite made things WORSE: `WEEKDAY(...)` passed to the
+  #    shared converter already comes back clean as `Weekday(...)` — a real
+  #    Sigma function (LOOK_FUNC_MAP in converter/sql.mjs) — but the old
+  #    rewrite's `DAYOFWEEK(...)` has NO Sigma mapping and gets flagged
+  #    unknown by lookUnknownFunctions. Verified live against the vendored
+  #    converter: `WEEKDAY([d])` → `Weekday([d])`, zero warnings;
+  #    `DAYOFWEEK([d])` → `Dayofweek([d])`, unknown-function warning.
   #
-  # ⚠️ MEASURED 2026-07-30 (bead, not fixed here — see progress ledger for
-  # 2026-07-30-track-a-sql-formula-converter, "LIKELY REAL PRODUCTION BUG"):
-  # this rewrite makes the formula WORSE, not better. `WEEKDAY(...)` passed to
-  # the shared converter comes back clean (`Weekday(...)` — Sigma has it), but
-  # this step rewrites it to `DAYOFWEEK(...)` FIRST, and `Dayofweek(...)` is
-  # NOT a real Sigma function — the converter now warns on it
-  # (lookUnknownFunctions) where the untouched WEEKDAY form would not have
-  # warned at all. Do not "fix" this by just deleting the rewrite without
-  # checking Sigma's WEEKDAY offset (1=Sunday) actually matches Beast Mode's —
-  # that offset question is exactly why this was added "for parity" in the
-  # first place, and is unverified either way. Tracked as its own bead; needs
-  # its own investigation, not a silent revert.
+  #    Before just deleting the old rewrite, the day-NUMBERING question this
+  #    script's prior comment flagged as unverified ("does Sigma's Weekday()
+  #    1=Sunday base actually match Beast Mode's own WEEKDAY()?") had to be
+  #    checked — a numbering mismatch would mean trading "wrong function name"
+  #    for "wrong day numbers", equally bad. VERIFIED (2026-08-03, Domo
+  #    Community Forum — "error in documentation of weekday beast mode
+  #    function" and others): Domo's own Beast Mode Functions Reference Guide
+  #    documents WEEKDAY() as MySQL-native 0=Monday, but that documentation is
+  #    itself wrong — Domo silently executes a Beast Mode WEEKDAY() call as
+  #    DAYOFWEEK() under the hood, so it ACTUALLY returns 1-7 with 1=Sunday in
+  #    practice (multiple independent reports: "WEEKDAY and DAYOFWEEK used to
+  #    display the same value, even though the beast mode editor function
+  #    description indicated one was 0-start and the other was 1-start").
+  #    Sigma's Weekday() is also 1=Sunday..7=Saturday (this file's own
+  #    refs/beast-mode-to-sigma.md DAYOFWEEK row; corroborated independently by
+  #    tableau-to-sigma's refs/column-gotchas.md and refs/window-functions.md).
+  #    So Beast Mode's REAL runtime numbering already matches Sigma's — no
+  #    compensating offset is needed, and none is applied. A bare passthrough
+  #    (i.e. no rewrite at all) is the fully correct fix, not just the
+  #    simpler one.
+  #
+  #    Residual, non-blocking caveat surfaced below rather than silently
+  #    assumed: at least one report says the value "depends on the instance
+  #    configuration (first day of the week) or time zone settings" — this
+  #    script has no way to know a specific target Domo instance's
+  #    first-day-of-week setting at conversion time, so a WEEKDAY() sighting
+  #    still gets a spot-check warning (not a lintError — the default/common
+  #    case is verified correct) rather than a claim of unconditional
+  #    correctness for every possible instance config.
   if s =~ /\bWEEKDAY\s*\(/i
-    s = s.gsub(/\bWEEKDAY\s*\(/i, 'DAYOFWEEK(')
-    warnings << 'WEEKDAY → DAYOFWEEK (1=Sunday base; verify offset).'
+    warnings << 'WEEKDAY(...) converts straight through to Sigma\'s Weekday() (1=Sunday) — verified to match Beast Mode\'s actual runtime numbering (also 1=Sunday, despite Domo\'s own docs claiming 0=Monday; Domo Community Forum-confirmed documentation bug — see refs/beast-mode-to-sigma.md). Spot-check the built formula against this specific Domo instance\'s actual WEEKDAY() output before shipping — at least one report ties the returned value to the instance\'s first-day-of-week/timezone config, which this script cannot see at conversion time.'
   end
 
   # 3. Unsupported functions.
   UNSUPPORTED.each do |fn|
-    next if fn == 'WEEKDAY' # handled above
     warnings << "Unsupported function #{fn}() present — legacy formula; review (SQRT → Power([x],0.5))." if s =~ /\b#{fn}\s*\(/i
   end
 
@@ -199,6 +229,66 @@ end
 
 NEEDS_REVIEW = %w[window lod].freeze
 
+# beads-sigma-kn8s: `IN(`/`In(` is textually identical whether it is a raw SQL
+# infix construct Sigma cannot express (`status IN (...)`, `[Status] IN
+# (...)` — must become an OR-chain, or Sigma's own In(...) rewritten by hand)
+# or Sigma's own documented `In([col], "a", "b")` FUNCTION CALL
+# (plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/
+# formulas.md — a real, valid Sigma function). A blanket substring ban wrongly
+# rejected the latter. The distinguishing signal is what sits immediately
+# BEFORE the keyword: a raw SQL infix always has a left-hand operand touching
+# it (an identifier, a bracketed column, a quoted literal, or a closing
+# paren/bracket/digit); the Sigma function-call form instead starts a fresh
+# expression — nothing before it (start of formula), or a `(`, `,`, or a
+# boolean/control keyword (and/or/if/then/else/when/case). `not` is deliberately
+# NOT in this list — see operand_immediately_before?'s special-case handling
+# below; unlike the others it cannot be treated as a plain keyword boundary
+# because `not` is also half of the two-word raw SQL infix operator `NOT IN`.
+NON_OPERAND_KEYWORDS = %w[and or if then else when case].freeze
+
+# Is there an "operand" (something that could be the left-hand side of a raw
+# SQL infix expression) immediately before position `pos` in `s`, ignoring
+# whitespace?
+#
+# Review fix (Critical regression): the first cut of this logic put `not` in
+# NON_OPERAND_KEYWORDS unconditionally, so `[Region] NOT IN (...)` — a raw SQL
+# infix operator, not a hint of Sigma's In(...) — was wrongly read as "not"
+# starting a fresh expression (the legitimate `not In(...)` boolean-prefix-
+# negation case) and silently NOT flagged. There is no Sigma spelling of a
+# two-word "NOT IN" operator, so `NOT IN (` must ALWAYS be raw infix — the
+# only real question is whether the `not` itself has an operand before IT
+# (`[Region] NOT IN (...)` — raw infix) or not (`not In(...)` — genuine prefix
+# negation of a real Sigma function call, same convention as this file's own
+# `Not (...)` infix-negation guidance elsewhere). So when the word immediately
+# before `IN (` is `not`, recurse one hop further back to answer that
+# question instead of treating `not` as an ordinary keyword boundary.
+def operand_immediately_before?(s, pos)
+  j = pos - 1
+  j -= 1 while j >= 0 && s[j] =~ /\s/
+  return false if j < 0 # start of formula — no operand
+
+  ch = s[j]
+  return true if ch =~ /[\]"'\)\d]/ # bracket-close, quote, paren-close, digit
+  return false unless ch =~ /\w/
+
+  k = j
+  k -= 1 while k >= 0 && s[k] =~ /\w/
+  word = s[(k + 1)..j].downcase
+
+  return operand_immediately_before?(s, k + 1) if word == 'not'
+
+  !NON_OPERAND_KEYWORDS.include?(word)
+end
+
+def raw_sql_infix_in?(formula)
+  s = formula.to_s
+  s.scan(/\bIN\s*\(/i) do
+    m = Regexp.last_match
+    return true if operand_immediately_before?(s, m.begin(0))
+  end
+  false
+end
+
 # Lint a translated Sigma formula for the traps that ship silently-broken output.
 # Returns [errors, warnings].
 def lint_formula(sigma, klass = nil)
@@ -206,9 +296,11 @@ def lint_formula(sigma, klass = nil)
   warnings = []
   f = sigma.to_s
 
-  # IN(...) survived translation → Sigma has no IsIn; it silently blanks the column.
-  if f =~ /\bIN\s*\(/i && f !~ /\bContains\s*\(/i
-    errors << 'Contains a raw IN(...) — Sigma has no IsIn; expand to an OR-chain ([c]=a or [c]=b) or it silently blanks the column (feedback_sigma_formula_isin).'
+  # A raw SQL infix IN (...) survived translation → Sigma has no infix IN; it
+  # silently blanks the column. Sigma's own In(col, "a", "b") function-call
+  # form is valid and must NOT be flagged here — see raw_sql_infix_in? above.
+  if raw_sql_infix_in?(f)
+    errors << 'Contains a raw SQL infix IN (...) — Sigma has no infix IN/IsIn; expand to an OR-chain ([c]=a or [c]=b), or use Sigma\'s own In([c], "a", "b") function form, or it silently blanks the column (feedback_sigma_formula_isin).'
   end
 
   # And()/Or()/Not() as FUNCTION CALLS silently produce null rows — must be infix.

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
@@ -40,6 +40,15 @@ FIXTURES = [
   { id: 'D-8', sql: 'ROUND([Margin Pct], 2)',                     expect: 'Round([Margin Pct], 2)' },
   { id: 'D-9', sql: "DATEDIFF('day', [Order Date], [Ship Date])", expect: 'DateDiff("day", [Order Date], [Ship Date])' },
   { id: 'D-10', sql: 'COALESCE([Discount], 0)',                   expect: 'Coalesce([Discount], 0)' },
+  # beads-sigma-nrml: normalize_bm no longer rewrites WEEKDAY(...) to the
+  # nonexistent-in-Sigma DAYOFWEEK — it now passes the call straight through
+  # unchanged (verified: Beast Mode's actual runtime WEEKDAY() numbering
+  # already matches Sigma's Weekday(), despite Domo's own docs claiming
+  # otherwise — see convert-beast-modes.rb normalize_bm step 2). Locks that
+  # this exact post-normalize_bm shape converts cleanly through the real
+  # vendored converter, matching what normalize_bm's own unit test
+  # (test-convert-beast-modes.rb) asserts it emits.
+  { id: 'D-11', sql: 'WEEKDAY([Order Date])',                      expect: 'Weekday([Order Date])' },
 ]
 # NOTE (converted:false expected): the vendored converter has no Sigma mapping
 # for LIKE/BETWEEN — this is intentional, not a bug (see design doc's Error

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes.rb
@@ -25,10 +25,51 @@ ok(n == "CONCAT([StringColumnCity], ', ', [StringColumnState])", 'backticks → 
 n, _ = normalize_bm("SUM(`Operating Budget`)")
 ok(n == 'SUM([Operating Budget])', 'spaced identifier preserved in brackets')
 
-puts "== normalize_bm: WEEKDAY → DAYOFWEEK =="
+puts "== normalize_bm: WEEKDAY passes through unrewritten, NOT to DAYOFWEEK (beads-sigma-nrml) =="
+# beads-sigma-nrml — RESOLVED: the old rewrite (WEEKDAY → DAYOFWEEK) made
+# things WORSE — WEEKDAY(...) already converts cleanly to Weekday(...) (a real
+# Sigma function; see LOOK_FUNC_MAP in converter/sql.mjs) while DAYOFWEEK(...)
+# has no Sigma mapping and gets flagged unknown.
+#
+# Before just deleting the rewrite, the day-numbering question the old code's
+# comment flagged as unverified had to be checked: does Sigma's Weekday()
+# (1=Sunday) actually match Beast Mode's own WEEKDAY()? VERIFIED (Domo
+# Community Forum — "error in documentation of weekday beast mode function"
+# and others; corroborated independently by multiple threads): Domo's own
+# published docs claim WEEKDAY() is MySQL-native 0=Monday, but that
+# documentation is ITSELF wrong — Domo silently executes WEEKDAY() as
+# DAYOFWEEK() under the hood, so it actually returns 1=Sunday..7=Saturday in
+# practice, identical to Sigma's Weekday(). So there is NO numbering mismatch
+# to compensate for — a bare, unrewritten passthrough is the fully correct
+# fix, not just the simpler one. (If a real mismatch had been found, a
+# compensating formula or a residual-gap warning would have been required
+# instead of a silent passthrough — this test would look very different.)
 n, w = normalize_bm('WEEKDAY(`d`)')
-ok(n == 'DAYOFWEEK([d])', 'WEEKDAY rewritten to DAYOFWEEK')
-ok(w.any? { |x| x.include?('WEEKDAY') }, 'WEEKDAY warning emitted')
+ok(n == 'WEEKDAY([d])', 'WEEKDAY(...) is passed straight through — only the backtick→bracket step (1) touches it')
+ok(!n.include?('DAYOFWEEK'), 'no more rewrite to the nonexistent-in-Sigma DAYOFWEEK name')
+ok(w.any? { |x| x.include?('WEEKDAY') && x.include?('Weekday') }, 'still emits an informational spot-check warning naming both functions')
+ok(w.none? { |x| x.include?('DAYOFWEEK') }, 'the warning does not suggest the old (wrong) DAYOFWEEK rewrite')
+
+puts "== normalize_bm: WEEKDAY(...) converts cleanly through the real vendored converter, matching Beast Mode's numbering =="
+if system('node', '--version', out: File::NULL, err: File::NULL)
+  out, status = Open3.capture2('node', '-e', <<~JS)
+    import(#{File.expand_path('../converter/sql.mjs', __dir__).to_json}).then(async (m) => {
+      const { lookSqlToSigmaRules, lookConvertExpression, hasResidualCaseKeyword, hasResidualInfixOperator, lookUnknownFunctions } = m;
+      const sql = #{n.to_json};
+      let sigma = lookSqlToSigmaRules(sql);
+      if (sigma == null) sigma = lookConvertExpression(sql);
+      const converted = !hasResidualCaseKeyword(sigma) && !hasResidualInfixOperator(sigma);
+      console.log(JSON.stringify({ sigma, converted, unknown: lookUnknownFunctions(sql) }));
+    });
+  JS
+  result = JSON.parse(out.lines.last.to_s)
+  ok(status.success?, "node conversion of the passthrough formula ran cleanly\n#{out}")
+  ok(result['sigma'] == 'Weekday([d])', "converts to Weekday([d]) exactly, got #{result['sigma'].inspect}")
+  ok(result['converted'] == true, 'no residual CASE/infix syntax — flagged converted:true')
+  ok(result['unknown'].empty?, 'no unknown-function warning (the DAYOFWEEK bug this replaces used to trigger one)')
+else
+  puts '  SKIPPED (node not on PATH)'
+end
 
 puts "== normalize_bm: unsupported functions flagged =="
 _, w = normalize_bm('SQRT(`x`)')
@@ -52,6 +93,62 @@ ok(errs.any? { |e| e.include?('IsIn') }, 'raw IN(...) → error (no IsIn)')
 errs, _ = lint_formula('If([col]="A" or [col]="B", 1, 0)')
 ok(errs.empty?, 'expanded OR-chain passes clean')
 
+# ---------------------------------------------------------------------------
+# beads-sigma-kn8s: lint_formula used to blanket-ban ANY "IN(" substring,
+# which also rejected Sigma's own documented In(col, "a", "b") FUNCTION CALL
+# (plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/
+# formulas.md line 244 confirms it's real). The fix narrows the rule to shape,
+# not substring: a raw SQL infix IN always has a left-hand operand touching
+# it (an identifier, bracketed column, or quoted literal); the Sigma function-
+# call form starts a fresh expression instead.
+# ---------------------------------------------------------------------------
+puts "== lint_formula: Sigma's real In(...) FUNCTION CALL passes clean (beads-sigma-kn8s) =="
+errs, _ = lint_formula('In([Status], "Open", "Pending")')
+ok(errs.empty?, 'In([Status], "Open", "Pending") is a valid Sigma function call — no lint error')
+
+puts "== lint_formula: raw SQL infix `x IN (...)` is still FLAGGED (Sigma has no infix IN) =="
+errs, _ = lint_formula("status IN ('a', 'b', 'c')")
+ok(errs.any? { |e| e.include?('IsIn') }, "bare identifier IN (...) is still a lint error")
+errs, _ = lint_formula("[Status] IN ('a','b')")
+ok(errs.any? { |e| e.include?('IsIn') }, "[Status] IN (...) is still a lint error")
+
+puts "== lint_formula: In(...) used inside a larger formula (after and/or/If() ) still passes =="
+errs, _ = lint_formula('If([Status]="Active" or In([Region], "East", "West"), 1, 0)')
+ok(errs.empty?, 'In(...) preceded by `or ` is still the function-call form — no lint error')
+errs, _ = lint_formula('If(In([Status], "Open", "Pending"), 1, 0)')
+ok(errs.empty?, 'In(...) as the first argument to If( is still the function-call form — no lint error')
+
+# ---------------------------------------------------------------------------
+# Review fix (Critical regression found by independent review): the first cut
+# of raw_sql_infix_in? put `not` in NON_OPERAND_KEYWORDS unconditionally, so
+# `x NOT IN (...)` — a raw SQL infix operator, not a hint of Sigma's In(...)
+# function call — was wrongly treated as "not" starting a fresh expression
+# (the legitimate `not In(...)` boolean-prefix-negation case) and silently
+# NOT flagged. There is no Sigma spelling of a two-word "NOT IN" operator, so
+# `NOT IN (` must ALWAYS be treated as raw infix — the only question is
+# whether the preceding `not` itself has an operand before it (`[Region] NOT
+# IN (...)` — raw infix) or not (`not In(...)` — genuine prefix negation of a
+# real Sigma function call, same convention as this file's own `Not (...)`
+# infix-negation guidance).
+# ---------------------------------------------------------------------------
+puts "== lint_formula: raw SQL infix `x NOT IN (...)` is FLAGGED, same as bare IN (critical regression fix) =="
+errs, _ = lint_formula('If([Region] NOT IN ("Test","Internal"), 1, 0)')
+ok(errs.any? { |e| e.include?('IsIn') }, '[Region] NOT IN (...) is a lint error — bracketed operand before NOT')
+errs, _ = lint_formula('If(status NOT IN (1,2,3), 1, 0)')
+ok(errs.any? { |e| e.include?('IsIn') }, 'status NOT IN (...) is a lint error — bare identifier operand before NOT')
+
+puts "== lint_formula: genuine boolean-prefix `not In(...)` (negating Sigma's real function call) still passes =="
+errs, _ = lint_formula('If(not In([x], "a"), 1, 0)')
+ok(errs.empty?, 'not In(...) with nothing but `(` before `not` is still the function-call form — no lint error')
+errs, _ = lint_formula('If([a]=1 and not In([x], "a"), 1, 0)')
+ok(errs.empty?, 'not In(...) preceded by `and ` is still the function-call form — no lint error')
+
+puts "== lint_formula: bracket-close correctly disambiguates a column literally named Case/Category before IN (Low finding — verified NOT a gap) =="
+errs, _ = lint_formula('If([Category] IN ("a","b"), 1, 0)')
+ok(errs.any? { |e| e.include?('IsIn') }, '[Category] IN (...) is still flagged — the `]` immediately before IN is the operand signal, not the word "Category"')
+errs, _ = lint_formula('If([Case] IN ("a","b"), 1, 0)')
+ok(errs.any? { |e| e.include?('IsIn') }, '[Case] IN (...) is still flagged even though "case" is in NON_OPERAND_KEYWORDS — bracket-close `]` is checked first, so the bracketed identifier "Case" never reaches the bare-word keyword check')
+
 puts "== lint_formula: And()/Or()/Not() function-call warnings =="
 _, w = lint_formula('If(And([a]>1, [b]<2), 1, 0)')
 ok(w.any? { |x| x.include?('infix') }, 'And() function-call warned (use infix)')
@@ -70,10 +167,11 @@ puts "== lint_formula: valid multi-condition If passes =="
 errs, w = lint_formula('If([Status]="Active","Active",[Status]="Pending","Pending","Other")')
 ok(errs.empty?, 'native multi-condition If is clean (no nesting needed)')
 
-puts '== normalize_bm: unsupported + WEEKDAY rewrite =='
+puts '== normalize_bm: unsupported + WEEKDAY passthrough (unbracketed identifier) =='
 n, w = normalize_bm('WEEKDAY(order_date)')
-ok(n.include?('DAYOFWEEK'), 'WEEKDAY → DAYOFWEEK')
-ok(!w.empty?, 'WEEKDAY rewrite warns')
+ok(n == 'WEEKDAY(order_date)', 'WEEKDAY(...) is unchanged even when the identifier is not backtick-quoted')
+ok(!n.include?('DAYOFWEEK'), 'still no DAYOFWEEK rewrite')
+ok(!w.empty?, 'WEEKDAY still emits its informational spot-check warning')
 _, w2 = normalize_bm('SQRT(x)')
 ok(w2.join.match?(/SQRT/i), 'SQRT flagged unsupported')
 


### PR DESCRIPTION
## Summary

Two independent, already-diagnosed Beast Mode lint/normalize bugs in `convert-beast-modes.rb`, both from the [domo-to-gold Track D backlog](docs/handoff/2026-08-03-domo-to-gold-track-e-done.md).

- **beads-sigma-kn8s**: `lint_formula` blanket-banned any `IN(` substring (meant to catch raw SQL infix `x IN (a,b,c)`, which Sigma can't express), but that also rejected Sigma's own legitimate `In([col], "a", "b")` function call. Replaced the substring ban with `raw_sql_infix_in?`/`operand_immediately_before?`, which distinguishes by shape: a raw infix always has a left-hand operand touching the `IN (` keyword; Sigma's function-call form starts a fresh expression. `NOT IN` is handled as its own always-raw-infix case (there's no Sigma spelling of a two-word `NOT IN` operator), while still correctly leaving genuine `not In(...)` boolean-prefix-negation alone — this distinction was missed in an earlier draft and caught by review (see Review history below).
- **beads-sigma-nrml**: `normalize_bm` used to rewrite `WEEKDAY(` → `DAYOFWEEK(`, which broke conversion (`WEEKDAY` converts cleanly to Sigma's `Weekday()`; `DAYOFWEEK` doesn't map to anything). Verified against Domo Community Forum threads that Domo's own docs are wrong here — `WEEKDAY()` actually executes as `DAYOFWEEK()` at runtime (1=Sunday), matching Sigma's `Weekday()` exactly — so there's no real numbering mismatch to compensate for. Dropped the rewrite, removed `WEEKDAY` from the `UNSUPPORTED` list, added a non-blocking informational warning about one residual, unverifiable-at-conversion-time caveat (first-day-of-week/timezone config), and corrected stale claims in `refs/beast-mode-to-sigma.md` + `SKILL.md`.

## Review history

An independent review caught a **Critical regression** in the first cut of the `kn8s` fix: putting `not` unconditionally in the "non-operand keyword" list meant `[Region] NOT IN ("Test","Internal")` was no longer flagged as raw infix — worse than the bug being fixed, since `NOT IN` is arguably more common than plain `IN` in real Beast Modes. Fixed by special-casing `NOT IN` (recurse past the `not` to check whether *it* has an operand before it) and independently re-verified by hand-tracing the logic against 8 concrete cases (`NOT IN`, `not In(...)`, `and not In(...)`, bracketed identifiers like `[Case]`/`[Category]` immediately before `IN(`, etc.) before pushing.

## Test plan
- [x] TDD: failing tests written first for both bugs, confirmed failing pre-fix
- [x] Full plugin suite: 862 `ok:` assertions, all green (was 844 before this PR)
- [x] Accuracy fixtures (`test-convert-beast-modes-fixtures.rb`): 13/13, incl. new `D-11` (`WEEKDAY` → `Weekday`)
- [x] Corpus check (`run-corpus.sh --check domo`): 2/2, unaffected
- [x] Repo governance hooks (shared-file drift, hygiene-sweep, tree-litter, ESM imports, TWB encoding, agent-variant sync): clean
- [x] Plugin version bumped 0.10.6 → 0.10.7
- [ ] TJ review

Closes beads-sigma-kn8s, beads-sigma-nrml.