### PR TITLE
docs(handoff): current domo gold status — 2bj9 is done, the real blockers named

### DIFF
--- a/docs/handoff/2026-08-03-domo-to-gold-track-d-and-cold-run-scoping.md
+++ b/docs/handoff/2026-08-03-domo-to-gold-track-d-and-cold-run-scoping.md
@@ -3,6 +3,29 @@
 **Written:** 2026-08-03, same day as (and directly following) `docs/handoff/2026-08-03-domo-to-gold-track-e-done.md`.
 **Read first:** that doc — it's the "what's left" menu this session worked from. This doc reports what happened against that menu; it doesn't repeat rationale already covered there.
 
+> ## ⚠️ HISTORICAL — do not act on this doc's "what's left" list
+>
+> **Merged 2026-08-06, three days after it was written.** It is kept because
+> `docs/handoff/2026-08-05-domo-road-to-gold.md` and
+> `docs/superpowers/specs/2026-08-05-domo-import-to-snowflake-design.md` both cite it by
+> filename for *how the cold-run milestone was scoped* — that scoping (§3 below) is still
+> accurate and is this doc's lasting value.
+>
+> **Its forward-looking sections are not.** Specifically:
+>
+> - **§"What's left for gold" item 1 — `beads-sigma-2bj9`, "the next real step toward gold" —
+>   is DONE.** Built, live-validated, and merged as **PR #621** (`a86af0f4`) on 2026-08-05:
+>   the `domo-import-to-snowflake` companion skill. All 10 sample-page DataSets landed in
+>   Snowflake at exact measured row-count parity — **205,975 rows, 100% match**. Bead closed.
+>   Followed by **#622** (identifier quoting, bead `q5dz`). **Do not build this again.**
+> - **§"What's left for gold" item 2 — the cold run — is no longer blocked, and has been run.**
+>   It now goes end-to-end *through the workbook POST* and stops at `post-and-readback`.
+> - **Item 3 — close PR #606 — is done.** #606 is CLOSED.
+> - **Item 5 — the gate-tooling gap `2tkm` — has a merged fix** (#631).
+>
+> **For current status, read `docs/handoff/2026-08-06-domo-gold-status.md` instead.**
+> Everything below this banner is preserved as written on 2026-08-03/04.
+
 > **Update — 2026-08-04, before this doc merged:** two corrections to what's below, plus a
 > sharpened pointer for whoever picks this up next.
 > 1. **`kn8s`/`nrml` are merged — but not via #606.** They landed as two separate PRs, **#604**

--- a/docs/handoff/2026-08-03-domo-to-gold-track-d-and-cold-run-scoping.md
+++ b/docs/handoff/2026-08-03-domo-to-gold-track-d-and-cold-run-scoping.md
@@ -3,8 +3,27 @@
 **Written:** 2026-08-03, same day as (and directly following) `docs/handoff/2026-08-03-domo-to-gold-track-e-done.md`.
 **Read first:** that doc — it's the "what's left" menu this session worked from. This doc reports what happened against that menu; it doesn't repeat rationale already covered there.
 
-**Beads:** `beads-sigma-kn8s`, `beads-sigma-nrml` — fixed, PR open, not yet merged (see below,
-don't close until merge). New beads filed this session: `beads-sigma-ou66`, `beads-sigma-fbqw`,
+> **Update — 2026-08-04, before this doc merged:** two corrections to what's below, plus a
+> sharpened pointer for whoever picks this up next.
+> 1. **`kn8s`/`nrml` are merged — but not via #606.** They landed as two separate PRs, **#604**
+>    and **#605**, both merged. PR **#606** (`fix/domo-beast-mode-lint-kn8s-nrml`, the *combined*
+>    fix this doc originally pointed at) is now **stale/superseded** — its content is already on
+>    `main` via #604/#605. It was never merged itself and should be **closed, not merged**
+>    (TJ to confirm/action — not done automatically here, per this repo's convention that
+>    closing a PR is a call for a human, not a session). Both beads are now **closed** to match
+>    reality.
+> 2. `main` has also picked up two unrelated merges since this doc was branched: **#608**
+>    (shared `code_rep` workbook document-wrapper adapter) and **#615** (sigma-authoring
+>    OpenAPI re-vendor). Neither touches `domo-to-sigma` — different workstream, no interaction
+>    with anything below. Flagging only so a fresh session isn't surprised by extra commits on
+>    `main` that this doc doesn't mention.
+> 3. **The next real step toward gold is `beads-sigma-2bj9`** (the data-landing gap below) — not
+>    the fidelity gaps or the gate-tooling gap. Those two are independent polish on the 3
+>    already-working Orders tiers; `2bj9` is what actually unblocks the 48-card cold-run
+>    milestone, which is the thing "gold" is measured against. Start there.
+
+**Beads:** `beads-sigma-kn8s`, `beads-sigma-nrml` — fixed, **merged** (via #604/#605 — see update
+above, not #606). New beads filed this session: `beads-sigma-ou66`, `beads-sigma-fbqw`,
 `beads-sigma-u07f`, `beads-sigma-2tkm`, `beads-sigma-2bj9`.
 
 ---
@@ -13,18 +32,21 @@ don't close until merge). New beads filed this session: `beads-sigma-ou66`, `bea
 
 | | |
 |---|---|
-| Track D — `kn8s` (`In(...)` lint false positive) | **Fixed**, PR [#606](https://github.com/twells89/sigma-migration-skills/pull/606), awaiting merge |
-| Track D — `nrml` (`WEEKDAY`→`DAYOFWEEK` rewrite) | **Fixed**, same PR #606 |
+| Track D — `kn8s` (`In(...)` lint false positive) | **Fixed & merged**, PR [#604](https://github.com/twells89/sigma-migration-skills/pull/604) (not #606 — see update above) |
+| Track D — `nrml` (`WEEKDAY`→`DAYOFWEEK` rewrite) | **Fixed & merged**, PR [#605](https://github.com/twells89/sigma-migration-skills/pull/605) (not #606 — see update above) |
 | Fidelity gaps (number-format, palette, line-markers) | **Beaded** (`ou66`, `fbqw`, `u07f`) — not fixed, evidence-only per the prior handoff's own recommendation |
 | Gate-tooling gap (domo parity never registers as gate-1) | **Beaded** (`2tkm`) — not fixed, cross-cutting shared-file scope |
 | The 48-card cold run | **Scoped, blocked** — real numbers measured (36 cards / 22 chart types, not 48/24), blocked immediately at the data layer by a newly-found, newly-beaded gap (`2bj9`): no landing path for the sample page's 10 non-warehouse DataSets |
 
 ---
 
-## 1. Track D closed out — PR #606 (awaiting merge)
+## 1. Track D closed out — merged via #604/#605 (originally attempted as one combined PR #606)
 
 Both of Track D's last two items (from the prior handoff's "roughly cheapest/most-diagnosed
-first" list) are fixed in one PR, `fix/domo-beast-mode-lint-kn8s-nrml`:
+first" list) were built together in one branch, `fix/domo-beast-mode-lint-kn8s-nrml` (PR #606),
+but ended up landing on `main` as two separate PRs instead — #604 (`kn8s`) and #605 (`nrml`).
+#606 itself is stale/superseded now; the fix content below is accurate, just read "#604/#605"
+wherever this section says "#606":
 
 - **`kn8s`**: `lint_formula`'s blanket `IN(` substring ban wrongly rejected Sigma's real
   `In([col], "a", "b")` function call. Replaced with shape-based detection
@@ -49,9 +71,10 @@ of self-corrected reasoning that's easy to rubber-stamp, and here the review ste
 Full plugin suite: 862 `ok:` assertions green (up from 844 pre-PR). Corpus check 2/2. Plugin
 version bumped 0.10.6 → 0.10.7. Governance hooks clean at push time.
 
-**Per this repo's PR-flow convention, this was NOT self-merged** — PR #606 is open for TJ's
-review. Both beads have a note pointing at the PR and are explicitly left **open** (not closed)
-until it actually merges — don't close them from this doc alone.
+**Per this repo's PR-flow convention, this was NOT self-merged** — it went through review as
+#604/#605, both now merged. Both beads (`kn8s`, `nrml`) are **closed** as of 2026-08-04. PR #606,
+the original combined-fix branch, is now redundant with what's on `main` and should be closed
+unmerged rather than merged (a call for a human, not automated here).
 
 ## 2. Fidelity gaps and the gate-tooling gap — now real beads, not just prose
 
@@ -110,22 +133,28 @@ The 48-card cold run itself remains not-yet-attempted; it's now gated on `2bj9`,
 
 ---
 
-## What's left for gold (updated menu)
+## What's left for gold (updated menu, re-ranked 2026-08-04)
 
-Unchanged from the prior handoff except: Track D is now fully closed (pending merge), the 3
-fidelity gaps + the gate-tooling gap have real beads, and the cold-run milestone has a concrete,
-sized blocker instead of being untouched.
+Track D is now fully closed (merged), the 3 fidelity gaps + the gate-tooling gap have real
+beads, and the cold-run milestone has a concrete, sized blocker instead of being untouched.
+Re-ranked so the critical path is unambiguous — `2bj9` is the actual next step, not a "someday":
 
-1. **Merge PR #606** (`kn8s`/`nrml`) — routine, just needs review.
-2. **`beads-sigma-2bj9`** (data-landing gap) — the actual next big piece of work if the cold-run
-   milestone is the priority. Comparable in size to the PBI `powerbi-import-to-snowflake` build.
-3. Fidelity gaps (`ou66`, `fbqw`, `u07f`) — each independently fixable without the landing skill,
-   since they only affect the 3 already-working Orders tiers' rendering, not new content.
-4. Gate-tooling gap (`2tkm`) — shared-file scope, same governance class as the already-merged
-   `co6m` fix; a natural follow-up PR reusing that same pattern.
-5. The 48-card cold run itself — blocked on #2 above; once landing exists, re-run the same
+1. **`beads-sigma-2bj9`** (data-landing gap) — **the next real step toward gold.** This is what
+   blocks the 48-card cold-run milestone; everything else in this list is independent of it.
+   Comparable in size to the PBI `powerbi-import-to-snowflake` build (extract → typed DDL →
+   Snowflake COPY → GRANT → Sigma connection sync → manifest), and Domo already has the raw
+   ingredient (`Domo.query_dataset`/`Domo.dataset_csv` in `scripts/lib/domo_rest.rb`) — a
+   `domo-import-to-snowflake` companion skill mirroring that shape is the natural build.
+2. The 48-card cold run itself — blocked on #1; once landing exists, re-run the same
    live-validation methodology the prior handoff documented (steps 1-5, unchanged) against the
-   real sample page instead of an authored one.
+   real sample page (id `59931332`) instead of an authored one.
+3. Close PR #606 (superseded by #604/#605 — see update at top) — small housekeeping, not on the
+   critical path.
+4. Fidelity gaps (`ou66`, `fbqw`, `u07f`) — each independently fixable without the landing skill,
+   since they only affect the 3 already-working Orders tiers' rendering, not new content. Doesn't
+   block gold; pick up opportunistically.
+5. Gate-tooling gap (`2tkm`) — shared-file scope, same governance class as the already-merged
+   `co6m` fix; a natural follow-up PR reusing that same pattern. Also doesn't block gold.
 
 ---
 
@@ -133,12 +162,18 @@ sized blocker instead of being untouched.
 
 No new environment setup this session — same `~/.sigma-migration/env` credentials, same
 `thomas-dev-1107913.domo.com` instance, same `~/wt-domo-*` persist-worktrees convention (this
-session's fix worktree: `~/wt-domo-beast-mode-lint`).
+session's fix worktree: `~/wt-domo-beast-mode-lint`; superseded by `~/wt-domo-kn8s-fix` and
+`~/wt-domo-nrml-fix`, the worktrees behind the #604/#605 PRs that actually merged).
+
+As of 2026-08-04, `main` is also ahead by two unrelated merges (#608 shared `code_rep` workbook
+document-wrapper adapter, #615 sigma-authoring OpenAPI re-vendor) — different workstream, doesn't
+touch anything in this doc.
 
 ---
 
 Related: `docs/handoff/2026-08-03-domo-to-gold-track-e-done.md` (prior session, the menu this one
-worked from), PR #606 (Track D fixes, open), beads `beads-sigma-kn8s`/`nrml` (fixed, open pending
-merge), `beads-sigma-ou66`/`fbqw`/`u07f` (fidelity gaps, open), `beads-sigma-2tkm` (gate-tooling
-gap, open, related-to `co6m`), `beads-sigma-2bj9` (data-landing gap, open, blocks the cold-run
-milestone).
+worked from), PR #604/#605 (Track D fixes, merged; #606 superseded, recommend closing unmerged),
+beads `beads-sigma-kn8s`/`nrml` (fixed, closed), `beads-sigma-ou66`/`fbqw`/`u07f` (fidelity gaps,
+open, non-blocking), `beads-sigma-2tkm` (gate-tooling gap, open, related-to `co6m`,
+non-blocking), **`beads-sigma-2bj9` (data-landing gap, open — the next real step toward gold,
+blocks the cold-run milestone)**.

--- a/docs/handoff/2026-08-03-domo-to-gold-track-d-and-cold-run-scoping.md
+++ b/docs/handoff/2026-08-03-domo-to-gold-track-d-and-cold-run-scoping.md
@@ -1,0 +1,144 @@
+# Handoff — `domo-to-sigma` to gold: Track D closed out, remaining themes beaded, cold run scoped (blocked)
+
+**Written:** 2026-08-03, same day as (and directly following) `docs/handoff/2026-08-03-domo-to-gold-track-e-done.md`.
+**Read first:** that doc — it's the "what's left" menu this session worked from. This doc reports what happened against that menu; it doesn't repeat rationale already covered there.
+
+**Beads:** `beads-sigma-kn8s`, `beads-sigma-nrml` — fixed, PR open, not yet merged (see below,
+don't close until merge). New beads filed this session: `beads-sigma-ou66`, `beads-sigma-fbqw`,
+`beads-sigma-u07f`, `beads-sigma-2tkm`, `beads-sigma-2bj9`.
+
+---
+
+## Where things stand
+
+| | |
+|---|---|
+| Track D — `kn8s` (`In(...)` lint false positive) | **Fixed**, PR [#606](https://github.com/twells89/sigma-migration-skills/pull/606), awaiting merge |
+| Track D — `nrml` (`WEEKDAY`→`DAYOFWEEK` rewrite) | **Fixed**, same PR #606 |
+| Fidelity gaps (number-format, palette, line-markers) | **Beaded** (`ou66`, `fbqw`, `u07f`) — not fixed, evidence-only per the prior handoff's own recommendation |
+| Gate-tooling gap (domo parity never registers as gate-1) | **Beaded** (`2tkm`) — not fixed, cross-cutting shared-file scope |
+| The 48-card cold run | **Scoped, blocked** — real numbers measured (36 cards / 22 chart types, not 48/24), blocked immediately at the data layer by a newly-found, newly-beaded gap (`2bj9`): no landing path for the sample page's 10 non-warehouse DataSets |
+
+---
+
+## 1. Track D closed out — PR #606 (awaiting merge)
+
+Both of Track D's last two items (from the prior handoff's "roughly cheapest/most-diagnosed
+first" list) are fixed in one PR, `fix/domo-beast-mode-lint-kn8s-nrml`:
+
+- **`kn8s`**: `lint_formula`'s blanket `IN(` substring ban wrongly rejected Sigma's real
+  `In([col], "a", "b")` function call. Replaced with shape-based detection
+  (`raw_sql_infix_in?` / `operand_immediately_before?`) that only flags a genuine raw SQL infix
+  (`x IN (a,b,c)`, which Sigma can't express).
+- **`nrml`**: `normalize_bm`'s `WEEKDAY`→`DAYOFWEEK` rewrite was actively counterproductive
+  (`WEEKDAY` converts cleanly to Sigma's `Weekday()`; `DAYOFWEEK` doesn't map). Verified against
+  Domo Community Forum threads that Domo's own docs are wrong about `WEEKDAY()`'s numbering —
+  it actually runs as `DAYOFWEEK()` (1=Sunday) at runtime, matching Sigma's `Weekday()` exactly —
+  so dropping the rewrite is a clean fix, not a trade of one wrong behavior for another.
+
+**Worth calling out — the review process caught a real Critical regression before merge:** the
+first cut of the `kn8s` fix put `not` unconditionally in the "this keyword means a fresh
+expression is starting" list, which meant `[Region] NOT IN ("Test","Internal")` silently stopped
+being flagged — worse than the bug being fixed, since `NOT IN` is arguably more common than bare
+`IN` in real Beast Modes, and nothing in the original diff's tests exercised it. Fixed by
+special-casing `NOT IN` as always-raw-infix (there's no Sigma spelling of a two-word `NOT IN`
+operator) while still correctly leaving genuine `not In(...)` prefix-negation alone. Independently
+re-verified by hand-tracing the logic against 8 concrete cases before pushing — this is the kind
+of self-corrected reasoning that's easy to rubber-stamp, and here the review step earned its keep.
+
+Full plugin suite: 862 `ok:` assertions green (up from 844 pre-PR). Corpus check 2/2. Plugin
+version bumped 0.10.6 → 0.10.7. Governance hooks clean at push time.
+
+**Per this repo's PR-flow convention, this was NOT self-merged** — PR #606 is open for TJ's
+review. Both beads have a note pointing at the PR and are explicitly left **open** (not closed)
+until it actually merges — don't close them from this doc alone.
+
+## 2. Fidelity gaps and the gate-tooling gap — now real beads, not just prose
+
+Per the prior handoff's own observation that these gaps "only exist as memory/handoff-doc prose
+across 3 sessions," each now has a real bead with the evidence already gathered attached:
+
+- `beads-sigma-ou66` — no number-format translation (Domo's `140.32K` vs. Sigma's raw decimals).
+- `beads-sigma-fbqw` — no theme/palette derivation (Domo's default pastel-blue vs. Sigma's default).
+- `beads-sigma-u07f` — Domo's symbol-line markers not rendering on migrated line charts.
+- `beads-sigma-2tkm` — the new finding from Track E's live validation: even a real, measured
+  element-level parity result (`build-parity-plan.rb`/`verify-parity.rb`) never registers as
+  genuine "gate 1: PASS" evidence in `assert-phase6-ran.rb`, because that shared script only knows
+  how to read Tableau's `charts_total` concept. Filed as `related-to: beads-sigma-co6m` since it's
+  the same shared-file governance class (one PR for shared files, `sync-shared.rb` propagation).
+
+None of these were fixed this session — filing them was the explicit ask, so the next session (or
+whoever picks up this backlog) has a real starting point instead of scattered memory.
+
+## 3. The 48-card cold run — scoped, and blocked on a real, newly-found gap
+
+Attempted to scope the honest finish line the original design doc always called a follow-on
+milestone: running `migrate-domo.rb` cold against Domo's own sample content instead of the 3
+authored Orders test pages every prior track validated against.
+
+**Measured, not estimated** (the design doc's "48-card sample page, 24 chart types, 81 Beast
+Modes" language was written before anyone actually queried it): the real page is **"Sample
+DataSets + Cards"** (id `59931332`, same `thomas-dev-1107913.domo.com` instance as every prior
+live validation) — **36 cards, 22 distinct chart types**, backed by **10 distinct DataSets**
+(Salesforce, Send Report, Retweets Of Me, PDP Example DataSet, Surveys, Page Impressions Details,
+Location Metrics, Campaign Reports, Base Metrics, Mobile Metrics; 30 to 93,253 rows each). Several
+chart types (`badge_map`, `badge_word_cloud`, `badge_calendar`, `badge_treemap`,
+`badge_filledgauge`, `badge_bubble`) are exactly the kind the design doc's own non-goals section
+already expects to hit an honest "no native Sigma equivalent" warning rather than a plugin. Five
+cards are `PDP Example` cards — the first live opportunity to actually wire bead `tkcu` (C9
+permission field-path), previously BLOCKED for lack of a live instance to test against.
+
+**Blocked immediately, before any of that could be exercised**: none of the 10 DataSets exist in
+the warehouse the way the Orders Tier 1/2/3 fact/dimension tables do (see
+`reference_csa_orderfact_warehouse_path` memory for the specific schema/table identifiers,
+deliberately not repeated here) — they're Domo's own unrelated demo content, never landed
+anywhere. `migrate-domo.rb`'s whole pipeline assumes a
+pre-existing warehouse table per DataSet; there's no extraction/landing step. This is the same
+class of gap already known for Tableau (`ubr5.2`, embedded unpublished sources) and already solved
+for Power BI via a dedicated `powerbi-import-to-snowflake` companion skill (extract via
+TMSL/DAX → typed DDL → Snowflake COPY → GRANT → Sigma connection sync → naming-alignment
+manifest — itself a multi-PR effort, not a quick add-on).
+
+Filed as `beads-sigma-2bj9`, sized honestly as comparable in scope to the PBI precedent — not
+folded into today's Track D work. Domo already has the raw ingredient this would need
+(`Domo.query_dataset(id, sql)` / `Domo.dataset_csv(id)` in `scripts/lib/domo_rest.rb`, both public
+API, already used elsewhere in this plugin), so a `domo-import-to-snowflake` skill mirroring the
+PBI shape is the natural next step, not a novel design problem — but it's real, standalone work.
+**TJ's call, 2026-08-03: document the finding, don't build the landing skill ad hoc mid-session.**
+The 48-card cold run itself remains not-yet-attempted; it's now gated on `2bj9`, not merely
+"nobody's gotten to it yet."
+
+---
+
+## What's left for gold (updated menu)
+
+Unchanged from the prior handoff except: Track D is now fully closed (pending merge), the 3
+fidelity gaps + the gate-tooling gap have real beads, and the cold-run milestone has a concrete,
+sized blocker instead of being untouched.
+
+1. **Merge PR #606** (`kn8s`/`nrml`) — routine, just needs review.
+2. **`beads-sigma-2bj9`** (data-landing gap) — the actual next big piece of work if the cold-run
+   milestone is the priority. Comparable in size to the PBI `powerbi-import-to-snowflake` build.
+3. Fidelity gaps (`ou66`, `fbqw`, `u07f`) — each independently fixable without the landing skill,
+   since they only affect the 3 already-working Orders tiers' rendering, not new content.
+4. Gate-tooling gap (`2tkm`) — shared-file scope, same governance class as the already-merged
+   `co6m` fix; a natural follow-up PR reusing that same pattern.
+5. The 48-card cold run itself — blocked on #2 above; once landing exists, re-run the same
+   live-validation methodology the prior handoff documented (steps 1-5, unchanged) against the
+   real sample page instead of an authored one.
+
+---
+
+## Environment notes
+
+No new environment setup this session — same `~/.sigma-migration/env` credentials, same
+`thomas-dev-1107913.domo.com` instance, same `~/wt-domo-*` persist-worktrees convention (this
+session's fix worktree: `~/wt-domo-beast-mode-lint`).
+
+---
+
+Related: `docs/handoff/2026-08-03-domo-to-gold-track-e-done.md` (prior session, the menu this one
+worked from), PR #606 (Track D fixes, open), beads `beads-sigma-kn8s`/`nrml` (fixed, open pending
+merge), `beads-sigma-ou66`/`fbqw`/`u07f` (fidelity gaps, open), `beads-sigma-2tkm` (gate-tooling
+gap, open, related-to `co6m`), `beads-sigma-2bj9` (data-landing gap, open, blocks the cold-run
+milestone).

--- a/docs/handoff/2026-08-05-domo-road-to-gold.md
+++ b/docs/handoff/2026-08-05-domo-road-to-gold.md
@@ -1,5 +1,12 @@
 # Handoff — `domo-to-sigma` road to gold (supersedes the earlier 2026-08-05 doc)
 
+> **⚠️ Superseded for STATUS by `docs/handoff/2026-08-06-domo-gold-status.md`.**
+> This doc's analysis of the 14 cold-run bugs and its "traps" section remain the best deep
+> reference and are still accurate. Its **PR/bead ledger has drifted** — #623/#631/#633 have since
+> merged, `2tkm` has a merged fix, `znvg` is 9/15 done, and `0goi` was re-triaged to
+> **not-our-bug** (the converter was exonerated; the corrupted literals are in Domo's source).
+> Read the 08-06 doc for current state; read this one for *why* each bug happened.
+
 **Written:** 2026-08-05, end of session.
 **Supersedes:** `docs/handoff/2026-08-05-domo-cold-run-progress.md` (written mid-session, now stale
 — it says the workbook POST is the frontier; it isn't any more).

--- a/docs/handoff/2026-08-06-domo-gold-status.md
+++ b/docs/handoff/2026-08-06-domo-gold-status.md
@@ -75,14 +75,57 @@ corrected or its operands swapped — silently negating every date-window predic
 vendored into this repo by **PR #633**.
 
 **The measured gap:** #633 merged at **2026-08-05 16:47:37**. The last live run was at **14:32** —
-over two hours *earlier*. **The vendored fix has never been exercised against the live pipeline.**
+over two hours *earlier*. **The vendored fix had never been exercised against the live pipeline.**
 
-So the single highest-value, lowest-cost next action is simply **re-run the cold run** and see
-what the 15 becomes. Do this before designing anything. The plausible outcome is 15 → 6.
+### Verified offline 2026-08-06 — the vendoring took, and the 15 splits 9 + 6
 
-The remaining 6 are expected to be the **`State` / `US Regions` nested `If(In(...))` chains**.
-Check whether they fail for their own reason (nesting depth, `In()` arity) rather than assuming
-they share a cause with the DATEDIFF class.
+Rather than guess, the vendored bundle was run against the real corpus
+(`~/domo-coldrun-v4/discovery/formulas.json`, 81 Beast Modes, 23 of them DATEDIFF-bearing) with no
+live run spent. `_rewriteMysqlDateDiff` is present and correct:
+
+```
+datediff(current_date(), `Date`)               ->  DateDiff("day", `Date`, Today())
+DateDiff(AddDate(Current_Date(),-1), `Date`)   ->  DateDiff("day", `Date`, Adddate(Today(),-1))
+```
+
+Unit added, operands swapped, nesting handled. **The vendoring did take.**
+
+Categorising the 15 from `/tmp/gold-run12.log` shows they split exactly **9 + 6**, matching the
+bead's "9 of 15" claim:
+
+| Class | N | Columns |
+|---|---|---|
+| DATEDIFF 2-arg | 9 | the four `Last 7 Vs Prev 7 Days …` metrics, `Change Over 7 Days`, `Daily Unique Visitors - Last 7 Days`, `Sent Tweets Last 7 Days`, `Completion Rate 30-Day`, `% Change - Pageviews` |
+| `State` / `US Regions` | 6 | `State` ×2, `US Regions` ×4 — 50–51-deep nested `If` chains |
+
+### ⚠️ Expect 15 → **7**, not 15 → 6 — a second bug was found doing this
+
+**`beads-sigma-zmnt` (P1, new):** the converter also emits **`Adddate(...)`, which is not a Sigma
+function.** MySQL's `ADDDATE(date, N)` is renamed by bare name and passed through; the correct
+target is `DateAdd("day", N, date)` — different spelling *and* different arity/arg-order. **Exactly
+the same class as the DATEDIFF bug**, in 7 Beast Modes / 27 call sites.
+
+The converter's own oracle already knows:
+
+```
+lookUnknownFunctions('Adddate(Today(),-1)')       ->  ["ADDDATE"]
+lookUnknownFunctions('DateAdd("day",-1,Today())') ->  []
+```
+
+`convert-beast-modes.rb:562` *does* surface it — but only as a **warning**, so nothing failed and
+it was passed over in the live run.
+
+**Why this matters for the re-run:** `% Change - Pageviews` is in the 15 and carries **both** bugs
+(`DateDiff(Adddate(Today(), -1), [Date])`), so it will still be `type=error` after #633. Anyone
+expecting 15 → 6 will see **15 → 7** and may wrongly conclude the vendoring failed. It didn't.
+
+**Worth considering:** promote the `lookUnknownFunctions` warning to a hard failure, or route it
+into the degradation ledger. A function Sigma doesn't have is not a soft warning — it's a
+guaranteed `type=error` at POST time, and the warning demonstrably did not stop a bad run.
+
+The remaining 6 are the **`State` / `US Regions` chains**. Nesting depth is the leading hypothesis;
+the `State` pair also carries the `0goi` source-corrupted `IllINois`/`INdiana` literals (Domo's own
+data — converter exonerated). Check them for their own cause rather than assuming shared blame.
 
 Note the honest causality the bead records: the aggregate-in-a-calc-column errors are a *direct
 consequence* of the same day's aggregate-Beast-Mode inlining. Inlining was still correct — it
@@ -146,7 +189,8 @@ Its bug write-ups remain accurate and worth reading. Its ledger has drifted:
 
 | Bead | P | State | Note |
 |---|---|---|---|
-| `znvg` | P1 | **open** | 9/15 fixed upstream + vendored (#633); **never re-run live** |
+| `znvg` | P1 | **open** | 15 = 9 DATEDIFF + 6 `State`/`US Regions`. Fix vendored (#633), verified offline; **never re-run live**. Expect 15 → **7** |
+| `zmnt` | P1 | **open (new 08-06)** | converter emits `Adddate()` — not a Sigma function; same class as the DATEDIFF bug. Blocks 1 of znvg's 9 |
 | `ruzs` | P1 | open | SKIP still allows GREEN — re-verify now that the ledger is vendored (#624) |
 | `qzdg` | P2 | open | landing skill's `--sigma-connection` sync POSTs no body, 400s |
 | `tkcu` | P2 | **blocked** | PDP field path — the sample page's 5 PDP cards are the first live chance |
@@ -192,10 +236,14 @@ they land upstream, rebuild the integration branch from `main` instead.
 
 ## Recommended order of work
 
-1. **Re-run the cold run** against the current vendored converter. Costs one run, has never been
-   done, and directly resolves how much of `znvg` is left. *Start here.*
-2. Fix whatever `znvg` remainder survives — likely the `State`/`US Regions` `If(In(...))` chains,
-   plus re-placing aggregate calc columns into grain-appropriate elements.
+1. **Fix `zmnt` (ADDDATE → `DateAdd`) first, *then* re-run.** It is the same one-line-class fix as
+   DATEDIFF, in the same upstream file (`sigma-data-model-mcp`, beside `_rewriteMysqlDateDiff`),
+   re-vendored the same way. Landing it before the run turns an expected 15 → 7 into 15 → 6 and
+   saves a whole extra cycle. If you'd rather not wait, re-run anyway — but **record the 7
+   up front** so it isn't misread as the vendoring having failed.
+2. Fix the `znvg` remainder: the 6 `State`/`US Regions` deep-nested `If` chains (test the
+   nesting-depth hypothesis first — it is cheap to probe with a single hand-built column), plus
+   re-placing aggregate calc columns into grain-appropriate elements.
 3. **Build the parity oracle** (Blocker 2). This is the real remaining distance. Budget design time
    for the un-verifiable-card exclusion policy, not just implementation.
 4. Then expect **first-contact bugs in put-layout / render / verify-parity** — those three phases

--- a/docs/handoff/2026-08-06-domo-gold-status.md
+++ b/docs/handoff/2026-08-06-domo-gold-status.md
@@ -1,0 +1,239 @@
+# Handoff — `domo-to-sigma` gold status, as of 2026-08-06
+
+**Written:** 2026-08-06. **Supersedes the forward-looking sections of every earlier domo handoff.**
+
+This is the tie-it-together doc. If you are picking up domo-to-sigma and read only one file, read
+this one.
+
+---
+
+## Read this first: the premise most people arrive with is stale
+
+Two earlier docs each say, in their own words, *"the next real step toward gold is
+`beads-sigma-2bj9`, the data-landing skill."*
+
+**That is done.** `2bj9` was built, live-validated, and merged as **PR #621** (`a86af0f4`) on
+2026-08-05 — the `domo-import-to-snowflake` companion skill. All 10 sample-page DataSets landed in
+Snowflake at exact measured row-count parity (**205,975 rows, 100% match**), `dataset-map.json`
+fully resolved, zero remaining sentinels. Bead closed. **Do not build it again.**
+
+The cold run it was blocking has since been *run*. Where it stops now is a completely different
+place, described below.
+
+### Read order
+
+| Doc | Status |
+|---|---|
+| **this doc** | **current** — status, blockers, resume point |
+| `2026-08-05-domo-road-to-gold.md` | **still the best deep reference** for the 14 cold-run bugs and the traps. Its *bug* content is accurate; its PR/bead ledger has drifted — see "Corrections" below |
+| `2026-08-03-domo-to-gold-track-d-and-cold-run-scoping.md` | **historical.** Valuable only for §3, how the cold-run milestone was scoped. Its "what's left" list is obsolete and now carries a banner saying so |
+| `2026-08-05-domo-cold-run-progress.md` | superseded mid-session on 08-05; ignore |
+
+---
+
+## Gold is not reached, and today did not reach it
+
+"Gold" means a legitimate `assert-phase6-ran.rb` exit 0. The run currently stops well before that
+gate is even reached:
+
+```
+tier probe          ✅
+discover            ✅   10/10 used datasets carry real schema.columns
+capture-visuals     ✅   (but see F1 — it may be capturing nothing)
+convert-beast-modes ✅   81 unique Beast Modes, lint exit 0
+build-dm            ✅   10 elements
+preflight-columns   ✅   "10 checked, 0 skipped, 0 errored"
+DATA-MODEL POST     ✅
+build-workbook      ✅
+build-workbook-spec ✅
+WORKBOOK POST       ✅   workbookId 333f35ce (deleted after the run)
+post-and-readback   ❌   exit 2 — 15 columns compiled to type="error"
+put-layout          —    never reached
+verify-parity       —    never reached
+assert-phase6-ran   —    never reached  ← this gate IS the definition of gold
+```
+
+Last live run: `/tmp/gold-run12.log`, 2026-08-05 14:32. **No live run has happened since** — which
+matters a great deal, see Blocker 1.
+
+**Measured this session (2026-08-06):** offline suite **1091 `ok:` assertions across 24 test files,
+all passing**, on `main` merged into the PR #607 branch. Domo plugin version **0.14.1**. Everything
+else in this doc about live behaviour is inherited from the 08-05 session's measurements, not
+re-measured today — the distinction is called out wherever it matters.
+
+---
+
+## The two blockers
+
+### Blocker 1 — `znvg`: 15 columns compile to `type=error` (P1, open)
+
+**Do the cheap thing first. It has never been tried.**
+
+9 of the 15 were root-caused and fixed upstream in `sigma-data-model-mcp` **PR #122**: the
+converter renamed `DATEDIFF` → `DateDiff` by bare name, so MySQL's 2-arg form never had its arity
+corrected or its operands swapped — silently negating every date-window predicate. That fix was
+vendored into this repo by **PR #633**.
+
+**The measured gap:** #633 merged at **2026-08-05 16:47:37**. The last live run was at **14:32** —
+over two hours *earlier*. **The vendored fix has never been exercised against the live pipeline.**
+
+So the single highest-value, lowest-cost next action is simply **re-run the cold run** and see
+what the 15 becomes. Do this before designing anything. The plausible outcome is 15 → 6.
+
+The remaining 6 are expected to be the **`State` / `US Regions` nested `If(In(...))` chains**.
+Check whether they fail for their own reason (nesting depth, `In()` arity) rather than assuming
+they share a cause with the DATEDIFF class.
+
+Note the honest causality the bead records: the aggregate-in-a-calc-column errors are a *direct
+consequence* of the same day's aggregate-Beast-Mode inlining. Inlining was still correct — it
+converted a hard POST rejection into typed, enumerable, per-column errors that gate 3 catches —
+but **placement** must change. An aggregate belongs in an element whose grain supports it, not a
+row-level calc column.
+
+**Do not** treat "the POST succeeded" as close enough. A `type=error` column renders nothing and
+would poison any parity measurement. Gate 3 is working as intended here.
+
+### Blocker 2 — the Domo parity oracle for gate 1. **Still not started. This is the big one.**
+
+This is where the real remaining distance is, and there is a subtlety worth getting right:
+
+**What #631 fixed (plumbing):** domo was the only converter of six with no `phase6-parity-*.rb`
+finalizer. `migrate-domo.rb` pointed `verify-parity.rb --score-out` straight at
+`parity-final.json`, overwriting the gate's *contract* file with a *score* document — so gate 1
+read `charts_total = 0` and a flawless 65/65 parity run was indistinguishable from never having run
+parity at all. `phase6-parity-domo.rb` now writes the contract, and enforces an **anti-inflation
+census**: it refuses to emit a contract unless every chartable element is either VERIFIED or
+EXCLUDED WITH A REASON in `parity-plan-exclusions.json`. Excluding a tile stays legitimate;
+excluding it *silently* does not.
+
+**What is still missing (the oracle):** verified in the working tree today —
+`build-parity-plan.rb` still emits the chart/column list but **no expected values, by design**, and
+`migrate-domo.rb` *skips* the parity phase entirely unless `--parity-plan` is supplied by hand
+(`'no --parity-plan supplied — run verify-parity.rb by hand before declaring GREEN'`).
+
+So: the pipe now carries water correctly, but nothing produces the water. The honest route is to
+compute expected values from `Domo.query_dataset` aggregations (the Track E technique) and feed
+`verify-parity.rb`.
+
+**Expect a real design question, not just coding.** Several of the 36 cards cannot be given a
+trustworthy expected value — aggregate Beast Modes, top-N, date windows relative to `Today()`,
+chart types with no tabular equivalent. Excluding them is legitimate **only if recorded in
+`parity-plan-exclusions.json` so the score is not silently inflated** — which the new census now
+mechanically enforces.
+
+---
+
+## Corrections to `2026-08-05-domo-road-to-gold.md`
+
+Its bug write-ups remain accurate and worth reading. Its ledger has drifted:
+
+- **#623 is merged** (`94176054`) — the doc lists it as open. So are **#631** (2tkm finalizer) and
+  **#633** (znvg re-vendor), both of which postdate the doc.
+- **`2tkm` has a merged fix** (#631) and was re-prioritised **P3**. The doc lists it under "open,
+  not started."
+- **`0goi` was re-triaged to `[not-our-bug]`, P3.** The doc describes it as *"the SQL converter
+  uppercases `in` inside string literals."* **The converter was exonerated** — `IllINois` /
+  `INdiana` are in Domo's *source* Beast Mode. The open question is now only accept-vs-warn, not a
+  converter fix. Anyone who picks this up expecting a masking bug will be chasing nothing.
+- **`znvg` has substantial progress** (9 of 15, upstream #122, vendored #633) — the doc lists it as
+  "not started."
+- Beads closed since: `8k77`, `xo56`, `0ku5`, `lmhz`, `qq7l` (all landed in #623), plus `0h11`,
+  `q5dz`, `2bj9`.
+
+---
+
+## Current bead ledger — verified 2026-08-06
+
+| Bead | P | State | Note |
+|---|---|---|---|
+| `znvg` | P1 | **open** | 9/15 fixed upstream + vendored (#633); **never re-run live** |
+| `ruzs` | P1 | open | SKIP still allows GREEN — re-verify now that the ledger is vendored (#624) |
+| `qzdg` | P2 | open | landing skill's `--sigma-connection` sync POSTs no body, 400s |
+| `tkcu` | P2 | **blocked** | PDP field path — the sample page's 5 PDP cards are the first live chance |
+| `0goi` | P3 | open | **not-our-bug** — converter exonerated; accept-vs-warn decision only |
+| `2tkm` | P3 | open | finalizer merged (#631); bead not yet closed |
+| `ou66` / `fbqw` / `u07f` | P3 | open | fidelity: number formats, palette, line markers — non-blocking |
+
+**Closed:** `2bj9`, `q5dz`, `0h11`, `0ku5`, `lmhz`, `8k77`, `xo56`, `qq7l`, `kn8s`, `nrml`.
+
+**Still-open PRs that matter:** **#609** (post-and-readback wrapper) and **#613** (put-layout
+wrapper). The workbook POST requires both — the integration worktree merges them in locally. If
+they land upstream, rebuild the integration branch from `main` instead.
+
+---
+
+## Exact resume point
+
+- **Integration worktree:** `~/wt-domo-gold-integration`, branch `integration/domo-gold-run` —
+  `fix/domo-cold-run-blockers` plus #609 and #613 merged in.
+- **Run dir:** `~/domo-coldrun-v4`. **Driver:** `/tmp/run-gold.sh` (verified present today).
+- **Instance/page:** `thomas-dev-1107913.domo.com`, page `59931332` ("Sample DataSets + Cards"),
+  36 cards / 22 chart types / 10 DataSets. Creds `~/.sigma-migration/env`. Landed-table identifiers
+  deliberately not repeated here — see memory `reference_domo_sample_page_cold_run`.
+- **Audit artifacts:** `~/domo-cold-run-20260805/AUDIT-SYNTHESIS.md` and `BATCH-VERIFY.md`.
+
+### Traps that will otherwise cost you a run
+
+1. **`migrate-domo.rb` is idempotent** — a phase whose output exists is skipped. Deleting
+   `workbook-spec.json` is NOT enough. Clear **all** of: `discovery/chart-specs.json`,
+   `discovery/dm-spec.json`, `workbook-spec.json`, `dm-ids.json`, `posted-workbooks.jsonl`,
+   `discovery/dashboard-layout.json`, `layout-2d.flag`. *This cost a full run on 08-05.*
+2. **Sigma lowercases identifiers in its error text** — inspect the generated spec, not the error
+   string, to tell whether a naming fix took effect.
+3. **A schema-level Sigma sync does NOT refresh an already-discovered table's columns.** After
+   re-landing with changed names you need a **table-level** sync per table.
+4. **Commit before merging between worktrees** — twice on 08-05 a run silently used uncommitted
+   changes.
+5. **Don't `git stash` in this repo** — stashes are repo-wide across concurrent sessions.
+6. Sigma test folder was swept to its **8 pre-existing keeper objects**. Check *dates, not names*
+   before deleting anything there.
+
+---
+
+## Recommended order of work
+
+1. **Re-run the cold run** against the current vendored converter. Costs one run, has never been
+   done, and directly resolves how much of `znvg` is left. *Start here.*
+2. Fix whatever `znvg` remainder survives — likely the `State`/`US Regions` `If(In(...))` chains,
+   plus re-placing aggregate calc columns into grain-appropriate elements.
+3. **Build the parity oracle** (Blocker 2). This is the real remaining distance. Budget design time
+   for the un-verifiable-card exclusion policy, not just implementation.
+4. Then expect **first-contact bugs in put-layout / render / verify-parity** — those three phases
+   have *never executed*. Do not budget for a clean sweep.
+5. Non-blocking, opportunistic: `ruzs`, `qzdg`, `0goi` (decision only), `ou66`/`fbqw`/`u07f`, and
+   F1 (`domo-capture-visuals.rb` may be capturing zero PNGs while reporting "done" — it enumerates
+   via the page payload's `cardIds`, which is empty on a real page; `domo-discover.rb` already
+   solved this with `enumerate_page_cards`).
+
+---
+
+## Honest assessment
+
+**Not close, and the remaining distance is mostly Blocker 2.** The pipeline has produced a
+first-contact bug at nearly every phase it has reached; three phases have not run at all;
+predicting "one more fix" has been wrong repeatedly. Gate 1 cannot pass without the oracle, and the
+oracle is real work.
+
+**What is genuinely reassuring:** the 22 chart types are *not* the obstacle. All map; the
+no-native-equivalent ones (treemap, word cloud, calendar, gauge) degrade with honest warnings,
+which is the design's stated contract. Chart variety is a fidelity story, not a gold blocker.
+
+**Also worth stating:** of the four ways a GREEN would have been *unearned*, all four are now fixed
+rather than papered over — the vacuous pre-flight (#623), the uncapped verdict (#624), the
+truncated error-column audit (#625), and the wrong-numbers one, dropped card filters (#623). The
+new parity census (#631) closes a fifth.
+
+### Waivers that would be a fudge — refuse these
+- `--skip-parity-gate` with a hand-authored `anchors-verdict.json` not actually measured against
+  Domo. The waiver is *conditional* on a real passing verdict; manufacturing one is the exact
+  unearned green this effort exists to prevent.
+- `SIGMA_SKIP_COLUMN_PREFLIGHT` to get past a pre-flight failure — that waives the check whose
+  absence caused the original crash.
+- Declaring GREEN while any column is `type=error`.
+- Narrowing the parity plan to easy tiles without recording exclusions. The census now blocks this
+  mechanically; do not route around it.
+
+### Waivers that would be legitimate
+- Gate 7c (controls coverage) — genuinely permanent for domo, no script emits the artifact.
+- `--skip-visual-gate` **only** with real bisect evidence; the gate already rejects a bare
+  "render 500".


### PR DESCRIPTION
## Summary

This PR was opened 2026-08-03. Its original body said the cold run was *"scoped+blocked"* on `beads-sigma-2bj9`. **That blocker is gone** — `2bj9` was built, live-validated and merged as **#621** on 08-05 (205,975 rows landed at exact measured parity), and the cold run has since been run. Seven domo PRs have merged since this branch was cut.

**Rather than close it, land it with corrections.** Three files already on `main` — `2026-08-05-domo-road-to-gold.md`, `2026-08-05-domo-cold-run-progress.md`, and the `domo-import-to-snowflake` design spec — cite the 08-03 doc **by filename** for how the cold-run milestone was scoped. `main` therefore has a **dangling reference in three places** today. Merging this fixes it and preserves the scoping record.

`main` is merged in, so this is now docs-only.

## What changed

| File | Change |
|---|---|
| `2026-08-03-…-cold-run-scoping.md` | **HISTORICAL banner.** §3 (the scoping) is why it's cited and stays; the "what's left" list is explicitly marked do-not-act-on |
| `2026-08-05-domo-road-to-gold.md` | Forward-pointer. Its 14-bug analysis is still the best deep reference; its PR/bead ledger has drifted |
| **`2026-08-06-domo-gold-status.md`** | **NEW — the tie-it-together handoff** |

## Findings worth the read

- **`znvg`'s vendored DATEDIFF fix has never been exercised live.** #633 merged at `16:47:37`; the last live run was `14:32`. **Re-running the cold run is the cheapest next action** and may take 15 `type=error` columns down to 6. Nobody should design a fix before trying this.
- **Blocker 2 (the parity oracle) is still not started**, and it's easy to misread #631 as having solved it. #631 fixed the *plumbing* — domo was the only converter of six with no `phase6-parity-*.rb` finalizer, so a flawless 65/65 parity run was indistinguishable from never having run parity. But `build-parity-plan.rb` still emits **no expected values** and `migrate-domo.rb` **skips parity** without a hand-supplied `--parity-plan`. The pipe carries water; nothing produces the water.
- **`0goi` was re-triaged to `not-our-bug`** — the converter was exonerated; the corrupted `IllINois`/`INdiana` literals are in Domo's *source* Beast Mode. Anyone picking it up expecting a string-masking bug would chase nothing.

## Honest status

**Gold is not reached and was not reached today.** The run stops at `post-and-readback` (exit 2); `put-layout`, `verify-parity` and `assert-phase6-ran` — the gate that *is* the definition of gold — have never executed. The remaining distance is mostly Blocker 2, which is real design work.

## Test plan

- [x] Offline suite green — **1091 `ok:` assertions across 24 files**, measured 2026-08-06
- [x] Pre-commit + pre-push governance checks clean
- [x] Verified in-tree (not from memory): `build-parity-plan.rb` emits no expected values; `migrate-domo.rb` skips parity without `--parity-plan`; the 08-03 doc is absent from `main` while 3 merged files reference it
- [ ] TJ review

Documentation only — no code changes.