### PR TITLE
feat(shared): code_rep workbook document-wrapper adapter

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData → Sigma",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex → Sigma",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Migrate Hex projects to Sigma — SQL cells, single-value/METRIC cells, and EXPLORE charts → Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense → Sigma",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma — data model + workbook (indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; columnar layout→24-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/shared/lib/code_rep.mjs
+++ b/shared/lib/code_rep.mjs
@@ -1,0 +1,25 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  if (isObj(response.document)) return response.document;
+  return Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(([k]) => k !== 'document' && !DOC_KEYS.includes(k)),
+  );
+}
+
+export function wrap(doc, extra = {}) {
+  return { ...extra, document: doc };
+}

--- a/shared/lib/code_rep.py
+++ b/shared/lib/code_rep.py
@@ -1,0 +1,37 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    if isinstance(inner, dict):
+        return inner
+    return {k: v for k, v in response.items() if k in DOC_KEYS}
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {k: v for k, v in response.items() if k != "document" and k not in DOC_KEYS}
+
+
+def wrap(doc, extra=None):
+    """Build a request body. Every live workbook code-rep endpoint requires the wrapper."""
+    out = dict(extra or {})
+    out["document"] = doc
+    return out

--- a/shared/lib/code_rep.rb
+++ b/shared/lib/code_rep.rb
@@ -1,0 +1,39 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        return inner if inner.is_a?(Hash)
+        response.select { |k, _| DOC_KEYS.include?(k) }
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject { |k, _| k == 'document' || DOC_KEYS.include?(k) }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => document_hash)
+      end
+    end
+  end
+end

--- a/shared/lib/tests/test_code_rep.py
+++ b/shared/lib/tests/test_code_rep.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+import code_rep
+
+LIVE = {'workbookId': 'w1', 'name': 'N',
+        'document': {'schemaVersion': 1, 'pages': [{'id': 'p'}]}}
+LEGACY = {'workbookId': 'w1', 'name': 'N',
+          'schemaVersion': 1, 'pages': [{'id': 'p'}]}
+
+
+class TestCodeRep(unittest.TestCase):
+    def test_reads_both_shapes(self):
+        for r in (LIVE, LEGACY):
+            self.assertEqual(code_rep.document(r)['schemaVersion'], 1)
+            self.assertEqual(code_rep.document(r)['pages'], [{'id': 'p'}])
+
+    def test_metadata_split(self):
+        for r in (LIVE, LEGACY):
+            self.assertEqual(sorted(code_rep.metadata(r).keys()), ['name', 'workbookId'])
+
+    def test_wrap_always_nests(self):
+        doc = {'schemaVersion': 1, 'pages': []}
+        self.assertEqual(code_rep.wrap(doc), {'document': doc})
+        self.assertEqual(code_rep.wrap(doc, extra={'name': 'N'}), {'name': 'N', 'document': doc})
+
+    def test_round_trip_lossless_from_both_shapes(self):
+        for r in (LIVE, LEGACY):
+            doc = code_rep.document(r)
+            self.assertEqual(code_rep.document(code_rep.wrap(doc)), doc)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/shared/lib/tests/test_code_rep.rb
+++ b/shared/lib/tests/test_code_rep.rb
@@ -1,0 +1,33 @@
+require 'minitest/autorun'
+require_relative '../code_rep'
+
+class TestCodeRep < Minitest::Test
+  LIVE   = { 'workbookId' => 'w1', 'name' => 'N',
+             'document' => { 'schemaVersion' => 1, 'pages' => [{ 'id' => 'p' }] } }
+  LEGACY = { 'workbookId' => 'w1', 'name' => 'N',
+             'schemaVersion' => 1, 'pages' => [{ 'id' => 'p' }] }
+
+  def test_reads_both_shapes
+    [LIVE, LEGACY].each do |r|
+      assert_equal 1, Sigma::CodeRep.document(r)['schemaVersion']
+      assert_equal [{ 'id' => 'p' }], Sigma::CodeRep.document(r)['pages']
+    end
+  end
+
+  def test_metadata_split
+    [LIVE, LEGACY].each { |r| assert_equal %w[name workbookId], Sigma::CodeRep.metadata(r).keys.sort }
+  end
+
+  def test_wrap_always_nests
+    doc = { 'schemaVersion' => 1, 'pages' => [] }
+    assert_equal({ 'document' => doc }, Sigma::CodeRep.wrap(doc))
+    assert_equal({ 'name' => 'N', 'document' => doc }, Sigma::CodeRep.wrap(doc, extra: { 'name' => 'N' }))
+  end
+
+  def test_round_trip_lossless_from_both_shapes
+    [LIVE, LEGACY].each do |r|
+      doc = Sigma::CodeRep.document(r)
+      assert_equal doc, Sigma::CodeRep.document(Sigma::CodeRep.wrap(doc))
+    end
+  end
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -89,6 +89,63 @@
       ]
     },
     {
+      "canonical": "shared/lib/code_rep.rb",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb"
+      ]
+    },
+    {
+      "canonical": "shared/lib/code_rep.py",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py",
+        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py",
+        "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py",
+        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py"
+      ]
+    },
+    {
+      "canonical": "shared/lib/code_rep.mjs",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs",
+        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs"
+      ]
+    },
+    {
       "canonical": "shared/lib/preflight_lint.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb",


### PR DESCRIPTION
## What
Adds a small shape adapter for Sigma **workbook** code-representation payloads in Ruby, Python and JS.

## Why
The workbook spec surface now requires a top-level `document` key.
Verified against the live API on 2026-08-03/04:
- `GET /v2/workbooks/{id}/spec` returns metadata plus `document: {schemaVersion, pages, kind, layout}`
- `POST /v2/workbooks/spec` with the old flat body → HTTP 400 demanding `0.document.*`
- `POST /v2/workbooks/spec/verify` behaves identically: nested → `{"valid":true}`, flat → 400

So every flat workbook write in this repo is currently being rejected, and every
`readback['pages']` is reading nil.

Sigma engineering confirmed on 2026-08-03 that the **data-model** code-representation
surface is NOT changing, so this adapter is workbook-only by design. Applying it to
data-model payloads would break them — that API ignores `document`.

## Design
Reads tolerate both the nested live shape and the legacy flat shape (flat artifacts
still exist in committed snapshots and fixtures). Writes always nest — no runtime
probe, no cache, no extra API call, and no endpoint-aware branching, because all four
workbook endpoints agree.

## Verification
Proven against the real API before this branch existed: live read gate including a
regression proof that direct `['pages']` access now returns nil, plus the `/verify`
contract. All test payloads are synthetic.

## Governance
Canonical edit + manifest registration + `sync-shared.rb` fan-out + all 13 plugin
version bumps in a single atomic commit, per the shared-file rule.
`check-shared.rb` and `check-plugin-version-bump.sh` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)