### PR TITLE
fix(shared): wrap workbook spec POST body via code_rep adapter

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos \u2192 Sigma",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Migrate IBM Cognos Analytics to Sigma \u2014 Data Module JSON \u2192 Sigma data model, and report-spec XML \u2192 Sigma workbook. Translates the Cognos expression DSL (total..for \u2192 window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData \u2192 Sigma",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma \u2014 the declarative workspace layout (LDM + analytics model) \u2192 Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.14",
+  "version": "1.8.15",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps \u2014 data model AND workbook \u2014 from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight \u2192 Sigma",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma \u2014 analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense \u2192 Sigma",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma \u2014 data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.6.17",
+  "version": "1.6.18",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-export-cache.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-export-cache.rb
@@ -499,8 +499,14 @@ GT_POOL_STUB = <<~'RUBY'
     def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
       File.open(ENV['GTP_LOG'], 'a') { |f| f.puts(JSON.generate('m' => method.to_s, 'p' => path)) }
       if method == :post && path == '/v2/workbooks/spec'
-        spec = JSON.parse(body)
-        n_els = spec['pages'][0]['elements'].length
+        posted = JSON.parse(body)
+        # Task 3.2: pooled_sql_probe now nests the workbook document under a
+        # top-level `document` key (the live surface 400s on the old flat
+        # body) — read pages from there. run-ground-truth.rb's own SERIAL
+        # per-entry probe POST (a different, untouched call site) still posts
+        # the flat shape, so tolerate both — same read-side tolerance as
+        # Sigma::CodeRep.document().
+        n_els = (posted['document'] || posted)['pages'][0]['elements'].length
         raise Error, 'stub: HTTP 502 pooled spec POST refused' if n_els > 1 && ENV['GTP_POOL_SPEC_FAIL'] == '1'
         n = File.exist?(ENV['GTP_SEQ']) ? File.read(ENV['GTP_SEQ']).to_i + 1 : 1
         File.write(ENV['GTP_SEQ'], n.to_s)

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/export_pool.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/shared/lib/export_pool.rb
+++ b/shared/lib/export_pool.rb
@@ -409,6 +409,7 @@ module ExportPool
                        row_limit: nil, name: nil, workdir: nil, script: nil)
     require 'csv'
     require 'securerandom'
+    require 'code_rep' # vendored alongside export_pool.rb wherever this lib ships
     begin
       require 'probe_registry' # soft: present in plugins that vendor it
     rescue LoadError
@@ -422,12 +423,18 @@ module ExportPool
           { 'id' => "c#{i}_#{j}", 'name' => c.to_s, 'formula' => "[Custom SQL/#{c}]" }
         end }
     end
-    spec = { 'name' => name || "_probe_pooled_#{SecureRandom.hex(4)}",
-             'schemaVersion' => 1,
-             'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
-    spec['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    probe_name = name || "_probe_pooled_#{SecureRandom.hex(4)}"
+    doc = { 'schemaVersion' => 1,
+            'pages' => [{ 'id' => 'p1', 'name' => 'p1', 'elements' => elements }] }
+    meta = { 'name' => probe_name }
+    meta['folderId'] = folder_id if folder_id # omitted key = My Documents (API default)
+    # The workbook code-rep surface nests non-metadata fields under a
+    # top-level `document` key and rejects the old flat body with HTTP 400
+    # (see code_rep.rb) — this pooled-probe POST is a second, independent
+    # call site for that same surface (Task 3.2).
+    body = JSON.generate(Sigma::CodeRep.wrap(doc, extra: meta))
     begin
-      r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+      r = Sigma.request(:post, '/v2/workbooks/spec', body: body)
     rescue Sigma::Error => e
       raise "pooled probe workbook POST failed: #{e.message.to_s.gsub(/\s+/, ' ').strip[0, 240]}"
     end
@@ -436,7 +443,7 @@ module ExportPool
     # Register FIRST — before any export can run (or raise). NEVER FATAL by
     # the registry's own contract, so bookkeeping cannot break the probe.
     if defined?(ProbeRegistry)
-      ProbeRegistry.created(wb_id, name: spec['name'], workdir: workdir,
+      ProbeRegistry.created(wb_id, name: probe_name, workdir: workdir,
                             script: script || 'pooled_sql_probe')
     end
     results = Array.new(entries.length)

--- a/shared/lib/tests/test_export_pool_shape.rb
+++ b/shared/lib/tests/test_export_pool_shape.rb
@@ -1,0 +1,77 @@
+# test_export_pool_shape.rb — regression test for Task 3.2 (workbook code-rep
+# document-wrapper, second call site). export_pool.rb#pooled_sql_probe (#7c)
+# independently POSTs a probe workbook spec to /v2/workbooks/spec — the same
+# live surface that now REJECTS a flat body with HTTP 400 (see code_rep.rb).
+# Phase 2 (#608) added the Sigma::CodeRep adapter and Task 3.1 fixed the 6
+# plugins' post-and-readback.* scripts, but export_pool.rb is a DIFFERENT
+# call site that PR did not touch.
+#
+# Run: ruby shared/lib/tests/test_export_pool_shape.rb
+require 'minitest/autorun'
+require 'json'
+require_relative '../code_rep'
+
+# export_pool.rb assumes the caller already `require 'sigma_rest'`d (its own
+# top comment says so); this test provides a minimal in-process stub instead
+# of hitting the network, and captures the body handed to the workbook-spec
+# POST so we can assert on its actual shape.
+$pooled_post_body = nil
+module Sigma
+  class Error < StandardError; end
+
+  def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
+    if method == :post && path == '/v2/workbooks/spec'
+      $pooled_post_body = JSON.parse(body)
+      return { 'workbookId' => 'wb-test' }
+    end
+    if method == :post && path.include?('/export')
+      req = JSON.parse(body)
+      return { 'queryId' => req['elementId'] }
+    end
+    return "H\n1\n" if method == :get && path.start_with?('/v2/query/')
+    return {} if method == :delete
+
+    raise Error, "stub: unexpected #{method} #{path}"
+  end
+end
+
+# export_pool.rb bare-`require`s 'code_rep' (matching the real caller
+# convention of `$LOAD_PATH.unshift File.expand_path('lib', __dir__)` before
+# requiring its libs) — extend the load path the same way here.
+$LOAD_PATH.unshift(File.expand_path('..', __dir__))
+require_relative '../export_pool'
+
+class TestExportPoolShape < Minitest::Test
+  # The adapter itself (brief's literal check): wrap() always nests.
+  def test_workbook_post_body_is_wrapped
+    doc  = { 'schemaVersion' => 1, 'pages' => [], 'kind' => 'workbook' }
+    body = Sigma::CodeRep.wrap(doc, extra: { 'name' => 'n', 'folderId' => 'f' })
+    assert_equal doc, body['document'], 'workbook POST body must nest the document'
+    refute body.key?('pages')
+  end
+
+  # The real regression signal: export_pool.rb's own probe-workbook POST call
+  # site (pooled_sql_probe, ~line 429) must ROUTE THROUGH the adapter — not
+  # spread a flat spec straight into the POST body. Pre-fix, this fails
+  # because $pooled_post_body carries top-level `pages`/`schemaVersion` and
+  # no `document` key at all — exactly the flat shape the live surface 400s.
+  def test_pooled_sql_probe_posts_wrapped_document
+    entries  = [{ 'sql' => 'SELECT 1', 'columns' => %w[A B] }]
+    deadline = ExportPool::Deadline.new(30)
+
+    ExportPool.pooled_sql_probe('conn-1', entries, deadline, pool: 1,
+                                folder_id: 'f1', name: 'probe-x')
+
+    refute_nil $pooled_post_body, 'pooled_sql_probe never POSTed to /v2/workbooks/spec'
+    assert $pooled_post_body.key?('document'),
+           'POST body must nest the workbook document under a top-level `document` key'
+    assert_equal 1, $pooled_post_body['document']['schemaVersion']
+    assert $pooled_post_body['document']['pages'].is_a?(Array)
+    refute $pooled_post_body.key?('pages'),
+           'pages must not remain top-level (flat body is HTTP 400 on this surface)'
+    refute $pooled_post_body.key?('schemaVersion'),
+           'schemaVersion must not remain top-level'
+    assert_equal 'probe-x', $pooled_post_body['name'], 'metadata (name) must stay outside document'
+    assert_equal 'f1', $pooled_post_body['folderId'], 'metadata (folderId) must stay outside document'
+  end
+end


### PR DESCRIPTION
## Summary
- `shared/lib/export_pool.rb`'s `pooled_sql_probe` (#7c) independently POSTs a probe-workbook spec to `/v2/workbooks/spec` — a second, separate call site from Task 3.1's `post-and-readback.*` fix (PR #609). The live workbook code-representation surface now rejects a flat body with HTTP 400; this routes the POST through the `Sigma::CodeRep` adapter added in Phase 2 (PR #608), nesting the document under a top-level `document` key and keeping `name`/`folderId` as metadata alongside it.
- Fanned the canonical fix to all 10 plugin copies via `tools/sync-shared.rb` (`check-shared.rb`: 676/676 match); bumped all 13 plugin `plugin.json` patch versions in the same commit per shared-file governance.
- Also fixed `plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-export-cache.rb`'s own `run-ground-truth.rb` pooled-probe stub, which asserted on the old flat body shape and would otherwise regress (made it tolerant of both the new nested and the old flat shape, since `run-ground-truth.rb`'s separate serial-path probe POST is untouched by this task).

## Test plan
- [x] New `shared/lib/tests/test_export_pool_shape.rb`: confirmed it fails pre-fix (flat body has no `document` key), passes post-fix (`ruby shared/lib/tests/test_export_pool_shape.rb` — 2 runs, 10 assertions, 0 failures).
- [x] `ruby tools/check-shared.rb` — 676 shared-file copies match canonical.
- [x] `bash tools/check-plugin-version-bump.sh <merge-base> HEAD` — all 13 plugins pass (strict patch bump).
- [x] `ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-export-cache.rb` — full pre-existing suite (pooled + serial probe paths) still passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)