### PR TITLE
fix(shared): unwrap workbook readbacks in the parity/anchors/enhance chain

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos \u2192 Sigma",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Migrate IBM Cognos Analytics to Sigma \u2014 Data Module JSON \u2192 Sigma data model, and report-spec XML \u2192 Sigma workbook. Translates the Cognos expression DSL (total..for \u2192 window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData \u2192 Sigma",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma \u2014 the declarative workspace layout (LDM + analytics model) \u2192 Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex \u2192 Sigma",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Migrate Hex projects to Sigma \u2014 SQL cells, single-value/METRIC cells, and EXPLORE charts \u2192 Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.13",
+  "version": "1.8.14",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
@@ -50,6 +50,7 @@ require 'optparse'
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'sigma_rest'
+require 'code_rep'
 
 opts = { probes: 3 }
 OptionParser.new do |o|
@@ -97,6 +98,25 @@ def clean(spec)
   s = JSON.parse(JSON.generate(spec))
   READONLY_KEYS.each { |k| s.delete(k) }
   s
+end
+
+# Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+# `document` key (live since 2026-08-03/04). Every helper below this point
+# (ensure_banded!, apply_patch!, find_element, etc.) was written against the
+# pre-nesting flat shape and freely mixes document fields (spec['pages'],
+# spec['layout']) with metadata (spec['name']) on the SAME hash — so rather
+# than threading two hashes through a dozen functions, flatten a live GET back
+# onto one hash and keep that as the single working `current` spec throughout.
+# Sigma::CodeRep.metadata/.document partition any hash with no risk of
+# collision (metadata explicitly excludes the document keys), so this round-
+# trips losslessly. Pair with wrap_spec below at every PUT boundary.
+def flatten_spec(raw)
+  Sigma::CodeRep.metadata(raw).merge(Sigma::CodeRep.document(raw))
+end
+
+# Inverse of flatten_spec — re-nest a flattened working spec for the wire.
+def wrap_spec(flat)
+  Sigma::CodeRep.wrap(Sigma::CodeRep.document(flat), extra: Sigma::CodeRep.metadata(flat))
 end
 
 # Sigma's workbook POST/PUT responses can come back as YAML — parse leniently.
@@ -729,7 +749,12 @@ end
 # ---------------------------------------------------------------------------
 orig_meta_before = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}")
 orig_spec = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}/spec")
-abort "FATAL: cannot read spec of #{ORIG_WB}" unless orig_spec.is_a?(Hash) && orig_spec['pages']
+# orig_spec stays the RAW (possibly document-nested) GET response — it is
+# POSTed close to verbatim below (clean() only strips top-level readonly
+# keys, leaving a `document` key untouched), and POST /v2/workbooks/spec
+# requires that nesting. orig_doc is the unwrapped view used for reads only.
+orig_doc = Sigma::CodeRep.document(orig_spec)
+abort "FATAL: cannot read spec of #{ORIG_WB}" unless orig_spec.is_a?(Hash) && orig_doc['pages']
 clone_name = opts[:name] || "#{orig_spec['name']} — Enhanced"
 
 clone_spec = clean(orig_spec)
@@ -745,7 +770,7 @@ puts "enhance-apply: clone '#{clone_name}' = #{clone_id} (original #{ORIG_WB} un
 # ---------------------------------------------------------------------------
 all_touched = accepted.flat_map { |c| touched_ids(c) }
 viz_kinds = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart kpi-chart table pivot-table]
-probe_pool = (orig_spec['pages'] || []).reject { |p| p['id'] == 'page-data' }
+probe_pool = (orig_doc['pages'] || []).reject { |p| p['id'] == 'page-data' }
                                        .flat_map { |p| p['elements'] || [] }
                                        .select { |e| viz_kinds.include?(e['kind']) }
                                        .reject { |e| all_touched.include?(e['id']) }
@@ -773,12 +798,16 @@ puts "   baseline: clone == original on #{probes.size}/#{probes.size} probe(s)"
 # ---------------------------------------------------------------------------
 # 3. Apply accepted items ONE AT A TIME with the parity-unchanged gate.
 # ---------------------------------------------------------------------------
+# `spec` here is the FLATTENED working document (flatten_spec below) — wrap
+# it back into the live nested shape right at the wire boundary so every
+# helper upstream (ensure_banded!, apply_patch!, find_element, ...) keeps
+# reading/writing spec['pages']/spec['layout']/spec['name'] on one flat hash.
 def put_spec(wb, spec)
   lenient(Sigma.request(:put, "/v2/workbooks/#{wb}/spec",
-                        body: JSON.generate(spec), binary: true))
+                        body: JSON.generate(wrap_spec(spec)), binary: true))
 end
 
-current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+current = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
 
 # Pre-container clone? (parity workbook built before banded layouts existed.)
 # Regenerate a banded layout FIRST so every applied item has a container
@@ -786,7 +815,7 @@ current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
 # parity probes are unaffected by construction.
 if ensure_banded!(current)
   put_spec(clone_id, current)
-  current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+  current = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
   puts '   clone layout predates containers — regenerated banded layout (header + row bands)'
 end
 
@@ -848,7 +877,11 @@ end
 # must lint CLEAN — a parity-green visual mess is exactly the regression this
 # phase exists to prevent.
 require 'layout_lint'
-live_spec = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+# layout_lint/control_lint keep their existing contract ("give me a plain
+# document") — unwrap/flatten at this caller rather than teaching the libs
+# about the document wrapper (they're also fed local pre-POST specs
+# elsewhere, which never carry one).
+live_spec = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
 lint_violations = LayoutLint.lint(live_spec)
 if lint_violations.any?
   warn "enhance-apply FINALIZE FAIL — layout lint: #{lint_violations.size} violation(s) on the clone:"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-scan.rb
@@ -58,6 +58,7 @@ require 'optparse'
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'sigma_rest'
+require 'code_rep'
 
 opts = { max_exports: 12 }
 OptionParser.new do |o|
@@ -92,8 +93,14 @@ source ||= 'unknown'
 # ---------------------------------------------------------------------------
 # Load the live spec + export element data (read-only).
 # ---------------------------------------------------------------------------
-spec = Sigma.request(:get, "/v2/workbooks/#{WB}/spec")
-abort "FATAL: could not read spec for workbook #{WB}" unless spec.is_a?(Hash) && spec['pages']
+# Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+# `document` key (live since 2026-08-03/04); flatten metadata (name, etc.)
+# and document content back onto one hash so every existing spec['...'] read
+# below (mixing both) keeps working unchanged. Read-only file — no PUT here,
+# so there is no wrap-back to worry about.
+raw_spec = Sigma.request(:get, "/v2/workbooks/#{WB}/spec")
+spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
+abort "FATAL: could not read spec for workbook #{WB}" unless raw_spec.is_a?(Hash) && spec['pages']
 wb_name = spec['name'].to_s
 
 VIZ_KINDS = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart].freeze

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
@@ -47,5 +47,32 @@ Dir.mktmpdir do |d|
   ok('zero charts → exit 2', !st && $?.exitstatus == 2)
 end
 
+# NESTED document shape (live code-rep API since 2026-08-03/04: GET/POST
+# /v2/workbooks/.../spec nests pages/layout under a top-level `document` key).
+# The keystone regression this test guards: a flat `spec['pages']` read on a
+# nested response silently returns [] (exit 2, not a crash) instead of the
+# real chart list — and --emit-spec must write the UNWRAPPED document, not a
+# double-wrapped {document:{...}} blob, so wb-readback.json stays plain for
+# blind_grade.rb / verify-anchors.rb offline mode / record-visual-check.rb.
+Dir.mktmpdir do |d|
+  nested = { 'workbookId' => 'w1', 'name' => 'N',
+             'document' => { 'schemaVersion' => 2, 'kind' => 'workbook', 'layout' => '<Layout/>',
+                             'pages' => SPEC['pages'] } }
+  File.write(File.join(d, 'nested-spec.json'), JSON.generate(nested))
+  out = File.join(d, 'parity-plan.json')
+  emit = File.join(d, 'wb-readback.json')
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'nested-spec.json'),
+              '--out', out, '--emit-spec', emit, out: File::NULL, err: File::NULL)
+  ok('nested document shape: exit 0 (not silently zeroed)', st)
+  plan = (JSON.parse(File.read(out))['charts'] rescue [])
+  ok('nested document shape: sees the same 2 charts as the flat fixture',
+     plan.map { |c| c['sigma_element_id'] }.sort == %w[el-bar el-kpi])
+  emitted = JSON.parse(File.read(emit))
+  ok('nested document shape: emit-spec is NOT double-wrapped', !emitted.key?('document'))
+  ok('nested document shape: emit-spec carries the unwrapped pages', emitted['pages'] == SPEC['pages'])
+  ok('nested document shape: emit-spec also carries layout/schemaVersion (full document, not just pages)',
+     emitted['layout'] == '<Layout/>' && emitted['schemaVersion'] == 2)
+end
+
 puts $fail.zero? ? "\nall build-parity-plan tests passed" : "\n#{$fail} FAILED"
 exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps \u2014 data model AND workbook \u2014 from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight \u2192 Sigma",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma \u2014 analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense \u2192 Sigma",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma \u2014 data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.6.16",
+  "version": "1.6.17",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
@@ -50,6 +50,7 @@ require 'optparse'
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'sigma_rest'
+require 'code_rep'
 
 opts = { probes: 3 }
 OptionParser.new do |o|
@@ -97,6 +98,25 @@ def clean(spec)
   s = JSON.parse(JSON.generate(spec))
   READONLY_KEYS.each { |k| s.delete(k) }
   s
+end
+
+# Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+# `document` key (live since 2026-08-03/04). Every helper below this point
+# (ensure_banded!, apply_patch!, find_element, etc.) was written against the
+# pre-nesting flat shape and freely mixes document fields (spec['pages'],
+# spec['layout']) with metadata (spec['name']) on the SAME hash — so rather
+# than threading two hashes through a dozen functions, flatten a live GET back
+# onto one hash and keep that as the single working `current` spec throughout.
+# Sigma::CodeRep.metadata/.document partition any hash with no risk of
+# collision (metadata explicitly excludes the document keys), so this round-
+# trips losslessly. Pair with wrap_spec below at every PUT boundary.
+def flatten_spec(raw)
+  Sigma::CodeRep.metadata(raw).merge(Sigma::CodeRep.document(raw))
+end
+
+# Inverse of flatten_spec — re-nest a flattened working spec for the wire.
+def wrap_spec(flat)
+  Sigma::CodeRep.wrap(Sigma::CodeRep.document(flat), extra: Sigma::CodeRep.metadata(flat))
 end
 
 # Sigma's workbook POST/PUT responses can come back as YAML — parse leniently.
@@ -729,7 +749,12 @@ end
 # ---------------------------------------------------------------------------
 orig_meta_before = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}")
 orig_spec = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}/spec")
-abort "FATAL: cannot read spec of #{ORIG_WB}" unless orig_spec.is_a?(Hash) && orig_spec['pages']
+# orig_spec stays the RAW (possibly document-nested) GET response — it is
+# POSTed close to verbatim below (clean() only strips top-level readonly
+# keys, leaving a `document` key untouched), and POST /v2/workbooks/spec
+# requires that nesting. orig_doc is the unwrapped view used for reads only.
+orig_doc = Sigma::CodeRep.document(orig_spec)
+abort "FATAL: cannot read spec of #{ORIG_WB}" unless orig_spec.is_a?(Hash) && orig_doc['pages']
 clone_name = opts[:name] || "#{orig_spec['name']} — Enhanced"
 
 clone_spec = clean(orig_spec)
@@ -745,7 +770,7 @@ puts "enhance-apply: clone '#{clone_name}' = #{clone_id} (original #{ORIG_WB} un
 # ---------------------------------------------------------------------------
 all_touched = accepted.flat_map { |c| touched_ids(c) }
 viz_kinds = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart kpi-chart table pivot-table]
-probe_pool = (orig_spec['pages'] || []).reject { |p| p['id'] == 'page-data' }
+probe_pool = (orig_doc['pages'] || []).reject { |p| p['id'] == 'page-data' }
                                        .flat_map { |p| p['elements'] || [] }
                                        .select { |e| viz_kinds.include?(e['kind']) }
                                        .reject { |e| all_touched.include?(e['id']) }
@@ -773,12 +798,16 @@ puts "   baseline: clone == original on #{probes.size}/#{probes.size} probe(s)"
 # ---------------------------------------------------------------------------
 # 3. Apply accepted items ONE AT A TIME with the parity-unchanged gate.
 # ---------------------------------------------------------------------------
+# `spec` here is the FLATTENED working document (flatten_spec below) — wrap
+# it back into the live nested shape right at the wire boundary so every
+# helper upstream (ensure_banded!, apply_patch!, find_element, ...) keeps
+# reading/writing spec['pages']/spec['layout']/spec['name'] on one flat hash.
 def put_spec(wb, spec)
   lenient(Sigma.request(:put, "/v2/workbooks/#{wb}/spec",
-                        body: JSON.generate(spec), binary: true))
+                        body: JSON.generate(wrap_spec(spec)), binary: true))
 end
 
-current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+current = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
 
 # Pre-container clone? (parity workbook built before banded layouts existed.)
 # Regenerate a banded layout FIRST so every applied item has a container
@@ -786,7 +815,7 @@ current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
 # parity probes are unaffected by construction.
 if ensure_banded!(current)
   put_spec(clone_id, current)
-  current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+  current = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
   puts '   clone layout predates containers — regenerated banded layout (header + row bands)'
 end
 
@@ -848,7 +877,11 @@ end
 # must lint CLEAN — a parity-green visual mess is exactly the regression this
 # phase exists to prevent.
 require 'layout_lint'
-live_spec = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+# layout_lint/control_lint keep their existing contract ("give me a plain
+# document") — unwrap/flatten at this caller rather than teaching the libs
+# about the document wrapper (they're also fed local pre-POST specs
+# elsewhere, which never carry one).
+live_spec = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
 lint_violations = LayoutLint.lint(live_spec)
 if lint_violations.any?
   warn "enhance-apply FINALIZE FAIL — layout lint: #{lint_violations.size} violation(s) on the clone:"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-scan.rb
@@ -58,6 +58,7 @@ require 'optparse'
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'sigma_rest'
+require 'code_rep'
 
 opts = { max_exports: 12 }
 OptionParser.new do |o|
@@ -92,8 +93,14 @@ source ||= 'unknown'
 # ---------------------------------------------------------------------------
 # Load the live spec + export element data (read-only).
 # ---------------------------------------------------------------------------
-spec = Sigma.request(:get, "/v2/workbooks/#{WB}/spec")
-abort "FATAL: could not read spec for workbook #{WB}" unless spec.is_a?(Hash) && spec['pages']
+# Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+# `document` key (live since 2026-08-03/04); flatten metadata (name, etc.)
+# and document content back onto one hash so every existing spec['...'] read
+# below (mixing both) keeps working unchanged. Read-only file — no PUT here,
+# so there is no wrap-back to worry about.
+raw_spec = Sigma.request(:get, "/v2/workbooks/#{WB}/spec")
+spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
+abort "FATAL: could not read spec for workbook #{WB}" unless raw_spec.is_a?(Hash) && spec['pages']
 wb_name = spec['name'].to_s
 
 VIZ_KINDS = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart].freeze

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-build-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-build-parity-plan.rb
@@ -47,5 +47,32 @@ Dir.mktmpdir do |d|
   ok('zero charts → exit 2', !st && $?.exitstatus == 2)
 end
 
+# NESTED document shape (live code-rep API since 2026-08-03/04: GET/POST
+# /v2/workbooks/.../spec nests pages/layout under a top-level `document` key).
+# The keystone regression this test guards: a flat `spec['pages']` read on a
+# nested response silently returns [] (exit 2, not a crash) instead of the
+# real chart list — and --emit-spec must write the UNWRAPPED document, not a
+# double-wrapped {document:{...}} blob, so wb-readback.json stays plain for
+# blind_grade.rb / verify-anchors.rb offline mode / record-visual-check.rb.
+Dir.mktmpdir do |d|
+  nested = { 'workbookId' => 'w1', 'name' => 'N',
+             'document' => { 'schemaVersion' => 2, 'kind' => 'workbook', 'layout' => '<Layout/>',
+                             'pages' => SPEC['pages'] } }
+  File.write(File.join(d, 'nested-spec.json'), JSON.generate(nested))
+  out = File.join(d, 'parity-plan.json')
+  emit = File.join(d, 'wb-readback.json')
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'nested-spec.json'),
+              '--out', out, '--emit-spec', emit, out: File::NULL, err: File::NULL)
+  ok('nested document shape: exit 0 (not silently zeroed)', st)
+  plan = (JSON.parse(File.read(out))['charts'] rescue [])
+  ok('nested document shape: sees the same 2 charts as the flat fixture',
+     plan.map { |c| c['sigma_element_id'] }.sort == %w[el-bar el-kpi])
+  emitted = JSON.parse(File.read(emit))
+  ok('nested document shape: emit-spec is NOT double-wrapped', !emitted.key?('document'))
+  ok('nested document shape: emit-spec carries the unwrapped pages', emitted['pages'] == SPEC['pages'])
+  ok('nested document shape: emit-spec also carries layout/schemaVersion (full document, not just pages)',
+     emitted['layout'] == '<Layout/>' && emitted['schemaVersion'] == 2)
+end
+
 puts $fail.zero? ? "\nall build-parity-plan tests passed" : "\n#{$fail} FAILED"
 exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-anchors.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}

--- a/shared/lib/tests/test_parity_chain_shape.rb
+++ b/shared/lib/tests/test_parity_chain_shape.rb
@@ -1,0 +1,33 @@
+require 'minitest/autorun'
+require_relative '../code_rep'
+
+class TestParityChainShape < Minitest::Test
+  NESTED = { 'workbookId' => 'w',
+             'document' => { 'pages' => [{ 'id' => 'p', 'elements' => [{ 'kind' => 'table' }] }],
+                             'layout' => '<Layout/>' } }
+
+  # build-parity-plan.rb:85 — the keystone silent failure.
+  def test_parity_plan_sees_pages
+    pages = Sigma::CodeRep.document(NESTED)['pages'] || []
+    refute_empty pages, 'parity plan must see pages, not silently zero them'
+    assert_empty(NESTED['pages'] || [], 'proves the old flat read yielded zero elements')
+  end
+
+  # --emit-spec must write the INNER document so blind_grade/verify-anchors stay simple.
+  def test_emit_spec_writes_unwrapped_document
+    emitted = Sigma::CodeRep.document(NESTED)
+    refute emitted.key?('document'), 'wb-readback.json must not be double-wrapped'
+    refute_empty Array(emitted['pages'])
+  end
+
+  # enhance-scan.rb / enhance-apply.rb abort guards must stop aborting.
+  def test_enhance_abort_guard_passes_on_nested
+    refute_nil Sigma::CodeRep.document(NESTED)['pages'],
+               'enhance-* abort guard must not fire on a nested readback'
+  end
+
+  def test_legacy_flat_readback_still_supported
+    flat = { 'pages' => [{ 'id' => 'p' }] }
+    assert_equal [{ 'id' => 'p' }], Sigma::CodeRep.document(flat)['pages']
+  end
+end

--- a/shared/scripts/build-parity-plan.rb
+++ b/shared/scripts/build-parity-plan.rb
@@ -13,7 +13,8 @@
 # Usage:
 #   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
 #     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
-#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here (unwrapped
+#                                                 # document: {schemaVersion, pages, kind, layout})
 #
 # Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
 #   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
@@ -25,6 +26,9 @@ require 'json'
 require 'optparse'
 require 'set'
 
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'code_rep'
+
 opts = {}
 OptionParser.new do |p|
   p.on('--workbook-id ID')     { |v| opts[:wb] = v }
@@ -35,15 +39,20 @@ end.parse!
 abort 'missing --out' unless opts[:out]
 abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
 
-# Load the spec: from a file if given, else from the live workbook.
+# Load the spec: from a file if given, else from the live workbook. Either
+# source may be the live nested shape (POST/GET /v2/workbooks/.../spec nests
+# pages/layout/schemaVersion/kind under a top-level `document` key, verified
+# live 2026-08-03/04) or a legacy flat artifact (committed fixtures, older
+# wb-readback.json snapshots) — Sigma::CodeRep.document() accepts both and
+# always hands back the plain pages/layout document.
 if opts[:spec] && File.exist?(opts[:spec])
-  spec = JSON.parse(File.read(opts[:spec]))
+  spec = Sigma::CodeRep.document(JSON.parse(File.read(opts[:spec])))
 else
-  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
   # /spec may wrap the spec under a key; accept either shape.
-  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  raw = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+  spec = Sigma::CodeRep.document(raw)
 end
 
 # Non-data element kinds we never verify (controls, text, images, containers).
@@ -107,7 +116,13 @@ if charts.empty?
 end
 
 File.write(opts[:out], JSON.pretty_generate('charts' => charts))
-File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+# Write the UNWRAPPED document (not just {pages:[...]}) — blind_grade.rb,
+# verify-anchors.rb's offline mode, and record-visual-check.rb all read
+# wb-readback.json expecting a plain pages/layout document at the top level;
+# this is what keeps them needing no changes of their own for the document
+# wrapper (they never see `document` nesting; CodeRep.document() already
+# stripped it above).
+File.write(opts[:emit], JSON.pretty_generate(spec)) if opts[:emit]
 
 puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
 puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]

--- a/shared/scripts/enhance-apply.rb
+++ b/shared/scripts/enhance-apply.rb
@@ -50,6 +50,7 @@ require 'optparse'
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'sigma_rest'
+require 'code_rep'
 
 opts = { probes: 3 }
 OptionParser.new do |o|
@@ -97,6 +98,25 @@ def clean(spec)
   s = JSON.parse(JSON.generate(spec))
   READONLY_KEYS.each { |k| s.delete(k) }
   s
+end
+
+# Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+# `document` key (live since 2026-08-03/04). Every helper below this point
+# (ensure_banded!, apply_patch!, find_element, etc.) was written against the
+# pre-nesting flat shape and freely mixes document fields (spec['pages'],
+# spec['layout']) with metadata (spec['name']) on the SAME hash — so rather
+# than threading two hashes through a dozen functions, flatten a live GET back
+# onto one hash and keep that as the single working `current` spec throughout.
+# Sigma::CodeRep.metadata/.document partition any hash with no risk of
+# collision (metadata explicitly excludes the document keys), so this round-
+# trips losslessly. Pair with wrap_spec below at every PUT boundary.
+def flatten_spec(raw)
+  Sigma::CodeRep.metadata(raw).merge(Sigma::CodeRep.document(raw))
+end
+
+# Inverse of flatten_spec — re-nest a flattened working spec for the wire.
+def wrap_spec(flat)
+  Sigma::CodeRep.wrap(Sigma::CodeRep.document(flat), extra: Sigma::CodeRep.metadata(flat))
 end
 
 # Sigma's workbook POST/PUT responses can come back as YAML — parse leniently.
@@ -729,7 +749,12 @@ end
 # ---------------------------------------------------------------------------
 orig_meta_before = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}")
 orig_spec = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}/spec")
-abort "FATAL: cannot read spec of #{ORIG_WB}" unless orig_spec.is_a?(Hash) && orig_spec['pages']
+# orig_spec stays the RAW (possibly document-nested) GET response — it is
+# POSTed close to verbatim below (clean() only strips top-level readonly
+# keys, leaving a `document` key untouched), and POST /v2/workbooks/spec
+# requires that nesting. orig_doc is the unwrapped view used for reads only.
+orig_doc = Sigma::CodeRep.document(orig_spec)
+abort "FATAL: cannot read spec of #{ORIG_WB}" unless orig_spec.is_a?(Hash) && orig_doc['pages']
 clone_name = opts[:name] || "#{orig_spec['name']} — Enhanced"
 
 clone_spec = clean(orig_spec)
@@ -745,7 +770,7 @@ puts "enhance-apply: clone '#{clone_name}' = #{clone_id} (original #{ORIG_WB} un
 # ---------------------------------------------------------------------------
 all_touched = accepted.flat_map { |c| touched_ids(c) }
 viz_kinds = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart kpi-chart table pivot-table]
-probe_pool = (orig_spec['pages'] || []).reject { |p| p['id'] == 'page-data' }
+probe_pool = (orig_doc['pages'] || []).reject { |p| p['id'] == 'page-data' }
                                        .flat_map { |p| p['elements'] || [] }
                                        .select { |e| viz_kinds.include?(e['kind']) }
                                        .reject { |e| all_touched.include?(e['id']) }
@@ -773,12 +798,16 @@ puts "   baseline: clone == original on #{probes.size}/#{probes.size} probe(s)"
 # ---------------------------------------------------------------------------
 # 3. Apply accepted items ONE AT A TIME with the parity-unchanged gate.
 # ---------------------------------------------------------------------------
+# `spec` here is the FLATTENED working document (flatten_spec below) — wrap
+# it back into the live nested shape right at the wire boundary so every
+# helper upstream (ensure_banded!, apply_patch!, find_element, ...) keeps
+# reading/writing spec['pages']/spec['layout']/spec['name'] on one flat hash.
 def put_spec(wb, spec)
   lenient(Sigma.request(:put, "/v2/workbooks/#{wb}/spec",
-                        body: JSON.generate(spec), binary: true))
+                        body: JSON.generate(wrap_spec(spec)), binary: true))
 end
 
-current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+current = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
 
 # Pre-container clone? (parity workbook built before banded layouts existed.)
 # Regenerate a banded layout FIRST so every applied item has a container
@@ -786,7 +815,7 @@ current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
 # parity probes are unaffected by construction.
 if ensure_banded!(current)
   put_spec(clone_id, current)
-  current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+  current = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
   puts '   clone layout predates containers — regenerated banded layout (header + row bands)'
 end
 
@@ -848,7 +877,11 @@ end
 # must lint CLEAN — a parity-green visual mess is exactly the regression this
 # phase exists to prevent.
 require 'layout_lint'
-live_spec = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+# layout_lint/control_lint keep their existing contract ("give me a plain
+# document") — unwrap/flatten at this caller rather than teaching the libs
+# about the document wrapper (they're also fed local pre-POST specs
+# elsewhere, which never carry one).
+live_spec = flatten_spec(clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec")))
 lint_violations = LayoutLint.lint(live_spec)
 if lint_violations.any?
   warn "enhance-apply FINALIZE FAIL — layout lint: #{lint_violations.size} violation(s) on the clone:"

--- a/shared/scripts/enhance-scan.rb
+++ b/shared/scripts/enhance-scan.rb
@@ -58,6 +58,7 @@ require 'optparse'
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'sigma_rest'
+require 'code_rep'
 
 opts = { max_exports: 12 }
 OptionParser.new do |o|
@@ -92,8 +93,14 @@ source ||= 'unknown'
 # ---------------------------------------------------------------------------
 # Load the live spec + export element data (read-only).
 # ---------------------------------------------------------------------------
-spec = Sigma.request(:get, "/v2/workbooks/#{WB}/spec")
-abort "FATAL: could not read spec for workbook #{WB}" unless spec.is_a?(Hash) && spec['pages']
+# Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+# `document` key (live since 2026-08-03/04); flatten metadata (name, etc.)
+# and document content back onto one hash so every existing spec['...'] read
+# below (mixing both) keeps working unchanged. Read-only file — no PUT here,
+# so there is no wrap-back to worry about.
+raw_spec = Sigma.request(:get, "/v2/workbooks/#{WB}/spec")
+spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
+abort "FATAL: could not read spec for workbook #{WB}" unless raw_spec.is_a?(Hash) && spec['pages']
 wb_name = spec['name'].to_s
 
 VIZ_KINDS = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart].freeze

--- a/shared/scripts/test-build-parity-plan.rb
+++ b/shared/scripts/test-build-parity-plan.rb
@@ -47,5 +47,32 @@ Dir.mktmpdir do |d|
   ok('zero charts → exit 2', !st && $?.exitstatus == 2)
 end
 
+# NESTED document shape (live code-rep API since 2026-08-03/04: GET/POST
+# /v2/workbooks/.../spec nests pages/layout under a top-level `document` key).
+# The keystone regression this test guards: a flat `spec['pages']` read on a
+# nested response silently returns [] (exit 2, not a crash) instead of the
+# real chart list — and --emit-spec must write the UNWRAPPED document, not a
+# double-wrapped {document:{...}} blob, so wb-readback.json stays plain for
+# blind_grade.rb / verify-anchors.rb offline mode / record-visual-check.rb.
+Dir.mktmpdir do |d|
+  nested = { 'workbookId' => 'w1', 'name' => 'N',
+             'document' => { 'schemaVersion' => 2, 'kind' => 'workbook', 'layout' => '<Layout/>',
+                             'pages' => SPEC['pages'] } }
+  File.write(File.join(d, 'nested-spec.json'), JSON.generate(nested))
+  out = File.join(d, 'parity-plan.json')
+  emit = File.join(d, 'wb-readback.json')
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'nested-spec.json'),
+              '--out', out, '--emit-spec', emit, out: File::NULL, err: File::NULL)
+  ok('nested document shape: exit 0 (not silently zeroed)', st)
+  plan = (JSON.parse(File.read(out))['charts'] rescue [])
+  ok('nested document shape: sees the same 2 charts as the flat fixture',
+     plan.map { |c| c['sigma_element_id'] }.sort == %w[el-bar el-kpi])
+  emitted = JSON.parse(File.read(emit))
+  ok('nested document shape: emit-spec is NOT double-wrapped', !emitted.key?('document'))
+  ok('nested document shape: emit-spec carries the unwrapped pages', emitted['pages'] == SPEC['pages'])
+  ok('nested document shape: emit-spec also carries layout/schemaVersion (full document, not just pages)',
+     emitted['layout'] == '<Layout/>' && emitted['schemaVersion'] == 2)
+end
+
 puts $fail.zero? ? "\nall build-parity-plan tests passed" : "\n#{$fail} FAILED"
 exit($fail.zero? ? 0 : 1)

--- a/shared/scripts/verify-anchors.rb
+++ b/shared/scripts/verify-anchors.rb
@@ -609,6 +609,7 @@ else
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
   require 'export_pool'
+  require 'code_rep'
 
   # ONE deadline for the entire run (issue #416: --timeout used to bound only
   # the per-element poll wait, so total runtime was unbounded). Computed here,
@@ -629,13 +630,22 @@ else
     end
 
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'text/yaml')
-  spec = begin
+  raw_spec = begin
     JSON.parse(body)
   rescue JSON::ParserError, TypeError
     require 'yaml'
     require 'date'
     body.is_a?(Hash) ? body : (YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {})
   end
+  # Workbook code-rep nests pages/layout/schemaVersion/kind under a top-level
+  # `document` key (live since 2026-08-03/04). Flatten metadata (workbookId,
+  # latestDocumentVersion, ...) and document content onto one hash: this file
+  # reads BOTH off `spec` below (elements from spec['pages'], the doc version
+  # from spec['latestDocumentVersion'] via ExportPool.resolve_doc_version, the
+  # workbook id from spec['workbookId']) and mutates elements in place for the
+  # pivot-totals strip/restore bracket, so one flat hash keeps every existing
+  # read/mutation site below working unchanged. put_spec re-nests at the wire.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
   elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
   queryable = elements.reject { |el| %w[control text image container].include?(el['kind'].to_s) }
 
@@ -650,7 +660,8 @@ else
   # step. Read-only spec fields are stripped before each PUT (Sigma rejects them).
   READONLY_SPEC_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].freeze
   put_spec = lambda do |s|
-    body = s.reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    meta = Sigma::CodeRep.metadata(s).reject { |k, _| READONLY_SPEC_KEYS.include?(k) }
+    body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(s), extra: meta)
     Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(body))
   end
   captured_totals = {}


### PR DESCRIPTION
## Summary

`shared/scripts/build-parity-plan.rb` GETs a live workbook spec and read `spec['pages']` flat. The workbook code-representation surface now nests non-metadata fields under a top-level `document` key (PR #608), so this silently returned zero pages instead of erroring — and `--emit-spec` then wrote that empty result into `wb-readback.json`, which four other places consume (`shared/lib/blind_grade.rb`, `shared/scripts/record-visual-check.rb`, `shared/scripts/verify-anchors.rb`'s offline mode, and `plugins/tableau-to-sigma/.../collect-parity-actuals.rb`).

- **`build-parity-plan.rb`**: GET + `--workbook-spec` file load now unwrap via `Sigma::CodeRep.document()`; `--emit-spec` writes the unwrapped document (schemaVersion/pages/kind/layout), not a narrower `{pages:[...]}` — verified all 4 downstream consumers only ever read flat `pages`/`tiles` from `wb-readback.json`, so **none of them needed changes** (confirmed by reading each, not assumed).
- **`verify-anchors.rb`**: live GET flattens metadata (workbookId, latestDocumentVersion, ...) + document content onto one hash so every existing read (`spec['pages']`, `ExportPool.resolve_doc_version(spec)`, `spec['workbookId']`) and the pivot-totals strip/restore mutation keep working unchanged; the PUT re-nests via `Sigma::CodeRep.wrap`. The offline mode (`--workbook-spec`/`wb-readback.json`) is untouched by design — it already only needs the fixed emitter's flat shape.
- **`enhance-scan.rb`**: same flatten at its one GET; the `unless spec['pages']` abort guard no longer fires on a real spec.
- **`enhance-apply.rb`**: `orig_spec` (used for the clone POST) stays the raw nested response — `clean()` already preserves nesting, so the POST needed no change; a `flatten_spec`/`wrap_spec` pair is introduced for the CLONE's own working `current` spec (mutated by ~15 pre-existing helpers that mix `spec['pages']`/`spec['layout']`/`spec['name']` on one hash) and re-nests at each PUT and the finalize lint GET.

## Test plan

- [x] New `shared/lib/tests/test_parity_chain_shape.rb` (adapter-level, per the task brief) — 4/4 pass
- [x] Extended `shared/scripts/test-build-parity-plan.rb` with a nested-document-shape fixture (the brief's own test only exercised the adapter, not the script — this proves the actual script fix: old code would exit 2 on this fixture, new code finds the same 2 charts and emits an unwrapped, non-double-wrapped document)
- [x] Existing `test-verify-anchors.rb` (63 assertions) and `test-build-parity-plan.rb` — all pass unchanged
- [x] **Live end-to-end proof** against a real workbook: `build-parity-plan.rb` went from 0 pages (old flat read) to 23 visible chart elements (fixed read); `enhance-scan.rb` no longer hard-aborts and finds a real candidate enhancement
- [x] `ruby tools/check-shared.rb` clean (676 copies match canonical)
- [x] `bash tools/check-plugin-version-bump.sh` clean for all 13 plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)