### PR TITLE
fix(coderep): wrap scout-validate/phase6-parity workbook code-rep calls in document envelope

### DIFF
--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/phase6-parity-looker.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/phase6-parity-looker.rb
@@ -117,12 +117,17 @@ if !opts[:finalize]
   abort('--workbook-id required for pass 1') unless opts[:wb]
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'code_rep'
 
   warn "Parity PASS 1: reading workbook spec #{opts[:wb]}"
   # binary:true returns the raw body — the spec endpoint answers in YAML even
   # when asked for JSON, so parse both.
   raw = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec", binary: true)
-  spec = parse_spec(raw)
+  # Live GET now nests non-metadata fields under `document` (verified 2026-08-03/04);
+  # unwrap so both this pass's flat `spec['pages']` read below and the on-disk
+  # wb-readback.json stay the flat shape this script (and any downstream reader)
+  # expects.
+  spec = Sigma::CodeRep.document(parse_spec(raw))
   File.write(File.join(opts[:dir], 'wb-readback.json'), JSON.pretty_generate(spec))
 
   charts = []

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/scout-validate.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/scout-validate.py
@@ -25,6 +25,7 @@ Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the t
 import json, os, sys, urllib.request, argparse, datetime, re, hashlib
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import scout_gate
+import code_rep
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
 def api(method, path, body=None, accept_json=True):
@@ -111,8 +112,13 @@ def main():
     else:
         test = {"id":"scout","kind":"table","name":"scout","source":{"elementId":"m","kind":"table"},
                 "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}]}
-    spec = {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id,"schemaVersion":1,
-            "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    doc = {"schemaVersion":1,
+           "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    # Live POST /v2/workbooks/spec now REJECTS the old flat body with a 400
+    # (verified 2026-08-03/04) — every non-metadata field must nest under a
+    # top-level `document` key. code_rep.wrap keeps the metadata (name,
+    # folderId) alongside it.
+    spec = code_rep.wrap(doc, {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id})
     st, body = api("POST","/v2/workbooks/spec",spec)
     wb = None
     try: wb = json.loads(body).get("workbookId")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/tests/test_phase6_parity_shape.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/tests/test_phase6_parity_shape.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+#
+# test_phase6_parity_shape.rb — regression test for phase6-parity-looker.rb's
+# workbook code-rep GET readback (Task 3.8).
+#
+# Live GET /v2/workbooks/{id}/spec now nests non-metadata fields under a
+# top-level `document` key (verified 2026-08-03/04). phase6-parity-looker.rb
+# GETs the live spec in PASS 1, reads spec['pages'] directly to enumerate
+# chart elements, and writes the spec to wb-readback.json — this checks both
+# reads route through the vendored Sigma::CodeRep.document() adapter rather
+# than the raw (now-nested) GET response.
+#
+# Run: ruby scripts/tests/test_phase6_parity_shape.rb
+
+require 'minitest/autorun'
+require_relative '../lib/code_rep'
+
+SCRIPT_NAME = 'phase6-parity-looker.rb'
+
+class TestPhase6ParityShape < Minitest::Test
+  # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+  # this alone would NOT fail pre-fix -- it documents the expected shape that
+  # the real regression test below actually enforces against the script.
+  def test_document_resolves_nested_readback
+    readback = { 'workbookId' => 'w', 'document' => { 'pages' => [{ 'id' => 'p1' }] } }
+    assert_equal [{ 'id' => 'p1' }], Sigma::CodeRep.document(readback)['pages']
+    assert_nil readback['pages'], 'proves the old flat read was nil'
+  end
+
+  # Real regression signal: the script must route its GET readback through
+  # Sigma::CodeRep.document(...) before writing wb-readback.json / reading
+  # spec['pages'] -- not the raw (now-nested) GET response.
+  def test_script_uses_code_rep_for_readback
+    src = File.read(File.join(__dir__, '..', SCRIPT_NAME))
+    assert_match(/Sigma::CodeRep\.document\(/, src,
+                 "#{SCRIPT_NAME} must unwrap the GET readback via Sigma::CodeRep.document(...)")
+  end
+end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/tests/test_scout_validate_shape.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/tests/test_scout_validate_shape.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Regression test for scout-validate.py's workbook code-rep POST body
+(Task 3.8).
+
+Live POST /v2/workbooks/spec now REJECTS the old flat body with HTTP 400
+(verified 2026-08-03/04) -- every non-metadata field must nest under a
+top-level `document` key. scout-validate.py builds a throwaway "SCOUT TEST"
+workbook and POSTs it to validate a candidate formula; this checks that POST
+body is built via the vendored code_rep.wrap() adapter rather than the old
+flat {name, folderId, schemaVersion, pages} dict.
+
+Run: python3 scripts/tests/test_scout_validate_shape.py
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "..", "scout-validate.py")
+sys.path.insert(0, os.path.join(HERE, "..", "lib"))
+import code_rep  # noqa: E402  (vendored adapter; sys.path set above)
+
+
+class TestScoutValidateShape(unittest.TestCase):
+    # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+    # this alone would NOT fail pre-fix -- it documents the expected shape
+    # that the real regression test below actually enforces against the script.
+    def test_wrap_nests_document(self):
+        doc = {"schemaVersion": 1, "pages": []}
+        body = code_rep.wrap(doc, {"name": "n", "folderId": "f"})
+        self.assertEqual(body["document"], doc)
+        self.assertNotIn("pages", body)
+
+    def test_document_resolves_nested_readback(self):
+        nested = {"workbookId": "w", "document": {"schemaVersion": 1, "pages": [{"id": "p"}]}}
+        self.assertEqual(code_rep.document(nested)["pages"], [{"id": "p"}])
+        self.assertIsNone(nested.get("pages"), "proves the old flat read was nil")
+
+    # Real regression signal: scout-validate.py's own POST body must be built
+    # via code_rep.wrap(...), not a flat dict with name/folderId/schemaVersion/
+    # pages all at the top level (the shape the live API now 400s on).
+    def test_post_body_uses_code_rep_wrap(self):
+        with open(SCRIPT) as fh:
+            src = fh.read()
+        m = re.search(r'api\("POST",\s*"/v2/workbooks/spec",\s*(\w+)\)', src)
+        self.assertIsNotNone(m, "expected a POST /v2/workbooks/spec call in scout-validate.py")
+        var = m.group(1)
+        assign = re.search(rf"\b{re.escape(var)}\s*=\s*code_rep\.wrap\(", src)
+        self.assertIsNotNone(assign, f"{var} (the POST body) must be built via code_rep.wrap(...)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-validate.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-validate.py
@@ -30,6 +30,7 @@ Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the t
 import json, os, sys, urllib.request, argparse, datetime, re, hashlib
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import scout_gate
+import code_rep
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
 def api(method, path, body=None, accept_json=True):
@@ -116,8 +117,13 @@ def main():
     else:
         test = {"id":"scout","kind":"table","name":"scout","source":{"elementId":"m","kind":"table"},
                 "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}]}
-    spec = {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id,"schemaVersion":1,
-            "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    doc = {"schemaVersion":1,
+           "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    # Live POST /v2/workbooks/spec now REJECTS the old flat body with a 400
+    # (verified 2026-08-03/04) — every non-metadata field must nest under a
+    # top-level `document` key. code_rep.wrap keeps the metadata (name,
+    # folderId) alongside it.
+    spec = code_rep.wrap(doc, {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id})
     st, body = api("POST","/v2/workbooks/spec",spec)
     wb = None
     try: wb = json.loads(body).get("workbookId")

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/tests/test_scout_validate_shape.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/tests/test_scout_validate_shape.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Regression test for scout-validate.py's workbook code-rep POST body
+(Task 3.8).
+
+Live POST /v2/workbooks/spec now REJECTS the old flat body with HTTP 400
+(verified 2026-08-03/04) -- every non-metadata field must nest under a
+top-level `document` key. scout-validate.py builds a throwaway "SCOUT TEST"
+workbook and POSTs it to validate a candidate formula; this checks that POST
+body is built via the vendored code_rep.wrap() adapter rather than the old
+flat {name, folderId, schemaVersion, pages} dict.
+
+Run: python3 scripts/tests/test_scout_validate_shape.py
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "..", "scout-validate.py")
+sys.path.insert(0, os.path.join(HERE, "..", "lib"))
+import code_rep  # noqa: E402  (vendored adapter; sys.path set above)
+
+
+class TestScoutValidateShape(unittest.TestCase):
+    # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+    # this alone would NOT fail pre-fix -- it documents the expected shape
+    # that the real regression test below actually enforces against the script.
+    def test_wrap_nests_document(self):
+        doc = {"schemaVersion": 1, "pages": []}
+        body = code_rep.wrap(doc, {"name": "n", "folderId": "f"})
+        self.assertEqual(body["document"], doc)
+        self.assertNotIn("pages", body)
+
+    def test_document_resolves_nested_readback(self):
+        nested = {"workbookId": "w", "document": {"schemaVersion": 1, "pages": [{"id": "p"}]}}
+        self.assertEqual(code_rep.document(nested)["pages"], [{"id": "p"}])
+        self.assertIsNone(nested.get("pages"), "proves the old flat read was nil")
+
+    # Real regression signal: scout-validate.py's own POST body must be built
+    # via code_rep.wrap(...), not a flat dict with name/folderId/schemaVersion/
+    # pages all at the top level (the shape the live API now 400s on).
+    def test_post_body_uses_code_rep_wrap(self):
+        with open(SCRIPT) as fh:
+            src = fh.read()
+        m = re.search(r'api\("POST",\s*"/v2/workbooks/spec",\s*(\w+)\)', src)
+        self.assertIsNotNone(m, "expected a POST /v2/workbooks/spec call in scout-validate.py")
+        var = m.group(1)
+        assign = re.search(rf"\b{re.escape(var)}\s*=\s*code_rep\.wrap\(", src)
+        self.assertIsNotNone(assign, f"{var} (the POST body) must be built via code_rep.wrap(...)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity.rb
@@ -57,6 +57,7 @@ end
 BASE = ENV.fetch('SIGMA_BASE_URL')
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
+require 'code_rep'
 
 # Sigma.request handles initial token fetch + 401-retry-with-refresh
 # transparently. Phase 6 is the longest pass in the pipeline; tokens
@@ -70,7 +71,11 @@ plan_path = File.join(opts[:tab], 'parity-plan.json')
 if !opts[:finalize]
   # PASS 1 — build plan + emit per-chart MCP instructions
   warn "Phase 6 PASS 1: reading workbook spec #{opts[:wb]}"
-  spec = http_json("/v2/workbooks/#{opts[:wb]}/spec")
+  raw_spec = http_json("/v2/workbooks/#{opts[:wb]}/spec")
+  # Live GET now nests non-metadata fields under `document` (verified 2026-08-03/04);
+  # unwrap so wb-readback.json keeps the flat {pages:[...]} shape downstream
+  # scripts (auto-parity-plan.rb, ...) already expect on disk.
+  spec = Sigma::CodeRep.document(raw_spec)
   File.write(File.join(opts[:tab], 'wb-readback.json'), JSON.pretty_generate(spec))
 
   warn "Phase 6 PASS 1: building parity plan"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/scout-validate.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/scout-validate.py
@@ -26,6 +26,7 @@ Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the t
 import json, os, sys, urllib.request, argparse, datetime, re, hashlib
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import scout_gate
+import code_rep
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
 def api(method, path, body=None, accept_json=True):
@@ -112,8 +113,13 @@ def main():
     else:
         test = {"id":"scout","kind":"table","name":"scout","source":{"elementId":"m","kind":"table"},
                 "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}]}
-    spec = {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id,"schemaVersion":1,
-            "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    doc = {"schemaVersion":1,
+           "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    # Live POST /v2/workbooks/spec now REJECTS the old flat body with a 400
+    # (verified 2026-08-03/04) — every non-metadata field must nest under a
+    # top-level `document` key. code_rep.wrap keeps the metadata (name,
+    # folderId) alongside it.
+    spec = code_rep.wrap(doc, {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id})
     st, body = api("POST","/v2/workbooks/spec",spec)
     wb = None
     try: wb = json.loads(body).get("workbookId")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/tests/test_phase6_parity_shape.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/tests/test_phase6_parity_shape.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+#
+# test_phase6_parity_shape.rb — regression test for phase6-parity.rb's
+# workbook code-rep GET readback (Task 3.8).
+#
+# Live GET /v2/workbooks/{id}/spec now nests non-metadata fields under a
+# top-level `document` key (verified 2026-08-03/04). phase6-parity.rb GETs the
+# live spec in PASS 1 and writes it to wb-readback.json for every downstream
+# parity script (auto-parity-plan.rb, verify-anchors.rb, ...) to consume FLAT
+# ({pages:[...]}) — this checks the read routes through the vendored
+# Sigma::CodeRep.document() adapter rather than re-serializing the raw
+# (now-nested) GET response straight to disk.
+#
+# Note: this plugin also ships phase6-parity-pbi.rb (the DAX/executeQueries
+# adapter). It is intentionally NOT covered here -- it never calls GET
+# /v2/workbooks/.../spec (its `expected` values come entirely from Power BI
+# executeQueries + agent-supplied Sigma actuals), so it isn't affected by the
+# workbook code-rep document-wrapper change. Confirmed via grep: no
+# "workbooks", "wb-readback", or "document" reference in that file.
+#
+# Run: ruby scripts/tests/test_phase6_parity_shape.rb
+
+require 'minitest/autorun'
+require_relative '../lib/code_rep'
+
+SCRIPT_NAME = 'phase6-parity.rb'
+
+class TestPhase6ParityShape < Minitest::Test
+  # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+  # this alone would NOT fail pre-fix -- it documents the expected shape that
+  # the real regression test below actually enforces against the script.
+  def test_document_resolves_nested_readback
+    readback = { 'workbookId' => 'w', 'document' => { 'pages' => [{ 'id' => 'p1' }] } }
+    assert_equal [{ 'id' => 'p1' }], Sigma::CodeRep.document(readback)['pages']
+    assert_nil readback['pages'], 'proves the old flat read was nil'
+  end
+
+  # Real regression signal: the script must route its GET readback through
+  # Sigma::CodeRep.document(...) before writing wb-readback.json / reading
+  # spec['pages'] -- not the raw (now-nested) GET response.
+  def test_script_uses_code_rep_for_readback
+    src = File.read(File.join(__dir__, '..', SCRIPT_NAME))
+    assert_match(/Sigma::CodeRep\.document\(/, src,
+                 "#{SCRIPT_NAME} must unwrap the GET readback via Sigma::CodeRep.document(...)")
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/tests/test_scout_validate_shape.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/tests/test_scout_validate_shape.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Regression test for scout-validate.py's workbook code-rep POST body
+(Task 3.8).
+
+Live POST /v2/workbooks/spec now REJECTS the old flat body with HTTP 400
+(verified 2026-08-03/04) -- every non-metadata field must nest under a
+top-level `document` key. scout-validate.py builds a throwaway "SCOUT TEST"
+workbook and POSTs it to validate a candidate formula; this checks that POST
+body is built via the vendored code_rep.wrap() adapter rather than the old
+flat {name, folderId, schemaVersion, pages} dict.
+
+Run: python3 scripts/tests/test_scout_validate_shape.py
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "..", "scout-validate.py")
+sys.path.insert(0, os.path.join(HERE, "..", "lib"))
+import code_rep  # noqa: E402  (vendored adapter; sys.path set above)
+
+
+class TestScoutValidateShape(unittest.TestCase):
+    # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+    # this alone would NOT fail pre-fix -- it documents the expected shape
+    # that the real regression test below actually enforces against the script.
+    def test_wrap_nests_document(self):
+        doc = {"schemaVersion": 1, "pages": []}
+        body = code_rep.wrap(doc, {"name": "n", "folderId": "f"})
+        self.assertEqual(body["document"], doc)
+        self.assertNotIn("pages", body)
+
+    def test_document_resolves_nested_readback(self):
+        nested = {"workbookId": "w", "document": {"schemaVersion": 1, "pages": [{"id": "p"}]}}
+        self.assertEqual(code_rep.document(nested)["pages"], [{"id": "p"}])
+        self.assertIsNone(nested.get("pages"), "proves the old flat read was nil")
+
+    # Real regression signal: scout-validate.py's own POST body must be built
+    # via code_rep.wrap(...), not a flat dict with name/folderId/schemaVersion/
+    # pages all at the top level (the shape the live API now 400s on).
+    def test_post_body_uses_code_rep_wrap(self):
+        with open(SCRIPT) as fh:
+            src = fh.read()
+        m = re.search(r'api\("POST",\s*"/v2/workbooks/spec",\s*(\w+)\)', src)
+        self.assertIsNotNone(m, "expected a POST /v2/workbooks/spec call in scout-validate.py")
+        var = m.group(1)
+        assign = re.search(rf"\b{re.escape(var)}\s*=\s*code_rep\.wrap\(", src)
+        self.assertIsNotNone(assign, f"{var} (the POST body) must be built via code_rep.wrap(...)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps \u2014 data model AND workbook \u2014 from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/scout-validate.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/scout-validate.py
@@ -19,6 +19,7 @@ Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the t
 import json, os, sys, urllib.request, argparse, datetime, re, hashlib
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import scout_gate
+import code_rep
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
 def api(method, path, body=None, accept_json=True):
@@ -106,8 +107,13 @@ def main():
     else:
         test = {"id":"scout","kind":"table","name":"scout","source":{"elementId":"m","kind":"table"},
                 "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}]}
-    spec = {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id,"schemaVersion":1,
-            "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    doc = {"schemaVersion":1,
+           "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    # Live POST /v2/workbooks/spec now REJECTS the old flat body with a 400
+    # (verified 2026-08-03/04) — every non-metadata field must nest under a
+    # top-level `document` key. code_rep.wrap keeps the metadata (name,
+    # folderId) alongside it.
+    spec = code_rep.wrap(doc, {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id})
     st, body = api("POST","/v2/workbooks/spec",spec)
     wb = None
     try: wb = json.loads(body).get("workbookId")

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/tests/test_scout_validate_shape.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/tests/test_scout_validate_shape.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Regression test for scout-validate.py's workbook code-rep POST body
+(Task 3.8).
+
+Live POST /v2/workbooks/spec now REJECTS the old flat body with HTTP 400
+(verified 2026-08-03/04) -- every non-metadata field must nest under a
+top-level `document` key. scout-validate.py builds a throwaway "SCOUT TEST"
+workbook and POSTs it to validate a candidate formula; this checks that POST
+body is built via the vendored code_rep.wrap() adapter rather than the old
+flat {name, folderId, schemaVersion, pages} dict.
+
+Run: python3 scripts/tests/test_scout_validate_shape.py
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "..", "scout-validate.py")
+sys.path.insert(0, os.path.join(HERE, "..", "lib"))
+import code_rep  # noqa: E402  (vendored adapter; sys.path set above)
+
+
+class TestScoutValidateShape(unittest.TestCase):
+    # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+    # this alone would NOT fail pre-fix -- it documents the expected shape
+    # that the real regression test below actually enforces against the script.
+    def test_wrap_nests_document(self):
+        doc = {"schemaVersion": 1, "pages": []}
+        body = code_rep.wrap(doc, {"name": "n", "folderId": "f"})
+        self.assertEqual(body["document"], doc)
+        self.assertNotIn("pages", body)
+
+    def test_document_resolves_nested_readback(self):
+        nested = {"workbookId": "w", "document": {"schemaVersion": 1, "pages": [{"id": "p"}]}}
+        self.assertEqual(code_rep.document(nested)["pages"], [{"id": "p"}])
+        self.assertIsNone(nested.get("pages"), "proves the old flat read was nil")
+
+    # Real regression signal: scout-validate.py's own POST body must be built
+    # via code_rep.wrap(...), not a flat dict with name/folderId/schemaVersion/
+    # pages all at the top level (the shape the live API now 400s on).
+    def test_post_body_uses_code_rep_wrap(self):
+        with open(SCRIPT) as fh:
+            src = fh.read()
+        m = re.search(r'api\("POST",\s*"/v2/workbooks/spec",\s*(\w+)\)', src)
+        self.assertIsNotNone(m, "expected a POST /v2/workbooks/spec call in scout-validate.py")
+        var = m.group(1)
+        assign = re.search(rf"\b{re.escape(var)}\s*=\s*code_rep\.wrap\(", src)
+        self.assertIsNotNone(assign, f"{var} (the POST body) must be built via code_rep.wrap(...)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight \u2192 Sigma",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma \u2014 analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/phase6-parity-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/phase6-parity-quicksight.rb
@@ -93,12 +93,17 @@ if !opts[:finalize]
   abort('--workbook-id required for pass 1') unless opts[:wb]
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'code_rep'
 
   warn "Phase 7 PASS 1: reading workbook spec #{opts[:wb]}"
   # binary:true returns the raw body — the spec endpoint answers in YAML even
   # when asked for JSON, so parse both.
   raw = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec", binary: true)
-  spec = parse_spec(raw)
+  # Live GET now nests non-metadata fields under `document` (verified 2026-08-03/04);
+  # unwrap so both this pass's flat `spec['pages']` read below and the on-disk
+  # wb-readback.json stay the flat shape this script (and any downstream reader)
+  # expects.
+  spec = Sigma::CodeRep.document(parse_spec(raw))
   File.write(File.join(opts[:dir], 'wb-readback.json'), JSON.pretty_generate(spec))
 
   charts = []

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/tests/test_phase6_parity_shape.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/tests/test_phase6_parity_shape.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+#
+# test_phase6_parity_shape.rb — regression test for
+# phase6-parity-quicksight.rb's workbook code-rep GET readback (Task 3.8).
+#
+# Live GET /v2/workbooks/{id}/spec now nests non-metadata fields under a
+# top-level `document` key (verified 2026-08-03/04). phase6-parity-quicksight.rb
+# GETs the live spec in PASS 1, reads spec['pages'] directly to enumerate
+# chart elements, and writes the spec to wb-readback.json — this checks both
+# reads route through the vendored Sigma::CodeRep.document() adapter rather
+# than the raw (now-nested) GET response.
+#
+# Run: ruby scripts/tests/test_phase6_parity_shape.rb
+
+require 'minitest/autorun'
+require_relative '../lib/code_rep'
+
+SCRIPT_NAME = 'phase6-parity-quicksight.rb'
+
+class TestPhase6ParityShape < Minitest::Test
+  # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+  # this alone would NOT fail pre-fix -- it documents the expected shape that
+  # the real regression test below actually enforces against the script.
+  def test_document_resolves_nested_readback
+    readback = { 'workbookId' => 'w', 'document' => { 'pages' => [{ 'id' => 'p1' }] } }
+    assert_equal [{ 'id' => 'p1' }], Sigma::CodeRep.document(readback)['pages']
+    assert_nil readback['pages'], 'proves the old flat read was nil'
+  end
+
+  # Real regression signal: the script must route its GET readback through
+  # Sigma::CodeRep.document(...) before writing wb-readback.json / reading
+  # spec['pages'] -- not the raw (now-nested) GET response.
+  def test_script_uses_code_rep_for_readback
+    src = File.read(File.join(__dir__, '..', SCRIPT_NAME))
+    assert_match(/Sigma::CodeRep\.document\(/, src,
+                 "#{SCRIPT_NAME} must unwrap the GET readback via Sigma::CodeRep.document(...)")
+  end
+end

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.6.19",
+  "version": "1.6.20",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
@@ -67,6 +67,7 @@ end
 BASE = ENV.fetch('SIGMA_BASE_URL')
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
+require 'code_rep'
 
 # Sigma.request handles initial token fetch + 401-retry-with-refresh
 # transparently. Phase 6 is the longest pass in the pipeline; tokens
@@ -92,7 +93,11 @@ end
 if !opts[:finalize]
   # PASS 1 — build plan + emit per-chart MCP instructions
   warn "Phase 6 PASS 1: reading workbook spec #{opts[:wb]}"
-  spec = http_json("/v2/workbooks/#{opts[:wb]}/spec")
+  raw_spec = http_json("/v2/workbooks/#{opts[:wb]}/spec")
+  # Live GET now nests non-metadata fields under `document` (verified 2026-08-03/04);
+  # unwrap so wb-readback.json keeps the flat {pages:[...]} shape downstream
+  # scripts (auto-parity-plan.rb, verify-anchors.rb, ...) already expect on disk.
+  spec = Sigma::CodeRep.document(raw_spec)
   File.write(File.join(opts[:tab], 'wb-readback.json'), JSON.pretty_generate(spec))
 
   # Idempotence guard: if a parity plan already exists, REUSE it (unless

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tests/test_phase6_parity_shape.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tests/test_phase6_parity_shape.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+#
+# test_phase6_parity_shape.rb — regression test for phase6-parity.rb's
+# workbook code-rep GET readback (Task 3.8).
+#
+# Live GET /v2/workbooks/{id}/spec now nests non-metadata fields under a
+# top-level `document` key (verified 2026-08-03/04). phase6-parity.rb GETs the
+# live spec in PASS 1 and writes it to wb-readback.json for every downstream
+# parity script (auto-parity-plan.rb, verify-anchors.rb, ...) to consume FLAT
+# ({pages:[...]}) — this checks the read routes through the vendored
+# Sigma::CodeRep.document() adapter rather than re-serializing the raw
+# (now-nested) GET response straight to disk.
+#
+# Run: ruby scripts/tests/test_phase6_parity_shape.rb
+
+require 'minitest/autorun'
+require_relative '../lib/code_rep'
+
+SCRIPT_NAME = 'phase6-parity.rb'
+
+class TestPhase6ParityShape < Minitest::Test
+  # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+  # this alone would NOT fail pre-fix -- it documents the expected shape that
+  # the real regression test below actually enforces against the script.
+  def test_document_resolves_nested_readback
+    readback = { 'workbookId' => 'w', 'document' => { 'pages' => [{ 'id' => 'p1' }] } }
+    assert_equal [{ 'id' => 'p1' }], Sigma::CodeRep.document(readback)['pages']
+    assert_nil readback['pages'], 'proves the old flat read was nil'
+  end
+
+  # Real regression signal: the script must route its GET readback through
+  # Sigma::CodeRep.document(...) before writing wb-readback.json / reading
+  # spec['pages'] -- not the raw (now-nested) GET response.
+  def test_script_uses_code_rep_for_readback
+    src = File.read(File.join(__dir__, '..', SCRIPT_NAME))
+    assert_match(/Sigma::CodeRep\.document\(/, src,
+                 "#{SCRIPT_NAME} must unwrap the GET readback via Sigma::CodeRep.document(...)")
+  end
+end

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/phase6-parity-thoughtspot.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/phase6-parity-thoughtspot.rb
@@ -107,12 +107,17 @@ if !opts[:finalize]
   abort('--workbook-id required for pass 1') unless opts[:wb]
   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
   require 'sigma_rest'
+  require 'code_rep'
 
   warn "Parity PASS 1: reading workbook spec #{opts[:wb]}"
   # binary:true returns the raw body — the spec endpoint answers in YAML even
   # when asked for JSON, so parse both.
   raw = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec", binary: true)
-  spec = parse_spec(raw)
+  # Live GET now nests non-metadata fields under `document` (verified 2026-08-03/04);
+  # unwrap so both this pass's flat `spec['pages']` read below and the on-disk
+  # wb-readback.json stay the flat shape this script (and any downstream reader)
+  # expects.
+  spec = Sigma::CodeRep.document(parse_spec(raw))
   File.write(File.join(opts[:dir], 'wb-readback.json'), JSON.pretty_generate(spec))
 
   charts = []

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/scout-validate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/scout-validate.py
@@ -26,6 +26,7 @@ Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the t
 import json, os, sys, ssl, urllib.request, argparse, datetime, re, hashlib
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import scout_gate
+import code_rep
 _SSL = ssl._create_unverified_context()
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
@@ -113,8 +114,13 @@ def main():
     else:
         test = {"id":"scout","kind":"table","name":"scout","source":{"elementId":"m","kind":"table"},
                 "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}]}
-    spec = {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id,"schemaVersion":1,
-            "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    doc = {"schemaVersion":1,
+           "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    # Live POST /v2/workbooks/spec now REJECTS the old flat body with a 400
+    # (verified 2026-08-03/04) — every non-metadata field must nest under a
+    # top-level `document` key. code_rep.wrap keeps the metadata (name,
+    # folderId) alongside it.
+    spec = code_rep.wrap(doc, {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id})
     st, body = api("POST","/v2/workbooks/spec",spec)
     wb = None
     try: wb = json.loads(body).get("workbookId")

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/tests/test_phase6_parity_shape.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/tests/test_phase6_parity_shape.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+#
+# test_phase6_parity_shape.rb — regression test for
+# phase6-parity-thoughtspot.rb's workbook code-rep GET readback (Task 3.8).
+#
+# Live GET /v2/workbooks/{id}/spec now nests non-metadata fields under a
+# top-level `document` key (verified 2026-08-03/04). phase6-parity-thoughtspot.rb
+# GETs the live spec in PASS 1, reads spec['pages'] directly to enumerate
+# chart elements, and writes the spec to wb-readback.json — this checks both
+# reads route through the vendored Sigma::CodeRep.document() adapter rather
+# than the raw (now-nested) GET response.
+#
+# Run: ruby scripts/tests/test_phase6_parity_shape.rb
+
+require 'minitest/autorun'
+require_relative '../lib/code_rep'
+
+SCRIPT_NAME = 'phase6-parity-thoughtspot.rb'
+
+class TestPhase6ParityShape < Minitest::Test
+  # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+  # this alone would NOT fail pre-fix -- it documents the expected shape that
+  # the real regression test below actually enforces against the script.
+  def test_document_resolves_nested_readback
+    readback = { 'workbookId' => 'w', 'document' => { 'pages' => [{ 'id' => 'p1' }] } }
+    assert_equal [{ 'id' => 'p1' }], Sigma::CodeRep.document(readback)['pages']
+    assert_nil readback['pages'], 'proves the old flat read was nil'
+  end
+
+  # Real regression signal: the script must route its GET readback through
+  # Sigma::CodeRep.document(...) before writing wb-readback.json / reading
+  # spec['pages'] -- not the raw (now-nested) GET response.
+  def test_script_uses_code_rep_for_readback
+    src = File.read(File.join(__dir__, '..', SCRIPT_NAME))
+    assert_match(/Sigma::CodeRep\.document\(/, src,
+                 "#{SCRIPT_NAME} must unwrap the GET readback via Sigma::CodeRep.document(...)")
+  end
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/tests/test_scout_validate_shape.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/tests/test_scout_validate_shape.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Regression test for scout-validate.py's workbook code-rep POST body
+(Task 3.8).
+
+Live POST /v2/workbooks/spec now REJECTS the old flat body with HTTP 400
+(verified 2026-08-03/04) -- every non-metadata field must nest under a
+top-level `document` key. scout-validate.py builds a throwaway "SCOUT TEST"
+workbook and POSTs it to validate a candidate formula; this checks that POST
+body is built via the vendored code_rep.wrap() adapter rather than the old
+flat {name, folderId, schemaVersion, pages} dict.
+
+Run: python3 scripts/tests/test_scout_validate_shape.py
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "..", "scout-validate.py")
+sys.path.insert(0, os.path.join(HERE, "..", "lib"))
+import code_rep  # noqa: E402  (vendored adapter; sys.path set above)
+
+
+class TestScoutValidateShape(unittest.TestCase):
+    # Sanity-checks the shared adapter itself. Already shipped (Task 3.x), so
+    # this alone would NOT fail pre-fix -- it documents the expected shape
+    # that the real regression test below actually enforces against the script.
+    def test_wrap_nests_document(self):
+        doc = {"schemaVersion": 1, "pages": []}
+        body = code_rep.wrap(doc, {"name": "n", "folderId": "f"})
+        self.assertEqual(body["document"], doc)
+        self.assertNotIn("pages", body)
+
+    def test_document_resolves_nested_readback(self):
+        nested = {"workbookId": "w", "document": {"schemaVersion": 1, "pages": [{"id": "p"}]}}
+        self.assertEqual(code_rep.document(nested)["pages"], [{"id": "p"}])
+        self.assertIsNone(nested.get("pages"), "proves the old flat read was nil")
+
+    # Real regression signal: scout-validate.py's own POST body must be built
+    # via code_rep.wrap(...), not a flat dict with name/folderId/schemaVersion/
+    # pages all at the top level (the shape the live API now 400s on).
+    def test_post_body_uses_code_rep_wrap(self):
+        with open(SCRIPT) as fh:
+            src = fh.read()
+        m = re.search(r'api\("POST",\s*"/v2/workbooks/spec",\s*(\w+)\)', src)
+        self.assertIsNotNone(m, "expected a POST /v2/workbooks/spec call in scout-validate.py")
+        var = m.group(1)
+        assign = re.search(rf"\b{re.escape(var)}\s*=\s*code_rep\.wrap\(", src)
+        self.assertIsNotNone(assign, f"{var} (the POST body) must be built via code_rep.wrap(...)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Live `POST /v2/workbooks/spec` now rejects the old flat body with HTTP 400, and `GET /v2/workbooks/{id}/spec` now nests non-metadata fields under a top-level `document` key (#608). Two script families still used the old flat shape:
  - `scout-validate.py` (qlik, looker, powerbi, thoughtspot, microstrategy) — throwaway "SCOUT TEST" workbook POST body now built via `code_rep.wrap()`.
  - `phase6-parity*.rb` (tableau, powerbi's `phase6-parity.rb`, looker, quicksight, thoughtspot) — PASS-1 GET readback now unwrapped via `Sigma::CodeRep.document()` before being written to `wb-readback.json`, so every downstream reader keeps seeing the flat `{pages:[...]}` shape it already expects.
- `powerbi-to-sigma`'s `phase6-parity-pbi.rb` (the DAX/executeQueries adapter) needs **no change** — confirmed via grep it never calls `GET /v2/workbooks/.../spec`; its `expected` values come entirely from Power BI executeQueries + agent-supplied Sigma actuals. Documented in its sibling test's header comment.
- Data-model code-rep call sites (e.g. `scout-validate.py`'s `GET /v2/dataModels/.../spec`) are untouched, per the adapter's own scope — that surface did not change.

## Test plan
- [x] One regression test per touched script (5 Python `test_scout_validate_shape.py`, 5 Ruby `test_phase6_parity_shape.rb`) — all green.
- [x] Sabotage-verified: reverted the fix on two representative files (tableau `phase6-parity.rb`, qlik `scout-validate.py`) and confirmed their tests fail; restored and re-confirmed green (not vacuous tests).
- [x] `bash tools/check-plugin-version-bump.sh origin/main HEAD` — all 7 touched plugins pass (strict patch bump each).
- [x] Pre-commit hygiene sweep + shared-file governance check (676/676) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)