### PR TITLE
fix(tableau-to-sigma): wrap/unwrap workbook-spec document envelope in one-off scripts

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.6.21",
+  "version": "1.6.22",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-datasource-filters.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-datasource-filters.rb
@@ -33,6 +33,7 @@ require 'net/http'
 require 'uri'
 require 'optparse'
 require_relative 'lib/datasource_filter_check'
+require_relative 'lib/code_rep'
 
 opts = {}
 OptionParser.new do |p|
@@ -100,7 +101,7 @@ unless res.is_a?(Net::HTTPSuccess)
   puts "[SKIP] datasource-filter gate: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
   exit 0
 end
-spec =
+raw_spec =
   begin
     JSON.parse(res.body)
   rescue JSON::ParserError
@@ -108,6 +109,11 @@ spec =
     require 'date'
     YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
   end
+# Workbook code-rep GETs nest pages/elements under `document` (live since
+# 2026-08); DatasourceFilterCheck.violations expects a flat `spec['pages']`
+# (its contract stays "give me a plain document" per the shared lint-lib
+# decision — unwrap at the caller, not in the lib).
+spec = Sigma::CodeRep.document(raw_spec)
 
 filter_shelf = []
 pr = File.join(work, 'png-read.json')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/collect-parity-actuals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/collect-parity-actuals.rb
@@ -97,6 +97,7 @@ end.parse!
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'export_pool'
+require 'code_rep'
 
 # Default = ExportPool::DEFAULT_EXPORT_ROW_LIMIT, the ONE shared default with
 # verify-anchors.rb (A3, wave-1 review: rowLimit is part of the raw-export
@@ -149,6 +150,12 @@ if opts[:drift_warn_min].to_f.positive?
 end
 
 spec = JSON.parse(File.read(opts[:spec]))
+# The --workbook-spec readback file may be a pre-fix flat artifact OR (once the
+# writer is fixed) a live-shaped nested `document` readback — Sigma::CodeRep's
+# document()/metadata() both tolerate either, so flatten unconditionally rather
+# than assume the file's vintage. Without this, spec['pages'] silently reads []
+# on a nested file and every chart is (wrongly) reported "no matching element".
+spec = Sigma::CodeRep.metadata(spec).merge(Sigma::CodeRep.document(spec))
 elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
 el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/export-chart-png.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/export-chart-png.rb
@@ -30,6 +30,7 @@ require 'net/http'
 require 'uri'
 require 'fileutils'
 require 'optparse'
+require_relative 'lib/code_rep'
 
 opts = { width: 1400, height: 700 }
 OptionParser.new do |p|
@@ -67,6 +68,10 @@ spec = begin
 rescue JSON::ParserError
   YAML.safe_load(spec_resp.body, permitted_classes: [Date, Time])
 end
+# Workbook code-rep GETs nest pages under `document` (live since 2026-08) — a
+# bare spec['pages'] read here was always nil, so `elements` came back empty
+# and every run hit the "no matching elements" abort below.
+spec = Sigma::CodeRep.document(spec)
 elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
 targets = if opts[:element_ids]
             elements.select { |e| opts[:element_ids].include?(e['id']) }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
@@ -62,6 +62,7 @@
 
 require 'json'
 require_relative 'lib/cli_encoding'
+require_relative 'lib/code_rep'
 require 'optparse'
 
 # ---------------------------------------------------------------------------
@@ -478,6 +479,12 @@ when 'apply-patch'
             YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
           end
         end
+      # Workbook code-rep GETs nest pages/layout/schemaVersion under `document`
+      # (live since 2026-08); flatten metadata+document onto ONE hash so every
+      # live['pages']/merged['layout'] read below stays correct whether `live`
+      # came from a live nested GET or a legacy flat --live-spec fixture (the
+      # adapter's document()/metadata() both tolerate an already-flat input).
+      live = Sigma::CodeRep.metadata(live).merge(Sigma::CodeRep.document(live))
       die 'live spec has no `pages` — refusing to PUT a spec that would blank the workbook', 4 unless live['pages']
       FidelityLoop.deep_merge(live, patch)
     end
@@ -521,7 +528,11 @@ when 'apply-patch'
     require_relative 'lib/sigma_rest'
     layout_was = merged['layout'].to_s
     begin
-      Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: merged.to_json)
+      # Workbook code-rep PUTs require the nested `document` envelope
+      # (verified live 2026-08-03/04: a flat body 400s) — split the flat
+      # `merged` hash back into document fields + metadata and wrap.
+      put_body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(merged), extra: Sigma::CodeRep.metadata(merged))
+      Sigma.request(:put, "/v2/workbooks/#{wb}/spec", body: JSON.generate(put_body))
     rescue StandardError => e
       die "PUT /v2/workbooks/#{wb}/spec failed (atomic — nothing written): #{e.message}", 4
     end
@@ -555,6 +566,9 @@ when 'apply-patch'
         require 'yaml'; require 'date'
         YAML.safe_load(fresh, permitted_classes: [Date, Time]) || {}
       end
+    # Same nested-`document` unwrap as the live GET above — the post-patch
+    # lints below need flat `pages`/`layout`.
+    spec = Sigma::CodeRep.metadata(spec).merge(Sigma::CodeRep.document(spec))
     lint_fail = false
     begin
       require_relative 'lib/layout_lint'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -163,6 +163,7 @@ require_relative 'lib/offramp' # structured "where did this run leave the golden
 require_relative 'lib/fast_path' # FAST-PATH routing + BOM-tolerant JSON reads
 require_relative 'lib/phase_cache' # sha-stamped phase-output reuse on re-entry (refs/performance.md)
 require_relative 'lib/sigma_rest' # in-process Sigma token minting (no bash/eval)
+require_relative 'lib/code_rep' # workbook code-rep document-wrapper adapter (nested GET/PUT shape)
 require_relative 'lib/metric_binding' # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 require_relative 'lib/tableau_rest' # in-process Tableau token minting (Windows-safe; no bash/eval)
 require_relative 'hydrate-custom-sql'
@@ -4765,7 +4766,15 @@ if opts[:wb_target]
   existing = begin
     # accept: application/json ⇒ Sigma.request returns an ALREADY-PARSED Hash
     # (see lib/sigma_rest.rb) — do not JSON.parse again.
-    Sigma.request(:get, "/v2/workbooks/#{opts[:wb_target]}/spec", accept: 'application/json')
+    raw_existing = Sigma.request(:get, "/v2/workbooks/#{opts[:wb_target]}/spec", accept: 'application/json')
+    # Workbook code-rep GETs nest pages/schemaVersion under a top-level `document`
+    # key (live since 2026-08); flatten metadata+document onto ONE hash so the
+    # existing['pages']/existing_el_ids reads below (and the eventual PUT via
+    # post-and-readback --update-id, which re-wraps at the wire boundary) see the
+    # same flat shape this file always worked with. Without this, a bare
+    # existing['pages'] read is nil and the FATAL guard just below fires on
+    # EVERY --workbook-target append, even against a perfectly valid workbook.
+    Sigma::CodeRep.metadata(raw_existing).merge(Sigma::CodeRep.document(raw_existing))
   rescue StandardError => e
     abort "FATAL: could not GET existing workbook #{opts[:wb_target]} spec for append (#{e.class}: #{e.message}). " \
           'Verify the id and that the token can read it.'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-control-formula.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-control-formula.rb
@@ -36,6 +36,7 @@ require 'uri'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'probe_registry'
+require 'code_rep'
 
 def jget(path); Sigma.request(:get, path); end
 
@@ -99,8 +100,17 @@ scalar_types = %w[checkbox switch number text]
 entries.each do |w|
   wid = w['workbookId'] || w['id']
   next unless wid
-  spec = (Sigma.request(:get, "/v2/workbooks/#{wid}/spec", accept: 'application/json') rescue next)
-  next unless spec.is_a?(Hash) && spec['schemaVersion']
+  raw_spec = (Sigma.request(:get, "/v2/workbooks/#{wid}/spec", accept: 'application/json') rescue next)
+  next unless raw_spec.is_a?(Hash)
+  # Workbook code-rep GETs nest schemaVersion/pages under `document` (live
+  # since 2026-08) -- a bare spec['schemaVersion'] read here was always nil,
+  # so this guard fired on every workbook and the discovery loop never found
+  # a source (hard-abort below: "could not find a warehouse-table source").
+  # all_ctls/find_wh recurse through every hash value regardless of key name,
+  # so they already tolerate the nested shape unchanged -- only the
+  # schemaVersion check needed the unwrap.
+  spec = Sigma::CodeRep.metadata(raw_spec).merge(Sigma::CodeRep.document(raw_spec))
+  next unless spec['schemaVersion']
   schema_version ||= spec['schemaVersion']
   ctls = all_ctls(spec)
   scalar = ctls.find { |c| scalar_types.include?(c['controlType']) }
@@ -152,7 +162,10 @@ spec = {
   }],
 }
 
-resp = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec),
+# Workbook code-rep POSTs require the nested `document` envelope (verified
+# live 2026-08-03/04: a flat body 400s) -- wrap the throwaway probe spec.
+post_body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(spec), extra: Sigma::CodeRep.metadata(spec))
+resp = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(post_body),
                      content_type: 'application/json', accept: 'application/json')
 wb = resp['workbookId'] || resp['id']
 abort "CREATE failed: #{resp.inspect}" unless wb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-window-contexts.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-window-contexts.rb
@@ -36,6 +36,7 @@ require 'uri'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'probe_registry'
+require 'code_rep'
 
 DM_ID   = ENV['DM_ID']   || '11111111-2222-4333-8444-555555555555' # WINPROBE Base
 EL_ID   = ENV['EL_ID']   || 'p13miPuGpa'                           # "Orders Base"
@@ -102,7 +103,13 @@ def find_schema_version
   (jget('/v2/workbooks?limit=30')['entries'] || []).each do |w|
     wid = w['workbookId'] || w['id']; next unless wid
     s = (Sigma.request(:get, "/v2/workbooks/#{wid}/spec", accept: 'application/json') rescue next)
-    return s['schemaVersion'] if s.is_a?(Hash) && s['schemaVersion']
+    next unless s.is_a?(Hash)
+    # Workbook code-rep GETs nest schemaVersion/pages under `document` (live
+    # since 2026-08); a bare s['schemaVersion'] read here was always nil,
+    # silently falling back to the schemaVersion=1 default below instead of
+    # the org's real value.
+    doc = Sigma::CodeRep.document(s)
+    return doc['schemaVersion'] if doc['schemaVersion']
   end
   1
 end
@@ -160,7 +167,10 @@ ungrouped = {
 wb_spec = { 'name' => 'ZZ probe-window-contexts (throwaway)', 'folderId' => HOME, 'schemaVersion' => SV,
             'description' => 'window-function calc-column context probe',
             'pages' => [{ 'id' => 'pg', 'name' => 'Probe', 'elements' => [grouped, ungrouped] }] }
-wresp = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(wb_spec),
+# Workbook code-rep POSTs require the nested `document` envelope (verified
+# live 2026-08-03/04: a flat body 400s) -- wrap the throwaway probe spec.
+wb_post_body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(wb_spec), extra: Sigma::CodeRep.metadata(wb_spec))
+wresp = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(wb_post_body),
                       content_type: 'application/json', accept: 'application/json')
 wb = wresp['workbookId'] || wresp['id']
 abort "workbook CREATE failed: #{wresp.inspect}" unless wb
@@ -228,7 +238,11 @@ begin
                  { 'kind' => 'table', 'id' => 't', 'name' => 'DM passthrough',
                    'source' => { 'kind' => 'data-model', 'dataModelId' => dm2, 'elementId' => new_el['id'] },
                    'columns' => cols, 'order' => cols.map { |c| c['id'] } }] }] }
-  w2resp = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(wb2_spec),
+  # Same workbook `document` wrap as the first probe-workbook POST above; the
+  # `dm_spec` POST just above (/v2/dataModels/spec) stays flat -- DM surface
+  # is confirmed unchanged.
+  wb2_post_body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(wb2_spec), extra: Sigma::CodeRep.metadata(wb2_spec))
+  w2resp = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(wb2_post_body),
                          content_type: 'application/json', accept: 'application/json')
   wb2 = w2resp['workbookId'] || w2resp['id']
   raise "DM-WB CREATE failed: #{w2resp.inspect}" unless wb2

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-customer-style.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-customer-style.rb
@@ -30,6 +30,7 @@ require 'net/http'
 require 'uri'
 require 'fileutils'
 require 'optparse'
+require_relative 'lib/code_rep'
 
 opts = { sample: 20, sort: 'updatedAt:desc', keep_raw: false }
 OptionParser.new do |p|
@@ -137,6 +138,10 @@ wb_ids.each_with_index do |wb_id, i|
   rescue JSON::ParserError
     YAML.safe_load(resp.body, permitted_classes: [Date, Time])
   end
+  # Workbook code-rep GETs nest schemaVersion/pages under `document` (live
+  # since 2026-08) — bare spec['schemaVersion']/spec['pages'] reads here were
+  # always nil/empty, so every workbook silently scanned as 0 pages/elements.
+  spec = Sigma::CodeRep.metadata(spec).merge(Sigma::CodeRep.document(spec))
   File.write(File.join(opts[:out_dir], 'raw-specs', "#{wb_id}.yaml"), spec.to_yaml) if opts[:keep_raw]
 
   profile['sample_size'] += 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-assert-datasource-filters.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-assert-datasource-filters.rb
@@ -1,0 +1,100 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-assert-datasource-filters.rb — regression test for the workbook
+# code-rep `document` unwrap in scripts/assert-datasource-filters.rb (#483).
+#
+# The gate GETs the live workbook spec and calls DatasourceFilterCheck.
+# violations(spec:) to see whether an always-on data-source filter was
+# actually applied. Workbook code-rep GETs nest `pages` under a top-level
+# `document` key (live since 2026-08). DatasourceFilterCheck.all_elements
+# falls back to `spec['elements']` when `spec['pages']` isn't an Array — so
+# an un-unwrapped nested response silently reads as ZERO elements, and a
+# data-source filter that WAS correctly applied as a master default filter
+# gets reported as a FALSE violation (gate FAILs, exit 1) on every run.
+#
+# use_ssl on this script derives from the URI scheme (`uri.scheme == 'https'`
+# at line ~99), so — unlike export-chart-png.rb / scan-customer-style.rb,
+# which hardcode use_ssl:true — a plain http:// loopback WEBrick server works
+# directly (same convention as test-put-layout-auth.rb).
+#
+# Run: ruby scripts/test-assert-datasource-filters.rb
+require 'webrick'
+require 'json'
+require 'tmpdir'
+require 'open3'
+
+SCRIPT = File.expand_path('assert-datasource-filters.rb', __dir__)
+
+# The LIVE (nested) readback: the data-source filter (an always-on
+# `Company Active` flag) IS correctly applied as a master default filter —
+# so a correct unwrap must find it and PASS (exit 0). Pre-fix, the bare
+# spec['pages'] read is nil, all_elements() returns [], and the gate reports
+# a false FAIL.
+LIVE_SPEC = {
+  'workbookId' => 'wb-test',
+  'document' => {
+    'schemaVersion' => 3,
+    'pages' => [{
+      'id' => 'p1',
+      'elements' => [
+        { 'id' => 'master', 'kind' => 'table',
+          'columns' => [{ 'id' => 'm-active', 'name' => 'Company Active' }],
+          'filters' => [{ 'columnId' => 'm-active', 'kind' => 'list', 'mode' => 'include', 'values' => ['true'] }] }
+      ]
+    }]
+  }
+}.freeze
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+def run_gate(script, dir, port)
+  Open3.capture3(
+    { 'SIGMA_BASE_URL' => "http://127.0.0.1:#{port}", 'SIGMA_API_TOKEN' => 'stub-token' },
+    'ruby', script, '--workdir', dir, '--workbook-id', 'wb-test'
+  )
+end
+
+puts '== assert-datasource-filters: nested live GET must not false-FAIL an applied filter =='
+Dir.mktmpdir do |dir|
+  File.write(File.join(dir, 'dashboard-layout-meta.json'), JSON.generate(
+    'datasource_filters' => [
+      { 'column_caption' => 'Company Active', 'is_datasource_filter' => true,
+        'is_active_flag' => true, 'members' => ['true'] }
+    ]
+  ))
+
+  srv = WEBrick::HTTPServer.new(Port: 0, BindAddress: '127.0.0.1',
+                                 Logger: WEBrick::Log.new(File::NULL), AccessLog: [])
+  port = srv.config[:Port]
+  srv.mount_proc('/v2/workbooks/wb-test/spec') do |req, res|
+    check(req.request_method == 'GET', 'gate issues a GET for the spec', fails)
+    res.body = JSON.generate(LIVE_SPEC)
+    res['Content-Type'] = 'application/json'
+    res.status = 200
+  end
+  th = Thread.new { srv.start }
+
+  out, err, st = run_gate(SCRIPT, dir, port)
+  srv.shutdown
+  th.join
+
+  check(st.exitstatus.zero?,
+        "gate exits 0 on a correctly-applied filter seen through a nested `document` readback (exit #{st.exitstatus}; out=#{out.inspect} err=#{err.inspect})",
+        fails)
+  check(out.include?('[OK]') && out.include?('applied'),
+        "gate reports [OK] (got stdout: #{out.inspect})", fails)
+  check(!out.include?('[FAIL]'), 'gate does NOT report a false [FAIL]', fails)
+end
+
+puts
+if fails.empty?
+  puts 'test-assert-datasource-filters: ALL PASS'
+else
+  puts "test-assert-datasource-filters: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-batch-validate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-batch-validate.rb
@@ -52,8 +52,14 @@ STUB = <<~'RUBY'
                                                 'columns' => [{ 'name' => 'Net Revenue', 'formula' => '[T/Net Revenue]' }] }] }] }
       end
       if method == :post && path == '/v2/workbooks/spec'
-        spec = JSON.parse(body)
-        test = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }.find { |e| e['id'] == 'el-scout-test' }
+        posted = JSON.parse(body)
+        # Workbook code-rep POSTs nest pages under a top-level `document` key
+        # (live since 2026-08) — validate-sigma-formula.rb now wraps its probe
+        # spec before POSTing, so the pages this stub inspects live at
+        # posted['document']['pages'], not posted['pages'].
+        raise Error, 'stub: probe POST body is not `document`-wrapped' unless posted.is_a?(Hash) && posted['document'].is_a?(Hash)
+        doc = posted['document']
+        test = (doc['pages'] || []).flat_map { |p| p['elements'] || [] }.find { |e| e['id'] == 'el-scout-test' }
         File.write(ENV['STUB_STATE'], JSON.generate((test && test['columns']) || []))
         return { 'workbookId' => 'wb-probe-1' }
       end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-collect-parity-actuals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-collect-parity-actuals.rb
@@ -1,0 +1,137 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-collect-parity-actuals.rb — regression test for the workbook code-rep
+# `document` unwrap in scripts/collect-parity-actuals.rb.
+#
+# Unlike the other one-offs, the fix here operates on the `--workbook-spec`
+# FILE (a saved readback JSON, not a live GET): `spec = JSON.parse(File.read
+# (opts[:spec]))` may now be a live-shaped nested `document` readback rather
+# than the legacy flat artifact. A bare `spec['pages']` read there was always
+# empty, so `el_by_id` came back empty and every chart in the plan was
+# (wrongly) reported "element not in workbook spec" instead of being
+# collected.
+#
+# No live version-probe GET is exercised here: the fixture spec carries no
+# `latestDocumentVersion`/`latestVersion`, so `ExportPool.resolve_doc_version`
+# returns nil and `build_export_cache` short-circuits before any network call
+# (see collect-parity-actuals.rb's own comment on that path) — the ONLY
+# network this test needs to stub is the pooled CSV export
+# (POST .../export, GET /v2/query/:id/download), via the same `sigma_rest.rb`
+# load-path-shadow convention as test-probe-control-formula.rb /
+# test-probe-window-contexts.rb.
+#
+# Run: ruby scripts/test-collect-parity-actuals.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPT = File.join(__dir__, 'collect-parity-actuals.rb')
+REAL_SIGMA_REST = File.expand_path('lib/sigma_rest.rb', __dir__)
+
+# A --workbook-spec readback shaped like the LIVE (nested) response: metadata
+# (workbookId) sits alongside `document`, which carries schemaVersion/pages.
+# No latestDocumentVersion/latestVersion anywhere — the raw-export cache
+# build must short-circuit on that (nil rb_ver) rather than attempt a live
+# version-probe GET.
+NESTED_WB_SPEC = {
+  'workbookId' => 'wb-test',
+  'document' => {
+    'schemaVersion' => 4,
+    'pages' => [{
+      'id' => 'p1',
+      'elements' => [
+        { 'id' => 'c1', 'kind' => 'bar-chart', 'name' => 'Revenue by Region',
+          'columns' => [{ 'id' => 'col-region', 'name' => 'Region' }] }
+      ]
+    }]
+  }
+}.freeze
+
+PLAN = { 'charts' => [
+  { 'chart' => 'Revenue by Region', 'sigma_element_id' => 'c1', 'sigma_kind' => 'bar-chart',
+    'sigma_columns' => ['col-region'] }
+] }.freeze
+
+SIGMA_STUB = <<~RUBY
+  require 'json'
+  module Sigma
+    class Error < StandardError; end
+    def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
+      if ENV['SIGMA_STUB_LOG']
+        File.open(ENV['SIGMA_STUB_LOG'], 'a') { |f| f.puts JSON.generate('method' => method.to_s, 'path' => path, 'body' => body) }
+      end
+      case
+      when method == :post && path == '/v2/workbooks/wb-test/export'
+        { 'queryId' => 'q1' }
+      when method == :get && path == '/v2/query/q1/download'
+        "Region\\nWest\\n"
+      else
+        raise Error, "stub: unexpected \#{method} \#{path}"
+      end
+    end
+    def self.base_url; 'https://stub.invalid'; end
+    def self.auth_token; 'stub-token'; end
+  end
+  real = ENV['REAL_SIGMA_REST']
+  $LOADED_FEATURES << real if real && !$LOADED_FEATURES.include?(real)
+RUBY
+
+def run_collect(dir, extra_env = {})
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir) unless Dir.exist?(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), SIGMA_STUB)
+
+  spec_path = File.join(dir, 'wb-readback.json')
+  plan_path = File.join(dir, 'parity-plan.json')
+  out_path  = File.join(dir, 'parity-actuals.json')
+  File.write(spec_path, JSON.generate(NESTED_WB_SPEC))
+  File.write(plan_path, JSON.generate(PLAN))
+
+  out, err, st = Open3.capture3(
+    { 'REAL_SIGMA_REST' => REAL_SIGMA_REST, 'SIGMA_BASE_URL' => 'https://stub.invalid',
+      'SIGMA_API_TOKEN' => 'stub-token' }.merge(extra_env),
+    RbConfig.ruby, '-I', stub_dir, '-r', 'sigma_rest', SCRIPT,
+    '--plan', plan_path, '--workbook-id', 'wb-test', '--workbook-spec', spec_path,
+    '--out', out_path, '--pool', '1', '--timeout', '30', '--drift-warn-minutes', '0'
+  )
+  [out, err, st, out_path]
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '== collect-parity-actuals: nested --workbook-spec file must resolve the chart element =='
+Dir.mktmpdir do |dir|
+  log = File.join(dir, 'stub.log')
+  out, err, st, out_path = run_collect(dir, { 'SIGMA_STUB_LOG' => log })
+
+  check(st.exitstatus.zero?, "exits 0 (got #{st.exitstatus}; out=#{out.inspect} err=#{err.inspect})", fails)
+  check(out.include?('1/1 chart(s) collected'),
+        "reports 1/1 charts collected, not 0/1 (got: #{out.inspect})", fails)
+  check(!out.include?('NOT COLLECTED'),
+        "does NOT report 'element not in workbook spec' (nested pages must resolve) (got: #{out.inspect})", fails)
+
+  check(File.exist?(out_path), 'parity-actuals.json written', fails)
+  if File.exist?(out_path)
+    actuals = JSON.parse(File.read(out_path))
+    check(actuals['Revenue by Region'] == [['West']],
+          "actuals carry the exported row (got #{actuals.inspect})", fails)
+  end
+
+  reqs = File.exist?(log) ? File.readlines(log).map { |l| JSON.parse(l) } : []
+  check(reqs.any? { |r| r['method'] == 'post' && r['path'] == '/v2/workbooks/wb-test/export' },
+        'export POST issued for the resolved element (proves el_by_id found c1)', fails)
+end
+
+puts
+if fails.empty?
+  puts 'test-collect-parity-actuals: ALL PASS'
+else
+  puts "test-collect-parity-actuals: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-export-chart-png.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-export-chart-png.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-export-chart-png.rb — regression test for the workbook code-rep
+# `document` unwrap in scripts/export-chart-png.rb.
+#
+# export-chart-png.rb GETs the live workbook spec to discover chart-shaped
+# elements to screenshot. Workbook code-rep GETs nest `pages` under a
+# top-level `document` key (live since 2026-08); a bare `spec['pages']` read
+# there is always nil, so `elements` comes back empty and the script hard-
+# aborts with "no matching elements" before ever reaching the export/PNG
+# flow.
+#
+# This script hardcodes `use_ssl: true` in its own `http` helper (unlike
+# assert-datasource-filters.rb, which derives use_ssl from the URI scheme), so
+# a plain http:// loopback WEBrick server can't be used without a TLS cert
+# dance. Instead we shadow the stdlib `net/http` via a `-I <stub>` load-path
+# shim — same "shadow the require, mark the real file already-loaded" trick
+# test-probe-control-formula.rb / test-probe-window-contexts.rb use for
+# `sigma_rest.rb`, applied here to `net/http` (this script never requires
+# `sigma_rest`, so `net/http` is the only network seam to intercept). No real
+# network, no TLS.
+#
+# Run: ruby scripts/test-export-chart-png.rb
+require 'json'
+require 'base64'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPT = File.join(__dir__, 'export-chart-png.rb')
+
+# The live (nested) workbook readback: one bar-chart element to screenshot,
+# plus a control element that must NOT be selected (not chart-shaped).
+NESTED_SPEC = {
+  'workbookId' => 'wb-test',
+  'document' => {
+    'schemaVersion' => 4,
+    'pages' => [{
+      'id' => 'p1',
+      'elements' => [
+        { 'id' => 'c1', 'kind' => 'bar-chart', 'name' => 'Revenue by Region' },
+        { 'id' => 'ctl1', 'kind' => 'control', 'controlType' => 'text' }
+      ]
+    }]
+  }
+}.freeze
+
+PNG_BYTES = ("\x89PNG\r\n\x1A\n".b + ('x' * 2000).b).freeze
+
+NET_HTTP_STUB = <<~RUBY
+  require 'json'
+  require 'base64'
+  module Net
+    class HTTPStubResp
+      attr_reader :code, :body
+      def initialize(code, body); @code = code.to_s; @body = body; end
+    end
+    class HTTPStubReq
+      attr_reader :uri
+      attr_accessor :body
+      def initialize(uri); @uri = uri; @headers = {}; end
+      def []=(k, v); @headers[k.to_s] = v; end
+      def [](k); @headers[k.to_s]; end
+    end
+    class HTTPGetStub < HTTPStubReq; def verb; 'GET'; end; end
+    class HTTPPostStub < HTTPStubReq; def verb; 'POST'; end; end
+    NESTED_SPEC = #{NESTED_SPEC.to_json}
+    PNG_B64 = #{Base64.strict_encode64(PNG_BYTES).inspect}
+    class HTTP
+      Get = HTTPGetStub
+      Post = HTTPPostStub
+      def self.start(_host, _port, **_opts)
+        yield new
+      end
+      def request(req)
+        if ENV['NET_HTTP_STUB_LOG']
+          File.open(ENV['NET_HTTP_STUB_LOG'], 'a') do |f|
+            f.puts JSON.generate('verb' => req.verb, 'path' => req.uri.request_uri, 'body' => req.body)
+          end
+        end
+        path = req.uri.request_uri
+        case
+        when req.verb == 'GET' && path == '/v2/workbooks/wb-test/spec'
+          HTTPStubResp.new(200, JSON.generate(NESTED_SPEC))
+        when req.verb == 'POST' && path == '/v2/workbooks/wb-test/export'
+          HTTPStubResp.new(200, JSON.generate('queryId' => 'q1'))
+        when req.verb == 'GET' && path == '/v2/query/q1/download'
+          HTTPStubResp.new(200, Base64.decode64(PNG_B64))
+        else
+          HTTPStubResp.new(404, 'not found')
+        end
+      end
+    end
+  end
+RUBY
+
+def run_export(dir, extra_env = {})
+  stub_dir = File.join(dir, 'stub', 'net')
+  require 'fileutils'
+  FileUtils.mkdir_p(stub_dir)
+  File.write(File.join(stub_dir, 'http.rb'), NET_HTTP_STUB)
+  out_dir = File.join(dir, 'out')
+  Open3.capture3(
+    { 'SIGMA_BASE_URL' => 'https://stub.invalid', 'SIGMA_API_TOKEN' => 'stub-token' }.merge(extra_env),
+    RbConfig.ruby, '-I', File.join(dir, 'stub'), SCRIPT,
+    '--workbook', 'wb-test', '--out-dir', out_dir
+  )
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '== export-chart-png: nested spec GET must not abort "no matching elements" =='
+Dir.mktmpdir do |dir|
+  log = File.join(dir, 'stub.log')
+  out, err, st = run_export(dir, { 'NET_HTTP_STUB_LOG' => log })
+
+  check(!err.include?('no matching elements'),
+        "does NOT hard-abort with 'no matching elements' (err=#{err.inspect})", fails)
+  check(st.exitstatus.zero?, "exits 0 (got #{st.exitstatus}; out=#{out.inspect} err=#{err.inspect})", fails)
+  check(err.include?('1/1 ok'), "reports 1/1 screenshots ok (got stderr: #{err.inspect})", fails)
+
+  manifest_path = File.join(dir, 'out', '_manifest.json')
+  check(File.exist?(manifest_path), 'manifest.json written', fails)
+  if File.exist?(manifest_path)
+    manifest = JSON.parse(File.read(manifest_path))
+    check(manifest.key?('c1'), "manifest carries the chart element c1 (got keys: #{manifest.keys.inspect})", fails)
+    check(manifest['c1'] && manifest['c1']['status'] == 'ok',
+          "c1 status ok (got #{manifest['c1'] && manifest['c1']['status']})", fails)
+    check(!manifest.key?('ctl1'), 'control element ctl1 NOT screenshotted (not chart-shaped)', fails)
+  end
+
+  reqs = File.exist?(log) ? File.readlines(log).map { |l| JSON.parse(l) } : []
+  check(reqs.any? { |r| r['verb'] == 'GET' && r['path'] == '/v2/workbooks/wb-test/spec' },
+        'spec GET issued', fails)
+  check(reqs.any? { |r| r['verb'] == 'POST' && r['path'] == '/v2/workbooks/wb-test/export' },
+        'export POST issued for the discovered chart', fails)
+end
+
+puts
+if fails.empty?
+  puts 'test-export-chart-png: ALL PASS'
+else
+  puts "test-export-chart-png: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-loop.rb
@@ -130,6 +130,32 @@ Dir.mktmpdir do |dir|
               '--dry-run', '--live-spec', File.join(dir, 'nopages.json'),
               '--out', File.join(dir, 'x.json'), dir: dir)
   ok(st.exitstatus == 4, 'apply-patch refuses a live spec with no pages (exit 4)')
+
+  # Workbook code-rep GETs nest pages/layout/schemaVersion under `document`
+  # (live since 2026-08). A --live-spec fixture shaped like the LIVE response
+  # (workbookId/name at top level, pages/layout nested) must merge correctly
+  # instead of tripping the "no `pages`" guard (exit 4) on a workbook that
+  # actually has pages.
+  nested_live = {
+    'workbookId' => 'wb1', 'name' => 'Exec Overview',
+    'document' => {
+      'schemaVersion' => 5,
+      'pages' => [{ 'id' => 'PG', 'elements' => [{ 'elementId' => 'k1', 'kind' => 'kpi-chart' }] }],
+      'layout' => '<Page><LayoutElement/></Page>'
+    }
+  }
+  File.write(File.join(dir, 'nested-live.json'), JSON.generate(nested_live))
+  out, st = run('apply-patch', '--patch', File.join(dir, 'patch.json'),
+                '--dry-run', '--live-spec', File.join(dir, 'nested-live.json'),
+                '--out', File.join(dir, 'nested-merged.json'), dir: dir)
+  ok(st.exitstatus.zero?, 'apply-patch on a nested-document --live-spec exits 0 (not exit 4)')
+  nested_merged = (JSON.parse(File.read(File.join(dir, 'nested-merged.json'))) rescue nil)
+  ok(nested_merged.is_a?(Hash) && nested_merged['pages'].is_a?(Array) && nested_merged['pages'].length == 1,
+     'nested `document.pages` recovered onto the flat merged spec')
+  ok(nested_merged && nested_merged['layout'] == nested_live['document']['layout'],
+     'nested `document.layout` preserved through the merge')
+  ok(nested_merged && nested_merged['themeOverrides']['categoricalScheme'] == ['#0e7c7b'],
+     'patch still applies on top of a flattened nested live spec')
 end
 
 puts 'RCF page picking (#422):'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-control-formula.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-control-formula.rb
@@ -1,0 +1,135 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-probe-control-formula.rb — regression test for the workbook code-rep
+# `document` unwrap/wrap in scripts/probe-control-formula.rb.
+#
+# probe-control-formula.rb borrows a schemaVersion + control + warehouse-table
+# source from a real workbook in the org (GET .../spec), then POSTs a
+# throwaway probe workbook built from those borrowed pieces. Workbook code-rep
+# GETs nest `schemaVersion`/`pages` under a top-level `document` key (live
+# since 2026-08); a bare `spec['schemaVersion']` read on that response is
+# always nil, so the discovery loop's `next unless spec['schemaVersion']`
+# guard fires on EVERY workbook it looks at and the script hard-aborts with
+# "could not find a warehouse-table source in any workbook" before it ever
+# reaches the probe-workbook POST.
+#
+# Same offline seam convention as test-probe-join-keys.rb: stub sigma_rest.rb,
+# run the real script via `ruby -I <stub> -r sigma_rest`, no live network.
+#
+# Run: ruby scripts/test-probe-control-formula.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPT = File.join(__dir__, 'probe-control-formula.rb')
+REAL_SIGMA_REST = File.expand_path('lib/sigma_rest.rb', __dir__)
+
+# The discovery-source workbook's LIVE (nested) readback: schemaVersion/pages
+# live under `document`; workbookId is metadata alongside it.
+DISCOVERY_SPEC = {
+  'workbookId' => 'wb-src',
+  'document' => {
+    'schemaVersion' => 3,
+    'pages' => [{
+      'id' => 'p1',
+      'elements' => [
+        { 'id' => 'src-tbl', 'kind' => 'table',
+          'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'conn-1', 'path' => %w[DB SCHEMA T] } },
+        { 'id' => 'src-ctl', 'kind' => 'control', 'controlType' => 'text', 'controlId' => 'SrcCtl' }
+      ]
+    }]
+  }
+}.freeze
+
+SIGMA_STUB = <<~RUBY
+  require 'json'
+  module Sigma
+    class Error < StandardError; end
+    DISCOVERY_SPEC = #{DISCOVERY_SPEC.to_json}
+    def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
+      if ENV['SIGMA_STUB_LOG']
+        File.open(ENV['SIGMA_STUB_LOG'], 'a') { |f| f.puts JSON.generate('method' => method.to_s, 'path' => path, 'body' => body) }
+      end
+      case
+      when method == :get && path == '/v2/whoami'
+        { 'userId' => 'u1' }
+      when method == :get && path == '/v2/members/u1'
+        { 'homeFolderId' => 'home-1' }
+      when method == :get && path.start_with?('/v2/workbooks?')
+        { 'entries' => [{ 'workbookId' => 'wb-src' }] }
+      when method == :get && path == '/v2/workbooks/wb-src/spec'
+        JSON.parse(JSON.generate(DISCOVERY_SPEC))
+      when method == :post && path == '/v2/workbooks/spec'
+        { 'workbookId' => 'wb-new' }
+      when method == :post && path.include?('/export')
+        { 'queryId' => 'q1' }
+      when method == :delete
+        nil
+      else
+        raise Error, "stub: unexpected \#{method} \#{path}"
+      end
+    end
+    def self.base_url; 'https://stub.invalid'; end
+    def self.auth_token; 'stub-token'; end
+  end
+  real = ENV['REAL_SIGMA_REST']
+  $LOADED_FEATURES << real if real && !$LOADED_FEATURES.include?(real)
+RUBY
+
+def run_probe(dir, extra_env = {})
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir) unless Dir.exist?(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), SIGMA_STUB)
+  Open3.capture3(
+    { 'REAL_SIGMA_REST' => REAL_SIGMA_REST, 'SIGMA_BASE_URL' => 'https://stub.invalid',
+      'SIGMA_API_TOKEN' => 'stub', 'TABLEAU_TO_SIGMA_HOME' => dir, 'KEEP' => '0' }.merge(extra_env),
+    RbConfig.ruby, '-I', stub_dir, '-r', 'sigma_rest', SCRIPT)
+end
+
+def spec_posts(log)
+  return [] unless File.exist?(log)
+  File.readlines(log).map { |l| JSON.parse(l) }
+      .select { |r| r['method'] == 'post' && r['path'] == '/v2/workbooks/spec' }
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '== probe-control-formula: nested discovery GET must not abort the run =='
+Dir.mktmpdir do |dir|
+  log = File.join(dir, 'stub.log')
+  out, err, _st = run_probe(dir, { 'SIGMA_STUB_LOG' => log })
+  check(!err.include?('could not find a warehouse-table source'),
+        'discovery loop does NOT hard-abort on the nested-document readback', fails)
+  check(out.include?('created throwaway workbook wb-new'),
+        'probe reaches workbook creation (schemaVersion + source + control all recovered)', fails)
+
+  posts = spec_posts(log)
+  check(posts.size == 1, "exactly one probe-workbook POST captured (got #{posts.size})", fails)
+  if posts.size == 1
+    body = JSON.parse(posts.first['body'])
+    check(body.key?('document') && body['document'].is_a?(Hash),
+          'probe-workbook POST body carries a top-level `document` key', fails)
+    check(!body.key?('pages') && !body.key?('schemaVersion'),
+          'probe-workbook POST body has NO top-level pages/schemaVersion (must be nested)', fails)
+    check(body['document']['schemaVersion'] == 3,
+          "wrapped document carries the borrowed schemaVersion=3 (got #{body['document']['schemaVersion'].inspect})", fails)
+    check(body['document']['pages'].is_a?(Array) && !body['document']['pages'].empty?,
+          'wrapped document carries pages', fails)
+    check(body['name'] && body['folderId'] == 'home-1',
+          'name/folderId stay OUTSIDE document as metadata', fails)
+  end
+end
+
+puts
+if fails.empty?
+  puts 'test-probe-control-formula: ALL PASS'
+else
+  puts "test-probe-control-formula: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-window-contexts.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-window-contexts.rb
@@ -1,0 +1,129 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-probe-window-contexts.rb — regression test for the workbook code-rep
+# `document` unwrap/wrap in scripts/probe-window-contexts.rb.
+#
+# find_schema_version borrows a schemaVersion from a real workbook (GET
+# .../spec). Workbook code-rep GETs nest `schemaVersion` under a top-level
+# `document` key (live since 2026-08); a bare `s['schemaVersion']` read there
+# is always nil, so the probe silently falls back to the schemaVersion
+# default of 1 instead of the org's real value. The two throwaway
+# probe-workbook POSTs (`wb_spec`, `wb2_spec`) also need the `document` wrap
+# — the data-model POST (`dm_spec`) in the same file is explicitly NOT
+# touched (DM surface unchanged).
+#
+# Same offline seam convention as test-probe-join-keys.rb: stub sigma_rest.rb,
+# run the real script via `ruby -I <stub> -r sigma_rest`, no live network.
+# The DM-element context (context 3) is left to fail gracefully inside its own
+# `rescue StandardError` (it needs a working dataModels stub this test does
+# not provide) -- irrelevant to the wrapper fix under test, which concerns
+# only the two workbook POSTs and the schemaVersion discovery GET.
+#
+# Run: ruby scripts/test-probe-window-contexts.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPT = File.join(__dir__, 'probe-window-contexts.rb')
+REAL_SIGMA_REST = File.expand_path('lib/sigma_rest.rb', __dir__)
+
+DISCOVERY_SPEC = {
+  'workbookId' => 'wb-src',
+  'document' => { 'schemaVersion' => 7, 'pages' => [{ 'id' => 'p1', 'elements' => [] }] }
+}.freeze
+
+SIGMA_STUB = <<~RUBY
+  require 'json'
+  module Sigma
+    class Error < StandardError; end
+    DISCOVERY_SPEC = #{DISCOVERY_SPEC.to_json}
+    def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
+      if ENV['SIGMA_STUB_LOG']
+        File.open(ENV['SIGMA_STUB_LOG'], 'a') { |f| f.puts JSON.generate('method' => method.to_s, 'path' => path, 'body' => body) }
+      end
+      case
+      when method == :get && path == '/v2/whoami'
+        { 'userId' => 'u1' }
+      when method == :get && path == '/v2/members/u1'
+        { 'homeFolderId' => 'home-1' }
+      when method == :get && path.start_with?('/v2/workbooks?')
+        { 'entries' => [{ 'workbookId' => 'wb-src' }] }
+      when method == :get && path == '/v2/workbooks/wb-src/spec'
+        JSON.parse(JSON.generate(DISCOVERY_SPEC))
+      when method == :post && path == '/v2/workbooks/spec'
+        @wb_posts ||= 0
+        @wb_posts += 1
+        { 'workbookId' => "wb-new-\#{@wb_posts}" }
+      when method == :get && path.start_with?('/v2/dataModels/')
+        raise Error, 'GET /v2/dataModels/x/spec -> 404 stub-not-implemented'
+      when method == :post && path.include?('/export')
+        { 'queryId' => 'q1' }
+      when method == :delete
+        nil
+      else
+        raise Error, "stub: unexpected \#{method} \#{path}"
+      end
+    end
+    def self.base_url; 'https://stub.invalid'; end
+    def self.auth_token; 'stub-token'; end
+  end
+  real = ENV['REAL_SIGMA_REST']
+  $LOADED_FEATURES << real if real && !$LOADED_FEATURES.include?(real)
+RUBY
+
+def run_probe(dir, extra_env = {})
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir) unless Dir.exist?(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), SIGMA_STUB)
+  Open3.capture3(
+    { 'REAL_SIGMA_REST' => REAL_SIGMA_REST, 'SIGMA_BASE_URL' => 'https://stub.invalid',
+      'SIGMA_API_TOKEN' => 'stub', 'TABLEAU_TO_SIGMA_HOME' => dir, 'KEEP' => '0' }.merge(extra_env),
+    RbConfig.ruby, '-I', stub_dir, '-r', 'sigma_rest', SCRIPT)
+end
+
+def wb_posts(log)
+  return [] unless File.exist?(log)
+  File.readlines(log).map { |l| JSON.parse(l) }
+      .select { |r| r['method'] == 'post' && r['path'] == '/v2/workbooks/spec' }
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '== probe-window-contexts: nested discovery GET must recover the real schemaVersion =='
+Dir.mktmpdir do |dir|
+  log = File.join(dir, 'stub.log')
+  out, _err, _st = run_probe(dir, { 'SIGMA_STUB_LOG' => log })
+  check(out.include?('schemaVersion=7'),
+        "discovery recovers the borrowed schemaVersion=7 from the nested document (got: #{out.lines.first})", fails)
+
+  posts = wb_posts(log)
+  check(posts.size == 1, "exactly one workbook POST captured (the DM-element context 3 stub 404s before its own workbook POST; got #{posts.size})", fails)
+  if posts.size >= 1
+    body = JSON.parse(posts.first['body'])
+    check(body.key?('document') && body['document'].is_a?(Hash),
+          'probe-workbook POST body carries a top-level `document` key', fails)
+    check(!body.key?('pages') && !body.key?('schemaVersion'),
+          'probe-workbook POST body has NO top-level pages/schemaVersion (must be nested)', fails)
+    doc = body['document'].is_a?(Hash) ? body['document'] : {}
+    check(doc['schemaVersion'] == 7,
+          "wrapped document carries the borrowed schemaVersion=7 (got #{doc['schemaVersion'].inspect})", fails)
+    check(doc['pages'].is_a?(Array) && !doc['pages'].empty?,
+          'wrapped document carries pages (grouped + ungrouped table elements)', fails)
+    check(body['name'] && body['folderId'] == 'home-1',
+          'name/folderId stay OUTSIDE document as metadata', fails)
+  end
+end
+
+puts
+if fails.empty?
+  puts 'test-probe-window-contexts: ALL PASS'
+else
+  puts "test-probe-window-contexts: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-scan-customer-style.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-scan-customer-style.rb
@@ -1,0 +1,133 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-scan-customer-style.rb — regression test for the workbook code-rep
+# `document` unwrap in scripts/scan-customer-style.rb.
+#
+# scan-customer-style.rb GETs each sampled workbook's spec and aggregates
+# style choices (chart kinds, palettes, pages/elements-per-page, etc). Workbook
+# code-rep GETs nest `schemaVersion`/`pages` under a top-level `document` key
+# (live since 2026-08); bare `spec['schemaVersion']`/`spec['pages']` reads
+# there were always nil/empty, so every workbook silently scanned as 0 pages
+# and 0 elements — the profile came back structurally empty on every run.
+#
+# This script hardcodes `use_ssl: true` in its own `http_get` helper, so (same
+# as test-export-chart-png.rb) we shadow the stdlib `net/http` via a
+# `-I <stub>` load-path shim instead of a plain-http loopback server. No real
+# network, no TLS.
+#
+# Run: ruby scripts/test-scan-customer-style.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+require 'fileutils'
+
+SCRIPT = File.join(__dir__, 'scan-customer-style.rb')
+
+NESTED_SPEC = {
+  'workbookId' => 'wb-test',
+  'document' => {
+    'schemaVersion' => 4,
+    'pages' => [{
+      'id' => 'p1',
+      'elements' => [
+        { 'id' => 'c1', 'kind' => 'bar-chart', 'name' => 'Revenue by Region',
+          'color' => { 'by' => 'series', 'scheme' => ['#0e7c7b', '#f4a261'] } },
+        { 'id' => 'ctl1', 'kind' => 'control', 'controlType' => 'text' }
+      ]
+    }]
+  }
+}.freeze
+
+NET_HTTP_STUB = <<~RUBY
+  require 'json'
+  module Net
+    class HTTPStubResp
+      attr_reader :code, :body
+      def initialize(code, body); @code = code.to_s; @body = body; end
+    end
+    class HTTPStubReq
+      attr_reader :uri
+      attr_accessor :body
+      def initialize(uri); @uri = uri; @headers = {}; end
+      def []=(k, v); @headers[k.to_s] = v; end
+      def [](k); @headers[k.to_s]; end
+    end
+    class HTTPGetStub < HTTPStubReq; def verb; 'GET'; end; end
+    NESTED_SPEC = #{NESTED_SPEC.to_json}
+    class HTTP
+      Get = HTTPGetStub
+      def self.start(_host, _port, **_opts)
+        yield new
+      end
+      def request(req)
+        if ENV['NET_HTTP_STUB_LOG']
+          File.open(ENV['NET_HTTP_STUB_LOG'], 'a') do |f|
+            f.puts JSON.generate('verb' => req.verb, 'path' => req.uri.request_uri)
+          end
+        end
+        path = req.uri.request_uri
+        case
+        when req.verb == 'GET' && path == '/v2/workbooks/wb-test/spec'
+          HTTPStubResp.new(200, JSON.generate(NESTED_SPEC))
+        else
+          HTTPStubResp.new(404, 'not found')
+        end
+      end
+    end
+  end
+RUBY
+
+def run_scan(dir, out_dir, extra_env = {})
+  stub_dir = File.join(dir, 'stub', 'net')
+  FileUtils.mkdir_p(stub_dir)
+  File.write(File.join(stub_dir, 'http.rb'), NET_HTTP_STUB)
+  Open3.capture3(
+    { 'SIGMA_BASE_URL' => 'https://stub.invalid', 'SIGMA_API_TOKEN' => 'stub-token' }.merge(extra_env),
+    RbConfig.ruby, '-I', File.join(dir, 'stub'), SCRIPT,
+    '--workbook-ids', 'wb-test', '--out-dir', out_dir
+  )
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '== scan-customer-style: nested spec GET must not scan as 0 pages/elements =='
+Dir.mktmpdir do |dir|
+  out_dir = File.join(dir, 'profile')
+  log = File.join(dir, 'stub.log')
+  out, err, st = run_scan(dir, out_dir, { 'NET_HTTP_STUB_LOG' => log })
+
+  check(st.exitstatus.zero?, "exits 0 (got #{st.exitstatus}; out=#{out.inspect} err=#{err.inspect})", fails)
+
+  profile_path = File.join(out_dir, 'style-profile.json')
+  check(File.exist?(profile_path), 'style-profile.json written', fails)
+  if File.exist?(profile_path)
+    profile = JSON.parse(File.read(profile_path))
+    check(profile['sample_size'] == 1, "sample_size == 1 (got #{profile['sample_size'].inspect})", fails)
+    check(profile['pages_per_workbook'] == [1],
+          "pages_per_workbook == [1], not [0] (got #{profile['pages_per_workbook'].inspect})", fails)
+    check(profile['schema_versions'] == { '4' => 1 },
+          "schema_versions recovers schemaVersion=4 from the nested document (got #{profile['schema_versions'].inspect})", fails)
+    check(profile['chart_kind_counts']['bar-chart'] == 1,
+          "chart_kind_counts counts the nested bar-chart element (got #{profile['chart_kind_counts'].inspect})", fails)
+    check(profile['palettes']['#0e7c7b,#f4a261'] == 1,
+          "palette scheme recovered from the nested element (got #{profile['palettes'].inspect})", fails)
+  end
+
+  reqs = File.exist?(log) ? File.readlines(log).map { |l| JSON.parse(l) } : []
+  check(reqs.any? { |r| r['verb'] == 'GET' && r['path'] == '/v2/workbooks/wb-test/spec' },
+        'spec GET issued', fails)
+end
+
+puts
+if fails.empty?
+  puts 'test-scan-customer-style: ALL PASS'
+else
+  puts "test-scan-customer-style: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-sigma-formula-wrap.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-validate-sigma-formula-wrap.rb
@@ -1,0 +1,129 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-validate-sigma-formula-wrap.rb — regression test for the workbook
+# code-rep `document` wrap in scripts/validate-sigma-formula.rb (both the
+# singleton probe POST and the --batch probe POST).
+#
+# This is a PLUGIN-LOCAL test (not the shared/scripts canonical
+# test-validate-sigma-formula-cleanup.rb, which this repo syncs byte-identical
+# across plugins per the shared-file manifest and which this fix does not
+# touch) — it exists specifically to prove the `document` envelope on the two
+# `POST /v2/workbooks/spec` call sites this fix wraps.
+#
+# Same offline seam convention as test-probe-control-formula.rb /
+# test-validate-sigma-formula-cleanup.rb: stub sigma_rest.rb, run the real
+# script via `ruby -I <stub> -r sigma_rest`, no live network.
+#
+# Run: ruby scripts/test-validate-sigma-formula-wrap.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+require 'fileutils'
+
+SCRIPT = File.join(__dir__, 'validate-sigma-formula.rb')
+REAL_SIGMA_REST = File.expand_path('lib/sigma_rest.rb', __dir__)
+
+SIGMA_STUB = <<~RUBY
+  require 'json'
+  module Sigma
+    class Error < StandardError; end
+    def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
+      if ENV['SIGMA_STUB_LOG']
+        File.open(ENV['SIGMA_STUB_LOG'], 'a') { |f| f.puts JSON.generate('method' => method.to_s, 'path' => path, 'body' => body) }
+      end
+      case
+      when method == :post && path == '/v2/workbooks/spec'
+        { 'workbookId' => 'wb-scout-1' }
+      when method == :get && path.include?('/dataModels/')
+        { 'schemaVersion' => 1, 'pages' => [{ 'elements' => [
+          { 'id' => 'el-1', 'name' => 'Data',
+            'columns' => [{ 'name' => 'Gross Revenue', 'formula' => '[SRC/Gross Revenue]' }] }] }] }
+      when method == :get && path.include?('/columns')
+        { 'entries' => [{ 'label' => 'scout-test-col', 'type' => { 'type' => 'number' } },
+                        { 'label' => 'batch-0', 'columnId' => 'col-b0', 'type' => { 'type' => 'number' } }] }
+      when method == :delete
+        nil
+      else
+        raise Error, "stub: unexpected \#{method} \#{path}"
+      end
+    end
+    def self.list_entries(path, limit: 1000, http: nil)
+      (request(:get, path, http: http) || {})['entries'] || []
+    end
+  end
+  real = ENV['REAL_SIGMA_REST']
+  $LOADED_FEATURES << real if real && !$LOADED_FEATURES.include?(real)
+RUBY
+
+def run_validate(dir, log, *args)
+  stub_dir = File.join(dir, 'stub')
+  FileUtils.mkdir_p(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), SIGMA_STUB)
+  Open3.capture3(
+    { 'REAL_SIGMA_REST' => REAL_SIGMA_REST, 'SIGMA_BASE_URL' => 'https://stub.invalid',
+      'SIGMA_API_TOKEN' => 'stub', 'HOME' => dir, 'SIGMA_STUB_LOG' => log,
+      'TABLEAU_TO_SIGMA_HOME' => dir },
+    RbConfig.ruby, '-I', stub_dir, '-r', 'sigma_rest', SCRIPT,
+    '--data-model-id', 'dm-1', '--master-element-id', 'el-1', '--keep-workbook', *args
+  )
+end
+
+def posts(log)
+  return [] unless File.exist?(log)
+  File.readlines(log).map { |l| JSON.parse(l) }
+      .select { |r| r['method'] == 'post' && r['path'] == '/v2/workbooks/spec' }
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts '== validate-sigma-formula (singleton): probe POST must carry the `document` envelope =='
+Dir.mktmpdir do |dir|
+  log = File.join(dir, 'stub.log')
+  _out, err, st = run_validate(dir, log, '--formula', 'Sum([Master/Gross Revenue])')
+  check(st.exitstatus.zero?, "singleton run exits 0 (got #{st.exitstatus}; err=#{err.inspect})", fails)
+  p = posts(log)
+  check(p.size == 1, "exactly one probe POST (got #{p.size})", fails)
+  if p.size == 1
+    body = JSON.parse(p.first['body'])
+    check(body.key?('document') && body['document'].is_a?(Hash), 'POST body carries a top-level `document` key', fails)
+    check(!body.key?('pages') && !body.key?('schemaVersion'),
+          'POST body has NO top-level pages/schemaVersion (must be nested)', fails)
+    doc = body['document'].is_a?(Hash) ? body['document'] : {}
+    check(doc['pages'].is_a?(Array) && !doc['pages'].empty?, 'wrapped document carries pages', fails)
+    check(body['name'].to_s.start_with?('[scout-test]'), 'name stays OUTSIDE document as metadata', fails)
+  end
+end
+
+puts
+puts '== validate-sigma-formula (--batch): probe POST must carry the `document` envelope =='
+Dir.mktmpdir do |dir|
+  batch_path = File.join(dir, 'batch.json')
+  File.write(batch_path, JSON.generate([{ 'label' => 'batch-0', 'formula' => 'Sum([Master/Gross Revenue])' }]))
+  log = File.join(dir, 'stub.log')
+  _out, err, st = run_validate(dir, log, '--batch', batch_path)
+  check(st.exitstatus.zero?, "batch run exits 0 (got #{st.exitstatus}; err=#{err.inspect})", fails)
+  p = posts(log)
+  check(p.size == 1, "exactly one batch probe POST (got #{p.size})", fails)
+  if p.size == 1
+    body = JSON.parse(p.first['body'])
+    check(body.key?('document') && body['document'].is_a?(Hash), 'batch POST body carries a top-level `document` key', fails)
+    check(!body.key?('pages') && !body.key?('schemaVersion'),
+          'batch POST body has NO top-level pages/schemaVersion (must be nested)', fails)
+    doc = body['document'].is_a?(Hash) ? body['document'] : {}
+    check(doc['pages'].is_a?(Array) && !doc['pages'].empty?, 'wrapped document carries pages', fails)
+  end
+end
+
+puts
+if fails.empty?
+  puts 'test-validate-sigma-formula-wrap: ALL PASS'
+else
+  puts "test-validate-sigma-formula-wrap: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-interaction-fetch-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-interaction-fetch-spec.rb
@@ -1,0 +1,145 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-verify-interaction-fetch-spec.rb — regression test for the workbook
+# code-rep `document` unwrap in scripts/verify-interaction.rb's `fetch_spec`.
+#
+# (A separate file from test-verify-interaction.rb, which `require_relative`s
+# the script to unit-test the pure InteractionOracle module offline — that
+# require path is CLI-guarded OUT before `fetch_spec` is even defined
+# (`return if $PROGRAM_NAME != __FILE__ ...` sits above it), so it cannot
+# exercise fetch_spec at all. This test instead runs the real CLI as a
+# subprocess.)
+#
+# fetch_spec GETs the live workbook spec; ControlLint.elements/controls_report
+# need a flat `spec['pages']`. Workbook code-rep GETs nest `pages` under a
+# top-level `document` key (live since 2026-08) — pre-fix, a control that IS
+# correctly wired (filters a same-page queryable element) would silently read
+# as "control not present in the live workbook spec" on every probe, because
+# ControlLint never saw the nested pages.
+#
+# Minimal workdir: only control-scope.json is hard-required by the script;
+# dashboard-layout.json / get-workbook.json / parity-plan.json / wb-ids.json
+# are all read with a `rescue nil`/`rescue {}` fallback, so omitting them
+# just means "no pairable element" — a SKIP reached only once `fetch_spec`
+# has correctly resolved the control via ControlLint, which is exactly the
+# signal this test needs (proves the unwrap without needing a full
+# Tableau-side flip, which is unrelated to this fix).
+#
+# Tableau creds are left unset (and HOME redirected to an empty scratch dir)
+# so `lib/tableau_rest.rb`'s neutral-env bootstrap can't leak in real
+# dev-box creds, and the Tableau PAT auto-refresh block (guarded on
+# TABLEAU_PAT_NAME/SECRET both present) never fires — no Tableau network is
+# ever attempted on this path.
+#
+# Same `sigma_rest.rb` load-path-shadow convention as
+# test-probe-control-formula.rb / test-probe-window-contexts.rb.
+#
+# Run: ruby scripts/test-verify-interaction-fetch-spec.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'rbconfig'
+
+SCRIPT = File.join(__dir__, 'verify-interaction.rb')
+REAL_SIGMA_REST = File.expand_path('lib/sigma_rest.rb', __dir__)
+
+# The live (nested) readback: a `filters`-mechanism control ("Region") wired
+# to a same-page queryable table element.
+NESTED_SPEC = {
+  'workbookId' => 'wb-test',
+  'document' => {
+    'schemaVersion' => 4,
+    'pages' => [{
+      'id' => 'p1', 'name' => 'Dashboard',
+      'elements' => [
+        { 'id' => 'ctl1', 'kind' => 'control', 'controlType' => 'list',
+          'controlId' => 'c-cid', 'name' => 'Region',
+          'filters' => [{ 'source' => { 'elementId' => 'tbl1' } }] },
+        { 'id' => 'tbl1', 'kind' => 'table', 'name' => 'Revenue Table' }
+      ]
+    }]
+  }
+}.freeze
+
+SIGMA_STUB = <<~RUBY
+  require 'json'
+  module Sigma
+    class Error < StandardError; end
+    NESTED_SPEC = #{NESTED_SPEC.to_json}
+    def self.request(method, path, body: nil, accept: nil, binary: false, content_type: nil, http: nil)
+      if ENV['SIGMA_STUB_LOG']
+        File.open(ENV['SIGMA_STUB_LOG'], 'a') { |f| f.puts JSON.generate('method' => method.to_s, 'path' => path) }
+      end
+      case
+      when method == :get && path == '/v2/workbooks/wb-test/spec'
+        JSON.parse(JSON.generate(NESTED_SPEC))
+      else
+        raise Error, "stub: unexpected \#{method} \#{path}"
+      end
+    end
+    def self.base_url; 'https://stub.invalid'; end
+    def self.auth_token; 'stub-token'; end
+  end
+  real = ENV['REAL_SIGMA_REST']
+  $LOADED_FEATURES << real if real && !$LOADED_FEATURES.include?(real)
+RUBY
+
+def run_verify(dir, extra_env = {})
+  stub_dir = File.join(dir, 'stub')
+  Dir.mkdir(stub_dir) unless Dir.exist?(stub_dir)
+  File.write(File.join(stub_dir, 'sigma_rest.rb'), SIGMA_STUB)
+
+  work = File.join(dir, 'work')
+  Dir.mkdir(work)
+  File.write(File.join(work, 'control-scope.json'), JSON.generate(
+    'controls' => [
+      { 'controlId' => 'c-cid', 'name' => 'Region', 'mechanism' => 'filters',
+        'status' => 'emitted', 'targets' => ['tbl1'] }
+    ]
+  ))
+
+  # Empty HOME so lib/tableau_rest.rb's ~/.sigma-migration/env neutral bootstrap
+  # can't leak real dev-box Tableau creds into this subprocess.
+  empty_home = File.join(dir, 'home')
+  Dir.mkdir(empty_home)
+
+  Open3.capture3(
+    { 'REAL_SIGMA_REST' => REAL_SIGMA_REST, 'SIGMA_BASE_URL' => 'https://stub.invalid',
+      'SIGMA_API_TOKEN' => 'stub-token', 'HOME' => empty_home,
+      'TABLEAU_PAT_NAME' => nil, 'TABLEAU_PAT_SECRET' => nil, 'TABLEAU_AUTH_TOKEN' => nil }.merge(extra_env),
+    RbConfig.ruby, '-I', stub_dir, '-r', 'sigma_rest', SCRIPT,
+    '--workdir', work, '--workbook-id', 'wb-test', '--no-renders'
+  )
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts "== verify-interaction fetch_spec: nested spec GET must resolve the control's reach =="
+Dir.mktmpdir do |dir|
+  log = File.join(dir, 'stub.log')
+  _out, err, st = run_verify(dir, { 'SIGMA_STUB_LOG' => log })
+
+  check(!err.include?('control not present in the live workbook spec'),
+        "control IS found via ControlLint on the unwrapped spec (got stderr: #{err.inspect})", fails)
+  check(err.include?('no pairable element'),
+        "reaches the (unrelated) pairing step -- proves fetch_spec + ControlLint saw the control and its reach (got: #{err.inspect})", fails)
+  check(st.exitstatus == 2,
+        "exits 2 (nothing PROBEABLE for Tableau pairing -- expected; unrelated to this fix) (got #{st.exitstatus})", fails)
+
+  reqs = File.exist?(log) ? File.readlines(log).map { |l| JSON.parse(l) } : []
+  check(reqs.any? { |r| r['method'] == 'get' && r['path'] == '/v2/workbooks/wb-test/spec' },
+        'spec GET issued', fails)
+end
+
+puts
+if fails.empty?
+  puts 'test-verify-interaction-fetch-spec: ALL PASS'
+else
+  puts "test-verify-interaction-fetch-spec: #{fails.size} FAILURE(S)"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-workbook-target-coderep-unwrap.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-workbook-target-coderep-unwrap.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Guards the --workbook-target PUT-append GET against the workbook code-rep
+# `document` wrapper (live since 2026-08).
+#
+# migrate-tableau.rb's --workbook-target flow GETs the live spec of an
+# EXISTING workbook to merge the newly-built page(s) into it before handing
+# the merged spec to post-and-readback.rb --update-id. That GET now nests
+# `pages`/`schemaVersion` under a top-level `document` key — a bare
+# `existing['pages']` read is always nil, so the very next line's guard
+# ("workbook spec readback is not a page-bearing spec") FATAL-aborts EVERY
+# --workbook-target append, even against a perfectly valid workbook.
+#
+# migrate-tableau.rb is the monolithic ~5800-line orchestrator (this block
+# depends on ~4700 lines of prior CLI/discovery/build state, so it can't be
+# isolated into a runnable unit without a full TWB fixture + pipeline run) —
+# source-level assertions, mirroring test-reuse-workbook.rb's approach to the
+# same file, rather than a live/subprocess run.
+#
+# Usage: ruby scripts/test-workbook-target-coderep-unwrap.rb
+
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+mig = File.read(File.join(__dir__, 'migrate-tableau.rb'))
+
+check(mig.include?("require_relative 'lib/code_rep'"),
+      'migrate-tableau.rb requires lib/code_rep', fails)
+
+# Isolate the --workbook-target append block for a scoped check (don't just
+# grep the whole 5800-line file — a Sigma::CodeRep call anywhere wouldn't
+# prove THIS GET is unwrapped).
+block = mig[/if opts\[:wb_target\].*?^end\n/m]
+check(!block.nil?, 'the `if opts[:wb_target]` PUT-append block is present', fails)
+
+if block
+  get_idx    = block.index(/Sigma\.request\(:get,.*workbooks.*spec/)
+  unwrap_idx = block.index(/Sigma::CodeRep\.metadata\(raw_existing\)\.merge\(Sigma::CodeRep\.document\(raw_existing\)\)/)
+  guard_idx  = block.index(/unless existing\.is_a\?\(Hash\) && existing\['pages'\]\.is_a\?\(Array\)/)
+
+  check(!get_idx.nil?, 'the existing-workbook spec GET is present', fails)
+  check(!unwrap_idx.nil?, 'the `document` unwrap (metadata+document merge) is present', fails)
+  check(!guard_idx.nil?, "the page-bearing-spec FATAL guard is present", fails)
+  if get_idx && unwrap_idx && guard_idx
+    check(get_idx < unwrap_idx && unwrap_idx < guard_idx,
+          'unwrap runs AFTER the GET and BEFORE the pages-Array guard (so `existing[\'pages\']` sees the flattened shape, not the raw nested GET)',
+          fails)
+  end
+  check(block.match?(/existing\s*=\s*begin.*raw_existing\s*=\s*Sigma\.request/m),
+        'the GET result is captured as `raw_existing`, not assigned directly to `existing` (the unwrap runs on the raw nested response, not a pre-flattened one)',
+        fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-sigma-formula.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-sigma-formula.rb
@@ -65,6 +65,7 @@ require 'optparse'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'probe_registry'
+require 'code_rep'
 
 opts = {
   chart_kind: 'table',
@@ -215,7 +216,10 @@ if batch_entries
   spec['folderId'] = opts[:folder_id] if opts[:folder_id]
 
   parsed = begin
-    Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+    # Workbook code-rep POSTs require the nested `document` envelope (verified
+    # live 2026-08-03/04: a flat body 400s) — wrap the throwaway batch probe spec.
+    post_body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(spec), extra: Sigma::CodeRep.metadata(spec))
+    Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(post_body))
   rescue StandardError => e
     { 'raw' => e.message }
   end
@@ -360,7 +364,10 @@ spec['folderId'] = opts[:folder_id] if opts[:folder_id]
 
 # --- POST + readback -------------------------------------------------------
 parsed = begin
-  Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+  # Workbook code-rep POSTs require the nested `document` envelope (verified
+  # live 2026-08-03/04: a flat body 400s) — wrap the throwaway singleton probe spec.
+  post_body = Sigma::CodeRep.wrap(Sigma::CodeRep.document(spec), extra: Sigma::CodeRep.metadata(spec))
+  Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(post_body))
 rescue StandardError => e
   { 'raw' => e.message }
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-interaction.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-interaction.rb
@@ -267,6 +267,7 @@ return if $PROGRAM_NAME != __FILE__ && !ENV['VERIFY_INTERACTION_CLI'] # allow `r
 # CLI — live probing.
 # ---------------------------------------------------------------------------
 require 'sigma_rest'
+require 'code_rep'
 require_relative 'lib/py_resolve'
 
 opts = { values: {}, controls: [], per_dashboard: 1, timeout: 90, renders: true }
@@ -308,10 +309,19 @@ end
 # vendored shared artifact, so the two stay independent by design) -----------
 def fetch_spec(wb)
   body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'application/json')
-  return body if body.is_a?(Hash)
-  require 'yaml'
-  require 'date'
-  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {}
+  spec =
+    if body.is_a?(Hash)
+      body
+    else
+      require 'yaml'
+      require 'date'
+      YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {}
+    end
+  # Workbook code-rep GETs nest pages/schemaVersion under `document` (live
+  # since 2026-08); ControlLint.elements/controls_report expect a flat
+  # spec['pages'] (same "unwrap at the caller, not in the lib" contract as
+  # assert-datasource-filters.rb / other lint-lib callers).
+  Sigma::CodeRep.metadata(spec).merge(Sigma::CodeRep.document(spec))
 end
 
 def export_csv(wb, element_id, params, timeout)


### PR DESCRIPTION
## Summary

Task 3.9 (per-plugin one-off scripts). The live Sigma workbook code-rep surface nests non-metadata fields (`pages`, `schemaVersion`, `layout`, `kind`) under a top-level `document` key on both GET readback and PUT/POST bodies. `post-and-readback.rb`'s primary call sites are covered separately (PR #609, still open) — this PR closes the remaining tableau-to-sigma one-off scripts that independently GET/PUT/POST a workbook spec and were still reading/writing the old flat shape.

Each was silently broken in one of two ways: a bare `spec['pages']` read after a live GET came back `nil`/`[]` (false "no matching elements" / 0-page scans), or a POST/PUT of a flat body 400s against the live API.

Fixed (unwrap via `Sigma::CodeRep.document`/`metadata` after GET, wrap via `Sigma::CodeRep.wrap` before PUT/POST — mirrors the existing post-and-readback.rb pattern, shared/lib/code_rep.rb from #608):
- `assert-datasource-filters.rb`, `collect-parity-actuals.rb`, `export-chart-png.rb`, `scan-customer-style.rb`, `verify-interaction.rb` (GET unwrap for lint-lib callers)
- `fidelity-loop.rb` (GET unwrap, PUT wrap, post-patch re-GET unwrap)
- `migrate-tableau.rb` (`--workbook-target` append GET unwrap)
- `probe-control-formula.rb`, `probe-window-contexts.rb`, `validate-sigma-formula.rb` (GET unwrap + POST wrap for throwaway probe workbooks)

Bumped `tableau-to-sigma` 1.6.9 → 1.6.10 (patch).

## Testing

- Added a regression test per touched script (9 new `test-*.rb` files) plus a nested-`document`-fixture case added to `test-fidelity-loop.rb`.
- Ran the FULL `scripts/test-*.rb` suite (238 files): 237 pass, 1 pre-existing unrelated failure (`test-calc-discovery.rb` needs a live Tableau token + a `/tmp/assessment-site` fixture not present in this sandbox — confirmed not in this PR's diff, pre-existing/environmental).
- Re-ran after rebasing onto current `origin/main` (post #615/#617 sigma-authoring merges): same 237/238, no regressions.
- `ruby tools/check-shared.rb`: clean (676/676).
- `bash tools/check-plugin-version-bump.sh origin/main HEAD`: OK.

## Test plan

- [x] All touched scripts + new tests green
- [x] Full tableau-to-sigma test suite: 237/238 (1 pre-existing environmental gap, unrelated)
- [x] Shared-file governance clean
- [x] Version-bump gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)