### PR TITLE
fix(domo-import-to-snowflake): always quote identifiers so Snowflake can't case-fold them (bead q5dz)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-import-to-snowflake/scripts/lib/snowflake_ddl.rb
+++ b/plugins/domo-to-sigma/skills/domo-import-to-snowflake/scripts/lib/snowflake_ddl.rb
@@ -38,14 +38,17 @@ module SnowflakeDDL
       .uniq
   end
 
-  # Snowflake identifiers: unquoted names uppercase automatically and accept
-  # only [A-Za-z_][A-Za-z0-9_]*; a raw Domo column name with spaces/symbols
-  # is double-quoted verbatim instead of mangled, so column order stays 1:1
-  # with what the COPY step (snowflake_load.rb) positionally relies on.
+  # ALWAYS double-quote, so the identifier lands with the source's exact case.
+  # Snowflake case-folds an UNQUOTED identifier to upper case; that silently
+  # destroys the camelCase word boundary domo-to-sigma's DomoSigma.display_name
+  # splits on downstream ('IsClosed' -> 'Is Closed', but 'ISCLOSED' -> the
+  # single token 'ISCLOSED'), so a landed column stops matching the Domo-declared
+  # one and column_preflight.rb reports it missing. Quoting only the names that
+  # strictly require it — the previous behavior — meant multi-word camelCase
+  # columns broke while single-word and symbol-bearing ones happened to survive.
+  # Found live by the 48-card cold run against the real PDP DataSet (bead q5dz).
   def quote_identifier(name)
-    s = name.to_s
-    return s if s =~ /\A[A-Za-z_][A-Za-z0-9_]*\z/
-    "\"#{s.gsub('"', '""')}\""
+    "\"#{name.to_s.gsub('"', '""')}\""
   end
 
   # database/schema/table: plain strings already chosen by the caller

--- a/plugins/domo-to-sigma/skills/domo-import-to-snowflake/test/test-snowflake-ddl.rb
+++ b/plugins/domo-to-sigma/skills/domo-import-to-snowflake/test/test-snowflake-ddl.rb
@@ -22,16 +22,28 @@ cols = [{ 'name' => 'a', 'type' => 'STRING' }, { 'name' => 'b', 'type' => 'PERCE
 eq(SnowflakeDDL.unknown_types(cols), ['PERCENT'], 'dedups unrecognized types, ignores known ones')
 
 puts "== quote_identifier =="
-eq(SnowflakeDDL.quote_identifier('ORDER_ID'), 'ORDER_ID', 'plain identifier unquoted')
-eq(SnowflakeDDL.quote_identifier('Order Id'), '"Order Id"', 'space forces quoting')
+eq(SnowflakeDDL.quote_identifier('ORDER_ID'), '"ORDER_ID"', 'always quoted, even a plain uppercase identifier')
+eq(SnowflakeDDL.quote_identifier('Order Id'), '"Order Id"', 'space is preserved inside the quotes')
 eq(SnowflakeDDL.quote_identifier('a"b'), '"a""b"', 'embedded quote is doubled, not escaped with backslash')
+# Snowflake case-folds an UNQUOTED identifier to upper case, which destroys the
+# camelCase word boundary that domo-to-sigma's DomoSigma.display_name splits on
+# ('IsClosed' -> 'Is Closed' vs 'ISCLOSED' -> 'ISCLOSED'), so the landed column
+# stops matching the Domo-declared one in column_preflight.rb. Found live by the
+# 48-card cold run (bead q5dz): 3/3 multi-word camelCase columns mismatched.
+eq(SnowflakeDDL.quote_identifier('IsClosed'), '"IsClosed"', 'camelCase is quoted so Snowflake cannot case-fold it (bead q5dz)')
+eq(SnowflakeDDL.quote_identifier('Account.Name'), '"Account.Name"', 'dotted name still quoted verbatim')
 
 puts "== create_table_sql =="
 sql = SnowflakeDDL.create_table_sql('DB', 'SCH', 'SURVEYS',
   [{ 'name' => 'RESPONSE_ID', 'type' => 'STRING' }, { 'name' => 'SCORE', 'type' => 'LONG' }])
-ok(sql.include?('CREATE TABLE IF NOT EXISTS DB.SCH.SURVEYS'), 'DDL names the target table')
-ok(sql.include?('RESPONSE_ID VARCHAR'), 'first column typed')
-ok(sql.include?('SCORE NUMBER(38,0)'), 'second column typed')
+ok(sql.include?('CREATE TABLE IF NOT EXISTS DB.SCH."SURVEYS"'), 'DDL names the target table, quoted')
+ok(sql.include?('"RESPONSE_ID" VARCHAR'), 'first column typed and quoted')
+ok(sql.include?('"SCORE" NUMBER(38,0)'), 'second column typed and quoted')
+
+camel = SnowflakeDDL.create_table_sql('DB', 'SCH', 'PDP',
+  [{ 'name' => 'IsClosed', 'type' => 'STRING' }, { 'name' => 'StageName', 'type' => 'STRING' }])
+ok(camel.include?('"IsClosed" VARCHAR'), 'camelCase column keeps its exact source case in DDL (bead q5dz)')
+ok(camel.include?('"StageName" VARCHAR'), 'second camelCase column keeps its exact source case')
 
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end

--- a/plugins/domo-to-sigma/skills/domo-import-to-snowflake/test/test-snowflake-load.rb
+++ b/plugins/domo-to-sigma/skills/domo-import-to-snowflake/test/test-snowflake-load.rb
@@ -16,8 +16,8 @@ eq(csv, "a,b\n\"x,y\",\"z\"\"w\"\n", 'quotes fields containing commas/embedded q
 puts "== load_sql =="
 sql = SnowflakeLoad.load_sql('CREATE TABLE DB.SCH.T (...);', 'DB', 'SCH', 'T', 'file:///tmp/x.csv')
 ok(sql.include?('CREATE TABLE DB.SCH.T'), 'includes the caller-supplied CREATE TABLE statement verbatim')
-ok(sql.include?("PUT 'file:///tmp/x.csv' @DB.SCH.%T"), 'PUTs to the fully-qualified table stage')
-ok(sql.include?('COPY INTO DB.SCH.T'), 'COPYs into the target table')
+ok(sql.include?(%q{PUT 'file:///tmp/x.csv' @DB.SCH.%"T"}), 'PUTs to the fully-qualified table stage (identifier always quoted)')
+ok(sql.include?('COPY INTO DB.SCH."T"'), 'COPYs into the target table (identifier always quoted)')
 ok(sql.include?('ON_ERROR = ABORT_STATEMENT'), 'aborts the whole COPY on any bad row, never a silent partial load')
 ok(sql.include?("NULL_IF = ('')"), 'treats empty CSV fields as NULL to handle sparse/nullable columns')
 
@@ -26,10 +26,10 @@ sql_quoted = SnowflakeLoad.load_sql('CREATE TABLE DB.SCH."My Table" (...);', 'DB
 ok(sql_quoted.include?('@DB.SCH.%"My Table"'), 'PUT stage reference is fully qualified with database.schema.%table')
 
 puts "== grant_sql =="
-eq(SnowflakeLoad.grant_sql('DB', 'SCH', 'T', 'PUBLIC'), 'GRANT SELECT ON DB.SCH.T TO ROLE PUBLIC;', 'grants SELECT to the given role')
+eq(SnowflakeLoad.grant_sql('DB', 'SCH', 'T', 'PUBLIC'), 'GRANT SELECT ON DB.SCH."T" TO ROLE PUBLIC;', 'grants SELECT to the given role')
 
 puts "== count_sql =="
-eq(SnowflakeLoad.count_sql('DB', 'SCH', 'T'), 'SELECT COUNT(*) AS CNT FROM DB.SCH.T;', 'builds a COUNT(*) AS CNT query against the target table')
+eq(SnowflakeLoad.count_sql('DB', 'SCH', 'T'), 'SELECT COUNT(*) AS CNT FROM DB.SCH."T";', 'builds a COUNT(*) AS CNT query against the target table')
 
 puts "== run_sql!: success path =="
 ok_runner = ->(cmd) { ok(cmd.include?('--connection'), 'passes --connection through to the snow CLI'); ['all good', true] }


### PR DESCRIPTION
## Summary
Found live by the **48-card cold run** — the first real end-to-end consumer of `domo-import-to-snowflake`'s landed data, run immediately after #621 merged.

`SnowflakeDDL.quote_identifier` only double-quoted names that *strictly required* it. Snowflake case-folds **unquoted** identifiers to upper case, so a camelCase column like `IsClosed` landed as `ISCLOSED`. That destroys the word boundary `DomoSigma.display_name` splits on downstream (`IsClosed` → `Is Closed`, but `ISCLOSED` → the single token `ISCLOSED`), so `column_preflight.rb` reported the column **missing even though it had landed** — hard-failing the cold run at the preflight phase.

Measured on the real PDP DataSet: **3/3 multi-word camelCase columns mismatched** (`IsClosed`, `LeadSource`, `StageName`); single-word and symbol-bearing ones (`Amount`, `Name`, `Account.Name`) happened to survive — the latter only because a dot forced them into the quoted branch.

Fix: always quote. This also makes the skill's existing `refs/naming-and-sentinel.md` claim ("raw Domo column names, unchanged") actually true — it wasn't before.

## Test plan
- [x] New regression assertions pinning camelCase case-preservation in both `quote_identifier` and `create_table_sql` (fail before the fix, pass after — verified in that order)
- [x] All 4 offline suites pass; consequential assertions in `test-snowflake-load` updated for the now-quoted table identifier (still valid SQL)
- [x] Hygiene-sweep clean; plugin version 0.11.0 → 0.11.1
- [x] **Live re-landing verified (measured):** dropped/recreated the target schema and re-landed all 10 real sample DataSets — 10/10 succeeded, and `PDP_EXAMPLE_DATASET` now lands `IsClosed`, `IsWon`, `LeadSource`, `StageName` with **exact source case**. Confirmed by querying `INFORMATION_SCHEMA.COLUMNS` directly, not from script output.
- [x] **End-to-end confirmed (measured):** after the re-land plus a **table-level** Sigma re-sync (a schema-level sync is NOT enough once a table is already discovered — its cached column list stays stale), `preflight-columns.rb` printed `clean — every used dataset's Domo columns are covered`, clearing the phase that this bug was hard-failing.
- [ ] TJ review

## Note for the reviewer
The cold run has since advanced to a **different**, pre-existing converter bug (`build-dm.rb` hard-fails because card-referenced sample DataSets never reach `datasets.json` and carry no `schema.columns`) — filed separately as `beads-sigma-8k77`. That one is not caused by, and does not affect, this fix.