### PR TITLE
fix(shared): list_entries silently truncated at 50 on nextPageToken endpoints (bead 0h11)

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData → Sigma",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex → Sigma",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Migrate Hex projects to Sigma — SQL cells, single-value/METRIC cells, and EXPLORE charts → Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense → Sigma",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma — data model + workbook (indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; columnar layout→24-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/shared/lib/sigma_rest.rb
+++ b/shared/lib/sigma_rest.rb
@@ -190,27 +190,55 @@ module Sigma
   # An optional block receives each page's parsed body as it arrives; callers
   # use it for page-level observability (e.g. announcing a multi-page fetch on
   # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
   def list_entries(path, limit: 1000, http: nil)
     entries = []
-    page = nil
+    cursor = nil
+    cursor_param = nil
     seen = {}
     pages = 0
     loop do
       qs = "limit=#{limit.to_i}"
-      qs += "&page=#{URI.encode_www_form_component(page)}" if page
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
       data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
       break unless data.is_a?(Hash)
       pages += 1
       yield data if block_given?
       entries.concat(data['entries'] || [])
-      page = data['nextPage']
-      break if page.nil? || page.to_s.empty?
-      if seen[page]
-        warn "#{path}: server repeated nextPage token #{page.inspect} — " \
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
              "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
         break
       end
-      seen[page] = true
+      seen[cursor] = true
     end
     entries
   end

--- a/shared/lib/tests/test_sigma_rest_pagination.rb
+++ b/shared/lib/tests/test_sigma_rest_pagination.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Regression tests for Sigma.list_entries' dual pagination conventions (bead 0h11).
+# No network: Sigma.request is stubbed per-case.
+#   ruby shared/lib/tests/test_sigma_rest_pagination.rb
+
+require_relative '../sigma_rest'
+
+$failures = 0
+def eq(a, b, m) if a == b then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}\n    exp #{b.inspect}\n    got #{a.inspect}" end end
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+
+# Replace Sigma.request with a scripted responder that records the paths it saw.
+def with_stubbed_request(pages)
+  seen = []
+  Sigma.singleton_class.send(:alias_method, :__real_request, :request)
+  Sigma.define_singleton_method(:request) do |_method, path, **_kw|
+    seen << path
+    pages.shift || { 'entries' => [] }
+  end
+  yield seen
+ensure
+  Sigma.singleton_class.send(:alias_method, :request, :__real_request)
+  Sigma.singleton_class.send(:remove_method, :__real_request)
+end
+
+puts '== nextPage / page= convention (most /v2 list endpoints) =='
+with_stubbed_request([
+  { 'entries' => [{ 'name' => 'a' }], 'nextPage' => 'CUR1' },
+  { 'entries' => [{ 'name' => 'b' }] }
+]) do |seen|
+  got = Sigma.list_entries('/v2/things')
+  eq(got.map { |e| e['name'] }, %w[a b], 'follows nextPage to exhaustion')
+  ok(seen[1].include?('page=CUR1'), "sends the cursor back as page=, got: #{seen[1]}")
+  ok(!seen[1].include?('pageToken='), 'does not use pageToken= for a nextPage cursor')
+end
+
+puts '== nextPageToken / pageToken= convention (the columns endpoint) =='
+# This is the case that silently truncated at 50: nextPage is absent entirely,
+# so the pre-fix loop stopped after page 1 with no error.
+with_stubbed_request([
+  { 'entries' => [{ 'name' => 'c1' }], 'nextPageToken' => 'TOK1' },
+  { 'entries' => [{ 'name' => 'c2' }], 'nextPageToken' => 'TOK2' },
+  { 'entries' => [{ 'name' => 'c3' }] }
+]) do |seen|
+  got = Sigma.list_entries('/v2/connections/tables/inode-1/columns')
+  eq(got.map { |e| e['name'] }, %w[c1 c2 c3], 'follows nextPageToken to exhaustion (no silent truncation)')
+  ok(seen[1].include?('pageToken=TOK1'), "sends the cursor back as pageToken=, got: #{seen[1]}")
+  ok(!seen[1].include?('page=TOK1'), 'does not send a token cursor as page= (that re-serves page 1 forever)')
+end
+
+puts '== a repeated cursor stops rather than looping forever =='
+# Guards the specific half-fix failure mode: reading nextPageToken but sending
+# it as page= makes the server re-serve page 1 with the same cursor.
+with_stubbed_request(Array.new(50) { { 'entries' => [{ 'name' => 'dup' }], 'nextPageToken' => 'SAME' } }) do |seen|
+  got = Sigma.list_entries('/v2/connections/tables/inode-2/columns')
+  ok(seen.size < 5, "bails out early on a repeated cursor instead of spinning (requests made: #{seen.size})")
+  ok(!got.empty?, 'still returns what it did manage to read')
+end
+
+puts '== neither cursor present -> single page =='
+with_stubbed_request([{ 'entries' => [{ 'name' => 'only' }] }]) do |seen|
+  got = Sigma.list_entries('/v2/things')
+  eq(got.size, 1, 'stops after one page when no cursor is returned')
+  eq(seen.size, 1, 'makes exactly one request')
+end
+
+puts
+if $failures.zero? then puts 'ALL PASS'; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end


### PR DESCRIPTION
## Summary
Found live during the domo 48-card cold run, against a real **149-column** warehouse table.

Sigma's list endpoints use **two** pagination conventions, and the cursor field and query param must be matched as a pair:

| response field | send back as | used by |
|---|---|---|
| `nextPage` | `page=` | most `/v2` list endpoints |
| `nextPageToken` | `pageToken=` | `/v2/connections/tables/{inodeId}/columns` |

`list_entries` only knew the first. On a second-convention endpoint `nextPage` is simply **absent**, so the loop ended after page 1 and returned exactly the server's default page size — **no error, no warning**. Silent truncation, not a failure.

### Measured live: 50 of 149 columns returned

Two harms, in increasing order of severity:
1. domo's column pre-flight reported **99 phantom "missing" columns** and hard-failed a migration whose table was perfectly fine — a false *positive*.
2. Far worse: `assert-phase6-ran.rb`'s live error-column audit reads through this same helper. On any table wider than 50 columns it inspects only the first 50 and still reports clean — a false **negative** on the gate whose entire job is catching `type=error` columns. Same class as bead `bf1f` (different endpoint), and exactly the field case already on record: a 599-column workbook audited one page deep.

### The half-fix trap
Mixing the pair is its own bug: feeding a `nextPageToken` back as `page=` makes the server re-serve page 1 **forever** (verified — 11 iterations, 550 duplicate rows). The pre-existing repeated-cursor guard is what stops that becoming an infinite loop; it's kept and is now cursor-aware.

## Test plan
- [x] **Live-verified after the fix:** the same table returns **149 columns, all distinct** (was 50)
- [x] **No regression on the other convention:** `/v2/connections` (a `nextPage` endpoint) still lists correctly
- [x] New offline regression test covering both conventions, the repeated-cursor bailout, and the no-cursor single-page case — **confirmed to FAIL against the pre-fix code** (returned 1 of 3 pages) and pass after
- [x] `tools/check-shared.rb` → `OK: 676 shared-file copies all match canonical`
- [x] Hygiene-sweep clean; patch bump for all 12 affected plugins
- [ ] TJ review

## Note
Third PR in this stack (#623 domo blockers, #624 shared ledger fan-out). #624 and this one both touch `domo-to-sigma`'s and `hex-to-sigma`'s `plugin.json` — whichever merges second needs a trivial version rebase.