### PR TITLE
fix(domo-to-sigma): parity results never reached gate 1 — add the missing finalizer (bead 2tkm)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -134,12 +134,13 @@ grid is only 6 wide, so widths scale ×4).
 | `scripts/build-domo-layout.rb` | 5d | Domo card geometry → zone-schema `dashboard-layout.json` (relative-normalized) |
 | `build-dashboard-layout.rb` *(vendored)* | 5d | Zone JSON → 24-col grid XML |
 | `put-layout.rb` *(vendored)* | 5d | PUT layout to workbook |
-| `verify-parity.rb` *(vendored)* | 6 | Compare Domo `query/execute` aggregations vs Sigma `query` |
+| `verify-parity.rb` *(vendored)* | 6 | Compare Domo `query/execute` aggregations vs Sigma `query` → `parity-score.json` (`tiles_*`) |
+| `scripts/phase6-parity-domo.rb` | 6 | **Finalizer.** Runs `verify-parity.rb`, derives the gate contract (`charts_*`/`status`) into `parity-final.json`, and refuses to emit one when the plan silently omits chartable tiles |
 | `assert-phase6-ran.rb` *(vendored)* | 6 | Hard gate before declaring GREEN (run with `--workdir`) |
 
 > The Domo-specific scripts — `convert-beast-modes.rb` (2), `find-or-pick-dm.rb`
 > integration (2.5), `build-dm.rb` (3), `build-workbook.rb` + `qa-check.rb` (5),
-> `build-domo-layout.rb` (5d), plus `get-domo-token.sh`, `lib/domo_rest.rb`,
+> `build-domo-layout.rb` (5d), `phase6-parity-domo.rb` (6), plus `get-domo-token.sh`, `lib/domo_rest.rb`,
 > `lib/domo_sigma_util.rb`, `domo-discover.rb`, `domo-capture-visuals.rb` — ship
 > with unit + end-to-end tests under `test/`. A final live field-path check on
 > first instance contact is still recommended.

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -24,7 +24,10 @@
 #   runs AFTER verify-parity rather than immediately after the render: it
 #   hard-requires parity-final.json to already exist on disk (it merges into
 #   it, never creates it from nothing), and that file is first written by
-#   verify-parity.rb's --score-out. This orchestrator has no image input, so
+#   phase6-parity-domo.rb, the parity finalizer (bead 2tkm — it used to be
+#   written by verify-parity.rb's --score-out, which is what BROKE gate 1:
+#   --score-out emits the tiles_* score schema, not the gate's charts_*
+#   contract. --score-out now targets parity-score.json). This orchestrator has no image input, so
 #   it records the only HONEST verdict it is entitled to — not-executable —
 #   rather than fabricate a pass; see phase_record_visual_check! below.
 #

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -819,15 +819,30 @@ def run_live!(opts)
 
   hr('verify-parity')
   if opts[:parity_plan] && File.exist?(opts[:parity_plan])
-    # --score-out (bead B6): without it verify-parity.rb only prints a report —
-    # parity-final.json is never written, so assert-phase6-ran.rb's gate 1
-    # (:715 reads it) sees no parity result even on a run that DID supply a
-    # plan. verify-parity.rb has supported --score-out since before this fix
-    # (see its own option parsing + writer); this was simply never plumbed
-    # through from here.
-    ok, code, _out = run_script!('verify-parity.rb', '--plan', opts[:parity_plan],
-                                  '--score-out', File.join(OUT, 'parity-final.json'))
-    fail_phase!('verify-parity', "verify-parity.rb exited #{code}") unless ok
+    # Bead 2tkm — finalize through phase6-parity-domo.rb, do NOT aim
+    # verify-parity.rb's --score-out at parity-final.json.
+    #
+    # B6 correctly spotted that --score-out was never plumbed through (without it
+    # verify-parity.rb only prints a report). But it aimed the score document at
+    # parity-final.json, which is the GATE'S contract file: assert-phase6-ran.rb
+    # reads charts_total/charts_pass/status, while --score-out writes
+    # tiles_total/tiles_pass/tiles_fail. So a flawless 65/65 run wrote a document
+    # in which the gate found none of its three keys, computed charts_total = 0,
+    # dropped into the anchors-oracle substitution branch, found no
+    # anchors-verdict.json, and exited 2 — a perfect parity run was
+    # indistinguishable from parity never having run.
+    #
+    # domo was the only converter of six with no phase6-parity-*.rb finalizer
+    # (tableau's phase6-parity.rb:344-382 is the reference). It now runs
+    # verify-parity.rb itself (--score-out -> parity-score.json), derives the
+    # gate contract into parity-final.json, and refuses to emit a contract when
+    # the plan silently omits chartable tiles.
+    ok, code, _out = run_script!('phase6-parity-domo.rb',
+                                  '--workdir', OUT,
+                                  '--plan', opts[:parity_plan],
+                                  '--workbook-id', workbook_id,
+                                  '--score-out', File.join(OUT, 'parity-score.json'))
+    fail_phase!('verify-parity', "phase6-parity-domo.rb exited #{code}") unless ok
     done_phase!('verify-parity')
   else
     skip_phase!('verify-parity', 'no --parity-plan supplied — run verify-parity.rb by hand before declaring GREEN')

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/phase6-parity-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/phase6-parity-domo.rb
@@ -34,11 +34,16 @@
 # Usage:
 #   ruby scripts/phase6-parity-domo.rb --workdir <wd> --plan <wd>/parity-plan.json \
 #     --workbook-id <id> [--workbook-spec PATH] [--exclusions PATH] [--out PATH]
-#     [--score-out PATH] [--skip-verify]
+#     [--score-out PATH] [--skip-verify] [--allow-missing-census REASON]
 #
 # Exit codes: 0 = contract written; 1 = bad invocation / missing input;
-#             5 = census unbalanced (unaccounted or reasonless-excluded tiles);
-#             6 = verify-parity.rb produced no score document.
+#             5 = census unbalanced or unverifiable (unaccounted tiles, a
+#                 reasonless exclusion, or no workbook spec and no named waiver);
+#             6 = verify-parity.rb produced no score document (it crashed).
+#
+# On every non-zero exit any pre-existing parity-final.json is INVALIDATED
+# (status=FAIL + finalize_error) rather than left behind, so a prior run's PASS
+# can never be read as this run's evidence. See die! below.
 require 'json'
 require 'optparse'
 require 'open3'
@@ -57,6 +62,10 @@ OptionParser.new do |p|
   p.on('--score-out PATH', 'default <workdir>/parity-score.json')      { |v| opts[:score_out] = v }
   p.on('--extract-mode', 'pass --extract-mode through to verify-parity.rb') { opts[:extract_mode] = true }
   p.on('--skip-verify', 'finalize from an existing parity-score.json (do not re-run verify-parity)') { opts[:skip_verify] = true }
+  p.on('--allow-missing-census REASON',
+       'proceed without a workbook spec (and therefore WITHOUT the anti-inflation census) — ' \
+       'REQUIRED reason string, recorded in parity-final.json as census_waiver and MUST be ' \
+       'named in the migration report') { |v| opts[:allow_missing_census] = v }
 end.parse!
 
 abort('phase6-parity-domo: --workdir is required') unless opts[:workdir]
@@ -109,6 +118,42 @@ rescue StandardError => e
   abort("phase6-parity-domo: cannot read #{path}: #{e.message}")
 end
 
+# Exit non-zero WITHOUT leaving a stale PASS contract behind.
+#
+# Every failure path here runs in a workdir that may already hold a
+# parity-final.json from an earlier, successful finalize (migrate-domo.rb is
+# idempotent and re-running into a populated workdir is the normal path). Simply
+# exiting would leave that prior `status: "PASS"` on disk for assert-phase6-ran.rb
+# to read as this run's evidence — the same presence-is-not-freshness trap as the
+# score document, one level up, and a direct route to an unearned GREEN.
+#
+# The prior contract is therefore overwritten with an explicit FAIL carrying the
+# reason. Visual-verdict keys are preserved (record-visual-check.rb owns them and
+# cannot re-derive them), but nothing that could read as passing parity survives.
+def die!(code, out_path, reason)
+  if File.exist?(out_path)
+    prior = (JSON.parse(File.read(out_path)) rescue nil)
+    prior = {} unless prior.is_a?(Hash)
+    invalid = {
+      'ran_at'          => Time.now.utc.iso8601,
+      'status'          => 'FAIL',
+      'charts_total'    => 0,
+      'charts_pass'     => 0,
+      'charts_fail'     => 0,
+      'finalize_error'  => reason,
+      'note'            => 'phase6-parity-domo.rb could not finalize; any previous PASS in this ' \
+                           'file has been invalidated so the gate cannot read it as fresh evidence.',
+    }
+    %w[visual_checked visual_verdict screenshot_path agent_vision visual_similarity].each do |k|
+      invalid[k] = prior[k] if prior.key?(k)
+    end
+    File.write(out_path, JSON.pretty_generate(invalid))
+    warn "       invalidated the prior #{File.basename(out_path)} (status=FAIL) — it would otherwise " \
+         'have been read as this run\'s parity evidence.'
+  end
+  exit code
+end
+
 # ---------------------------------------------------------------------------
 # 1. Census FIRST — fail before spending a parity run on a narrowed plan.
 # ---------------------------------------------------------------------------
@@ -136,17 +181,42 @@ if File.exist?(opts[:spec])
       end
       warn '       A reason is REQUIRED so the exclusion lands in the migration report'
       warn '       instead of quietly shrinking the parity denominator.'
-      exit 5
+      die!(5, opts[:out], "exclusion(s) with no reason in #{File.basename(opts[:excl])}")
     end
   end
   excluded_names = excluded.map { |e| e['chart'].to_s }
 
-  unaccounted = chartable_names - plan_names - excluded_names
+  # MULTISET comparison, deliberately not `chartable_names - plan_names`.
+  # Ruby's Array#- is SET difference: it removes EVERY occurrence of a matching
+  # value. Two chartable elements sharing a name (the same KPI title repeated on
+  # two pages is routine) and a plan verifying only ONE of them therefore came out
+  # as fully accounted — exactly the silent inflation this census exists to catch.
+  # Counting per name closes that: a name verified 1x but chartable 2x leaves a
+  # deficit of 1. Hand-rolled because Array#tally is Ruby 2.7+ and the system
+  # ruby here is 2.6.
+  def tally(arr)
+    arr.each_with_object(Hash.new(0)) { |x, h| h[x] += 1 }
+  end
+  chartable_tally = tally(chartable_names)
+  accounted_tally = tally(plan_names + excluded_names)
+  unaccounted = []
+  chartable_tally.each do |name, want|
+    deficit = want - accounted_tally.fetch(name, 0)
+    deficit.times { unaccounted << name } if deficit.positive?
+  end
+  # A plan/exclusion naming something the workbook has no chartable element for is
+  # not fatal (a renamed or removed tile), but it means the denominator and the
+  # plan disagree, so say so rather than absorbing it silently.
+  stray = accounted_tally.keys - chartable_tally.keys
+  warn "[WARN] phase6-parity-domo: #{stray.length} plan/exclusion entr(ies) match no chartable " \
+       "element: #{stray.join(', ')}" unless stray.empty?
+
   census = {
     'chartable_total' => chartable_names.length,
     'plan_total'      => plan_names.length,
     'excluded_total'  => excluded_names.length,
     'unaccounted'     => unaccounted,
+    'stray_entries'   => stray,
     'source'          => File.basename(opts[:spec]),
   }
 
@@ -159,13 +229,25 @@ if File.exist?(opts[:spec])
     warn '       A plan narrowed to the easy tiles reports "100% (n/n)" and reads exactly like a'
     warn '       full pass. Either verify these, or record each in'
     warn "       #{opts[:excl]} as {\"chart\":\"<name>\",\"reason\":\"<why>\"}."
-    exit 5
+    die!(5, opts[:out], "#{unaccounted.length} chartable element(s) neither verified nor excluded: #{unaccounted.join(', ')}")
   end
   warn "census: #{census['chartable_total']} chartable, #{census['plan_total']} verified, " \
        "#{census['excluded_total']} excluded — balanced"
+elsif opts[:allow_missing_census]
+  warn "[WAIVED] phase6-parity-domo: no #{opts[:spec]} — anti-inflation census SKIPPED by explicit " \
+       "request: #{opts[:allow_missing_census]}"
+  warn '          This waiver MUST be named in the migration report: the parity denominator was NOT verified.'
 else
-  warn "[WARN] phase6-parity-domo: no #{opts[:spec]} — census SKIPPED, the parity denominator " \
-       'is unverified. Pass --workbook-spec to enable the anti-inflation check.'
+  # Fail closed. A bare [WARN] here silently voided the whole anti-inflation
+  # guarantee for any invocation that did not happen to have workbook-spec.json
+  # beside it — and this script documents standalone use, so that is reachable.
+  # An unverifiable denominator is now a NAMED decision, never a default.
+  warn "[FAIL] phase6-parity-domo: no #{opts[:spec]} — cannot verify the parity denominator."
+  warn '       Without it, a plan narrowed to the easy tiles reports "100% (n/n)" and reads exactly'
+  warn '       like a full pass, which is the failure mode this census exists to prevent.'
+  warn '       Pass --workbook-spec PATH, or, if the spec is genuinely unavailable, waive it'
+  warn '       explicitly with --allow-missing-census "<reason>" (recorded in parity-final.json).'
+  die!(5, opts[:out], "no #{File.basename(opts[:spec])} — parity denominator unverifiable")
 end
 
 # ---------------------------------------------------------------------------
@@ -174,6 +256,17 @@ end
 unless opts[:skip_verify]
   vp = File.expand_path('verify-parity.rb', __dir__)
   abort("phase6-parity-domo: #{vp} not found") unless File.exist?(vp)
+  # Remove any prior score document FIRST, so "the file exists afterwards" can
+  # only mean "this invocation wrote it".
+  #
+  # verify-parity.rb exits non-zero on a genuine divergence, so its exit code
+  # cannot distinguish a finding from a crash, and the crash check below is
+  # presence-of-file. But migrate-domo.rb is idempotent and re-runs into an
+  # ALREADY-POPULATED workdir as the normal path — so a verify-parity that
+  # aborted (e.g. its own missing-requested-column guard) left the PREVIOUS
+  # run's score on disk, which was then finalized into a fresh-timestamped PASS.
+  # Presence is not freshness.
+  File.delete(opts[:score_out]) if File.exist?(opts[:score_out])
   argv = ['ruby', vp, '--plan', opts[:plan], '--score-out', opts[:score_out]]
   argv << '--extract-mode' if opts[:extract_mode]
   out, err, _st = Open3.capture3(*argv)
@@ -186,7 +279,7 @@ end
 unless File.exist?(opts[:score_out])
   warn "[FAIL] phase6-parity-domo: verify-parity.rb wrote no #{opts[:score_out]} — it crashed " \
        'rather than reporting a divergence. Fix that before finalizing; do NOT hand-author the score.'
-  exit 6
+  die!(6, opts[:out], 'verify-parity.rb wrote no score document (it crashed)')
 end
 score = load_json(opts[:score_out])
 tiles = Array(score['tiles'])
@@ -225,7 +318,17 @@ end
 # read (it fails closed when value_parity_score is absent).
 summary['value_parity_score'] = score['value_parity_score']
 summary['per_tile_scores']    = tiles
-summary['tile_census']        = census if census
+# Deliberately NOT the key `tile_census`. The shared gate's gate 5 reads
+# summary['tile_census'] and, whenever it is present, pulls tableau's ZONE-census
+# keys out of it (zones_total / charts_built / zones_unmatched /
+# unmatched_zone_names — assert-phase6-ran.rb:1637-1640). Publishing a
+# differently-shaped document under that name turned gate 5's honest
+# "[SKIP] no tile_census" into an always-true "[OK] ... 0 zones, 0 unmatched":
+# a gate that had been abstaining started reporting success it had not measured.
+# domo builds no dashboard zone tree, so SKIP is the truthful answer, and this
+# census lives under its own key.
+summary['parity_tile_census'] = census if census
+summary['census_waiver']      = opts[:allow_missing_census] if opts[:allow_missing_census]
 if census && census['excluded_total'].to_i.positive?
   doc = load_json(opts[:excl])
   summary['excluded_with_reason'] = (doc.is_a?(Hash) ? (doc['exclusions'] || []) : Array(doc))

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/phase6-parity-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/phase6-parity-domo.rb
@@ -1,0 +1,249 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# phase6-parity-domo.rb — the Phase-6 parity FINALIZER for domo-to-sigma.
+# Bead beads-sigma-2tkm.
+#
+# WHY THIS EXISTS
+# ---------------
+# domo was the only converter of six with no phase6-parity-*.rb finalizer
+# (looker/powerbi/quicksight/tableau/thoughtspot all have one). Without it,
+# migrate-domo.rb pointed verify-parity.rb's --score-out directly at
+# parity-final.json — overwriting the GATE'S CONTRACT FILE with a score
+# document. assert-phase6-ran.rb gate 1 reads charts_total/charts_pass/status;
+# the score document carries tiles_total/tiles_pass/tiles_fail. So the gate read
+# charts_total = 0, fell into the anchors-oracle substitution branch, found no
+# anchors-verdict.json, and exited 2 — meaning a flawless 65/65 parity run was
+# indistinguishable from never having run parity at all.
+#
+# Two documents, two jobs — the same split tableau's phase6-parity.rb:344-382 makes:
+#
+#   parity-score.json   verify-parity.rb --score-out    tiles_*, per-tile value scores
+#   parity-final.json   THIS script                     charts_*/status — the gate contract
+#
+# THE CENSUS (anti-inflation)
+# ---------------------------
+# Gate 1 computes its pass rate purely from what the plan contains; nothing
+# cross-checks the plan against the workbook's actual chartable elements. So a
+# plan quietly narrowed to the easy tiles scores "100% (45/45)" and reads
+# identically to a genuine full pass. This finalizer refuses to emit a contract
+# unless every chartable element is either VERIFIED or EXCLUDED WITH A REASON in
+# parity-plan-exclusions.json. Excluding a tile stays legitimate; excluding it
+# silently does not.
+#
+# Usage:
+#   ruby scripts/phase6-parity-domo.rb --workdir <wd> --plan <wd>/parity-plan.json \
+#     --workbook-id <id> [--workbook-spec PATH] [--exclusions PATH] [--out PATH]
+#     [--score-out PATH] [--skip-verify]
+#
+# Exit codes: 0 = contract written; 1 = bad invocation / missing input;
+#             5 = census unbalanced (unaccounted or reasonless-excluded tiles);
+#             6 = verify-parity.rb produced no score document.
+require 'json'
+require 'optparse'
+require 'open3'
+require 'time'
+
+opts = { workdir: nil, plan: nil, wb: nil, spec: nil, excl: nil, out: nil,
+         score_out: nil, skip_verify: false, extract_mode: false }
+OptionParser.new do |p|
+  p.banner = 'Usage: phase6-parity-domo.rb --workdir DIR --plan PATH [options]'
+  p.on('--workdir DIR', 'run directory (migrate-domo.rb --out)')       { |v| opts[:workdir] = v }
+  p.on('--plan PATH', 'parity plan actually verified')                 { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')                                            { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH', 'default <workdir>/workbook-spec.json') { |v| opts[:spec] = v }
+  p.on('--exclusions PATH', 'default <workdir>/parity-plan-exclusions.json') { |v| opts[:excl] = v }
+  p.on('--out PATH', 'default <workdir>/parity-final.json')            { |v| opts[:out] = v }
+  p.on('--score-out PATH', 'default <workdir>/parity-score.json')      { |v| opts[:score_out] = v }
+  p.on('--extract-mode', 'pass --extract-mode through to verify-parity.rb') { opts[:extract_mode] = true }
+  p.on('--skip-verify', 'finalize from an existing parity-score.json (do not re-run verify-parity)') { opts[:skip_verify] = true }
+end.parse!
+
+abort('phase6-parity-domo: --workdir is required') unless opts[:workdir]
+abort("phase6-parity-domo: --workdir #{opts[:workdir]} does not exist") unless Dir.exist?(opts[:workdir])
+opts[:plan]      ||= File.join(opts[:workdir], 'parity-plan.json')
+opts[:spec]      ||= File.join(opts[:workdir], 'workbook-spec.json')
+opts[:excl]      ||= File.join(opts[:workdir], 'parity-plan-exclusions.json')
+opts[:out]       ||= File.join(opts[:workdir], 'parity-final.json')
+opts[:score_out] ||= File.join(opts[:workdir], 'parity-score.json')
+abort("phase6-parity-domo: --plan #{opts[:plan]} does not exist") unless File.exist?(opts[:plan])
+
+# ---------------------------------------------------------------------------
+# Chartable predicate — kept byte-identical in behaviour to
+# shared/scripts/build-parity-plan.rb:50-57. If that predicate ever changes,
+# this census over-counts and FAILS CLOSED (unaccounted tiles) rather than
+# silently shrinking the denominator; test/test-phase6-parity-domo.rb group E
+# pins the behaviour.
+# ---------------------------------------------------------------------------
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false
+  (el['columns'] || []).any?
+end
+
+# build-parity-plan.rb's own naming rule, so census names and plan names match.
+def element_name(el)
+  n = el['name'].is_a?(Hash) ? el['name']['text'] : el['name']
+  n = nil if n.to_s.empty?
+  (n || el['title'] || el['id']).to_s
+end
+
+def spec_pages(spec)
+  # workbook-spec.json is flat; a GET-back readback nests under `document`
+  # (code-rep wrapper migration) — accept either.
+  return spec['pages'] if spec.is_a?(Hash) && spec['pages'].is_a?(Array)
+  wrapped = spec.is_a?(Hash) ? spec['document'] : nil
+  return wrapped['pages'] if wrapped.is_a?(Hash) && wrapped['pages'].is_a?(Array)
+  if wrapped.is_a?(Array)
+    pg = wrapped.find { |e| e.is_a?(Hash) && e['pages'].is_a?(Array) }
+    return pg['pages'] if pg
+  end
+  []
+end
+
+def load_json(path)
+  JSON.parse(File.read(path))
+rescue StandardError => e
+  abort("phase6-parity-domo: cannot read #{path}: #{e.message}")
+end
+
+# ---------------------------------------------------------------------------
+# 1. Census FIRST — fail before spending a parity run on a narrowed plan.
+# ---------------------------------------------------------------------------
+plan_raw    = load_json(opts[:plan])
+plan_charts = plan_raw.is_a?(Hash) ? (plan_raw['charts'] || []) : Array(plan_raw)
+plan_names  = plan_charts.map { |c| c['chart'].to_s }.reject(&:empty?)
+
+census = nil
+if File.exist?(opts[:spec])
+  chartable_names = spec_pages(load_json(opts[:spec]))
+                    .flat_map { |pg| (pg['elements'] || []) }
+                    .select { |el| chartable?(el) }
+                    .map { |el| element_name(el) }
+
+  excluded = []
+  if File.exist?(opts[:excl])
+    doc = load_json(opts[:excl])
+    excluded = (doc.is_a?(Hash) ? (doc['exclusions'] || []) : Array(doc))
+    reasonless = excluded.select { |e| !e.is_a?(Hash) || e['reason'].to_s.strip.empty? }
+    unless reasonless.empty?
+      warn '[FAIL] phase6-parity-domo: exclusion(s) with no reason in ' \
+           "#{opts[:excl]} — an excluded tile must say WHY:"
+      reasonless.each do |e|
+        warn "         - #{(e.is_a?(Hash) ? e['chart'] : e).to_s.empty? ? '(unnamed)' : e['chart']}"
+      end
+      warn '       A reason is REQUIRED so the exclusion lands in the migration report'
+      warn '       instead of quietly shrinking the parity denominator.'
+      exit 5
+    end
+  end
+  excluded_names = excluded.map { |e| e['chart'].to_s }
+
+  unaccounted = chartable_names - plan_names - excluded_names
+  census = {
+    'chartable_total' => chartable_names.length,
+    'plan_total'      => plan_names.length,
+    'excluded_total'  => excluded_names.length,
+    'unaccounted'     => unaccounted,
+    'source'          => File.basename(opts[:spec]),
+  }
+
+  unless unaccounted.empty?
+    warn "[FAIL] phase6-parity-domo: #{unaccounted.length} chartable element(s) are neither " \
+         'verified nor excluded:'
+    unaccounted.each { |n| warn "         - #{n}" }
+    warn "       chartable=#{chartable_names.length}  in plan=#{plan_names.length}  " \
+         "excluded=#{excluded_names.length}"
+    warn '       A plan narrowed to the easy tiles reports "100% (n/n)" and reads exactly like a'
+    warn '       full pass. Either verify these, or record each in'
+    warn "       #{opts[:excl]} as {\"chart\":\"<name>\",\"reason\":\"<why>\"}."
+    exit 5
+  end
+  warn "census: #{census['chartable_total']} chartable, #{census['plan_total']} verified, " \
+       "#{census['excluded_total']} excluded — balanced"
+else
+  warn "[WARN] phase6-parity-domo: no #{opts[:spec]} — census SKIPPED, the parity denominator " \
+       'is unverified. Pass --workbook-spec to enable the anti-inflation check.'
+end
+
+# ---------------------------------------------------------------------------
+# 2. Run verify-parity.rb for the per-tile score document.
+# ---------------------------------------------------------------------------
+unless opts[:skip_verify]
+  vp = File.expand_path('verify-parity.rb', __dir__)
+  abort("phase6-parity-domo: #{vp} not found") unless File.exist?(vp)
+  argv = ['ruby', vp, '--plan', opts[:plan], '--score-out', opts[:score_out]]
+  argv << '--extract-mode' if opts[:extract_mode]
+  out, err, _st = Open3.capture3(*argv)
+  # A non-zero exit here is EXPECTED when tiles diverge — the divergence is the
+  # finding, not an error. Only a missing score document is fatal.
+  warn out unless out.to_s.strip.empty?
+  warn err unless err.to_s.strip.empty?
+end
+
+unless File.exist?(opts[:score_out])
+  warn "[FAIL] phase6-parity-domo: verify-parity.rb wrote no #{opts[:score_out]} — it crashed " \
+       'rather than reporting a divergence. Fix that before finalizing; do NOT hand-author the score.'
+  exit 6
+end
+score = load_json(opts[:score_out])
+tiles = Array(score['tiles'])
+
+# ---------------------------------------------------------------------------
+# 3. Derive the gate contract.
+# ---------------------------------------------------------------------------
+# PENDING tiles (render-verify fallback) are unresolved, not divergent — they
+# block PASS but are reported separately, as tableau's finalizer does.
+pending_names = tiles.select { |t| t['status'].to_s == 'PENDING' }.map { |t| t['chart'].to_s }
+pass_names    = tiles.select { |t| t['status'].to_s == 'PASS' }.map { |t| t['chart'].to_s }
+fail_names    = tiles.reject { |t| %w[PASS PENDING].include?(t['status'].to_s) }
+                     .map { |t| t['chart'].to_s }
+total = tiles.length
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => score['mode'] || 'strict',
+  # Domo values come from Domo.query_dataset aggregations diffed against live
+  # Sigma element exports — a genuine source comparison, so the gate's
+  # warehouse-only honesty banner does not apply.
+  'verified_against' => 'source',
+  'charts_total'     => total,
+  'charts_pass'      => pass_names.length,
+  'charts_fail'      => fail_names.length,
+  'pass_names'       => pass_names,
+  'fail_names'       => fail_names,
+  'status'           => (total.positive? && fail_names.empty? && pending_names.empty?) ? 'PASS' : 'FAIL',
+}
+unless pending_names.empty?
+  summary['charts_pending_manual'] = pending_names.length
+  summary['pending_names']         = pending_names
+end
+# Fold the value score through so gate 1 --min-parity-score has something to
+# read (it fails closed when value_parity_score is absent).
+summary['value_parity_score'] = score['value_parity_score']
+summary['per_tile_scores']    = tiles
+summary['tile_census']        = census if census
+if census && census['excluded_total'].to_i.positive?
+  doc = load_json(opts[:excl])
+  summary['excluded_with_reason'] = (doc.is_a?(Hash) ? (doc['exclusions'] || []) : Array(doc))
+end
+
+# record-visual-check.rb merges its verdict INTO parity-final.json; never clobber
+# a verdict that is already recorded (same doctrine as tableau preserving
+# tile_census across a finalize-only invocation).
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue nil)
+  if prior.is_a?(Hash)
+    %w[visual_checked visual_verdict screenshot_path agent_vision visual_similarity].each do |k|
+      summary[k] = prior[k] if prior.key?(k)
+    end
+  end
+end
+
+File.write(opts[:out], JSON.pretty_generate(summary))
+warn "wrote #{opts[:out]} (status=#{summary['status']} #{summary['charts_pass']}/#{summary['charts_total']}" \
+     "#{pending_names.empty? ? '' : ", #{pending_names.length} pending"})"
+exit 0

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -85,9 +85,22 @@ end
 # just a guard against the exact regression each fix closes (--score-out
 # silently dropped again, or the render/record calls silently removed)
 # slipping back in unnoticed between now and the next live validation.
-ok(migrate_src.include?("'verify-parity.rb', '--plan', opts[:parity_plan],") &&
-   migrate_src.include?("'--score-out', File.join(OUT, 'parity-final.json')"),
-   'bead B6: run_live! passes --score-out to verify-parity.rb so parity-final.json actually gets written')
+#
+# CORRECTED 2026-08-05 (bead beads-sigma-2tkm). B6's original assertion pinned
+# `--score-out File.join(OUT, 'parity-final.json')` — which was itself the bug.
+# parity-final.json is the GATE'S contract file (assert-phase6-ran.rb reads
+# charts_total/charts_pass/status); verify-parity.rb --score-out writes
+# tiles_total/tiles_pass/tiles_fail. Aiming one at the other meant a flawless
+# 65/65 parity run landed a tiles_*-shaped document where the gate expected
+# charts_*, so the gate read charts_total = 0 and exited 2. The two documents are
+# now distinct, with phase6-parity-domo.rb finalizing score -> contract.
+ok(migrate_src.include?("'phase6-parity-domo.rb'"),
+   'bead 2tkm: run_live! finalizes parity through phase6-parity-domo.rb (the gate-contract writer)')
+ok(!migrate_src.include?("'--score-out', File.join(OUT, 'parity-final.json')"),
+   'bead 2tkm: verify-parity.rb --score-out no longer overwrites the gate contract file')
+ok(migrate_src.include?("'--score-out', File.join(OUT, 'parity-score.json')") ||
+   migrate_src.include?('phase6-parity-domo.rb'),
+   'bead 2tkm: the tiles_* score document lands in parity-score.json, not parity-final.json')
 
 render_call_at  = migrate_src.index('phase_render_visual!(opts, workbook_id, wb_ids)')
 parity_hdr_at   = migrate_src.index("hr('verify-parity')")

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-phase6-parity-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-phase6-parity-domo.rb
@@ -137,8 +137,12 @@ Dir.mktmpdir do |dir|
   truthy(g[:accepted], "assert-phase6-ran.rb gate 1 ACCEPTS a clean 5/5 run (got exit #{g[:exit]})")
 end
 
-puts '== A3. regression guard: the raw score doc alone is NOT gate-readable =='
-# This is the pre-fix state — proves the suite would have caught the original bug.
+puts '== A3. characterisation: the raw score doc alone is NOT gate-readable =='
+# CHARACTERISATION, not a regression guard for this fix. It documents the shared
+# gate's behaviour on the pre-fix artifact (a tiles_*-shaped parity-final.json)
+# and never invokes the finalizer, so reverting the production change would NOT
+# flip it. The actual revert-detecting coverage is groups A/A2/B, which shell out
+# to phase6-parity-domo.rb and fail outright when it is absent.
 Dir.mktmpdir do |dir|
   setup_wd(dir, TILES5)
   VP = File.expand_path('../scripts/verify-parity.rb', __dir__)
@@ -189,7 +193,7 @@ Dir.mktmpdir do |dir|
   eq(r[:exit], 0, 'finalizer exits 0 when every omission is recorded with a reason')
   eq(at(r[:final],'status'), 'PASS', 'status=PASS on the recorded-exclusion run')
   eq(at(r[:final],'charts_total'), 3, 'charts_total is the VERIFIED pool')
-  census = at(r[:final],'tile_census') || {}
+  census = at(r[:final],'parity_tile_census') || {}
   eq(census['chartable_total'], 5, 'census records the true denominator')
   eq(census['excluded_total'],  2, 'census records how many were excluded')
   eq(Array(census['unaccounted']).size, 0, 'census balances: plan + exclusions == chartable')
@@ -231,7 +235,7 @@ Dir.mktmpdir do |dir|
   setup_wd(dir, TILES5)
   r = run_finalizer(dir)
   eq(r[:exit], 0, 'a complete plan passes despite 5 non-chartable elements in the spec')
-  eq(at(r[:final],'tile_census','chartable_total'), 5,
+  eq(at(r[:final],'parity_tile_census','chartable_total'), 5,
      'census excludes controls, text, image, container and hidden masters')
 end
 
@@ -243,7 +247,7 @@ Dir.mktmpdir do |dir|
              JSON.pretty_generate({ 'document' => { 'pages' => flat['pages'] } }))
   r = run_finalizer(dir)
   eq(r[:exit], 0, 'a {document:{pages:[...]}} spec is understood (wrapper migration in flight)')
-  eq(at(r[:final],'tile_census','chartable_total'), 5, 'wrapped spec yields the same denominator')
+  eq(at(r[:final],'parity_tile_census','chartable_total'), 5, 'wrapped spec yields the same denominator')
 end
 
 # --- F. do not clobber a recorded visual verdict ----------------------------
@@ -258,6 +262,132 @@ Dir.mktmpdir do |dir|
   eq(at(r[:final],'visual_verdict'), 'divergent', 'visual_verdict is preserved')
   eq(at(r[:final],'screenshot_path'), 'sigma-render.png', 'screenshot_path is preserved')
   eq(at(r[:final],'charts_total'), 5, 'and the gate contract is still written')
+end
+
+# --- G. duplicate tile names must not launder an unverified tile ------------
+# Review finding 1 (critical). Ruby's Array#- is SET difference: it removes
+# EVERY occurrence of a matching value, not one per match. With two chartable
+# elements sharing a name, a plan verifying only ONE of them produced
+# `unaccounted == []` and a PASS contract — precisely the silent inflation the
+# census exists to stop. The census must compare MULTISETS.
+
+puts '== G. two same-named tiles, only one verified -> caught (Array#- set-difference trap) =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, ['Region Total', 'Region Total', 'Pipeline'], plan_tiles: ['Region Total', 'Pipeline'])
+  r = run_finalizer(dir)
+  truthy(r[:exit] != 0,
+         "one of two same-named chartable tiles is unverified -> must FAIL (got exit #{r[:exit]})")
+  truthy((r[:stdout] + r[:stderr]).include?('Region Total'),
+         'the under-verified duplicate name is reported')
+  truthy(!(r[:final] && at(r[:final], 'status') == 'PASS'),
+         'no PASS contract for a plan that covers only one of two same-named tiles')
+end
+
+puts '== G2. both same-named tiles verified -> census balances =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, ['Region Total', 'Region Total', 'Pipeline'],
+           plan_tiles: ['Region Total', 'Region Total', 'Pipeline'])
+  r = run_finalizer(dir)
+  eq(r[:exit], 0, 'verifying both duplicates passes the census')
+  eq(at(r[:final], 'status'), 'PASS', 'and yields a PASS contract')
+  eq(at(r[:final], 'parity_tile_census', 'chartable_total'), 3, 'denominator counts both duplicates')
+end
+
+puts '== G3. one reasoned exclusion does not silence BOTH same-named tiles =='
+Dir.mktmpdir do |dir|
+  excl = { 'exclusions' => [{ 'chart' => 'Region Total', 'reason' => 'top-N tie-break unstable' }] }
+  setup_wd(dir, ['Region Total', 'Region Total', 'Pipeline'],
+           plan_tiles: ['Pipeline'], exclusions: excl)
+  r = run_finalizer(dir)
+  truthy(r[:exit] != 0,
+         "1 plan + 1 exclusion cannot account for 2 same-named tiles (got exit #{r[:exit]})")
+end
+
+# --- H. a stale score document must not be read as this run's result --------
+# Review finding 2 (critical). verify-parity.rb exits non-zero on a genuine
+# divergence, so the finalizer deliberately ignores its exit code and treats a
+# missing score file as the only crash signal. But presence-of-file is not
+# freshness-of-file: on a reused workdir (the NORMAL path — migrate-domo.rb is
+# idempotent and skips phases whose artifacts exist) a crashing verify-parity
+# left the PREVIOUS run's score document on disk, which was then finalized into a
+# fresh-timestamped PASS.
+
+puts '== H. a crashing verify-parity cannot be masked by a previous run\'s score doc =='
+Dir.mktmpdir do |dir|
+  # 1. a clean run leaves a passing parity-score.json behind
+  setup_wd(dir, ['Tile A'])
+  first = run_finalizer(dir)
+  eq(at(first[:final], 'status'), 'PASS', 'setup: the first clean run PASSes')
+  truthy(File.exist?(File.join(dir, 'parity-score.json')), 'setup: a score document is on disk')
+
+  # 2. re-verify the SAME workdir with a plan that makes verify-parity.rb abort
+  #    (its documented missing-requested-column guard), writing nothing new
+  crash_plan = { 'charts' => [
+    { 'chart' => 'Tile A',
+      'expected' => { 'columns' => %w[lines orders], 'rows' => [[1, 2]],
+                      'requested_columns' => %w[lines totally_absent_measure] },
+      'actual' => { 'rows' => [[1, 2]] } },
+  ] }
+  File.write(File.join(dir, 'parity-plan.json'), JSON.pretty_generate(crash_plan))
+  r = run_finalizer(dir)
+  truthy(r[:exit] != 0,
+         "a crashed verify-parity must FAIL the finalizer, not inherit a stale score (got exit #{r[:exit]})")
+  truthy(!(r[:final] && at(r[:final], 'status') == 'PASS'),
+         'no PASS contract may be derived from a previous run\'s score document')
+end
+
+# --- I. the census is not optional ------------------------------------------
+# Review finding 3. The census was skipped with a bare [WARN] when
+# workbook-spec.json was absent, so the whole anti-inflation guarantee silently
+# evaporated for any standalone invocation — and the script's own usage banner
+# documents standalone use. An absent denominator must be a NAMED decision.
+
+puts '== I. a missing workbook-spec is a hard failure, not a silent [WARN] =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  File.delete(File.join(dir, 'workbook-spec.json'))
+  r = run_finalizer(dir)
+  truthy(r[:exit] != 0,
+         "no workbook-spec -> no denominator -> must FAIL rather than warn (got exit #{r[:exit]})")
+  truthy(!(r[:final] && at(r[:final], 'status') == 'PASS'),
+         'no PASS contract without a verified denominator')
+end
+
+puts '== I2. ...unless the operator names the reason, which is recorded in the contract =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  File.delete(File.join(dir, 'workbook-spec.json'))
+  r = run_finalizer(dir, '--allow-missing-census', 'spec pruned by an external archive step')
+  eq(r[:exit], 0, 'an explicitly named opt-out is accepted')
+  eq(at(r[:final], 'census_waiver'), 'spec pruned by an external archive step',
+     'the reason is recorded in the contract so the report cannot omit it')
+end
+
+# --- J. gate 5 must keep its honest SKIP -----------------------------------
+# Review finding 4 (self-inflicted). The shared gate's gate 5 reads
+# summary['tile_census'] and, when present, pulls tableau's ZONE-census keys
+# (zones_total / charts_built / zones_unmatched / unmatched_zone_names). Emitting
+# a differently-shaped doc under that exact key turned gate 5's honest
+# "[SKIP] no tile_census" into a always-true "[OK] ... 0 zones, 0 unmatched".
+# domo has no dashboard zone tree, so the honest answer is SKIP.
+
+puts '== J. the parity census does not hijack gate 5\'s zone-census key =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  r = run_finalizer(dir)
+  truthy(!(r[:final] || {}).key?('tile_census'),
+         'parity-final.json must NOT carry a tile_census key (gate 5 would misread it as zones)')
+  truthy((r[:final] || {}).key?('parity_tile_census'),
+         'the census is still recorded, under its own key')
+  # Gate 5 itself cannot be exercised offline — it sits behind gate 3, which
+  # live-GETs the workbook. So assert the CONTRACT statically instead: the gate
+  # keys its zone census on 'tile_census', and our document must not answer to
+  # that name. This is checked against the real gate source, not a copy of it.
+  gate_src = File.read(GATE)
+  truthy(gate_src.include?("summary['tile_census']"),
+         "sanity: the shared gate really does key gate 5 on 'tile_census'")
+  truthy(gate_src.include?("census['zones_total']"),
+         'sanity: and reads tableau ZONE keys out of it, which domo has no equivalent for')
 end
 
 puts

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-phase6-parity-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-phase6-parity-domo.rb
@@ -1,0 +1,265 @@
+#!/usr/bin/env ruby
+# Contract tests for scripts/phase6-parity-domo.rb — the missing PARITY FINALIZER
+# (bead beads-sigma-2tkm).
+#
+# Root cause this covers: domo was the ONLY converter of six with no
+# phase6-parity-*.rb finalizer. migrate-domo.rb aimed verify-parity.rb's
+# --score-out straight at parity-final.json, so the gate's contract file was
+# overwritten with a tiles_*-shaped score document. assert-phase6-ran.rb gate 1
+# reads charts_total/charts_pass/status, found none of them, computed
+# charts_total = 0, and dropped into the anchors-oracle substitution branch —
+# so a flawless 65/65 parity run exited 2. The two documents are distinct:
+#
+#   parity-score.json  <- verify-parity.rb --score-out   (tiles_*, per-tile scores)
+#   parity-final.json  <- THIS finalizer                 (charts_*/status, gate contract)
+#
+# Every other converter already draws that line (tableau phase6-parity.rb:344-382
+# is the reference implementation). This restores it for domo.
+#
+# The suite deliberately asserts BOTH directions against the REAL shared gate:
+# a clean run must be ACCEPTED, and a planted divergence must be REJECTED. A
+# finalizer that only ever emits status=PASS would satisfy the first half alone.
+#
+# Offline: no network, no creds.
+#   ruby test/test-phase6-parity-domo.rb
+require 'json'
+require 'tmpdir'
+require 'open3'
+require 'fileutils'
+
+FINALIZER = File.expand_path('../scripts/phase6-parity-domo.rb', __dir__)
+GATE      = File.expand_path('../scripts/assert-phase6-ran.rb', __dir__)
+
+$failures = 0
+def eq(a, b, m)
+  if a == b then puts "  ok: #{m}"
+  else $failures += 1; puts "  FAIL: #{m}\n    exp #{b.inspect}\n    got #{a.inspect}" end
+end
+def truthy(v, m)
+  if v then puts "  ok: #{m}"
+  else $failures += 1; puts "  FAIL: #{m}\n    got #{v.inspect}" end
+end
+# Nil-safe fetch: before the finalizer exists every group must still report its
+# own failure rather than the first one aborting the suite.
+def at(doc, *path) path.reduce(doc) { |d, k| d.is_a?(Hash) || d.is_a?(Array) ? d[k] : nil } end
+
+# --- fixture helpers ---------------------------------------------------------
+
+# One chartable element per tile name, plus the non-chartable furniture that
+# build-parity-plan.rb's own `chartable?` predicate excludes. If this drifts out
+# of sync with shared/scripts/build-parity-plan.rb the census denominator is
+# wrong, so the drift is asserted directly (group E).
+def wb_spec(tile_names, extras: true)
+  els = tile_names.each_with_index.map do |n, i|
+    { 'id' => "el-#{i}", 'kind' => 'kpi-chart', 'name' => n,
+      'columns' => [{ 'id' => "c-#{i}", 'name' => 'v' }] }
+  end
+  if extras
+    els += [
+      { 'id' => 'ctl-1',  'kind' => 'control-list-values', 'name' => 'Region control',
+        'columns' => [{ 'id' => 'cc', 'name' => 'v' }] },
+      { 'id' => 'txt-1',  'kind' => 'text',      'name' => 'Header',  'columns' => [] },
+      { 'id' => 'img-1',  'kind' => 'image',     'name' => 'Logo',    'columns' => [] },
+      { 'id' => 'cont-1', 'kind' => 'container', 'name' => 'Wrapper', 'columns' => [] },
+      # hidden data-page master: chartable kind + columns, but visibleAsSource=false
+      { 'id' => 'master-1', 'kind' => 'table', 'name' => 'Master (SALESFORCE)',
+        'visibleAsSource' => false, 'columns' => [{ 'id' => 'mc', 'name' => 'v' }] },
+    ]
+  end
+  { 'name' => 'WB', 'schemaVersion' => 1, 'kind' => 'workbook', 'pages' => [{ 'elements' => els }] }
+end
+
+# A verify-parity plan whose tiles carry inline expected+actual, so the whole
+# chain runs offline. `diverge` names tiles whose actual is wrong on purpose.
+def plan_for(tile_names, diverge: [])
+  charts = tile_names.map do |n|
+    actual = diverge.include?(n) ? [['east', 999]] : [['east', 100]]
+    { 'chart' => n, 'expected' => [['east', 100]], 'actual' => { 'rows' => actual } }
+  end
+  { 'charts' => charts }
+end
+
+def setup_wd(dir, tile_names, plan_tiles: nil, diverge: [], exclusions: nil, extras: true)
+  plan_tiles ||= tile_names
+  File.write(File.join(dir, 'workbook-spec.json'), JSON.pretty_generate(wb_spec(tile_names, extras: extras)))
+  File.write(File.join(dir, 'parity-plan.json'),   JSON.pretty_generate(plan_for(plan_tiles, diverge: diverge)))
+  File.write(File.join(dir, 'parity-plan-exclusions.json'), JSON.pretty_generate(exclusions)) if exclusions
+  dir
+end
+
+def run_finalizer(dir, *extra)
+  out, err, st = Open3.capture3('ruby', FINALIZER, '--workdir', dir,
+                                '--plan', File.join(dir, 'parity-plan.json'),
+                                '--workbook-id', 'wb-test', *extra)
+  final_path = File.join(dir, 'parity-final.json')
+  score_path = File.join(dir, 'parity-score.json')
+  { stdout: out, stderr: err, exit: st.exitstatus,
+    final: (File.exist?(final_path) ? JSON.parse(File.read(final_path)) : nil),
+    score: (File.exist?(score_path) ? JSON.parse(File.read(score_path)) : nil) }
+end
+
+# Gate 1 verdict only. Gate 1 exits 2 on failure before any later gate runs; on
+# success it prints "[OK] gate 1/7" and falls through to gates that this bare
+# fixture workdir cannot satisfy — so the OK line, not the exit code, is the
+# signal for the accept case.
+def gate1(dir)
+  out, err, st = Open3.capture3('ruby', GATE, '--workdir', dir, '--workbook-id', 'wb-test')
+  combined = out + err
+  { accepted: combined.include?('[OK] gate 1/7'),
+    rejected: st.exitstatus == 2 && combined.include?('[FAIL] parity status='),
+    exit: st.exitstatus, out: combined }
+end
+
+TILES5 = ['Deals Won', 'Pipeline', 'Win Rate', 'Avg Deal Size', 'Survey Completion Rate'].freeze
+
+# --- A. the gate contract ----------------------------------------------------
+
+puts '== A. a clean parity run writes the gate-shaped contract (charts_*, not tiles_*) =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  r = run_finalizer(dir)
+  eq(r[:exit], 0, 'finalizer exits 0 on a clean run')
+  truthy(r[:final], 'parity-final.json is written')
+  eq(at(r[:final],'charts_total'), 5, 'charts_total is the tile count (the key the gate actually reads)')
+  eq(at(r[:final],'charts_pass'),  5, 'charts_pass is populated')
+  eq(at(r[:final],'charts_fail'),  0, 'charts_fail is populated')
+  eq(at(r[:final],'status'), 'PASS', 'status=PASS on a clean run')
+  truthy(r[:score], 'the tiles_* score document is preserved SEPARATELY as parity-score.json')
+  eq(at(r[:score],'tiles_total'), 5, 'parity-score.json keeps the tiles_* schema')
+  truthy(!(r[:final] || {}).key?('tiles_total'), 'parity-final.json is not just the score doc renamed')
+end
+
+puts '== A2. the REAL shared gate accepts that contract (this is what 2tkm broke) =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  run_finalizer(dir)
+  g = gate1(dir)
+  truthy(g[:accepted], "assert-phase6-ran.rb gate 1 ACCEPTS a clean 5/5 run (got exit #{g[:exit]})")
+end
+
+puts '== A3. regression guard: the raw score doc alone is NOT gate-readable =='
+# This is the pre-fix state — proves the suite would have caught the original bug.
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  VP = File.expand_path('../scripts/verify-parity.rb', __dir__)
+  Open3.capture3('ruby', VP, '--plan', File.join(dir, 'parity-plan.json'),
+                 '--score-out', File.join(dir, 'parity-final.json'))
+  g = gate1(dir)
+  truthy(!g[:accepted], 'a tiles_*-shaped parity-final.json is NOT accepted by gate 1 (the 2tkm bug)')
+end
+
+# --- B. fail-first: a planted divergence must be REJECTED -------------------
+
+puts '== B. a planted divergence produces status=FAIL and is REJECTED by the gate =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5, diverge: ['Win Rate'])
+  r = run_finalizer(dir)
+  eq(at(r[:final],'status'), 'FAIL', 'status=FAIL when one tile diverges')
+  eq(at(r[:final],'charts_pass'), 4, 'charts_pass counts only the passing tiles')
+  eq(at(r[:final],'charts_fail'), 1, 'charts_fail counts the divergence')
+  truthy(Array(at(r[:final],'fail_names')).include?('Win Rate'),
+         'fail_names names the diverging tile so the gate can report it')
+  g = gate1(dir)
+  truthy(g[:rejected], "gate 1 REJECTS the diverging run with exit 2 (got exit #{g[:exit]})")
+end
+
+# --- C. the anti-inflation census -------------------------------------------
+
+puts '== C. omitting chartable tiles from the plan is caught, not silently inflated =='
+# The audit failure mode: a plan carrying only the 45 easy tiles scores
+# "100% (45/45)" and reads identically to a genuine 65/65 pass.
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5, plan_tiles: TILES5.first(3))
+  r = run_finalizer(dir)
+  truthy(r[:exit] != 0, "finalizer FAILS when 2 of 5 chartable tiles are absent from the plan (got exit #{r[:exit]})")
+  truthy((r[:stdout] + r[:stderr]).include?('Avg Deal Size'),
+         'the unaccounted tiles are named, not just counted')
+  truthy(!(r[:final] && at(r[:final],'status') == 'PASS'),
+         'no PASS contract is emitted for a silently-narrowed plan')
+end
+
+puts '== C2. a RECORDED exclusion balances the census and is carried into the contract =='
+Dir.mktmpdir do |dir|
+  excl = { 'exclusions' => [
+    { 'chart' => 'Avg Deal Size', 'reason' => 'top-N with no documented secondary sort — tie-break unstable' },
+    { 'chart' => 'Survey Completion Rate', 'reason' => 'date window baked into the plotted value; true answer changes daily' },
+  ] }
+  setup_wd(dir, TILES5, plan_tiles: TILES5.first(3), exclusions: excl)
+  r = run_finalizer(dir)
+  eq(r[:exit], 0, 'finalizer exits 0 when every omission is recorded with a reason')
+  eq(at(r[:final],'status'), 'PASS', 'status=PASS on the recorded-exclusion run')
+  eq(at(r[:final],'charts_total'), 3, 'charts_total is the VERIFIED pool')
+  census = at(r[:final],'tile_census') || {}
+  eq(census['chartable_total'], 5, 'census records the true denominator')
+  eq(census['excluded_total'],  2, 'census records how many were excluded')
+  eq(Array(census['unaccounted']).size, 0, 'census balances: plan + exclusions == chartable')
+  truthy(Array(at(r[:final],'excluded_with_reason')).size == 2,
+         'the exclusions ride along in the contract so the report cannot omit them')
+end
+
+puts '== C3. an exclusion without a reason cannot launder a dropped tile =='
+Dir.mktmpdir do |dir|
+  excl = { 'exclusions' => [{ 'chart' => 'Avg Deal Size' },
+                            { 'chart' => 'Survey Completion Rate', 'reason' => '' }] }
+  setup_wd(dir, TILES5, plan_tiles: TILES5.first(3), exclusions: excl)
+  r = run_finalizer(dir)
+  truthy(r[:exit] != 0, "a reasonless exclusion is rejected (got exit #{r[:exit]})")
+  truthy((r[:stdout] + r[:stderr]).downcase.include?('reason'),
+         'the failure explains that a reason is required')
+end
+
+# --- D. score fold-through so --min-parity-score works ----------------------
+
+puts '== D. the per-tile value score is folded into the contract =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  r = run_finalizer(dir)
+  truthy(!at(r[:final],'value_parity_score').nil?,
+         'value_parity_score is present (gate 1 --min-parity-score fails closed without it)')
+  truthy(Array(at(r[:final],'per_tile_scores')).size == 5,
+         'per_tile_scores carries every tile so the gate can name the low scorers')
+  eq(at(r[:final],'verified_against'), 'source',
+     'verified_against=source — Domo values, not the warehouse honesty banner')
+end
+
+# --- E. census predicate must match build-parity-plan.rb --------------------
+
+puts '== E. controls / text / images / containers / hidden masters are not chartable =='
+Dir.mktmpdir do |dir|
+  # 5 real tiles + 5 pieces of furniture; a census that counted furniture would
+  # report chartable_total = 10 and fail a plan that is genuinely complete.
+  setup_wd(dir, TILES5)
+  r = run_finalizer(dir)
+  eq(r[:exit], 0, 'a complete plan passes despite 5 non-chartable elements in the spec')
+  eq(at(r[:final],'tile_census','chartable_total'), 5,
+     'census excludes controls, text, image, container and hidden masters')
+end
+
+puts '== E2. the census reads a document-wrapped readback too =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  flat = JSON.parse(File.read(File.join(dir, 'workbook-spec.json')))
+  File.write(File.join(dir, 'workbook-spec.json'),
+             JSON.pretty_generate({ 'document' => { 'pages' => flat['pages'] } }))
+  r = run_finalizer(dir)
+  eq(r[:exit], 0, 'a {document:{pages:[...]}} spec is understood (wrapper migration in flight)')
+  eq(at(r[:final],'tile_census','chartable_total'), 5, 'wrapped spec yields the same denominator')
+end
+
+# --- F. do not clobber a recorded visual verdict ----------------------------
+
+puts '== F. a pre-existing visual verdict survives the finalizer =='
+Dir.mktmpdir do |dir|
+  setup_wd(dir, TILES5)
+  File.write(File.join(dir, 'parity-final.json'), JSON.pretty_generate(
+    { 'visual_checked' => true, 'visual_verdict' => 'divergent',
+      'screenshot_path' => 'sigma-render.png' }))
+  r = run_finalizer(dir)
+  eq(at(r[:final],'visual_verdict'), 'divergent', 'visual_verdict is preserved')
+  eq(at(r[:final],'screenshot_path'), 'sigma-render.png', 'screenshot_path is preserved')
+  eq(at(r[:final],'charts_total'), 5, 'and the gate contract is still written')
+end
+
+puts
+if $failures.zero? then puts 'ALL PASS'; exit 0
+else puts "#{$failures} FAILURE(S)"; exit 1 end


### PR DESCRIPTION
Bead `beads-sigma-2tkm`, promoted to *the* gate blocker by the road-to-gold audit (#629).

## The bug

A flawless 65/65 Domo-vs-Sigma parity run was **indistinguishable from parity never having run** — `assert-phase6-ran.rb` gate 1 exited 2 on it.

## Root cause — not the schema shim the audit proposed

The audit called this a schema mismatch and scoped a shim into the **shared** gate. It's simpler than that: **`domo` was the only converter of six with no `phase6-parity-*.rb` finalizer.**

| converter | finalizer |
|---|---|
| looker, powerbi, quicksight, tableau, thoughtspot | ✅ |
| **domo** | ❌ |

Two documents were being conflated:

| file | writer | schema |
|---|---|---|
| `parity-score.json` | `verify-parity.rb --score-out` | `tiles_total` / `tiles_pass` / `tiles_fail` |
| `parity-final.json` | **the finalizer** | `charts_total` / `charts_pass` / `status` |

`migrate-domo.rb` aimed `--score-out` straight at `parity-final.json`, overwriting the gate's contract file with a score document. The gate reads `charts_total`/`charts_pass`/`status` (`assert-phase6-ran.rb:1116-1118`), found none of them, computed `charts_total = 0`, dropped into the anchors-oracle substitution branch, found no `anchors-verdict.json`, and exited 2.

That wiring came from bead B6 in #623, which correctly spotted `--score-out` was never plumbed through but aimed it at the wrong file. The static guard added alongside it (`test-migrate-domo.rb:88`) **pinned the bug in place**; it's corrected here rather than deleted, with the reasoning inline.

**Fixing the shared gate instead would have loosened one script across 8 plugins and lost the `status`/`pass_names` derivation. This touches no shared file** — pre-commit confirms all 680 shared-file copies still match canonical.

`tableau-to-sigma/scripts/phase6-parity.rb:344-382` is the reference implementation this follows.

## Also: the anti-inflation census

Gate 1 computes its pass rate purely from what the plan contains; nothing cross-checked the plan against the workbook's real chartable elements. A plan narrowed to the easy tiles scores **"100% (45/45)" and reads identically to a genuine 65/65 pass**. The finalizer now refuses to emit a contract unless every chartable element is either verified or recorded in `parity-plan-exclusions.json` **with a reason**, and the exclusions ride along in the contract so the report can't omit them.

## Review round (second commit)

An independent review found two further ways to emit an unearned PASS, plus one regression I introduced. All reproduced before fixing:

- **Duplicate tile names laundered an unverified tile.** `Array#-` is *set* difference — it removes every occurrence. Two same-named chartable elements + a plan verifying one = `unaccounted == []` and a PASS. Now a multiset comparison.
- **A stale `parity-score.json` masked a crash as a fresh PASS.** Presence ≠ freshness, and re-running into a populated workdir is the *normal* path. The score doc is deleted before `verify-parity` runs. Fixing that exposed the same trap one level up: a failed finalize left the earlier `parity-final.json` (PASS) for the gate to read — every non-zero exit now invalidates it.
- **I made gate 5 dishonest.** Publishing a differently-shaped census under the key `tile_census` turned gate 5's honest `[SKIP]` into an always-true `[OK] ... 0 zones, 0 unmatched`. Renamed to `parity_tile_census`; domo has no zone tree, so SKIP is the truthful answer.
- The census was skippable with a bare `[WARN]` when the spec was absent — now a hard failure unless waived by name with `--allow-missing-census REASON`.

## Test plan

- [x] `test/test-phase6-parity-domo.rb` — 63 assertions, asserting **both directions against the real unmodified shared gate**, because a finalizer that only ever emitted `status=PASS` would satisfy the accept case alone:
  - a clean 5/5 run is **ACCEPTED** by gate 1
  - a **planted divergence** yields `status=FAIL` and is **REJECTED** with exit 2
  - the pre-fix artifact is not gate-readable; a narrowed plan fails and names the unaccounted tiles; a reasonless exclusion can't launder a drop
- [x] Full offline suite: 24 files, ALL SUITES PASS
- [x] Hygiene clean; shared-file governance clean; plugin version 0.13.0 → 0.14.0
- [ ] **Live re-run still required.** This is gate *plumbing*, not evidence of parity. Do not read a passing gate here as a gold verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)