### PR TITLE
chore(domo-to-sigma): re-vendor sql.mjs for the DATEDIFF fix (bead znvg) + pin the 2-arg form

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "2f8c6cd",
-  "source_commit_date": "2026-07-31",
+  "source_commit": "0641a62",
+  "source_commit_date": "2026-08-05",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "sql.mjs",
   "source_file": "src/formulas.ts",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs
@@ -1,4 +1,4 @@
-// ../../../private/tmp/sigma-data-model-mcp-vendor/build/sigma-ids.js
+// ../../../../sigma-data-model-mcp/.git-wt/main-vendor/build/sigma-ids.js
 var NS_MODULUS = 62 ** 4;
 var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "a",
@@ -58,7 +58,7 @@ Groupings (for LOD / different aggregation levels):
   Array order = nesting hierarchy. Use child elements for LOD patterns.
 `.trim();
 
-// ../../../private/tmp/sigma-data-model-mcp-vendor/build/formulas.js
+// ../../../../sigma-data-model-mcp/.git-wt/main-vendor/build/formulas.js
 function decodeXmlEntities(s) {
   if (!s || s.indexOf("&") === -1)
     return s;
@@ -365,6 +365,84 @@ function lookIsComplexSql(sql) {
   if (/[=<>!+\-*\/%]/.test(cleaned.replace(/'[^']*'/g, "")))
     return true;
   return false;
+}
+function _splitTopLevelArgs(s) {
+  const args = [];
+  let depth = 0, quote = "", bracket = false, cur = "";
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      cur += c;
+      if (c === quote)
+        quote = "";
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      quote = c;
+      cur += c;
+      continue;
+    }
+    if (c === "[")
+      bracket = true;
+    else if (c === "]")
+      bracket = false;
+    if (!bracket) {
+      if (c === "(")
+        depth++;
+      else if (c === ")")
+        depth--;
+      else if (c === "," && depth === 0) {
+        args.push(cur);
+        cur = "";
+        continue;
+      }
+    }
+    cur += c;
+  }
+  args.push(cur);
+  return args;
+}
+var _MYSQL_DIFF_UNIT = { DATEDIFF: "day", TIMEDIFF: "second" };
+function _rewriteMysqlDateDiff(expr) {
+  const NAME = /\b(DATEDIFF|TIMEDIFF)\s*\(/i;
+  let out = "", rest = expr;
+  for (; ; ) {
+    const m = NAME.exec(rest);
+    if (!m) {
+      out += rest;
+      break;
+    }
+    const open = m.index + m[0].length - 1;
+    let depth = 0, close = -1;
+    for (let i = open; i < rest.length; i++) {
+      if (rest[i] === "(")
+        depth++;
+      else if (rest[i] === ")") {
+        depth--;
+        if (depth === 0) {
+          close = i;
+          break;
+        }
+      }
+    }
+    if (close === -1) {
+      out += rest;
+      break;
+    }
+    const inner = rest.slice(open + 1, close);
+    const args = _splitTopLevelArgs(inner);
+    out += rest.slice(0, m.index);
+    if (args.length === 2) {
+      const unit = _MYSQL_DIFF_UNIT[m[1].toUpperCase()];
+      const end = _rewriteMysqlDateDiff(args[0]).trim();
+      const start = _rewriteMysqlDateDiff(args[1]).trim();
+      out += `DateDiff("${unit}", ${start}, ${end})`;
+    } else {
+      out += `${rest.slice(m.index, open + 1)}${_rewriteMysqlDateDiff(inner)})`;
+    }
+    rest = rest.slice(close + 1);
+  }
+  return out;
 }
 var LOOK_FUNC_MAP = {
   "MONTH": "Month",
@@ -738,6 +816,7 @@ function lookConvertExpression(expr) {
   const cd = _maskCountDistinct(expr);
   const { masked, lits } = _maskLiterals(cd.masked);
   expr = masked;
+  expr = _rewriteMysqlDateDiff(expr);
   const ec = _convertNestedCases(expr, lits, "leave-raw", cd.args);
   expr = ec.text;
   expr = expr.replace(/\b([A-Z_][A-Z0-9_]*)\s*(?=\()/gi, (match, fn) => {

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-convert-beast-modes-fixtures.rb
@@ -40,6 +40,27 @@ FIXTURES = [
   { id: 'D-8', sql: 'ROUND([Margin Pct], 2)',                     expect: 'Round([Margin Pct], 2)' },
   { id: 'D-9', sql: "DATEDIFF('day', [Order Date], [Ship Date])", expect: 'DateDiff("day", [Order Date], [Ship Date])' },
   { id: 'D-10', sql: 'COALESCE([Discount], 0)',                   expect: 'Coalesce([Discount], 0)' },
+  # D-11..D-14 — MySQL 2-arg DATEDIFF/TIMEDIFF (bead beads-sigma-znvg, upstream
+  # PR #122, vendored at source 0641a62). D-9 above only ever covered the 3-arg
+  # form; the 2-arg form is what Domo Beast Modes actually emit, and it produced
+  # `DateDiff(Today(),[Date])` — wrong arity AND wrong operand order — which is
+  # not valid Sigma and caused 9 of the 15 type=error columns on the live
+  # 36-card cold run. These fixtures fail on the PRE-#122 bundle (measured:
+  # `DateDiff(Today(),[Date])`), so they are what makes a re-vendor regression
+  # loud on the domo side rather than only upstream.
+  #
+  # D-12 is the important one: both operands are columns, so a half-fix that adds
+  # the unit WITHOUT swapping still compiles and silently returns the negation —
+  # no error anywhere. Pinning the exact operand order is the only thing that
+  # catches it.
+  { id: 'D-11', sql: 'datediff(current_date(),[Date])',
+    expect: 'DateDiff("day", [Date], Today())' },
+  { id: 'D-12', sql: 'DATEDIFF([CloseDate],[CreatedDate])',
+    expect: 'DateDiff("day", [CreatedDate], [CloseDate])' },
+  { id: 'D-13', sql: 'TIMEDIFF([ended_at],[started_at])',
+    expect: 'DateDiff("second", [started_at], [ended_at])' },
+  { id: 'D-14', sql: 'SUM(CASE WHEN DATEDIFF(current_date(),[Date]) < 7 THEN 1 ELSE 0 END)',
+    expect: 'Sum(If(DateDiff("day", [Date], Today()) < 7, 1, 0))' },
 ]
 # NOTE (converted:false expected): the vendored converter has no Sigma mapping
 # for LIKE/BETWEEN — this is intentional, not a bug (see design doc's Error


### PR DESCRIPTION
Companion to [sigma-data-model-mcp#122](https://github.com/twells89/sigma-data-model-mcp/pull/122) (merged, `0641a62`). **Until this lands the fix has no effect on the pipeline** — `domo-to-sigma` runs the committed bundle, never the upstream source (memory `mcp-sync`).

## Verified through the bundle, not just upstream

All five `DATEDIFF` call sites **measured** from the cold run's own `discovery/formulas.json`:

| source (post-normalize) | vendored bundle output |
|---|---|
| `datediff(current_date(),[Date])` | `DateDiff("day", [Date], Today())` |
| `DateDiff(Current_Date(),[Date])` | `DateDiff("day", [Date], Today())` |
| `DATEDIFF(current_date(),[created_on])` | `DateDiff("day", [created_on], Today())` |
| `DATEDIFF([CloseDate],[CreatedDate])` | `DateDiff("day", [CreatedDate], [CloseDate])` |
| `datediff(current_date(),[Created At])` | `DateDiff("day", [Created At], Today())` |
| `DATEDIFF('day', [c], [d])` | `DateDiff("day", [c], [d])` — 3-arg, unchanged |

## Fixtures D-11..D-14, and the fail-first proof

The existing `D-9` only ever covered the **3-arg** form — which is exactly why the 2-arg form reached a live run. `D-12` is the load-bearing case: both operands are columns, so a half-fix that adds the unit **without** swapping still compiles and silently returns the negation, with no error anywhere.

These aren't assumed to work. With the pre-#122 bundle planted back in place:

```
FAIL  D-11  ...  FAIL  D-12  ...  FAIL  D-13  ...  FAIL  D-14
4 FAILURE(S)
```

and with the re-vendored bundle all four pass. The guard demonstrably catches the defect it claims to (memory `verification-gates-must-fail-first`).

## Test plan

- [x] Full offline suite: 24 files, ALL SUITES PASS
- [x] Fail-first proven on the old bundle (4 failures), passing on the new
- [x] `PROVENANCE.json` stamped to `0641a62`; plugin 0.14.0 → 0.14.1
- [x] Shared-file governance clean (680 copies match canonical); hygiene clean

## Scope — does NOT close bead `znvg`

This addresses **9 of the 15** `type=error` columns. The other 6 (`State` / `US Regions`) remain unexplained: they convert to valid, lint-clean Sigma (`converted:true`, `lintErrors:[]`), and two candidate mechanisms were actively **disproved** — a dotted-identifier/infix-`IN` mangling (doesn't occur; backticks are normalised to brackets before the converter) and the `0goi` literal corruption (source data, not ours). The doc's mega-`If` depth hypothesis is still **inferred** and needs one live `diagnose_sigma_save_error` call. Don't budget it as understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)