### PR TITLE
fix(test): unwrap the code-rep document envelope in test-put-layout-prune (unblocks #613 CI)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-put-layout-prune.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-put-layout-prune.rb
@@ -85,8 +85,19 @@ Dir.mktmpdir do |work|
                             'ruby', SCRIPT, '--workbook', 'wb-test', '--layout', layout)
   ok('re-PUT exits 0') { st.exitstatus == 0 }
   ok('a PUT was sent') { put_bodies.length == 1 }
-  spec = put_bodies.empty? ? {} : (JSON.parse(put_bodies.first) rescue {})
+  raw_put = put_bodies.empty? ? {} : (JSON.parse(put_bodies.first) rescue {})
+  # Workbook code-rep nests the document under a top-level `document` key, and the
+  # old flat PUT body is now REJECTED with a 400 — so put-layout.rb wraps what it
+  # sends. Accept either envelope: this test pins the PRUNE behaviour, not the
+  # transport shape.
+  #
+  # Without this unwrap `spec['pages']` was nil, so `ids` came out EMPTY — which
+  # made the three "stale ... pruned" checks below pass VACUOUSLY (they are negative
+  # assertions: `!ids.include?`). Only the positive assertions failed, so the suite
+  # under-reported the breakage. The envelope-sanity check keeps that from recurring.
+  spec = raw_put['document'].is_a?(Hash) ? raw_put['document'] : raw_put
   els = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  ok('the PUT body carries a document with pages (envelope sanity)') { !els.empty? }
   ids = els.map { |e| e['id'] }
   ok('stale injected safety-net container pruned (tc-page-pw-extra)') { !ids.include?('tc-page-pw-extra') }
   ok('stale fabricated header text pruned (band-page-pw-hdrtext)') { !ids.include?('band-page-pw-hdrtext') }


### PR DESCRIPTION
Targets **`fix/coderep-put-layout-family`** (#613), not `main` — it fixes that PR's own red checks. Opened as a PR rather than pushed directly because your branch is checked out in an active worktree (`.claude/worktrees/coderep-put-layout`).

## What's wrong

#613's product change is **correct**: it wraps the PUT body under `document` because the flat body now 400s. But `test-put-layout-prune.rb:88` still reads the captured PUT body at the top level:

```ruby
spec = JSON.parse(put_bodies.first)
els  = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }   # => nil -> []
...
ok('the new layout XML rode the PUT') { spec['layout'].to_s.include?(...) }  # => nil
```

So four assertions fail. That's what the `offline unit/regression tests (creds-free)` and `full ruby suite` checks are red on.

## The part that matters more

Three *other* assertions in the same block are **negative** — `!ids.include?('tc-page-pw-extra')` — and `ids` came out **empty**. They passed **vacuously**. The suite reported "4 failures" when the true state was "nothing was verified at all": had those three been the only assertions, #613 would have looked green while pruning was entirely unexercised.

Added an envelope-sanity assertion so an empty document can never again read as a clean prune. The unwrap accepts either envelope, so the test pins prune behaviour rather than transport shape.

## Attribution, measured

| tree | result |
|---|---|
| `main` | ALL PASS |
| `main` + #609 | ALL PASS |
| `main` + #609 + #613 | **4 FAILED** |
| + this commit | ALL PASS |

So it's this PR, not branch staleness (both wrapper branches are 11 commits behind main).

Rest of the tableau suite is green on your branch. `test-calc-discovery.rb` fails on `main` too — it needs `TABLEAU_AUTH_TOKEN` and a local `.twb`, so it's creds-dependent and unrelated.

## Why I care

`put-layout` is on `domo-to-sigma`'s road to gold: the layout phase has never been exercised end-to-end, and gates 4/4b/8c depend on it. I need #613 green to collapse `integration/domo-gold-run-v2` back into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)