### PR TITLE
fix(tableau): K11, K3, K7/N1, K2, K12a — first executed tasks from the bug-register plan

### DIFF
--- a/docs/superpowers/plans/2026-08-05-tableau-bug-register-remediation.md
+++ b/docs/superpowers/plans/2026-08-05-tableau-bug-register-remediation.md
@@ -2,6 +2,14 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Execution status (2026-08-06):** Tasks 1-4 are DONE and shipped in
+> `sigma-migration-skills` PR #637 (bead `beads-sigma-pu5e`, plugin 1.6.11). Each
+> shipped with a deterministic offline regression test proven RED on a planted
+> defect first. Full tableau suite 232/233 — the one failure,
+> `test-calc-discovery.rb`, needs `TABLEAU_AUTH_TOKEN` plus a `.twb` fixture and
+> fails on `main` too. Task 10 Step 1 (C1) shipped separately as `sigma-skills`
+> PR #33. Tasks 5-10 remain.
+
 **Goal:** Fix the `tableau-to-sigma` skill defects that survived validation against v1.6.10, and correct the authoring docs that describe API behavior which no longer exists.
 
 **Architecture:** Each task is an independent fix to one script, guarded by a deterministic offline `test-*.rb` regression test following the repo's existing convention (`ruby scripts/test-<name>.rb`, PASS/FAIL lines, non-zero exit on failure). Tasks are ordered cheapest-and-most-certain first. Two tasks (9, 10) are scoped as spec-first because they are behavioral and cannot be closed by static reasoning.
@@ -45,7 +53,7 @@ The Phase-5b visual-QA render calls `String#strip` and `each_line` on raw `Open3
 - Consumes: nothing.
 - Produces: nothing consumed by later tasks.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `test-phase5b-encoding-scrub.rb`:
 
@@ -100,7 +108,7 @@ puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
 exit(fails.empty? ? 0 : 1)
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 ```bash
 ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-phase5b-encoding-scrub.rb
@@ -108,7 +116,7 @@ ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-phase5b-encod
 
 Expected: FAIL on "Phase-5b block force_encodings subprocess output" and "Phase-5b block scrubs subprocess output". This is the planted-defect proof for this gate — record the red output.
 
-- [ ] **Step 3: Apply the fix**
+- [x] **Step 3: Apply the fix**
 
 In `migrate-tableau.rb`, replace lines 5283-5285:
 
@@ -126,7 +134,7 @@ with:
         o.each_line { |l| puts "   #{l.rstrip}" } unless o.strip.empty?
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 ```bash
 ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-phase5b-encoding-scrub.rb
@@ -134,7 +142,7 @@ ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-phase5b-encod
 
 Expected: `ALL PASS`.
 
-- [ ] **Step 5: Bump version and commit**
+- [x] **Step 5: Bump version and commit**
 
 Bump `plugins/tableau-to-sigma/.claude-plugin/plugin.json` to `1.6.11`.
 
@@ -159,7 +167,7 @@ git commit -m "fix(tableau): scrub non-UTF-8 subprocess output in Phase-5b rende
 - Consumes: nothing.
 - Produces: nothing.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `test-page-extras-id-namespacing.rb`:
 
@@ -216,7 +224,7 @@ puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
 exit(fails.empty? ? 0 : 1)
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 ```bash
 ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-extras-id-namespacing.rb
@@ -224,7 +232,7 @@ ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-extras-i
 
 Expected: FAIL on both Part A checks (Part B passes — it tests the helper's logic, which is correct; the bug is that `page_extras` never reaches it). Record the red output.
 
-- [ ] **Step 3: Extract the namespacing into a reusable lambda**
+- [x] **Step 3: Extract the namespacing into a reusable lambda**
 
 In `build-charts-from-signals.rb`, the existing block at `:8382` is `els.map! do |el| … end`. Replace that block's opening line and the page assembly so both lists share one helper. Immediately before `els.map! do |el|`, insert:
 
@@ -252,7 +260,7 @@ In `build-charts-from-signals.rb`, the existing block at `:8382` is `els.map! do
     end
 ```
 
-- [ ] **Step 4: Route page_extras through it**
+- [x] **Step 4: Route page_extras through it**
 
 Replace line 8415:
 
@@ -268,7 +276,7 @@ with:
 
 `els` keeps its existing `els.map!` block — that block already handles the `source.elementId` restoration that top-N helpers need, which `page_extras` elements never have.
 
-- [ ] **Step 5: Run test to verify it passes**
+- [x] **Step 5: Run test to verify it passes**
 
 ```bash
 ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-extras-id-namespacing.rb
@@ -277,7 +285,7 @@ ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-na
 
 Expected: both `ALL PASS`. The second is the pre-existing test — it must not regress.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb \
@@ -309,7 +317,7 @@ Live evidence:
 - Consumes: nothing.
 - Produces: image elements shaped `{id, kind: "image", source: {kind: "url", url: <string>}}`.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `test-image-element-shape.rb`:
 
@@ -349,7 +357,7 @@ puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
 exit(fails.empty? ? 0 : 1)
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 ```bash
 ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-image-element-shape.rb
@@ -357,7 +365,7 @@ ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-image-element
 
 Expected: FAIL on Part A (one flat site at `:6684`), Part B, and Part C. Record the red output.
 
-- [ ] **Step 3: Fix the emission site**
+- [x] **Step 3: Fix the emission site**
 
 Replace line 6684:
 
@@ -373,7 +381,7 @@ with:
           '_dashboard' => dash['dashboard'] }
 ```
 
-- [ ] **Step 4: Correct the stale comment**
+- [x] **Step 4: Correct the stale comment**
 
 Replace the comment at `:6602-6603`:
 
@@ -391,7 +399,7 @@ with:
 # the nested `source` wrapper is mandatory. Zones with a hosted `image_file_url` use the
 ```
 
-- [ ] **Step 5: Run test to verify it passes**
+- [x] **Step 5: Run test to verify it passes**
 
 ```bash
 ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-image-element-shape.rb
@@ -399,11 +407,11 @@ ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-image-element
 
 Expected: `ALL PASS`.
 
-- [ ] **Step 6: Check the page-level backgroundImage sibling**
+- [x] **Step 6: Check the page-level backgroundImage sibling**
 
 `page['backgroundImage']` at `:8423` uses `{ 'url' => …, 'style' => … }`. Per prior live findings, `backgroundImage` must be a **sibling of** `style`, not nested — and its own shape may have moved to `source.kind=url` alongside the image element. Verify against a live GET-back before changing it. If a live check is not available in this session, leave it and record the open question in the PR body. **Do not change it on inference.**
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb \
@@ -426,7 +434,7 @@ The `controlId` paths are clean — every one uses `.downcase.gsub(/\W+/, '-')`,
 - Consumes: nothing.
 - Produces: page ids matching `/\Apage-[a-z0-9-]*\z/`.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `test-page-id-slug.rb`:
 
@@ -486,7 +494,7 @@ puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
 exit(fails.empty? ? 0 : 1)
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 ```bash
 ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-id-slug.rb
@@ -494,7 +502,7 @@ ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-id-slug.
 
 Expected: Part C FAILs. Part D must PASS — it proves the test discriminates. Record the red output.
 
-- [ ] **Step 3: Apply the fix**
+- [x] **Step 3: Apply the fix**
 
 Replace lines 171-173:
 
@@ -514,7 +522,7 @@ with:
                     .sub(/\A-/, '').sub(/-\z/, '')[0..40].to_s
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 ```bash
 ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-id-slug.rb
@@ -522,7 +530,7 @@ ruby plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-id-slug.
 
 Expected: `ALL PASS`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb \

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -6600,8 +6600,12 @@ end
 # ---- v5.0: image (bitmap) zones → Sigma image elements ---------------------
 # Tableau image zones ship their bitmap INSIDE the .twbx (`image_path` is the
 # exact zip path, e.g. 'Image/title art.png'). Extract each to <tab>/assets/
-# and emit {kind:"image", url:"data:image/…;base64,…"} (data URIs live-verified
-# — refs/workbook-layout.md). Zones with a web-hosted `image_file_url` use the
+# and emit {kind:"image", source:{kind:"url", url:"data:image/…;base64,…"}}.
+# The URL may be a data: URI or a hosted URL — BOTH validate. What the API
+# rejects is the FLAT `url:` shape, for every image (live-probed 2026-08-06:
+# flat -> 400 Invalid kind: "image"; nested source -> valid:true). The original
+# register blamed data: URIs; the shape was the actual defect.
+# Zones with a web-hosted `image_file_url` use the
 # URL directly. Full-canvas backgrounds (is_background) are page-level design,
 # not grid tiles: extracted + recorded in <tab>/image-assets.json for the
 # background/composite step, never emitted as elements (the layout builder
@@ -6681,7 +6685,9 @@ unless opts[:pages_mode] == :worksheet
         next
       end
       styled_text_by_dash[dash['dashboard']] <<
-        { 'id' => "img-#{z['id']}", 'kind' => 'image', 'url' => url, '_dashboard' => dash['dashboard'] }
+        { 'id' => "img-#{z['id']}", 'kind' => 'image',
+          'source' => { 'kind' => 'url', 'url' => url },
+          '_dashboard' => dash['dashboard'] }
     end
   end
   if image_asset_records.any?
@@ -8373,6 +8379,31 @@ elsif opts[:pages_mode] == :dashboard
         col['formula'] = f
       end
     end
+    # K3: page_extras (styled text, title text, images) carry Tableau ZONE ids,
+    # which are unique per dashboard but NOT globally — "text-550" recurs on the
+    # next dashboard. They were concatenated in after this pass, so they never
+    # got namespaced and the POST hard-failed on "Duplicate id". Same op as the
+    # els pass below, minus the top-N source-restore (page_extras have no
+    # source.elementId).
+    namespace_ids = lambda do |list|
+      list.map do |el|
+        stem = el['id']
+        next el unless stem
+
+        if seen_el_ids[stem]
+          ns = "#{stem}-#{d_slug[0..20]}"
+          ($hidden_title_ns_ids ||= []) << ns if ($hidden_title_ids || []).include?(stem)
+          if (pv = $chart_provenance[stem])
+            $chart_provenance[ns] = pv.merge('dashboard' => dash_name)
+          end
+          JSON.parse(el.to_json.gsub(stem, ns))
+        else
+          seen_el_ids[stem] = true
+          el
+        end
+      end
+    end
+
     # Namespace element ids that already appeared on a prior page (a worksheet
     # placed on multiple dashboards). The element id is the stem of its column
     # ids (x-<id>/y-<id>/g-<id>) and grouping refs, so gsub the stem across the
@@ -8412,7 +8443,7 @@ elsif opts[:pages_mode] == :dashboard
         el
       end
     end
-    page = { 'name' => dash_name, 'elements' => page_extras + els }
+    page = { 'name' => dash_name, 'elements' => namespace_ids.call(page_extras) + els }
     # v5.0: full-canvas designed background (the Figma/PPT card-art pattern) →
     # page-level backgroundImage (data URI live-verified rendering behind the
     # page's elements). image_asset_records carries the extracted asset.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
@@ -168,9 +168,11 @@ warn "  Data page: + #{helper_elements.size} hidden helper element(s) [#{helper_
 visible_pages = []
 if specs.is_a?(Hash) && specs['pages']
   specs['pages'].each do |p|
-    slug = p['name'].to_s.downcase
-    %w[ / ( ) %].each { |ch| slug = slug.tr(ch, '-') }
-    slug = slug.tr(' ', '-').gsub(/-+/, '-').sub(/^-/, '').sub(/-$/, '')[0..40]
+    # K2: allow-list, not deny-list. The old hand-listed set (/ ( ) %) plus space
+    # left ? ! # & and every other punctuation mark in the id — a Tableau page
+    # "How many weeks?" became `page-how-many-weeks?`, which Sigma rejects.
+    slug = p['name'].to_s.downcase.gsub(/[^a-z0-9]+/, '-')
+                    .sub(/\A-/, '').sub(/-\z/, '')[0..40].to_s
     page = {
       'id'       => "page-#{slug}",
       'name'     => p['name'],

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -5279,6 +5279,12 @@ Array.new([3, content_pages.size].min.clamp(1, 3)) do
       o, st = Open3.capture2e({ 'SIGMA_API_TOKEN' => vqa_tok },
                               *PyResolve.argv, PyResolve.winpath(File.join(HERE, 'sigma-export-png.py')),
                               '--workbook', wb_id, '--page', pg['id'], '--out', PyResolve.winpath(out), '--w', '1800', '--h', '1000')
+      # K11: the PNG-export subprocess emits console-codepage bytes on Windows.
+      # Ruby tags Open3 output UTF-8 regardless, so `o.strip` on invalid bytes
+      # raises Encoding::CompatibilityError and kills this render thread. Scrub
+      # before ANY use of `o` — same idiom as :1191 and :2105.
+      o = o.force_encoding(Encoding::UTF_8)
+      o = o.scrub('?') unless o.valid_encoding?
       vqa_mx.synchronize do
         o.each_line { |l| puts "   #{l.rstrip}" } unless o.strip.empty?
         st.success? ? (rendered += 1) : line("WARN: visual-QA render failed for page #{pg['id']}")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-join-keys.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-join-keys.rb
@@ -65,6 +65,13 @@ require 'json'
 require 'csv'
 require 'optparse'
 require 'securerandom'
+
+# K12(a): how long to wait for a probe's CSV export before giving up. Bounded by
+# wall-clock, not iteration count. The previous ~30s ceiling was routinely
+# exceeded by a cold warehouse, which made the probe report a failure for a query
+# that would have succeeded. Raise it for a very cold warehouse:
+#   PROBE_EXPORT_TIMEOUT_S=600 ruby scripts/probe-join-keys.rb ...
+PROBE_EXPORT_TIMEOUT_S = Integer(ENV.fetch('PROBE_EXPORT_TIMEOUT_S', '180'))
 require_relative 'lib/sql_ident_check' # single identifier-legality oracle (W2.9)
 
 opts = { dialect: 'snowflake' }
@@ -211,8 +218,15 @@ def sigma_sql_rows(conn_id, folder_id, sql, columns, workdir: nil)
     qid = exp && exp['queryId']
     raise "export POST returned no queryId: #{exp.inspect[0, 160]}" unless qid
     csv = nil
-    30.times do |i|
+    # K12(a): bound by WALL-CLOCK, not iteration count. The old `30.times` loop
+    # gave a ~30s ceiling; a cold warehouse routinely exceeds it, so the probe
+    # reported failure for a query that would have succeeded. Operators were
+    # hand-patching this to 180s every run.
+    started = Time.now
+    i = 0
+    while Time.now - started < PROBE_EXPORT_TIMEOUT_S
       sleep(i.zero? ? 0.5 : 1)
+      i += 1
       begin
         b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
         (csv = b) && break if b && !b.to_s.empty?
@@ -220,7 +234,11 @@ def sigma_sql_rows(conn_id, folder_id, sql, columns, workdir: nil)
         raise unless e.message.lines.first.to_s =~ /\b404\b/
       end
     end
-    raise 'export did not complete in 30s' unless csv
+    unless csv
+      raise "export did not complete in #{PROBE_EXPORT_TIMEOUT_S}s " \
+            "(PROBE_EXPORT_TIMEOUT_S env var raises this; a cold warehouse can " \
+            'legitimately need longer — this is not necessarily a probe failure)'
+    end
     CSV.parse(csv, headers: true)
   ensure
     begin

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-image-element-shape.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-image-element-shape.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for K7/N1: image elements must use the nested source shape.
+#
+# Live-probed 2026-08-05/06 against /v2/workbooks/spec/verify:
+#   {kind:"image", url:"https://..."}                     -> 400 Invalid kind: "image"
+#   {kind:"image", url:"data:image/png;base64,..."}       -> 400 Invalid kind: "image"
+#   {kind:"image", source:{kind:"url", url:"https://..."}} -> valid:true
+#   {kind:"image", source:{kind:"url", url:"data:..."}}    -> valid:true
+#
+# So the flat `url:` shape fails for EVERY image, hosted or data: URI — the
+# original register had the diagnosis backwards (it blamed data: URIs).
+# Deterministic + offline.
+
+DIR = __dir__
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+src = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+
+puts 'Part A — no flat url: image element is emitted'
+# Image element literals: a hash containing 'kind' => 'image'. Reject any that
+# carries a top-level 'url' instead of a 'source'.
+# Line-based, NOT brace-balanced: the real literal contains \#{z['id']}
+# interpolation, and a [^{}]* matcher silently misses it — that false-negative
+# is exactly how this test first passed against unfixed code.
+# Statement-aware: an emission literal may wrap across lines, so look at the
+# matching line PLUS the next two before concluding there is no 'source'.
+# (Line-only was a false POSITIVE once the fix wrapped the literal; brace-
+# balanced was a false NEGATIVE because of \#{...} interpolation. Both failure
+# modes were hit while writing this test.)
+lines = src.lines
+flat = lines.each_with_index.select { |l, _| l.match?(/'kind'\s*=>\s*'image'/) }
+            .reject { |_, i| lines[i, 3].join.include?("'source'") }
+            .map    { |l, i| "#{i + 1}: #{l.strip[0, 70]}" }
+check(flat.empty?,
+      "no flat {kind: image, url: ...} emission sites (found #{flat.size}: #{flat.inspect})", fails)
+
+puts 'Part B — the nested source shape IS emitted'
+check(src.match?(/'kind'\s*=>\s*'image'.*?'source'\s*=>\s*\{\s*'kind'\s*=>\s*'url'/m),
+      'image elements carry source: {kind: url, url: ...}', fails)
+
+puts 'Part C — the stale data-URI comment is corrected'
+check(!src.include?('data URIs live-verified'),
+      'stale "data URIs live-verified" comment removed (the SHAPE was the bug)', fails)
+
+puts 'Part D — planted-defect guard: the matcher really does catch a flat shape'
+# Both samples carry the same \#{...} interpolation the real emitter uses.
+sample_flat   = %q({ 'id' => "img-#{z['id']}", 'kind' => 'image', 'url' => url })
+sample_nested = %q({ 'id' => "img-#{z['id']}", 'kind' => 'image', 'source' => { 'kind' => 'url', 'url' => url } })
+det = lambda do |txt|
+  ls = txt.lines
+  ls.each_with_index.select { |l, _| l.match?(/'kind'\s*=>\s*'image'/) }
+    .reject { |_, i| ls[i, 3].join.include?("'source'") }
+end
+# A WRAPPED nested literal must not be flagged — the false positive this
+# detector hit on its first pass.
+sample_wrapped = %Q({ 'id' => "img-x", 'kind' => 'image',\n  'source' => { 'kind' => 'url', 'url' => url } })
+check(det.call(sample_flat).size == 1,
+      'PLANTED-DEFECT GUARD: a flat image literal is detected', fails)
+check(det.call(sample_nested).empty?,
+      'PLANTED-DEFECT GUARD: a nested image literal is NOT flagged', fails)
+check(det.call(sample_wrapped).empty?,
+      'PLANTED-DEFECT GUARD: a WRAPPED nested literal is NOT flagged', fails)
+
+puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
+exit(fails.empty? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-extras-id-namespacing.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-extras-id-namespacing.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for K3: element ids in page_extras (styled text, title text,
+# images) must go through the same cross-page namespacing as `els`.
+#
+# Tableau zone ids are unique per DASHBOARD, not globally. A styled-text element
+# is emitted as id "text-<zone id>", so the same zone id reused on a second
+# dashboard ships a duplicate Sigma element id and the POST hard-fails on
+# "Duplicate id". The existing seen_el_ids pass only covered `els`; page_extras
+# were concatenated in afterwards, bypassing it. Deterministic + offline.
+
+require 'json'
+DIR = __dir__
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts 'Part A — source contract'
+src = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+check(src.match?(/namespace_ids\s*=\s*lambda/),
+      'a shared namespace_ids lambda exists', fails)
+check(src.match?(/'elements'\s*=>\s*namespace_ids\.call\(page_extras\)/),
+      'page assembly routes page_extras through namespace_ids', fails)
+# Scope this to the DASHBOARD emitter only. The page-per-worksheet emitter
+# (`'name' => ws_name`, ~:8284) also concatenates page_extras, but it is already
+# safe by construction and must NOT be "fixed": its title text is keyed on the
+# worksheet name, and its duplicated controls suffix BOTH `id` and `controlId`
+# with the ws_slug precisely because Sigma rejects duplicates. Only the dashboard
+# emitter carries zone-id-keyed styled text, which is what collides.
+dash_assembly = src[/page = \{ 'name' => dash_name.*/].to_s
+check(!dash_assembly.empty?, 'located the dashboard page assembly', fails)
+check(!dash_assembly.match?(/page_extras\s*\+\s*els/),
+      'the dashboard assembly no longer concatenates raw page_extras', fails)
+ws_assembly = src[/'name'\s*=>\s*ws_name,\s*\n\s*'elements'\s*=>\s*page_extras \+ els/m].to_s
+check(!ws_assembly.empty?,
+      'the page-per-worksheet emitter is left alone (already unique by construction)', fails)
+
+puts 'Part B — behavioral: replicate the shipped op across two pages'
+seen = {}
+namespace_ids = lambda do |list, slug|
+  list.map do |el|
+    stem = el['id']
+    next el unless stem
+
+    if seen[stem]
+      JSON.parse(el.to_json.gsub(stem, "#{stem}-#{slug}"))
+    else
+      seen[stem] = true
+      el
+    end
+  end
+end
+
+page1 = namespace_ids.call([{ 'id' => 'text-550', 'kind' => 'text', 'body' => 'A' }], 'dash-one')
+page2 = namespace_ids.call([{ 'id' => 'text-550', 'kind' => 'text', 'body' => 'B' }], 'dash-two')
+check(page1[0]['id'] == 'text-550', 'first occurrence keeps its id', fails)
+check(page2[0]['id'] == 'text-550-dash-two', 'second occurrence is namespaced', fails)
+all = (page1 + page2).map { |e| e['id'] }
+check(all.uniq.size == all.size, 'ids are globally unique across pages', fails)
+check(page2[0]['body'] == 'B', 'namespacing preserves the element body', fails)
+
+puts 'Part C — an element with no id is passed through untouched'
+noid = namespace_ids.call([{ 'kind' => 'divider' }], 'dash-three')
+check(noid[0] == { 'kind' => 'divider' }, 'id-less element survives unchanged', fails)
+
+puts 'Part D — planted-defect guard: the OLD concat really did collide'
+# If this ever stops colliding, Part B proves nothing.
+naive = [{ 'id' => 'text-550' }, { 'id' => 'text-550' }].map { |e| e['id'] }
+check(naive.uniq.size != naive.size,
+      'PLANTED-DEFECT GUARD: un-namespaced ids do collide', fails)
+
+puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
+exit(fails.empty? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-id-slug.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-page-id-slug.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for K2: page ids must contain only [a-z0-9-].
+#
+# The old slug replaced a hand-listed deny-list (/ ( ) % and space) and left
+# every other punctuation mark intact, so a Tableau page named "How many weeks?"
+# produced `page-how-many-weeks?`. Deny-lists rot; this pins an allow-list.
+# Deterministic + offline.
+
+DIR = __dir__
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Mirror of the shipped op — keep in lock-step with build-workbook-spec.rb.
+def page_slug(name)
+  name.to_s.downcase.gsub(/[^a-z0-9]+/, '-').sub(/\A-/, '').sub(/-\z/, '')[0..40].to_s
+end
+
+puts 'Part A — punctuation is stripped'
+{
+  'How many weeks?'      => 'how-many-weeks',
+  'Sales (YTD) / Region' => 'sales-ytd-region',
+  'Margin % & Growth!'   => 'margin-growth',
+  'Q1 2026 — Overview'   => 'q1-2026-overview',
+  'Trailing 30d #1'      => 'trailing-30d-1'
+}.each do |input, want|
+  got = page_slug(input)
+  check(got == want, "#{input.inspect} -> #{got.inspect} (want #{want.inspect})", fails)
+end
+
+puts 'Part B — output charset is safe for every input'
+['A?B', 'x' * 80, '///', 'Ünïcodé Pagé', '', '   '].each do |input|
+  got = page_slug(input)
+  check(got.match?(/\A[a-z0-9-]*\z/),
+        "#{input.inspect} -> #{got.inspect} is [a-z0-9-] only", fails)
+end
+
+puts 'Part C — the shipped source uses the allow-list slug'
+src = File.read(File.join(DIR, 'build-workbook-spec.rb'))
+check(src.match?(/gsub\(\/\[\^a-z0-9\]\+\/, '-'\)/),
+      'build-workbook-spec.rb uses an allow-list slug', fails)
+check(!src.include?("%w[ / ( ) %].each"),
+      'the hand-listed deny-list is gone', fails)
+
+puts 'Part D — planted-defect guard: the OLD slug really did leak punctuation'
+old_slug = lambda do |name|
+  s = name.to_s.downcase
+  %w[/ ( ) %].each { |ch| s = s.tr(ch, '-') }
+  s.tr(' ', '-').gsub(/-+/, '-').sub(/^-/, '').sub(/-$/, '')[0..40]
+end
+check(old_slug.call('How many weeks?').include?('?'),
+      'PLANTED-DEFECT GUARD: the old slug leaks "?"', fails)
+check(!page_slug('How many weeks?').include?('?'),
+      'PLANTED-DEFECT GUARD: the new slug does not', fails)
+
+puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
+exit(fails.empty? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-phase5b-encoding-scrub.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-phase5b-encoding-scrub.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for K11: the Phase-5b visual-QA render threads must scrub
+# non-UTF-8 subprocess output before calling String#strip / each_line.
+#
+# On Windows the PNG-export subprocess emits console-codepage bytes. Ruby tags
+# Open3 output UTF-8, so `o.strip` on invalid bytes raises
+# Encoding::CompatibilityError and kills the render thread.
+#
+# The scrub idiom already exists at migrate-tableau.rb:1191 and :2105 — a keyword
+# grep therefore reports this "fixed" when it is not. This test pins the ACTUAL
+# failure site instead. Deterministic + offline.
+
+DIR = __dir__
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts 'Part A — source contract: the Phase-5b render site scrubs before strip'
+src = File.read(File.join(DIR, 'migrate-tableau.rb'))
+# Anchor on the 5b thread's own Open3 capture — NOT on 'sigma-export-png.py',
+# which also appears at :1412 inside a help string; anchoring there spans ~3900
+# lines and swallows the unrelated scrub at :2105, making this test false-PASS.
+block = src[/Open3\.capture2e\(\{ 'SIGMA_API_TOKEN' => vqa_tok \}.*?end\.each\(&:join\)/m].to_s
+check(!block.empty?, 'located the Phase-5b render block', fails)
+check(block.include?('force_encoding'),
+      'Phase-5b block force_encodings the subprocess output', fails)
+check(block.match?(/\.scrub/),
+      'Phase-5b block scrubs the subprocess output', fails)
+# The scrub must come BEFORE the first use of `o`.
+if block.include?('force_encoding')
+  scrub_at = block.index('force_encoding')
+  use_at   = block.index('o.each_line') || block.index('o.strip')
+  check(use_at.nil? || scrub_at < use_at,
+        'the scrub precedes the first use of the captured output', fails)
+end
+
+puts 'Part B — behavioral: the shipped idiom survives invalid UTF-8'
+raw = "ok\xFF\xFE bad\n".dup.force_encoding(Encoding::ASCII_8BIT)
+scrubbed = raw.force_encoding(Encoding::UTF_8)
+scrubbed = scrubbed.scrub('?') unless scrubbed.valid_encoding?
+begin
+  scrubbed.strip
+  scrubbed.each_line(&:rstrip)
+  check(true, 'scrubbed output survives strip + each_line', fails)
+rescue StandardError => e
+  check(false, "scrubbed output still raises: #{e.class}", fails)
+end
+
+puts 'Part C — planted-defect guard: UNSCRUBBED input must blow up'
+# If this ever stops raising, Part B proves nothing and this test is vacuous.
+begin
+  bad = "ok\xFF\xFE bad\n".dup.force_encoding(Encoding::UTF_8)
+  bad.strip
+  bad =~ / /              # regex against invalid UTF-8 is the raising operation
+  check(false, 'PLANTED-DEFECT GUARD: unscrubbed input should have raised', fails)
+rescue ArgumentError, Encoding::CompatibilityError
+  check(true, 'PLANTED-DEFECT GUARD: unscrubbed input raises as expected', fails)
+end
+
+puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
+exit(fails.empty? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-join-keys-poll.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-join-keys-poll.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for K12(a): the join-key probe's export poll must be bounded by
+# WALL-CLOCK, not a fixed iteration count, and the budget must be generous enough
+# for a cold warehouse.
+#
+# The original loop was `30.times { sleep(i.zero? ? 0.5 : 1) }` — a ~30s ceiling.
+# A cold warehouse routinely exceeds it, so the probe reported failure for a query
+# that would have succeeded, and the operator hot-fixed it to 180s locally every
+# run. Deterministic + offline.
+
+DIR = __dir__
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+src = File.read(File.join(DIR, 'probe-join-keys.rb'))
+
+puts 'Part A — the budget is a named, env-overridable constant'
+check(src.match?(/PROBE_EXPORT_TIMEOUT_S\s*=/),
+      'PROBE_EXPORT_TIMEOUT_S is defined', fails)
+check(src.match?(/ENV\.fetch\(\s*'PROBE_EXPORT_TIMEOUT_S'\s*,\s*'180'\s*\)/),
+      "the default is 180 and comes from ENV.fetch('PROBE_EXPORT_TIMEOUT_S', '180')", fails)
+
+puts 'Part B — the loop is wall-clock bounded, not iteration-count bounded'
+check(!src.match?(/^\s*30\.times do \|i\|/),
+      'the fixed `30.times` poll is gone', fails)
+check(src.match?(/PROBE_EXPORT_TIMEOUT_S/) && src.match?(/Time\.now/),
+      'the poll compares elapsed Time.now against the budget', fails)
+check(!src.include?("export did not complete in 30s"),
+      'the hardcoded "30s" failure message is gone', fails)
+check(src.match?(/PROBE_EXPORT_TIMEOUT_S.*?(?:override|env)/mi) ||
+      src.match?(/did not complete in .*PROBE_EXPORT_TIMEOUT_S/),
+      'the timeout message names the budget so a slow warehouse is distinguishable', fails)
+
+puts 'Part C — behavioral: the budget arithmetic honours the env override'
+budget = ->(env) { Integer((env || {}).fetch('PROBE_EXPORT_TIMEOUT_S', '180')) }
+check(budget.call({}) == 180, 'unset env -> 180s default', fails)
+check(budget.call('PROBE_EXPORT_TIMEOUT_S' => '600') == 600, 'env override is honoured', fails)
+
+puts 'Part D — planted-defect guard: 30s really is too short for a cold export'
+# A cold warehouse export of ~60s must fail under the OLD budget and pass under
+# the new one. If this ever stops discriminating, Part A/B prove nothing.
+cold_export_s = 60
+check(cold_export_s > 30, 'PLANTED-DEFECT GUARD: a 60s cold export exceeds the old 30s ceiling', fails)
+check(cold_export_s < budget.call({}), 'PLANTED-DEFECT GUARD: it fits inside the new 180s budget', fails)
+
+puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
+exit(fails.empty? ? 0 : 1)


### PR DESCRIPTION
Executes Tasks 1–4 and 6 of the remediation plan. Five real converter bugs, each
with a deterministic offline regression test **proven RED on a planted defect
before the fix**. Bead: `beads-sigma-pu5e`.

| Bug | Site | Fix |
|---|---|---|
| **K11** | `migrate-tableau.rb:5283` | Phase-5b render threads called `strip` on unscrubbed `Open3` output → `Encoding::CompatibilityError` kills the thread on Windows |
| **K3** | `build-charts-from-signals.rb:8446` | `page_extras` bypassed the `seen_el_ids` namespacing; zone-id-keyed styled text collided across pages → POST fails on Duplicate id |
| **K7/N1** | `build-charts-from-signals.rb:6684` | Emitted the flat `{kind:'image', url:}` shape, rejected by the live API for **every** image; nested `source:{kind:'url'}` is required |
| **K2** | `build-workbook-spec.rb:172` | Page-id slug used a deny-list and leaked `?` `!` `#` `&` |
| **K12a** | `probe-join-keys.rb:214` | Export poll was a ~30s iteration ceiling; now wall-clock bounded via `PROBE_EXPORT_TIMEOUT_S` (default 180, env-overridable) |

Plus: plan Tasks 1–4 checkboxes ticked with an execution-status banner.

## Three things worth a reviewer's attention

**1. Two gates false-passed before they worked.** Both are documented in-code:

- The K11 test first anchored on `sigma-export-png.py` — which also appears at
  `:1412` in a help string, so the match spanned ~3900 lines and swallowed an
  unrelated scrub at `:2105`. Now anchored on the 5b thread's own `Open3` capture.
- The K7 detector took three passes: brace-balanced missed the real literal
  because of `#{...}` interpolation; line-only then false-*positived* once the fix
  wrapped the literal. Now statement-aware, with guards for flat, nested and
  wrapped-nested forms, and confirmed RED by temporarily reverting the fix.

**2. K7 inverts the original diagnosis.** The register blamed `data:` URIs. Live
probing shows `data:` URIs are fine — the *flat shape* is what fails, for hosted
URLs too. This was breaking every image, not just logos.

**3. Deliberately not touched.** The page-per-worksheet emitter also concatenates
`page_extras` but is already unique by construction (title text keyed on the
worksheet name; duplicated controls suffix both `id` and `controlId` with the
`ws_slug` for exactly this reason). The test asserts it stays untouched, so a
future "consistency" edit fails the gate.

Also: the register filed **K2** against `controlId` sanitization. Every
`controlId` path already strips punctuation; the surviving instance of that bug
class is the page-id slug.

## Verification

- 5 new tests, each with planted-defect guards.
- Full tableau suite: **233/234 pass**. The one failure, `test-calc-discovery.rb`,
  needs `TABLEAU_AUTH_TOKEN` plus a `.twb` fixture and **fails on `main` too** —
  environmental, not a regression from this branch.
- `tableau-to-sigma` bumped 1.6.10 → 1.6.11.

> ⚠️ **CI has not run on this branch.** GitHub Actions stopped firing for this repo
> around 20:38 UTC — no runs repo-wide since, across any branch, despite three
> pushes and a close/reopen here. The 7 required checks are therefore absent and
> the PR shows BLOCKED. Verification above is local. **Do not merge until Actions
> recovers and the checks go green.**

## Scope notes

- **K12** is (a) only. Sub-claims (b) `sqlproxy` right_table, (c) re-entry wiping
  probe evidence, (d) the quoted-identifier oracle each need a live run.
- Tasks 5, 8, 8.5, 8.6, 8.7, 9, 10 remain. **8.7 (K22) is a shared-lib change
  fanning out to 12 plugins** and must be its own PR with a cross-converter audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)