### PR TITLE
fix(domo-to-sigma): restore the card date window — 55 of 65 tiles were unfiltered (step 6)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -949,6 +949,150 @@ def filter_target_column(el, col)
   new_col['id']
 end
 
+
+# ---------------------------------------------------------------------------
+# Step 6 / bead beads-sigma-datewin — a card's Domo DATE WINDOW.
+#
+# MEASURED on the 36-card cold run: 29 of 36 cards carry a date window (24
+# ROLLING_PERIOD + 5 INTERVAL_OFFSET) and the generated Sigma spec carried ZERO
+# date filters. Mapping tiles back to cards via `el-<cardId>[-summary]`, 55 of the
+# 65 chartable tiles derive from a windowed card — so ~85% of the parity pool was
+# aggregating over ALL history while its Domo counterpart aggregated over a
+# rolling window. `min_pass_rate` defaults to 1.0, so that alone makes gate 1
+# unpassable no matter how good the parity oracle is. This is a PREREQUISITE for
+# the oracle, not a fidelity nicety.
+#
+# WHY A HIDDEN BOOLEAN COLUMN + A `list` FILTER, and not the obvious things:
+#
+#   - Sigma has NO element-level date-range filter kind. Live-verified by
+#     PUT+GET round-trip: only `list`, `top-n` and `number-range` persist on an
+#     element's own `filters[]`. There is nothing to emit directly.
+#   - A `controlType: date-range` CONTROL is the documented way to express a
+#     relative window — but a control targets a TABLE, so it propagates to every
+#     element sourcing the shared master. The corpus has 20 DISTINCT windows
+#     across 9 datasets, and up to 4 different windows on a SINGLE dataset, so one
+#     control per master cannot express them. Per-window masters would be a
+#     structural rewrite.
+#   - Baking the window into each measure (`Sum(If(<window>, [x], 0))`) filters
+#     the aggregate but not the ROW SET, so a grouped chart would still render
+#     empty categories that the source card does not show.
+#
+# So: one HIDDEN calc column per (element, date column) returning "in"/"out", and
+# a `list` filter including only "in". Uses only the verified-supported `list`
+# kind, stays element-local (no propagation), and matches the hidden-column shape
+# `filter_target_column` already uses. Safe here because no tile in this corpus is
+# a `pivot-table` — the one kind whose own `filters[]` Sigma silently drops (the
+# 65 chartable tiles are kpi-chart/bar/combo/region-map/line/table/scatter/donut).
+#
+# BOUNDARY CONVENTION, stated because getting it wrong is silent: a Domo
+# ROLLING_PERIOD of `count` N is emitted as `>= DateAdd(unit, -N, Today())`, i.e.
+# an N-unit lookback measured back from today. If Domo's rolling window is instead
+# N units INCLUSIVE of today, the correct constant is -(N-1). That is a one-token
+# change here (ROLLING_LOOKBACK_OFFSET) and it is pinned by a test rather than
+# left implicit. Confirm against a card PNG before declaring value parity — this
+# is the same class of silent-wrong-numbers risk as the 2-arg DateDiff operand
+# order (bead znvg), where a wrong window compiles clean and every number is off.
+DOMO_DATE_INTERVAL_UNIT = {
+  'DAY' => 'day', 'WEEK' => 'week', 'MONTH' => 'month',
+  'QUARTER' => 'quarter', 'YEAR' => 'year', 'HOUR' => 'hour', 'MINUTE' => 'minute'
+}.freeze
+
+# 0 = "N units back from today"; set to 1 for "N units inclusive of today".
+ROLLING_LOOKBACK_OFFSET = 0
+
+def apply_card_date_window!(card, el)
+  return el if el.nil?
+  drf = card['dateRangeFilter'] || card['dateTimeRange']
+  return el unless drf.is_a?(Hash)
+  rng = drf['dateTimeRange']
+  return el unless rng.is_a?(Hash)
+
+  type     = rng['dateTimeRangeType'].to_s
+  interval = rng['interval'].to_s.upcase
+  count    = rng['count'].to_i
+  offset   = rng['offset'].to_i
+  payload  = "type=#{type} interval=#{interval} offset=#{offset} count=#{count}"
+  date_col = (drf['column'].is_a?(Hash) ? drf['column']['column'] : drf['column']).to_s
+
+  # Same two Sigma traps apply_card_filters! guards: an image element has nothing
+  # to filter, and a pivot-table's own filters[] is silently dropped.
+  if el['kind'] == 'image'
+    warn_card(card, "date window NOT applied (#{payload}): an image element has no source/columns to " \
+                    'filter — the card was exported to a static PNG that already reflects the windowed query.')
+    return el
+  end
+  if el['kind'] == 'pivot-table'
+    warn_card(card, "date window NOT applied (#{payload}): Sigma silently DROPS a pivot-table element's " \
+                    'own filters — apply the predicate on its source element instead.')
+    return el
+  end
+
+  # Refuse anything whose boundary semantics are not established. Guessing is the
+  # same silent-wrong-numbers class as bead znvg: a wrong window compiles green.
+  unless type == 'ROLLING_PERIOD'
+    warn_card(card, "date window NOT applied (#{payload}): only ROLLING_PERIOD has an established Sigma " \
+                    "mapping here. Domo's exact boundary semantics for #{type} (offset/count) are not " \
+                    'documented in any source available to this converter, and a wrong window compiles ' \
+                    'cleanly while returning wrong numbers everywhere — so it is refused rather than ' \
+                    'guessed. Hand-author the equivalent window and re-run, or establish the semantics live.')
+    return el
+  end
+  unless offset.zero?
+    warn_card(card, "date window NOT applied (#{payload}): a non-zero ROLLING_PERIOD offset shifts the " \
+                    'window back by whole intervals; that boundary is unestablished here. Refused rather ' \
+                    'than guessed.')
+    return el
+  end
+  unit = DOMO_DATE_INTERVAL_UNIT[interval]
+  unless unit
+    warn_card(card, "date window NOT applied (#{payload}): interval '#{interval}' has no Sigma datepart " \
+                    "mapping (handled: #{DOMO_DATE_INTERVAL_UNIT.keys.join('/')}).")
+    return el
+  end
+  unless count.positive?
+    warn_card(card, "date window NOT applied (#{payload}): count must be positive to express a lookback.")
+    return el
+  end
+  if date_col.strip.empty?
+    warn_card(card, "date window NOT applied (#{payload}): the card names no date column.")
+    return el
+  end
+
+  date_cid = filter_target_column(el, date_col)
+  unless date_cid
+    warn_card(card, "date window NOT applied (#{payload}): date column '#{date_col}' does not resolve to a " \
+                    'data-model column (mirrors prune_unresolvable_columns!) — never ship a filter with a ' \
+                    'nil columnId.')
+    return el
+  end
+  date_formula = (Array(el['columns']).find { |c| c['id'] == date_cid } || {})['formula']
+  if date_formula.to_s.strip.empty?
+    warn_card(card, "date window NOT applied (#{payload}): resolved date column '#{date_col}' carries no " \
+                    'formula to build the predicate from.')
+    return el
+  end
+
+  lookback = count - ROLLING_LOOKBACK_OFFSET
+  slug = date_col.downcase.gsub(/\W+/, '-')
+  win_id = "f-datewin-#{slug}-#{unit}-#{count}"
+  unless Array(el['columns']).any? { |c| c['id'] == win_id }
+    el['columns'] = Array(el['columns']) + [{
+      'id' => win_id,
+      'name' => "In last #{count} #{unit}#{count == 1 ? '' : 's'} (#{date_col})",
+      'formula' => %(If(#{date_formula} >= DateAdd("#{unit}", -#{lookback}, Today()), "in", "out")),
+      'hidden' => true
+    }]
+    el['order'] = Array(el['order']) + [win_id] if el.key?('order')
+  end
+  already = Array(el['filters']).any? { |f| f['columnId'] == win_id && f['id'].to_s.start_with?('dw-') }
+  unless already
+    el['filters'] = Array(el['filters']) +
+                    [{ 'id' => "dw-#{el['id']}-#{Array(el['filters']).size}", 'columnId' => win_id,
+                       'kind' => 'list', 'mode' => 'include', 'values' => ['in'] }]
+  end
+  el
+end
+
 # Turn THIS card's own `filters[]` into Sigma ELEMENT filters on `el` —
 # refs/card-to-element.md:430-435's "card-level filters (the filter clauses
 # inside each card definition) -> element/source filters on that element."
@@ -1228,7 +1372,7 @@ def build_element_body(card, overrides)
   kind = card['sigmaKindHint']
   is_kpi = kind == 'kpi-chart' ||
            (card['summaryNumber'] && Array(card['groupBy']).empty? && (card['columns'] || []).size <= 1)
-  return apply_card_filters!(card, build_kpi(card, overrides)) if is_kpi
+  return apply_card_date_window!(card, apply_card_filters!(card, build_kpi(card, overrides))) if is_kpi
 
   # Domo prints a Summary Number at the top of EVERY viz card, not just KPI
   # cards. Sigma's chart/table elements have no summary slot, so this
@@ -1302,6 +1446,7 @@ def build_element_body(card, overrides)
   # below). Applied here, after the case-branch, so it covers every kind
   # (bar/line/scatter/donut/table/map/combo/kpi-fallback) built above.
   el = apply_card_filters!(card, el)
+  el = apply_card_date_window!(card, el)
 
   if companion
     if el
@@ -1312,6 +1457,7 @@ def build_element_body(card, overrides)
       # correctly filtered chart (the exact B4 divergence this fix exists to
       # close, just one element over).
       companion = apply_card_filters!(card, companion)
+      companion = apply_card_date_window!(card, companion)
       $companion_elements << companion
       warn_card(card, "source Summary Number ALSO represented as a companion KPI element " \
                       "'#{companion['name']}' alongside this #{el['kind'] || kind || 'chart'} element " \

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-build-workbook.rb
@@ -774,5 +774,115 @@ Dir.mktmpdir do |dir|
   end
 end
 
+
+puts "== step 6 / dateRangeFilter: a ROLLING_PERIOD card window becomes an element filter =="
+# MEASURED on the 36-card cold run: 29 of 36 cards carry a date window
+# (24 ROLLING_PERIOD + 5 INTERVAL_OFFSET), and the generated Sigma spec carried
+# ZERO date filters — so 55 of the 65 chartable tiles aggregated over ALL history
+# while their Domo counterparts aggregated over a rolling window. Against
+# min_pass_rate 1.0 that alone makes gate 1 unpassable, no matter how good the
+# parity oracle is.
+#
+# Sigma has NO element-level date-range filter kind (live-verified 2026-07-17:
+# only list / top-n / number-range round-trip), and a date-range CONTROL is not
+# usable here: a control targets a TABLE, so it would propagate to every element
+# sourcing the shared master — yet the corpus has 20 DISTINCT windows across 9
+# datasets, up to 4 different windows on a single dataset. So the window has to be
+# element-local: a HIDDEN boolean window column + a `list` filter including "in".
+# That shape uses only the verified-supported `list` kind, is element-local (no
+# propagation), and no tile in this corpus is a pivot-table (the one kind whose
+# own filters Sigma silently drops).
+$warnings = []
+win = build_element({ 'id' => 'c40', 'title' => 'Page Views (last 14 days)', 'chartType' => 'badge_line',
+                      'dateRangeFilter' => {
+                        'column' => { 'column' => 'Date', 'exprType' => 'COLUMN' },
+                        'dateTimeRange' => { 'dateTimeRangeType' => 'ROLLING_PERIOD',
+                                             'interval' => 'DAY', 'offset' => 0, 'count' => 14 } },
+                      'columns' => [{ 'column' => 'Date' },
+                                    { 'column' => 'views', 'aggregation' => 'SUM' }] }, {})
+ok(win.key?('filters'), 'a ROLLING_PERIOD window produced an element filter')
+dfs = Array(win['filters']).select { |f| f['id'].to_s.start_with?('dw-') }
+eq(dfs.size, 1, 'exactly one date-window filter')
+eq(dfs.first['kind'], 'list', "filter kind is list (Sigma has NO element date-range kind)")
+eq(dfs.first['mode'], 'include', 'mode is include')
+eq(dfs.first['values'], ['in'], 'includes only the in-window sentinel')
+wc = Array(win['columns']).find { |c| c['id'] == dfs.first['columnId'] }
+ok(!wc.nil?, 'the filter targets a column the element actually has')
+eq(wc['hidden'], true, 'the window column is HIDDEN — the source card never rendered it')
+ok(wc['formula'].include?('DateAdd("day", -14,'),
+   "predicate uses DateAdd(\"day\", -14, ...) — got #{wc && wc['formula']}")
+ok(wc['formula'].include?('Today()'), 'predicate is anchored on Today()')
+
+puts "== step 6: unit mapping covers every interval the corpus actually uses =="
+# MEASURED intervals in the corpus: DAY, MONTH, QUARTER, WEEK, YEAR.
+{ 'DAY' => 'day', 'MONTH' => 'month', 'QUARTER' => 'quarter',
+  'WEEK' => 'week', 'YEAR' => 'year' }.each do |domo, sigma|
+  $warnings = []
+  e = build_element({ 'id' => "c41-#{domo}", 'title' => "T #{domo}", 'chartType' => 'badge_line',
+                      'dateRangeFilter' => {
+                        'column' => { 'column' => 'Date' },
+                        'dateTimeRange' => { 'dateTimeRangeType' => 'ROLLING_PERIOD',
+                                             'interval' => domo, 'offset' => 0, 'count' => 3 } },
+                      'columns' => [{ 'column' => 'Date' },
+                                    { 'column' => 'v', 'aggregation' => 'SUM' }] }, {})
+  c = Array(e['columns']).find { |x| x['id'].to_s.start_with?('f-datewin') }
+  # NB: a %(...) literal would balance the nested paren and silently append ")"
+  # to the needle — use an explicit escaped string.
+  needle = "DateAdd(\"#{sigma}\", -3,"
+  ok(c && c['formula'].include?(needle),
+     "#{domo} -> \"#{sigma}\" (got #{c && c['formula']})")
+end
+
+puts "== step 6: no dateRangeFilter -> no window column and no window filter =="
+$warnings = []
+nowin = build_element({ 'id' => 'c42', 'title' => 'All History', 'chartType' => 'badge_line',
+                        'columns' => [{ 'column' => 'Date' },
+                                      { 'column' => 'v', 'aggregation' => 'SUM' }] }, {})
+ok(Array(nowin['filters']).none? { |f| f['id'].to_s.start_with?('dw-') },
+   'never emit a default/empty date window')
+ok(Array(nowin['columns']).none? { |c| c['id'].to_s.start_with?('f-datewin') },
+   'and no orphan window column')
+
+puts "== step 6: INTERVAL_OFFSET is NOT guessed — it is dropped LOUDLY =="
+# 5 of the 29 windowed cards are INTERVAL_OFFSET (offset>=1, count=0). Domo's
+# exact boundary semantics for those are not documented in any source available
+# here, and guessing is the SAME silent-wrong-numbers class as the 2-arg DateDiff
+# operand order (bead znvg): a wrong window compiles clean and returns wrong
+# values everywhere. So it is refused with a warning naming the exact payload,
+# rather than shipped as a plausible guess.
+$warnings = []
+io = build_element({ 'id' => 'c43', 'title' => 'Survey Completion Rate', 'chartType' => 'badge_line',
+                     'dateRangeFilter' => {
+                       'column' => { 'column' => 'created_on' },
+                       'dateTimeRange' => { 'dateTimeRangeType' => 'INTERVAL_OFFSET',
+                                            'interval' => 'WEEK', 'offset' => 1, 'count' => 0 } },
+                     'columns' => [{ 'column' => 'created_on' },
+                                   { 'column' => 'v', 'aggregation' => 'SUM' }] }, {})
+ok(Array(io['filters']).none? { |f| f['id'].to_s.start_with?('dw-') },
+   'no window filter is invented for INTERVAL_OFFSET')
+ok($warnings.any? { |w| w['warning'].to_s.include?('INTERVAL_OFFSET') },
+   'the refusal is warned, not silent')
+ok($warnings.any? { |w| w['warning'].to_s.include?('offset') },
+   'the warning echoes the payload so it is actionable')
+
+puts "== step 6: an unresolvable date column is dropped LOUDLY, never a broken filter =="
+$warnings = []
+# The card needs a real dimension, or build_element legitimately declines to emit a
+# line element at all and this would assert nothing.
+bad = build_element({ 'id' => 'c44', 'title' => 'Bad Col', 'chartType' => 'badge_line',
+                      'dateRangeFilter' => {
+                        'column' => { 'column' => '' },
+                        'dateTimeRange' => { 'dateTimeRangeType' => 'ROLLING_PERIOD',
+                                             'interval' => 'DAY', 'offset' => 0, 'count' => 7 } },
+                      'columns' => [{ 'column' => 'region' },
+                                    { 'column' => 'v', 'aggregation' => 'SUM' }] }, {})
+ok(!bad.nil?, 'the card still produces an element (the window is dropped, not the card)')
+ok(Array(bad && bad['filters']).none? { |f| f['id'].to_s.start_with?('dw-') },
+   'no filter with a nil/blank columnId is ever emitted')
+ok(Array(bad && bad['columns']).none? { |c| c['id'].to_s.start_with?('f-datewin') },
+   'and no orphan window column is left behind')
+ok($warnings.any? { |w| w['warning'].to_s.include?('names no date column') },
+   'the blank date column is warned, not silent')
+
 puts
 if $failures.zero? then puts "ALL PASS"; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end


### PR DESCRIPTION
Step 6 of the road to gold — and it turns out to be a **prerequisite for the parity oracle**, not the "fidelity, non-blocking" item the doc lists.

## The bug

`build-workbook.rb`'s `apply_card_filters!` only ever read `card['filters']`. **`card['dateRangeFilter']` was never read at all.**

Measured on the 36-card cold run:

| | |
|---|---|
| Domo cards carrying a date window | **29 of 36** (24 `ROLLING_PERIOD` + 5 `INTERVAL_OFFSET`) |
| Date filters in the generated Sigma spec | **0** |
| Sigma spec element filters, by kind | `{list: 36, top-n: 1}` |

Mapping tiles back to cards via `el-<cardId>[-summary]`: **55 of the 65 chartable tiles derive from a windowed card** (29 base + 26 `-summary` companions). Only 10 are unaffected.

So ~85% of the parity pool aggregated over **all history** while its Domo counterpart aggregated over a rolling window. `min_pass_rate` defaults to **1.0** — so this alone made gate 1 unpassable no matter how good the oracle is. Building the oracle first would have meant building it against tiles guaranteed to diverge.

## Why a hidden boolean column + a `list` filter

The two obvious approaches don't work here:

- **There is no element-level date-range filter kind.** Only `list` / `top-n` / `number-range` persist on an element's own `filters[]` (live-verified by PUT+GET round-trip). There is nothing to emit directly.
- **A `controlType: date-range` control can't express this corpus.** A control targets a *table*, so it propagates to every element sourcing the shared master — but the corpus has **20 distinct windows across 9 datasets, up to 4 different windows on a single dataset**. Per-window masters would be a structural rewrite.
- **Baking the window into each measure** (`Sum(If(<window>, [x], 0))`) filters the aggregate but not the row set, so grouped charts would still render categories the source card doesn't show.

So: one **hidden** calc column per `(element, date column, unit, count)` returning `"in"`/`"out"`, plus a `list` filter including only `"in"`. Uses only the verified-supported kind, stays element-local (no propagation), and matches the hidden-column shape `filter_target_column` already uses. Safe here because **no tile in this corpus is a `pivot-table`** — the one kind whose own `filters[]` Sigma silently drops.

## `INTERVAL_OFFSET` is refused, not guessed

The 5 `INTERVAL_OFFSET` cards are dropped with a warning echoing the exact payload. Domo's boundary semantics for them aren't documented in any source available here, and **a wrong window compiles cleanly while returning wrong numbers everywhere** — the same silent class as the 2-arg `DateDiff` operand order (bead `znvg`). Refusing loudly beats shipping a plausible guess.

## Boundary convention — stated, not implicit

A `ROLLING_PERIOD` of count N emits `>= DateAdd(unit, -N, Today())`: an N-unit lookback measured back from today. **If Domo's window is instead N units inclusive of today, the correct constant is `-(N-1)`.** That's one token here (`ROLLING_LOOKBACK_OFFSET`) and it's pinned by a test rather than left implicit. ⚠️ **Confirm against a card PNG before declaring value parity.**

## Test plan

- [x] 22 new assertions in `test/test-build-workbook.rb` — filter shape, hidden column, the full `DAY`/`WEEK`/`MONTH`/`QUARTER`/`YEAR` unit mapping, no-window → no filter *and* no orphan column, `INTERVAL_OFFSET` refused + warned, blank date column refused + warned
- [x] Full offline suite: 24 files, **ALL SUITES PASS**
- [x] **Real-corpus end-to-end** against the cold run's own `cards.json` — emitted `If([Master/Created Date] >= DateAdd("month", -24, Today()), "in", "out")` with `hidden: true` and `{"kind":"list","mode":"include","values":["in"]}`, across 3 distinct window columns (`createddate-month-24`, `closedate-month-24`, `closedate-quarter-5`), plus 4 `INTERVAL_OFFSET` refusals warned
- [x] Hygiene + shared-file governance clean; domo 0.14.3 → 0.14.4

**Scope limit, stated plainly:** the offline corpus replay routes only the master's own dataset, so it emitted 10 of the 65 elements (8 of which got a window). The full 65-element case needs the live data-model element map — i.e. a live run. **This is converter correctness, not evidence of parity.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
