### PR TITLE
fix(shared): add settings/agents to DOC_KEYS in code_rep adapter

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData → Sigma",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex → Sigma",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Migrate Hex projects to Sigma — SQL cells, single-value/METRIC cells, and EXPLORE charts → Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense → Sigma",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma — data model + workbook (indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; columnar layout→24-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/shared/lib/code_rep.mjs
+++ b/shared/lib/code_rep.mjs
@@ -3,7 +3,10 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+// `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+// them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+// valid keys, silently dropping theme + agents on every write.
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/shared/lib/code_rep.py
+++ b/shared/lib/code_rep.py
@@ -11,7 +11,10 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+# `settings` (theme/navigation) and `agents` belong INSIDE `document` too — omitting
+# them sweeps themeName/themeOverrides/agents onto the top level, where they are not
+# valid keys, silently dropping theme + agents on every write.
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/shared/lib/code_rep.rb
+++ b/shared/lib/code_rep.rb
@@ -14,7 +14,10 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    # `settings` (theme/navigation) and `agents` belong here too — omitting them
+    # sweeps themeName/themeOverrides/agents onto the top level, where they are
+    # not valid keys, silently dropping theme + agents on every write.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/shared/lib/tests/test_code_rep.py
+++ b/shared/lib/tests/test_code_rep.py
@@ -32,5 +32,38 @@ class TestCodeRep(unittest.TestCase):
             self.assertEqual(code_rep.document(code_rep.wrap(doc)), doc)
 
 
+LIVE_WITH_SETTINGS = {
+    'workbookId': 'w1', 'name': 'N',
+    'document': {'schemaVersion': 1, 'pages': [{'id': 'p'}],
+                 'settings': {'theme': {'name': 'dark'}}, 'agents': [{'id': 'a1'}]},
+}
+LEGACY_WITH_SETTINGS = {
+    'workbookId': 'w1', 'name': 'N',
+    'schemaVersion': 1, 'pages': [{'id': 'p'}],
+    'settings': {'theme': {'name': 'dark'}}, 'agents': [{'id': 'a1'}],
+}
+
+
+class TestCodeRepSettingsAgents(unittest.TestCase):
+    # Regression for the "themeName/agents silently dropped" bug: DOC_KEYS previously
+    # listed only schemaVersion/pages/kind/layout, so settings/agents fell through to
+    # metadata() and got wrapped OUTSIDE `document` on write.
+    def test_settings_and_agents_stay_inside_document(self):
+        for r in (LIVE_WITH_SETTINGS, LEGACY_WITH_SETTINGS):
+            doc = code_rep.document(r)
+            self.assertEqual(doc['settings'], {'theme': {'name': 'dark'}})
+            self.assertEqual(doc['agents'], [{'id': 'a1'}])
+            self.assertNotIn('settings', code_rep.metadata(r))
+            self.assertNotIn('agents', code_rep.metadata(r))
+
+    def test_settings_and_agents_round_trip_through_wrap(self):
+        for r in (LIVE_WITH_SETTINGS, LEGACY_WITH_SETTINGS):
+            doc = code_rep.document(r)
+            wrapped = code_rep.wrap(doc, extra=code_rep.metadata(r))
+            self.assertEqual(wrapped['document'], doc)
+            self.assertNotIn('settings', wrapped)
+            self.assertNotIn('agents', wrapped)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/shared/lib/tests/test_code_rep.rb
+++ b/shared/lib/tests/test_code_rep.rb
@@ -30,4 +30,37 @@ class TestCodeRep < Minitest::Test
       assert_equal doc, Sigma::CodeRep.document(Sigma::CodeRep.wrap(doc))
     end
   end
+
+  LIVE_WITH_SETTINGS = { 'workbookId' => 'w1', 'name' => 'N',
+                         'document' => { 'schemaVersion' => 1, 'pages' => [{ 'id' => 'p' }],
+                                         'settings' => { 'theme' => { 'name' => 'dark' } },
+                                         'agents' => [{ 'id' => 'a1' }] } }.freeze
+  LEGACY_WITH_SETTINGS = { 'workbookId' => 'w1', 'name' => 'N',
+                           'schemaVersion' => 1, 'pages' => [{ 'id' => 'p' }],
+                           'settings' => { 'theme' => { 'name' => 'dark' } },
+                           'agents' => [{ 'id' => 'a1' }] }.freeze
+
+  # Regression for the "themeName/agents silently dropped" bug: DOC_KEYS previously
+  # listed only schemaVersion/pages/kind/layout, so settings/agents fell through to
+  # metadata() and got wrapped OUTSIDE `document` on write — invalid on PUT (document-only
+  # allowlist) and stripped on POST/verify. See project_sigma_document_wrapper_migration.
+  def test_settings_and_agents_stay_inside_document
+    [LIVE_WITH_SETTINGS, LEGACY_WITH_SETTINGS].each do |r|
+      doc = Sigma::CodeRep.document(r)
+      assert_equal({ 'theme' => { 'name' => 'dark' } }, doc['settings'])
+      assert_equal [{ 'id' => 'a1' }], doc['agents']
+      refute_includes Sigma::CodeRep.metadata(r).keys, 'settings'
+      refute_includes Sigma::CodeRep.metadata(r).keys, 'agents'
+    end
+  end
+
+  def test_settings_and_agents_round_trip_through_wrap
+    [LIVE_WITH_SETTINGS, LEGACY_WITH_SETTINGS].each do |r|
+      doc = Sigma::CodeRep.document(r)
+      wrapped = Sigma::CodeRep.wrap(doc, extra: Sigma::CodeRep.metadata(r))
+      assert_equal doc, wrapped['document']
+      assert_nil wrapped['settings'] # must NOT leak to top level — PUT allowlists document only
+      assert_nil wrapped['agents']
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `DOC_KEYS` in `shared/lib/code_rep.{rb,py,mjs}` only listed `schemaVersion pages kind layout`. Since the workbook document wrapper moved `themeName`/`themeOverrides` → `document.settings.theme` and added `document.agents`, both fell through `document()`/`metadata()` and got wrapped **outside** `document` on write — invalid on PUT (document-only allowlist) and dropped on POST/verify. Net effect: theme and agents were silently lost on every workbook write through this adapter, across all 14 vendored targets (13 plugins, qlik has 2 copies).
- Fix: add `settings`, `agents` to `DOC_KEYS` in all three canonical files, re-vendor via `tools/sync-shared.rb`.
- Added regression tests (`test_settings_and_agents_stay_inside_document`, `test_settings_and_agents_round_trip_through_wrap`) to `shared/lib/tests/test_code_rep.{rb,py}` — confirmed RED against the old `DOC_KEYS`, GREEN after the fix.
- Patch-bumped all 13 affected plugins' `plugin.json` per the version-bump gate: cognos-to-sigma, gooddata-to-sigma, looker-to-sigma, microstrategy-to-sigma, powerbi-to-sigma, qlik-to-sigma, quicksight-to-sigma, tableau-to-sigma, thoughtspot-to-sigma, sisense-to-sigma, domo-to-sigma, hex-to-sigma, sigma-authoring.

## Test plan
- [x] `ruby shared/lib/tests/test_code_rep.rb` — 6 runs, 0 failures (confirmed 2 new tests RED on pre-fix `DOC_KEYS`, GREEN post-fix)
- [x] `python3 shared/lib/tests/test_code_rep.py` — 6 tests OK (same RED→GREEN confirmation)
- [x] `ruby tools/sync-shared.rb` — fanned out cleanly to all 14 targets
- [x] `ruby tools/check-shared.rb` — `OK: 680 shared-file copies all match canonical (1 allowlisted exceptions)`
- [x] Pre-commit governance hooks (hygiene-sweep, byte budgets, plugin-variant sync, converter freshness) all passed at commit time

🤖 Generated with [Claude Code](https://claude.com/claude-code)