### PR TITLE
fix(shared): code_rep DOC_KEYS omitted settings/agents — theme silently lost on every migration

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData → Sigma",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex → Sigma",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Migrate Hex projects to Sigma — SQL cells, single-value/METRIC cells, and EXPLORE charts → Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense → Sigma",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma — data model + workbook (indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; columnar layout→24-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/shared/lib/code_rep.mjs
+++ b/shared/lib/code_rep.mjs
@@ -3,7 +3,7 @@
 // /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
 // NOT changing — do not use this on /v2/dataModels/.../spec payloads.
 
-export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout'];
+export const DOC_KEYS = ['schemaVersion', 'pages', 'kind', 'layout', 'settings', 'agents'];
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 

--- a/shared/lib/code_rep.py
+++ b/shared/lib/code_rep.py
@@ -11,7 +11,7 @@ Reads stay tolerant of the legacy flat shape because flat artifacts still exist
 on disk (committed workbook snapshots, fixtures).
 """
 
-DOC_KEYS = ("schemaVersion", "pages", "kind", "layout")
+DOC_KEYS = ("schemaVersion", "pages", "kind", "layout", "settings", "agents")
 
 
 def document(response):

--- a/shared/lib/code_rep.rb
+++ b/shared/lib/code_rep.rb
@@ -14,7 +14,15 @@
 module Sigma
   module CodeRep
     # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
-    DOC_KEYS = %w[schemaVersion pages kind layout].freeze
+    #
+    # `settings` and `agents` are load-bearing: omitting them here does not merely
+    # misplace them, it SILENTLY LOSES DATA. metadata() would push them to the top
+    # level of the request body, where (live-probed 2026-08-06) a top-level
+    # `settings` passes /verify, creates 200, and the theme is gone with no error
+    # anywhere. (A top-level `agents` at least fails loudly, 400 on the chat
+    # element's agentId.) `settings` holds theme + navigation; see the workbook
+    # spec's document schema.
+    DOC_KEYS = %w[schemaVersion pages kind layout settings agents].freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.

--- a/shared/lib/tests/test_code_rep.py
+++ b/shared/lib/tests/test_code_rep.py
@@ -9,6 +9,11 @@ LIVE = {'workbookId': 'w1', 'name': 'N',
         'document': {'schemaVersion': 1, 'pages': [{'id': 'p'}]}}
 LEGACY = {'workbookId': 'w1', 'name': 'N',
           'schemaVersion': 1, 'pages': [{'id': 'p'}]}
+FLAT_RICH = {'workbookId': 'w1', 'name': 'N',
+             'schemaVersion': 1, 'kind': 'workbook', 'pages': [{'id': 'p'}],
+             'layout': '<Page/>',
+             'settings': {'theme': {'name': 'Dark'}},
+             'agents': [{'id': 'ag1', 'name': 'Helper', 'instructions': 'Help.'}]}
 
 
 class TestCodeRep(unittest.TestCase):
@@ -30,6 +35,36 @@ class TestCodeRep(unittest.TestCase):
         for r in (LIVE, LEGACY):
             doc = code_rep.document(r)
             self.assertEqual(code_rep.document(code_rep.wrap(doc)), doc)
+
+    # --- settings / agents belong INSIDE document ---------------------------
+    #
+    # Regression guard for a SILENT data-loss bug. DOC_KEYS omitted `settings`
+    # and `agents`, so document() dropped them and metadata() pushed them to the
+    # TOP level of the request body. Live-probed 2026-08-06:
+    #   * `settings` at top level -> /verify CLEAN, create 200, THEME SILENTLY LOST
+    #   * `agents`   at top level -> 400 ("references unknown agent"), i.e. loud
+    # The theme case is the dangerous one: migrated dashboards come out unthemed
+    # with no error anywhere.
+
+    def test_settings_stays_in_document(self):
+        doc = code_rep.document(FLAT_RICH)
+        self.assertEqual(doc.get('settings'), {'theme': {'name': 'Dark'}},
+                         'settings must live INSIDE document — at top level the theme is silently dropped')
+
+    def test_agents_stays_in_document(self):
+        doc = code_rep.document(FLAT_RICH)
+        self.assertEqual(len(doc.get('agents') or []), 1,
+                         'agents must live INSIDE document — at top level the API 400s on the chat agentId')
+
+    def test_metadata_excludes_settings_and_agents(self):
+        meta = code_rep.metadata(FLAT_RICH)
+        self.assertNotIn('settings', meta, 'settings must not be swept into top-level metadata')
+        self.assertNotIn('agents', meta, 'agents must not be swept into top-level metadata')
+        self.assertEqual(sorted(meta.keys()), ['name', 'workbookId'])
+
+    def test_rich_round_trip_is_lossless(self):
+        doc = code_rep.document(FLAT_RICH)
+        self.assertEqual(code_rep.document(code_rep.wrap(doc)), doc)
 
 
 if __name__ == '__main__':

--- a/shared/lib/tests/test_code_rep.rb
+++ b/shared/lib/tests/test_code_rep.rb
@@ -30,4 +30,46 @@ class TestCodeRep < Minitest::Test
       assert_equal doc, Sigma::CodeRep.document(Sigma::CodeRep.wrap(doc))
     end
   end
+
+  # --- settings / agents belong INSIDE document -------------------------------
+  #
+  # Regression guard for a SILENT data-loss bug. DOC_KEYS omitted `settings` and
+  # `agents`, so document() dropped them and metadata() pushed them to the TOP
+  # level of the request body. Live-probed 2026-08-06 against the workbook
+  # code-rep API:
+  #   * `settings` at top level  -> /verify CLEAN, create 200, THEME SILENTLY LOST
+  #   * `agents`   at top level  -> 400 ("references unknown agent"), i.e. loud
+  # The theme case is the dangerous one: every migrated dashboard would come out
+  # unthemed with no error anywhere.
+
+  FLAT_RICH = {
+    'workbookId' => 'w1', 'name' => 'N',
+    'schemaVersion' => 1, 'kind' => 'workbook', 'pages' => [{ 'id' => 'p' }], 'layout' => '<Page/>',
+    'settings' => { 'theme' => { 'name' => 'Dark' } },
+    'agents' => [{ 'id' => 'ag1', 'name' => 'Helper', 'instructions' => 'Help.' }]
+  }.freeze
+
+  def test_settings_stays_in_document
+    doc = Sigma::CodeRep.document(FLAT_RICH)
+    assert_equal({ 'theme' => { 'name' => 'Dark' } }, doc['settings'],
+                 'settings must live INSIDE document — at top level the theme is silently dropped')
+  end
+
+  def test_agents_stays_in_document
+    doc = Sigma::CodeRep.document(FLAT_RICH)
+    assert_equal 1, (doc['agents'] || []).length,
+                 'agents must live INSIDE document — at top level the API 400s on the chat agentId'
+  end
+
+  def test_metadata_excludes_settings_and_agents
+    meta = Sigma::CodeRep.metadata(FLAT_RICH)
+    refute meta.key?('settings'), 'settings must not be swept into top-level metadata'
+    refute meta.key?('agents'),   'agents must not be swept into top-level metadata'
+    assert_equal %w[name workbookId], meta.keys.sort
+  end
+
+  def test_rich_round_trip_is_lossless
+    doc = Sigma::CodeRep.document(FLAT_RICH)
+    assert_equal doc, Sigma::CodeRep.document(Sigma::CodeRep.wrap(doc))
+  end
 end


### PR DESCRIPTION
## The bug

`DOC_KEYS = [schemaVersion, pages, kind, layout]` drives **both** halves of the adapter — `document()` selects those keys, `metadata()` rejects them. Anything else in a flat on-disk spec is therefore dropped from `document` and pushed to the **top level** of the request body. That includes `settings` (theme + navigation) and `agents`.

## Live-probed, not inferred

Against the workbook code-rep API, 2026-08-06:

| sent as | result |
|---|---|
| `settings` at top level | `/verify` **clean**, create **200**, **theme silently gone** |
| `agents` at top level | **400** `references unknown agent` — loud, self-catching via the chat element's `agentId` |
| `document.themeName` (old in-document key) | **400** `no longer supported. Use document.settings.theme.name instead` — loud, with a perfect message |

Only the `settings` path is silent — and it's the one that matters. Every migrated dashboard comes out unthemed with nothing in any log.

This **narrows** the claim in the wrapper-migration notes that "theme and agents [are] silently dropped": agents and `document.themeName` both fail loudly. Theme-via-`settings` is the sole silent case.

## Fix

Add `settings` and `agents` to `DOC_KEYS` in all three canonical adapters (`.rb` / `.py` / `.mjs`), re-fanned to the 13 plugins that vendor them.

## End-to-end proof

Same script, both ways, against a live org — a flat spec carrying `settings.theme.name = "Dark"` pushed through the **real** adapter:

```
with fix   -> settings inside document, create 200, theme back as {"name"=>"Dark"}   ✅
reverted   -> settings at top level,    create 200, theme back as nil                ❌
```

## Tests — written first, proven to fail first

Per the repo's "prove the gate fails on a planted defect" rule: **3 failures in Ruby, 3 in Python** against the unpatched adapter; 0 after. Guards cover document placement, metadata exclusion, and rich round-trip losslessness. Re-verified by reverting the adapter under the committed tests.

## Scope / what this does NOT fix

**10+ converter scripts still emit the OLD top-level `themeName` key** (`harvest-theme-registry.py`, `verify-styling-surfaces-e2e.rb`, tableau/domo/powerbi/quicksight `build-workbook-*`, …). This adapter change does **not** rescue them — `themeName` isn't a DOC_KEY either, so it still sweeps out and is still silently ignored. Renaming those to `settings.theme.name` is cross-plugin work that belongs with the document-wrapper programme.

## Coordination

- **No open PR touches `code_rep.*`** — checked all of #610/#611/#612/#614/#618/#619/#620/#626. No conflict on the changed files.
- **`sigma-authoring` version does collide**: this bumps 1.9.3 → **1.9.4**, same target as #610/#611/#612. Per the wrapper-migration merge notes that's expected — first one merges, the rest rebase. My other PR #627 targets 1.10.0 and should merge **after** all of these.
- 13 plugins get a patch bump (user-facing bugfix, so a real bump rather than `Skip-Version-Bump`).

Gates: `check-shared` OK (680 copies), `check-agent-variants` OK (16), `lint-skills` clean, `plugin-version-bump` OK.

Bead: `beads-sigma-cofo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)