### PR TITLE
fix(powerbi): preserve NativeQuery sources and schedule materializations

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -277,6 +277,10 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-element-match.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-native-query.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-composite-gate.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-convert-model-reprefix.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-materialization-schedules.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-scout-ledger-integrity.rb

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.10",
+  "version": "1.8.11",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -136,6 +136,9 @@ Caches `<WORK>/connection.json` (the orchestrator reads it when `--connection` i
 point `--out` at the same `<WORK>`) and writes `intake.json` (run-start + mode feed the
 telemetry ping). Multiple connections + no id/name → it lists them and asks you to pick;
 never guesses. (Power BI input is almost always `--mode file` — TMSL + PBIR exports.)
+Every orchestrated run also writes `<WORK>/run-provenance.json` with the plugin
+version, repository SHA (when installed from Git), real skill path, and pinned
+converter provenance. Include that file in any migration incident summary.
 
 > **ASK FOR SOURCE DASHBOARD SCREENSHOTS UP FRONT (file mode).** Layout is inferred from the
 > export's `x,y,w,h` **coordinates only** — never from an image — and those free-form/absolute
@@ -188,6 +191,22 @@ resume with `--converter-out`. The hosted MCP is a fallback, not the default pat
 
 `convertPowerBIToSigma(model_json, connection_id, database, schema)`.
 
+**Native warehouse SQL is preserved.** TMSL partitions that use
+`Value.NativeQuery(...)` or a connector `[Query="SELECT …"]` option are restored
+after conversion as named Sigma Custom SQL elements (`source.kind: "sql"`) with
+the complete statement and exact `[Custom SQL/<sourceColumn>]` bindings. They
+must never be reduced to the first table in the query's `FROM`. Distinct Power BI
+tables remain distinct even when their queries share that first physical table.
+Array-valued calculation-item expressions are normalized before the pinned
+converter runs. The run records these repairs in
+`<WORK>/native-query-conversion.json`.
+
+If a native query is followed by Power Query steps such as
+`Table.RenameColumns` or `Table.SelectRows`, the orchestrator stops at an OPEN
+QUESTION: preserving the SQL alone would drop those semantics. Fold the steps
+into the SQL and rerun. `--allow-native-m-transforms` is only for a model whose
+SQL was already corrected manually.
+
 > **Databricks / lower-case warehouses (beads-sigma-lanq.7):** physical identifiers default to
 > UPPER (Snowflake/BigQuery fold that way). Databricks/Spark store identifiers **lower-case** and
 > bind only against a lower-cased warehouse path, so an UPPER path fails at POST with
@@ -211,7 +230,9 @@ resume with `--converter-out`. The hosted MCP is a fallback, not the default pat
 
 - DAX measures → Sigma metrics. ~70% mechanical; see `refs/dax-to-sigma-coverage.md` and `fixtures/MANIFEST.md` (test oracle: 94 DAX expressions bucketed a/b/c).
 - **PromoteHeaders**: if `pbi-dm-signature.py` reports `promoted_header_tables` (the model's M-query used `Table.PromoteHeaders`), the warehouse table's real columns are auto-named (`C1`, `C2`, …) with the semantic names in row 0 — the TMSL `sourceColumn` names will NOT resolve. Verify the landed table's real columns and remap with `convert-model.rb --table-map` (in Sigma formulas the columns appear as `C 1`, `C 2`, … and in JOIN SQL alias them, e.g. `c.C2 AS CUSTOMER_NAME`).
-- **Known gap `j89`**: the Snowflake `Snowflake.Databases(...) + Navigation` M pattern isn't parsed → pass `database`/`schema` explicitly until fixed.
+- Snowflake/Databricks/SQL-family navigation paths and native-query partitions are
+  regression-covered. Caller `--database`/`--schema` values remain explicit
+  single-schema repoints; they never replace a native SQL statement.
 - **DAX gaps → gap-scout**: for measures the converter buckets `b` (restructure) or `c` (no-equivalent) — `RANKX`, `ALLEXCEPT`, `SUMMARIZE`, `USERELATIONSHIP`, `PATH*` — spawn the **gap-scout** sub-agent (`scripts/gap-scout.md`): it proposes a Sigma translation, validates it against the live API (`scripts/scout-validate.py`), and persists the rule to `~/.powerbi-to-sigma/learned-rules.yaml` (loaded by `scripts/learned-rules.py`) so future conversions auto-apply it. Time-intelligence (YTD/SPLY) is usually translatable — see `refs/measure-patterns.md`, not the scout.
 
 ## Phase 3.5 — Reuse an existing DM? (avoid sprawl — the reuse-first DM gate every converter runs before building)
@@ -236,6 +257,29 @@ The converter output (`sigmaDataModel`) needs 3 fixups before `POST /v2/dataMode
 3. **Element `name`** on each base warehouse-table element (= `source.path[-1]`) — the converter only names joined View elements, but workbook masters reference DM elements by name.
    > These joined View elements are query-time joins Sigma runs in the warehouse. For *why* Sigma modeling differs and when to consider an upstream OBT / Sigma-native materialization instead (an opt-in optimization, not something this skill does automatically), see `refs/modeling-strategy.md`. When the converted model has ≥2 joins, the orchestrator prints a one-line MODELING ADVISORY pointing there.
 Then: `tableau-to-sigma/scripts/post-and-readback.rb --type datamodel`. See `refs/spec-fixups.md`.
+
+### Optional after Phase 4 — materialize Custom SQL elements
+
+For expensive converted native SQL, opt in to a data-model element
+materialization schedule (the schedule API is Beta; scheduling is OFF by
+default):
+
+```bash
+ruby scripts/migrate-powerbi.rb ... \
+  --materialization-cron "0 2 * * *" \
+  --materialization-timezone "America/Chicago" \
+  [--materialization-elements "COR,Property"]   # omitted = every Custom SQL element
+```
+
+The post-readback step lists existing schedules and is idempotent: it creates a
+missing schedule, leaves an identical schedule unchanged, or patches a changed
+cron/timezone. Results go to `<WORK>/materialization-actions.json`. The API
+credential owner needs **Schedule materializations** permission and the
+connection needs warehouse write access. A schedule failure is surfaced with a
+specific remediation but does not invalidate the already-correct data model.
+Materialization is performance-only; Phase 6 parity still runs against the
+materialized result. Workbook-element schedules are a separate API surface and
+are not created by this Power BI migration option.
 
 > **What Phase 4 "validation" catches — and what it does NOT (read before trusting a clean DM).**
 > `validate-spec.rb` is spec-**shape** only (kinds, formula function names, ref prefixes — no
@@ -497,6 +541,8 @@ The conversion is script-driven (mirrors `tableau-to-sigma/scripts/`). `scripts/
 | `sigma-export-png.py` | 5e/5f compare | Renders a built Sigma page to PNG (`--workbook <id> --page <pageId> --out … --w 1600`) for the source-vs-target compare AND the Phase 5f Visual QA read (checked against `refs/layout-visual-qa.md`). |
 | `assert-visual-compare.rb` | 5e gate | HARD GATE: blocks Phase 6 unless visual-compare.json has a PASS/ACCEPTED verdict (with explained deltas) for every content page. |
 | `convert-model.rb` | 2–3 convert/post | MODE A prints the exact `convert_powerbi_to_sigma` MCP call for a `model.bim`; MODE B takes the converter output and applies the 3 fixups (schemaVersion + folderId/ownerId via a ref-DM harvest + base-element names) → postable DM spec. |
+| `lib/pbi_native_query.rb` | 2 convert | Compatibility layer around the provenance-pinned converter: joins array calc-item expressions, preserves full `Value.NativeQuery`/`Query=` SQL as named Custom SQL elements, and gates downstream M transforms. |
+| `lib/materialization_schedules.rb` | 4 post-DM (optional) | Idempotent Beta lifecycle client for data-model element schedules: paginated list, create/no-op/patch with exact cron/timezone, and actionable permission/write-access errors. |
 | `build-workbook-from-pbir.rb` | 4 build | `signals.json` + a `master-map.json` → full workbook spec + 24-col layout XML. Applies the measure-translation patterns in `refs/measure-patterns.md`; **line charts default to a single series** (`beads-sigma-c07`) unless PBI bound a Series/Legend role. **Carries the PBI visual sort** (`f972` — PBIR `query.sortDefinition` / classic `prototypeQuery.OrderBy` → chart `xAxis.sort`/`color.sort`; grouped table → `groupings[0].sort` — element-level sort is rejected on grouped tables). Analog of `build-charts-from-signals.rb`. **Writes `coverage.json`** (`--coverage-out`): every dropped/degraded/approximated component aggregated (Phase 5c) — nothing silently dropped. |
 | `phase6-parity-pbi.rb` | 7 parity | executeQueries(DAX) adapter: `--emit-dax` runs the PBI side and writes the parity plan's `expected` rows; `--finalize` injects Sigma actuals and runs the shared `verify-parity.rb`. The PBI analog of Tableau's view-CSV parity adapter. |
 | `enhance-scan.rb` | E scan (opt-in) | **Phase E part 1 — SCAN (read-only).** Source signals + built spec + live element exports → `enhancements.json` candidates `{id, category, evidence, proposed, risk, verdict_hint, patch}` + descoped propose-in-UI notes. Shared Phase-E engine, vendored byte-identical across plugins (md5 discipline). |

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/fixtures/native_query_cor_pl/model.bim
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/fixtures/native_query_cor_pl/model.bim
@@ -1,0 +1,82 @@
+{
+  "model": {
+    "name": "Native Query P&L Regression",
+    "tables": [
+      {
+        "name": "COR",
+        "columns": [
+          { "name": "Cost Center", "sourceColumn": "COST_CENTER", "dataType": "string" },
+          { "name": "Property Id", "sourceColumn": "PROPERTY_ID", "dataType": "int64" },
+          { "name": "Amount", "sourceColumn": "AMOUNT", "dataType": "decimal" }
+        ],
+        "measures": [
+          { "name": "Total Amount", "expression": "SUM(COR[Amount])" }
+        ],
+        "partitions": [
+          {
+            "name": "COR",
+            "mode": "import",
+            "source": {
+              "type": "m",
+              "expression": [
+                "let",
+                "  Source = Value.NativeQuery(Snowflake.Databases(\"example-account\"){[Name=\"ENTERPRISE\"]}[Data], \"SELECT c.COST_CENTER, c.PROPERTY_ID, c.AMOUNT#(lf)FROM ENTERPRISE.MASTER.COR_DETAIL c#(lf)JOIN ENTERPRISE.MASTER.PROPERTY p ON p.ID = c.PROPERTY_ID\", null, [EnableFolding=true])",
+                "in",
+                "  Source"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Property",
+        "columns": [
+          { "name": "Property Id", "sourceColumn": "PROPERTY_ID", "dataType": "int64" },
+          { "name": "Property Name", "sourceColumn": "PROPERTY_NAME", "dataType": "string" }
+        ],
+        "partitions": [
+          {
+            "name": "Property",
+            "mode": "import",
+            "source": {
+              "type": "m",
+              "expression": [
+                "let",
+                "  Source = Value.NativeQuery(Snowflake.Databases(\"example-account\"){[Name=\"ENTERPRISE\"]}[Data], \"SELECT c.PROPERTY_ID, p.PROPERTY_NAME#(lf)FROM ENTERPRISE.MASTER.COR_DETAIL c#(lf)JOIN ENTERPRISE.MASTER.PROPERTY p ON p.ID = c.PROPERTY_ID\", null, [EnableFolding=true])",
+                "in",
+                "  Source"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "Time Intelligence",
+        "calculationGroup": {
+          "calculationItems": [
+            { "name": "Current", "expression": ["SELECTEDMEASURE", "()"] },
+            {
+              "name": "Prior Year",
+              "expression": [
+                "CALCULATE(",
+                "  SELECTEDMEASURE(),",
+                "  SAMEPERIODLASTYEAR('Month - Accounting'[Date])",
+                ")"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "name": "COR to Property",
+        "fromTable": "COR",
+        "fromColumn": "Property Id",
+        "toTable": "Property",
+        "toColumn": "Property Id",
+        "isActive": true
+      }
+    ]
+  }
+}

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-model-gotchas.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-model-gotchas.md
@@ -16,7 +16,7 @@ lowercase, mostly-ungranted multi-schema, 100s of tables, heavy `CALCULATE`.
 ## VERIFIED gaps (grepped; beaded)
 | Gap | Stage | Bead |
 |---|---|---|
-| M-parser misses whole warehouse families: SQL-family flat `[Schema=,Item=]`, the common `Sql.Databases()` two-tier (Kind db step **then** flat Schema/Item), Databricks shape-B `{[Item=,Schema=,Catalog=]}`, native-query (`Value.NativeQuery`/`[Query=SELECT…]`), BigQuery Name-only 3-tier | convert | `beads-sigma-lanq.9` (P1) |
+| M-parser warehouse families: SQL-family flat `[Schema=,Item=]`, `Sql.Databases()` two-tier, Databricks shape-B, BigQuery Name-only 3-tier | convert | `beads-sigma-lanq.9` (path families remain regression targets; do not lose them during re-vendor) |
 | Field parameters (`NAMEOF` calc tables) → phantom warehouse table; should be a control-driven `Switch([ctl],…)` picker | convert | `beads-sigma-lanq.10` (P2) |
 | Multi-partition tables + incremental-refresh `refreshPolicy.sourceExpression` + Direct Lake/`entity` partitions (only `partitions[0]` read) | convert | `beads-sigma-lanq.11` (P2) |
 | Relationship fidelity: many-to-many + bidirectional `crossFilteringBehavior` not inspected (fan-out / wrong subtotals) | convert | `beads-sigma-lanq.12` (P2) |
@@ -32,7 +32,10 @@ converter) — the critic's "completely absent" was wrong. Don't bead it.
 ## Already-handled (don't re-flag)
 Kind-chain nav (Snowflake/Databricks-A/BigQuery-with-Kind/Athena), Redshift 2-level
 Name-nav, calculated tables (CALENDAR/GENERATESERIES → SQL spine; else loud
-placeholder), calc groups (excluded as source + loud item stubs), RLS/OLS
+placeholder), native-query partitions (`Value.NativeQuery` / connector `Query=`
+preserved as complete named Custom SQL by `lib/pbi_native_query.rb`; post-query M
+steps gate), calc groups (excluded as source + loud item stubs; array-valued item
+expressions normalized before conversion), RLS/OLS
 (makeRlsSecurity/makeClsSecurity, surfaced not injected), USERELATIONSHIP (activated
 as named alt join), inactive rels (only emitted if a measure uses them), rowNumber/
 isGenerated skipped, calc columns (window/EARLIER → SQL helpers), binary skipped,

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/convert-model.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/convert-model.rb
@@ -136,8 +136,8 @@ dm['name'] = opts[:name] if opts[:name]
 # is the customer's manual "proper-case element naming" workaround, automated. Only
 # rewrite a base element's OWN 2-segment ref whose prefix matches NO element name — a
 # valid cross-element ref (prefix IS a known element) is left untouched.
-known_norm = []
-(dm['pages'] || []).each { |pg| (pg['elements'] || []).each { |el| known_norm << el['name'].to_s.downcase.gsub(/[^a-z0-9]/, '') } }
+known_names = []
+(dm['pages'] || []).each { |pg| (pg['elements'] || []).each { |el| known_names << el['name'].to_s } }
 reprefixed = 0
 (dm['pages'] || []).each do |pg|
   (pg['elements'] || []).each do |el|
@@ -151,7 +151,10 @@ reprefixed = 0
       next unless m
       pfx = m[1]
       next if pfx == name # already references its own element
-      next if known_norm.include?(pfx.downcase.gsub(/[^a-z0-9]/, '')) # valid ref to a known element
+      # Sigma element references are literal. Treating spaces/underscores or
+      # case as equivalent makes `[Cost Center/X]` look valid when the actual
+      # element is `COST_CENTER`, leaving a dependency-not-found formula.
+      next if known_names.include?(pfx) # exact valid ref to a known element
       c['formula'] = "[#{name}/#{m[2]}]"
       reprefixed += 1
     end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/materialization_schedules.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/materialization_schedules.rb
@@ -11,7 +11,9 @@ module MaterializationSchedules
 
   def validate!(cron:, timezone: nil)
     raise ArgumentError, 'materialization cron must contain exactly 5 fields' unless cron.to_s.split(/\s+/).size == 5
-    if timezone && !timezone.empty? && timezone !~ %r{\A[A-Za-z_+-]+(?:/[A-Za-z0-9_+.-]+)+\z}
+    valid_timezone = timezone.to_s.empty? || timezone == 'UTC' ||
+                     timezone.match?(%r{\A[A-Za-z_+-]+(?:/[A-Za-z0-9_+.-]+)+\z})
+    unless valid_timezone
       raise ArgumentError, "materialization timezone must be an IANA name (got #{timezone.inspect})"
     end
   end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/materialization_schedules.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/materialization_schedules.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'uri'
+
+# Idempotent lifecycle client for Sigma data-model element materialization
+# schedules (Beta). Kept Power-BI-local until another converter adopts the same
+# create/list/patch contract; shared infrastructure changes require a separate PR.
+module MaterializationSchedules
+  module_function
+
+  def validate!(cron:, timezone: nil)
+    raise ArgumentError, 'materialization cron must contain exactly 5 fields' unless cron.to_s.split(/\s+/).size == 5
+    if timezone && !timezone.empty? && timezone !~ %r{\A[A-Za-z_+-]+(?:/[A-Za-z0-9_+.-]+)+\z}
+      raise ArgumentError, "materialization timezone must be an IANA name (got #{timezone.inspect})"
+    end
+  end
+
+  def default_request(method, path, payload = nil)
+    require_relative 'sigma_rest'
+    Sigma.request(method, path, body: payload && JSON.generate(payload))
+  end
+
+  def list(data_model_id, request: method(:default_request), page_size: 500)
+    entries = []
+    token = nil
+    seen = {}
+    loop do
+      path = "/v2/dataModels/#{data_model_id}/materializationSchedules?pageSize=#{page_size}"
+      path += "&pageToken=#{URI.encode_www_form_component(token)}" if token
+      body = request.call(:get, path, nil)
+      break unless body.is_a?(Hash)
+
+      entries.concat(body['entries'] || [])
+      token = body['nextPageToken']
+      break if token.to_s.empty?
+      raise "materialization schedule list repeated pageToken #{token.inspect}" if seen[token]
+
+      seen[token] = true
+    end
+    entries
+  end
+
+  def reconcile(data_model_id:, elements:, cron:, timezone: nil, request: method(:default_request))
+    validate!(cron: cron, timezone: timezone)
+    existing = list(data_model_id, request: request).each_with_object({}) do |entry, memo|
+      memo[entry['elementId']] = entry
+    end
+    desired_schedule = { 'cronSpec' => cron }
+    desired_schedule['timezone'] = timezone unless timezone.to_s.empty?
+
+    elements.map do |element|
+      element_id = element.fetch('id')
+      element_name = element['name'] || element_id
+      current = existing[element_id]
+      current_schedule = current && current['schedule']
+      action = {
+        'elementId' => element_id,
+        'elementName' => element_name,
+        'requestedSchedule' => desired_schedule
+      }
+      begin
+        if current.nil?
+          response = request.call(
+            :post,
+            "/v2/dataModels/#{data_model_id}/elements/#{element_id}/materializationSchedules",
+            { 'schedule' => desired_schedule }
+          )
+          action.merge!('status' => 'created', 'schedule' => response && response['schedule'])
+        elsif current_schedule == desired_schedule ||
+              (timezone.to_s.empty? && current_schedule&.fetch('cronSpec', nil) == cron)
+          action.merge!('status' => 'unchanged', 'schedule' => current_schedule)
+        else
+          response = request.call(
+            :patch,
+            "/v2/dataModels/#{data_model_id}/elements/#{element_id}/materializationSchedules",
+            { 'schedule' => desired_schedule }
+          )
+          action.merge!('status' => 'updated', 'schedule' => response && response['schedule'])
+        end
+      rescue StandardError => e
+        message = e.message.to_s
+        hint =
+          if message.match?(/403|not.?permitted|permission/i)
+            'API owner needs the Schedule materializations permission'
+          elsif message.match?(/write access|writeback|write-back/i)
+            'enable write access on the element connection'
+          elsif message.match?(/404|not found|beta|entitlement/i)
+            'confirm the organization is entitled to the materialization schedule Beta'
+          else
+            'review the Sigma API error and element materialization eligibility'
+          end
+        action.merge!('status' => 'error', 'error' => message[0, 500], 'remediation' => hint)
+      end
+      action
+    end
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_composite.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_composite.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Detect Fabric-extracted models that are incomplete because they reference a
+# remote Power BI / Analysis Services semantic model. NativeQuery is ordinary
+# warehouse SQL and deliberately is not a composite signal.
+module PbiComposite
+  module_function
+
+  REMOTE_CONNECTOR = /AnalysisServices\.Database|PowerBIServiceLive|DirectQueryToAS|pbiazure|PowerBI\.Datasets/i
+
+  def incomplete_reasons(model)
+    reasons = []
+    (model['tables'] || []).each do |table|
+      name = table['name']
+      next if name.to_s.start_with?('LocalDateTable_', 'DateTableTemplate_')
+
+      Array(table['partitions']).each do |partition|
+        mode = partition['mode'].to_s.downcase
+        reasons << "table '#{name}' has a DirectQuery partition" if mode == 'directquery'
+        source = partition['source'] || {}
+        reasons << "table '#{name}' is an 'entity' partition bound to a remote model" \
+          if source['type'].to_s.downcase == 'entity'
+        expression = source['expression']
+        expression = expression.join("\n") if expression.is_a?(Array)
+        if expression.is_a?(String) && expression.match?(REMOTE_CONNECTOR)
+          reasons << "table '#{name}' M expression references a remote Power BI dataset"
+        end
+      end
+    end
+    reasons.uniq
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_native_query.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_native_query.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+# Compatibility layer for Power BI partition SQL that the pinned converter
+# historically reduced to the first table in the query's FROM clause.
+#
+# The vendored converter remains immutable/provenance-pinned. This module:
+#   1. normalizes array-valued calculation-item expressions before conversion;
+#   2. extracts Value.NativeQuery / connector Query= SQL from the original TMSL;
+#   3. restores those source elements to Sigma kind:"sql" after conversion.
+require 'json'
+
+module PbiNativeQuery
+  module_function
+
+  Native = Struct.new(:table, :statement, :source, :post_transform, keyword_init: true)
+
+  def model_from(tmsl)
+    tmsl['model'] || tmsl
+  end
+
+  def expression_text(value)
+    value.is_a?(Array) ? value.join("\n") : value.to_s
+  end
+
+  def normalize_tmsl(tmsl)
+    copy = JSON.parse(JSON.generate(tmsl))
+    (model_from(copy)['tables'] || []).each do |table|
+      items = table.dig('calculationGroup', 'calculationItems') || []
+      items.each do |item|
+        item['expression'] = expression_text(item['expression']) if item['expression'].is_a?(Array)
+      end
+    end
+    copy
+  end
+
+  def split_call_args(text, start_idx)
+    args = []
+    depth = 1
+    arg_start = start_idx
+    quote = nil
+    i = start_idx
+    while i < text.length
+      ch = text[i]
+      if quote
+        if ch == quote
+          if quote == '"' && text[i + 1] == '"'
+            i += 2
+            next
+          end
+          quote = nil
+        end
+        i += 1
+        next
+      end
+      if ch == '"' || ch == "'"
+        quote = ch
+      elsif '([{'.include?(ch)
+        depth += 1
+      elsif ')]}'.include?(ch)
+        depth -= 1
+        if depth.zero?
+          args << text[arg_start...i].strip
+          return [args, i + 1]
+        end
+      elsif ch == ',' && depth == 1
+        args << text[arg_start...i].strip
+        arg_start = i + 1
+      end
+      i += 1
+    end
+    [args, i]
+  end
+
+  def decode_m_string(raw)
+    text = raw.to_s.strip
+    return nil unless text.start_with?('"')
+
+    out = +''
+    i = 1
+    while i < text.length
+      if text[i] == '"'
+        if text[i + 1] == '"'
+          out << '"'
+          i += 2
+          next
+        end
+        return [out, i + 1]
+      end
+      if text[i, 2] == '#('
+        close = text.index(')', i + 2)
+        if close
+          decoded = text[(i + 2)...close].split(',').map do |token|
+            case token.strip.downcase
+            when 'lf' then "\n"
+            when 'cr' then "\r"
+            when 'tab' then "\t"
+            else
+              t = token.strip
+              t.match?(/\A[0-9a-f]{4,8}\z/i) ? [t.to_i(16)].pack('U') : "#(#{token})"
+            end
+          end.join
+          out << decoded
+          i = close + 1
+          next
+        end
+      end
+      out << text[i]
+      i += 1
+    end
+    nil
+  end
+
+  def post_transform?(text, end_pos)
+    tail = text[end_pos..].to_s
+    before_in = tail.split(/\n\s*in\s+/i, 2).first.to_s
+    before_in.match?(/(?:^|[\r\n])\s*(?:#"(?:[^"]|"")*"|[A-Za-z_][\w.]*)\s*=/m)
+  end
+
+  def extract_from_expression(table_name, expression)
+    text = expression_text(expression)
+    if (match = text.match(/\bValue\.NativeQuery\s*\(/i))
+      args, end_pos = split_call_args(text, match.end(0))
+      decoded = decode_m_string(args[1]) if args.length >= 2
+      if decoded && !decoded[0].strip.empty?
+        return Native.new(
+          table: table_name,
+          statement: decoded[0].strip.sub(/;\s*\z/, ''),
+          source: 'Value.NativeQuery',
+          post_transform: post_transform?(text, end_pos)
+        )
+      end
+    end
+
+    if (match = text.match(/\bQuery\s*=\s*"/i))
+      quote_pos = text.index('"', match.begin(0))
+      decoded = decode_m_string(text[quote_pos..]) if quote_pos
+      if decoded && !decoded[0].strip.empty?
+        return Native.new(
+          table: table_name,
+          statement: decoded[0].strip.sub(/;\s*\z/, ''),
+          source: 'Query option',
+          post_transform: post_transform?(text, quote_pos + decoded[1])
+        )
+      end
+    end
+    nil
+  end
+
+  def native_queries(model)
+    (model['tables'] || []).filter_map do |table|
+      partition = (table['partitions'] || []).first
+      next unless partition&.dig('source', 'expression')
+
+      extract_from_expression(table['name'], partition.dig('source', 'expression'))
+    end
+  end
+
+  def convertible_tables(model)
+    (model['tables'] || []).reject do |table|
+      name = table['name'].to_s
+      calc_group = table['calculationGroup']
+      cols = (table['columns'] || []).reject { |c| c['type'] == 'rowNumber' || c['isGenerated'] }
+      measures_only = cols.empty? && (table['measures'] || []).any?
+      calc_group || measures_only ||
+        name.start_with?('LocalDateTable_', 'DateTableTemplate_')
+    end
+  end
+
+  def base_elements(dm)
+    (dm['pages'] || []).flat_map { |page| page['elements'] || [] }.select do |element|
+      %w[warehouse-table sql].include?(element.dig('source', 'kind')) &&
+        element.dig('source', 'connectionId')
+    end
+  end
+
+  # Mutates dm (the converter output) and returns a result artifact.
+  def apply!(dm, model)
+    natives = native_queries(model)
+    return { 'converted' => [], 'blockers' => [] } if natives.empty?
+
+    tables = convertible_tables(model)
+    elements = base_elements(dm)
+    all_elements = (dm['pages'] || []).flat_map { |page| page['elements'] || [] }
+    converted = []
+    blockers = []
+
+    natives.each do |native|
+      table_index = tables.index { |table| table['name'] == native.table }
+      table = tables[table_index] if table_index
+      element = elements[table_index] if table_index
+      unless table && element
+        blockers << { 'table' => native.table, 'reason' => 'converter element could not be attributed by table order' }
+        next
+      end
+
+      old_name = element['name'].to_s
+      element['name'] = native.table
+      element['source'] = {
+        'connectionId' => element.dig('source', 'connectionId'),
+        'kind' => 'sql',
+        'statement' => native.statement
+      }
+
+      source_columns = (table['columns'] || []).reject do |column|
+        column['type'] == 'rowNumber' || column['isGenerated'] ||
+          column['type'] == 'calculated' || column['dataType'] == 'binary'
+      end
+      source_columns.zip(element['columns'] || []).each do |column, emitted|
+        next unless column && emitted
+
+        output_name = (column['sourceColumn'] || column['name']).to_s.sub(/\A\[/, '').sub(/\]\z/, '')
+        emitted['formula'] = "[Custom SQL/#{output_name}]"
+        emitted['name'] = column['name'] || output_name
+      end
+
+      # The pinned converter built relationship Views while this was still a
+      # warehouse-table. Keep them, but point their formulas/names at the newly
+      # restored logical base name.
+      all_elements.each do |child|
+        next unless child.dig('source', 'kind') == 'table' &&
+                    child.dig('source', 'elementId') == element['id']
+
+        child['name'] = "#{native.table} View" if child['name'].to_s == "#{old_name} View"
+        (child['columns'] || []).each do |column|
+          formula = column['formula']
+          column['formula'] = formula.sub("[#{old_name}/", "[#{native.table}/") if formula.is_a?(String)
+        end
+      end
+
+      converted << {
+        'table' => native.table,
+        'elementId' => element['id'],
+        'source' => native.source,
+        'postTransform' => native.post_transform
+      }
+      if native.post_transform
+        blockers << {
+          'table' => native.table,
+          'reason' => 'native SQL is followed by Power Query M transforms that are not represented'
+        }
+      end
+    end
+
+    { 'converted' => converted, 'blockers' => blockers }
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -69,6 +69,7 @@ require 'fileutils'
 require 'open3'
 require 'digest'
 require 'set'
+require 'time'
 require_relative 'lib/py_resolve'
 require_relative 'lib/pbi_field_alts'
 require_relative 'lib/pbi_master_key'
@@ -82,6 +83,9 @@ require 'dax_gate'      # DAX warning → decision-question classifier (regressi
 require 'coverage_gate' # workbook-build coverage.json → consolidated report + assistance prompt
 require 'pbi_element_match' # converter→readback element pairing (POST reorders; regression-tested)
 require 'pbi_timeintel_route' # time-intel fallback-router fact-provenance guard (regression-tested)
+require 'pbi_native_query' # preserve Value.NativeQuery/Query= SQL around the pinned converter
+require 'pbi_composite' # remote-model detection; NativeQuery is warehouse SQL
+require 'materialization_schedules' # opt-in DM element schedule lifecycle
 
 # Converter resolution (issue #227). The pinned VENDORED bundle is the DEFAULT so a
 # developer machine and a customer machine produce identical output for the same
@@ -187,7 +191,21 @@ OptionParser.new do |o|
   # model lives in the local .pbix (prefer --pbix). Pass this to proceed anyway
   # on the (known-incomplete) Fabric model.
   o.on('--allow-incomplete-model') { opts[:allow_incomplete_model] = true }
+  # Native SQL followed by Table.RenameColumns/Table.SelectRows/etc. cannot be
+  # represented by preserving the SQL alone. Gate by default; this override is
+  # only for a user who has manually folded those transforms into the SQL.
+  o.on('--allow-native-m-transforms') { opts[:allow_native_m_transforms] = true }
+  # Opt-in materialization schedule for converted Custom SQL elements. Cron is
+  # required; timezone is IANA. Without --materialization-elements every SQL
+  # source element is targeted. A comma-list selects exact element names.
+  o.on('--materialization-cron CRON') { |v| opts[:materialization_cron] = v }
+  o.on('--materialization-timezone TZ') { |v| opts[:materialization_timezone] = v }
+  o.on('--materialization-elements LIST') { |v| opts[:materialization_elements] = v }
 end.parse!
+
+if opts[:materialization_timezone] && !opts[:materialization_cron]
+  abort 'FATAL: --materialization-timezone requires --materialization-cron'
+end
 
 # #347: publish the target tenant into the env so EVERY Power BI child process
 # (fabric-extract.py, pbi-freshness.py, phase6 harness, …) inherits it and
@@ -264,6 +282,24 @@ name_slug = File.basename(opts[:tmsl] || opts[:pbix], '.*').gsub(/[^A-Za-z0-9_-]
 WORK = opts[:out] || File.expand_path("~/powerbi-migration/#{name_slug}")
 FileUtils.mkdir_p(WORK)
 WB_NAME = opts[:name] || "#{name_slug.gsub(/[_]+/, ' ').strip} (from Power BI)"
+
+# Persist exact executable provenance for every incident report. A plugin file
+# copy may have no git metadata; the plugin version + converter pin + real path
+# still identify what actually ran.
+plugin_manifest = File.expand_path('../../../.claude-plugin/plugin.json', HERE)
+plugin_json = JSON.parse(File.read(plugin_manifest)) rescue {}
+converter_prov_path = File.join(File.dirname(VENDORED_PBI), 'PROVENANCE.json')
+converter_prov = JSON.parse(File.read(converter_prov_path)) rescue {}
+repo_sha, repo_status = Open3.capture2('git', '-C', HERE, 'rev-parse', '--short', 'HEAD')
+run_provenance = {
+  'pluginVersion' => plugin_json['version'],
+  'repoSha' => repo_status.success? ? repo_sha.strip : nil,
+  'skillPath' => File.realpath(File.expand_path('..', HERE)),
+  'converter' => CONVERTER_DESC,
+  'converterProvenance' => converter_prov,
+  'recordedAt' => Time.now.utc.iso8601
+}
+File.write(File.join(WORK, 'run-provenance.json'), JSON.pretty_generate(run_provenance))
 
 # ---- phase timings (always written to <WORK>/timings.json) ------------------
 # Fast-discovery evidence trail: every terminal exit (success, decisions gate,
@@ -385,28 +421,6 @@ end
 # Returns a list of human-readable reason strings ([] when the model is a
 # complete import model). The offline analog is the .pbix Connections
 # RemoteArtifacts tell (extract-model-pbix.py is_composite_connections).
-def detect_incomplete_composite(model)
-  reasons = []
-  (model['tables'] || []).each do |t|
-    name = t['name']
-    next if name.to_s.start_with?('LocalDateTable_', 'DateTableTemplate_')
-    Array(t['partitions']).each do |p|
-      mode = p['mode'].to_s.downcase
-      reasons << "table '#{name}' has a DirectQuery partition" if mode == 'directquery'
-      src = p['source'] || {}
-      reasons << "table '#{name}' is an 'entity' partition bound to a remote model" \
-        if src['type'].to_s.downcase == 'entity'
-      expr = src['expression']
-      expr = expr.join("\n") if expr.is_a?(Array)
-      if expr.is_a?(String) &&
-         expr =~ /AnalysisServices\.Database|PowerBIServiceLive|DirectQueryToAS|pbiazure|PowerBI\.Datasets|Value\.NativeQuery/i
-        reasons << "table '#{name}' M expression references a remote Power BI dataset"
-      end
-    end
-  end
-  reasons.uniq
-end
-
 TOTAL = 6
 
 # Python interpreter resolution (shared by Phase 0 local extract + Phase 1).
@@ -499,13 +513,36 @@ signals = JSON.parse(File.read(signals_path))
 tmsl = JSON.parse(File.read(opts[:tmsl]))
 model = tmsl['model'] || tmsl
 
+# NativeQuery is ordinary warehouse SQL, not evidence of a remote/composite
+# semantic model. Preserve it through the pinned converter. Downstream M steps
+# are a separate fidelity question: they must be folded into the SQL or
+# explicitly accepted, never silently discarded.
+native_queries = PbiNativeQuery.native_queries(model)
+native_transform_gaps = native_queries.select(&:post_transform)
+if native_transform_gaps.any? && !opts[:allow_native_m_transforms]
+  puts
+  puts '╭─ OPEN QUESTION — NativeQuery has downstream Power Query transforms ─'
+  native_transform_gaps.each do |native|
+    puts "│  • #{native.table}: #{native.source} is followed by M transform steps"
+  end
+  puts '│'
+  puts '│  The SQL itself can be preserved, but Table.RenameColumns/Table.SelectRows/etc.'
+  puts '│  after it are not part of that SQL. Fold those steps into the SQL and rerun.'
+  puts '│  If they are already represented manually, rerun with --allow-native-m-transforms.'
+  puts '╰──────────────────────────────────────────────────────────────────────────────'
+  exit 10
+end
+
+normalized_tmsl_path = File.join(WORK, 'model-normalized.bim')
+File.write(normalized_tmsl_path, JSON.pretty_generate(PbiNativeQuery.normalize_tmsl(tmsl)))
+
 # COMPOSITE GATE (Fabric --tmsl path only; --pbix already IS the complete local
 # model). getDefinition returns an INCOMPLETE model for composite / live-
 # connected reports — the full model lives in the local .pbix. Detect it and
 # PROMPT for the .pbix instead of silently building a broken DM. --allow-
 # incomplete-model overrides. This is what MOTIVATES the local front door.
 unless opts[:pbix] || opts[:allow_incomplete_model]
-  composite_reasons = detect_incomplete_composite(model)
+  composite_reasons = PbiComposite.incomplete_reasons(model)
   unless composite_reasons.empty?
     puts
     puts '╭─ OPEN QUESTION — composite / live-connected report (incomplete Fabric model) ─'
@@ -624,7 +661,7 @@ import_specifier =
 File.write(shim, <<~JS)
   import { readFileSync, writeFileSync } from 'node:fs';
   import { convertPowerBIToSigma } from #{import_specifier.to_json};
-  const model = JSON.parse(readFileSync(#{opts[:tmsl].to_json}, 'utf8'));
+  const model = JSON.parse(readFileSync(#{normalized_tmsl_path.to_json}, 'utf8'));
   const out = convertPowerBIToSigma(model, {
     connectionId: #{(opts[:conn] || '').to_json},
     database: #{opts[:db].to_json},
@@ -647,6 +684,22 @@ conv = JSON.parse(File.read(File.join(WORK, 'conv-meta.json')))
 dm_model = conv['model']
 conv_warnings = conv['warnings'] || []
 conv_stats = conv['stats'] || {}
+native_result = PbiNativeQuery.apply!(dm_model, model)
+native_blockers = native_result['blockers'].reject do |blocker|
+  opts[:allow_native_m_transforms] &&
+    blocker['reason'].to_s.include?('followed by Power Query M transforms')
+end
+unless native_blockers.empty?
+  abort "FATAL: NativeQuery restoration failed:\n" +
+        native_blockers.map { |b| "  - #{b['table']}: #{b['reason']}" }.join("\n")
+end
+if native_result['converted'].any?
+  File.write(File.join(WORK, 'native-query-conversion.json'), JSON.pretty_generate(native_result))
+  File.write(File.join(WORK, 'dm-raw.json'), JSON.pretty_generate(dm_model))
+  conv['model'] = dm_model
+  File.write(File.join(WORK, 'conv-meta.json'), JSON.pretty_generate(conv))
+  puts "   restored #{native_result['converted'].size} NativeQuery source(s) as Custom SQL"
+end
 puts "   #{conv_stats['elements'] || (dm_model['pages'] || []).flat_map { |p| p['elements'] || [] }.size} element(s), " \
      "#{conv_stats['columns']} column(s), #{conv_stats['metrics']} metric(s); #{conv_warnings.size} converter warning(s)"
 # Vendor-neutral CDW join-cost advisory (informational only; never gates). See refs/modeling-strategy.md.
@@ -971,6 +1024,68 @@ dm_rb = JSON.parse(File.read(dm_readback))
 dm_id = dm_rb['dataModelId']
 puts "   dataModelId = #{dm_id}"
 end # unless reuse_dm_id (build-new path)
+
+# Optional data-model materialization schedules (Beta). Run after readback so
+# schedule calls use authoritative server element IDs. This is performance-only:
+# failures are recorded and surfaced but do not invalidate the migrated model.
+if opts[:materialization_cron]
+  spec_elements = (dm_model['pages'] || []).flat_map { |page| page['elements'] || [] }
+  readback_elements = (dm_rb['pages'] || []).flat_map { |page| page['elements'] || [] }
+  paired = PbiElementMatch.pair(spec_elements, readback_elements)
+  sql_with_readback = spec_elements.each_with_index.filter_map do |element, index|
+    next unless element.dig('source', 'kind') == 'sql'
+    server = paired[index]
+    next unless server
+    [element, { 'id' => server['id'], 'name' => server['name'] || element['name'] || element['id'] }]
+  end
+
+  selectors = opts[:materialization_elements].to_s.split(',').map(&:strip).reject(&:empty?)
+  selected =
+    if selectors.empty? || selectors == ['all-sql']
+      sql_with_readback
+    else
+      sql_with_readback.select do |spec_element, server|
+        selectors.include?(spec_element['name'].to_s) || selectors.include?(server['name'].to_s)
+      end
+    end
+
+  missing = selectors.reject do |selector|
+    selector == 'all-sql' || sql_with_readback.any? do |spec_element, server|
+      selector == spec_element['name'].to_s || selector == server['name'].to_s
+    end
+  end
+  actions = missing.map do |selector|
+    {
+      'elementName' => selector,
+      'status' => 'error',
+      'error' => 'requested materialization element was not found among Custom SQL elements',
+      'remediation' => 'use an exact Custom SQL element name or all-sql'
+    }
+  end
+
+  if selected.empty?
+    puts '   materialization: no matching Custom SQL elements'
+  else
+    puts "   materialization: reconciling #{selected.size} Custom SQL schedule(s)"
+    actions.concat(
+      MaterializationSchedules.reconcile(
+        data_model_id: dm_id,
+        elements: selected.map(&:last),
+        cron: opts[:materialization_cron],
+        timezone: opts[:materialization_timezone]
+      )
+    )
+  end
+  File.write(File.join(WORK, 'materialization-actions.json'), JSON.pretty_generate(actions))
+  actions.each do |action|
+    if action['status'] == 'error'
+      warn "   [warn] materialization #{action['elementName']}: #{action['error'].to_s.lines.first.to_s.strip[0, 140]}"
+      warn "          remediation: #{action['remediation']}"
+    else
+      puts "   materialization #{action['status']}: #{action['elementName']}"
+    end
+  end
+end
 
 # ---------------------------------------------------------------------------
 # Phase 4 — Build workbook (auto master-map from converter + signals, then build+POST)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-composite-gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-composite-gate.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'lib/pbi_composite'
+
+fails = []
+check = lambda do |condition, message|
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+  fails << message unless condition
+end
+
+native = {
+  'tables' => [{
+    'name' => 'COR',
+    'partitions' => [{
+      'mode' => 'import',
+      'source' => {
+        'type' => 'm',
+        'expression' => [
+          'let',
+          'Source = Value.NativeQuery(Snowflake.Databases("acct"), "SELECT * FROM DB.SCHEMA.COR")',
+          'in Source'
+        ]
+      }
+    }]
+  }]
+}
+check.call(PbiComposite.incomplete_reasons(native).empty?,
+           'Value.NativeQuery import partition is not classified as a remote model')
+
+analysis_services = {
+  'tables' => [{
+    'name' => 'Remote',
+    'partitions' => [{
+      'source' => { 'type' => 'm', 'expression' => 'AnalysisServices.Database("server", "dataset")' }
+    }]
+  }]
+}
+check.call(PbiComposite.incomplete_reasons(analysis_services).any? { |r| r.include?('remote Power BI dataset') },
+           'Analysis Services connector remains a remote-model signal')
+
+entity = {
+  'tables' => [{
+    'name' => 'Proxy',
+    'partitions' => [{ 'mode' => 'directQuery', 'source' => { 'type' => 'entity' } }]
+  }]
+}
+reasons = PbiComposite.incomplete_reasons(entity)
+check.call(reasons.any? { |r| r.include?('DirectQuery') }, 'DirectQuery partition remains gated')
+check.call(reasons.any? { |r| r.include?("'entity'") }, 'entity partition remains gated')
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |failure| puts "  - #{failure}" }
+exit(fails.empty? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-convert-model-reprefix.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-convert-model-reprefix.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'open3'
+require 'tmpdir'
+
+fails = []
+check = lambda do |condition, message|
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+  fails << message unless condition
+end
+
+raw = {
+  'pages' => [{
+    'id' => 'p1',
+    'elements' => [
+      {
+        'id' => 'cost', 'kind' => 'table', 'name' => 'COST_CENTER',
+        'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'c', 'path' => %w[DB SCHEMA COST_CENTER] },
+        'columns' => [
+          { 'id' => 'id', 'formula' => '[Cost Center/ID]' },
+          { 'id' => 'dim', 'formula' => '[DIM/Label]' }
+        ]
+      },
+      {
+        'id' => 'dim', 'kind' => 'table', 'name' => 'DIM',
+        'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'c', 'path' => %w[DB SCHEMA DIM] },
+        'columns' => [{ 'id' => 'label', 'formula' => '[DIM/LABEL]' }]
+      }
+    ]
+  }]
+}
+
+Dir.mktmpdir('reprefix-test') do |dir|
+  input = File.join(dir, 'raw.json')
+  output = File.join(dir, 'spec.json')
+  File.write(input, JSON.generate(raw))
+  cmd = [
+    'ruby', File.expand_path('convert-model.rb', __dir__),
+    '--converter-out', input, '--out', output,
+    '--folder-id', 'folder', '--owner-id', 'owner'
+  ]
+  text, status = Open3.capture2e(*cmd)
+  check.call(status.success?, "convert-model succeeds#{": #{text}" unless status.success?}")
+  if status.success?
+    spec = JSON.parse(File.read(output))
+    cost = spec['pages'][0]['elements'][0]
+    check.call(cost['columns'][0]['formula'] == '[COST_CENTER/ID]',
+               'space/underscore lookalike is rewritten to the literal element name')
+    check.call(cost['columns'][1]['formula'] == '[DIM/Label]',
+               'an exact reference to another known element is preserved')
+    check.call(spec['pages'][0]['elements'][1]['columns'][0]['formula'] == '[DIM/LABEL]',
+               'an exact self-reference remains unchanged')
+  end
+end
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |failure| puts "  - #{failure}" }
+exit(fails.empty? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-materialization-schedules.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-materialization-schedules.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'lib/materialization_schedules'
+
+fails = []
+check = lambda do |condition, message|
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+  fails << message unless condition
+end
+
+puts "\n1. list follows nextPageToken with pageSize"
+calls = []
+request = lambda do |method, path, _payload|
+  calls << [method, path]
+  if path.include?('pageToken=next')
+    { 'entries' => [{ 'elementId' => 'e2', 'schedule' => { 'cronSpec' => '0 2 * * *' } }] }
+  else
+    { 'entries' => [{ 'elementId' => 'e1', 'schedule' => { 'cronSpec' => '0 1 * * *' } }],
+      'nextPageToken' => 'next' }
+  end
+end
+entries = MaterializationSchedules.list('dm', request: request)
+check.call(entries.map { |e| e['elementId'] } == %w[e1 e2], 'all schedule pages are collected')
+check.call(calls[0][1].include?('pageSize=500') && calls[1][1].include?('pageToken=next'),
+           'data-model pagination uses pageSize/pageToken')
+
+puts "\n2. reconcile creates, preserves, and patches schedules"
+requests = []
+request = lambda do |method, path, payload|
+  requests << [method, path, payload]
+  if method == :get
+    {
+      'entries' => [
+        { 'elementId' => 'same', 'schedule' => { 'cronSpec' => '0 2 * * *', 'timezone' => 'America/Chicago' } },
+        { 'elementId' => 'change', 'schedule' => { 'cronSpec' => '0 1 * * *', 'timezone' => 'UTC' } }
+      ]
+    }
+  else
+    { 'schedule' => payload['schedule'] }
+  end
+end
+actions = MaterializationSchedules.reconcile(
+  data_model_id: 'dm',
+  elements: [
+    { 'id' => 'new', 'name' => 'New SQL' },
+    { 'id' => 'same', 'name' => 'Same SQL' },
+    { 'id' => 'change', 'name' => 'Changed SQL' }
+  ],
+  cron: '0 2 * * *',
+  timezone: 'America/Chicago',
+  request: request
+)
+check.call(actions.map { |a| a['status'] } == %w[created unchanged updated],
+           'reconcile selects POST, no-op, and PATCH correctly')
+check.call(requests.any? { |m, p, _| m == :post && p.include?('/elements/new/') },
+           'missing schedule is created on the element endpoint')
+check.call(requests.none? { |m, p, _| m != :get && p.include?('/elements/same/') },
+           'matching schedule makes no write call')
+check.call(requests.any? { |m, p, _| m == :patch && p.include?('/elements/change/') },
+           'changed schedule is patched')
+
+puts "\n3. permission and write-access failures are actionable"
+denied = lambda do |method, _path, _payload|
+  method == :get ? { 'entries' => [] } : raise('POST -> 403 not_permitted')
+end
+action = MaterializationSchedules.reconcile(
+  data_model_id: 'dm', elements: [{ 'id' => 'e', 'name' => 'Expensive SQL' }],
+  cron: '0 2 * * *', request: denied
+).first
+check.call(action['status'] == 'error', 'API failure is recorded, not swallowed')
+check.call(action['remediation'].include?('Schedule materializations'), 'permission remediation is explicit')
+
+puts "\n4. invalid schedules fail before API calls"
+begin
+  MaterializationSchedules.validate!(cron: 'hourly')
+  check.call(false, 'invalid cron rejected')
+rescue ArgumentError
+  check.call(true, 'invalid cron rejected')
+end
+begin
+  MaterializationSchedules.validate!(cron: '0 2 * * *', timezone: 'CST')
+  check.call(false, 'non-IANA timezone rejected')
+rescue ArgumentError
+  check.call(true, 'non-IANA timezone rejected')
+end
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |failure| puts "  - #{failure}" }
+exit(fails.empty? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-materialization-schedules.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-materialization-schedules.rb
@@ -73,6 +73,12 @@ check.call(action['remediation'].include?('Schedule materializations'), 'permiss
 
 puts "\n4. invalid schedules fail before API calls"
 begin
+  MaterializationSchedules.validate!(cron: '0 2 * * *', timezone: 'UTC')
+  check.call(true, 'UTC is accepted as an IANA timezone')
+rescue ArgumentError
+  check.call(false, 'UTC is accepted as an IANA timezone')
+end
+begin
   MaterializationSchedules.validate!(cron: 'hourly')
   check.call(false, 'invalid cron rejected')
 rescue ArgumentError

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-native-query.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-native-query.rb
@@ -51,7 +51,8 @@ Dir.mktmpdir('pbi-native-query-test') do |dir|
   File.write(input, JSON.generate(normalized))
   File.write(shim, <<~JS)
     import { readFileSync, writeFileSync } from 'node:fs';
-    import { convertPowerBIToSigma } from #{converter.to_json};
+    import { pathToFileURL } from 'node:url';
+    const { convertPowerBIToSigma } = await import(pathToFileURL(#{converter.to_json}).href);
     const out = convertPowerBIToSigma(JSON.parse(readFileSync(#{input.to_json}, 'utf8')), { connectionId: 'conn' });
     writeFileSync(#{output.to_json}, JSON.stringify(out.model || out.sigmaDataModel || out));
   JS

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-native-query.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-native-query.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'open3'
+require 'tmpdir'
+require_relative 'lib/pbi_native_query'
+
+fails = []
+check = lambda do |condition, message|
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+  fails << message unless condition
+end
+
+native_m = lambda do |sql, post = nil|
+  escaped = sql.gsub('"', '""').gsub("\n", '#(lf)')
+  lines = [
+    'let',
+    "  Source = Value.NativeQuery(Snowflake.Databases(\"acct\"){[Name=\"ENTERPRISE\"]}[Data], \"#{escaped}\", null, [EnableFolding=true])#{post ? ',' : ''}"
+  ]
+  lines << post if post
+  lines << "in #{post ? '#\"Renamed Columns\"' : 'Source'}"
+  lines
+end
+
+cor_sql = <<~SQL.strip
+  SELECT c.COST_CENTER, c.PROPERTY_ID, c.AMOUNT
+  FROM ENTERPRISE.MASTER.COR_DETAIL c
+  JOIN ENTERPRISE.MASTER.PROPERTY p ON p.ID = c.PROPERTY_ID
+SQL
+property_sql = <<~SQL.strip
+  SELECT c.PROPERTY_ID, p.PROPERTY_NAME
+  FROM ENTERPRISE.MASTER.COR_DETAIL c
+  JOIN ENTERPRISE.MASTER.PROPERTY p ON p.ID = c.PROPERTY_ID
+SQL
+
+fixture = File.expand_path('../fixtures/native_query_cor_pl/model.bim', __dir__)
+tmsl = JSON.parse(File.read(fixture))
+
+puts "\n1. normalize array-valued calculation items"
+normalized = PbiNativeQuery.normalize_tmsl(tmsl)
+expr = normalized.dig('model', 'tables', 2, 'calculationGroup', 'calculationItems', 1, 'expression')
+check.call(expr.is_a?(String) && expr.include?("SELECTEDMEASURE(),\n"), 'calculation-item expression is joined into a string')
+
+puts "\n2. pinned converter runs, then compatibility layer restores native SQL"
+Dir.mktmpdir('pbi-native-query-test') do |dir|
+  input = File.join(dir, 'model.json')
+  output = File.join(dir, 'result.json')
+  shim = File.join(dir, 'convert.mjs')
+  converter = File.expand_path('../converter/powerbi.mjs', __dir__)
+  File.write(input, JSON.generate(normalized))
+  File.write(shim, <<~JS)
+    import { readFileSync, writeFileSync } from 'node:fs';
+    import { convertPowerBIToSigma } from #{converter.to_json};
+    const out = convertPowerBIToSigma(JSON.parse(readFileSync(#{input.to_json}, 'utf8')), { connectionId: 'conn' });
+    writeFileSync(#{output.to_json}, JSON.stringify(out.model || out.sigmaDataModel || out));
+  JS
+  _out, err, status = Open3.capture3('node', shim)
+  check.call(status.success?, "pinned converter accepts normalized calc group#{": #{err}" unless status.success?}")
+  if status.success?
+    dm = JSON.parse(File.read(output))
+    result = PbiNativeQuery.apply!(dm, tmsl['model'])
+    check.call(result['blockers'].empty?, 'native queries restore without blockers')
+    sql_elements = dm['pages'][0]['elements'].select { |e| e.dig('source', 'kind') == 'sql' && %w[COR Property].include?(e['name']) }
+    check.call(sql_elements.size == 2, 'two logical Custom SQL elements remain distinct')
+    cor = sql_elements.find { |e| e['name'] == 'COR' }
+    property = sql_elements.find { |e| e['name'] == 'Property' }
+    check.call(cor&.dig('source', 'statement') == cor_sql, 'COR preserves the complete multi-join SQL')
+    check.call(property&.dig('source', 'statement') == property_sql, 'Property preserves its distinct SQL')
+    check.call(cor && cor['columns'].first['formula'] == '[Custom SQL/COST_CENTER]', 'column formula uses exact SQL output name')
+    check.call(cor && cor['columns'].first['name'] == 'Cost Center', 'column keeps the Power BI display name')
+    check.call(!dm['pages'][0]['elements'].any? { |e| e.dig('source', 'kind') == 'warehouse-table' && e.dig('source', 'path')&.last == 'COR_DETAIL' },
+               'first FROM table is not emitted as the source architecture')
+    view = dm['pages'][0]['elements'].find { |e| e['name'] == 'COR View' }
+    check.call(view && view['columns'].all? { |c| !c['formula'].to_s.start_with?('[COR_DETAIL/') },
+               'derived View references are re-prefixed to the logical table')
+  end
+end
+
+puts "\n3. unsupported post-query M transforms are gated"
+post_tmsl = JSON.parse(JSON.generate(tmsl))
+post = '  #"Renamed Columns" = Table.RenameColumns(Source, {{"COST_CENTER", "Cost Center"}})'
+post_tmsl['model']['tables'][0]['partitions'][0]['source']['expression'] = native_m.call(cor_sql, post)
+native = PbiNativeQuery.native_queries(post_tmsl['model']).first
+check.call(native.post_transform, 'post-NativeQuery transform is detected')
+
+puts "\n4. connector Query option is extracted"
+query = PbiNativeQuery.extract_from_expression(
+  'Orders',
+  'let Source = Sql.Database("server", "DB", [Query="SELECT ORDER_ID FROM dbo.orders"]) in Source'
+)
+check.call(query&.statement == 'SELECT ORDER_ID FROM dbo.orders', 'Query= SQL is preserved')
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |failure| puts "  - #{failure}" }
+exit(fails.empty? ? 0 : 1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Fix the Power BI migration failure where `Value.NativeQuery` models were reduced to the first physical `FROM` table, array-valued calculation items crashed conversion, and space/underscore lookalikes escaped base-column reprefixing. Adds opt-in, idempotent data-model element materialization schedules for expensive converted Custom SQL.

## Scope

- Plugin(s) touched: `powerbi-to-sigma` (plus required CI suite registration)
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check powerbi` — green (3/3)
- [x] Both Power BI Ruby/Python test directories — green
- [x] Converter provenance freshness — green
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in
- [x] Bumped the touched plugin's `plugin.json` version

## Implementation notes

- Keeps the provenance-pinned generated converter untouched; a Power BI-local compatibility layer normalizes TMSL before conversion and restores full native SQL afterward.
- Gates downstream Power Query transforms that cannot be represented by preserving SQL alone.
- Schedule lifecycle uses paginated list plus create/no-op/patch and remains disabled unless an explicit cron is supplied.
- Live disposable-DM validation confirmed Custom SQL posts and resolves in the supplied org. Schedule list is available, while schedule creation returns `404`, correctly classified as missing private-Beta entitlement; disposable objects were deleted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a515ffb8-39b7-4add-af43-258e467dfb57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a515ffb8-39b7-4add-af43-258e467dfb57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

