### PR TITLE
fix(tableau): migrate Tableau <alphabetic-sort> (K21, narrowed)

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -969,6 +969,12 @@ end
 # (field sort on the measure, unresolvable) sorts by the measure, which was
 # the previous hardcoded behaviour.
 def sort_target_column_id(sort_info, dim, dim_hdr, dim_col_id, meas_col_id)
+  # K21: an <alphabetic-sort> is by definition a sort on the dimension itself.
+  # This MUST precede the empty-token fallback below — that fallback returns the
+  # measure, and an alphabetic-sort carries no `column` attribute (the XSD
+  # declares it as an empty element), so without this the axis is silently wrong.
+  return dim_col_id if sort_info['alphabetic']
+
   raw   = sort_info['column'].to_s
   inner = raw[/\[([^\[\]]+)\]\z/, 1].to_s
   token = (inner.split(':')[1] || inner).downcase.gsub(/\W+/, '')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -765,6 +765,22 @@ xml.elements.each('//worksheet') do |ws|
     }
   end
 
+  # K21: <alphabetic-sort> — "sort this dimension alphabetically". The vendored
+  # XSD (schemas/twb_2026.2.0.xsd, Sort-Alphabetic-G) declares it as an EMPTY
+  # element with no attributes, so there is no `column` to resolve. That matters:
+  # sort_target_column_id falls back to the MEASURE on an empty column token, so
+  # wiring this through without an explicit marker silently sorts the wrong axis.
+  # Hence `alphabetic: true`, which the resolver checks before that fallback.
+  # `direction`/`column` are read defensively in case a real export carries them
+  # (the XSD says it does not; not verified against a live .twb).
+  if sort_info.nil? && (as = ws.elements['.//alphabetic-sort'])
+    sort_info = {
+      direction:  (as.attributes['direction'].to_s =~ /desc/i ? 'descending' : 'ascending'),
+      column:     as.attributes['column'],
+      alphabetic: true
+    }
+  end
+
   # Per-worksheet view-level filters. Each filter is normalized via
   # normalize_filter (resolves GUID → caption + datatype, extracts member values
   # for categorical, period spec for relative-date, min/max for quantitative,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-alphabetic-sort.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-alphabetic-sort.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for K21 (narrowed): Tableau's <alphabetic-sort> must be
+# migrated, and must sort by the DIMENSION.
+#
+# Scope discipline: <computed-sort> is ALREADY migrated end to end
+# (parse-twb-layout.rb -> sort_target_column_id -> three consumers). K21 as filed
+# said "Tableau sorts are not migrated at all", which is wrong. Only
+# <alphabetic-sort> is unhandled. This test asserts the alphabetic path works AND
+# that the computed-sort path is left intact.
+#
+# THE TRAP: the vendored XSD (schemas/twb_2026.2.0.xsd, Sort-Alphabetic-G, ~:3034)
+# declares <alphabetic-sort> as an EMPTY element — no attributes at all. So a
+# naive wire-through gives sort_target_column_id an empty column token, and its
+# existing `return meas_col_id if token.empty?` sorts by the MEASURE — silently
+# the wrong axis. An explicit alphabetic marker is required.
+# Deterministic + offline.
+
+DIR = __dir__
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+parser = File.read(File.join(DIR, 'parse-twb-layout.rb'))
+builder = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+
+puts 'Part A — the parser recognises <alphabetic-sort>'
+check(parser.include?('alphabetic-sort'),
+      'parse-twb-layout.rb looks for .//alphabetic-sort', fails)
+check(parser.match?(/alphabetic:\s*true/),
+      'the parser sets an explicit `alphabetic: true` marker', fails)
+
+puts 'Part B — the consumer sorts by the DIMENSION when the marker is set'
+check(builder.match?(/sort_info\[['"]alphabetic['"]\]/),
+      'sort_target_column_id reads the alphabetic marker', fails)
+# The marker check must come BEFORE the empty-token bail-out, or the measure wins.
+if builder.match?(/sort_info\[['"]alphabetic['"]\]/)
+  fn = builder[/def sort_target_column_id.*?\nend/m].to_s
+  a = fn.index('alphabetic')
+  b = fn.index('token.empty?')
+  check(!a.nil? && !b.nil? && a < b,
+        'the alphabetic check precedes the empty-token measure fallback', fails)
+end
+
+puts 'Part C — <computed-sort> is left intact (do not regress the working path)'
+check(parser.include?('.//computed-sort'), 'computed-sort parsing still present', fails)
+check(builder.include?('sort_target_column_id'), 'the shared resolver is still used', fails)
+
+puts 'Part D — behavioral: replicate the shipped resolver'
+# Mirror of the shipped op. Keep in lock-step with build-charts-from-signals.rb.
+def resolve(sort_info, dim_name, dim_col_id, meas_col_id)
+  return dim_col_id if sort_info['alphabetic']
+
+  raw   = sort_info['column'].to_s
+  inner = raw[/\[([^\[\]]+)\]\z/, 1].to_s
+  token = (inner.split(':')[1] || inner).downcase.gsub(/\W+/, '')
+  return meas_col_id if token.empty?
+
+  key = dim_name.to_s.downcase.gsub(/\W+/, '')
+  return dim_col_id if !key.empty? && (token == key || token.include?(key) || key.include?(token))
+
+  meas_col_id
+end
+
+check(resolve({ 'alphabetic' => true }, 'Region', 'x-dim', 'y-meas') == 'x-dim',
+      'alphabetic marker -> sorts by the dimension', fails)
+check(resolve({ 'column' => '[federated.a].[none:REGION:nk]' }, 'Region', 'x-dim', 'y-meas') == 'x-dim',
+      'computed-sort on the dim -> dimension (unchanged)', fails)
+check(resolve({ 'column' => '[federated.a].[sum:NET_REVENUE:qk]' }, 'Region', 'x-dim', 'y-meas') == 'y-meas',
+      'computed-sort on a measure -> measure (unchanged)', fails)
+
+puts 'Part E — planted-defect guard: without the marker, an empty token picks the MEASURE'
+# This is the silent-wrong-axis bug. If it ever stops happening, Part D proves nothing.
+naive = lambda do |si, dim_col_id, meas_col_id|
+  token = si['column'].to_s[/\[([^\[\]]+)\]\z/, 1].to_s.split(':')[1].to_s.downcase.gsub(/\W+/, '')
+  token.empty? ? meas_col_id : dim_col_id
+end
+check(naive.call({}, 'x-dim', 'y-meas') == 'y-meas',
+      'PLANTED-DEFECT GUARD: an attribute-less alphabetic-sort would sort by the MEASURE', fails)
+check(resolve({ 'alphabetic' => true }, 'Region', 'x-dim', 'y-meas') != naive.call({}, 'x-dim', 'y-meas'),
+      'PLANTED-DEFECT GUARD: the marker changes the outcome', fails)
+
+puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILURE(S)")
+exit(fails.empty? ? 0 : 1)


### PR DESCRIPTION
Task 8.6 of the bug-register remediation plan. Bead: `beads-sigma-12vs`.

## K21 as filed was overstated — this narrows it

The register says *"Tableau sorts are not migrated at all"*. They largely are.
**`<computed-sort>` is migrated end to end**: parsed in `parse-twb-layout.rb`,
resolved by `sort_target_column_id`, and applied at three call sites (table
`groupings[0].sort`, pie `color.sort`, bar/line/area/combo `xAxis.sort`).

Only **`<alphabetic-sort>`** was unhandled — zero occurrences in any script. This
change is scoped to exactly that, and the test asserts the computed-sort path is
left intact so nobody "fixes" working code.

## The trap

The vendored XSD (`schemas/twb_2026.2.0.xsd`, `Sort-Alphabetic-G` ~:3034) declares
`<alphabetic-sort>` as an **empty element with no attributes** — there is no
`column` to resolve.

`sort_target_column_id` already has `return meas_col_id if token.empty?`. So a
naive wire-through hands it an empty token and it sorts by the **measure** —
silently the wrong axis, with no error anywhere.

The fix therefore emits an explicit `alphabetic: true` marker, and the resolver
checks it **before** that fallback. **The test pins that ordering**, because
reversing the two lines reintroduces the silent-wrong-axis bug while every other
assertion still passes.

## Verification

- `test-alphabetic-sort.rb`, proven RED on the unfixed tree (3 failures).
- Two planted-defect guards: one asserts an attribute-less alphabetic-sort *would*
  pick the measure under naive handling, the other that the marker changes the
  outcome. Without these the behavioral checks would be vacuous.
- Part C guards the computed-sort path against regression.
- Full tableau suite: **234/235**. The one failure, `test-calc-discovery.rb`, needs
  `TABLEAU_AUTH_TOKEN` plus a `.twb` fixture and fails on `main` too.
- `tableau-to-sigma` 1.6.13 → 1.6.14 (re-derived from current `main`, which had
  already moved past 1.6.11 via #613/#640).

## Unverified, flagged in-code

`direction` and `column` are read defensively in case a real export carries them.
The XSD says it does not, and no `.twb` containing an `<alphabetic-sort>` was
available — so the ascending default is a reasoned choice, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)