### PR TITLE
chore(sigma-authoring): re-vendor C1 (Lookup() for cross-element refs) + close a SYNC.md gap

### DIFF
--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/SYNC.md
+++ b/plugins/sigma-authoring/SYNC.md
@@ -7,7 +7,7 @@ hard dependency on `sigma-workbooks` (the canonical Sigma spec reference) ships
 in the **same marketplace** — installing any converter, install this too.
 
 - **Source of truth:** https://github.com/twells89/sigma-skills (edit there)
-- **Vendored at:** sigma-skills `main` @ `9fa3e79218a3dcc11a2c9400d5f346ca25f9498c`
+- **Vendored at:** sigma-skills `main` @ `6c8ce18` (2026-08-07)
 
 ## Refresh
 
@@ -27,6 +27,21 @@ done
 # or the shared-lib drift gate (tools/check-shared.rb in CI) fails:
 ruby tools/sync-shared.rb        # restore the fanned shared copies the cp -R dropped
 ruby tools/check-shared.rb       # MUST be green before committing
+
+# VARIANT-DRIFT SAFETY (required, and easy to miss): the two repos generate the
+# generated/ agent variants with DIFFERENT tools, and upstream's copies can be
+# stale relative to its own SKILL.md. A bare cp -R therefore imports variants
+# that (a) carry upstream's header instead of this repo's, and (b) can be OLDER
+# than the SKILL.md they sit beside — on the 2026-08-07 re-vendor that would
+# have silently DELETED ~33 lines of Windows/shell-neutral token guidance from
+# custom-sql-to-data-model's four variants. Regenerate from the canonical
+# SKILL.md instead of shipping what upstream had:
+ruby tools/gen-agent-variants.rb --all   # regenerate all 16 from SKILL.md
+ruby tools/check-agent-variants.rb       # MUST be green (16/16, drift 0)
+
+# Sanity check before committing: `git status` should show ONLY the files that
+# genuinely changed upstream. If generated/ files appear in the diff after the
+# regenerate step, something else moved — inspect it, don't wave it through.
 
 # then update the "Vendored at" SHA above and commit
 ```

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/calc-columns.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/calc-columns.md
@@ -17,10 +17,49 @@ A calc column has no warehouse-column ID prefix — its `id` is a generated shor
 ## Formula references
 
 - **Within the same element** — bare `[Column Name]` (case-sensitive, must match a column's `name` field on the same element).
-- **Cross-element** — `[Element Name/Column Name]`. The element name is the source element's `name`.
+- **Cross-element** — **use `Lookup()`. Do not use the bare `[Element Name/Column Name]` form.**
+  See the warning immediately below: the bare form is accepted at PUT, reports a
+  clean type, and then returns NULL for every row.
 - **From a warehouse-table source** — `[TABLE_NAME/Column Display Name]` where `TABLE_NAME` is the last segment of the source's `path` (uppercase, as it appears in the warehouse).
 
 A calc column **cannot reference itself**, even transitively — the server rejects circular references.
+
+### ⚠️ Cross-element refs: `Lookup()` only — the bare form silently returns NULL
+
+A bare cross-element reference in a DM calc column — `[Other Element/Column]` —
+**compiles clean and then evaluates to NULL for every row.** It is accepted at
+PUT, `/columns` reports a normal type with `error: null`, and nothing surfaces a
+problem at any layer you can inspect. The dashboard just quietly shows nothing.
+
+Measured 2026-08-06 on a two-element model with a defined relationship, 906 fact
+rows, two calc columns identical in intent:
+
+| Formula | Non-null rows |
+|---|---|
+| `[Customer Dim/Region]` (bare) | **0 / 906** |
+| `Lookup([Customer Dim/Region], [Customer Key], [Customer Dim/Customer Key])` | **872 / 906** |
+
+Both reported `type: text`, `error: null`. Always write:
+
+```
+Lookup(<value from the other element>, <local key>, <other element's key>)
+```
+
+The local key column must already exist on this element.
+
+Two caveats that matter at scale:
+
+1. **Orphan rows return NULL.** The 34-row gap above is genuine — fact rows whose
+   key is absent from the dimension. If you are porting logic from a tool whose
+   `ELSE` branch swallowed NULLs (Tableau does: `NULL >= 5000` falls through),
+   wrap it: `Coalesce(Lookup(...), "Bronze")`. Otherwise you get a NULL bucket
+   where the source had a default.
+2. **`Lookup()` returns ONE ARBITRARY match per key.** On a non-unique join key
+   the pick is nondeterministic and silent. Confirm the target key is unique
+   before relying on it.
+
+There is no supported bare-reference form to fall back to. If `Lookup()` cannot
+express what you need, push the join into a `sql` source instead.
 
 ## The `*Over` window functions don't work — but the native family does
 


### PR DESCRIPTION
Re-vendors `sigma-skills` main @ `6c8ce18`, which is **exactly one commit** past
the previous pin: the C1 correction (`twells89/sigma-skills` #33, merged).

## The content change

`calc-columns.md` documented bare `[Element Name/Column Name]` cross-element refs
in DM calc columns as supported, with no caveat. Measured: **0/906 non-null** vs
**872/906** via `Lookup()` on the same relationship, both columns reporting
`type: text`, `error: null`. Nothing surfaces the problem at any inspectable
layer. The doc now mandates `Lookup()` and carries the two caveats that bite at
scale — orphan rows return NULL, and `Lookup()` returns one arbitrary match per
key on a non-unique key.

## A gap in SYNC.md, found doing this

The documented procedure (`cp -R`, then `sync-shared.rb`) imports the
`generated/` agent variants verbatim from upstream. That is wrong twice over:
the two repos generate those variants with **different tools**, and upstream's
copies can be **stale against its own SKILL.md**.

Following SYNC.md literally here produced:

- **12 of 16 variants drifting** — `tools/check-agent-variants.rb` reports
  `drift: 12 / 16`, so CI's "16 agent variant(s) match their canonical SKILL.md"
  check would have failed; and
- **~33 lines silently deleted** from each of `custom-sql-to-data-model`'s four
  variants — the Windows/shell-neutral token guidance (`get_token.py`,
  `SIGMA_WORKDIR`, 401 auto-refresh) that exists only in the vendored copies.
  Note `SKILL.md` itself was identical, so nothing in the diff *looked* alarming.

Running `ruby tools/gen-agent-variants.rb --all` after the copy reduces the diff
to **exactly one file** — `calc-columns.md`, +40/−1 — which is the correct
outcome for a one-commit re-vendor.

SYNC.md now documents that step, the check that proves it, and a "the diff should
contain only what genuinely changed upstream" sanity gate, with the concrete
failure recorded so the next person doesn't rediscover it.

## Verification

- `ruby tools/check-shared.rb` — green (680 copies, 1 allowlisted exception).
- `ruby tools/check-agent-variants.rb` — green, 16/16, drift 0.
- Final diff: 1 file.
- `sigma-authoring` 1.9.4 → 1.9.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)