### PR TITLE
fix: theme moved to document.settings.theme — every converter still wrote the removed keys

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo → Sigma",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "Migrate Domo dashboards to Sigma — DataSets → Sigma data model (flat materialized tables → table elements), Beast Mode calc fields → Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards → charts/KPIs/pivots (every card's Summary Number → a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory → value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook-spec.rb
@@ -319,11 +319,16 @@ wb['description'] = opts[:description] if opts[:description]
 if opts[:layout]
   theme = derive_theme(JSON.parse(File.read(opts[:layout])))
   unless theme.empty?
-    wb['themeName'] = 'Light'
+    # Theme path: document.settings.theme.{name,overrides}. The old top-level
+    # themeName/themeOverrides keys were REMOVED from the workbook spec — a
+    # top-level themeName is silently ignored (workbook created UNTHEMED, no
+    # error). Canonical builder: Sigma::CodeRep.theme_settings in shared/lib.
     overrides = {}
     overrides['colorOverrides'] = { 'backgroundCanvas' => theme['backgroundCanvas'] } if theme['backgroundCanvas']
     overrides['categoricalScheme'] = theme['categoricalScheme'] if theme['categoricalScheme']
-    wb['themeOverrides'] = overrides unless overrides.empty?
+    theme_block = { 'name' => 'Light' }
+    theme_block['overrides'] = overrides unless overrides.empty?
+    wb['settings'] = (wb['settings'] || {}).merge('theme' => theme_block)
     warn "  theme: canvas=#{theme['backgroundCanvas'] || '(default)'}, categoricalScheme=#{(theme['categoricalScheme'] || []).size} color(s)"
   end
 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData → Sigma",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex → Sigma",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Migrate Hex projects to Sigma — SQL cells, single-value/METRIC cells, and EXPLORE charts → Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker → Sigma",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq → TMSL model + UTF-16LE Report/Layout, no Fabric), DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -2835,8 +2835,12 @@ spec = {
   # Style fidelity: reproduce the PBI report's look — card chrome, subtle borders,
   # and the source theme's categorical palette (drives donut/pie + multi-series
   # colors). Stacked on the built-in Light theme. See lib/pbi_theme.rb.
-  'themeName'      => 'Light',
-  'themeOverrides' => PbiTheme.overrides($pbi_theme)
+  # Theme path: document.settings.theme.{name,overrides}. The old top-level
+  # themeName/themeOverrides keys were REMOVED — a top-level themeName is
+  # silently ignored (workbook created UNTHEMED, no error). Canonical builder:
+  # Sigma::CodeRep.theme_settings in shared/lib.
+  'settings' => { 'theme' => { 'name' => 'Light',
+                               'overrides' => PbiTheme.overrides($pbi_theme) } }
 }
 spec['folderId'] = opts[:folder] if opts[:folder]
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik → Sigma",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma — discovery via qlik-cli, Qlik-expression → Sigma-formula translation (incl. Set Analysis + a gap-scout), data model + workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps — data model AND workbook — from the -prj project folder. Includes a tenant assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight → Sigma",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -1650,12 +1650,18 @@ spec['folderId'] = opts[:folder] if opts[:folder]
 #      border is skipped on a dark QS theme, which also flips the base to Sigma "Dark").
 unless THEME_COLORS.empty?
   ov = { 'categoricalScheme' => THEME_COLORS, 'hasCards' => 'shown', 'borderRadius' => 'round' }
+  theme_block = {}
   if THEME && THEME['isDark']
-    spec['themeName'] = 'Dark'
+    theme_block['name'] = 'Dark'
   else
     ov['elementBorder'] = { 'color' => '#E2E8F0', 'width' => 1 }
   end
-  spec['themeOverrides'] = ov
+  theme_block['overrides'] = ov
+  # Theme path: document.settings.theme.{name,overrides}. The old top-level
+  # themeName/themeOverrides keys were REMOVED — a top-level themeName is
+  # silently ignored (workbook created UNTHEMED, no error). Canonical builder:
+  # Sigma::CodeRep.theme_settings in shared/lib.
+  spec['settings'] = (spec['settings'] || {}).merge('theme' => theme_block)
   STDERR.puts "  theme: applied QuickSight palette (#{THEME_COLORS.size} colors) + card chrome via themeOverrides#{THEME['isDark'] ? ' + themeName:Dark' : ''}"
 end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense → Sigma",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma — data model + workbook (indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; columnar layout→24-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau → Sigma",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "description": "Migrate Tableau workbooks and datasources to Sigma — discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS→warehouse data-landing skill (Snowflake or Databricks).",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/style_normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/style_normalize.rb
@@ -55,6 +55,8 @@
 # NOT here: SN-1 title-hide ships separately via put-layout — the live API
 # rejects name:{text, visibility:'hidden'} (probed 2026-07-11: 400 "cannot mix
 # visibility:'hidden' with title content").
+require_relative 'theme_derive'
+
 module StyleNormalize
   RULE_TOTALS  = 'SN-2-pivot-totals'
   RULE_GRAMMAR = 'SN-3-format-grammar'
@@ -243,7 +245,10 @@ module StyleNormalize
   def normalize_scheme_defaults!(spec, el, changes)
     cfs = el['conditionalFormats']
     return unless cfs.is_a?(Array)
-    theme = spec['themeOverrides'].is_a?(Hash) ? spec['themeOverrides']['categoricalScheme'] : nil
+    # theme moved to document.settings.theme.overrides; ThemeDerive.theme_overrides
+    # reads the current shape with a legacy fallback.
+    ov = defined?(ThemeDerive) ? ThemeDerive.theme_overrides(spec) : nil
+    theme = ov.is_a?(Hash) ? ov['categoricalScheme'] : nil
     return unless theme.is_a?(Array) && !theme.empty?
     dominant = theme.first.to_s.strip.downcase
     cfs.each_with_index do |cf, i|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/theme_derive.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/theme_derive.rb
@@ -144,9 +144,32 @@ module ThemeDerive
     overrides['colorOverrides'] = { 'backgroundCanvas' => theme['backgroundCanvas'] } if theme['backgroundCanvas']
     overrides['categoricalScheme'] = theme['categoricalScheme'] if theme['categoricalScheme']
     unless overrides.empty?
-      spec['themeName'] = 'Light'
-      spec['themeOverrides'] = overrides
+      # Theme path: document.settings.theme.{name,overrides}. The old top-level
+      # themeName/themeOverrides keys were REMOVED from the workbook spec — a
+      # top-level themeName is silently ignored (workbook created UNTHEMED, no
+      # error). Canonical builder: Sigma::CodeRep.theme_settings in shared/lib.
+      spec['settings'] = (spec['settings'] || {}).merge(
+        'theme' => { 'name' => 'Light', 'overrides' => overrides }
+      )
     end
     spec
+  end
+
+  # Gotcha (live-verified 2026-08-06): Sigma LOWERCASES hex colors on readback
+  # (#0E8DA0 -> #0e8da0). Any parity/round-trip comparison of theme colors must
+  # be case-insensitive or it reports a false mismatch.
+  #
+  # Read side, so callers never hand-roll the path. Current shape first, with a
+  # legacy fallback for flat artifacts still on disk (committed spec snapshots,
+  # fixtures) written before the move.
+  def theme_overrides(spec)
+    return nil unless spec.is_a?(Hash)
+
+    doc = spec['document'].is_a?(Hash) ? spec['document'] : spec
+    ov = ((doc['settings'] || {})['theme'] || {})['overrides']
+    return ov if ov.is_a?(Hash) && ov.any?
+
+    legacy = doc['themeOverrides'] || spec['themeOverrides']
+    legacy.is_a?(Hash) && legacy.any? ? legacy : nil
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -4695,8 +4695,9 @@ if mechanical
     data_elements: data_elements,
     theme: (raw_charts.is_a?(Hash) ? raw_charts['theme'] : nil),
     folder_id: opts[:folder])
-  if spec['themeOverrides']
-    line "theme: #{spec['themeOverrides'].keys.join(', ')} (derived from source style rules)"
+  theme_ov = ThemeDerive.theme_overrides(spec)
+  if theme_ov
+    line "theme: #{theme_ov.keys.join(', ')} (derived from source style rules)"
   end
   # Formula-normalize hook (sibling workstream): case-fix converter-derived
   # formulas on the mechanical workbook spec before validate/POST.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -65,6 +65,9 @@ FileUtils.mkdir_p(opts[:workdir])
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'dm_quarantine'
+# Hoisted to file level: ensure_theme! is extracted and eval'd by
+# scripts/test-theme-ensure.rb, where require_relative cannot infer a basepath.
+require_relative 'lib/theme_derive'
 require 'code_rep'
 begin
   require 'offramp' # off-ramp trail (waiver observability); optional — never load-bearing
@@ -186,12 +189,13 @@ end
 # own palette, because only build_wb_spec applied the theme). The derived
 # theme lives in the builder's output ('theme' key of chart-specs.json) or
 # its flat-mode sidecar (chart-specs-theme.json). No-op when the spec already
-# carries themeOverrides or no derived theme exists; never load-bearing.
+# carries a theme (document.settings.theme.overrides) or no derived theme
+# exists; never load-bearing.
 def ensure_theme!(body_str, workdir)
   return body_str unless $opts_type == 'workbook'
   spec = JSON.parse(body_str) rescue nil
   return body_str unless spec.is_a?(Hash) && spec['pages']
-  return body_str if spec['themeOverrides'].is_a?(Hash) && spec['themeOverrides'].any?
+  return body_str if ThemeDerive.theme_overrides(spec)
   theme = nil
   side = File.join(workdir, 'chart-specs-theme.json')
   main = File.join(workdir, 'chart-specs.json')
@@ -202,10 +206,10 @@ def ensure_theme!(body_str, workdir)
     theme = cs['theme'] if cs.is_a?(Hash)
   end
   return body_str unless theme.is_a?(Hash) && theme.any?
-  require_relative 'lib/theme_derive'
   ThemeDerive.apply!(spec, theme)
-  if spec['themeOverrides'].is_a?(Hash) && spec['themeOverrides'].any?
-    warn "theme: source-derived theme applied at post time (#{spec['themeOverrides'].keys.join(', ')}) — " \
+  applied = ThemeDerive.theme_overrides(spec)
+  if applied
+    warn "theme: source-derived theme applied at post time (#{applied.keys.join(', ')}) — " \
          'path-independent palette (the incoming spec carried none)'
     return JSON.generate(spec)
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-loop.rb
@@ -31,12 +31,14 @@ end
 
 puts 'deep_merge:'
 # Hash recursion
-base = { 'themeName' => 'Light', 'themeOverrides' => { 'borderRadius' => 'round' } }
-patch = { 'themeOverrides' => { 'categoricalScheme' => %w[#0e7c7b #14b8a6] } }
+base = { 'schemaVersion' => 1,
+         'settings' => { 'theme' => { 'name' => 'Light', 'overrides' => { 'borderRadius' => 'round' } } } }
+patch = { 'settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => %w[#0e7c7b #14b8a6] } } } }
 m = FidelityLoop.deep_merge(base, patch)
-ok(m['themeName'] == 'Light', 'untouched scalar preserved')
-ok(m['themeOverrides']['borderRadius'] == 'round', 'nested untouched key preserved')
-ok(m['themeOverrides']['categoricalScheme'].length == 2, 'nested new key added')
+ok(m['schemaVersion'] == 1, 'untouched scalar preserved')
+ok(m.dig('settings', 'theme', 'name') == 'Light', 'untouched nested scalar preserved')
+ok(m.dig('settings', 'theme', 'overrides', 'borderRadius') == 'round', 'nested untouched key preserved')
+ok(m.dig('settings', 'theme', 'overrides', 'categoricalScheme').length == 2, 'nested new key added')
 
 # Array-of-hashes merge by elementId — patch one element's style, others intact
 base2 = { 'pages' => [{ 'id' => 'p1', 'elements' => [
@@ -105,19 +107,22 @@ Dir.mktmpdir do |dir|
   _, st = run('status', dir: dir)
   ok(st.exitstatus == 6, 'status exits 6 while a spec-fixable delta is unresolved')
 
-  # dry-run apply-patch: merge a themeOverrides patch into a fake live spec
+  # dry-run apply-patch: merge a theme patch into a fake live spec
   live = { 'pages' => [{ 'id' => 'PG', 'elements' => [{ 'elementId' => 'k1', 'kind' => 'kpi-chart' }] }],
-           'layout' => '<Page><LayoutElement/></Page>', 'themeName' => 'Light' }
+           'layout' => '<Page><LayoutElement/></Page>',
+           'settings' => { 'theme' => { 'name' => 'Light' } } }
   File.write(File.join(dir, 'live.json'), JSON.generate(live))
   File.write(File.join(dir, 'patch.json'),
-             JSON.generate({ 'themeOverrides' => { 'categoricalScheme' => ['#0e7c7b'] } }))
+             JSON.generate({ 'settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => ['#0e7c7b'] } } } }))
   out, st = run('apply-patch', '--patch', File.join(dir, 'patch.json'),
                 '--dry-run', '--live-spec', File.join(dir, 'live.json'),
                 '--out', File.join(dir, 'merged.json'), '--resolves', 'e0', dir: dir)
   ok(st.exitstatus.zero?, 'dry-run apply-patch exits 0')
   merged = JSON.parse(File.read(File.join(dir, 'merged.json')))
   ok(merged['layout'] == live['layout'], 'layout preserved through the merge (PUT-wipes-layout trap avoided)')
-  ok(merged['themeOverrides']['categoricalScheme'] == ['#0e7c7b'], 'patch applied to merged spec')
+  ok(merged.dig('settings', 'theme', 'overrides', 'categoricalScheme') == ['#0e7c7b'],
+     'patch applied to merged spec')
+  ok(merged.dig('settings', 'theme', 'name') == 'Light', 'sibling theme key survived the merge')
   ok(merged['pages'][0]['elements'][0]['elementId'] == 'k1', 'existing element retained')
 
   # after --resolves e0, status clears
@@ -125,7 +130,8 @@ Dir.mktmpdir do |dir|
   ok(st.exitstatus.zero?, 'status exits 0 after the delta is resolved')
 
   # apply-patch refuses a merge that would blank the workbook (no pages)
-  File.write(File.join(dir, 'nopages.json'), JSON.generate({ 'themeName' => 'Light' }))
+  File.write(File.join(dir, 'nopages.json'),
+             JSON.generate({ 'settings' => { 'theme' => { 'name' => 'Light' } } }))
   _, st = run('apply-patch', '--patch', File.join(dir, 'patch.json'),
               '--dry-run', '--live-spec', File.join(dir, 'nopages.json'),
               '--out', File.join(dir, 'x.json'), dir: dir)
@@ -209,20 +215,21 @@ Dir.mktmpdir do |dir|
   run('init', '--workbook-id', 'WB', '--page-id', 'PG', dir: dir)
   wb_spec = { 'pages' => [{ 'id' => 'page-ov', 'elements' => [
     { 'elementId' => 'k1', 'kind' => 'kpi-chart', 'style' => { 'x' => 1 } },
-    { 'elementId' => 'k2', 'kind' => 'bar-chart' }] }], 'themeName' => 'Light' }
+    { 'elementId' => 'k2', 'kind' => 'bar-chart' }] }],
+           'settings' => { 'theme' => { 'name' => 'Light' } } }
   File.write(File.join(dir, 'wb-spec.json'), JSON.generate(wb_spec))
   live = { 'pages' => [{ 'id' => 'PG', 'elements' => [{ 'elementId' => 'k1', 'kind' => 'kpi-chart' }] }] }
   File.write(File.join(dir, 'live.json'), JSON.generate(live))
   File.write(File.join(dir, 'patch.json'),
-             JSON.generate('themeOverrides' => { 'categoricalScheme' => ['#0e7c7b'] }))
+             JSON.generate('settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => ['#0e7c7b'] } } }))
   out, st = run('apply-patch', '--patch', File.join(dir, 'patch.json'), '--dry-run',
                 '--live-spec', File.join(dir, 'live.json'), '--out', File.join(dir, 'merged.json'), dir: dir)
   ok(st.exitstatus.zero?, 'apply-patch (dual-write) exits 0')
   ok(out.include?('persisted into'), 'apply-patch reports the wb-spec.json persistence')
   ws = JSON.parse(File.read(File.join(dir, 'wb-spec.json')))
-  ok(ws['themeOverrides'] == { 'categoricalScheme' => ['#0e7c7b'] },
+  ok(ws.dig('settings', 'theme', 'overrides') == { 'categoricalScheme' => ['#0e7c7b'] },
      'patch deep-merged into wb-spec.json (a re-entry full-spec PUT now carries the fix)')
-  ok(ws['pages'][0]['elements'].length == 2 && ws['themeName'] == 'Light',
+  ok(ws['pages'][0]['elements'].length == 2 && ws.dig('settings', 'theme', 'name') == 'Light',
      'wb-spec.json untouched keys/elements preserved by the merge')
 
   # guard: unparseable wb-spec.json → warned, left untouched, apply still succeeds

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-recipes.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-recipes.rb
@@ -27,7 +27,7 @@ end
 # A representative live workbook spec: two elements + a real layout string.
 def base_spec
   {
-    'themeName' => 'Light',
+    'settings' => { 'theme' => { 'name' => 'Light' } },
     'pages' => [{
       'id' => 'p1',
       'elements' => [

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-style-normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-style-normalize.rb
@@ -152,7 +152,7 @@ check(col.call('p8')['format'] == { 'kind' => 'number', 'formatString' => ',.1%'
 # ---- SN-5: royal default scheme guard --------------------------------------
 puts '-- SN-5 default scheme guard'
 themed = lambda do |cfs|
-  { 'themeOverrides' => { 'categoricalScheme' => ['#52baee', '#c5e8f9'] },
+  { 'settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => ['#52baee', '#c5e8f9'] } } },
     'pages' => [{ 'elements' => [{ 'id' => 'pv-s', 'kind' => 'pivot-table',
       'totals' => {}, 'conditionalFormats' => cfs }] }] }
 end
@@ -192,7 +192,7 @@ check(spec_nt['pages'][0]['elements'][0]['conditionalFormats'][0]['scheme'] ==
 # uppercase theme hue still derives (downcased) correctly
 spec_uc = themed.call([{ 'type' => 'dataBars', 'columnIds' => %w[v1],
                          'scheme' => ['#1a70f1'] }])
-spec_uc['themeOverrides']['categoricalScheme'] = ['#52BAEE']
+spec_uc['settings']['theme']['overrides']['categoricalScheme'] = ['#52BAEE']
 StyleNormalize.normalize!(spec_uc)
 check(spec_uc['pages'][0]['elements'][0]['conditionalFormats'][0]['scheme'] == derived,
       'uppercase theme hue normalizes to the same derived scheme', fails)
@@ -209,7 +209,7 @@ check(StyleNormalize.el_name({}) == '' && StyleNormalize.el_name(nil) == '',
 puts '-- integration mini-spec + idempotence'
 mini = {
   'name' => 'Hero Art Mini',
-  'themeOverrides' => { 'categoricalScheme' => ['#52baee', '#c5e8f9', '#f1f1f1'] },
+  'settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => ['#52baee', '#c5e8f9', '#f1f1f1'] } } },
   'pages' => [{ 'name' => 'Dashboard', 'elements' => [
     { 'id' => 'el-room', 'kind' => 'pivot-table', 'name' => 'Room Presets',
       'columns' => [

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-derivation.rb
@@ -98,6 +98,32 @@ fb = derive_theme([{
 check(fb['categoricalScheme'] == %w[#07b4a2 #e8519a],
       "single-colour brand_palette falls back to the tint palette (got #{fb['categoricalScheme'].inspect})", fails)
 
+# --- apply! writes the CURRENT path; theme_overrides reads both -------------
+# The old top-level themeName/themeOverrides keys were REMOVED from the workbook
+# spec. A top-level themeName is silently ignored (workbook created UNTHEMED,
+# no error), so a regression here is invisible without these assertions.
+puts
+puts '-- theme path (settings.theme) --'
+applied = ThemeDerive.apply!({ 'pages' => [] },
+                             { 'categoricalScheme' => %w[#111111 #222222] })
+check(applied.dig('settings', 'theme', 'name') == 'Light',
+      'apply! writes settings.theme.name', fails)
+check(applied.dig('settings', 'theme', 'overrides', 'categoricalScheme') == %w[#111111 #222222],
+      'apply! writes settings.theme.overrides', fails)
+check(!applied.key?('themeName') && !applied.key?('themeOverrides'),
+      'apply! never writes the REMOVED top-level keys', fails)
+
+check(ThemeDerive.theme_overrides(applied)['categoricalScheme'] == %w[#111111 #222222],
+      'theme_overrides reads the current shape', fails)
+check(ThemeDerive.theme_overrides({ 'document' => applied })['categoricalScheme'] == %w[#111111 #222222],
+      'theme_overrides reads through a document wrapper', fails)
+check(ThemeDerive.theme_overrides({ 'themeOverrides' => { 'categoricalScheme' => ['#333'] } })['categoricalScheme'] == ['#333'],
+      'theme_overrides still reads legacy flat artifacts on disk', fails)
+check(ThemeDerive.theme_overrides({ 'pages' => [] }).nil?,
+      'theme_overrides is nil when there is no theme', fails)
+check(ThemeDerive.theme_overrides(nil).nil?,
+      'theme_overrides tolerates garbage', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — D1/Pass-7 theme derivation (canvas + region palette + brand palette)'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-ensure.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-ensure.rb
@@ -32,22 +32,23 @@ Dir.mktmpdir do |d|
   File.write(File.join(d, 'chart-specs-theme.json'), JSON.generate(THEME))
   out = ensure_theme!(JSON.generate(SPEC), d)
   spec = JSON.parse(out)
-  check(spec.dig('themeOverrides', 'categoricalScheme') == THEME['categoricalScheme'],
+  check(spec.dig('settings', 'theme', 'overrides', 'categoricalScheme') == THEME['categoricalScheme'],
         'sidecar theme applied to a spec that carried none', fails)
-  check(spec['themeName'] == 'Light', 'themeName stamped by ThemeDerive.apply!', fails)
+  check(spec.dig('settings', 'theme', 'name') == 'Light',
+        "settings.theme.name stamped by ThemeDerive.apply! (NOT the removed top-level themeName)", fails)
 
-  # a spec that ALREADY carries themeOverrides is untouched
-  themed = SPEC.merge('themeOverrides' => { 'categoricalScheme' => ['#ABCDEF'] })
+  # a spec that ALREADY carries a theme is untouched
+  themed = SPEC.merge('settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => ['#ABCDEF'] } } })
   out2 = ensure_theme!(JSON.generate(themed), d)
-  check(JSON.parse(out2)['themeOverrides'] == themed['themeOverrides'],
-        'existing themeOverrides never overwritten', fails)
+  check(JSON.parse(out2)['settings'] == themed['settings'],
+        'existing settings.theme never overwritten', fails)
 end
 
 Dir.mktmpdir do |d|
   # theme via the pages-mode 'theme' key of chart-specs.json
   File.write(File.join(d, 'chart-specs.json'), JSON.generate('pages' => [], 'theme' => THEME))
   out = ensure_theme!(JSON.generate(SPEC), d)
-  check(JSON.parse(out).dig('themeOverrides', 'colorOverrides', 'backgroundCanvas') == '#FFFFFF',
+  check(JSON.parse(out).dig('settings', 'theme', 'overrides', 'colorOverrides', 'backgroundCanvas') == '#FFFFFF',
         "builder-output 'theme' key applied", fails)
 end
 

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot → Sigma",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma — TML discovery, model→data-model conversion, Liveboard→workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/shared/lib/code_rep.mjs
+++ b/shared/lib/code_rep.mjs
@@ -26,3 +26,33 @@ export function metadata(response) {
 export function wrap(doc, extra = {}) {
   return { ...extra, document: doc };
 }
+
+// The ONE place that knows where theming lives.
+//
+// `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming is
+// now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+// `document.themeName` is a hard 400 ("no longer supported. Use
+// document.settings.theme.name instead"), and a themeName that lands at the TOP
+// level (outside `document`) is accepted and SILENTLY IGNORED — the workbook is
+// created unthemed with no error. Emitters must route through here.
+//
+// Returns {} when there is nothing to say, so it is safe to merge blindly.
+export function themeSettings({ name, overrides } = {}) {
+  const theme = {};
+  if (name) theme.name = name;
+  if (overrides && Object.keys(overrides).length) theme.overrides = overrides;
+  if (!Object.keys(theme).length) return {};
+  return { settings: { theme } };
+}
+
+// Deep-merge a {settings:…} fragment without clobbering siblings (e.g. navigation).
+export function mergeSettings(doc, fragment) {
+  if (!fragment || !Object.keys(fragment).length) return doc;
+  const out = { ...doc };
+  for (const [section, value] of Object.entries(fragment.settings || {})) {
+    const existing = (out.settings || {})[section];
+    const merged = isObj(existing) && isObj(value) ? { ...existing, ...value } : value;
+    out.settings = { ...(out.settings || {}), [section]: merged };
+  }
+  return out;
+}

--- a/shared/lib/code_rep.py
+++ b/shared/lib/code_rep.py
@@ -38,3 +38,38 @@ def wrap(doc, extra=None):
     out = dict(extra or {})
     out["document"] = doc
     return out
+
+
+def theme_settings(name=None, overrides=None):
+    """The ONE place that knows where theming lives.
+
+    `themeName` / `themeOverrides` were REMOVED from the workbook spec. Theming
+    is now `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+    `document.themeName` is a hard 400 ("no longer supported. Use
+    document.settings.theme.name instead"), and a themeName that lands at the
+    TOP level (outside `document`) is accepted and SILENTLY IGNORED — the
+    workbook is created unthemed with no error. Emitters must route through
+    here rather than hand-rolling either key.
+
+    Returns {} when there is nothing to say, so it is safe to merge blindly.
+    """
+    theme = {}
+    if name:
+        theme["name"] = name
+    if overrides:
+        theme["overrides"] = overrides
+    if not theme:
+        return {}
+    return {"settings": {"theme": theme}}
+
+
+def merge_settings(doc, fragment):
+    """Deep-merge a {'settings': ...} fragment without clobbering siblings."""
+    if not fragment:
+        return doc
+    out = dict(doc)
+    for section, value in (fragment.get("settings") or {}).items():
+        existing = (out.get("settings") or {}).get(section)
+        merged = {**existing, **value} if isinstance(existing, dict) and isinstance(value, dict) else value
+        out["settings"] = {**(out.get("settings") or {}), section: merged}
+    return out

--- a/shared/lib/code_rep.rb
+++ b/shared/lib/code_rep.rb
@@ -37,6 +37,40 @@ module Sigma
       def wrap(document_hash, extra: {})
         extra.merge('document' => document_hash)
       end
+
+      # The ONE place that knows where theming lives.
+      #
+      # `themeName` / `themeOverrides` were REMOVED from the workbook spec.
+      # Theming is now `document.settings.theme.{name,overrides}`. Live-probed
+      # 2026-08-06: `document.themeName` is a hard 400 ("no longer supported.
+      # Use document.settings.theme.name instead"), and a themeName that lands
+      # at the TOP level (outside `document`) is accepted and SILENTLY IGNORED —
+      # the workbook is created unthemed with no error. Emitters must route
+      # through here rather than hand-rolling either key.
+      #
+      # Returns {} when there is nothing to say, so it is safe to merge blindly.
+      def theme_settings(name: nil, overrides: nil)
+        theme = {}
+        theme['name'] = name if name && !name.to_s.empty?
+        theme['overrides'] = overrides if overrides && !overrides.empty?
+        return {} if theme.empty?
+
+        { 'settings' => { 'theme' => theme } }
+      end
+
+      # Deep-merge a `{'settings' => ...}` fragment into a document without
+      # clobbering sibling settings (e.g. `navigation`). Non-destructive.
+      def merge_settings(document_hash, fragment)
+        return document_hash if fragment.nil? || fragment.empty?
+
+        out = document_hash.dup
+        (fragment['settings'] || {}).each do |section, value|
+          existing = (out['settings'] || {})[section]
+          merged = existing.is_a?(Hash) && value.is_a?(Hash) ? existing.merge(value) : value
+          out['settings'] = (out['settings'] || {}).merge(section => merged)
+        end
+        out
+      end
     end
   end
 end

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -48,7 +48,7 @@ def theme(accent=None):
 SURFACES = {
     "kpi_name_color": True,      # name:{text,color} on a kpi-chart (value.color bonus also GO, not emitted here)
     "chart_color_by": True,      # color:{by:"single",value:"#hex"} on a chart element
-    "categorical_scheme": True,  # workbook-level themeOverrides:{categoricalScheme:[...]}
+    "categorical_scheme": True,  # document.settings.theme.overrides:{categoricalScheme:[...]}
     "format_string": True,       # format:{kind:"number",formatString:<d3>} -- Excel-style formatString is 400-rejected, never emitted
     "container_style": True,     # container style:{backgroundColor,borderRadius,borderColor,borderWidth} (borderRadius, NOT cornerRadius; never combine with padding)
     "typography": True,          # themeOverrides.titleFont + per-element name:{fontSize} -- GO, but no helper below emits it (out of this task's scope); kept for a complete surface map
@@ -144,7 +144,8 @@ def chart_color(theme, categorical=False, surfaces=None):
     if categorical:
         if not s["categorical_scheme"]:
             return {}
-        return {"themeOverrides": {"categoricalScheme": theme["categorical"]}}
+        # theming moved: document.settings.theme.overrides (themeOverrides was REMOVED)
+        return {"settings": {"theme": {"overrides": {"categoricalScheme": theme["categorical"]}}}}
     if not s["chart_color_by"]:
         return {}
     return {"color": {"by": "single", "value": theme["categorical"][0]}}

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -47,10 +47,10 @@ module Styling
   SURFACES = {
     kpi_name_color: true,     # name:{text,color} on a kpi-chart (value.color bonus also GO, not emitted here)
     chart_color_by: true,     # color:{by:"single",value:"#hex"} on a chart element
-    categorical_scheme: true, # workbook-level themeOverrides:{categoricalScheme:[...]}
+    categorical_scheme: true, # document.settings.theme.overrides:{categoricalScheme:[...]}
     format_string: true,      # format:{kind:"number",formatString:<d3>} — Excel-style formatString is 400-rejected, never emitted
     container_style: true,    # container style:{backgroundColor,borderRadius,borderColor,borderWidth} (borderRadius, NOT cornerRadius; never combine with padding)
-    typography: true,         # themeOverrides.titleFont + per-element name:{fontSize} — GO, but no helper below emits it (out of this task's scope); kept for a complete surface map
+    typography: true,         # settings.theme.overrides.titleFont + per-element name:{fontSize} — GO, but no helper below emits it (out of this task's scope); kept for a complete surface map
     # WS4 Task 2 (build-plugs-command-center.rb HDRBG probe): container
     # backgroundImage:{url:"data:image/svg+xml;base64,...",style:{fit:"cover"}}
     # carrying a composed <linearGradient>+motif SVG survived readback + a
@@ -138,7 +138,8 @@ module Styling
   def self.chart_color(theme, categorical: false, surfaces: SURFACES)
     if categorical
       return {} unless surfaces[:categorical_scheme]
-      { 'themeOverrides' => { 'categoricalScheme' => theme[:categorical] } }
+      # theming moved: document.settings.theme.overrides (themeOverrides was REMOVED)
+      { 'settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => theme[:categorical] } } } }
     else
       return {} unless surfaces[:chart_color_by]
       { 'color' => { 'by' => 'single', 'value' => theme[:categorical][0] } }

--- a/shared/lib/test_styling.py
+++ b/shared/lib/test_styling.py
@@ -105,7 +105,8 @@ class StylingHelpersTest(unittest.TestCase):
 
     def test_chart_color_categorical(self):
         self.assertEqual(styling.chart_color(self.theme, categorical=True),
-                          {"themeOverrides": {"categoricalScheme": self.theme["categorical"]}})
+                         {"settings": {"theme": {"overrides":
+                          {"categoricalScheme": self.theme["categorical"]}}}})
 
     def test_chart_color_no_go_chart_color_by(self):
         surfaces = dict(styling.SURFACES, chart_color_by=False)

--- a/shared/lib/test_styling.rb
+++ b/shared/lib/test_styling.rb
@@ -96,7 +96,7 @@ check('chart_color(theme): single-series color:{by:"single",value:} (categorical
 end
 check('chart_color(theme, categorical: true): workbook-level categoricalScheme patch') do
   Styling.chart_color(Styling::DEFAULT_THEME, categorical: true) ==
-    { 'themeOverrides' => { 'categoricalScheme' => Styling::DEFAULT_THEME[:categorical] } }
+    { 'settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => Styling::DEFAULT_THEME[:categorical] } } } }
 end
 check('chart_color: NO-GO chart_color_by -> {}') do
   Styling.chart_color(Styling::DEFAULT_THEME, surfaces: Styling::SURFACES.merge(chart_color_by: false)) == {}

--- a/shared/lib/testdata/styling_golden.json
+++ b/shared/lib/testdata/styling_golden.json
@@ -1,16 +1,20 @@
 {
   "chart_color_categorical": {
-    "themeOverrides": {
-      "categoricalScheme": [
-        "#2563EB",
-        "#0EA5E9",
-        "#14B8A6",
-        "#F59E0B",
-        "#8B5CF6",
-        "#EF4444",
-        "#10B981",
-        "#64748B"
-      ]
+    "settings": {
+      "theme": {
+        "overrides": {
+          "categoricalScheme": [
+            "#2563EB",
+            "#0EA5E9",
+            "#14B8A6",
+            "#F59E0B",
+            "#8B5CF6",
+            "#EF4444",
+            "#10B981",
+            "#64748B"
+          ]
+        }
+      }
     }
   },
   "chart_color_single": {

--- a/shared/lib/tests/test_code_rep.py
+++ b/shared/lib/tests/test_code_rep.py
@@ -64,6 +64,36 @@ class TestCodeRepSettingsAgents(unittest.TestCase):
             self.assertNotIn('settings', wrapped)
             self.assertNotIn('agents', wrapped)
 
+    # --- theme_settings: the ONE place that knows the theme path ------------
+    #
+    # themeName/themeOverrides were REMOVED. document.themeName is a hard 400;
+    # a top-level themeName is silently ignored. Emitters go through here.
+
+    def test_theme_settings_name_only(self):
+        self.assertEqual(code_rep.theme_settings(name='Dark'),
+                         {'settings': {'theme': {'name': 'Dark'}}})
+
+    def test_theme_settings_overrides_only(self):
+        ov = {'categoricalScheme': ['#111', '#222']}
+        self.assertEqual(code_rep.theme_settings(overrides=ov),
+                         {'settings': {'theme': {'overrides': ov}}})
+
+    def test_theme_settings_empty_when_nothing_to_say(self):
+        self.assertEqual(code_rep.theme_settings(), {})
+        self.assertEqual(code_rep.theme_settings(overrides={}), {})
+
+    def test_theme_settings_never_emits_removed_keys(self):
+        flat = str(code_rep.theme_settings(name='Dark', overrides={'hasCards': 'shown'}))
+        self.assertNotIn('themeName', flat)
+        self.assertNotIn('themeOverrides', flat)
+
+    def test_merge_settings_is_deep_and_non_destructive(self):
+        doc = {'schemaVersion': 1, 'settings': {'navigation': {'tabs': 'shown'}}}
+        out = code_rep.merge_settings(doc, code_rep.theme_settings(name='Dark'))
+        self.assertEqual(out['settings']['navigation'], {'tabs': 'shown'})
+        self.assertEqual(out['settings']['theme']['name'], 'Dark')
+        self.assertNotIn('theme', doc['settings'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/shared/lib/tests/test_code_rep.rb
+++ b/shared/lib/tests/test_code_rep.rb
@@ -63,4 +63,51 @@ class TestCodeRep < Minitest::Test
       assert_nil wrapped['agents']
     end
   end
+
+  # --- theme_settings: the ONE place that knows the theme path ----------------
+  #
+  # `themeName` / `themeOverrides` were REMOVED from the workbook spec; theming
+  # is `document.settings.theme.{name,overrides}`. Live-probed 2026-08-06:
+  # `document.themeName` 400s ("no longer supported"), and a top-level
+  # `themeName` is silently ignored. Emitters must go through this helper.
+
+  def test_theme_settings_name_only
+    assert_equal({ 'settings' => { 'theme' => { 'name' => 'Dark' } } },
+                 Sigma::CodeRep.theme_settings(name: 'Dark'))
+  end
+
+  def test_theme_settings_overrides_only
+    ov = { 'categoricalScheme' => %w[#111 #222] }
+    assert_equal({ 'settings' => { 'theme' => { 'overrides' => ov } } },
+                 Sigma::CodeRep.theme_settings(overrides: ov))
+  end
+
+  def test_theme_settings_both
+    got = Sigma::CodeRep.theme_settings(name: 'Light', overrides: { 'hasCards' => 'shown' })
+    assert_equal 'Light', got.dig('settings', 'theme', 'name')
+    assert_equal({ 'hasCards' => 'shown' }, got.dig('settings', 'theme', 'overrides'))
+  end
+
+  def test_theme_settings_empty_when_nothing_to_say
+    assert_equal({}, Sigma::CodeRep.theme_settings)
+    assert_equal({}, Sigma::CodeRep.theme_settings(overrides: {}))
+  end
+
+  def test_theme_settings_never_emits_the_removed_keys
+    got = Sigma::CodeRep.theme_settings(name: 'Dark', overrides: { 'hasCards' => 'shown' })
+    flat = got.to_s
+    refute_includes flat, 'themeName'
+    refute_includes flat, 'themeOverrides'
+  end
+
+  def test_merge_settings_is_deep_and_non_destructive
+    doc = { 'schemaVersion' => 1, 'settings' => { 'navigation' => { 'tabs' => 'shown' } } }
+    out = Sigma::CodeRep.merge_settings(doc, Sigma::CodeRep.theme_settings(name: 'Dark'))
+    assert_equal({ 'tabs' => 'shown' }, out.dig('settings', 'navigation'),
+                 'merging a theme must not clobber sibling settings like navigation')
+    assert_equal 'Dark', out.dig('settings', 'theme', 'name')
+    assert_equal 1, out['schemaVersion']
+    # input untouched
+    refute doc['settings'].key?('theme')
+  end
 end

--- a/shared/scripts/harvest-theme-registry.py
+++ b/shared/scripts/harvest-theme-registry.py
@@ -2,9 +2,9 @@
 """harvest-theme-registry.py — build a persistent per-org theme registry.
 
 Themes have no list API (unlike plugins, which now have GET /v2/plugins). The
-only place a theme id appears is a workbook spec's top-level `themeName`. So we
-harvest: list every workbook, GET each spec, collect the distinct `themeName`
-values (built-in names + org-theme UUIDs) and how many workbooks use each.
+only place a theme id appears is a workbook spec's `document.settings.theme.name`.
+So we harvest: list every workbook, GET each spec, collect the distinct theme
+names (built-in names + org-theme UUIDs) and how many workbooks use each.
 
 Persists to ~/.sigma-migration/theme-registry.yaml keyed by org host, so the
 authoring skill can offer known themes instead of asking the user to supply a
@@ -77,10 +77,30 @@ def list_workbooks(base, tok, cap=None):
         page = d["nextPage"]
 
 
+def theme_name_from_spec(spec):
+    """Pull the theme id out of a workbook spec, current shape first.
+
+    The theme moved: it is now `document.settings.theme.name`. The old
+    top-level `themeName` was REMOVED from the spec (live-probed 2026-08-06:
+    `document.themeName` 400s, a top-level one is silently ignored). Reading
+    only the old key made this harvester return None for every workbook and
+    silently write an EMPTY registry — which reads identically to "this org
+    has no themes". The legacy branch stays for flat artifacts still on disk.
+    """
+    if not isinstance(spec, dict):
+        return None
+    doc = spec.get("document")
+    doc = doc if isinstance(doc, dict) else spec
+    theme = ((doc.get("settings") or {}).get("theme") or {})
+    name = theme.get("name")
+    if name:
+        return name
+    return doc.get("themeName") or spec.get("themeName")  # legacy flat artifacts
+
+
 def theme_of(base, tok, wb):
     try:
-        spec = api(base, tok, f"/v2/workbooks/{wb}/spec")
-        return spec.get("themeName")  # None if no theme set
+        return theme_name_from_spec(api(base, tok, f"/v2/workbooks/{wb}/spec"))
     except Exception as e:
         return ("__error__", str(e)[:40])
 

--- a/shared/scripts/verify-styling-surfaces-e2e.rb
+++ b/shared/scripts/verify-styling-surfaces-e2e.rb
@@ -35,7 +35,7 @@
 #   chart-categorical (bar-chart)         — SURFACE 3: color:{by:category,
 #                                           column} with NO per-element scheme,
 #                                           relying on workbook-level
-#                                           themeOverrides.categoricalScheme;
+#                                           settings.theme.overrides.categoricalScheme;
 #                                           a side-experiment then adds an
 #                                           explicit per-element `scheme` (the
 #                                           documented Recipe-5 alternative) to
@@ -54,7 +54,7 @@
 #                                           or the docs' `borderRadius` is the
 #                                           real one) + a top-level (NOT
 #                                           pages[].layout) <GridContainer>.
-#   workbook-level themeOverrides.titleFont — SURFACE 6: the documented
+#   workbook-level settings.theme.overrides.titleFont — SURFACE 6: the documented
 #                                           workbook-wide typography lever,
 #                                           tested against the two bare chart
 #                                           titles (which carry no per-element
@@ -122,7 +122,7 @@ HERO_BG              = '#0B3D91' # surface 5: container style.backgroundColor
 # distinct from every other test color (checked against each within the
 # pixel-probe's tol=40) so no region's signal can be attributed to this one.
 HERO_BORDER          = '#1E293B'
-TITLEFONT_COLOR      = '#7C3AED' # surface 6: workbook-level themeOverrides.titleFont
+TITLEFONT_COLOR      = '#7C3AED' # surface 6: workbook-level settings.theme.overrides.titleFont
 TABLE_NAME_COLOR     = '#DC2626' # surface 6: per-element `name` object (table)
 
 # Generic demo data — region/category/revenue/orders/margin. No customer/
@@ -270,10 +270,17 @@ def build_spec(home, schema_version, src_formula_fn, flags)
     'folderId' => home,
     'schemaVersion' => schema_version,
     'description' => 'Live GO/NO-GO proof of dashboard-styling spec surfaces. Throwaway test artifact.',
-    'themeName' => 'Light',
-    'themeOverrides' => {
-      'categoricalScheme' => CATEGORICAL_HEXES,
-      'titleFont' => { 'color' => TITLEFONT_COLOR, 'fontSize' => 20, 'fontWeight' => 'bold' },
+    # Theme path: document.settings.theme.{name,overrides}. The old top-level
+    # themeName/themeOverrides keys were REMOVED — a top-level themeName is
+    # silently ignored, so probing the old shape would report a false NO-GO.
+    'settings' => {
+      'theme' => {
+        'name' => 'Light',
+        'overrides' => {
+          'categoricalScheme' => CATEGORICAL_HEXES,
+          'titleFont' => { 'color' => TITLEFONT_COLOR, 'fontSize' => 20, 'fontWeight' => 'bold' },
+        },
+      },
     },
     'pages' => [
       {
@@ -661,8 +668,8 @@ begin
     kpi_value: kpi_el && kpi_el['value'],
     chart_single_color: cs_el && cs_el['color'],
     chart_cat_color: cc_el && cc_el['color'],
-    workbook_categorical_scheme: spec['themeOverrides'] && spec['themeOverrides']['categoricalScheme'],
-    workbook_title_font: spec['themeOverrides'] && spec['themeOverrides']['titleFont'],
+    workbook_categorical_scheme: spec.dig('settings', 'theme', 'overrides', 'categoricalScheme'),
+    workbook_title_font: spec.dig('settings', 'theme', 'overrides', 'titleFont'),
     table_name: tbl_el && tbl_el['name'],
     table_formats: tbl_el && (tbl_el['columns'] || []).map { |c| { id: c['id'], format: c['format'] } },
     hero_style: hero_el && hero_el['style'],
@@ -682,7 +689,7 @@ begin
 
   # --- side experiment: does an EXPLICIT per-element `scheme` (the
   # documented Recipe-5 shape) do what the workbook-level
-  # themeOverrides.categoricalScheme alone didn't? Same workbook, one extra
+  # settings.theme.overrides.categoricalScheme alone didn't? Same workbook, one extra
   # PUT + a targeted element-only render (cheaper than a full-page re-render).
   flags[:categorical_explicit_scheme] = true
   spec2 = build_spec(home, schema_version, src_formula_candidates.find { |c| c[:label] == resolved[:candidate] }[:fn], flags)
@@ -791,11 +798,11 @@ begin
         per_element_explicit_scheme: { attempted: !probe2.nil?, rendered: !!cat_explicit_scheme_rendered },
         surviving_shape:
           if cat_theme_only_rendered
-            { themeOverrides: { categoricalScheme: CATEGORICAL_HEXES } }
+            { settings: { theme: { overrides: { categoricalScheme: CATEGORICAL_HEXES } } } }
           elsif cat_explicit_scheme_rendered
             { color: { by: 'category', column: '<category-col-id>', scheme: CATEGORICAL_HEXES } }
           end,
-        note: 'brief literally asks for workbook-level themeOverrides.categoricalScheme driving a bar chart ' \
+        note: 'brief literally asks for workbook-level settings.theme.overrides.categoricalScheme driving a bar chart ' \
               'with NO per-element color.scheme. Also tested the documented Recipe-5 alternative (an explicit ' \
               'per-element `color.scheme`) as a side experiment, since that is the field the module would fall ' \
               'back to if the workbook-level lever does not drive non-donut/pie charts.',
@@ -840,7 +847,7 @@ begin
         go: !!((titlefont_survived && titlefont_rendered) || (table_name_object_survived && table_name_object_rendered)),
         workbook_level_titleFont: { readback_survived: !!titlefont_survived, rendered: !!titlefont_rendered,
                                      surviving_shape: (titlefont_survived && titlefont_rendered ?
-                                       { themeOverrides: { titleFont: { color: TITLEFONT_COLOR, fontSize: 20, fontWeight: 'bold' } } } : nil) },
+                                       { settings: { theme: { overrides: { titleFont: { color: TITLEFONT_COLOR, fontSize: 20, fontWeight: 'bold' } } } } } : nil) },
         per_element_name_object: {
           readback_survived: !!table_name_object_survived,
           rendered_color: !!table_name_object_rendered,
@@ -855,7 +862,7 @@ begin
                   'is now pixel-verified via rendered_color above (a distinct test hex from the workbook-wide ' \
                   'titleFont, so a hit here cannot be confused with that lever).'),
         },
-        note: 'stretch surface. Two INDEPENDENT levers both tested live: workbook-wide themeOverrides.titleFont ' \
+        note: 'stretch surface. Two INDEPENDENT levers both tested live: workbook-wide settings.theme.overrides.titleFont ' \
               '(applies to every element title with no per-element override) and a per-element `name` object ' \
               'with fontSize/color (table only, isolated with a different test hex) — the per-element color, ' \
               'where present, wins over the workbook-wide one (see table_title pixel evidence).',


### PR DESCRIPTION
Rebuilt on current `main` (supersedes #645, which was stacked on #641 — see below). Cherry-picked clean; **0 deletions vs main**.

## Why this is still needed after #640

#640 landed the `DOC_KEYS` fix (adapter stops sweeping `settings`/`agents` out of `document`) — that was the same fix my #641 carried, so **#641 is closed as duplicate**. But `DOC_KEYS` alone doesn't help: **every emitter was still writing the removed `themeName`/`themeOverrides` keys**, so the theme was lost anyway. This fixes the emitters and readers.

## The bug

`themeName`/`themeOverrides` were removed from the workbook spec. Live-probed 2026-08-06:

| sent as | result |
|---|---|
| `document.themeName` | **400** — `no longer supported. Use document.settings.theme.name instead` |
| top-level `themeName` | accepted, create **200**, **silently ignored** |

## Write side — was producing unthemed dashboards

`tableau lib/theme_derive.rb` (the shared derive path) · `domo build-workbook-spec.rb` · `powerbi build-workbook-from-pbir.rb` · `quicksight build-workbook-from-quicksight.rb` · `shared/lib/styling.{rb,py}` · `shared/scripts/verify-styling-surfaces-e2e.rb` — that last one **probed** the old shape, so styling surfaces 5 and 6 would have reported a **false NO-GO**.

## Read side — was finding nothing

`harvest-theme-registry.py` read only the old top-level key → `None` for every workbook → **empty registry**, indistinguishable from "this org has no themes". The authoring skill's "use the registry instead of asking blind" guidance was silently dead.

**Measured on 60 live workbooks: before 0 themes, after 2** (9× `Light`, 1 org UUID).

Tableau's `style_normalize` / `migrate-tableau` / `post-and-readback` now read via a new `ThemeDerive.theme_overrides` accessor (current shape + legacy fallback for flat artifacts on disk).

## One place knows the path

`Sigma::CodeRep.theme_settings` + `merge_settings` (`.rb`/`.py`/`.mjs`; the latter deep-merges so a theme never clobbers `settings.navigation`), plus `ThemeDerive.theme_overrides`.

## End-to-end proof

`ThemeDerive.apply!` → adapter → live create → `GET`:

```
READBACK settings.theme -> {"name"=>"Light",
  "overrides"=>{"colorOverrides"=>{"backgroundCanvas"=>"#ffffff"},
                "categoricalScheme"=>["#0e8da0", "#123456"]}}
✅ survived the full converter -> adapter -> API round trip
```

**Gotcha documented in `theme_derive.rb`:** Sigma **lowercases hex colors** on readback (`#0E8DA0` → `#0e8da0`). Theme parity comparisons must be case-insensitive — my first assertion reported a false "theme LOST" on exactly this.

## Tests

New guards in `test_code_rep.{rb,py}` (shape; never emits the removed keys; deep-merge preserves `navigation`) and `test-theme-derivation.rb` (`apply!` writes the new path **and never the old**; accessor reads current / `document`-wrapped / legacy / nil / garbage).

All fixtures moved off the removed keys so suites exercise the **current** path — several were passing only via the legacy fallback, leaving the real path uncovered.

Verified **by exit code**: `test-style-normalize` was exiting 1 on a stderr crash while its tail still printed `PASS`. All 10 suites (4 shared + 6 tableau) exit 0.

## Scope

13 plugins get a patch bump, re-derived against current `main`. Gates: `check-shared` OK (680), `check-agent-variants` OK (16), `lint-skills` clean, version gate OK.

**Companion:** `sigma-authoring`'s vendored `styling.rb` had the same bug but vendors from **sigma-skills** (separate lineage) — fixed there in twells89/sigma-skills#30, which is merged; it reaches this repo on the next re-vendor (#627).

Bead: `beads-sigma-cofo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)