### PR TITLE
feat(domo-to-sigma): generate parity-plan-exclusions.json — the census had no writer

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/SKILL.md
@@ -135,12 +135,13 @@ grid is only 6 wide, so widths scale ×4).
 | `build-dashboard-layout.rb` *(vendored)* | 5d | Zone JSON → 24-col grid XML |
 | `put-layout.rb` *(vendored)* | 5d | PUT layout to workbook |
 | `verify-parity.rb` *(vendored)* | 6 | Compare Domo `query/execute` aggregations vs Sigma `query` → `parity-score.json` (`tiles_*`) |
+| `scripts/build-parity-exclusions.rb` | 6 | Derives `parity-plan-exclusions.json` from machine facts in `warnings.json` (today: refused date windows). Carries the originating warning as evidence; **aborts** rather than excluding a runaway share of the pool |
 | `scripts/phase6-parity-domo.rb` | 6 | **Finalizer.** Runs `verify-parity.rb`, derives the gate contract (`charts_*`/`status`) into `parity-final.json`, and refuses to emit one when the plan silently omits chartable tiles |
 | `assert-phase6-ran.rb` *(vendored)* | 6 | Hard gate before declaring GREEN (run with `--workdir`) |
 
 > The Domo-specific scripts — `convert-beast-modes.rb` (2), `find-or-pick-dm.rb`
 > integration (2.5), `build-dm.rb` (3), `build-workbook.rb` + `qa-check.rb` (5),
-> `build-domo-layout.rb` (5d), `phase6-parity-domo.rb` (6), plus `get-domo-token.sh`, `lib/domo_rest.rb`,
+> `build-domo-layout.rb` (5d), `phase6-parity-domo.rb` + `build-parity-exclusions.rb` (6), plus `get-domo-token.sh`, `lib/domo_rest.rb`,
 > `lib/domo_sigma_util.rb`, `domo-discover.rb`, `domo-capture-visuals.rb` — ship
 > with unit + end-to-end tests under `test/`. A final live field-path check on
 > first instance contact is still recommended.

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-exclusions.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-exclusions.rb
@@ -1,0 +1,209 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# build-parity-exclusions.rb — generate `parity-plan-exclusions.json` for the
+# Phase-6 census. Companion to phase6-parity-domo.rb (bead beads-sigma-2tkm).
+#
+# WHY THIS EXISTS
+# ---------------
+# phase6-parity-domo.rb REFUSES to emit a gate-1 contract unless every chartable
+# element is either verified by the parity plan or recorded here WITH A REASON.
+# That check shipped in PR #631; nothing wrote the file it reads. This writes it.
+#
+# THE CONSTRAINT THAT SHAPES THE WHOLE DESIGN
+# -------------------------------------------
+# An exclusions generator is itself a potential silent-inflation loophole — the
+# exact failure mode the census exists to prevent. Excluding a tile removes it
+# from the parity denominator, so a generous generator turns "45 of 65 verified"
+# into a clean-looking "100% (45/45)". Three rules keep it honest:
+#
+#   1. Exclusions derive ONLY from MACHINE FACTS the converter already recorded in
+#      warnings.json. No heuristics, no chart-kind guesses, no "probably fine".
+#   2. The originating warning text rides along as `evidence`, so every exclusion
+#      is auditable back to the line of converter output that justified it.
+#   3. A RUNAWAY GUARD: if the derived exclusions would exceed
+#      MAX_EXCLUSION_RATE of a non-trivial pool, this ABORTS and tells the
+#      operator to fix the converter rather than widen the exclusions. Overriding
+#      it requires an explicitly named --accept-exclusion-rate REASON, which is
+#      recorded in the artifact.
+#
+# WHAT ACTUALLY DISQUALIFIES A TILE
+# ---------------------------------
+# Only warnings that mean "the Domo side and the Sigma side cannot agree by
+# construction". Today that is exactly one class: a REFUSED DATE WINDOW. When
+# build-workbook.rb declines to translate a card's date window (INTERVAL_OFFSET,
+# non-zero offset, unmapped interval — see apply_card_date_window!), Domo
+# aggregates over a window and the Sigma tile aggregates over all history. No
+# oracle can reconcile that, so scoring the tile would produce a guaranteed
+# failure that says nothing about conversion quality.
+#
+# A layout, geometry, series-assignment or sub-master routing warning is NOT
+# grounds for exclusion — those are fidelity concerns whose VALUES should still
+# agree, and dropping them would hide real divergence.
+#
+# Usage:
+#   ruby scripts/build-parity-exclusions.rb --workdir <wd> \
+#     [--workbook-spec PATH] [--warnings PATH] [--out PATH] \
+#     [--max-rate F] [--accept-exclusion-rate REASON]
+#
+# Exit codes: 0 = written; 1 = bad invocation / missing input;
+#             7 = runaway guard tripped (too many exclusions, no named override).
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { workdir: nil, spec: nil, warns: nil, out: nil, max_rate: 0.4, accept: nil }
+OptionParser.new do |p|
+  p.banner = 'Usage: build-parity-exclusions.rb --workdir DIR [options]'
+  p.on('--workdir DIR', 'run directory')                                { |v| opts[:workdir] = v }
+  p.on('--workbook-spec PATH', 'default <workdir>/workbook-spec.json')  { |v| opts[:spec] = v }
+  p.on('--warnings PATH', 'default <workdir>/warnings.json (or discovery/warnings.json)') { |v| opts[:warns] = v }
+  p.on('--out PATH', 'default <workdir>/parity-plan-exclusions.json')   { |v| opts[:out] = v }
+  p.on('--max-rate F', Float, 'runaway guard: max excluded fraction of the pool (default 0.4)') { |v| opts[:max_rate] = v }
+  p.on('--accept-exclusion-rate REASON',
+       'override the runaway guard — REQUIRED reason, recorded as rate_waiver and MUST be named ' \
+       'in the migration report') { |v| opts[:accept] = v }
+end.parse!
+
+abort('build-parity-exclusions: --workdir is required') unless opts[:workdir]
+abort("build-parity-exclusions: --workdir #{opts[:workdir]} does not exist") unless Dir.exist?(opts[:workdir])
+opts[:spec] ||= File.join(opts[:workdir], 'workbook-spec.json')
+opts[:out]  ||= File.join(opts[:workdir], 'parity-plan-exclusions.json')
+if opts[:warns].nil?
+  cand = [File.join(opts[:workdir], 'warnings.json'),
+          File.join(opts[:workdir], 'discovery', 'warnings.json')]
+  opts[:warns] = cand.find { |c| File.exist?(c) } || cand.first
+end
+abort("build-parity-exclusions: no workbook spec at #{opts[:spec]}") unless File.exist?(opts[:spec])
+
+# A rate guard on a tiny pool is meaningless (2 of 3 is not a runaway), so it only
+# engages once the pool is big enough for a fraction to mean anything.
+MIN_POOL_FOR_RATE_GUARD = 5
+
+# Chartable predicate — behaviourally identical to
+# shared/scripts/build-parity-plan.rb:50-57 and phase6-parity-domo.rb, so this
+# generator and the census it feeds always agree on the denominator.
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false
+  (el['columns'] || []).any?
+end
+
+def element_name(el)
+  n = el['name'].is_a?(Hash) ? el['name']['text'] : el['name']
+  n = nil if n.to_s.empty?
+  (n || el['title'] || el['id']).to_s
+end
+
+def spec_pages(spec)
+  return spec['pages'] if spec.is_a?(Hash) && spec['pages'].is_a?(Array)
+  w = spec.is_a?(Hash) ? spec['document'] : nil
+  return w['pages'] if w.is_a?(Hash) && w['pages'].is_a?(Array)
+  []
+end
+
+def load_json(path, default)
+  return default unless File.exist?(path)
+  JSON.parse(File.read(path))
+rescue StandardError => e
+  abort("build-parity-exclusions: cannot read #{path}: #{e.message}")
+end
+
+# Tile ids follow `el-<cardId>[-summary]` (build-workbook.rb), which is what makes
+# a tile joinable to the card-level warning that disqualifies it.
+def card_id_of(el_id)
+  m = /\Ael-(\d+)/.match(el_id.to_s)
+  m && m[1]
+end
+
+# The ONLY disqualifying signature today. Keyed on the exact prefix
+# apply_card_date_window! emits, so a reworded unrelated warning cannot start
+# silently excluding tiles.
+DISQUALIFYING = [
+  { key: 'date-window-not-applied',
+    match: ->(w) { w.include?('date window NOT applied') },
+    why: 'Domo applies a date window this converter refused to translate, so the Sigma tile ' \
+         'aggregates over all history while the Domo card aggregates over a window — the two ' \
+         'cannot agree by construction and scoring it would produce a guaranteed, uninformative ' \
+         'failure. Restore the window (see apply_card_date_window!) to score this tile.' },
+].freeze
+
+spec  = load_json(opts[:spec], {})
+tiles = spec_pages(spec).flat_map { |pg| pg['elements'] || [] }.select { |el| chartable?(el) }
+
+raw = load_json(opts[:warns], [])
+warns = raw.is_a?(Array) ? raw : Array(raw['warnings'])
+
+# Group disqualifying warnings by card id, and surface any that cannot be joined.
+by_card = {}
+unjoinable = []
+warns.each do |w|
+  text = w['warning'].to_s
+  sig = DISQUALIFYING.find { |d| d[:match].call(text) }
+  next unless sig
+  cid = w['card_id'].to_s
+  if cid.empty?
+    unjoinable << w
+    next
+  end
+  (by_card[cid] ||= []) << { sig: sig, warning: text, card: w['card'] }
+end
+
+unless unjoinable.empty?
+  warn "[WARN] build-parity-exclusions: #{unjoinable.length} disqualifying warning(s) carry no " \
+       'card_id and could not be joined to a tile — they are NOT excluded, so those tiles will be ' \
+       'scored and may fail. Re-run build-workbook.rb (warn_card now records card_id):'
+  unjoinable.first(10).each { |w| warn "         - #{w['card']}: #{w['warning'][0, 90]}" }
+end
+
+exclusions = []
+tiles.each do |el|
+  cid = card_id_of(el['id'])
+  next unless cid
+  hits = by_card[cid]
+  next unless hits && !hits.empty?
+  hit = hits.first
+  exclusions << {
+    'chart'    => element_name(el),
+    'reason'   => "#{hit[:sig][:key]}: #{hit[:warning]} — #{hit[:sig][:why]}",
+    'evidence' => { 'card_id' => cid, 'element_id' => el['id'],
+                    'card' => hit[:card], 'warning' => hit[:warning] },
+  }
+end
+
+total = tiles.length
+rate  = total.zero? ? 0.0 : (exclusions.length.to_f / total)
+warn format('build-parity-exclusions: %d chartable tile(s), %d excluded (%.1f%%)',
+            total, exclusions.length, rate * 100)
+
+if total >= MIN_POOL_FOR_RATE_GUARD && rate > opts[:max_rate] && opts[:accept].nil?
+  warn "[FAIL] build-parity-exclusions: would exclude #{exclusions.length} of #{total} tiles " \
+       "(#{(rate * 100).round(1)}% > #{(opts[:max_rate] * 100).round(0)}% limit) — too many."
+  warn '       Excluding this much of the pool does not measure a conversion, it hides one: the'
+  warn '       remaining tiles would score "100%" while most of the dashboard went unverified.'
+  warn '       FIX THE CONVERTER instead of widening the exclusions — every entry below names the'
+  warn '       warning that caused it:'
+  exclusions.first(10).each { |e| warn "         - #{e['chart']}: #{e['evidence']['warning'][0, 90]}" }
+  warn '       If the converter fix is genuinely deferred, re-run with'
+  warn '       --accept-exclusion-rate "<reason>" and name it in the migration report.'
+  exit 7
+end
+
+doc = {
+  'generated_at'     => Time.now.utc.iso8601,
+  'source'           => File.basename(opts[:spec]),
+  'chartable_total'  => total,
+  'excluded_total'   => exclusions.length,
+  'exclusion_rate'   => rate.round(4),
+  'note'             => 'Derived ONLY from machine facts recorded in warnings.json; every entry ' \
+                        'carries the originating warning as evidence. Never hand-widen this file — ' \
+                        'fix the converter so the tile can be scored.',
+  'exclusions'       => exclusions,
+}
+doc['rate_waiver'] = opts[:accept] if opts[:accept]
+
+File.write(opts[:out], JSON.pretty_generate(doc))
+warn "wrote #{opts[:out]} (#{exclusions.length} exclusion(s) of #{total} chartable tile(s))"
+exit 0

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -44,7 +44,14 @@ end
 def mref(display) "[Master/#{display}]" end
 
 $warnings = []
-def warn_card(card, msg) $warnings << { 'card' => card['title'] || card['id'], 'warning' => msg } end
+# `card_id` is additive (existing consumers read 'card'/'warning') and exists so
+# warnings.json is MACHINE-JOINABLE to workbook-spec tile ids, which follow
+# `el-<cardId>[-summary]`. build-parity-exclusions.rb derives parity exclusions
+# from recorded warnings, and joining on a human title would be ambiguous the
+# moment two cards share one.
+def warn_card(card, msg)
+  $warnings << { 'card' => card['title'] || card['id'], 'card_id' => card['id'].to_s, 'warning' => msg }
+end
 
 $companion_elements = [] # bead 08sf — Task 5 populates this
 $sub_masters = {}        # bead ziht — datasetId => sub-master element Hash

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -840,6 +840,19 @@ def run_live!(opts)
     # verify-parity.rb itself (--score-out -> parity-score.json), derives the
     # gate contract into parity-final.json, and refuses to emit a contract when
     # the plan silently omits chartable tiles.
+    # Generate parity-plan-exclusions.json FIRST — the finalizer's census consumes
+    # it, and #631 shipped the census with nothing writing the file it reads. The
+    # generator derives exclusions only from machine facts already in
+    # warnings.json (today: refused date windows, where Domo applies a window the
+    # Sigma tile lacks, so the two cannot agree by construction) and aborts rather
+    # than excluding a runaway share of the pool.
+    #
+    # A non-zero exit here is FATAL, not advisory: it means either the runaway
+    # guard tripped (fix the converter) or the artifact is unreadable — and
+    # continuing would hand the census a stale or absent exclusions file.
+    ok, code, _out = run_script!('build-parity-exclusions.rb', '--workdir', OUT)
+    fail_phase!('verify-parity', "build-parity-exclusions.rb exited #{code}") unless ok
+
     ok, code, _out = run_script!('phase6-parity-domo.rb',
                                   '--workdir', OUT,
                                   '--plan', opts[:parity_plan],

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -96,6 +96,16 @@ end
 # now distinct, with phase6-parity-domo.rb finalizing score -> contract.
 ok(migrate_src.include?("'phase6-parity-domo.rb'"),
    'bead 2tkm: run_live! finalizes parity through phase6-parity-domo.rb (the gate-contract writer)')
+
+# The census in phase6-parity-domo.rb CONSUMES parity-plan-exclusions.json, and
+# #631 shipped that check with nothing writing the file. Pin both that the
+# generator runs and that it runs BEFORE the finalizer — reversed, the census
+# would read a stale or absent exclusions file and fail a run that was fine.
+gen_at = migrate_src.index("'build-parity-exclusions.rb'")
+fin_at = migrate_src.index("'phase6-parity-domo.rb'")
+ok(!gen_at.nil?, 'run_live! generates parity-plan-exclusions.json (the census consumes it)')
+ok(gen_at && fin_at && gen_at < fin_at,
+   'the exclusions generator runs BEFORE the finalizer that reads its output')
 ok(!migrate_src.include?("'--score-out', File.join(OUT, 'parity-final.json')"),
    'bead 2tkm: verify-parity.rb --score-out no longer overwrites the gate contract file')
 ok(migrate_src.include?("'--score-out', File.join(OUT, 'parity-score.json')") ||

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-exclusions.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-exclusions.rb
@@ -1,0 +1,239 @@
+#!/usr/bin/env ruby
+# Contract tests for scripts/build-parity-exclusions.rb.
+#
+# WHY IT EXISTS: phase6-parity-domo.rb (bead 2tkm, PR #631) REFUSES to emit a
+# gate-1 contract unless every chartable element is either verified by the parity
+# plan or recorded in parity-plan-exclusions.json WITH A REASON — but nothing
+# wrote that file. This generates it.
+#
+# THE DESIGN CONSTRAINT THAT MATTERS: an exclusions generator is itself a
+# potential silent-inflation loophole — the failure mode the census exists to
+# stop. If it can exclude a tile on a heuristic, it can quietly shrink the parity
+# denominator and make a narrow run read as a full pass. So it derives exclusions
+# ONLY from MACHINE FACTS the converter already recorded in warnings.json, carries
+# the originating warning text through as evidence, and refuses to run away: if it
+# would exclude more than MAX_EXCLUSION_RATE of the pool it ABORTS and tells the
+# operator to fix the converter instead of excluding.
+#
+# Offline: no network, no creds.
+#   ruby test/test-parity-exclusions.rb
+require 'json'
+require 'tmpdir'
+require 'open3'
+
+GEN = File.expand_path('../scripts/build-parity-exclusions.rb', __dir__)
+
+$failures = 0
+def eq(a, b, m)
+  if a == b then puts "  ok: #{m}"
+  else $failures += 1; puts "  FAIL: #{m}\n    exp #{b.inspect}\n    got #{a.inspect}" end
+end
+def truthy(v, m)
+  if v then puts "  ok: #{m}"
+  else $failures += 1; puts "  FAIL: #{m}\n    got #{v.inspect}" end
+end
+def at(doc, *path) path.reduce(doc) { |d, k| d.is_a?(Hash) || d.is_a?(Array) ? d[k] : nil } end
+
+# A workbook spec whose tile ids follow the real convention el-<cardId>[-summary],
+# plus the non-chartable furniture the census predicate excludes.
+def spec_for(tiles)
+  els = tiles.map do |t|
+    { 'id' => t[:id], 'kind' => t[:kind] || 'kpi-chart', 'name' => t[:name],
+      'columns' => [{ 'id' => 'c1', 'name' => 'v' }] }
+  end
+  els << { 'id' => 'ctl-1', 'kind' => 'control-list-values', 'name' => 'Region',
+           'columns' => [{ 'id' => 'cc', 'name' => 'v' }] }
+  els << { 'id' => 'master-1', 'kind' => 'table', 'name' => 'Master (DS)',
+           'visibleAsSource' => false, 'columns' => [{ 'id' => 'mc', 'name' => 'v' }] }
+  { 'name' => 'WB', 'kind' => 'workbook', 'pages' => [{ 'elements' => els }] }
+end
+
+def run_gen(dir, *extra)
+  out, err, st = Open3.capture3('ruby', GEN, '--workdir', dir, *extra)
+  p = File.join(dir, 'parity-plan-exclusions.json')
+  { stdout: out, stderr: err, exit: st.exitstatus,
+    doc: (File.exist?(p) ? JSON.parse(File.read(p)) : nil) }
+end
+
+def setup(dir, tiles, warnings)
+  File.write(File.join(dir, 'workbook-spec.json'), JSON.pretty_generate(spec_for(tiles)))
+  File.write(File.join(dir, 'warnings.json'), JSON.pretty_generate(warnings))
+  dir
+end
+
+DATEWIN_WARN = 'date window NOT applied (type=INTERVAL_OFFSET interval=WEEK offset=1 count=0): ' \
+               'only ROLLING_PERIOD has an established Sigma mapping here.'
+
+# --- A. derive an exclusion from a recorded refusal -------------------------
+
+puts '== A. a refused date window excludes that card\'s tiles, with the warning as evidence =='
+Dir.mktmpdir do |dir|
+  setup(dir,
+        [{ id: 'el-983053598', name: 'Survey Completion Rate' },
+         { id: 'el-983053598-summary', name: 'Survey Completion Rate (Summary)' },
+         { id: 'el-111', name: 'Clean Tile' }],
+        [{ 'card' => 'Survey Completion Rate', 'card_id' => '983053598', 'warning' => DATEWIN_WARN }])
+  r = run_gen(dir)
+  eq(r[:exit], 0, 'generator exits 0')
+  excl = Array(at(r[:doc], 'exclusions'))
+  eq(excl.size, 2, 'BOTH the base tile and its -summary companion are excluded')
+  names = excl.map { |e| e['chart'] }.sort
+  eq(names, ['Survey Completion Rate', 'Survey Completion Rate (Summary)'],
+     'excluded by tile NAME (the key phase6-parity-domo.rb matches on)')
+  truthy(excl.all? { |e| !e['reason'].to_s.strip.empty? },
+         'every exclusion carries a non-empty reason (the finalizer rejects reasonless ones)')
+  truthy(excl.any? { |e| e['reason'].include?('INTERVAL_OFFSET') },
+         'the reason quotes the originating warning, not a generic string')
+  truthy(excl.all? { |e| at(e, 'evidence', 'warning') },
+         'the raw warning rides along as evidence so the exclusion is auditable')
+  truthy(excl.none? { |e| e['chart'] == 'Clean Tile' },
+         'a tile with no disqualifying warning is NOT excluded')
+end
+
+puts '== A2. the output is exactly the shape phase6-parity-domo.rb consumes =='
+Dir.mktmpdir do |dir|
+  setup(dir, [{ id: 'el-1', name: 'T1' }],
+        [{ 'card' => 'T1', 'card_id' => '1', 'warning' => DATEWIN_WARN }])
+  r = run_gen(dir)
+  truthy(at(r[:doc], 'exclusions').is_a?(Array), "top level carries an 'exclusions' array")
+  e = Array(at(r[:doc], 'exclusions')).first
+  truthy(e.key?('chart') && e.key?('reason'), 'each entry has chart + reason')
+end
+
+# --- B. never exclude on anything but a recorded machine fact ---------------
+
+puts '== B. an unrelated warning excludes nothing =='
+Dir.mktmpdir do |dir|
+  setup(dir, [{ id: 'el-1', name: 'T1' }],
+        [{ 'card' => 'T1', 'card_id' => '1',
+           'warning' => 'no grid geometry for page — layout will fall back to a single-column stack' }])
+  r = run_gen(dir)
+  eq(Array(at(r[:doc], 'exclusions')).size, 0,
+     'a layout/cosmetic warning is NOT grounds for dropping a tile from parity')
+end
+
+puts '== B2. no warnings at all -> an EMPTY exclusions file, not a missing one =='
+Dir.mktmpdir do |dir|
+  setup(dir, [{ id: 'el-1', name: 'T1' }], [])
+  r = run_gen(dir)
+  eq(r[:exit], 0, 'still exits 0')
+  truthy(!r[:doc].nil?, 'the file is written even when empty')
+  eq(Array(at(r[:doc], 'exclusions')).size, 0, 'with zero exclusions')
+end
+
+# --- C. the runaway guard --------------------------------------------------
+# An exclusions generator that can exclude the whole pool IS the silent-inflation
+# bug wearing a different hat.
+
+puts '== C. excluding most of the pool ABORTS rather than shrinking the denominator =='
+Dir.mktmpdir do |dir|
+  tiles = (1..10).map { |i| { id: "el-#{i}", name: "T#{i}" } }
+  warns = (1..8).map { |i| { 'card' => "T#{i}", 'card_id' => i.to_s, 'warning' => DATEWIN_WARN } }
+  setup(dir, tiles, warns)
+  r = run_gen(dir)
+  truthy(r[:exit] != 0, "8 of 10 tiles excludable -> non-zero exit (got #{r[:exit]})")
+  combined = r[:stdout] + r[:stderr]
+  truthy(combined.downcase.include?('fix the converter') || combined.downcase.include?('too many'),
+         'the abort tells the operator to fix the converter, not to widen the exclusions')
+  truthy(!(r[:doc] && Array(r[:doc]['exclusions']).size >= 8),
+         'and no runaway exclusions file is left behind for the finalizer to consume')
+end
+
+puts '== C2. the guard can be overridden only by an explicit, named decision =='
+Dir.mktmpdir do |dir|
+  tiles = (1..10).map { |i| { id: "el-#{i}", name: "T#{i}" } }
+  warns = (1..8).map { |i| { 'card' => "T#{i}", 'card_id' => i.to_s, 'warning' => DATEWIN_WARN } }
+  setup(dir, tiles, warns)
+  r = run_gen(dir, '--accept-exclusion-rate', 'converter fix deferred to the next pass; named in the report')
+  eq(r[:exit], 0, 'an explicitly named override is accepted')
+  eq(at(r[:doc], 'rate_waiver'), 'converter fix deferred to the next pass; named in the report',
+     'and the reason is recorded in the artifact')
+end
+
+# --- D. census arithmetic is reported, so plan+exclusions can be checked ----
+
+puts '== D. the generator reports the census arithmetic it is feeding =='
+Dir.mktmpdir do |dir|
+  setup(dir,
+        [{ id: 'el-1', name: 'T1' }, { id: 'el-2', name: 'T2' }, { id: 'el-3', name: 'T3' }],
+        [{ 'card' => 'T1', 'card_id' => '1', 'warning' => DATEWIN_WARN }])
+  r = run_gen(dir)
+  eq(at(r[:doc], 'chartable_total'), 3, 'records the true denominator')
+  eq(at(r[:doc], 'excluded_total'), 1, 'records how many it excluded')
+  truthy((r[:stdout] + r[:stderr]).include?('3'), 'and states the arithmetic on stdout/stderr')
+end
+
+# --- E. warnings without a joinable card_id must not silently no-op ---------
+
+puts '== E. a warning with no card_id is reported, never silently ignored =='
+Dir.mktmpdir do |dir|
+  setup(dir, [{ id: 'el-1', name: 'T1' }],
+        [{ 'card' => 'T1', 'warning' => DATEWIN_WARN }])  # no card_id
+  r = run_gen(dir)
+  combined = r[:stdout] + r[:stderr]
+  truthy(combined.downcase.include?('card_id'),
+         'the un-joinable disqualifying warning is surfaced, not dropped on the floor')
+end
+
+
+# --- F. INTEGRATION: the generator's output actually satisfies the census ----
+# The whole point. Two independently-written scripts have to agree on the
+# exclusions contract: build-parity-exclusions.rb writes {chart, reason} entries,
+# and phase6-parity-domo.rb's census must accept them and balance
+# plan + exclusions == chartable. A test on either script alone would not catch a
+# key-name or matching mismatch between them.
+
+puts '== F. generator output + a partial plan makes the FINALIZER census balance =='
+FINALIZER = File.expand_path('../scripts/phase6-parity-domo.rb', __dir__)
+Dir.mktmpdir do |dir|
+  # 3 chartable tiles; the card behind T1 had its date window refused.
+  setup(dir,
+        [{ id: 'el-1', name: 'T1' }, { id: 'el-2', name: 'T2' }, { id: 'el-3', name: 'T3' }],
+        [{ 'card' => 'T1', 'card_id' => '1', 'warning' => DATEWIN_WARN }])
+  g = run_gen(dir)
+  eq(g[:exit], 0, 'setup: generator wrote the exclusions')
+  eq(at(g[:doc], 'excluded_total'), 1, 'setup: exactly T1 is excluded')
+
+  # A plan covering ONLY the two scoreable tiles — the census must accept that,
+  # because the third is accounted for by the generated exclusions file.
+  plan = { 'charts' => %w[T2 T3].map { |n|
+    { 'chart' => n, 'expected' => [['east', 100]], 'actual' => { 'rows' => [['east', 100]] } } } }
+  File.write(File.join(dir, 'parity-plan.json'), JSON.pretty_generate(plan))
+
+  out, err, st = Open3.capture3('ruby', FINALIZER, '--workdir', dir,
+                                '--plan', File.join(dir, 'parity-plan.json'),
+                                '--workbook-id', 'wb-test')
+  combined = out + err
+  eq(st.exitstatus, 0, "finalizer accepts the generated exclusions (got #{st.exitstatus}: #{combined[0, 200]})")
+  final = JSON.parse(File.read(File.join(dir, 'parity-final.json'))) rescue nil
+  eq(at(final, 'status'), 'PASS', 'and derives a PASS contract')
+  eq(at(final, 'charts_total'), 2, 'charts_total is the VERIFIED pool, not the full 3')
+  eq(at(final, 'parity_tile_census', 'chartable_total'), 3, 'census still records the true denominator')
+  eq(at(final, 'parity_tile_census', 'excluded_total'), 1, 'census counts the generated exclusion')
+  eq(Array(at(final, 'parity_tile_census', 'unaccounted')).size, 0,
+     'census BALANCES: plan + generated exclusions == chartable')
+  truthy(Array(at(final, 'excluded_with_reason')).any? { |e| e['chart'] == 'T1' },
+         'the generated exclusion rides into the contract, so the report cannot omit it')
+end
+
+puts '== F2. dropping a tile the generator did NOT excuse still FAILS the census =='
+# Proves F is not vacuous: the census is still strict about un-excused omissions.
+Dir.mktmpdir do |dir|
+  setup(dir,
+        [{ id: 'el-1', name: 'T1' }, { id: 'el-2', name: 'T2' }, { id: 'el-3', name: 'T3' }],
+        [{ 'card' => 'T1', 'card_id' => '1', 'warning' => DATEWIN_WARN }])
+  run_gen(dir)
+  # T3 is silently dropped from the plan and has NO exclusion entry.
+  plan = { 'charts' => [{ 'chart' => 'T2', 'expected' => [['east', 100]],
+                          'actual' => { 'rows' => [['east', 100]] } }] }
+  File.write(File.join(dir, 'parity-plan.json'), JSON.pretty_generate(plan))
+  out, err, st = Open3.capture3('ruby', FINALIZER, '--workdir', dir,
+                                '--plan', File.join(dir, 'parity-plan.json'),
+                                '--workbook-id', 'wb-test')
+  truthy(st.exitstatus != 0, "an un-excused omission still fails (got #{st.exitstatus})")
+  truthy((out + err).include?('T3'), 'and names the unaccounted tile')
+end
+
+puts
+if $failures.zero? then puts 'ALL PASS'; exit 0
+else puts "#{$failures} FAILURE(S)"; exit 1 end


### PR DESCRIPTION
[#631](https://github.com/twells89/sigma-migration-skills/pull/631) shipped a census in `phase6-parity-domo.rb` that **refuses** to emit a gate-1 contract unless every chartable element is either verified by the parity plan or recorded in `parity-plan-exclusions.json` **with a reason**. Nothing wrote that file. This writes it, and wires it into `migrate-domo.rb` ahead of the finalizer that consumes it.

## The constraint that shaped the design

An exclusions generator is itself a potential silent-inflation loophole — the exact failure mode the census exists to stop. Excluding a tile removes it from the parity denominator, so a generous generator turns "45 of 65 verified" into a clean-looking **"100% (45/45)"**. Three rules:

1. **Machine facts only.** Exclusions derive solely from what the converter already recorded in `warnings.json`. No heuristics, no chart-kind guesses.
2. **Auditable.** The originating warning text rides along as `evidence`, so every exclusion traces back to the converter output that justified it.
3. **Runaway guard.** Above 40% of a non-trivial pool (≥5 tiles — a rate on 3 tiles is meaningless) it **aborts** and tells the operator to fix the converter rather than widen the exclusions. Override requires an explicitly named `--accept-exclusion-rate REASON`, recorded as `rate_waiver`.

## What disqualifies a tile — exactly one class today

**A refused date window.** When `apply_card_date_window!` (#639) declines to translate a card's window (`INTERVAL_OFFSET`, non-zero offset, unmapped interval), Domo aggregates over a window while the Sigma tile aggregates over all history. The two cannot agree *by construction*, so scoring the tile yields a guaranteed failure that says nothing about conversion quality.

A layout, geometry, series-assignment or sub-master routing warning is explicitly **not** grounds for exclusion — those are fidelity concerns whose *values* should still agree, and excluding them would hide real divergence. Group B pins that.

## Also: `warnings.json` is now joinable

`warn_card` records `card_id` (additive — existing consumers read `card`/`warning`). It was keyed by human **title**, which isn't joinable to workbook-spec tile ids (`el-<cardId>[-summary]`) and would be ambiguous the moment two cards share a title. A disqualifying warning that still can't be joined is **reported**, never silently ignored (group E).

## Test plan

- [x] `test/test-parity-exclusions.rb` — 31 assertions. The load-bearing ones are the **integration pair (group F)**: the generator's output must actually satisfy the finalizer's census — two independently-written scripts agreeing on a contract that a test of either alone would not catch.
  - **F**: `plan + generated exclusions == chartable`, and a `PASS` contract
  - **F2**: proves F isn't vacuous — drop an **un-excused** tile and the census still fails (exit 5) and names it
- [x] Static wiring guard in `test-migrate-domo.rb`: the generator runs, **and runs before** the finalizer (reversed, the census would read a stale/absent file)
- [x] Full offline suite: 25 files, **ALL SUITES PASS**; hygiene clean; domo 0.14.4 → 0.14.5
- [x] **Real corpus**, against the cold run's own 65-element `workbook-spec.json`: 65 chartable tiles, **2 excluded (3.1%)**, both from card `2071758146` (base tile + its `-summary` companion), each carrying the real warning text as evidence. All 39 warnings now carry `card_id`.

**Scope limit:** that offline replay routes only the master's own dataset, so only 2 of the ~5 `INTERVAL_OFFSET` cards were processed. A full live run should produce roughly 10 exclusions of 65 (~15%) — still well under the guard, but that number is **projected, not measured**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
