### PR TITLE
docs: agent entry contract, maturity index, and docs taxonomy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — sigma-migration-skills
 
 Migration skills for moving BI tools (**Tableau, Power BI, Qlik, ThoughtSpot,
-QuickSight, Looker, Cognos, MicroStrategy**) to
+QuickSight, Looker, Cognos, MicroStrategy, Sisense, GoodData, Domo, Hex**) to
 **Sigma**: per-tool *converters* (source → Sigma data model + workbook, with
 warehouse parity verification) and read-only *assessments* (tenant inventory →
 migration-readiness readout + shortlist).
@@ -11,44 +11,57 @@ agent-neutral: each is a `SKILL.md` (instructions) plus `scripts/` (Ruby/Python/
 shell) and `refs/`. Any coding agent (Cursor, Cortex Code, etc.) can run them by
 reading the relevant `SKILL.md` and executing its scripts.
 
+**First-time / non-Claude agents:** read [`docs/agent-entry.md`](docs/agent-entry.md)
+for install shapes, companion `sigma-authoring`, path rules, and MCP stance.
+
 ## How to use a skill
 
 1. Pick the skill from the index below that matches the user's intent.
+   Prefer `gold` / `live` over `foundation` / `scaffold` unless the user is
+   explicitly building out a scaffold.
 2. **Read that skill's `SKILL.md` in full first** — it is the source of truth for
    the phased workflow. The `refs/*.md` next to it cover details.
 3. Run its scripts **from the skill directory** (script paths are relative, e.g.
    `scripts/setup.rb`). `cd` into the skill dir, then invoke.
+4. Install / load the companion **`sigma-authoring`** plugin alongside any
+   converter (`sigma-workbooks` + `sigma-data-models`).
+
+Maturity labels (`gold` / `live` / `foundation` / `scaffold`) are defined in
+[`docs/agent-entry.md`](docs/agent-entry.md).
 
 ## Skill index
 
-| Intent | Skill | Path (read its `SKILL.md`) |
-|---|---|---|
-| Convert a Tableau datasource/workbook → Sigma | `tableau-to-sigma` | `plugins/tableau-to-sigma/skills/tableau-to-sigma/` |
-| Scope/assess a Tableau site for migration | `tableau-assessment` | `plugins/tableau-to-sigma/skills/tableau-assessment/` |
-| Convert a Power BI report + semantic model → Sigma (DAX translation) | `powerbi-to-sigma` | `plugins/powerbi-to-sigma/skills/powerbi-to-sigma/` |
-| Scope/assess a Power BI / Fabric tenant | `powerbi-assessment` | `plugins/powerbi-to-sigma/skills/powerbi-assessment/` |
-| Convert a Qlik Sense / Qlik Cloud app → Sigma | `qlik-to-sigma` | `plugins/qlik-to-sigma/skills/qlik-to-sigma/` |
-| Scope/assess a Qlik Cloud tenant | `qlik-assessment` | `plugins/qlik-to-sigma/skills/qlik-assessment/` |
-| Convert a ThoughtSpot model + Liveboards → Sigma (TML) | `thoughtspot-to-sigma` | `plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/` |
-| Scope/assess a ThoughtSpot instance | `thoughtspot-assessment` | `plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/` |
-| Convert an Amazon QuickSight analysis/dashboard → Sigma | `quicksight-to-sigma` | `plugins/quicksight-to-sigma/skills/quicksight-to-sigma/` |
-| Scope/assess a QuickSight instance | `quicksight-assessment` | `plugins/quicksight-to-sigma/skills/quicksight-assessment/` |
-| Convert a Looker (LookML model + dashboards) → Sigma | `looker-to-sigma` | `plugins/looker-to-sigma/skills/looker-to-sigma/` |
-| Scope/assess a Looker instance | `looker-assessment` | `plugins/looker-to-sigma/skills/looker-assessment/` |
-| Convert an IBM Cognos data module + report → Sigma | `cognos-to-sigma` | `plugins/cognos-to-sigma/skills/cognos-to-sigma/` |
-| Scope/assess a Cognos Analytics instance | `cognos-assessment` | `plugins/cognos-to-sigma/skills/cognos-assessment/` |
-| Convert a MicroStrategy dossier + semantic model → Sigma | `microstrategy-to-sigma` | `plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/` |
-| Scope/assess a MicroStrategy (Strategy One) instance | `microstrategy-assessment` | `plugins/microstrategy-to-sigma/skills/microstrategy-assessment/` |
-| Convert a Sisense (ElastiCube / Live model + dashboards) → Sigma | `sisense-to-sigma` | `plugins/sisense-to-sigma/skills/sisense-to-sigma/` |
-| Scope/assess a Sisense instance | `sisense-assessment` | `plugins/sisense-to-sigma/skills/sisense-assessment/` |
-| Convert a GoodData Cloud / .CN workspace (LDM + MAQL + insights + dashboards) → Sigma | `gooddata-to-sigma` | `plugins/gooddata-to-sigma/skills/gooddata-to-sigma/` |
-| Scope/assess a GoodData workspace | `gooddata-assessment` | `plugins/gooddata-to-sigma/skills/gooddata-assessment/` |
-| Convert a Domo dashboard (DataSets + Beast Modes + cards) → Sigma | `domo-to-sigma` | `plugins/domo-to-sigma/skills/domo-to-sigma/` |
-| Scope/assess a Domo instance | `domo-assessment` | `plugins/domo-to-sigma/skills/domo-assessment/` |
-| Convert a Hex project (SQL/METRIC cells, EXPLORE charts, app layout) → Sigma | `hex-to-sigma` | `plugins/hex-to-sigma/skills/hex-to-sigma/` |
-| Scope/assess a Hex instance (scaffolded, not yet built out) | `hex-assessment` | `plugins/hex-to-sigma/skills/hex-assessment/` |
-| Land a Tableau published-datasource/extract in Snowflake or Databricks | `tableau-vds-to-cdw` | `plugins/tableau-to-sigma/skills/tableau-vds-to-cdw/` |
-| Land an Import-mode Power BI model's data in Snowflake (before converting) | `powerbi-import-to-snowflake` | `plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/` |
+| Intent | Skill | Maturity | Path (read its `SKILL.md`) |
+|---|---|---|---|
+| Convert a Tableau datasource/workbook → Sigma | `tableau-to-sigma` | gold | `plugins/tableau-to-sigma/skills/tableau-to-sigma/` |
+| Scope/assess a Tableau site for migration | `tableau-assessment` | live | `plugins/tableau-to-sigma/skills/tableau-assessment/` |
+| Land a Tableau published-datasource/extract in Snowflake or Databricks | `tableau-vds-to-cdw` | live | `plugins/tableau-to-sigma/skills/tableau-vds-to-cdw/` |
+| Convert a Power BI report + semantic model → Sigma (DAX translation) | `powerbi-to-sigma` | live | `plugins/powerbi-to-sigma/skills/powerbi-to-sigma/` |
+| Scope/assess a Power BI / Fabric tenant | `powerbi-assessment` | live | `plugins/powerbi-to-sigma/skills/powerbi-assessment/` |
+| Land an Import-mode Power BI model's data in Snowflake (before converting) | `powerbi-import-to-snowflake` | live | `plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/` |
+| Convert a Qlik Sense / Qlik Cloud app → Sigma | `qlik-to-sigma` | live | `plugins/qlik-to-sigma/skills/qlik-to-sigma/` |
+| Scope/assess a Qlik Cloud tenant | `qlik-assessment` | foundation | `plugins/qlik-to-sigma/skills/qlik-assessment/` |
+| Convert a ThoughtSpot model + Liveboards → Sigma (TML) | `thoughtspot-to-sigma` | live | `plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/` |
+| Scope/assess a ThoughtSpot instance | `thoughtspot-assessment` | foundation | `plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/` |
+| Convert an Amazon QuickSight analysis/dashboard → Sigma | `quicksight-to-sigma` | foundation | `plugins/quicksight-to-sigma/skills/quicksight-to-sigma/` |
+| Scope/assess a QuickSight instance | `quicksight-assessment` | foundation | `plugins/quicksight-to-sigma/skills/quicksight-assessment/` |
+| Convert a Looker (LookML model + dashboards) → Sigma | `looker-to-sigma` | live | `plugins/looker-to-sigma/skills/looker-to-sigma/` |
+| Scope/assess a Looker instance | `looker-assessment` | live | `plugins/looker-to-sigma/skills/looker-assessment/` |
+| Convert an IBM Cognos data module + report → Sigma | `cognos-to-sigma` | live | `plugins/cognos-to-sigma/skills/cognos-to-sigma/` |
+| Scope/assess a Cognos Analytics instance | `cognos-assessment` | foundation | `plugins/cognos-to-sigma/skills/cognos-assessment/` |
+| Convert a MicroStrategy dossier + semantic model → Sigma | `microstrategy-to-sigma` | live | `plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/` |
+| Scope/assess a MicroStrategy (Strategy One) instance | `microstrategy-assessment` | foundation | `plugins/microstrategy-to-sigma/skills/microstrategy-assessment/` |
+| Convert a Sisense (ElastiCube / Live model + dashboards) → Sigma | `sisense-to-sigma` | live | `plugins/sisense-to-sigma/skills/sisense-to-sigma/` |
+| Scope/assess a Sisense instance | `sisense-assessment` | scaffold | `plugins/sisense-to-sigma/skills/sisense-assessment/` |
+| Convert a GoodData Cloud / .CN workspace (LDM + MAQL + insights + dashboards) → Sigma | `gooddata-to-sigma` | live | `plugins/gooddata-to-sigma/skills/gooddata-to-sigma/` |
+| Scope/assess a GoodData workspace | `gooddata-assessment` | live | `plugins/gooddata-to-sigma/skills/gooddata-assessment/` |
+| Convert a Domo dashboard (DataSets + Beast Modes + cards) → Sigma | `domo-to-sigma` | live | `plugins/domo-to-sigma/skills/domo-to-sigma/` |
+| Scope/assess a Domo instance | `domo-assessment` | foundation | `plugins/domo-to-sigma/skills/domo-assessment/` |
+| Land Domo API/upload/sample DataSets in Snowflake (before converting) | `domo-import-to-snowflake` | foundation | `plugins/domo-to-sigma/skills/domo-import-to-snowflake/` |
+| Convert a Hex project (SQL/METRIC cells, EXPLORE charts, app layout) → Sigma | `hex-to-sigma` | live | `plugins/hex-to-sigma/skills/hex-to-sigma/` |
+| Scope/assess a Hex instance | `hex-assessment` | scaffold | `plugins/hex-to-sigma/skills/hex-assessment/` |
+| Author / repair Sigma workbooks (canonical spec) | `sigma-workbooks` | live | `plugins/sigma-authoring/skills/sigma-workbooks/` |
+| Author / repair Sigma data models (canonical spec) | `sigma-data-models` | live | `plugins/sigma-authoring/skills/sigma-data-models/` |
 
 Assessments are read-only (never write to the source or post to Sigma); run one
 to pick what to convert, then hand off to the matching converter.
@@ -72,6 +85,9 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md). Enforced by CI:
 - **New skills:** `ruby tools/new-skill.rb <tool> "<Display Name>"`.
 - **Parallel sessions:** claim work in beads at plugin granularity; one PR = one
   plugin; shared-lib changes are their own PR.
+- **Docs taxonomy:** durable contracts vs session residue —
+  [`docs/README.md`](docs/README.md). Structure follow-ups:
+  [`docs/structure-roadmap.md`](docs/structure-roadmap.md).
 
 ## Corpus (regression fixtures)
 
@@ -115,13 +131,15 @@ ThoughtSpot) have their own auth — see each skill's `SKILL.md` / `QUICKSTART.m
 
 ## Optional MCP servers
 
-The skills use the Sigma REST API directly (via the scripts above), so MCP is not
-required. Where available, these enhance discovery/verification:
+The **core migration pipeline uses the Sigma REST API** (via the scripts above).
+MCP is **not required** to run a converter. Where available, these enhance
+discovery/verification — see [`docs/agent-entry.md`](docs/agent-entry.md) §MCP:
 
-- **Sigma MCP** — query built workbooks to verify parity.
+- **Sigma MCP** — query built workbooks during parity (recommended when present).
 - **Tableau MCP** — view/datasource discovery without PAT setup.
-- **sigma-data-model converter** (MCP) — used by the Power BI / Qlik converters
-  for source-formula → Sigma-formula translation.
+- **sigma-data-model converter** (MCP) — optional hosted fallback for
+  source-formula → Sigma-formula translation; skills bundle a local converter
+  by default.
 
 Configure them in your agent's MCP config; the skills fall back to REST/CLI when
 they're absent.
@@ -133,3 +151,5 @@ they're absent.
 - **Scripts are relative to the skill dir** — `cd` there first.
 - **Tokens expire (~1h)** — re-mint on a 401; never cache across long runs except
   via the Ruby libs, which auto-refresh.
+- **No legacy `sigma-skills/` paths** — use the companion `sigma-authoring`
+  skills in this repo (see [`docs/agent-entry.md`](docs/agent-entry.md)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ phase-number mapping. **Never renumber a skill's phases** — scripts, gates, an
 memory notes reference the local numbers. When you add a converter, add its
 column to that table.
 
+Agent load rules (Claude marketplace vs full clone), maturity labels, and MCP
+stance: [`docs/agent-entry.md`](docs/agent-entry.md). Docs taxonomy (durable vs
+session residue) and the structure follow-up backlog:
+[`docs/README.md`](docs/README.md), [`docs/structure-roadmap.md`](docs/structure-roadmap.md).
+Update the maturity column in [`AGENTS.md`](AGENTS.md) when a skill graduates.
+
 Mandatory gates (CI lints each converter SKILL.md for them — `tools/lint-skills.rb`):
 
 - **C3 Reuse-check** — score existing Sigma DMs before creating one (`find-or-pick-dm.rb`).

--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ shared `~/.sigma-migration/env` under any agent.
 ```
 
 **Other agents (Cursor, Cortex Code, …)** — clone the repo and point your agent at the
-skill folders; [`AGENTS.md`](AGENTS.md) maps each task to its skill. For example, Cortex Code:
+skill folders; [`AGENTS.md`](AGENTS.md) maps each task to its skill (with maturity labels).
+Full load rules (companion `sigma-authoring`, path rules, MCP stance):
+[`docs/agent-entry.md`](docs/agent-entry.md). For example, Cortex Code:
 
 ```bash
 git clone https://github.com/twells89/sigma-migration-skills
 cortex skill add sigma-migration-skills/plugins/tableau-to-sigma/skills/tableau-to-sigma
+cortex skill add sigma-migration-skills/plugins/sigma-authoring/skills/sigma-workbooks
 ```
 
-**Connect the Sigma MCP server (required).** These skills drive your Sigma org through the
-**Sigma MCP server** — connect it in your coding agent following Sigma's official guide:
-**[Use the Sigma MCP server](https://help.sigmacomputing.com/docs/use-sigma-mcp-server)**.
-It's how the agent reads/queries Sigma (e.g. the parity gate) and builds + validates the
-migrated data model and workbook. Install it alongside the plugins, before running a migration.
+**Sigma access:** converters drive your org through the **Sigma REST API** (client id/secret -> bearer token via `scripts/get-token.sh`). The optional Sigma MCP server is recommended for interactive query/parity checks when your agent supports MCP; it is **not required** for the core migrate -> POST -> parity scripts. Setup details: [`docs/agent-entry.md`](docs/agent-entry.md).
+
 
 Then just describe what you want migrated — e.g. *"migrate this Power BI report to Sigma"* —
 and the skill drives discovery → translation → build → parity.
@@ -63,8 +63,9 @@ and the skill drives discovery → translation → build → parity.
 | [`microstrategy-to-sigma`](plugins/microstrategy-to-sigma/) | MicroStrategy (Strategy One) | `microstrategy-to-sigma`, `microstrategy-assessment` |
 | [`sisense-to-sigma`](plugins/sisense-to-sigma/) | Sisense (ElastiCube / Live) | `sisense-to-sigma`, `sisense-assessment` |
 | [`gooddata-to-sigma`](plugins/gooddata-to-sigma/) | GoodData Cloud / .CN | `gooddata-to-sigma`, `gooddata-assessment` |
-| [`domo-to-sigma`](plugins/domo-to-sigma/) | Domo | `domo-to-sigma` |
-| [`hex-to-sigma`](plugins/hex-to-sigma/) | Hex | `hex-to-sigma` |
+| [`domo-to-sigma`](plugins/domo-to-sigma/) | Domo | `domo-to-sigma`, `domo-assessment`, `domo-import-to-snowflake` |
+| [`hex-to-sigma`](plugins/hex-to-sigma/) | Hex | `hex-to-sigma`, `hex-assessment` (scaffold) |
+| [`sigma-authoring`](plugins/sigma-authoring/) | (companion) | `sigma-workbooks`, `sigma-data-models`, … — install alongside every converter |
 
 In Claude Code, installed skills are namespaced — e.g. `/powerbi-to-sigma:powerbi-assessment`.
 
@@ -116,9 +117,10 @@ corpus/run-corpus.sh --check      # no creds needed; CI-safe
 ## Requirements
 
 - **A coding agent that runs skills** (Claude Code, Cursor, Cortex Code, …).
-- The **[Sigma MCP server](https://help.sigmacomputing.com/docs/use-sigma-mcp-server)** connected in your agent — how the agent reads/queries your Sigma org and builds + validates the migrated data model and workbook. Follow Sigma's setup guide.
-- **No converter to install** — each skill bundles its data-model converter (`convert_*_to_sigma`) and runs it **locally by default** (no network, no data egress). A [hosted converter MCP](https://github.com/twells89/sigma-data-model-mcp) is available as an **optional, opt-in fallback** that sends the source spec off-machine.
-- A **Sigma API token** and a Sigma **connection** pointing at the same warehouse as the source content (needed for the parity gate).
+- **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET` / `SIGMA_BASE_URL`) and a Sigma **connection** pointing at the same warehouse as the source content (needed for the parity gate). See [`AGENTS.md`](AGENTS.md) §Credentials.
+- **`sigma-authoring` installed alongside** any converter (canonical workbook/DM spec).
+- **No converter binary to install** — each skill bundles its data-model converter (`convert_*_to_sigma`) and runs it **locally by default** (no network, no data egress). A [hosted converter MCP](https://github.com/twells89/sigma-data-model-mcp) is available as an **optional, opt-in fallback** that sends the source spec off-machine.
+- **Optional:** Sigma MCP for interactive read/query during parity — not required for the REST pipeline ([`docs/agent-entry.md`](docs/agent-entry.md)).
 - Per-tool source access — see each plugin's `refs/connection.md` (e.g. `qlik-cli` for Qlik; device-code / Fabric `getDefinition` for Power BI).
 
 ## Provenance

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Docs index
+
+What belongs under `docs/` and what agents should preload.
+
+## Durable (agent-facing contracts)
+
+Read these when the task needs the cross-skill contract — not by default on
+every run.
+
+| Doc | When to read |
+|---|---|
+| [`agent-entry.md`](agent-entry.md) | First time running skills from a non-Claude agent, or clarifying MCP / path / companion-plugin rules |
+| [`phase-schema.md`](phase-schema.md) | Mapping a skill's local phase numbers to the canonical C1–C10 arc |
+| [`migration-runtime-contract.md`](migration-runtime-contract.md) | Intake / connection / completion seams shared across converters |
+| [`structure-roadmap.md`](structure-roadmap.md) | Ordered follow-up PRs for repo-structure work |
+| [`chart-fidelity-rubric.md`](chart-fidelity-rubric.md) | Visual/chart fidelity bar during parity |
+| [`warehouse-transforms.md`](warehouse-transforms.md) | Warehouse transform expectations |
+
+Skill-specific operating detail lives next to the skill (`SKILL.md`, `refs/`),
+not here.
+
+## Workshop / session residue (not agent preload)
+
+These are plans, handoffs, and spike notes. Useful for humans reconstructing
+history; **agents should not preload them** unless the user points at a
+specific file.
+
+| Path | Contents |
+|---|---|
+| [`handoff/`](handoff/) | Dated session handoffs |
+| [`superpowers/plans/`](superpowers/plans/), [`superpowers/specs/`](superpowers/specs/) | Implementation plans and design specs |
+| [`wave2/`](wave2/) | One-off patches / wave notes |
+| `PLAN-*.md`, `*-HANDOFF.md`, `*-plan.md` at this level | Same class — keep for history; prefer durable docs above for contracts |
+| Root `V5.*-*.md` | Version-scoped audits/handoffs; same rule |
+
+When a plan graduates into a lasting rule, fold the rule into a durable doc or
+into the relevant `SKILL.md` / `refs/`, then leave the plan as archive.

--- a/docs/agent-entry.md
+++ b/docs/agent-entry.md
@@ -1,0 +1,84 @@
+# Agent entry contract
+
+How any coding agent (Claude Code, Cursor, Cortex Code, Codex, …) should load
+and run skills from this repo. Skills are agent-neutral; packaging differs.
+
+## Two install shapes
+
+| Shape | Who | What you have on disk |
+|---|---|---|
+| **Claude Code marketplace plugin** | `/plugin install <name>@sigma-migration-skills` | One plugin tree under the agent's plugin root (self-contained `skills/`) |
+| **Full repo clone** | Cursor, Cortex, Codex, plain checkout | Whole monorepo; point the agent at skill folders via [`AGENTS.md`](../AGENTS.md) |
+
+Both shapes share the same unit of work: a skill directory containing
+`SKILL.md` + `scripts/` + `refs/`.
+
+## Load sequence (every agent)
+
+1. **Pick the skill** from the [`AGENTS.md`](../AGENTS.md) index (intent → path).
+   Prefer a skill whose maturity is `live` or `gold` unless the user explicitly
+   wants a scaffold.
+2. **Install / open the companion `sigma-authoring` plugin** alongside any
+   converter. Converters defer workbook/DM idioms to `sigma-workbooks` /
+   `sigma-data-models`; they are not self-sufficient for authoring edge cases.
+3. **Read that skill's `SKILL.md` in full** before running anything. Follow its
+   mandatory pre-read block (at most a few `refs/` files).
+4. **`cd` into the skill directory**, then run scripts with relative paths
+   (`scripts/…`). Do not invent absolute paths into other plugins.
+5. **Credentials** come from env vars (see `AGENTS.md` §Credentials). Prefer
+   `~/.sigma-migration/env`; Claude Code may also load `~/.claude/settings.json`.
+
+## Path rules (marketplace-safe)
+
+Skills must keep working when installed as a **single plugin** (no monorepo
+siblings on disk):
+
+- **Do** reference `scripts/` and `refs/` inside the current skill.
+- **Do** refer to companion skills by **skill name** (`sigma-workbooks`,
+  `sigma-data-models`) and, when a filesystem path is required in a full clone,
+  the stable monorepo path
+  `plugins/sigma-authoring/skills/<skill>/…` (from repo root).
+- **Do not** link with deep `../../../../docs/…` relatives from a `SKILL.md` —
+  those break under marketplace install. Point at repo docs by name
+  (`docs/phase-schema.md`) only as "when working from a full clone".
+- **Do not** reference the legacy sibling repo path `sigma-skills/…` or
+  `~/sigma-skills/…`. That tree is upstream of `sigma-authoring` only; runners
+  of *this* marketplace never need it.
+
+`tools/lint-skill-paths.rb` enforces the banned path patterns.
+
+## MCP stance
+
+| Server | Required? | Role |
+|---|---|---|
+| **None for the core pipeline** | — | Converters drive Sigma via REST (`scripts/get-token.sh`, `lib/sigma_rest.rb`, orchestrators). |
+| **Sigma MCP** | Optional, recommended | Read/query workbooks during parity and exploratory checks. |
+| **Source-tool MCP** (e.g. Tableau) | Optional | Discovery without PAT/CLI when available. |
+| **Hosted data-model converter MCP** | Optional, opt-in | Fallback for formula translation; each skill bundles a **local** converter by default (no data egress). |
+
+Do not block a run solely because an MCP server is missing if the skill
+documents a REST/CLI path.
+
+## Runtime bookends (target shape)
+
+Every converter should eventually expose the same seams (see
+[`migration-runtime-contract.md`](migration-runtime-contract.md)):
+
+1. bootstrap / doctor
+2. one orchestrator entrypoint
+3. hard completion gate (`assert-phase6` / `verify-complete`)
+4. telemetry on finalize
+
+Until a skill has all four, follow its local `SKILL.md` phases exactly — do not
+improvise a lighter path.
+
+## Maturity labels
+
+Defined for the [`AGENTS.md`](../AGENTS.md) index:
+
+| Label | Meaning |
+|---|---|
+| `gold` | Orchestrated end-to-end spine + hard completion gate; preferred default |
+| `live` | Live-validated against a real Sigma org (parity and/or assessment readout) |
+| `foundation` | End-to-end path exists; expect sharper edges / more agent judgment |
+| `scaffold` | Skeleton only — do not run for customer work unless explicitly building the skill |

--- a/docs/migration-runtime-contract.md
+++ b/docs/migration-runtime-contract.md
@@ -1,6 +1,6 @@
 # Migration Runtime Contract
 
-**Status:** proposed · **Owner:** tj@sigmacomputing.com · **Date:** 2026-06-26
+**Status:** proposed (rollout tracked in [`structure-roadmap.md`](structure-roadmap.md) §R1) · **Date:** 2026-06-26
 
 ## Problem
 

--- a/docs/structure-roadmap.md
+++ b/docs/structure-roadmap.md
@@ -6,10 +6,11 @@ skill's local phases.
 
 ## Landed / in flight
 
-| PR theme | Intent |
+| PR | Intent |
 |---|---|
-| Agent entry contract + maturity index | `docs/agent-entry.md`, `AGENTS.md` maturity, MCP stance, docs taxonomy |
-| Skill path hygiene | Ban `sigma-skills/` + marketplace-unsafe relatives; fix shared `layout-visual-qa` + converter SKILL refs; CI lint |
+| #650 | Agent entry contract + maturity index + docs taxonomy |
+| #651 | Skill path hygiene + `tools/lint-skill-paths.rb` |
+| #652 (stacked on #651) | `new-skill.rb` stamps marketplace / AGENTS / `plugin.json` |
 
 ## Next (highest ROI)
 
@@ -33,11 +34,7 @@ Drive `tools/skill-lint-baseline.json` toward empty: shrink each over-budget
 `SKILL.md` into phase-scoped `refs/` (tableau-to-sigma is the template). Order
 by baseline size: looker → powerbi → qlik → quicksight → thoughtspot → …
 
-### R3 — `new-skill.rb` registry stamp
-
-Scaffold should append `AGENTS.md` rows (with `scaffold` maturity), a
-`plugin.json`, and a marketplace stub — not only `phase-schema.md` — so indexes
-cannot drift on day one.
+### R3 — `new-skill.rb` registry stamp — **in #652**
 
 ### R4 — Companion dependency check
 

--- a/docs/structure-roadmap.md
+++ b/docs/structure-roadmap.md
@@ -1,0 +1,53 @@
+# Structure roadmap (follow-up PRs)
+
+Ordered backlog from the 2026-08 repo-structure review. Each item is meant to
+land as its **own PR** (or one-plugin PRs where noted). Do not renumber any
+skill's local phases.
+
+## Landed / in flight
+
+| PR theme | Intent |
+|---|---|
+| Agent entry contract + maturity index | `docs/agent-entry.md`, `AGENTS.md` maturity, MCP stance, docs taxonomy |
+| Skill path hygiene | Ban `sigma-skills/` + marketplace-unsafe relatives; fix shared `layout-visual-qa` + converter SKILL refs; CI lint |
+
+## Next (highest ROI)
+
+### R1 — Runtime bookends fanout (shared-lib + per-orchestrator)
+
+Promote [`migration-runtime-contract.md`](migration-runtime-contract.md) from
+proposed → active by landing its three rolls in order:
+
+1. **Completion gate** — wire telemetry + Gate 9 into every orchestrator
+   finalize; extend `assert-phase6-ran.rb` fanout to plugins that still lack it
+   (shared-lib PR, then thin per-plugin wiring PRs).
+2. **Intake + `resolve-connection` cache** — one connection resolution per run.
+3. **Raw-mode warehouse-verify** — file-only exports verify against warehouse.
+
+Template skill: `tableau-to-sigma` (`bootstrap` → `migrate-*.rb` →
+`verify-complete` / `assert-phase6`).
+
+### R2 — E9 context diet (one plugin per PR)
+
+Drive `tools/skill-lint-baseline.json` toward empty: shrink each over-budget
+`SKILL.md` into phase-scoped `refs/` (tableau-to-sigma is the template). Order
+by baseline size: looker → powerbi → qlik → quicksight → thoughtspot → …
+
+### R3 — `new-skill.rb` registry stamp
+
+Scaffold should append `AGENTS.md` rows (with `scaffold` maturity), a
+`plugin.json`, and a marketplace stub — not only `phase-schema.md` — so indexes
+cannot drift on day one.
+
+### R4 — Companion dependency check
+
+Add a small doctor/bootstrap probe: converter skills warn when
+`sigma-authoring` / `sigma-workbooks` is not loadable in the current agent
+install shape.
+
+## Explicit non-goals
+
+- Collapsing plugins into one mega-plugin
+- Stopping `shared/` → plugin vendoring (marketplace self-containment)
+- Renumbering existing local phases
+- Moving `scripts/` out of skill directories


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First PR in the repo-structure stack. Makes the multi-agent load path explicit without changing converter code.

- Add [`docs/agent-entry.md`](docs/agent-entry.md): marketplace vs full-clone install, companion `sigma-authoring`, marketplace-safe path rules, MCP stance (REST-first; MCP optional).
- Add maturity column to [`AGENTS.md`](AGENTS.md) (`gold` / `live` / `foundation` / `scaffold`); include bridges + `sigma-authoring` skills; add missing `domo-import-to-snowflake`.
- Align [`README.md`](README.md) with REST-first MCP stance; fix Domo/Hex/sigma-authoring skill listings.
- Add [`docs/README.md`](docs/README.md) (durable vs workshop residue) and [`docs/structure-roadmap.md`](docs/structure-roadmap.md) for ordered follow-ups.
- Point [`docs/migration-runtime-contract.md`](docs/migration-runtime-contract.md) at the roadmap for rollout tracking.

## Stack (merge in order)

1. **This PR (#650)** → `main`
2. [#651](https://github.com/twells89/sigma-migration-skills/pull/651) — path hygiene + lint
3. [#652](https://github.com/twells89/sigma-migration-skills/pull/652) — `new-skill.rb` registry stamp (stacked on #651)

Later (not opened yet): runtime bookends (R1), E9 diet per plugin (R2) — see `docs/structure-roadmap.md`.

## Test plan

- [ ] Skim `AGENTS.md` maturity labels for obvious mis-ratings
- [ ] Confirm README no longer says Sigma MCP is required
- [ ] Confirm `docs/agent-entry.md` + `docs/README.md` + `docs/structure-roadmap.md` cross-link cleanly
- [ ] No plugin code / versions touched (docs-only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c33481e-e22f-4f42-8356-3913f4862e4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c33481e-e22f-4f42-8356-3913f4862e4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

