### PR TITLE
chore(domo-to-sigma): re-vendor sql.mjs — ADDDATE + deep-If/Switch (beads zmnt, znvg)

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.14.11",
+  "version": "0.14.12",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/converter/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "0641a62",
-  "source_commit_date": "2026-08-05",
+  "source_commit": "21f3167",
+  "source_commit_date": "2026-08-07",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "sql.mjs",
   "source_file": "src/formulas.ts",

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/converter/sql.mjs
@@ -1,4 +1,4 @@
-// ../../../../sigma-data-model-mcp/.git-wt/main-vendor/build/sigma-ids.js
+// ../wt-mcp-adddate/build/sigma-ids.js
 var NS_MODULUS = 62 ** 4;
 var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
   "a",
@@ -58,7 +58,7 @@ Groupings (for LOD / different aggregation levels):
   Array order = nesting hierarchy. Use child elements for LOD patterns.
 `.trim();
 
-// ../../../../sigma-data-model-mcp/.git-wt/main-vendor/build/formulas.js
+// ../wt-mcp-adddate/build/formulas.js
 function decodeXmlEntities(s) {
   if (!s || s.indexOf("&") === -1)
     return s;
@@ -377,16 +377,22 @@ function _splitTopLevelArgs(s) {
         quote = "";
       continue;
     }
-    if (c === "'" || c === '"') {
-      quote = c;
+    if (c === "[") {
+      bracket = true;
       cur += c;
       continue;
     }
-    if (c === "[")
-      bracket = true;
-    else if (c === "]")
+    if (c === "]") {
       bracket = false;
+      cur += c;
+      continue;
+    }
     if (!bracket) {
+      if (c === "'" || c === '"') {
+        quote = c;
+        cur += c;
+        continue;
+      }
       if (c === "(")
         depth++;
       else if (c === ")")
@@ -439,6 +445,83 @@ function _rewriteMysqlDateDiff(expr) {
       out += `DateDiff("${unit}", ${start}, ${end})`;
     } else {
       out += `${rest.slice(m.index, open + 1)}${_rewriteMysqlDateDiff(inner)})`;
+    }
+    rest = rest.slice(close + 1);
+  }
+  return out;
+}
+var _MYSQL_ADD_SPEC = {
+  ADDDATE: { unit: "day", negate: false },
+  SUBDATE: { unit: "day", negate: true },
+  DATE_ADD: { unit: "day", negate: false },
+  DATE_SUB: { unit: "day", negate: true }
+};
+var _MYSQL_INTERVAL_UNIT = {
+  SECOND: "second",
+  MINUTE: "minute",
+  HOUR: "hour",
+  DAY: "day",
+  WEEK: "week",
+  MONTH: "month",
+  QUARTER: "quarter",
+  YEAR: "year"
+};
+function _negateAmount(amount) {
+  const t = amount.trim();
+  const num = t.match(/^([+-]?)(\d+(?:\.\d+)?)$/);
+  if (num)
+    return num[1] === "-" ? num[2] : `-${num[2]}`;
+  return `-(${t})`;
+}
+function _rewriteMysqlDateAdd(expr) {
+  const NAME = /\b(ADDDATE|SUBDATE|DATE_ADD|DATE_SUB)\s*\(/i;
+  let out = "", rest = expr;
+  for (; ; ) {
+    const m = NAME.exec(rest);
+    if (!m) {
+      out += rest;
+      break;
+    }
+    const open = m.index + m[0].length - 1;
+    let depth = 0, close = -1;
+    for (let i = open; i < rest.length; i++) {
+      if (rest[i] === "(")
+        depth++;
+      else if (rest[i] === ")") {
+        depth--;
+        if (depth === 0) {
+          close = i;
+          break;
+        }
+      }
+    }
+    if (close === -1) {
+      out += rest;
+      break;
+    }
+    const inner = rest.slice(open + 1, close);
+    const args = _splitTopLevelArgs(inner);
+    out += rest.slice(0, m.index);
+    const spec = _MYSQL_ADD_SPEC[m[1].toUpperCase()];
+    let unit = spec.unit;
+    let amount = null;
+    if (args.length === 2) {
+      const iv = args[1].trim().match(/^INTERVAL\s+(.+?)\s+([A-Za-z_]+)\s*$/i);
+      if (iv) {
+        const mapped = _MYSQL_INTERVAL_UNIT[iv[2].toUpperCase()];
+        if (mapped) {
+          unit = mapped;
+          amount = _rewriteMysqlDateAdd(iv[1]).trim();
+        }
+      } else {
+        amount = _rewriteMysqlDateAdd(args[1]).trim();
+      }
+    }
+    if (amount !== null) {
+      const date = _rewriteMysqlDateAdd(args[0]).trim();
+      out += `DateAdd("${unit}", ${spec.negate ? _negateAmount(amount) : amount}, ${date})`;
+    } else {
+      out += `${rest.slice(m.index, open + 1)}${_rewriteMysqlDateAdd(inner)})`;
     }
     rest = rest.slice(close + 1);
   }
@@ -664,16 +747,62 @@ function lookConvertCase(expr) {
   let result = elseVal !== null ? convertLeaf(elseVal, true) : "null";
   if (result === null)
     return null;
+  const conv = new Array(branches.length);
   for (let i = branches.length - 1; i >= 0; i--) {
     const sigmaCond = convertLeaf(branches[i].cond, false);
     const sigmaVal = convertLeaf(branches[i].val, true);
     if (sigmaCond === null || sigmaVal === null)
       return null;
-    result = `If(${sigmaCond}, ${sigmaVal}, ${result})`;
+    conv[i] = { cond: sigmaCond, val: sigmaVal };
+  }
+  const flat = _flattenToSwitch(conv, result);
+  if (flat !== null)
+    return _isBalanced(flat) ? flat : null;
+  for (let i = conv.length - 1; i >= 0; i--) {
+    result = `If(${conv[i].cond}, ${conv[i].val}, ${result})`;
   }
   if (!_isBalanced(result))
     return null;
   return result;
+}
+var _SWITCH_MIN_BRANCHES = 45;
+var _SWITCH_LITERAL_RE = /^(?:"(?:[^"]|"")*"|-?\d+(?:\.\d+)?)$/;
+function _flattenToSwitch(conv, elseVal) {
+  if (conv.length < _SWITCH_MIN_BRANCHES)
+    return null;
+  let subject = null;
+  const pairs = [];
+  for (const { cond, val } of conv) {
+    let subj = null;
+    let matches = null;
+    const eq = /^(.+?)\s*=\s*(.+)$/.exec(cond);
+    if (eq && !/[<>!=]$/.test(eq[1].trim()) && _SWITCH_LITERAL_RE.test(eq[2].trim())) {
+      subj = eq[1].trim();
+      matches = [eq[2].trim()];
+    } else {
+      const inm = /^In\(([\s\S]*)\)$/i.exec(cond.trim());
+      if (inm) {
+        const args = _splitTopLevelArgs(inm[1]);
+        if (args.length >= 2) {
+          subj = args[0].trim();
+          matches = args.slice(1).map((a) => a.trim());
+        }
+      }
+    }
+    if (subj === null || matches === null || matches.length === 0)
+      return null;
+    if (!matches.every((m) => _SWITCH_LITERAL_RE.test(m)))
+      return null;
+    if (subject === null)
+      subject = subj;
+    else if (subject !== subj)
+      return null;
+    for (const m of matches)
+      pairs.push(`${m}, ${val}`);
+  }
+  if (subject === null)
+    return null;
+  return `Switch(${subject}, ${pairs.join(", ")}, ${elseVal})`;
 }
 function lookConvertMathExpr(expr) {
   expr = expr.replace(/NULLIF\s*\(([A-Z_][A-Z0-9_]*)\s*,\s*([^)]+)\)/gi, (_, col, val) => `If(${lookColRef(col)} = ${val.trim()}, null, ${lookColRef(col)})`);
@@ -817,6 +946,7 @@ function lookConvertExpression(expr) {
   const { masked, lits } = _maskLiterals(cd.masked);
   expr = masked;
   expr = _rewriteMysqlDateDiff(expr);
+  expr = _rewriteMysqlDateAdd(expr);
   const ec = _convertNestedCases(expr, lits, "leave-raw", cd.args);
   expr = ec.text;
   expr = expr.replace(/\b([A-Z_][A-Z0-9_]*)\s*(?=\()/gi, (match, fn) => {
@@ -869,7 +999,8 @@ function _sigmaPassthrough() {
   return names;
 }
 function lookUnknownFunctions(sql) {
-  const { masked } = _maskLiterals(sql);
+  const { masked: rawMasked } = _maskLiterals(sql);
+  const masked = _rewriteMysqlDateAdd(_rewriteMysqlDateDiff(rawMasked));
   const passthrough = _sigmaPassthrough();
   const seen = /* @__PURE__ */ new Set();
   for (const m of masked.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)\s*(?=\()/g)) {


### PR DESCRIPTION
Refreshes `converter/sql.mjs` off `sigma-data-model-mcp` main @ `21f3167`, picking up both fixes merged there today. v0.14.11 → v0.14.12.

- **#123** MySQL `ADDDATE` family → Sigma `DateAdd(unit, amount, date)` — bead `zmnt`
- **#124** long same-subject CASE chain → flat `Switch` — bead `znvg` group 2

## This is the commit that actually changes pipeline behaviour

The skill runs the **committed bundle**, not the upstream repo, so neither fix had any effect until now — the same trap bead `znvg` hit on 2026-08-06, where #633 merged at 16:47 and the last live run was 14:32, so a vendored `DATEDIFF` fix was recorded as verified having never once been exercised.

## Measured through the vendored bundle

Against the real cold-run corpus (81 Beast Modes), via a replica of `convert-beast-modes.rb`'s own `--convert` shim:

| | before | after |
|---|---|---|
| `Adddate(` emitted | 27 (7 Beast Modes) | **0** |
| `DateDiff(` without a quoted unit | 109 (pre-#122) | **0** |
| formulas at `If`-depth ≥ 50 | 2 (`State`, `US Regions`) | **0** |
| unknown-function warnings | `ADDDATE` in 7 BMs | **none** |

All three converter-level defect classes are clear.

## This supersedes bead `zmnt`'s recorded prediction

That bead predicted **"15 → 7 remaining = 6 State/US Regions + 1 % Change - Pageviews"**, which was correct when only the `DATEDIFF` fix existed. With `ADDDATE` and the deep-`If` flattening both vendored, all three root causes of the 15 `type=error` columns are addressed, so the prediction is now **15 → 0 from the converter side**. A non-zero count on the next run is a **new** cause, not a remnant of these three — check before concluding a fix didn't take.

The deep-`If` limit is live-measured, not inferred: nested `If` compiles at depth **49** and is `type=error` at **50** (probed against a real data model — it is *depth*, not length; one `If` with a 5,998-char literal compiles fine). Flat `Switch` was measured to accept 120 branches, and the actual converter output for both real formulas was POSTed live and came back `type=text`.

Offline suite green with the new bundle. The one non-passing test, `test-telemetry-gate.rb`, is a pre-existing `LoadError` on main (bead `beads-sigma-nirn`) — it requires `lib/py_resolve`, which this skill deliberately never carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)