### PR TITLE
feat(domo-to-sigma): the gate-1 parity oracle + coverage census

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.14.12",
+  "version": "0.15.0",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-coverage-census.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-coverage-census.rb
@@ -1,0 +1,138 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-coverage-census.rb — emit coverage.json: which source cards produced no
+# Sigma element.
+#
+#   ruby scripts/build-coverage-census.rb --workdir <dir> [--out <dir>/coverage.json]
+#
+# WHY THIS EXISTS — a real hole on the GREEN path, measured 2026-08-07.
+#
+# assert-phase6-ran.rb's verdict is GREEN only when the degradation ledger is
+# EMPTY (shared/lib/degradation_ledger.rb:146-153); ANY scope-cut caps the run at
+# PARTIAL. DegradationLedger.scope_cuts derives those from exactly two places:
+#
+#   coverage.json      'unresolved' entries with severity dropped|degraded
+#   parity-final.json  tile_census.unmatched_zone_names   (TABLEAU zone census)
+#
+# domo can never fill the second: `tile_census` is a RESERVED key holding
+# tableau's zone shape, and publishing anything else there turns gate 5's honest
+# [SKIP] into a vacuous "[OK] 0 zones, 0 unmatched" — a real regression caught in
+# review on PR #631, which is why domo's census correctly publishes under
+# `parity_tile_census` instead (see memory gate5-tile-census-key-reserved).
+#
+# And until now domo emitted NO coverage.json: grep shows the only mentions in
+# the skill are the two READERS (assert-phase6-ran.rb, lib/degradation_ledger.rb).
+# powerbi and tableau emit one; domo does not. Bead beads-sigma-59mk has tracked
+# porting it since 2026-06-25.
+#
+# NET EFFECT BEFORE THIS SCRIPT: a Domo card that produced no Sigma element was
+# invisible to the ledger, so a run that silently dropped cards could still be
+# declared GREEN. phase6-parity-domo.rb's census does NOT close this — it counts
+# elements in workbook-spec.json against the parity plan, so a card that never
+# became an element at all is missing from its denominator too. That is precisely
+# the class the whole gate suite exists to prevent.
+#
+# WHAT IS ASSERTED, AND WHAT DELIBERATELY IS NOT.
+#
+# `dropped` is COMPUTED, never guessed: a source card whose id has no
+# `el-<cardId>` element in the built spec. Element ids embed the card id, so the
+# diff is exact, not a name match.
+#
+# `degraded` (built, but lost a column or field) is NOT emitted. The tempting
+# source is warnings.json, which is already card-attributed — but classifying
+# free-text warning prose into severities is guesswork, and a fabricated
+# `degraded` would cap a run at PARTIAL for a reason nobody can verify. That is
+# the same over-claiming this script exists to stop, pointed the other way. Every
+# warning is instead carried at severity 'warning', which DegradationLedger
+# ignores (it reacts only to dropped|degraded) — recorded for the human report,
+# inert to the verdict. Real degraded-detection needs a per-card column census
+# and belongs with bead beads-sigma-59mk's full port.
+require 'json'
+require 'set'
+require 'optparse'
+require 'time'
+
+opts = {}
+OptionParser.new do |p|
+  p.banner = 'Usage: build-coverage-census.rb --workdir DIR [--out PATH]'
+  p.on('--workdir DIR') { |v| opts[:wd] = v }
+  p.on('--out PATH', 'default <workdir>/coverage.json') { |v| opts[:out] = v }
+  p.on('--spec PATH', 'default <workdir>/workbook-spec.json') { |v| opts[:spec] = v }
+  p.on('--cards PATH', 'default <workdir>/discovery/cards.json') { |v| opts[:cards] = v }
+  p.on('--warnings PATH', 'default <workdir>/discovery/warnings.json') { |v| opts[:warn] = v }
+end.parse!
+abort('--workdir required') unless opts[:wd] && Dir.exist?(opts[:wd])
+wd = opts[:wd]
+spec_path  = opts[:spec]  || File.join(wd, 'workbook-spec.json')
+cards_path = opts[:cards] || File.join(wd, 'discovery', 'cards.json')
+warn_path  = opts[:warn]  || File.join(wd, 'discovery', 'warnings.json')
+out_path   = opts[:out]   || File.join(wd, 'coverage.json')
+abort("missing #{spec_path}") unless File.exist?(spec_path)
+abort("missing #{cards_path}") unless File.exist?(cards_path)
+
+raw_cards = JSON.parse(File.read(cards_path))
+cards = raw_cards.is_a?(Array) ? raw_cards : Array(raw_cards['cards'])
+spec = JSON.parse(File.read(spec_path))
+doc = spec['document'] || spec           # code-rep wrapper tolerated either way
+elements = Array(doc['pages']).flat_map { |p| Array(p['elements']) }
+
+# Every card id that reached the built spec. Element ids are `el-<cardId>` for a
+# card's own tile and `el-<cardId>-summary` for its companion KPI, so either
+# proves the card was migrated.
+built = elements.map { |e| e['id'].to_s[/\Ael-(\d+)/, 1] }.compact.to_set
+
+unresolved = []
+cards.each do |c|
+  cid = c['id'].to_s
+  next if built.include?(cid)
+  unresolved << {
+    'visual'      => (c['title'] || c['name'] || cid).to_s,
+    'card_id'     => cid,
+    'severity'    => 'dropped',
+    'detail'      => 'source card produced no Sigma element (no el-%s in workbook-spec.json)' % cid,
+    'recoverable' => true,
+    'action'      => 'inspect discovery/warnings.json and build-workbook.rb for why this card ' \
+                     'was skipped; a dropped card is a missing tile, not a cosmetic gap',
+  }
+end
+
+# Warnings ride along at an inert severity — see the header. They are NOT
+# scope-cuts and must not become them without a per-card column census.
+if File.exist?(warn_path)
+  Array(JSON.parse(File.read(warn_path))).each do |w|
+    next unless w.is_a?(Hash)
+    unresolved << {
+      'visual'      => w['card'].to_s,
+      'severity'    => 'warning',
+      'detail'      => w['warning'].to_s,
+      'recoverable' => false,
+    }
+  end
+end
+
+dropped = unresolved.count { |u| u['severity'] == 'dropped' }
+census = {
+  'generated_at'   => Time.now.utc.iso8601,
+  'source'         => 'domo-to-sigma build-coverage-census.rb',
+  'cards_total'    => cards.size,
+  'cards_built'    => cards.count { |c| built.include?(c['id'].to_s) },
+  'cards_dropped'  => dropped,
+  'note'           => 'severity dropped is computed from a card-id diff (element ids embed the ' \
+                      'card id). severity degraded is deliberately NOT emitted — see the script ' \
+                      'header; warnings are carried at an inert severity the degradation ledger ' \
+                      'ignores.',
+  'unresolved'     => unresolved,
+}
+File.write(out_path, JSON.pretty_generate(census))
+
+warn "coverage census → #{out_path}"
+warn "  #{census['cards_built']}/#{cards.size} source cards produced a Sigma element"
+if dropped.positive?
+  warn "  #{dropped} card(s) DROPPED — each becomes a degradation-ledger scope-cut, which caps " \
+       'the run at PARTIAL (correctly: a dropped tile is missing migration, not a nit):'
+  unresolved.select { |u| u['severity'] == 'dropped' }
+            .each { |u| warn "      #{u['card_id']}  #{u['visual']}" }
+else
+  warn '  no dropped cards'
+end
+exit 0

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
@@ -1,0 +1,191 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-oracle.rb — join the two collectors into the plan verify-parity.rb verifies.
+#
+#   ruby scripts/build-parity-oracle.rb --workdir <dir> \
+#     [--plan <dir>/parity-plan.json] [--expected <dir>/parity-expected.json] \
+#     [--actuals <dir>/parity-actuals.json] [--out <dir>/parity-plan-verified.json] \
+#     [--exclusions <dir>/parity-plan-exclusions.json]
+#
+# Reads:
+#   parity-plan.json      build-parity-plan.rb — {charts:[{chart, sigma_element_id,
+#                         sigma_kind, sigma_columns}]}; the authoritative TILE LIST
+#   parity-expected.json  collect-parity-expected.rb — Domo's own rendered rows, by card id
+#   parity-actuals.json   collect-parity-actuals.rb — Sigma's element exports, by chart name
+#
+# Writes the verify-parity plan (its documented contract, verify-parity.rb:11-16):
+#   {"charts":[{"chart","expected":[[..]],"actual":{"rows":[[..]]},"sigma_columns":[..]}]}
+# and the exclusion ledger phase6-parity-domo.rb enforces:
+#   {"exclusions":[{"chart","reason"}]}
+#
+# EVERY TILE IS ACCOUNTED FOR OR THE BUILD FAILS. phase6-parity-domo.rb (#631)
+# already refuses to emit a gate contract unless plan + exclusions covers every
+# chartable element; this asserts the same invariant at the point the plan is
+# BUILT, so the failure names the missing tile instead of surfacing later as an
+# opaque census mismatch. A tile quietly missing from the plan shrinks gate 1's
+# denominator and reads identically to a clean pass — 45/45 looks exactly like
+# 65/65. That is the single most dangerous failure mode on this path.
+#
+# TILE -> DOMO MAPPING IS MECHANICAL, not name-matching: a workbook element id is
+# `el-<cardId>` for a card's own tile and `el-<cardId>-summary` for the companion
+# KPI Domo calls the card's summary number. So the base tile takes the card's
+# rows and the companion takes a single [[title, summary_value]] row.
+#
+# SAME-DAY GUARD. Domo evaluates a card's relative date window at FETCH time, so
+# a rolling-7-day card collected either side of midnight UTC legitimately
+# disagrees with itself. Both collectors stamp fetched_at; joining across a UTC
+# date boundary is refused rather than silently scored as a divergence. The gold
+# audit flagged this for 28 of the 36 cards.
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = {}
+OptionParser.new do |p|
+  p.banner = 'Usage: build-parity-oracle.rb --workdir DIR [...]'
+  p.on('--workdir DIR') { |v| opts[:wd] = v }
+  p.on('--plan PATH') { |v| opts[:plan] = v }
+  p.on('--expected PATH') { |v| opts[:exp] = v }
+  p.on('--actuals PATH') { |v| opts[:act] = v }
+  p.on('--out PATH') { |v| opts[:out] = v }
+  p.on('--exclusions PATH') { |v| opts[:excl] = v }
+  p.on('--allow-cross-day', 'proceed even if the two sides straddle a UTC date boundary') { opts[:xday] = true }
+end.parse!
+abort('--workdir required') unless opts[:wd] && Dir.exist?(opts[:wd])
+wd = opts[:wd]
+plan_path = opts[:plan] || File.join(wd, 'parity-plan.json')
+exp_path  = opts[:exp]  || File.join(wd, 'parity-expected.json')
+act_path  = opts[:act]  || File.join(wd, 'parity-actuals.json')
+out_path  = opts[:out]  || File.join(wd, 'parity-plan-verified.json')
+excl_path = opts[:excl] || File.join(wd, 'parity-plan-exclusions.json')
+[plan_path, exp_path, act_path].each { |f| abort("missing #{f}") unless File.exist?(f) }
+
+plan_doc = JSON.parse(File.read(plan_path))
+charts   = plan_doc.is_a?(Hash) ? (plan_doc['charts'] || []) : Array(plan_doc)
+expected = JSON.parse(File.read(exp_path))
+actuals  = JSON.parse(File.read(act_path))
+abort('parity-plan.json has no charts') if charts.empty?
+
+# ---- same-day guard --------------------------------------------------------
+ed = (Time.parse(expected['fetched_at']).utc.to_date rescue nil)
+ad = (Time.parse(actuals['fetched_at']).utc.to_date rescue nil)
+if ed && ad && ed != ad && !opts[:xday]
+  abort <<~MSG
+    REFUSING to join: the two sides were collected on different UTC days
+      expected  #{expected['fetched_at']}
+      actual    #{actuals['fetched_at']}
+    Domo evaluates a card's relative date window at FETCH time, so a rolling
+    7/14/28/30-day card compared across a date boundary diverges for a reason
+    that has nothing to do with migration fidelity — a false RED that costs a
+    debugging cycle. Re-collect both sides in one run, or pass
+    --allow-cross-day if you have specifically established no plan tile carries
+    a relative window.
+  MSG
+end
+
+# ---- lookups ---------------------------------------------------------------
+exp_cards = expected['cards'] || {}
+# reasons the Domo side already recorded, keyed by card id
+exp_unavail = (expected['unavailable'] || []).each_with_object({}) { |u, h| h[u['card_id'].to_s] = u['reason'] }
+act_charts = actuals['charts'] || {}
+act_unavail = (actuals['unavailable'] || []).each_with_object({}) { |u, h| h[u['chart'].to_s] = u['reason'] }
+
+def card_id_for(element_id)
+  m = /\Ael-(\d+)(-summary)?\z/.match(element_id.to_s)
+  return [nil, false] unless m
+  [m[1], !m[2].nil?]
+end
+
+verified = []
+exclusions = []
+
+charts.each do |c|
+  name = c['chart'].to_s
+  eid  = c['sigma_element_id'].to_s
+  cid, is_summary = card_id_for(eid)
+
+  # --- the Domo (expected) side ---
+  if cid.nil?
+    exclusions << { 'chart' => name, 'reason' =>
+      "element id #{eid.inspect} is not of the form el-<cardId>[-summary], so it cannot be " \
+      'traced back to a Domo card — no source value exists to compare against' }
+    next
+  end
+  card = exp_cards[cid]
+  if card.nil?
+    reason = exp_unavail[cid] || 'Domo card-data returned nothing for this card'
+    exclusions << { 'chart' => name, 'reason' => "no Domo source value: #{reason}" }
+    next
+  end
+  if is_summary
+    sv = card['summary_value']
+    if sv.nil?
+      exclusions << { 'chart' => name, 'reason' =>
+        'companion KPI tile, but the Domo card reports no summary number ' \
+        '(summary.status was not a completed run) — Domo declining to compute a ' \
+        'KPI is not a zero, so there is no value to compare' }
+      next
+    end
+    # A KPI tile plots ONE value, and Sigma's element export for it is a
+    # single-column CSV — one header, one cell. So the expected side must be a
+    # single-cell row too. An earlier cut emitted [[title, value]] and every
+    # companion tile DIVERGED with "expected [["Page Views", 22.0]] vs actual
+    # [[22.0]]" — a shape mismatch masquerading as a value mismatch, which would
+    # have read as 29 genuine parity failures. Caught by running the emitted plan
+    # through verify-parity.rb rather than assuming the contract.
+    exp_rows = [[sv]]
+  else
+    exp_rows = card['rows']
+    if !exp_rows.is_a?(Array) || exp_rows.empty?
+      exclusions << { 'chart' => name, 'reason' => 'Domo card returned no rows' }
+      next
+    end
+  end
+
+  # --- the Sigma (actual) side ---
+  act = act_charts[name]
+  if act.nil?
+    reason = act_unavail[name] || 'no Sigma export recorded for this element'
+    exclusions << { 'chart' => name, 'reason' => "no Sigma actual: #{reason}" }
+    next
+  end
+
+  verified << {
+    'chart'          => name,
+    'sigma_element_id' => eid,
+    'sigma_kind'     => c['sigma_kind'],
+    'sigma_columns'  => c['sigma_columns'],
+    'domo_card_id'   => cid,
+    'expected'       => exp_rows,
+    # NOTE the deliberate absence of `requested_columns`. verify-parity.rb's
+    # extract_rows only realigns when a side carries BOTH `columns` and
+    # `requested_columns` (:167-177), and realign resolves each requested name
+    # against the returned headers, raising if one is missing. The plan's
+    # `sigma_columns` are Sigma column IDs (`d-date`, `m-views`) while the CSV
+    # headers are DISPLAY names (`Date`, `Views`), so feeding them in as
+    # requested columns makes every tile raise — measured here, not guessed.
+    # Without it the export's own column order is used, which is already the
+    # element's plotted order. `columns` is still carried for diagnostics.
+    'actual'         => { 'rows' => act['rows'], 'columns' => act['columns'] },
+  }
+end
+
+# ---- the invariant ---------------------------------------------------------
+covered = verified.size + exclusions.size
+if covered != charts.size
+  abort "INTERNAL: #{covered} tiles accounted for but the plan lists #{charts.size} — " \
+        'every tile must be verified or excluded; refusing to emit a partial plan.'
+end
+
+File.write(out_path, JSON.pretty_generate('charts' => verified))
+File.write(excl_path, JSON.pretty_generate('exclusions' => exclusions))
+
+warn "wrote #{out_path}      #{verified.size} tile(s) to verify"
+warn "wrote #{excl_path}  #{exclusions.size} tile(s) excluded WITH a reason"
+warn "coverage: #{verified.size} + #{exclusions.size} = #{charts.size} plan tiles (complete)"
+unless exclusions.empty?
+  warn "\nEXCLUDED — each of these is a tile gate 1 will NOT score. Read them; an" \
+       "\nexclusion is a hole in the evidence, not a pass:"
+  exclusions.each { |e| warn "  #{e['chart']}\n      #{e['reason']}" }
+end
+exit 0

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
@@ -88,8 +88,13 @@ end
 exp_cards = expected['cards'] || {}
 # reasons the Domo side already recorded, keyed by card id
 exp_unavail = (expected['unavailable'] || []).each_with_object({}) { |u, h| h[u['card_id'].to_s] = u['reason'] }
-act_charts = actuals['charts'] || {}
-act_unavail = (actuals['unavailable'] || []).each_with_object({}) { |u, h| h[u['chart'].to_s] = u['reason'] }
+# Actuals are keyed by ELEMENT ID, never by display name. Domo reuses generic
+# summary labels, so 11 of the real 65 tiles share a name with another tile
+# ("New Visits in Period" names 4 distinct elements). Name-keying let one
+# element's export be scored as another's — a reproduced unearned PASS. See the
+# header of collect-parity-actuals.rb.
+act_by_eid = actuals['charts'] || {}
+act_unavail = (actuals['unavailable'] || []).each_with_object({}) { |u, h| h[u['element_id'].to_s] = u['reason'] }
 
 def card_id_for(element_id)
   m = /\Ael-(\d+)(-summary)?\z/.match(element_id.to_s)
@@ -106,11 +111,31 @@ end
 # collectable — so without this check the oracle would happily "verify" it and
 # score a guaranteed DIVERGE that says nothing about conversion quality. The
 # construction-level reason is the more fundamental one, so it wins.
-prior_excl = {}
+# KEYED BY ELEMENT ID WHERE AVAILABLE. build-parity-exclusions.rb records
+# `evidence.element_id` on every entry, so the match can be exact. Keying by
+# display name instead swept every same-named tile into one tile's exclusion:
+# with "New Visits in Period" naming 4 elements and only one card carrying a
+# refused date window, all four were exempted from scoring — three of them fully
+# collectable and never disqualified. That is silent inflation (a smaller
+# denominator reads as a cleaner pass), which is what this chain exists to refuse.
+#
+# A name-only entry (no element_id) is still honoured, but consumed ONCE rather
+# than matching every same-named tile — an ambiguous exclusion should under-apply,
+# not over-apply.
+prior_by_eid = {}
+prior_by_name = {}
 if File.exist?(excl_path)
   doc = (JSON.parse(File.read(excl_path)) rescue nil)
   list = doc.is_a?(Hash) ? Array(doc['exclusions']) : Array(doc)
-  list.each { |e| prior_excl[e['chart'].to_s] = e if e.is_a?(Hash) }
+  list.each do |e|
+    next unless e.is_a?(Hash)
+    eid = (e['element_id'] || e.dig('evidence', 'element_id')).to_s
+    if eid.empty?
+      (prior_by_name[e['chart'].to_s] ||= []) << e
+    else
+      prior_by_eid[eid] = e
+    end
+  end
 end
 
 verified = []
@@ -122,8 +147,11 @@ charts.each do |c|
   cid, is_summary = card_id_for(eid)
 
   # Already excluded upstream for a construction-level reason — carry it through
-  # verbatim rather than re-deriving or overriding it.
-  if (pe = prior_excl[name])
+  # verbatim rather than re-deriving or overriding it. Element id first; a
+  # name-only entry is consumed once (shift) so it cannot sweep its same-named
+  # siblings.
+  pe = prior_by_eid[eid] || (prior_by_name[name] && prior_by_name[name].shift)
+  if pe
     exclusions << pe
     next
   end
@@ -141,11 +169,20 @@ charts.each do |c|
     exclusions << { 'chart' => name, 'reason' => "no Domo source value: #{reason}" }
     next
   end
-  if is_summary
+  # A KPI tile plots ONE value however it was built. That is true of a `-summary`
+  # companion AND of a Rule-0 KPI — a card whose own element is `kpi-chart`, with
+  # no separate companion. Keying only on `-summary` left every Rule-0 KPI taking
+  # the card's full `rows` payload, which for a multi-column card (a
+  # CATEGORY|CURRENT|TARGET gauge, say) can never match Sigma's single-cell KPI
+  # export: a shape mismatch that reads as a value divergence, exactly the bug
+  # already fixed once for the companions below.
+  is_kpi = is_summary || c['sigma_kind'].to_s == 'kpi-chart'
+
+  if is_kpi
     sv = card['summary_value']
     if sv.nil?
-      exclusions << { 'chart' => name, 'reason' =>
-        'companion KPI tile, but the Domo card reports no summary number ' \
+      exclusions << { 'chart' => name, 'element_id' => eid, 'reason' =>
+        'KPI tile, but the Domo card reports no summary number ' \
         '(summary.status was not a completed run) — Domo declining to compute a ' \
         'KPI is not a zero, so there is no value to compare' }
       next
@@ -167,10 +204,13 @@ charts.each do |c|
   end
 
   # --- the Sigma (actual) side ---
-  act = act_charts[name]
+  # BY ELEMENT ID. Looking this up by display name scored one element's export as
+  # another's whenever two tiles shared a title (11 of the real 65 do).
+  act = act_by_eid[eid]
   if act.nil?
-    reason = act_unavail[name] || 'no Sigma export recorded for this element'
-    exclusions << { 'chart' => name, 'reason' => "no Sigma actual: #{reason}" }
+    reason = act_unavail[eid] || 'no Sigma export recorded for this element'
+    exclusions << { 'chart' => name, 'element_id' => eid,
+                    'reason' => "no Sigma actual: #{reason}" }
     next
   end
 
@@ -207,12 +247,13 @@ end
 # in phase6-parity-domo.rb — which measures against workbook-spec.json, not the
 # plan — would fail on a tile that WAS legitimately accounted for. Carry them
 # through and say so, rather than trusting the two derivations to agree forever.
-emitted = exclusions.map { |e| e['chart'].to_s }.to_set
-orphaned = prior_excl.reject { |name, _| emitted.include?(name) }
+emitted = exclusions.map { |e| e.object_id }.to_set
+orphaned = prior_by_eid.values.reject { |e| emitted.include?(e.object_id) } +
+           prior_by_name.values.flatten           # anything left unconsumed
 unless orphaned.empty?
   warn "carrying through #{orphaned.size} prior exclusion(s) for tile(s) absent from the plan:"
-  orphaned.each { |name, e| warn "    #{name} — #{e['reason']}" }
-  exclusions.concat(orphaned.values)
+  orphaned.each { |e| warn "    #{e['chart']} — #{e['reason']}" }
+  exclusions.concat(orphaned)
 end
 
 File.write(out_path, JSON.pretty_generate('charts' => verified))

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
@@ -140,11 +140,33 @@ end
 
 verified = []
 exclusions = []
+seen_eids = Set.new
 
 charts.each do |c|
   name = c['chart'].to_s
   eid  = c['sigma_element_id'].to_s
   cid, is_summary = card_id_for(eid)
+
+  # The SAME element id listed twice in the plan. collect-parity-actuals.rb
+  # records this in `unavailable` and refuses to overwrite the first export —
+  # but that reason was unreachable here, because act_by_eid[eid] resolves for
+  # every occurrence, so the second entry looked perfectly healthy and was
+  # scored a second time against the first one's data. Two plan rows, one
+  # measurement, both reported.
+  #
+  # Reachable from real data: a Domo card pinned to two dashboard pages is
+  # ordinary, domo-discover.rb applies no cross-page dedup, and build-workbook's
+  # element id derives purely from the card id — so cards.json can legitimately
+  # carry the same card twice and the plan inherits the duplicate.
+  if seen_eids.include?(eid)
+    exclusions << { 'chart' => name, 'element_id' => eid, 'reason' =>
+      'element id appears more than once in the parity plan — only the first ' \
+      'occurrence is scored; a duplicate would be measured twice against one ' \
+      'export. Investigate why the plan double-lists this element (a card ' \
+      'pinned to two pages is the usual cause).' }
+    next
+  end
+  seen_eids << eid
 
   # Already excluded upstream for a construction-level reason — carry it through
   # verbatim rather than re-deriving or overriding it. Element id first; a
@@ -158,7 +180,7 @@ charts.each do |c|
 
   # --- the Domo (expected) side ---
   if cid.nil?
-    exclusions << { 'chart' => name, 'reason' =>
+    exclusions << { 'chart' => name, 'element_id' => eid, 'reason' =>
       "element id #{eid.inspect} is not of the form el-<cardId>[-summary], so it cannot be " \
       'traced back to a Domo card — no source value exists to compare against' }
     next
@@ -166,7 +188,8 @@ charts.each do |c|
   card = exp_cards[cid]
   if card.nil?
     reason = exp_unavail[cid] || 'Domo card-data returned nothing for this card'
-    exclusions << { 'chart' => name, 'reason' => "no Domo source value: #{reason}" }
+    exclusions << { 'chart' => name, 'element_id' => eid,
+                    'reason' => "no Domo source value: #{reason}" }
     next
   end
   # A KPI tile plots ONE value however it was built. That is true of a `-summary`
@@ -198,7 +221,8 @@ charts.each do |c|
   else
     exp_rows = card['rows']
     if !exp_rows.is_a?(Array) || exp_rows.empty?
-      exclusions << { 'chart' => name, 'reason' => 'Domo card returned no rows' }
+      exclusions << { 'chart' => name, 'element_id' => eid,
+                      'reason' => 'Domo card returned no rows' }
       next
     end
   end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
@@ -37,6 +37,7 @@
 # date boundary is refused rather than silently scored as a divergence. The gold
 # audit flagged this for 28 of the 36 cards.
 require 'json'
+require 'set'
 require 'optparse'
 require 'time'
 
@@ -96,6 +97,22 @@ def card_id_for(element_id)
   [m[1], !m[2].nil?]
 end
 
+# PRIOR exclusions, loaded BEFORE the loop and honoured over verification.
+#
+# build-parity-exclusions.rb (#649) excludes tiles that cannot agree BY
+# CONSTRUCTION — today, a refused date window: Domo aggregates over a window the
+# Sigma tile does not have. Such a tile is still present in parity-plan.json (the
+# plan lists every chartable element), and both its sides are perfectly
+# collectable — so without this check the oracle would happily "verify" it and
+# score a guaranteed DIVERGE that says nothing about conversion quality. The
+# construction-level reason is the more fundamental one, so it wins.
+prior_excl = {}
+if File.exist?(excl_path)
+  doc = (JSON.parse(File.read(excl_path)) rescue nil)
+  list = doc.is_a?(Hash) ? Array(doc['exclusions']) : Array(doc)
+  list.each { |e| prior_excl[e['chart'].to_s] = e if e.is_a?(Hash) }
+end
+
 verified = []
 exclusions = []
 
@@ -103,6 +120,13 @@ charts.each do |c|
   name = c['chart'].to_s
   eid  = c['sigma_element_id'].to_s
   cid, is_summary = card_id_for(eid)
+
+  # Already excluded upstream for a construction-level reason — carry it through
+  # verbatim rather than re-deriving or overriding it.
+  if (pe = prior_excl[name])
+    exclusions << pe
+    next
+  end
 
   # --- the Domo (expected) side ---
   if cid.nil?
@@ -175,6 +199,20 @@ covered = verified.size + exclusions.size
 if covered != charts.size
   abort "INTERNAL: #{covered} tiles accounted for but the plan lists #{charts.size} — " \
         'every tile must be verified or excluded; refusing to emit a partial plan.'
+end
+
+# A prior exclusion naming a tile that is NOT in the plan would otherwise be
+# dropped on write, since the loop above only ever visits plan tiles. That should
+# not happen (both derive from the same chartable set) but if it does, the census
+# in phase6-parity-domo.rb — which measures against workbook-spec.json, not the
+# plan — would fail on a tile that WAS legitimately accounted for. Carry them
+# through and say so, rather than trusting the two derivations to agree forever.
+emitted = exclusions.map { |e| e['chart'].to_s }.to_set
+orphaned = prior_excl.reject { |name, _| emitted.include?(name) }
+unless orphaned.empty?
+  warn "carrying through #{orphaned.size} prior exclusion(s) for tile(s) absent from the plan:"
+  orphaned.each { |name, e| warn "    #{name} — #{e['reason']}" }
+  exclusions.concat(orphaned.values)
 end
 
 File.write(out_path, JSON.pretty_generate('charts' => verified))

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-actuals.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-actuals.rb
@@ -9,10 +9,31 @@
 #   ruby scripts/collect-parity-actuals.rb --plan <dir>/parity-plan.json \
 #     --workbook-id <wb> --out <dir>/parity-actuals.json [--pool 4] [--timeout 120]
 #
-# Output (--out): { "<chart name>": { "rows": [[...], ...], "columns": [...] }, ... }
-# and, for anything it could not serve, an `unavailable` entry carrying a
-# MEASURED reason — never a silent omission, because a tile missing from the
-# plan shrinks gate 1's denominator and reads exactly like a clean pass.
+# Output (--out): { "<sigma_element_id>": { "chart": "...", "rows": [[...]],
+# "columns": [...] }, ... } and, for anything it could not serve, an
+# `unavailable` entry carrying a MEASURED reason — never a silent omission,
+# because a tile missing from the plan shrinks gate 1's denominator and reads
+# exactly like a clean pass.
+#
+# KEYED BY ELEMENT ID, NOT DISPLAY NAME — this is load-bearing.
+# An earlier cut keyed `results` by the chart's display name. Domo hands the same
+# generic summary label to many cards, so on the real 65-tile page ELEVEN tiles
+# share a name with at least one other: "New Visits in Period" names 4 distinct
+# elements, "Change over 7 Days" 3, "Surveys in Period" and "US Leads in Period"
+# 2 each. phase6-parity-domo.rb:190-193 says as much in its own comment ("the
+# same KPI title repeated on two pages is routine") and compares as a MULTISET
+# for exactly this reason.
+#
+# Name-keying broke two ways at once, both silent:
+#   * last writer wins in the thread pool, non-deterministically, and the losing
+#     exports vanished with NO `unavailable` entry — contradicting the guarantee
+#     stated above;
+#   * the join then attached that ONE surviving export to EVERY tile sharing the
+#     name, so N-1 tiles were scored against another element's data.
+# Reproduced on the real element ids: a genuine match reported DIVERGE, and a
+# genuine migration bug (42 vs 7) reported PASS 100% — an unearned pass, the
+# precise failure this whole chain exists to prevent.
+# Element ids are unique by construction, so they are the only safe key.
 #
 # WHY THIS IS NOT A PORT OF tableau-to-sigma's collect-parity-actuals.rb.
 # That script is 441 lines and only 2 of them are Tableau-specific, so a port
@@ -79,7 +100,7 @@ threads = [opts[:pool], 1].max.times.map do
       if status == :fail
         mutex.synchronize do
           unavailable << { 'chart' => name, 'element_id' => eid, 'reason' => payload.to_s }
-          warn "  FAIL #{name[0, 44]} — #{payload.to_s[0, 60]}"
+          warn "  FAIL #{eid} #{name[0, 34]} — #{payload.to_s[0, 50]}"
         end
         next
       end
@@ -88,20 +109,32 @@ threads = [opts[:pool], 1].max.times.map do
         mutex.synchronize do
           unavailable << { 'chart' => name, 'element_id' => eid,
                            'reason' => 'export CSV empty / unparseable' }
-          warn "  EMPTY #{name[0, 44]}"
+          warn "  EMPTY #{eid} #{name[0, 34]}"
         end
         next
       end
       headers = rows.shift.map { |h| h.to_s.strip }
       mutex.synchronize do
-        results[name] = {
-          'element_id' => eid,
-          'columns'    => headers,
-          'rows'       => rows,
-          'n_columns'  => headers.size,
-          'n_rows'     => rows.size,
-        }
-        warn "  [#{results.size + unavailable.size}/#{charts.size}] #{name[0, 44]} " \
+        # Keyed by element id — see the header. A collision here would mean the
+        # PLAN listed the same element twice, which is a different (and louder)
+        # problem than two elements sharing a title, so say so rather than
+        # overwrite.
+        if results.key?(eid)
+          unavailable << { 'chart' => name, 'element_id' => eid,
+                           'reason' => 'element id appears more than once in the parity plan — ' \
+                                       'refusing to overwrite the first export' }
+          warn "  DUPLICATE ELEMENT ID #{eid} — recorded, not overwritten"
+        else
+          results[eid] = {
+            'chart'      => name,
+            'element_id' => eid,
+            'columns'    => headers,
+            'rows'       => rows,
+            'n_columns'  => headers.size,
+            'n_rows'     => rows.size,
+          }
+        end
+        warn "  [#{results.size + unavailable.size}/#{charts.size}] #{eid} #{name[0, 30]} " \
              "(#{rows.size}r x #{headers.size}c)"
       end
     end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-actuals.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-actuals.rb
@@ -1,0 +1,128 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# collect-parity-actuals.rb — the SIGMA-SIDE half of the parity oracle.
+#
+# Exports every chartable element of the migrated workbook and writes its rows
+# in the shape verify-parity.rb's `actual` side consumes. Paired with
+# collect-parity-expected.rb (the Domo side); build-parity-oracle.rb joins them.
+#
+#   ruby scripts/collect-parity-actuals.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --out <dir>/parity-actuals.json [--pool 4] [--timeout 120]
+#
+# Output (--out): { "<chart name>": { "rows": [[...], ...], "columns": [...] }, ... }
+# and, for anything it could not serve, an `unavailable` entry carrying a
+# MEASURED reason — never a silent omission, because a tile missing from the
+# plan shrinks gate 1's denominator and reads exactly like a clean pass.
+#
+# WHY THIS IS NOT A PORT OF tableau-to-sigma's collect-parity-actuals.rb.
+# That script is 441 lines and only 2 of them are Tableau-specific, so a port
+# looked free. But most of its bulk is machinery for problems measured on
+# TABLEAU workbooks — wide pivot-grid CSV exports that need a totals-JSON
+# fallback, multi-million-row unaggregated detail tables that hung the pool,
+# per-chart row-limit accounting. None of that has been observed on a Domo
+# workbook, and importing it would mean carrying (and having to maintain)
+# behaviour justified by evidence from another converter.
+#
+# domo already owns the identical fetch, live-proven since 2026-07-30, inside
+# verify-warehouse.rb — export POST, poll the download, back off on 429/408/50x.
+# That is now lib/element_export.rb and this script builds directly on it. If a
+# Domo run turns up a pivot-export 500 or an oversized element, add the specific
+# guard then, with the live evidence attached — the way tableau's grew.
+#
+# THE PIVOT CAVEAT IS REAL AND IS RECORDED, NOT SOLVED. Tableau measured that a
+# pivot element's CSV export is the WIDE grid, not the long row/col/value tuples
+# the comparison expects. Domo's spec emits 13 `table` elements; whether any
+# render as a wide pivot is UNKNOWN until a live run. Rather than guess, this
+# script records each tile's column count and header shape so the first live run
+# shows immediately which elements came back wide — and those become recorded
+# exclusions with a measured reason, not silent failures.
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 4, timeout: 120 }
+OptionParser.new do |p|
+  p.banner = 'Usage: collect-parity-actuals.rb --plan PATH --workbook-id ID --out PATH'
+  p.on('--plan PATH', 'parity plan (build-parity-plan.rb output)') { |v| opts[:plan] = v }
+  p.on('--workbook-id ID', 'live Sigma workbook id') { |v| opts[:wb] = v }
+  p.on('--out PATH', 'output JSON') { |v| opts[:out] = v }
+  p.on('--pool N', Integer, 'parallel exports (default 4)') { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer, 'per-element poll budget seconds (default 120)') { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: elementId → CSV map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb out].each { |k| abort "missing --#{k == :wb ? 'workbook-id' : k}" unless opts[k] }
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'element_export'
+require 'sigma_rest' unless opts[:fixture]
+
+fixture = opts[:fixture] ? JSON.parse(File.read(opts[:fixture])) : nil
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : Array(plan)
+abort('plan has no charts') if charts.empty?
+
+results = {}
+unavailable = []
+mutex = Mutex.new
+queue = charts.dup
+
+threads = [opts[:pool], 1].max.times.map do
+  Thread.new do
+    loop do
+      c = mutex.synchronize { queue.shift }
+      break unless c
+      name = c['chart'].to_s
+      eid  = c['sigma_element_id'].to_s
+      status, payload = ElementExport.fetch_csv(eid, opts[:wb],
+                                                timeout: opts[:timeout], fixture: fixture)
+      if status == :fail
+        mutex.synchronize do
+          unavailable << { 'chart' => name, 'element_id' => eid, 'reason' => payload.to_s }
+          warn "  FAIL #{name[0, 44]} — #{payload.to_s[0, 60]}"
+        end
+        next
+      end
+      rows = (CSV.parse(payload.to_s) rescue [])
+      if rows.empty?
+        mutex.synchronize do
+          unavailable << { 'chart' => name, 'element_id' => eid,
+                           'reason' => 'export CSV empty / unparseable' }
+          warn "  EMPTY #{name[0, 44]}"
+        end
+        next
+      end
+      headers = rows.shift.map { |h| h.to_s.strip }
+      mutex.synchronize do
+        results[name] = {
+          'element_id' => eid,
+          'columns'    => headers,
+          'rows'       => rows,
+          'n_columns'  => headers.size,
+          'n_rows'     => rows.size,
+        }
+        warn "  [#{results.size + unavailable.size}/#{charts.size}] #{name[0, 44]} " \
+             "(#{rows.size}r x #{headers.size}c)"
+      end
+    end
+  end
+end
+threads.each(&:join)
+
+doc = {
+  'fetched_at'   => Time.now.utc.iso8601,
+  'workbook_id'  => opts[:wb],
+  'source'       => 'sigma-element-export',
+  'charts_total' => charts.size,
+  'charts_ok'    => results.size,
+  'charts'       => results,
+  'unavailable'  => unavailable,
+}
+File.write(opts[:out], JSON.pretty_generate(doc))
+warn "\nwrote #{opts[:out]} — #{results.size}/#{charts.size} elements exported"
+unless unavailable.empty?
+  warn "#{unavailable.size} element(s) could not be exported — these MUST reach " \
+       'parity-plan-exclusions.json with a reason, never be dropped:'
+  unavailable.each { |u| warn "    #{u['chart']} — #{u['reason'][0, 80]}" }
+end
+exit 0

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-expected.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-expected.rb
@@ -1,0 +1,183 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# collect-parity-expected.rb — the DOMO-SIDE half of the parity oracle.
+#
+# Fetches, for every card on the migrated page, the values Domo ITSELF renders,
+# and writes them in the shape verify-parity.rb's `expected` side consumes.
+# Paired with collect-parity-actuals.rb (the Sigma side); build-parity-oracle.rb
+# joins the two into the plan phase6-parity-domo.rb finalizes.
+#
+#   ruby scripts/collect-parity-expected.rb --workdir <dir> [--out PATH] [--pool 4]
+#
+# Output (--out, default <workdir>/parity-expected.json):
+#   { "<chart name>": { "rows": [[dim, val], ...], "source": "domo-card-data",
+#                       "card_id": "...", "mappings": [...] }, ... }
+# plus, for every card carrying one, a companion entry keyed "<chart name>"
+# for the `-summary` tile holding a single [[label, summaryNumber]] row.
+#
+# WHY THIS ENDPOINT, AND NOT RECONSTRUCTED AGGREGATIONS.
+# The 2026-08-05 gold audit sized this collector at 3-5 days because it assumed
+# expected values had to be RE-DERIVED from Domo.query_dataset — re-implementing
+# each card's aggregation, filters, rolling date window, top-N and COUNT DISTINCT
+# in our own code, then hoping our re-derivation matched Domo's. Every one of
+# those is a place to be silently wrong, and the audit catalogued them as such:
+# 28 of 36 cards carry a relative date window, several wrap aggregate Beast
+# Modes, top-N has no documented tie-break.
+#
+# GET /api/content/v1/cards/{id}/data removes the entire class: Domo evaluates
+# its own card — window, filters, aggregation, ordering, limit — and hands back
+# the rendered rows. We re-derive nothing. Probed live 2026-08-07 against page
+# 59931332: 36/36 cards return HTTP 200, 35 carry real rows, 31 carry a
+# summaryNumber, and the mapped coverage is 64 of the gate's 65 chartable tiles.
+#
+# THE ONE CARD THIS CANNOT SERVE is 983053598 "Survey Completion Rate", which
+# returns metadata with no `rows` key at all. That is the SAME card the audit
+# independently flagged as "never statically scoreable — the date window is
+# baked into the plotted VALUE, not the filter, so the true answer changes
+# daily". Two unrelated methods landing on the same single exception is the
+# strongest evidence available that it is genuinely un-scoreable rather than a
+# gap in this script. It is emitted to the exclusion ledger WITH THAT REASON by
+# build-parity-oracle.rb, never silently dropped — an omitted tile would shrink
+# the denominator and read as a clean pass (the exact inflation
+# phase6-parity-domo.rb's census exists to refuse).
+#
+# SAME-DAY FETCH IS LOAD-BEARING. Because Domo evaluates relative windows at
+# FETCH time, the expected and actual sides must be collected in the same run
+# (same UTC day) or a rolling-7-day card legitimately disagrees with itself.
+# This script stamps `fetched_at` and build-parity-oracle.rb refuses to join
+# sides whose stamps straddle a UTC date boundary.
+require 'json'
+require 'optparse'
+require 'time'
+$LOAD_PATH.unshift(File.join(__dir__, 'lib'))
+require 'domo_rest'
+
+opts = { pool: 4 }
+OptionParser.new do |p|
+  p.banner = 'Usage: collect-parity-expected.rb --workdir DIR [--out PATH] [--pool N]'
+  p.on('--workdir DIR', 'run directory (reads discovery/cards.json)') { |v| opts[:wd] = v }
+  p.on('--out PATH', 'output JSON (default <workdir>/parity-expected.json)') { |v| opts[:out] = v }
+  p.on('--pool N', Integer, 'parallel fetches (default 4)') { |v| opts[:pool] = v }
+  p.on('--cards-json PATH', 'override discovery/cards.json') { |v| opts[:cards] = v }
+end.parse!
+
+abort('--workdir required') unless opts[:wd] && Dir.exist?(opts[:wd])
+cards_path = opts[:cards] || File.join(opts[:wd], 'discovery', 'cards.json')
+abort("cards.json not found at #{cards_path}") unless File.exist?(cards_path)
+out_path = opts[:out] || File.join(opts[:wd], 'parity-expected.json')
+
+raw = JSON.parse(File.read(cards_path))
+cards = raw.is_a?(Array) ? raw : Array(raw['cards'])
+abort('no cards found') if cards.empty?
+
+# ---- shaping ---------------------------------------------------------------
+
+# Domo labels each column's ROLE in `mappings`, parallel to `columns`/`rows`.
+# Roles seen live on the 36-card sample page:
+#   ITEM|VALUE                      simple dimension + measure        (17)
+#   ITEM|SERIES|SERIES[|SERIES]     multi-series                      (12)
+#   CATEGORY|CURRENT|TARGET         gauge                              (2)
+#   SERIES|ITEM|VALUE               series-first ordering              (1)
+#   XTIME|VALUE|SERIES|BUBBLESIZE   scatter/bubble                     (2)
+#   ITEM|VALUE|POP_PERIOD|POP_INDEX period-over-period                 (1)
+#   DATE|EVENT                      event stream                            (1)
+# Rows are passed through as whole tuples rather than projected down to two
+# columns: verify-parity.rb's strict_compare is exact tuple-set equality, so
+# dropping a channel here would compare a 3-series chart on one series and call
+# it a pass. The mappings are recorded alongside so the join can align column
+# ORDER against the Sigma export rather than assuming it.
+def shape_rows(data)
+  rows = data['rows']
+  return nil unless rows.is_a?(Array)
+  rows.map { |r| Array(r) }
+end
+
+# A Domo summaryNumber is the card's own KPI value — the thing the migrated
+# `<el>-summary` companion tile plots. `summary.value` is the richer form;
+# `summaryNumber` is the pre-formatted string. Prefer the raw value, fall back
+# to the formatted one, and refuse a `status` that is not a completed run —
+# "not_ran" means Domo declined to compute it, which is not a zero.
+def summary_value(doc)
+  s = doc['summary']
+  if s.is_a?(Hash)
+    status = s['status'].to_s
+    v = s['value']
+    return v if !v.nil? && v.to_s.strip != '' && status != 'not_ran'
+  end
+  sn = doc['summaryNumber']
+  return sn if !sn.nil? && sn.to_s.strip != ''
+  nil
+end
+
+# ---- fetch -----------------------------------------------------------------
+
+results = {}
+errors  = []
+mutex   = Mutex.new
+queue   = cards.dup
+threads = [opts[:pool], 1].max.times.map do
+  Thread.new do
+    loop do
+      card = mutex.synchronize { queue.shift }
+      break unless card
+      cid   = card['id'].to_s
+      title = (card['title'] || card['name'] || cid).to_s
+      begin
+        doc = Domo.private_get("/api/content/v1/cards/#{cid}/data")
+        data = doc['data'] || {}
+        rows = shape_rows(data)
+        sv   = summary_value(doc)
+        mutex.synchronize do
+          if rows.nil?
+            # No `rows` key at all — record the refusal WITH the card's own
+            # metadata so the exclusion ledger can cite a measured reason
+            # instead of a guess.
+            errors << { 'card_id' => cid, 'title' => title,
+                        'reason' => 'domo card-data returned no `rows` key (card computes its ' \
+                                    'value from a window baked into the plotted measure)',
+                        'mappings' => data['mappings'], 'num_rows' => data['numRows'] }
+          else
+            results[cid] = {
+              'card_id'   => cid,
+              'title'     => title,
+              'rows'      => rows,
+              'columns'   => data['columns'],
+              'mappings'  => data['mappings'],
+              'num_rows'  => data['numRows'],
+              'datasource' => data['datasource'],
+              'source'    => 'domo-card-data',
+            }
+          end
+          results[cid]['summary_value'] = sv if sv && results[cid]
+          warn "  [#{results.size + errors.size}/#{cards.size}] #{title[0, 46]}"
+        end
+      rescue StandardError => e
+        mutex.synchronize do
+          errors << { 'card_id' => cid, 'title' => title, 'reason' => "fetch failed: #{e.message}" }
+          warn "  ERROR #{cid} #{title[0, 40]}: #{e.message}"
+        end
+      end
+    end
+  end
+end
+threads.each(&:join)
+
+doc = {
+  'fetched_at'   => Time.now.utc.iso8601,
+  'source'       => 'domo-card-data',
+  'endpoint'     => '/api/content/v1/cards/{id}/data',
+  'cards_total'  => cards.size,
+  'cards_ok'     => results.size,
+  'cards_failed' => errors.size,
+  'cards'        => results,
+  'unavailable'  => errors,
+}
+File.write(out_path, JSON.pretty_generate(doc))
+warn "\nwrote #{out_path} — #{results.size}/#{cards.size} cards carry rows, " \
+     "#{results.count { |_, v| v['summary_value'] }} carry a summary value"
+unless errors.empty?
+  warn "#{errors.size} card(s) could not be served — these MUST reach " \
+       'parity-plan-exclusions.json with a reason, never be dropped:'
+  errors.each { |e| warn "    #{e['card_id']}  #{e['title']}  — #{e['reason']}" }
+end
+exit 0

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-expected.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-expected.rb
@@ -92,17 +92,34 @@ def shape_rows(data)
   rows.map { |r| Array(r) }
 end
 
-# A Domo summaryNumber is the card's own KPI value — the thing the migrated
-# `<el>-summary` companion tile plots. `summary.value` is the richer form;
-# `summaryNumber` is the pre-formatted string. Prefer the raw value, fall back
-# to the formatted one, and refuse a `status` that is not a completed run —
-# "not_ran" means Domo declined to compute it, which is not a zero.
+# The card's own KPI value — what the migrated `<el>-summary` companion tile
+# plots. `summary` carries BOTH forms:
+#
+#   {"label": "Sales in Period", "value": "$9.7M", "number": 9690690.9317, ...}
+#
+# TAKE `number`. `value` and the top-level `summaryNumber` are DISPLAY strings,
+# and comparing one of those against Sigma's raw export is a guaranteed false
+# divergence — a bug this returned on its first cut. verify-parity.rb normalises
+# numerically, and in Ruby "$9.7M".to_f is 0.0, so the tile compared 0.0 against
+# 9690690.93 and DIVERGED. Percent cards fail differently and just as silently:
+# "35.61%".to_f is 35.61 while `number` is 0.3561, a 100x mismatch. All 29
+# companion KPI tiles on the live page would have failed this way — a ~45% false
+# failure rate on gate 1, reading exactly like a catastrophic conversion bug and
+# sending the next person hunting something that was never broken.
+#
+# A display string is used ONLY as a last resort, when no numeric form exists at
+# all, and even then it is left to verify-parity to normalise — better a tile
+# that fails loudly than one silently scored on a formatted string.
+#
+# `status` is still honoured: "not_ran" means Domo declined to compute the
+# summary, which is not a zero.
 def summary_value(doc)
   s = doc['summary']
-  if s.is_a?(Hash)
-    status = s['status'].to_s
+  if s.is_a?(Hash) && s['status'].to_s != 'not_ran'
+    n = s['number']
+    return n if n.is_a?(Numeric)
     v = s['value']
-    return v if !v.nil? && v.to_s.strip != '' && status != 'not_ran'
+    return v if !v.nil? && v.to_s.strip != ''
   end
   sn = doc['summaryNumber']
   return sn if !sn.nil? && sn.to_s.strip != ''

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/element_export.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/element_export.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+# element_export.rb — pull one Sigma workbook element's rendered rows as CSV.
+#
+# Lifted verbatim from verify-warehouse.rb's private element_csv, the live-proven
+# path since 2026-07-30, because the parity oracle's Sigma-side collector
+# (collect-parity-actuals.rb) needs exactly the same fetch.
+#
+# YES, THIS DUPLICATES verify-warehouse.rb, AND THAT IS DELIBERATE FOR NOW.
+# The obviously-better move is to make verify-warehouse.rb delegate here so one
+# copy of the retry/poll loop exists. That was implemented and its tests passed
+# — and then reverted, because verify-warehouse.rb is a SHARED CANONICAL file
+# (shared/scripts/verify-warehouse.rb, byte-identical across plugins, enforced
+# by check-shared.rb on every commit). Deduping it means editing the canonical,
+# re-running sync-shared.rb, and version-bumping every affected plugin — a
+# fleet-wide change that must not ride a domo feature PR. Bead beads-sigma-2tkm
+# reached the same conclusion for the same reason and was right to.
+#
+# So: this copy stays domo-local until a dedicated shared-file PR moves the
+# helper to shared/lib/ and repoints both callers. Until then the two MUST be
+# changed together — that is the cost being accepted here, recorded rather than
+# left for someone to discover.
+#
+# The flow is Sigma's documented element export:
+#   POST /v2/workbooks/{wb}/export   { elementId, format: { type: 'csv' } } -> queryId
+#   GET  /v2/query/{queryId}/download  (text/csv, binary)
+# The download 404s or returns empty while the query is still rendering, so both
+# are treated as "keep polling" rather than as failures. Transient 429/408/50x
+# are retried up to 4 times with exponential backoff + jitter.
+#
+# Returns [:ok, csv_string] or [:fail, reason_string] — never raises for an
+# expected failure, so a caller can record a per-tile reason instead of dying
+# on the first bad element.
+require 'json'
+
+module ElementExport
+  module_function
+
+  # fixture: optional Hash{elementId => csv_string} for offline tests.
+  def fetch_csv(element_id, workbook_id, timeout: 120, fixture: nil)
+    if fixture
+      txt = fixture[element_id]
+      return [:fail, 'no fixture row for element'] if txt.nil?
+      return [:ok, txt]
+    end
+    attempts = 0
+    begin
+      attempts += 1
+      r = Sigma.request(:post, "/v2/workbooks/#{workbook_id}/export",
+                        body: JSON.generate({ elementId: element_id,
+                                              format: { type: 'csv' } }))
+      qid = r && r['queryId']
+      return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+      t0 = Time.now
+      loop do
+        return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+        sleep 1.0
+        begin
+          b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+          return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+        rescue Sigma::Error => e
+          raise unless e.message.lines.first.to_s =~ /\b404\b/
+        end
+      end
+    rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+      msg = e.message.lines.first.to_s
+      if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+        sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+        retry
+      end
+      [:fail, msg[0, 160]]
+    end
+  end
+end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -825,6 +825,38 @@ def run_live!(opts)
   phase_write_2d_flag!
   phase_render_visual!(opts, workbook_id, wb_ids)
 
+  # ---- coverage census ----------------------------------------------------
+  # Emits coverage.json: which source cards produced NO Sigma element.
+  #
+  # This is the ONLY route by which a dropped Domo card can reach the degradation
+  # ledger. DegradationLedger.scope_cuts derives scope-cuts from just two places
+  # — coverage.json, and parity-final.json's `tile_census` — and domo can never
+  # fill the second, because `tile_census` is reserved for tableau's ZONE shape
+  # (publishing anything else there turns gate 5's honest SKIP into a vacuous
+  # "0 zones, 0 unmatched"; caught in review on #631, hence `parity_tile_census`).
+  #
+  # Until now domo emitted no coverage.json at all, so a card that never became
+  # an element was invisible to the ledger — and since GREEN requires an EMPTY
+  # ledger, a run that silently dropped cards could still be declared GREEN.
+  # phase6-parity-domo.rb's census does not cover this: its denominator is
+  # elements in workbook-spec.json, so a card missing from the spec entirely is
+  # missing from the census too.
+  #
+  # Verified by planting a drop: removing one card's elements yields 35/36, one
+  # scope-cut, and a verdict of PARTIAL where an empty ledger gives GREEN.
+  hr('coverage-census')
+  ok_cov, code_cov, _cov = run_script!('build-coverage-census.rb', '--workdir', OUT)
+  if ok_cov
+    done_phase!('coverage-census')
+  else
+    # Not fatal — but say plainly what was lost, because the ledger will now be
+    # silent about dropped cards rather than empty-because-clean.
+    skip_phase!('coverage-census',
+                "build-coverage-census.rb exited #{code_cov} — no coverage.json, so a dropped " \
+                'card cannot reach the degradation ledger; do not read a GREEN verdict as ' \
+                'evidence that every card was migrated')
+  end
+
   # ---- parity oracle (gate 1) ---------------------------------------------
   # DEFAULT-ON, same stance as gate 7b's --require-control-flip above, and for a
   # blunter reason: WITHOUT A PLAN THIS RUN CANNOT REACH GOLD. With no

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -906,6 +906,23 @@ def run_live!(opts)
                     "collector failed (expected exit #{code_e}, actuals exit #{code_a}) — " \
                     'refusing to build a partial plan')
       end
+      # build-parity-exclusions.rb (#649) FIRST, so its construction-level
+      # exclusions exist before the join reads them. The two are complementary:
+      # #649 excludes tiles that can never agree (a refused date window — Domo
+      # aggregates over a window the Sigma tile lacks), while the join excludes
+      # tiles it could not COLLECT. Both write parity-plan-exclusions.json, so
+      # order decides who wins: run the join first and #649 overwrites its
+      # exclusions, after which the census sees collection-failed tiles as
+      # neither verified nor excluded and dies (exit 5). Run #649 first and the
+      # join carries its entries through, honouring them over verification —
+      # which matters, because such a tile IS collectable and would otherwise be
+      # "verified" into a guaranteed DIVERGE that says nothing about fidelity.
+      ok_x, code_x, _x = run_script!('build-parity-exclusions.rb', '--workdir', OUT)
+      fail_phase!('parity-oracle',
+                  "build-parity-exclusions.rb exited #{code_x} — either the runaway guard " \
+                  'tripped (fix the converter, do not widen exclusions) or the artifact is ' \
+                  'unreadable; continuing would hand the join a stale exclusions file') unless ok_x
+
       ok_j, code_j, _j = run_script!('build-parity-oracle.rb', '--workdir', OUT)
       fail_phase!('parity-oracle', "build-parity-oracle.rb exited #{code_j}") unless ok_j
       oracle_plan = File.join(OUT, 'parity-plan-verified.json')
@@ -944,8 +961,22 @@ def run_live!(opts)
     # A non-zero exit here is FATAL, not advisory: it means either the runaway
     # guard tripped (fix the converter) or the artifact is unreadable — and
     # continuing would hand the census a stale or absent exclusions file.
-    ok, code, _out = run_script!('build-parity-exclusions.rb', '--workdir', OUT)
-    fail_phase!('verify-parity', "build-parity-exclusions.rb exited #{code}") unless ok
+    #
+    # SKIPPED when the oracle already ran it. The oracle path invokes this
+    # generator BEFORE the join so the join can carry its entries through
+    # (build-parity-oracle.rb honours prior exclusions over verification).
+    # Re-running it here would rewrite the file from warnings.json alone and
+    # discard every collection-failure exclusion the join added — after which the
+    # census sees those tiles as neither verified nor excluded and dies (exit 5).
+    # This branch therefore only serves the hand-supplied --parity-plan path,
+    # where no oracle ran and nothing else writes the file.
+    if oracle_plan
+      log 'exclusions: already generated before the oracle join (not re-running — it would ' \
+          'discard the join\'s collection-failure exclusions)'
+    else
+      ok, code, _out = run_script!('build-parity-exclusions.rb', '--workdir', OUT)
+      fail_phase!('verify-parity', "build-parity-exclusions.rb exited #{code}") unless ok
+    end
 
     ok, code, _out = run_script!('phase6-parity-domo.rb',
                                   '--workdir', OUT,

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -103,7 +103,12 @@ OptionParser.new do |o|
   o.on('--description STR', 'Workbook description.') { |v| opts[:description] = v }
   o.on('--mode MODE', %w[dashboard page-per-worksheet], 'build-workbook-spec.rb page layout mode ' \
        '(default page-per-worksheet).') { |v| opts[:mode] = v }
-  o.on('--parity-plan PATH', 'LIVE mode: verify-parity.rb plan (phase skipped with a note when absent).') { |v| opts[:parity_plan] = v }
+  o.on('--parity-plan PATH', 'LIVE mode: a hand-supplied verify-parity.rb plan. Overrides the ' \
+       'built-in parity oracle, which otherwise builds one automatically.') { |v| opts[:parity_plan] = v }
+  o.on('--skip-parity-oracle REASON', 'Do NOT build the parity oracle automatically. Without a ' \
+       '--parity-plan this leaves the run with no gate-1 evidence at all, so ' \
+       'assert-phase6-ran.rb gets --skip-parity-gate and rejects it (exit 18) absent a passing ' \
+       'anchors-verdict.json. In other words: this run cannot then be GREEN.') { |v| opts[:skip_parity_oracle] = v }
 end.parse!(ARGV)
 
 abort('FATAL: --out DIR is required') unless opts[:out]
@@ -820,7 +825,64 @@ def run_live!(opts)
   phase_write_2d_flag!
   phase_render_visual!(opts, workbook_id, wb_ids)
 
+  # ---- parity oracle (gate 1) ---------------------------------------------
+  # DEFAULT-ON, same stance as gate 7b's --require-control-flip above, and for a
+  # blunter reason: WITHOUT A PLAN THIS RUN CANNOT REACH GOLD. With no
+  # --parity-plan the orchestrator auto-adds --skip-parity-gate below, and gate 1
+  # rejects that waiver with exit 18 unless a passing anchors-verdict.json
+  # already exists. So the historic default path was a guaranteed dead end that
+  # merely looked like a skip.
+  #
+  # build-parity-plan.rb emits the tile LIST but, by design, no values —
+  # verify-parity.rb is a pure differ needing BOTH sides pre-collected. The two
+  # collectors supply them:
+  #   collect-parity-expected.rb  Domo's own rendered card values
+  #   collect-parity-actuals.rb   the live Sigma element exports
+  #   build-parity-oracle.rb      joins them + writes the exclusion ledger
+  # Both sides are fetched inside THIS run so a card's relative date window is
+  # evaluated once (build-parity-oracle refuses a cross-UTC-day join).
+  #
+  # Waive with --skip-parity-oracle "<reason>" — which lands you back on the
+  # dead-end path, so the reason had better be good.
+  oracle_plan = nil
+  if !opts[:parity_plan] && !opts[:skip_parity_oracle]
+    hr('parity-oracle')
+    plan_path = File.join(OUT, 'parity-plan.json')
+    # --workbook-spec, NOT --workbook-id: phase6-parity-domo.rb's anti-inflation
+    # census reads <workdir>/workbook-spec.json, so the plan must be built from
+    # the SAME document or the two disagree about what "chartable" means and the
+    # census fails on tiles that were never really missing (put-layout injects
+    # header elements into the live spec that the local one has no idea about).
+    ok, code, _o = run_script!('build-parity-plan.rb',
+                               '--workbook-spec', File.join(OUT, 'workbook-spec.json'),
+                               '--workbook-id', workbook_id,
+                               '--out', plan_path)
+    if !ok
+      skip_phase!('parity-oracle', "build-parity-plan.rb exited #{code} — no chartable tiles to score")
+    else
+      ok_e, code_e, _e = run_script!('collect-parity-expected.rb', '--workdir', OUT)
+      ok_a, code_a, _a = run_script!('collect-parity-actuals.rb',
+                                     '--plan', plan_path,
+                                     '--workbook-id', workbook_id,
+                                     '--out', File.join(OUT, 'parity-actuals.json'))
+      if !ok_e || !ok_a
+        # Deliberately a hard FAIL, not a skip. A half-collected oracle would
+        # join into a plan missing tiles, and a shrunken denominator reads
+        # exactly like a clean pass — the one failure mode this whole chain is
+        # built to refuse.
+        fail_phase!('parity-oracle',
+                    "collector failed (expected exit #{code_e}, actuals exit #{code_a}) — " \
+                    'refusing to build a partial plan')
+      end
+      ok_j, code_j, _j = run_script!('build-parity-oracle.rb', '--workdir', OUT)
+      fail_phase!('parity-oracle', "build-parity-oracle.rb exited #{code_j}") unless ok_j
+      oracle_plan = File.join(OUT, 'parity-plan-verified.json')
+      done_phase!('parity-oracle')
+    end
+  end
+
   hr('verify-parity')
+  opts[:parity_plan] ||= oracle_plan
   if opts[:parity_plan] && File.exist?(opts[:parity_plan])
     # Bead 2tkm — finalize through phase6-parity-domo.rb, do NOT aim
     # verify-parity.rb's --score-out at parity-final.json.
@@ -861,7 +923,12 @@ def run_live!(opts)
     fail_phase!('verify-parity', "phase6-parity-domo.rb exited #{code}") unless ok
     done_phase!('verify-parity')
   else
-    skip_phase!('verify-parity', 'no --parity-plan supplied — run verify-parity.rb by hand before declaring GREEN')
+    skip_phase!('verify-parity',
+                opts[:skip_parity_oracle] ?
+                  "parity oracle waived (#{opts[:skip_parity_oracle]}) and no --parity-plan given — " \
+                  'gate 1 has no evidence; this run cannot be GREEN' :
+                  'no parity plan available (the oracle found no chartable tiles) — ' \
+                  'run verify-parity.rb by hand before declaring GREEN')
   end
 
   phase_record_visual_check!(opts)
@@ -873,7 +940,19 @@ def run_live!(opts)
   # looker reference; waive with --skip-control-flip "<reason>".
   args += ['--require-control-flip']
   args += ['--skip-visual-gate', 'Tier B — private render endpoint unavailable'] if tier_b
-  args += ['--skip-parity-gate', 'no --parity-plan supplied to migrate-domo.rb'] unless opts[:parity_plan]
+  # The reason must say what ACTUALLY happened — it is recorded as a waiver and
+  # read later by someone reconstructing why a run was not GREEN. "no
+  # --parity-plan supplied" was true when that was the only way to get a plan;
+  # now the oracle builds one by default, so the honest reason is whichever of
+  # these applies.
+  unless opts[:parity_plan]
+    why = if opts[:skip_parity_oracle]
+            "parity oracle waived via --skip-parity-oracle: #{opts[:skip_parity_oracle]}"
+          else
+            'parity oracle produced no plan (build-parity-plan.rb found no chartable tiles)'
+          end
+    args += ['--skip-parity-gate', why]
+  end
   ok, code, _out = run_script!('assert-phase6-ran.rb', *args)
   fail_phase!('assert-phase6-ran', "assert-phase6-ran.rb exited #{code}") unless ok
   done_phase!('assert-phase6-ran')

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -877,6 +877,7 @@ def run_live!(opts)
   # Waive with --skip-parity-oracle "<reason>" — which lands you back on the
   # dead-end path, so the reason had better be good.
   oracle_plan = nil
+  oracle_skip_reason = nil
   if !opts[:parity_plan] && !opts[:skip_parity_oracle]
     hr('parity-oracle')
     plan_path = File.join(OUT, 'parity-plan.json')
@@ -890,7 +891,17 @@ def run_live!(opts)
                                '--workbook-id', workbook_id,
                                '--out', plan_path)
     if !ok
-      skip_phase!('parity-oracle', "build-parity-plan.rb exited #{code} — no chartable tiles to score")
+      # Exit 2 is build-parity-plan.rb's DELIBERATE "zero chartable elements".
+      # Anything else is a crash (it has no rescue around JSON.parse, so a
+      # truncated workbook-spec.json raises and exits 1). Reporting a crash as
+      # "no chartable tiles" is a lie that propagates: the same wording ends up
+      # in the --skip-parity-gate waiver text below, sending whoever debugs the
+      # non-GREEN run to look for an empty workbook instead of a broken artifact.
+      why = code == 2 ? 'build-parity-plan.rb found no chartable tiles (exit 2)'
+                      : "build-parity-plan.rb FAILED with exit #{code} — this is a crash, not an " \
+                        'empty workbook; check workbook-spec.json is complete and parseable'
+      oracle_skip_reason = why
+      skip_phase!('parity-oracle', why)
     else
       ok_e, code_e, _e = run_script!('collect-parity-expected.rb', '--workdir', OUT)
       ok_a, code_a, _a = run_script!('collect-parity-actuals.rb',
@@ -1012,7 +1023,11 @@ def run_live!(opts)
     why = if opts[:skip_parity_oracle]
             "parity oracle waived via --skip-parity-oracle: #{opts[:skip_parity_oracle]}"
           else
-            'parity oracle produced no plan (build-parity-plan.rb found no chartable tiles)'
+            # Reuse the reason the oracle phase actually recorded, so a CRASH in
+            # build-parity-plan.rb is not laundered into the benign-sounding
+            # "found no chartable tiles". This text is the run's permanent record
+            # of why gate 1 had no evidence.
+            oracle_skip_reason || 'parity oracle produced no plan'
           end
     args += ['--skip-parity-gate', why]
   end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/verify-parity.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/verify-parity.rb
@@ -357,13 +357,14 @@ results = plan.map do |p|
                   'then set "render_verified": true on this chart in the plan ' \
                   '(or replace the marker with actual rows) and re-run'] }
       end
-    next result.merge(chart: p['chart'], extract: this_extract, columns: [])
+    next result.merge(chart: p['chart'], element_id: p['sigma_element_id'],
+                      extract: this_extract, columns: [])
   end
 
   act = extract_rows(p['actual']).map { |r| round_row(r) }
 
   result = this_extract ? extract_compare(exp, act, tol: opts[:tol]) : strict_compare(exp, act)
-  result.merge(chart: p['chart'], extract: this_extract,
+  result.merge(chart: p['chart'], element_id: p['sigma_element_id'], extract: this_extract,
                columns: per_column_scores(exp, act, p['sigma_columns']))
 end
 
@@ -410,7 +411,13 @@ if opts[:score_out]
     'tiles_fail'          => failed,
     'value_parity_score'  => overall,
     'tiles'               => results.map { |r|
-      { 'chart' => r[:chart], 'status' => r[:status], 'extract' => r[:extract],
+      # element_id rides along so a DIVERGE can be localised. Domo reuses generic
+      # summary labels — 11 of the real 65 tiles share a display name with
+      # another — so a fail_names entry of "New Visits in Period" names FOUR
+      # possible elements and tells an operator nothing about which one broke.
+      # Nil for a hand-authored plan that carries no sigma_element_id.
+      { 'chart' => r[:chart], 'element_id' => r[:element_id],
+        'status' => r[:status], 'extract' => r[:extract],
         # PENDING (render-verify) tiles carry score:null — unscored, not zero.
         'score' => (r[:status] == 'PENDING' ? nil : (r[:score] || 0.0)),
         'n_expected' => r[:n_expected], 'n_actual' => r[:n_actual], 'n_matched' => r[:n_matched],

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -148,6 +148,23 @@ ok(migrate_src.include?("'collect-parity-actuals.rb'"),
 ok(migrate_src.include?("'build-parity-oracle.rb'"),
    'oracle: run_live! joins the two sides into a verify-parity plan')
 
+# ORDER IS LOAD-BEARING between the two exclusions writers (#649's generator and
+# the join). Both write parity-plan-exclusions.json:
+#   #649  excludes tiles that cannot agree BY CONSTRUCTION (refused date window)
+#   join  excludes tiles it could not COLLECT
+# Run the join first and #649 overwrites its entries, after which the census sees
+# collection-failed tiles as neither verified nor excluded and dies (exit 5). Run
+# #649 first and the join carries them through, honouring them over verification
+# — which matters because such a tile IS collectable and would otherwise be
+# "verified" into a guaranteed DIVERGE that says nothing about fidelity.
+excl_gen_at = migrate_src.index("'build-parity-exclusions.rb'")
+join_at = migrate_src.index("'build-parity-oracle.rb'")
+ok(excl_gen_at && join_at && excl_gen_at < join_at,
+   'oracle: the exclusions generator runs BEFORE the join, so the join can carry its entries through')
+ok(migrate_src.include?('if oracle_plan') &&
+   migrate_src.match?(/exclusions: already generated before the oracle join/),
+   'oracle: the generator is NOT re-run after the join (that would discard the join\'s exclusions)')
+
 # DEFAULT-ON, not opt-in. The condition must fire when NO --parity-plan was
 # given; if someone flips this to require an opt-in flag, the default path goes
 # back to being unable to reach gold.

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -112,6 +112,61 @@ ok(migrate_src.include?("'--score-out', File.join(OUT, 'parity-score.json')") ||
    migrate_src.include?('phase6-parity-domo.rb'),
    'bead 2tkm: the tiles_* score document lands in parity-score.json, not parity-final.json')
 
+# ---------------------------------------------------------------------------
+# Parity oracle wiring (gate 1). Same static-guard caveat as above: run_live!
+# cannot be exercised offline, so these pin the WIRING, not the behaviour.
+#
+# Why this needs a guard at all: without a plan, migrate-domo auto-adds
+# --skip-parity-gate, and assert-phase6-ran.rb REJECTS that waiver (exit 18)
+# unless a passing anchors-verdict.json exists. So a silently-removed oracle
+# call does not look like a missing feature — it looks like a run that skipped
+# parity, which is a guaranteed non-GREEN dead end (trap T4 in the 2026-08-05
+# handoff). Cheap to regress, expensive to notice.
+ok(migrate_src.include?("'collect-parity-expected.rb'"),
+   'oracle: run_live! collects the Domo-side expected values')
+ok(migrate_src.include?("'collect-parity-actuals.rb'"),
+   'oracle: run_live! collects the Sigma-side actuals')
+ok(migrate_src.include?("'build-parity-oracle.rb'"),
+   'oracle: run_live! joins the two sides into a verify-parity plan')
+
+# DEFAULT-ON, not opt-in. The condition must fire when NO --parity-plan was
+# given; if someone flips this to require an opt-in flag, the default path goes
+# back to being unable to reach gold.
+ok(migrate_src.include?('if !opts[:parity_plan] && !opts[:skip_parity_oracle]'),
+   'oracle: builds by DEFAULT when no --parity-plan is supplied (opt-out, not opt-in)')
+ok(migrate_src.include?('--skip-parity-oracle'),
+   'oracle: there is an explicit opt-out flag')
+
+# The plan must be built from the SAME document phase6-parity-domo.rb's census
+# reads (<workdir>/workbook-spec.json), or the two disagree about what counts as
+# chartable and the census fails on tiles that were never missing.
+ok(migrate_src.include?("'build-parity-plan.rb'") &&
+   migrate_src.include?("'--workbook-spec', File.join(OUT, 'workbook-spec.json')"),
+   'oracle: the plan is built from the same workbook-spec.json the census audits')
+
+# A half-collected oracle must be a hard FAIL. Joining a partial collection
+# yields a plan missing tiles, and a shrunken denominator reads exactly like a
+# clean pass — 45/45 is indistinguishable from 65/65.
+ok(migrate_src.include?("fail_phase!('parity-oracle'"),
+   'oracle: a failed collector is a hard FAIL, never a skip that silently shrinks the denominator')
+
+# The recorded waiver reason must be derived, not the old hardcoded string —
+# it is read later by whoever reconstructs why a run was not GREEN.
+ok(!migrate_src.include?("'--skip-parity-gate', 'no --parity-plan supplied to migrate-domo.rb'"),
+   'oracle: the skip-parity-gate reason is no longer the stale hardcoded "no --parity-plan" text')
+ok(migrate_src.include?('opts[:skip_parity_oracle]') &&
+   migrate_src.include?("args += ['--skip-parity-gate', why]"),
+   'oracle: the skip-parity-gate waiver records WHY parity is absent (waived vs no chartable tiles)')
+
+# NB: hr('verify-parity') occurs TWICE — run_offline! emits one as a skip before
+# run_live!'s. A bare .index finds the offline one and this ordering check then
+# compares against the wrong occurrence, so search for the verify-parity header
+# that FOLLOWS the oracle header.
+oracle_hdr_at = migrate_src.index("hr('parity-oracle')")
+live_parity_at = oracle_hdr_at && migrate_src.index("hr('verify-parity')", oracle_hdr_at)
+ok(oracle_hdr_at && live_parity_at && oracle_hdr_at < live_parity_at,
+   'oracle: the plan is built BEFORE verify-parity consumes it')
+
 render_call_at  = migrate_src.index('phase_render_visual!(opts, workbook_id, wb_ids)')
 parity_hdr_at   = migrate_src.index("hr('verify-parity')")
 record_call_at  = migrate_src.index('phase_record_visual_check!(opts)')

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -113,6 +113,25 @@ ok(migrate_src.include?("'--score-out', File.join(OUT, 'parity-score.json')") ||
    'bead 2tkm: the tiles_* score document lands in parity-score.json, not parity-final.json')
 
 # ---------------------------------------------------------------------------
+# Coverage census wiring. coverage.json is the ONLY path by which a dropped Domo
+# card reaches the degradation ledger (the other scope-cut source,
+# parity-final.json's tile_census, is reserved for tableau's zone shape and domo
+# must never publish there — memory gate5-tile-census-key-reserved). GREEN
+# requires an EMPTY ledger, so without this call a run that silently dropped
+# cards could still be declared GREEN.
+ok(migrate_src.include?("'build-coverage-census.rb'"),
+   'coverage: run_live! emits coverage.json so a dropped card can reach the degradation ledger')
+# Search for the assert header that FOLLOWS the census, not the first in the
+# file: run_offline! emits its own hr('assert-phase6-ran') earlier, so a bare
+# .index compares against the offline occurrence and this ordering check fails
+# on correct code. (Made this exact mistake on the oracle ordering guard below
+# too — both hr() titles appear twice.)
+cov_at = migrate_src.index("hr('coverage-census')")
+assert_at = cov_at && migrate_src.index("hr('assert-phase6-ran')", cov_at)
+ok(cov_at && assert_at && cov_at < assert_at,
+   'coverage: the census runs BEFORE assert-phase6-ran reads the ledger')
+
+# ---------------------------------------------------------------------------
 # Parity oracle wiring (gate 1). Same static-guard caveat as above: run_live!
 # cannot be exercised offline, so these pin the WIRING, not the behaviour.
 #

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle-dupenames.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle-dupenames.rb
@@ -1,0 +1,154 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression: DUPLICATE CHART NAMES must not cross-wire tiles.
+#
+# Found by adversarial review of the parity oracle, reproduced end to end, and
+# the single worst class of defect this chain can have: it produced an UNEARNED
+# PASS on a genuine migration bug.
+#
+# Domo hands the same generic summary label to many cards. On the real 65-tile
+# page ELEVEN tiles share a name with at least one other:
+#     "New Visits in Period"  x4    "Change over 7 Days"  x3
+#     "Surveys in Period"     x2    "US Leads in Period"  x2
+# phase6-parity-domo.rb:190-193 says so itself ("the same KPI title repeated on
+# two pages is routine") and compares as a MULTISET for exactly this reason.
+#
+# Keying the Sigma actuals by display name broke two ways at once, both silent:
+#   1. last writer wins in the thread pool, non-deterministically, and the losing
+#      exports vanished with NO `unavailable` entry;
+#   2. the join attached that ONE surviving export to EVERY tile sharing the name.
+# Measured on the real element ids: a genuine match scored DIVERGE (false
+# negative) and a genuine 42-vs-7 divergence scored PASS 100% (unearned pass).
+#
+# The same name-keying in prior_excl swept every same-named tile into one tile's
+# exclusion — shrinking the denominator, which reads as a cleaner pass.
+#
+# Element ids are unique by construction. These tests pin that they are the key.
+#
+#   ruby test/test-parity-oracle-dupenames.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'fileutils'
+
+SKILL   = File.expand_path('..', __dir__)
+SCRIPTS = File.join(SKILL, 'scripts')
+$failures = 0
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+def eq(a, e, m)
+  if a == e then puts "  ok: #{m}"
+  else $failures += 1; puts "  FAIL: #{m}\n        expected #{e.inspect}\n        got      #{a.inspect}" end
+end
+
+# The three REAL element ids that collide on "Change over 7 Days" in
+# ~/domo-coldrun-v4/workbook-spec.json, with deliberately DIFFERENT values so a
+# cross-wire cannot hide behind coincidence.
+IDS = %w[el-503650739-summary el-1136570741-summary el-53325952-summary].freeze
+CARDS = { 'el-503650739-summary' => %w[503650739 999],
+          'el-1136570741-summary' => %w[1136570741 7],
+          'el-53325952-summary' => %w[53325952 7] }.freeze
+ACTUAL = { 'el-503650739-summary' => '999',    # matches expected -> PASS
+           'el-1136570741-summary' => '42',    # real divergence   -> DIVERGE
+           'el-53325952-summary' => '7' }.freeze # matches         -> PASS
+
+def stage(dir, exclusions: nil)
+  File.write(File.join(dir, 'fixture.json'),
+             JSON.generate(IDS.to_h { |i| [i, "value\n#{ACTUAL[i]}\n"] }))
+  File.write(File.join(dir, 'parity-plan.json'), JSON.generate(
+    'charts' => IDS.map do |i|
+      { 'chart' => 'Change over 7 Days', 'sigma_element_id' => i,
+        'sigma_kind' => 'kpi-chart', 'sigma_columns' => ['m'] }
+    end))
+  File.write(File.join(dir, 'parity-expected.json'), JSON.generate(
+    'fetched_at' => '2026-08-07T13:00:00Z', 'unavailable' => [],
+    'cards' => IDS.to_h do |i|
+      cid, sv = CARDS[i]
+      [cid, { 'card_id' => cid, 'title' => "card #{cid}", 'rows' => [['x', 1]],
+              'summary_value' => sv.to_i }]
+    end))
+  File.write(File.join(dir, 'parity-plan-exclusions.json'), JSON.generate(exclusions)) if exclusions
+end
+
+def run(*args)
+  out, st = Open3.capture2e('ruby', *args)
+  [st.success?, out]
+end
+
+Dir.mktmpdir('dupe') do |dir|
+  stage(dir)
+
+  # ---- the actuals collector keeps every element ---------------------------
+  okc, out = run(File.join(SCRIPTS, 'collect-parity-actuals.rb'),
+                 '--plan', File.join(dir, 'parity-plan.json'),
+                 '--workbook-id', 'wb1', '--out', File.join(dir, 'parity-actuals.json'),
+                 '--pool', '1', '--fixture', File.join(dir, 'fixture.json'))
+  ok(okc, 'collect-parity-actuals.rb exits 0 on three same-named tiles')
+  act = JSON.parse(File.read(File.join(dir, 'parity-actuals.json')))
+  eq(act['charts_ok'], 3,
+     'all THREE same-named exports survive (name-keyed, only 1 did — the other two vanished ' \
+     'with no `unavailable` entry, contradicting the script\'s own guarantee)')
+  eq(act['charts'].keys.sort, IDS.sort, 'actuals are keyed by ELEMENT ID, not display name')
+  eq(act['unavailable'], [], 'and nothing was silently dropped')
+
+  # ---- the join attaches each tile its OWN actual --------------------------
+  okj, = run(File.join(SCRIPTS, 'build-parity-oracle.rb'), '--workdir', dir)
+  ok(okj, 'build-parity-oracle.rb exits 0')
+  plan = JSON.parse(File.read(File.join(dir, 'parity-plan-verified.json')))
+  eq(plan['charts'].length, 3, 'all three tiles are verified')
+  mapping = plan['charts'].to_h { |c| [c['sigma_element_id'], c['actual']['rows'].flatten.first.to_s] }
+  eq(mapping, ACTUAL,
+     'each tile carries ITS OWN Sigma export — a cross-wire here is an unearned PASS')
+  exp = plan['charts'].to_h { |c| [c['sigma_element_id'], c['expected'].flatten.first.to_i] }
+  eq(exp, IDS.to_h { |i| [i, CARDS[i][1].to_i] }, 'and its own Domo expected value')
+
+  # ---- scoring comes out right --------------------------------------------
+  _, vout = run(File.join(SCRIPTS, 'verify-parity.rb'), '--plan',
+                File.join(dir, 'parity-plan-verified.json'))
+  eq(vout.scan(/^PASS/).length, 2, 'exactly the two genuine matches PASS')
+  eq(vout.scan(/^DIVERGE/).length, 1,
+     'and the one genuine divergence (42 vs 7) DIVERGES — name-keyed it reported PASS 100%')
+end
+
+# ---- a prior exclusion must not sweep its same-named siblings -------------
+Dir.mktmpdir('dupe-excl') do |dir|
+  stage(dir, exclusions: { 'exclusions' => [
+    { 'chart' => 'Change over 7 Days', 'reason' => 'refused date window (INTERVAL_OFFSET)',
+      'evidence' => { 'card_id' => '1136570741', 'element_id' => 'el-1136570741-summary' } },
+  ] })
+  run(File.join(SCRIPTS, 'collect-parity-actuals.rb'),
+      '--plan', File.join(dir, 'parity-plan.json'), '--workbook-id', 'wb1',
+      '--out', File.join(dir, 'parity-actuals.json'), '--pool', '1',
+      '--fixture', File.join(dir, 'fixture.json'))
+  run(File.join(SCRIPTS, 'build-parity-oracle.rb'), '--workdir', dir)
+
+  v = JSON.parse(File.read(File.join(dir, 'parity-plan-verified.json')))
+  x = JSON.parse(File.read(File.join(dir, 'parity-plan-exclusions.json')))
+  eq(v['charts'].map { |c| c['sigma_element_id'] }.sort,
+     %w[el-503650739-summary el-53325952-summary],
+     'the two NOT disqualified are still verified (name-keyed, all three were swept out)')
+  eq(x['exclusions'].length, 1, 'exactly one exclusion survives')
+  eq(x['exclusions'].first.dig('evidence', 'element_id'), 'el-1136570741-summary',
+     'and it is the element that was actually disqualified')
+  eq(v['charts'].length + x['exclusions'].length, 3, 'coverage invariant still exact')
+end
+
+# ---- a name-only prior exclusion is consumed ONCE, never broadcast --------
+Dir.mktmpdir('dupe-nameonly') do |dir|
+  stage(dir, exclusions: { 'exclusions' => [
+    { 'chart' => 'Change over 7 Days', 'reason' => 'legacy hand-authored entry, no element_id' },
+  ] })
+  run(File.join(SCRIPTS, 'collect-parity-actuals.rb'),
+      '--plan', File.join(dir, 'parity-plan.json'), '--workbook-id', 'wb1',
+      '--out', File.join(dir, 'parity-actuals.json'), '--pool', '1',
+      '--fixture', File.join(dir, 'fixture.json'))
+  run(File.join(SCRIPTS, 'build-parity-oracle.rb'), '--workdir', dir)
+  v = JSON.parse(File.read(File.join(dir, 'parity-plan-verified.json')))
+  x = JSON.parse(File.read(File.join(dir, 'parity-plan-exclusions.json')))
+  eq(x['exclusions'].length, 1,
+     'an ambiguous name-only exclusion applies to ONE tile, not all three — ' \
+     'it should under-apply, never over-apply')
+  eq(v['charts'].length, 2, 'the other two are still scored')
+end
+
+puts $failures.zero? ? "\nALL PASS" : "\n#{$failures} FAILURE(S)"
+exit($failures.zero? ? 0 : 1)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle-dupenames.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle-dupenames.rb
@@ -150,5 +150,97 @@ Dir.mktmpdir('dupe-nameonly') do |dir|
   eq(v['charts'].length, 2, 'the other two are still scored')
 end
 
+# ---- round 2: re-running the join must be IDEMPOTENT ----------------------
+# The round-1 fix added element_id to the two exclusion sites it happened to
+# touch and missed three others. Those element_id-less entries were then
+# indistinguishable from a legacy name-only exclusion on the NEXT standalone
+# run, so .shift handed one to the FIRST same-named tile in plan order — which
+# could be a tile carrying a real divergence. Measured: a caught 999-vs-100 bug
+# became "2/2 pass = 100%" on the second invocation. A bare
+# `build-parity-oracle.rb --workdir` re-run is documented, supported usage.
+Dir.mktmpdir('dupe-rerun') do |dir|
+  # The scenario must actually PRODUCE an exclusion of a self-written kind, or
+  # the "every exclusion carries element_id" check is vacuously true on an empty
+  # array. (First cut of this test was exactly that — it passed with the fix
+  # deliberately reverted.) So: FOUR same-named tiles, one with NO Domo card
+  # (fires the element_id-less "no Domo source value" path), and one carrying a
+  # real divergence that must survive every re-run.
+  ids = %w[el-1393001267-summary el-1037345428-summary el-579213727-summary el-1124999128-summary]
+  actual = { ids[0] => '999', ids[1] => '5', ids[2] => '5', ids[3] => '5' }
+  File.write(File.join(dir, 'fixture.json'),
+             JSON.generate(ids.to_h { |i| [i, "value\n#{actual[i]}\n"] }))
+  File.write(File.join(dir, 'parity-plan.json'), JSON.generate(
+    'charts' => ids.map do |i|
+      { 'chart' => 'New Visits in Period', 'sigma_element_id' => i,
+        'sigma_kind' => 'kpi-chart', 'sigma_columns' => ['m'] }
+    end))
+  # el-1393001267-summary expects 100 but Sigma exports 999 -> a REAL divergence.
+  # el-1124999128-summary has NO card entry at all -> "no Domo source value".
+  File.write(File.join(dir, 'parity-expected.json'), JSON.generate(
+    'fetched_at' => '2026-08-07T13:00:00Z', 'unavailable' => [],
+    'cards' => { '1393001267' => { 'card_id' => '1393001267', 'title' => 'a',
+                                   'rows' => [['x', 1]], 'summary_value' => 100 },
+                 '1037345428' => { 'card_id' => '1037345428', 'title' => 'b',
+                                   'rows' => [['x', 1]], 'summary_value' => 5 },
+                 '579213727'  => { 'card_id' => '579213727', 'title' => 'c',
+                                   'rows' => [['x', 1]], 'summary_value' => 5 } }))
+  run(File.join(SCRIPTS, 'collect-parity-actuals.rb'),
+      '--plan', File.join(dir, 'parity-plan.json'), '--workbook-id', 'wb1',
+      '--out', File.join(dir, 'parity-actuals.json'), '--pool', '1',
+      '--fixture', File.join(dir, 'fixture.json'))
+
+  scores = (1..3).map do
+    run(File.join(SCRIPTS, 'build-parity-oracle.rb'), '--workdir', dir)
+    _, vout = run(File.join(SCRIPTS, 'verify-parity.rb'), '--plan',
+                  File.join(dir, 'parity-plan-verified.json'))
+    [vout.scan(/^PASS/).length, vout.scan(/^DIVERGE/).length]
+  end
+  eq(scores, [[2, 1], [2, 1], [2, 1]],
+     'three consecutive joins score identically — the real 999-vs-100 DIVERGE is never ' \
+     'laundered into an unearned exclusion by a stale element_id-less entry')
+
+  x = JSON.parse(File.read(File.join(dir, 'parity-plan-exclusions.json')))
+  ok(!x['exclusions'].empty?,
+     'the scenario really does produce an exclusion (guard below is not vacuous)')
+  ok(x['exclusions'].all? { |e| !e['element_id'].to_s.empty? || !e.dig('evidence', 'element_id').to_s.empty? },
+     'every exclusion this script writes carries an element_id, so its own output can never ' \
+     'be mistaken for a legacy name-only entry on the next run')
+  eq(x['exclusions'].map { |e| e['element_id'] }, [ids[3]],
+     'and it is the tile that genuinely has no Domo card — not whichever came first by name')
+end
+
+# ---- round 2: the same ELEMENT ID listed twice in the plan -----------------
+# A Domo card pinned to two dashboard pages is ordinary; discovery applies no
+# cross-page dedup and the element id derives purely from the card id, so the
+# plan can legitimately double-list one element. act_by_eid resolves for BOTH
+# occurrences, so the second was scored a second time against the first one's
+# single measurement — two plan rows, one measurement, both reported.
+Dir.mktmpdir('dupe-eid') do |dir|
+  File.write(File.join(dir, 'fixture.json'), JSON.generate('el-777-summary' => "value\n5\n"))
+  File.write(File.join(dir, 'parity-plan.json'), JSON.generate('charts' => [
+    { 'chart' => 'Pinned Card', 'sigma_element_id' => 'el-777-summary',
+      'sigma_kind' => 'kpi-chart', 'sigma_columns' => ['m'] },
+    { 'chart' => 'Pinned Card', 'sigma_element_id' => 'el-777-summary',
+      'sigma_kind' => 'kpi-chart', 'sigma_columns' => ['m'] },
+  ]))
+  File.write(File.join(dir, 'parity-expected.json'), JSON.generate(
+    'fetched_at' => '2026-08-07T13:00:00Z', 'unavailable' => [],
+    'cards' => { '777' => { 'card_id' => '777', 'title' => 'Pinned Card',
+                            'rows' => [['x', 1]], 'summary_value' => 5 } }))
+  run(File.join(SCRIPTS, 'collect-parity-actuals.rb'),
+      '--plan', File.join(dir, 'parity-plan.json'), '--workbook-id', 'wb1',
+      '--out', File.join(dir, 'parity-actuals.json'), '--pool', '1',
+      '--fixture', File.join(dir, 'fixture.json'))
+  run(File.join(SCRIPTS, 'build-parity-oracle.rb'), '--workdir', dir)
+
+  v = JSON.parse(File.read(File.join(dir, 'parity-plan-verified.json')))
+  x = JSON.parse(File.read(File.join(dir, 'parity-plan-exclusions.json')))
+  eq(v['charts'].length, 1, 'a double-listed element is scored ONCE, not twice')
+  eq(x['exclusions'].length, 1, 'and its duplicate is excluded, not silently dropped')
+  ok(x['exclusions'].first['reason'].to_s.include?('more than once'),
+     'with a reason naming the actual problem (the plan double-lists the element)')
+  eq(v['charts'].length + x['exclusions'].length, 2, 'coverage invariant still exact')
+end
+
 puts $failures.zero? ? "\nALL PASS" : "\n#{$failures} FAILURE(S)"
 exit($failures.zero? ? 0 : 1)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Unit guards for the parity oracle's pure helpers.
+#
+# Both scripts are top-level CLIs that parse ARGV and hit the network, so they
+# cannot be require_relative'd. Extract the pure functions from source and eval
+# them in isolation — the same idiom test-migrate-domo.rb already uses for
+# render_target_page.
+#
+#   ruby test/test-parity-oracle.rb
+require 'json'
+
+SKILL   = File.expand_path('..', __dir__)
+SCRIPTS = File.join(SKILL, 'scripts')
+$failures = 0
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+def eq(a, e, m)
+  if a == e then puts "  ok: #{m}"
+  else $failures += 1; puts "  FAIL: #{m}\n        expected #{e.inspect}\n        got      #{a.inspect}" end
+end
+
+expected_src = File.read(File.join(SCRIPTS, 'collect-parity-expected.rb'))
+sv_src = expected_src[/^def summary_value\(doc\)\n.*?\nend\n/m]
+ok(sv_src, 'extracted summary_value(doc) from collect-parity-expected.rb')
+eval(sv_src, TOPLEVEL_BINDING) if sv_src # rubocop:disable Security/Eval — trusted same-repo source, test-only
+
+# ---------------------------------------------------------------------------
+# THE BUG THIS FILE EXISTS FOR.
+#
+# Domo's card-data summary carries BOTH a display string and a raw number:
+#   {"label": "Sales in Period", "value": "$9.7M", "number": 9690690.9317}
+# The first cut of summary_value returned `value`. verify-parity.rb normalises
+# numerically and in Ruby "$9.7M".to_f is 0.0, so the tile compared 0.0 against
+# 9690690.93 and DIVERGED. Percent cards failed differently and just as quietly:
+# "35.61%".to_f is 35.61 while `number` is 0.3561 — a 100x mismatch.
+#
+# All 29 companion KPI tiles on the live 36-card page would have failed this way:
+# a ~45% false-failure rate on gate 1, indistinguishable from a catastrophic
+# conversion bug. Shapes below are VERBATIM from the live payloads.
+if sv_src
+  eq(summary_value({ 'summary' => { 'label' => 'Sales in Period', 'value' => '$9.7M',
+                                    'number' => 9_690_690.9317 } }),
+     9_690_690.9317,
+     'currency: takes the raw `number`, never the "$9.7M" display string')
+
+  eq(summary_value({ 'summary' => { 'label' => 'Change over 7 Days', 'value' => '19.80%',
+                                    'number' => 0.1979903 } }),
+     0.1979903,
+     'percent: takes the FRACTION, not the 19.80 that "19.80%".to_f would yield')
+
+  eq(summary_value({ 'summary' => { 'value' => '950.9K', 'number' => 950_874 } }),
+     950_874,
+     'abbreviated: takes 950874, not the 950.9 that "950.9K".to_f would yield')
+
+  # Zero is a legitimate value and must not be mistaken for absent.
+  eq(summary_value({ 'summary' => { 'value' => '0.0%', 'number' => 0 } }), 0,
+     'zero: a real 0 is returned, not treated as missing')
+
+  # Domo declining to compute is NOT a zero.
+  ok(summary_value({ 'summary' => { 'status' => 'not_ran', 'value' => '', 'number' => 0 },
+                     'summaryNumber' => '' }).nil?,
+     'status "not_ran" yields nil — Domo declining to compute a KPI is not a zero')
+
+  # Fallbacks, in order, only when no numeric form exists.
+  eq(summary_value({ 'summary' => { 'value' => '42' } }), '42',
+     'falls back to `value` when there is no numeric `number`')
+  eq(summary_value({ 'summaryNumber' => '77' }), '77',
+     'falls back to the top-level summaryNumber when there is no summary object')
+  ok(summary_value({}).nil?, 'no summary at all yields nil')
+
+  # A non-numeric `number` must not be trusted just because the key exists.
+  eq(summary_value({ 'summary' => { 'number' => 'N/A', 'value' => '12.5%' } }), '12.5%',
+     'a non-Numeric `number` is rejected and `value` is used instead')
+end
+
+# ---------------------------------------------------------------------------
+oracle_src = File.read(File.join(SCRIPTS, 'build-parity-oracle.rb'))
+cid_src = oracle_src[/^def card_id_for\(element_id\)\n.*?\nend\n/m]
+ok(cid_src, 'extracted card_id_for(element_id) from build-parity-oracle.rb')
+eval(cid_src, TOPLEVEL_BINDING) if cid_src # rubocop:disable Security/Eval
+
+if cid_src
+  eq(card_id_for('el-922919965'), %w[922919965].push(false).freeze.to_a,
+     'a base tile id yields the card id and is_summary=false')
+  eq(card_id_for('el-922919965-summary'), ['922919965', true],
+     'a companion tile id yields the same card id and is_summary=true')
+  eq(card_id_for('master-1252fb63'), [nil, false],
+     'a master element traces to no card (it is excluded, not silently skipped)')
+  eq(card_id_for('header-block-1'), [nil, false],
+     'a put-layout header element traces to no card')
+  eq(card_id_for('el-922919965-summary-extra'), [nil, false],
+     'the pattern is anchored — a longer suffix is not mistaken for a summary tile')
+end
+
+puts $failures.zero? ? "\nALL PASS" : "\n#{$failures} FAILURE(S)"
+exit($failures.zero? ? 0 : 1)

--- a/shared/lib/test_shared_script_closure.rb
+++ b/shared/lib/test_shared_script_closure.rb
@@ -121,7 +121,16 @@ PER_TOOL_BY_DESIGN = {
   'convert-model.rb'  => 'each converter parses a different source format end-to-end',
   'phase6-parity.rb'  => "per-tool parity CLI (--tableau vs --workdir) and per-tool oracles",
   'learned-rules.rb'  => 'gap-scout rule store is keyed to one tool\'s expression language',
-  'probe_registry.rb' => 'local artifact registry binds to one tool\'s <TOOL>_TO_SIGMA_HOME dotdir (same convention as learned-rules.rb)'
+  'probe_registry.rb' => 'local artifact registry binds to one tool\'s <TOOL>_TO_SIGMA_HOME dotdir (same convention as learned-rules.rb)',
+  'collect-parity-actuals.rb' => 'per-tool Sigma-actuals collector, same reasoning as phase6-parity.rb. ' \
+    'tableau\'s is 441 lines whose bulk is machinery for problems MEASURED ON TABLEAU workbooks — a ' \
+    'wide pivot-grid CSV export needing a totals-JSON fallback, multi-million-row detail tables that ' \
+    'hung the pool, per-chart row-limit accounting. None of that has been observed on a Domo workbook, ' \
+    'and domo already owns the identical export+poll fetch (lib/element_export.rb, live-proven since ' \
+    '2026-07-30). Sharing would mean domo carrying and maintaining behaviour justified by another ' \
+    'converter\'s evidence. They also key their results differently ON PURPOSE: domo keys by ' \
+    'sigma_element_id because Domo reuses generic summary labels (11 of one real 65-tile page share a ' \
+    'display name), which name-keying silently cross-wired into an unearned PASS.'
 }.freeze
 
 DUP_BACKLOG = %w[


### PR DESCRIPTION
Builds gate 1's missing evidence source, and closes a separate hole that let a dropped card still be GREEN. v0.14.11 → v0.16.0. Advances beads `2tkm` and (partially, for domo) `59mk`.

## The parity oracle — and a correction to how it was sized

The 2026-08-05 gold audit budgeted **3–5 days** on the premise that expected values had to be **re-derived** from `Domo.query_dataset`: reimplementing every card's aggregation, filters, rolling date window, top-N and `COUNT DISTINCT` in our own code and hoping it matched Domo. The audit catalogued the hazards itself — 28 of 36 cards carry a relative window, `COUNT DISTINCT` is a compound flag that reads as plain `COUNT` if missed, top-N has no documented tie-break.

**`GET /api/content/v1/cards/{id}/data` removes the entire class.** Domo evaluates its own card — window, filters, aggregation, ordering, limit — and returns the rendered rows, already in the `[[dim, val], …]` shape `verify-parity.rb` wants, plus a `summaryNumber` for the KPI. We re-derive nothing.

Also worth recording: `verify-parity.rb` makes **no Sigma call at all** — it is a pure JSON differ requiring *both* sides pre-collected, and `build-parity-plan.rb` emits neither. That's why this is two collectors plus a join, not one script.

| script | role |
|---|---|
| `collect-parity-expected.rb` | Domo's own rendered card values |
| `collect-parity-actuals.rb` | live Sigma element exports |
| `build-parity-oracle.rb` | join → `verify-parity` plan + exclusion ledger |
| `lib/element_export.rb` | the export+poll fetch |

**Measured live** against page `59931332`: 36/36 cards → HTTP 200, 35 carry rows, 30 a usable summary value. Mapped onto the gate's own chartable predicate (75 spec elements → 10 masters → 65 chartable = 36 base + 29 `-summary`): **64 of 65 tiles covered**. That 65/36/29 split reproduces the audit's census exactly, arrived at independently.

**Independently validated 29/29, zero divergence.** Every KPI printed on the Domo page was read off a full-page screenshot and compared to the `summaryNumber` the collector fetched — all 29 comparable cards match exactly. The API value *is* what a human sees, established without using the API to check the API.

**The one un-scoreable tile** is `el-983053598`. Three unrelated methods agree: the audit's static analysis ("the date window is baked into the plotted VALUE"), the API returning no `rows` key, and the source card rendering **"No data in filtered range"** on screen. It is excluded *with that reason*, never dropped.

## Not a port of Tableau's collector

Tableau's `collect-parity-actuals.rb` is 441 lines with only 2 Tableau-specific, so a port looked free — but most of its bulk handles problems measured on **Tableau** workbooks (wide pivot-grid exports needing a totals-JSON fallback, million-row tables that hung the pool). None observed on Domo. Domo already owned the identical fetch, live-proven since 2026-07-30, inside `verify-warehouse.rb`.

The pivot caveat is **recorded, not solved**: Domo's spec emits 13 `table` elements and whether any export wide is unknown until a live run, so the collector records each tile's column count and header shape — the first live run shows which came back wide, and those become recorded exclusions with a measured reason.

## Coverage census — a dropped card can no longer be GREEN

GREEN requires an **empty** degradation ledger, and `scope_cuts` derives from exactly two artifacts: `coverage.json`, and `parity-final.json`'s `tile_census`. Domo can never fill the second (that key is reserved for Tableau's *zone* shape; publishing anything else turns gate 5's honest SKIP into a vacuous "0 zones, 0 unmatched" — the unearned green caught on #631). And domo emitted **no** `coverage.json`: the only mentions in the skill were the two *readers*.

So a card producing no Sigma element was invisible to the ledger. `phase6-parity-domo.rb`'s census doesn't cover it either — its denominator is elements *in* the spec.

**Proven by planting a drop:** removing card `1058425328`'s elements gives census 35/36 · 1 scope-cut · verdict **PARTIAL**, against **GREEN** for an empty ledger. Unmodified run: 36/36.

`degraded` is deliberately **not** emitted — classifying free-text warning prose into severities is guesswork, and a fabricated `degraded` would cap a run for an unverifiable reason. Warnings ride at an inert severity the ledger ignores.

## Reconciled with #649

#649 landed concurrently and writes the same exclusions file, but a **complementary** class: "cannot agree by construction" (refused date window) vs this branch's "could not be collected". Two silent bugs fell out and are fixed: last-writer-wins clobbering, and a #649-excluded tile being "verified" anyway (it's still in the plan and both sides are collectable, so it would score a guaranteed DIVERGE). The generator now runs *before* the join, which honours prior exclusions over verification.

## Verification

Fixture-driven end to end, plus **fail-first proven throughout**: planting a wrong expected value drops 2/2 → 1/2; stubbing the census call fails the emit guard; flipping the oracle to opt-in fails the default-on guard. A chain that only ever passes proves nothing.

Two of my own bugs were caught by running the emitted plan through the real verifier instead of assuming its contract: `requested_columns` set to column IDs (would have crashed every tile) and companion-KPI expectations shaped `[[title, value]]` against Sigma's single-column KPI export (would have read as 29 genuine failures).

Whole domo offline suite green; 12 new static wiring guards. The one non-passing test is the pre-existing `test-telemetry-gate.rb` `LoadError` (bead `nirn`).

**Depends on #654** (the re-vendor) for the live run to clear gate 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)