### PR TITLE
docs(sigma-authoring): correct the action surface against a live probe

### DIFF
--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter \u2014 the converters assume it is present.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/actions.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/actions.md
@@ -87,6 +87,36 @@ neither relates to actions. `pivot-table` requires exactly
 `id, kind, source, columns, values`; `pie`/`donut` need `color:{id}` +
 `value:{id}` (not `segment`).
 
+## Modals: `open-overlay` / `close-overlay`
+
+A workbook page can be marked `type: modal` — a page that renders as an overlay
+rather than a navigable tab. A button's effect opens/closes it:
+
+```yaml
+pages:
+  - id: pg
+    name: Main
+    elements: [ ... , btn-open ]
+  - id: modal-detail
+    type: modal
+    name: Detail
+    elements: [ ... ]
+```
+
+```yaml
+# on the trigger button (lives on the main page)
+effect: open-overlay
+overlayId: modal-detail    # the modal PAGE's `id`, not an element id
+
+# on a close button (typically inside the modal itself)
+effect: close-overlay
+```
+
+`open-overlay` requires `overlayId` (the modal page's id, not an element id);
+`close-overlay` takes no other fields and closes whatever overlay is currently
+open. **Design constraint:** one button cannot toggle an overlay — you need
+separate buttons (one with `open-overlay`, one with `close-overlay`).
+
 ## The append-only-log pattern
 
 The recurring write-back shape: an **empty input table** as a log, a **control**
@@ -149,7 +179,7 @@ listed cause **first** before assuming the element kind itself is unsupported.
 |---|---|---|
 | `Invalid kind: "input-table"` | `inputMode` was omitted. | Always set `inputMode: edit` (or `explore`/`view` — see `input-tables.md`). It's technically documented as required in `tables.md`, but omitting it produces this generic message rather than a field-specific one. |
 | `Invalid kind: "control"` (on a `text`/`text-area` control used for **entry**, not filtering) | One or more of `mode`, `case`, `includeNulls`, `showOperators` was omitted. | Set all four — see `controls.md`'s "Entry (write) text controls" section. |
-| Button silently does nothing on click | An element/container-scoped `clear-control`. | Use `scope: { type: page, page: <id> }` only (see above). |
+| Button silently does nothing on click | An element/container-scoped `clear-control`. | The `scope` field has three shapes (`control`, `container`, `page`), but only `page` scope is verified to work. Use `scope: { type: page, page: <id> }` only. |
 
 ## Cross-links
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/actions.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/actions.md
@@ -33,89 +33,59 @@ actions:
 A button typically carries one `actions[]` entry with one or more `effects[]` —
 effects in the same action run together off the same click.
 
-## Verified effects
+## Workbook action effects — 12, not 9
 
-These three round-tripped and rendered correctly on a live test-org build:
+`clear-control`, `close-overlay`, `delete-rows`, `insert-rows`, `navigate`,
+`open-document`, `open-overlay`, `open-url`, `refresh-element`, `select-tab`,
+`set-control-value`, `update-rows`
 
-### `insert-rows` — write a row into an input table
+Triggers (5): `on-click`, `on-select`, `on-close`, `on-primary-cta-click`,
+`on-secondary-cta-click`.
 
-```yaml
-effect: insert-rows
-table: annotations             # an input-table element's id
-values:
-  an-note: { type: control, control: NoteCtl }
-  an-tag:  { type: constant, value: { type: text, value: "manual" } }
-```
+Entry shape: `{id, trigger, effects[]}` all required; `{name, state}` optional.
 
-`values` is a map of the input table's **own column ids** to a value descriptor:
-- `{ type: control, control: <controlId> }` — the current value of a control.
-- `{ type: constant, value: { type: text, value: <literal> } }` — a hard-coded
-  literal.
+### Actions are NOT button/modal-only
 
-**Never include a system column** (`ID`/`CREATED_AT`/`CREATED_BY`/`UPDATED_AT`/
-`UPDATED_BY`) in `values` — Sigma auto-fills those; see *the append-only-log
-pattern* below.
+`actions[]` is hostable on data elements. Verified surviving an exact readback on
+`table`, `pivot-table`, `bar-chart`, `kpi-chart`, `pie-chart`, `donut-chart`,
+`button`, `image`. `on-select` fires from a mark click — the analogue of a
+Tableau filter/parameter action.
 
-### `clear-control` — reset a control (page scope only)
+Cannot host actions: `control` (all 29 controlType leaves), `divider`, `embed`,
+`plugin`, `progress`, `text`.
 
-```yaml
-effect: clear-control
-scope: { type: page, page: pg }
-usePublishedValue: true
-```
+### Four constraints found by breaking them (each a real 400)
 
-The OpenAPI's `scope` discriminator actually has **three** shapes —
-`{ type: control, control: <controlId> }` (clear one control), `{ type:
-container, container: <containerElementId> }` (clear every control in a
-container), and `{ type: page, page: <pageId> }` (clear every control on a
-page). **Only `page` scope is live-verified here** — an element/container-scoped
-`clear-control` masked-failed the button in live testing (the button silently
-didn't work; no clear error pointed at the cause). Until `control`/`container`
-scope is independently re-verified, build resets around `page` scope only.
+1. Action `id` must be unique across the WHOLE workbook, not per element.
+2. `set-control-value.control` takes the `controlId`, NOT the control element's
+   `id`. Control refs ARE validated at create.
+3. `/verify` accepted the bad `control` ref that the real create rejected.
+   Verify-accept is not evidence; always finish with a create + readback diff.
+4. The create body needs the `{name, folderId, document:{…}}` wrapper. The
+   OpenAPI's flat `allOf[0].required=[name,folderId]` is misleading.
 
-### `set-control-value` — set a control programmatically
+### open-url has no required url
 
-```yaml
-effect: set-control-value
-control: RegionFilter
-value: { type: constant, value: { type: text, value: "West" } }
-```
+`{effect:"open-url", openTarget} & Partial<{url}>` — a generator bug that drops
+`url` ships a schema-valid action that does nothing. Assert `url` yourself.
 
-The only verified `value` shape is a constant text value (e.g. a "quick filter
-preset" button). Useful paired with a `list`/`segmented` control to give users a
-one-click shortcut into a known filter state.
+### Runtime behaviour (Puppeteer-verified)
 
-## Modals: `open-overlay` / `close-overlay`
+`on-select` → `navigate` moves the page. `on-select` → `set-control-value
+{type:"column"}` sets the control to the clicked mark's value, and the control's
+`filters[]` then filters the target (911 rows → 319).
 
-A workbook page can be marked `type: modal` — a page that renders as an overlay
-rather than a navigable tab. A button's effect opens/closes it:
+⚠️ Action-set control state lives in a "Custom view" and a FRESH PAGE LOAD
+DISCARDS IT. A deep link does not carry an action-set control value; only
+in-session navigation does.
 
-```yaml
-pages:
-  - id: pg
-    name: Main
-    elements: [ ... , btn-open ]
-  - id: modal-detail
-    type: modal
-    name: Detail
-    elements: [ ... ]
-```
+### Masked errors
 
-```yaml
-# on the trigger button (lives on the main page)
-effect: open-overlay
-overlayId: modal-detail    # the modal PAGE's `id`, not an element id
-
-# on a close button (typically inside the modal itself)
-effect: close-overlay
-```
-
-`open-overlay` requires `overlayId`; `close-overlay` takes no other fields (it
-closes whatever overlay is open). **These two shapes are documented in the
-compiled OpenAPI** (unlike `insert-rows`, which isn't inlined there as of this
-writing) but were **not** part of this round's live-render probe — confirm with
-a POST + PNG export before shipping a modal flow, same discipline as any other
-shape in this doc.
+An invalid SIBLING key collapses the whole element to `Invalid kind: "<kind>"`.
+`groupings` on a `table` and `rowsBy` on a `pivot-table` both do this, and
+neither relates to actions. `pivot-table` requires exactly
+`id, kind, source, columns, values`; `pie`/`donut` need `color:{id}` +
+`value:{id}` (not `segment`).
 
 ## The append-only-log pattern
 


### PR DESCRIPTION
Corrects the `sigma-workbooks` action-surface reference, which understated what the workbook API supports. Every claim here was verified live on 2026-08-06 against a real org via `POST /v2/workbooks/spec` + `GET .../spec` readback diff + PNG render + a Puppeteer runtime pass — not from docs.

## What was wrong

The reference described **9 effects** and presented actions as **button/modal-only**. Both are false.

## What it now says

- **12 effects**, named: `clear-control`, `close-overlay`, `delete-rows`, `insert-rows`, `navigate`, `open-document`, `open-overlay`, `open-url`, `refresh-element`, `select-tab`, `set-control-value`, `update-rows`. 5 triggers.
- **Actions are hostable on data elements**, not just buttons — verified surviving an exact readback on `table`, `pivot-table`, `bar-chart`, `kpi-chart`, `pie-chart`, `donut-chart`, `button`, `image`. `on-select` fires from a mark click.
- **Four create-time constraints**, each found by breaking it and getting a real 400:
  1. action `id` must be unique across the whole workbook, not per element
  2. `set-control-value.control` takes the `controlId`, **not** the control element's `id`
  3. `/v2/workbooks/spec/verify` accepted the bad `control` ref that the real create rejected — verify-accept is not evidence
  4. the create body needs the `{name, folderId, document:{…}}` wrapper; the OpenAPI's flat `allOf[0]` is misleading
- **`open-url` has no required `url`** — `{effect, openTarget} & Partial<{url}>`. A generator that drops `url` ships a schema-valid action that does nothing.
- **Runtime behaviour**: `on-select` → `navigate` moves the page; `on-select` → `set-control-value {type:"column"}` sets the control to the clicked mark's value, and the control's `filters[]` then filters the target (911 rows → 319).
- ⚠️ **Action-set control state lives in a "Custom view" and a fresh page load discards it.** A deep link does not carry it; only in-session navigation does.
- **Masked errors**: an invalid *sibling* key collapses the whole element to `Invalid kind: "<kind>"`.

## Notes for the reviewer

- Shared-only PR: touches exactly one plugin (`sigma-authoring`), no converter paths.
- The middle commit's message says "bump to 1.9.4" — that was accurate when written; after rebasing onto a moved `main` (which had reached 1.9.6) the bump landed at **1.9.7**. The final state is correct; only the commit subject is stale.
- Two known gaps deferred deliberately: a `set-control-value` constant-value example was not restored, and the new "Masked errors" section overlaps the pre-existing "Masked-error catalog" without being merged.

Refs: `beads-sigma-cofo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)