### PR TITLE
feat(tableau-to-sigma): auto-emit nav-action mark clicks and parameter actions

### DIFF
--- a/docs/superpowers/specs/2026-08-07-actions-live-verification-runbook.md
+++ b/docs/superpowers/specs/2026-08-07-actions-live-verification-runbook.md
@@ -1,0 +1,71 @@
+# Live verification runbook — Tableau action emitters
+
+**For:** PR #664 (`feat/tableau-actions-emitters`), held in draft until this runbook passes.
+**Why:** the design's method rule — *every emitter PR lands with a real create + GET readback diff + runtime click; `/verify` output is not evidence.* Three shapes on this workstream passed `/verify` and were then dropped or rejected, one of them accepted by verify **and** create before being silently dropped on readback.
+
+Nothing in the offline suite can answer the three questions below. The tests pass because they assert the shape we chose — that is not the same as the shape Sigma accepts.
+
+## Prerequisites
+
+```bash
+export SIGMA_BASE_URL=...     # the org where the 2026-08-06 action probe was run
+export SIGMA_API_TOKEN=...    # or mint from client id/secret
+```
+
+One warehouse workstream at a time — confirm nothing else is running against this org first. The readback probe **creates a real workbook**, registers it with `ProbeRegistry`, and deletes it in an `ensure` block. A crash between create and delete leaves it tracked but present.
+
+Both probes SKIP at exit 0 without credentials, so a missing token produces a false pass. **Confirm you see real output, not a SKIP line.**
+
+## Q1 — Is `value.column` a columnId or a column name?
+
+**Highest stakes.** The emitter currently sends the host element's column **id** (e.g. `x-el-metric-buttons`), on the strength of the design's live-probe record. If Sigma wants a display name instead, every auto-emitted parameter action is wrong and the offline suite still passes.
+
+```bash
+cd plugins/tableau-to-sigma/skills/tableau-to-sigma
+ruby scripts/probe-actions-readback.rb \
+  --spec <chart-specs.json> \
+  --expect-actions <chart-specs-actions-emitted.json>
+```
+
+- **Create rejects it** → Sigma wants something else. Try the display name; whichever survives a readback is correct.
+- **Create succeeds, readback returns it unchanged** → the id form is right. Still confirm at runtime (Q4) that clicking actually sets the control — a schema-valid action that does nothing is exactly the failure mode `open-url` without a `url` already demonstrated on this workstream.
+
+## Q2 — Does create validate `navigate.target.page`?
+
+**Widest blast radius, and new by default.** At merge-base the only emitter sat behind `SIGMA_BUTTON_ELEMENTS` (default off), so a default migration emitted no actions at all. Now nav-action mark clicks emit by default.
+
+The emitters write a provisional `page-<slug>`. The orchestrated pipeline assigns `page-dash-<N>`. `put-layout.rb` repairs `navigate.target.page` **by name, after create**. So the posted spec deliberately contains a page id that does not exist in it.
+
+Post a spec whose `navigate.target.page` names a page id absent from the payload:
+
+- **Create succeeds** → the post-publish repair is sound; no change needed.
+- **Create 400s** → every migration with a qualifying nav-action hard-fails at publish. The emitter must resolve the real page id before POST, or omit the effect and let `put-layout.rb` add it afterward. This would block PR #664 outright.
+
+## Q3 — Does the readback assign effect ids?
+
+Low stakes; the probe is id-agnostic either way (it pairs by id-when-present → composite signature → position). Worth recording so the next person doesn't re-derive it. Read the readback JSON and note whether effects come back with an `id`.
+
+## Q4 — Runtime: does the action actually fire?
+
+```bash
+node scripts/probe-actions-runtime.mjs \
+  --url <workbook-url> \
+  --click-text "<a mark label>" \
+  --expect-rows-before <N> --expect-rows-after <M>
+```
+
+**Navigate in-app only.** The harness contains exactly one `page.goto` (the initial load) by design — a fresh page load discards the control state an action just set, which produced a false negative during the original probe. Do not add one.
+
+Expected chain: mark click → the control adopts the clicked value → that control's `filters[]` filters the target.
+
+A control with an empty `filters[]` is a **silent no-op** — no error, nothing happens. If the row count doesn't move, check `filters[]` before assuming the action failed.
+
+## On success
+
+1. Record the answers in `beads-sigma-bfxd`.
+2. Take PR #664 out of draft, noting which questions the run settled and how.
+3. If Q1 or Q2 came back negative, fix before merge — both are correctness issues, not polish.
+
+## On failure
+
+Leave #664 in draft. The emitters are on by default, so a wrong shape ships silently to every migration. Residue is always the safer outcome than a guess.

--- a/docs/superpowers/specs/2026-08-07-pr-e-filter-actions-design-pass.md
+++ b/docs/superpowers/specs/2026-08-07-pr-e-filter-actions-design-pass.md
@@ -1,0 +1,385 @@
+# PR E (filter actions) — design pass findings
+
+Investigation date 2026-08-07. Worktree `/Users/tjwells/wt-actions-emitters`, branch
+`feat/tableau-actions-emitters`, HEAD `ed012519`.
+
+Every claim below is tagged **[V]** verified by executing code, **[VR]** verified by reading the
+exact source line (cited), or **[I]** inferred. Probe scripts live in the session scratchpad
+(`probe.rb` / `probe2.rb` / `probe3.rb` + `scripts-copy/`), not in the repo. No production file
+was modified.
+
+---
+
+## 0. Headline: the spec's own corrected framing is still wrong
+
+The spec says `:7335` (really **`build-charts-from-signals.rb:7419`**) is "the real change".
+**It is not, on its own — it is very nearly a no-op.** [V]
+
+`:7419` sits inside a loop over `(meta['shared_filters'] || []) + promoted_int_dim_filters`
+(`build-charts-from-signals.rb:7418`). `meta['shared_filters']` is populated **only** from
+`//shared-view/filter` (`parse-twb-layout.rb:2149-2163`). [VR]
+
+Tableau's `[Action (X)]` filters are **per-worksheet `sheet_link` filters**, not shared-view
+filters. Measured on the one real corpus workbook that has a filter action
+(`corpus/tableau/orders-overview/workbook-content.twb`): [V]
+
+```
+shared_filters total=3  is_action=0        <-- ZERO reach :7419
+worksheets carrying [Action (Region)]: 5   <-- Gross Margin %…, Gross Revenue…,
+                                               Monthly Revenue Trend, Order Channel…,
+                                               Return Rate…
+zones carrying [Action (Region)]:      5   (same five, in layout.json)
+```
+
+Reproduce:
+```
+ruby scripts/parse-twb-layout.rb corpus/tableau/orders-overview/workbook-content.twb /tmp/oo.json
+# then inspect /tmp/oo-meta.json shared_filters vs worksheets[*].filters
+```
+
+So **un-picking `:7419` alone emits nothing for the corpus workbook.** The population of action
+filters lives in `meta['worksheets'][ws]['filters']` and `layout[].zones[].filters`. A
+shared-view action filter is theoretically possible (a filter action scoped "All Using This Data
+Source") but does not occur in this repo's corpus. [V for absence, I for possibility]
+
+**Consequence:** PR E must add a **new emitter**, not un-pick a line. `:7419` should stay as-is
+(defensively rejecting the rare shared-view case, which carries none of the data the emitter
+needs anyway).
+
+---
+
+## 1. Complete map of the `auto_controls` dispatch (`:7416`–`:7740`)
+
+Loop header `:7418`; per-branch behaviour below. "Record" = `control_scope_records` push.
+
+| # | Line | Guard / input | Record status | Control emitted? | Warning |
+|---|---|---|---|---|---|
+| 1 | 7419 | `f['is_action']` | **none** | no | **none** (silent) |
+| 2 | 7421-7424 | `cap.nil?` | **none** | no | "shared filter #N has no resolvable column_caption … skipping auto-control" |
+| 3 | 7429-7442 | `f['topn']` truthy | `needs-wiring` | no | native top-N, N + direction + order_expr named |
+| 4 | 7443-7452 | `map_column` miss → `materialized_calc_column` hit | falls through to emit path | yes | "binds to a calculated field that is ALREADY materialized … wiring it" |
+| 5 | 7460-7473 | still nil, caption is in `calc_formula_by_caption` | **`needs-materialization`** (+ `tableau_formula`, `sigma_formula`) | no | materialize on master + add master-columns.json regex |
+| 6 | 7474-7492 | still nil, `f['is_datasource_filter']` | **`needs-master-default`** (+ `datasource_filter`, `is_active_flag`, `members`) | no | "always-on … NOT optional … gate blocks GREEN" |
+| 7 | 7493-7496 | still nil, neither | **none** | no | "has no master-map entry — add a regex to master-columns.json" |
+| 8 | 7502-7516 | resolved, but `control_targets` returns `targets.empty?` | **`dropped`** (+ `intended`, `unreachable`) | no | "DROPPED auto-control … no chart root carries a matching column" |
+| 9 | 7517-7535 | resolved + reachable | **`emitted`** (+ `intended`, `targets`, `zone_dashboards`, `action_worksheets`, `unreachable`) | pending controlType | — |
+| 9a | 7537-7646 | `kind` `list` / `list+condition` | stays `emitted` (may gain `integer_dim`, `decode`) | **yes** (`list`/`segmented`) | exclude-mode, condition, null-option helper, integer decode |
+| 9b | 7647-7676 | `kind` `relative-date` | stays `emitted` | **yes** (`date-range`) | rolling vs frozen mode named |
+| 9c | 7677-7708 | `kind` `number-range` | stays `emitted` | **yes** (`date-range`/`range-slider`/`slider`) | ISO-8601 normalization |
+| 9d | 7709-7726 | `kind` `wildcard`, pattern parsed | stays `emitted` | **yes** (`text`) | mode + pattern named |
+| 9e | 7713-7719 | `kind` `wildcard`, pattern **not** parsed | **downgraded to `needs-wiring`** | no | "STAYS-MANUAL … NOT treated as 'All'" |
+| 9f | 7727-7736 | **any other `kind`** | **downgraded to `needs-wiring`** | no | "kind=… has no controlType mapping — NOT emitted" |
+
+Note branches 9e/9f **mutate a record already pushed at `:7527`** (`control_scope_records.reverse.find`).
+That is the only place in this loop where a record's status changes after the fact.
+
+### What an action filter actually carries
+
+`normalize_filter` **returns early** for `is_action` (`parse-twb-layout.rb:378-381`), so the hash
+has exactly seven keys and nothing else: [V]
+
+```json
+{"raw_class":"categorical","raw_param":"[federated.…].[Action (Region)]",
+ "column_guid":"Action (Region)","column_caption":"Action (Region)",
+ "datatype":null,"is_action":true,"kind":"action"}
+```
+
+Therefore, for an action filter, branches **3, 5, 6, 9a–9e are all structurally unreachable**:
+no `topn`, no `is_datasource_filter`, no `members`/`exclude`/`excludes_null`/`min`/`max`/
+`wildcard`/`period_type`, no `datatype`, and `kind == 'action'`. [VR]
+
+### Measured behaviour of a naive un-pick
+
+Probe: inject a synthetic action filter with exactly that shape into `shared_filters`, un-pick
+`:7419` **and** `:7864`, run the real script. [V]
+
+* With a master map that does **not** match the raw caption → branch **7**:
+  `"shared filter on 'Action (Region)' has no master-map entry"`, **no record at all**, and the
+  census reports `1 UNACCOUNTED (Action (Region)) — must be 0`.
+* With a master map that **does** match `Action (Region)` → branch **9f**:
+  `"shared filter 'Action (Region)' kind=\"action\" has no controlType mapping — NOT emitted"`,
+  record `ctl-action-region` / name `"Action (Region)"` / status `needs-wiring`. Census green.
+
+Two facts fall straight out:
+
+1. **The caption must be unwrapped `[Action (X)]` → `X` before `map_column`,** or nothing ever
+   resolves and the control is named `Action (Region)` in the customer's UI. [V]
+2. **`case f['kind']` needs an explicit `when 'action'` branch** or the emitter can only ever
+   produce `needs-wiring`. [V]
+
+---
+
+## 2. What an action filter should do in each branch
+
+The closest existing branch is **9a (`list`)** — an action filter is always a discrete member
+filter on a dimension. But it must be built from the **resolved column**, not from the filter
+hash, because the filter hash is empty (§1).
+
+Recommended dispatch for a new `when 'action'` branch (or, better, a new emitter — see §7):
+
+| Situation | Status | Emit? | Rationale |
+|---|---|---|---|
+| Unwrap fails (`raw_param` has no `[Action (…)]`) | `needs-wiring` | no | can't name a column; never guess |
+| `map_column(X)` hits | **`emitted`** | yes — `controlType: 'list'`, `mode: 'include'`, `selectionMode: 'multiple'`, `values: []`, `source` → master column, `filters` → `targets` | `values: []` in include mode is this codebase's own "default to all" (`:7550-7552` comment) — correct unfiltered initial state |
+| `map_column` misses, `materialized_calc_column(X)` hits | **`emitted`** | yes | identical to branch 4; reuse verbatim |
+| `map_column` misses, `calc_formula_by_caption[X]` hits | **`needs-materialization`** | no | reuse branch 5 wholesale, including `tableau_formula`/`sigma_formula` — the agent materializes and re-runs. Do **not** invent a new status. |
+| `map_column` misses, no calc | **`needs-wiring`** *(not branch 7's silent-ish path)* | no | branch 7 pushes **no record**, which is what made the census go red in the probe. An action filter must always leave a record. |
+| resolved but `targets.empty?` | **`dropped`** | no | reuse branch 8 |
+| resolved column is INTEGER / numeric | `emitted` **+ decode** | yes, via `route_integer_dim_decode` | `scan-workbook-gaps.rb:98` states a numeric list-control target 400s then 500s at query time. The existing guard is `if f['integer_dim'] && …` (`:7611`) and `integer_dim` is **absent** on action filters — integer-ness must be re-derived from the resolved master column. **This is a real, verified gap.** [VR] |
+
+**`needs-master-default` is never correct for an action filter** — `is_datasource_filter` is set
+only on shared-view filters whose shared-view is named after a datasource
+(`parse-twb-layout.rb:2160`). [VR]
+
+**No new status is needed.** The four existing statuses cover every case.
+
+---
+
+## 3. The `:7864` lockstep requirement (real line: `build-charts-from-signals.rb:7859-7893`)
+
+The census builds `expected` from `meta['parameters']` + `meta['shared_filters']` (skipping
+`is_action` at **`:7864`**), and `accounted` from `control_scope_records` **keyed by `name`**
+(`:7871`), then `param_controls + auto_controls` by name with `||=` (`:7872`).
+
+Downstream: `assert-phase6-ran.rb` **gate 7c, exit 31** reads `*-controls-coverage.json` `detail`
+rows and fails BY NAME on any row that is not `emitted`, not declared in `control-scope.json`
+(matched on `name`/`sourceName`, `assert-phase6-ran.rb:1864-1874`), and not in
+`controls-waivers.json`. That is what goes red. [VR]
+
+**Exactly what must change, and the three ways it breaks:**
+
+1. **Record-or-don't-expect.** The census only stays green if every action filter added to
+   `expected` is guaranteed a `control_scope_records` entry. **Measured failure:** un-picking both
+   `:7419` and `:7864` while `map_column` misses lands on branch 7, which pushes no record →
+   `1 UNACCOUNTED … must be 0` → gate 7c exit 31. [V]
+2. **Name must match on both sides.** `expected` uses `f['column_caption'].to_s.strip` — the raw
+   `"Action (Region)"`. If the emitter (correctly) names the control `"Region"`, the census row is
+   still `"Action (Region)"` and is UNACCOUNTED. **`:7864`'s caption must be unwrapped in exactly
+   the same way as the emitter's.** [V]
+3. **Name collision silently masks a failure.** `accounted[name] = status` is a plain assignment —
+   **last writer wins** — and `expected` dedupes by caption (`seen_f`). **Measured:** with a real
+   quick filter `Region` *and* an action filter unwrapping to `Region`, two `control_scope_records`
+   both named `"Region"` (`ctl-region-overview` = `needs-wiring`, `ctl-region` = `emitted`)
+   collapsed to **one** census row reading `emitted`. The `needs-wiring` one vanished. [V]
+   Tableau users filter on Region *and* action-filter on Region constantly, so this is the common
+   case, not an edge. Gate 7c's `ctl_declared` map is name-keyed too, so it has the same hole.
+
+**Recommendation:** if the emitter reads the worksheet/zone population (§0), `:7864` needs no
+change at all — the census simply never sees action filters and stays green by accident. That is
+worse, not better: the coverage ledger would carry no evidence for N emitted controls. So PR E
+should **add** action filters to `expected` from the worksheet/zone population, deduped by
+*unwrapped* caption, and **should change the census key from `name` to `[kind, name]` or
+`controlId`** to close item 3. Without that key change PR E can ship a green gate over a
+`needs-wiring` control.
+
+---
+
+## 4. The source→target join
+
+`detect-only` output for `test-fixtures/postpublish-actions.twb` (`--detect-only /tmp/d.json`): [V]
+
+```json
+{"kind":"filter-action","caption":"Region Filter",
+ "source":{"dashboard":"Overview","worksheets":["Sales by Region"]},
+ "trigger":"on select","actionName":"[Action1_AAAA]",
+ "fields":["Region"],
+ "targets":[{"name":"Overview","dashboard":true,
+             "sheets":["Sales by Region","Region Detail","Filter Panel Sheet"]}]}
+```
+
+### (a) source element
+`det['source']['worksheets']` → `elements.find { |e| e['_worksheet'] == sheets.first }`, exactly
+as the parameter-action emitter does (`:7928-7939`). Then the **HOST-COLUMN BINDING** guard
+(`:7970-7981`) — `value: {type:'column', column: <hostColumnId>}` requires the column be on the
+host. Reuse verbatim.
+
+Fork: `parse_source` (`build-postpublish-guide.rb:253-275`) emits **no `worksheets` key** when the
+action's source is `type='dashboard'` ("any sheet on dashboard X"). The parameter-action emitter
+turns that into residue (`sheets.length != 1`). For a filter action a dashboard-source means
+**every** sheet is a source — N host elements, N actions. PR E must decide: fan out or residue.
+Recommend **fan out**, since a dashboard-wide "use as filter" is common; each host still passes
+the host-column guard independently. [VR]
+
+### (b) the column, and the two blockers
+
+**`fields` is unusable as-is.** `link_fields` (`build-postpublish-guide.rb:298-311`) runs each ref
+through `field_caption`, which `ActionColumnResolver`'s own header calls deliberately lossy
+("Mixing the two is what made parameter actions unbuildable"). Worse, it flattens the link
+expression's `target~s0=<source>` pairs into a single `uniq`'d list with no roles. Measured on a
+probe fixture with a non-identity mapping: `fields: ["Region Name","Region"]` — order is
+[target, source], but when source == target `uniq` collapses to one entry, so **arity cannot even
+be read off the list**. [V]
+
+**Fix:** extend `extract_action_blocks`'s `filter-action` case with a raw, non-lossy
+`fieldPairs` (mirroring PR D's `sourceFieldRef`). The link expression parses cleanly: [V]
+
+```
+decoded: tsl:Overview?[federated.f1].[Region Name]~s0=<[federated.f1].[Region]~na>
+split on "&", then "=":  lhs.sub(/~s\d+$/,'') = TARGET ref
+                         rhs[/\A<(.+)>\z/,1].sub(/~na$/,'') = SOURCE ref
+→ [["[federated.f1].[Region Name]", "[federated.f1].[Region]"]]
+```
+Verified for identity, mismatched, two-pair, and `none:Calculation_100:nk` source refs — the last
+of which `ActionColumnResolver.strip_qualifier` already handles.
+
+**Blocker 2 — `special-fields=all` has no `<link>` at all.** The *only real* filter action in the
+repo corpus is exactly this shape: [V]
+
+```xml
+<action caption='Filter 1 (generated)' name='[Action1_82E31…]'>
+  <source dashboard='Orders Overview' type='sheet' worksheet='Revenue by Region' />
+  <command command='tsc:tsl-filter'>
+    <param name='special-fields' value='all' />
+    <param name='target' value='Orders Overview' />
+  </command></action>
+```
+`fields` becomes the literal sentinel `["(all shared fields)"]`
+(`build-postpublish-guide.rb:437`). Any emitter that does `map_column(fields.first)` will try to
+map that string. This is the **default** action Tableau's "Use as Filter" button creates, so it is
+the majority case, not an edge. [V]
+
+**The resolution for both blockers is the same signal:** the **worksheet-level `[Action (X)]`
+filters**. Tableau materializes which field the action actually binds into a hidden
+`<group caption='Action (Region)' … user:auto-column='sheet_link'>` on each affected sheet. In
+orders-overview: 6 sheets on the dashboard, the source `Revenue by Region` carries none, and
+**all five non-source sheets carry `[Action (Region)]`**. [V]
+
+That gives the resolved column caption (`Region`) *and* the true affected-sheet set, for
+`special-fields=all` and explicit-link actions alike.
+
+**Recommended join:**
+* `detected_actions` (kind `filter-action`) → source sheet, trigger, `actionName`, ledger identity.
+* worksheet-level `[Action (X)]` filters → the column X and the real affected sheets.
+* the new `fieldPairs` → disambiguation when a dashboard has ≥2 filter actions (see §7).
+* `targets` / `expand_target` → useful for the *stated fidelity loss* (§5) but **not** as the
+  primary target signal.
+
+### (c) the control
+Build it into **`auto_controls`**, not a new array. `:8692` iterates `param_controls +
+auto_controls` to build `ctl_rewrites`, and `:8737-8742` rewrites `set-control-value`'s `control`
+in lockstep. A control outside those two arrays never gets its per-page suffix and the effect
+ships a dangling controlId — the exact "references unknown control" live rejection the
+parameter-action header calls out. [VR]
+
+Latent bug worth flagging: `:8739-8740` is `nxt = ctl_rewrites[eff['control']]; eff['control'] =
+nxt if … && nxt`. If a control is skipped for a page by `_scope_dashboards` (`:8695-8696`), no
+rewrite entry exists and the effect keeps the **un-suffixed** id → dangling. Filter-action
+controls will be dashboard-scoped, so PR E hits this where parameter actions mostly did not. [VR]
+
+---
+
+## 5. The named fidelity loss — confirmed, and it has no current home
+
+**Confirmed in code.** `control_targets` (`:7109-7131`) buckets in-scope elements by
+`root_of.call(e)` into a `roots` hash and emits **one target per root**
+(`:7115-7125`). Measured: `intended` listed 2 elements, both root `master`; `targets` had **one**
+entry. [V]
+
+So when Tableau's `<param name='exclude' value='Metric Buttons'/>` separates two sheets that both
+source the master, Sigma cannot separate them — the control's single master-rooted filter reaches
+the excluded sheet too. `expand_target` **does** honour `exclude` at detection time (fixture:
+`sheets` correctly omits `Metric Buttons`) [V], which makes this worse, not better: the detected
+entry claims an exclusion the emitted spec silently cannot honour.
+
+**Where it must be surfaced — and the spec's stated placement does not currently work.**
+
+The spec says "written into the residue guide as a stated loss". But
+`build-postpublish-guide.rb:1218` is `File.write(opts[:out], render_guide(ledger['residue'],
+opts))` — the guide renders **residue only**, and `ActionLedger.join` puts an auto-emitted action
+in `emitted`, disjointly (`action_ledger.rb:95-104`). An auto-emitted filter action therefore
+**drops out of POSTPUBLISH_GUIDE.md entirely** and the loss has nowhere to land. [VR]
+
+PR E must pick one and it is a real scope item:
+* **(A)** add a `fidelity` / `notes` field to the emitted manifest entry **and** give
+  `render_guide` an "auto-wired, with caveats" section fed from `ledger['emitted']`. Matches the
+  spec's words; changes the guide's contract and `ActionGates.guide_residue_violations`.
+* **(B)** route it through `warnings` → `coverage.json` (`severity: 'degraded'`), the converter's
+  existing channel for named losses, **plus** the emitted-manifest field. Least disruptive.
+* Either way, also record it on the `control_scope_records` entry so `control-scope.json` carries
+  the evidence gate 7c reads.
+
+Recommend **(B) + the manifest field**, and amend the spec sentence rather than bending the guide.
+
+---
+
+## 6. The second guide surface — `<out>-actions.md` (real line: `:9118-9169`)
+
+It is driven off **layout zones**, not the detection ledger:
+`(z['filters'] || []).select { |f| f['is_action'] }`, `dim = raw[/\[Action \(([^)]+)\)\]/, 1]`,
+`'target' => z['caption']` (`:9128-9138`). It then writes a table under the heading *"For each row
+below, in the published Sigma workbook: select the source element, open Actions → Add filter
+action…"* — i.e. it tells the customer to hand-wire precisely what PR E will auto-build.
+
+For orders-overview it would emit five rows (Region → each of the five target zones). [V, from the
+verified zone dump]
+
+**What must happen:**
+1. Re-drive the filter-action half from the ledger, not the zones:
+   `ActionLedger.join(detected: opts[:detected_actions], emitted: emitted_actions)['residue']
+   .select { |e| e['kind'] == 'filter-action' }`. Both locals are in scope at `:9124`
+   (`emitted_actions` declared `:6743`, `opts[:detected_actions]` `:137`). [VR]
+   The zone-driven rows have no `actionName`, so they **cannot** be joined by
+   `ActionLedger.key_of` as they stand — this is a rewrite of the row source, not a filter added
+   on top.
+2. Keep the nav-button half (`:9157-9166`) unchanged.
+3. Keep the file emitted even when the filter half is empty, or update the four surfaces that
+   reference it: `refs/script-map.md:95`, `refs/phase-5-workbook.md:73`,
+   `refs/postpublish-interactivity.md:19`, `scan-workbook-gaps.rb:906`.
+
+**Bonus defect found while reading — fix it in PR E.** `:5834-5840` claims to surface action
+filters per chart:
+```ruby
+action_filters = (z['filters'] || []).select { |f|
+  f['column'].to_s.include?('[Action (') || f['column'].to_s.start_with?('[Action ') }
+```
+Normalized filters have **no `column` key** — the keys are exactly
+`raw_class, raw_param, column_guid, column_caption, datatype, is_action, kind`. [V] So
+`action_filters` is always empty and the warning **`'X' has N Tableau action filter(s) —
+skipped`** *never fires*. `refs/phase-5-workbook.md:73` documents a warning that cannot occur,
+and `:5871`'s comment "skip action filters — already warned above" is false: today they are
+skipped in total silence. Use `f['is_action']`.
+
+---
+
+## 7. What makes this harder than it looks
+
+1. **The emitter has to be written from scratch against a different data source.** Not a five-line
+   un-pick. (§0)
+2. **`special-fields=all` is the majority shape** and carries no field list; the whole design hangs
+   on the worksheet-level `[Action (X)]` back-channel. (§4)
+3. **Two filter actions on the same field are indistinguishable.** The Tableau group is named
+   `[Action (<field caption>)]`, so two actions on `Region` from different source sheets produce
+   the identical marker on the target sheets. `fieldPairs` + `actionName` can disambiguate the
+   *detected* side; the *worksheet* side cannot be split. **[I]** — no corpus workbook exercises it.
+4. **Compound filter actions (N field pairs)** → N controls and N `set-control-value` effects on
+   one action. `ActionLedger.validate_action` allows an N-effect array
+   (`action_ledger.rb:47-70`) [VR], but N controls per action multiplies the collision surface in §3.
+5. **controlId collision with a real quick filter of the same caption** — both slug to
+   `ctl-<caption>`. Survived the probe only because the per-page duplication pass suffixed one of
+   them; on a single-page build it is a live "Duplicate id" 400. **Namespace action-filter
+   controls distinctly** (e.g. `ctl-xf-<caption>`) and reflect that in the census key. [V]
+6. **Numeric/integer dimensions.** `route_integer_dim_decode` exists for exactly this, but its
+   guard reads `f['integer_dim']`, which action filters never carry. (§2)
+7. **Control placement vs. dangling controlId.** `_scope_dashboards` + the `:8739` nil-guard. (§4c)
+8. **Corpus regression risk is low if `:7419` is left alone**, and that is the strongest argument
+   for the §0 recommendation: leaving `:4271` / `:4330` / `:5873` / `:7419` untouched makes every
+   zero-action workbook byte-identical by construction, satisfying the spec's own mitigation
+   without needing to prove it.
+
+### Cannot be determined without a live Sigma org
+
+* Whether a `list` control with `mode: 'include'` and `values: []` truly means "no filtering"
+  at query time. The codebase asserts it (`:7550-7552`) but nothing has round-tripped it for an
+  action-driven control.
+* Whether `set-control-value` writing a **numeric** host column into a control whose filter target
+  was Text()-decoded matches anything. Strongly suspect a type mismatch; PR-18's decode was built
+  for user-driven selection, not click-driven assignment. **This is the single most likely
+  runtime-silent failure.**
+* Whether the target control element must live on the **same page** as the action's host element,
+  or whether a workbook-global controlId reference is accepted.
+* Whether multiple `set-control-value` effects on one `on-select` trigger apply atomically.
+* Whether a control that is BOTH driven by a `set-control-value` effect AND user-editable behaves
+  sanely (Tableau's `auto-clear='true'` — deselecting a mark clears the filter — has no obvious
+  Sigma analogue; `clear-control` is a separate effect with no second trigger to hang it on).
+* Whether an action-driven control can be visually hidden. A Tableau filter action shows no widget;
+  emitting a visible list control per action changes the dashboard's look.

--- a/docs/superpowers/specs/2026-08-07-tableau-actions-wrapup-design.md
+++ b/docs/superpowers/specs/2026-08-07-tableau-actions-wrapup-design.md
@@ -147,12 +147,73 @@ be born, and `:7780` must follow or the controls-coverage gate goes red.
 (`needs-wiring`, `needs-materialization`, `needs-master-default`, plus the emitting path). Deciding
 which status an action filter takes needs its own design pass.
 
-PR E is therefore **not planned alongside PRs A–D**. It also depends on the
-`ActionColumnResolver.resolve` signature, which does not exist until PR D lands. Write PR E's plan
-after PR D merges.
+### SECOND CORRECTION, 2026-08-07 — the correction above is also wrong
 
-Reconcile the `:8832` `-actions.md` writer with the ledger in this PR — it is the filter-action
-hand-wiring table, so it belongs here rather than with the earlier PRs.
+The design pass ran, and it measured rather than read. **`:7335` is not "the real change" either —
+on its own it is very nearly a no-op.**
+
+Real line is `build-charts-from-signals.rb:7419`. It sits in a loop over
+`(meta['shared_filters'] || []) + promoted_int_dim_filters`, and `meta['shared_filters']` is
+populated **only** from `//shared-view/filter` (`parse-twb-layout.rb:2149-2163`). Tableau's
+`[Action (X)]` filters are per-worksheet `sheet_link` filters, not shared-view filters. Measured on
+the one corpus workbook that has a filter action:
+
+```
+shared_filters total=3  is_action=0        <-- ZERO reach :7419
+worksheets carrying [Action (Region)]: 5
+zones carrying [Action (Region)]:      5
+```
+
+So un-picking `:7419` emits nothing. The population lives in `meta['worksheets'][ws]['filters']`
+and `layout[].zones[].filters`.
+
+**PR E needs a NEW emitter, not an un-pick.** All four rejection sites stay exactly as they are —
+which also means zero-action workbooks are byte-identical by construction, retiring the corpus
+regression risk named in the Risks section below.
+
+The new emitter joins `detected_actions[kind='filter-action']` (source sheet, `actionName`) with
+the worksheet-level `[Action (X)]` filters (the column, and the true set of affected sheets), and
+appends its control to `auto_controls` so the existing `ctl_rewrites` namespacing picks it up.
+
+Supporting findings, each verified against the code:
+
+- **No new status is needed.** `normalize_filter` returns early for `is_action`
+  (`parse-twb-layout.rb:378-381`), so an action filter carries exactly seven keys — no `topn`, no
+  `members`, no `datatype`, `kind == 'action'`. Branches 3, 5, 6 and 9a–9e of the dispatch are
+  structurally unreachable for it. Reuse `emitted` / `needs-materialization` / `dropped` /
+  `needs-wiring`.
+- **Unwrap `[Action (X)]` → `X` before `map_column`.** Without it the caption never resolves and the
+  control is literally named "Action (Region)".
+- **The census (`:7864`) must change its key from `name` to `[kind, name]`**, and index on the
+  unwrapped caption. A quick filter "Region" and an action filter "Region" otherwise collapse to one
+  row, last-writer-wins, hiding a `needs-wiring` behind an `emitted` — and gate 7c (exit 31) then
+  passes falsely.
+- **The `-actions.md` writer (`:9128`) must render from `ActionLedger.join(...)['residue']`.** Its
+  zone-derived rows carry no `actionName`, so they cannot be joined as-is.
+- **Dead code found:** the action-filter warning at `:5834` tests `f['column']`, a key that never
+  exists on an action filter. Dead since it was written, and documented as live behaviour in
+  `refs/phase-5-workbook.md:73`.
+
+**Biggest risk:** `special-fields=all` — the default "Use as Filter" shape, and the only real corpus
+instance — emits no `<link>`, so the detected entry's `fields` is the sentinel
+`"(all shared fields)"`. The entire design then depends on the `[Action (X)]` back-channel to name
+the column.
+
+**Cannot be settled without a live org:** whether `set-control-value` writing a numeric host column
+into a `Text()`-decoded control target matches anything (most likely a silent runtime failure);
+whether an include-mode `values: []` means "no filtering"; whether the target control must live on
+the host's page; and Tableau's `auto-clear`, which has no Sigma analogue.
+
+Full findings, with reproduction commands and V/VR/I tags on every claim, are in the design-pass
+report referenced from `beads-sigma-bfxd`.
+
+### Sequencing
+
+PR E is **not planned alongside PRs A–D**. It also depends on the `ActionColumnResolver.resolve`
+signature, which does not exist until PR D lands. Write PR E's plan after PR D merges.
+
+Reconcile the `-actions.md` writer with the ledger in this PR — it is the filter-action hand-wiring
+table, so it belongs here rather than with the earlier PRs.
 
 **Named fidelity loss.** Tableau targets *sheets*; Sigma targets an element's *source root*. Two
 sheets sharing a root collapse, so a `<param name='exclude'>` that separates them cannot be

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -6802,15 +6802,27 @@ end
 # (the workbook URL doesn't exist until the POST returns).
 action_id_registry = {} # workbook-wide — ActionLedger.new_id, never per-dash/per-zone
 emitted_actions = []
-# (dash_name, pre-namespacing host id) → the SAME hash object held in
-# emitted_actions, so the --page-per-dashboard rename hook below (namespace_ids)
-# can mutate the manifest entry in place when its host element id gets
-# suffixed. Keyed by a compound (dashboard, host) pair, NOT by host alone —
-# two unrelated dashboards' buttons can share a host string ("btn-10") purely
-# because Tableau zone ids restart per dashboard, and a stem-only key (the
-# pattern chart-provenance uses, which assumes stem collisions are the SAME
-# worksheet reused) would silently pair one dashboard's caption with another's
-# action.
+# (dash_name, pre-namespacing host id) → an ARRAY of the SAME hash objects held
+# in emitted_actions, so the --page-per-dashboard rename hooks below
+# (namespace_ids and the els.map! pass) can mutate every affected manifest entry
+# in place when its host element id gets suffixed. Keyed by a compound
+# (dashboard, host) pair, NOT by host alone — two unrelated dashboards' buttons
+# can share a host string ("btn-10") purely because Tableau zone ids restart per
+# dashboard, and a stem-only key (the pattern chart-provenance uses, which
+# assumes stem collisions are the SAME worksheet reused) would silently pair one
+# dashboard's caption with another's action.
+#
+# The value is an ARRAY, never a single entry: ONE host element can carry
+# actions of MORE THAN ONE KIND (a worksheet with both a <nav-action> and an
+# <edit-parameter-action> yields an on-select→navigate AND an
+# on-select→set-control-value on the same chart, both keyed by the same
+# (dashboard, host) pair). A scalar value made the second writer EVICT the
+# first; the rename pass then synced only the survivor, and the evicted entry
+# shipped a stale hostElementId/actionId. put-layout.rb:224 looks the manifest
+# up BY actionId against the posted spec — a stale id misses, and the whole
+# navigate.target.page repair is skipped with NO warning, leaving the
+# provisional page id live in the published workbook. Action counts still
+# match, so no gate catches it. Append here; iterate at both rename sites.
 emitted_action_index = {}
 nav_button_records = []
 unless opts[:pages_mode] == :worksheet
@@ -6876,7 +6888,7 @@ unless opts[:pages_mode] == :worksheet
             'effects'        => action['effects']
           }
           emitted_actions << manifest_entry
-          emitted_action_index[[dash['dashboard'], host]] = manifest_entry
+          (emitted_action_index[[dash['dashboard'], host]] ||= []) << manifest_entry
           e = { 'id' => host, 'kind' => 'button', 'text' => label,
                 'appearance' => 'filled', 'align' => 'center', 'size' => 'small',
                 'actions' => [action] }
@@ -6981,7 +6993,7 @@ unless opts[:pages_mode] == :worksheet
       'effects'        => action['effects']
     }
     emitted_actions << manifest_entry
-    emitted_action_index[[host_el['_dashboard'], host_el['id']]] = manifest_entry
+    (emitted_action_index[[host_el['_dashboard'], host_el['id']]] ||= []) << manifest_entry
     (host_el['actions'] ||= []) << action
   end
 end
@@ -7961,7 +7973,10 @@ end
 #   - a control with no filters[] makes this a SILENT no-op. There is no direct
 #     chart->chart filter effect; it always routes through a control.
 #   - the clicked column must exist on the HOST element for {type: "column"} to
-#     bind. When it does not, that is residue, not a guess.
+#     bind, and the effect carries that column's ID. When the host does not
+#     carry it, that is residue, not a guess. Enforced by the HOST-COLUMN
+#     BINDING guard below — `mmap` answers a workbook-global question and
+#     cannot enforce this on its own.
 unless opts[:pages_mode] == :worksheet
   Array(opts[:detected_actions]).each do |det|
     next unless det['kind'] == 'parameter-action'
@@ -7993,6 +8008,40 @@ unless opts[:pages_mode] == :worksheet
                   'add a master-columns.json regex, or wire it by hand (named residue)'
       next
     end
+
+    # HOST-COLUMN BINDING — the third hard constraint in this block's header,
+    # and the one `mmap` alone cannot enforce. `ActionColumnResolver.resolve`
+    # answers a WORKBOOK-GLOBAL question ("which Sigma column NAME does this
+    # Tableau ref mean?"); {type: "column"} asks a per-element one ("which
+    # column OF THE HOST does the clicked mark carry?"). A source field that
+    # resolves globally but is not on this chart binds to nothing: the click
+    # sets the control to the wrong value (or to nothing at all), through a
+    # schema-valid action every gate passes — action_column_resolver.rb's own
+    # stated anti-goal. Proven before this guard existed: an [Order ID] source
+    # field on a host carrying only Region / Profit Ratio / Region Not Null
+    # emitted column "Order ID" with no warning at all.
+    #
+    # The effect takes the host column's **id**, not its name — the
+    # live-probed shape is `value: {type: "column", column: <columnId>}` (the
+    # design's VERIFIED SIGMA SHAPES). Host columns are {id:, name:, formula:}
+    # (e.g. {"id" => "x-el-sales-by-region", "name" => "Region"}), and their
+    # `name` is the same master-map `name` the resolver returns, so an exact
+    # match is the normal case; the strip/case-insensitive second pass covers
+    # incidental whitespace/casing drift between the two, never a different
+    # column. No match at all is RESIDUE, never a guess.
+    host_cols = Array(host_el['columns']).select { |c| c.is_a?(Hash) && c['id'] }
+    host_col  = host_cols.find { |c| c['name'].to_s == col.to_s } ||
+                host_cols.find { |c| c['name'].to_s.strip.casecmp(col.to_s.strip).zero? }
+    if host_col.nil?
+      warnings << "parameter-action '#{caption}' source field " \
+                  "#{det['sourceFieldRef'].inspect} resolves to column #{col.inspect}, which is " \
+                  "NOT a column of its host element '#{host_el['id']}' " \
+                  "(has: #{host_cols.map { |c| c['name'] }.inspect}) — a {type: \"column\"} value " \
+                  'can only bind a column the clicked mark actually carries, so this would set the ' \
+                  'control to the wrong value; wire it by hand (named residue)'
+      next
+    end
+    col_id = host_col['id']
 
     # The control the parameter already migrated to. A Tableau parameter's
     # auto-generated control lives in `param_controls` (built from
@@ -8031,7 +8080,12 @@ unless opts[:pages_mode] == :worksheet
                       # emitted_action_index keeps nav-action/nav-button
                       # references correct across that same per-page rename.
                       'control' => ctl['controlId'],
-                      'value'   => { 'type' => 'column', 'column' => col } }]
+                      # The HOST element's columnId (not a bare column name):
+                      # the live-probed shape is
+                      # {type: "column", column: <columnId>}. Resolved just
+                      # above against host_el['columns'] — see the
+                      # HOST-COLUMN BINDING note there.
+                      'value'   => { 'type' => 'column', 'column' => col_id } }]
     }
     errs = ActionLedger.validate_action(action)
     raise "emitted an invalid parameter-action on #{host_el['id']}: #{errs.join('; ')}" if errs.any?
@@ -8046,7 +8100,7 @@ unless opts[:pages_mode] == :worksheet
       'effects'       => action['effects']
     }
     emitted_actions << manifest_entry
-    emitted_action_index[[host_el['_dashboard'], host_el['id']]] = manifest_entry
+    (emitted_action_index[[host_el['_dashboard'], host_el['id']]] ||= []) << manifest_entry
     (host_el['actions'] ||= []) << action
   end
 end
@@ -8774,16 +8828,25 @@ elsif opts[:pages_mode] == :dashboard
           if (pv = $chart_provenance[stem])
             $chart_provenance[ns] = pv.merge('dashboard' => dash_name)
           end
-          # A nav-button's manifest entry (keyed by the EXACT (dashboard, host)
-          # pair — never by stem alone, since two unrelated dashboards' buttons
-          # can share a host string) gets updated IN PLACE so its
-          # hostElementId/actionId track the same rename this gsub is about to
-          # apply to the real element. Without this, write_manifest below would
-          # ship a hostElementId/actionId that no longer exists in the spec —
-          # exactly the staleness the manifest exists to prevent.
-          if (entry = emitted_action_index[[dash_name, stem]])
+          # EVERY manifest entry hosted here (keyed by the EXACT (dashboard,
+          # host) pair — never by stem alone, since two unrelated dashboards'
+          # buttons can share a host string) gets updated IN PLACE so its
+          # hostElementId/actionId/effects track the same rename this gsub is
+          # about to apply to the real element. Without this, write_manifest
+          # below would ship a hostElementId/actionId that no longer exists in
+          # the spec — exactly the staleness the manifest exists to prevent.
+          # ITERATE, never `= entry`: one host can carry actions of several
+          # kinds (see the emitted_action_index declaration), and syncing only
+          # one of them re-creates the stale-actionId silent skip.
+          Array(emitted_action_index[[dash_name, stem]]).each do |entry|
             entry['hostElementId'] = ns
             entry['actionId'] = entry['actionId'].to_s.gsub(stem, ns)
+            # Effects can EMBED the stem too — a set-control-value's
+            # value.column is the host column's id (x-<stem>/y-<stem>/…), which
+            # the whole-element gsub below rewrites in the spec. The manifest
+            # copy must move in lockstep or probe-actions-readback.rb diffs a
+            # pre-rename column id against the posted one.
+            entry['effects'] = JSON.parse(entry['effects'].to_json.gsub(stem, ns)) if entry['effects']
           end
           JSON.parse(el.to_json.gsub(stem, ns))
         else
@@ -8814,18 +8877,29 @@ elsif opts[:pages_mode] == :dashboard
         if (pv = $chart_provenance[stem])
           $chart_provenance[ns] = pv.merge('dashboard' => dash_name)
         end
-        # A nav-action's manifest entry (keyed by the EXACT (dashboard, host)
-        # pair, same as namespace_ids above) gets updated IN PLACE so its
-        # hostElementId/actionId track the same rename this gsub is about to
-        # apply to the real element. Without this, put-layout.rb's
+        # EVERY manifest entry hosted here (keyed by the EXACT (dashboard,
+        # host) pair, same as namespace_ids above) gets updated IN PLACE so its
+        # hostElementId/actionId/effects track the same rename this gsub is
+        # about to apply to the real element. Without this, put-layout.rb's
         # navigate.target.page repair looks up the manifest by actionId
         # against the POSTED spec's action id, finds nothing (stale), and
         # silently skips the repair — no warning — leaving the provisional
         # page id live. Mirrors namespace_ids exactly; do not invent a
         # different mechanism.
-        if (entry = emitted_action_index[[dash_name, stem]])
+        #
+        # ITERATE over an ARRAY, never `if (entry = ...)`: one chart element
+        # can host BOTH a nav-action (on-select→navigate) and a
+        # parameter-action (on-select→set-control-value) when its worksheet is
+        # the source of both Tableau actions. A scalar index let the second
+        # emitter evict the first, and syncing only the survivor left the
+        # evicted entry's actionId stale — the exact silent-skip this block
+        # exists to prevent, reintroduced through the back door.
+        Array(emitted_action_index[[dash_name, stem]]).each do |entry|
           entry['hostElementId'] = ns
           entry['actionId'] = entry['actionId'].to_s.gsub(stem, ns)
+          # See namespace_ids above: value.column is a host column id, which
+          # embeds the stem, so the manifest's effects must be rewritten too.
+          entry['effects'] = JSON.parse(entry['effects'].to_json.gsub(stem, ns)) if entry['effects']
         end
         src_before = el.dig('source', 'elementId')
         el2 = JSON.parse(el.to_json.gsub(stem, ns))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -72,6 +72,7 @@ require_relative 'lib/tableau_dynamic_title'
 require_relative 'lib/kpi_card'       # shared KPI-chart emitter (comparative-KPI-ready)
 require_relative 'lib/kpi_comparison_detect' # Task 5: prior/target comparison-measure detector
 require_relative 'lib/action_ledger' # workbook-wide action id registry + validate/manifest
+require_relative 'lib/action_column_resolver' # Task 5: raw Tableau source-field ref -> emitted Sigma column name
 require 'erb'
 
 opts = { master_id: 'master' }
@@ -7941,6 +7942,115 @@ rescue => e
   warnings << "control-coverage reconciliation error: #{e.message}"
 end
 
+# ---- PARAMETER actions (bfxd step 2) ---------------------------------------
+# on-select -> set-control-value {type: "column"}: the mark click sets a control
+# to the clicked row's value. RUNTIME-PROVEN 2026-08-06 end to end.
+#
+# Placement note: structurally this cannot sit right after Task 3's nav-action
+# block (immediately after the zones/nav-button loop, before `param_controls`/
+# `auto_controls` are even declared) — resolving `target_name` to a control
+# needs both arrays fully populated, and they aren't until further down. This
+# is the earliest point after both exist, while `elements` still carry
+# `_worksheet`/`_dashboard` (stripped inside the pages_mode branches below) and
+# before the actions-emitted manifest is written — the same two constraints
+# Task 3's block had to satisfy.
+#
+# Three hard constraints, each confirmed by breaking it:
+#   - `control` takes the controlId, NOT the control element's id. /verify
+#     ACCEPTS the wrong form; the live create rejects it.
+#   - a control with no filters[] makes this a SILENT no-op. There is no direct
+#     chart->chart filter effect; it always routes through a control.
+#   - the clicked column must exist on the HOST element for {type: "column"} to
+#     bind. When it does not, that is residue, not a guess.
+unless opts[:pages_mode] == :worksheet
+  Array(opts[:detected_actions]).each do |det|
+    next unless det['kind'] == 'parameter-action'
+
+    caption = det['caption'].to_s
+    unless det['trigger'].to_s.strip.casecmp('on select').zero?
+      warnings << "parameter-action '#{caption}' activates on #{det['trigger'].inspect} — " \
+                  'Sigma has no equivalent trigger (named residue)'
+      next
+    end
+    sheets = Array(det.dig('source', 'worksheets'))
+    if sheets.length != 1
+      warnings << "parameter-action '#{caption}' sources #{sheets.length} worksheet(s) — " \
+                  'no unambiguous host element (named residue)'
+      next
+    end
+    host_el = elements.find { |e| e['_worksheet'] == sheets.first }
+    if host_el.nil?
+      warnings << "parameter-action '#{caption}' sources worksheet '#{sheets.first}', " \
+                  'which produced no emitted element (named residue)'
+      next
+    end
+
+    col = ActionColumnResolver.resolve(ref: det['sourceFieldRef'], mmap: mmap,
+                                       columns_by_guid: meta['columns_by_guid'] || {})
+    if col.nil?
+      warnings << "parameter-action '#{caption}' source field " \
+                  "#{det['sourceFieldRef'].inspect} does not resolve to an emitted column — " \
+                  'add a master-columns.json regex, or wire it by hand (named residue)'
+      next
+    end
+
+    # The control the parameter already migrated to. A Tableau parameter's
+    # auto-generated control lives in `param_controls` (built from
+    # meta['parameters']); a quick-filter's lives in `auto_controls` (built
+    # from meta['shared_filters']) — search both, exactly as every other
+    # consumer of "all controls" in this file does (control-coverage above,
+    # and the page-emission duplication passes at :8437/:8515/:8659).
+    # targetParameterRef's caption is what extract_parameter_actions rendered
+    # into targets[0]['name'].
+    target_name = Array(det['targets']).first.to_h['name'].to_s
+    ctl = (param_controls + auto_controls).find { |c| c['name'].to_s.strip.casecmp(target_name.strip).zero? }
+    if ctl.nil?
+      warnings << "parameter-action '#{caption}' targets parameter '#{target_name}', which " \
+                  'has no emitted control — the click has nothing to set (named residue)'
+      next
+    end
+    if Array(ctl['filters']).empty?
+      warnings << "parameter-action '#{caption}' targets control '#{ctl['controlId']}', " \
+                  'which carries no filters[] — setting it would be a SILENT no-op ' \
+                  '(named residue)'
+      next
+    end
+
+    action = {
+      'id'      => ActionLedger.new_id(action_id_registry, host_el['id']),
+      'trigger' => 'on-select',
+      'effects' => [{ 'effect'  => 'set-control-value',
+                      # controlId, NOT the control element's id. In
+                      # --page-per-dashboard/--page-per-worksheet mode this
+                      # captured id is PROVISIONAL: the per-page control-
+                      # duplication pass further down suffixes every
+                      # param/auto control's controlId per page via
+                      # `ctl_rewrites`, and that pass has been extended (see
+                      # the two `ctl_rewrites` loops below) to rewrite this
+                      # exact field in lockstep — mirroring how
+                      # emitted_action_index keeps nav-action/nav-button
+                      # references correct across that same per-page rename.
+                      'control' => ctl['controlId'],
+                      'value'   => { 'type' => 'column', 'column' => col } }]
+    }
+    errs = ActionLedger.validate_action(action)
+    raise "emitted an invalid parameter-action on #{host_el['id']}: #{errs.join('; ')}" if errs.any?
+
+    manifest_entry = {
+      'actionId'      => action['id'],
+      'source'        => { 'kind' => 'parameter-action', 'caption' => caption,
+                           'sourceSheet' => sheets.first,
+                           'actionName' => det['actionName'] },
+      'hostElementId' => host_el['id'],
+      'trigger'       => action['trigger'],
+      'effects'       => action['effects']
+    }
+    emitted_actions << manifest_entry
+    emitted_action_index[[host_el['_dashboard'], host_el['id']]] = manifest_entry
+    (host_el['actions'] ||= []) << action
+  end
+end
+
 # ---- v5.1 leaked-ref guard (fail-closed) ------------------------------------
 # A column ref whose inner name contains formula punctuation or a Tableau pill
 # qualifier ([Master/-WINDOW_MAX(…)], [Master/Rank N (copy)_…:ok:9]) is ALWAYS
@@ -8516,6 +8626,19 @@ if opts[:pages_mode] == :worksheet
         end
         col['formula'] = f
       end
+      # A set-control-value effect's `control` names a param/auto controlId —
+      # the SAME id this page just suffixed above. Without this, an emitted
+      # action (parameter-action emission is currently gated off in
+      # page-per-worksheet mode, but this keeps the two duplication sites in
+      # lockstep against future changes) would reference a controlId that no
+      # longer exists on this page, exactly the staleness class the
+      # formula-rewrite above exists to prevent.
+      (el['actions'] || []).each do |a|
+        (a['effects'] || []).each do |eff|
+          nxt = ctl_rewrites[eff['control']]
+          eff['control'] = nxt if eff['effect'] == 'set-control-value' && nxt
+        end
+      end
     end
     pages << {
       'name'     => ws_name,
@@ -8617,6 +8740,21 @@ elsif opts[:pages_mode] == :dashboard
         f = col['formula'].to_s
         ctl_rewrites.each { |from, to| f = f.gsub("[#{from}]", "[#{to}]") }
         col['formula'] = f
+      end
+      # A parameter-action's set-control-value effect names a param/auto
+      # controlId — the SAME id this dashboard page just suffixed above via
+      # ctl_rewrites. Without this rewrite the emitted action would reference
+      # a controlId that only existed pre-namespacing and never appears in
+      # this page's own control list — a schema-valid action the live create
+      # rejects ("references unknown control"), same failure mode as passing
+      # an element id instead of a controlId. Mirrors the formula rewrite
+      # immediately above; mutates the effect hash in place, which the
+      # actions-emitted manifest (built from the SAME object) picks up too.
+      (el['actions'] || []).each do |a|
+        (a['effects'] || []).each do |eff|
+          nxt = ctl_rewrites[eff['control']]
+          eff['control'] = nxt if eff['effect'] == 'set-control-value' && nxt
+        end
       end
     end
     # K3: page_extras (styled text, title text, images) carry Tableau ZONE ids,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -8676,6 +8676,19 @@ elsif opts[:pages_mode] == :dashboard
         if (pv = $chart_provenance[stem])
           $chart_provenance[ns] = pv.merge('dashboard' => dash_name)
         end
+        # A nav-action's manifest entry (keyed by the EXACT (dashboard, host)
+        # pair, same as namespace_ids above) gets updated IN PLACE so its
+        # hostElementId/actionId track the same rename this gsub is about to
+        # apply to the real element. Without this, put-layout.rb's
+        # navigate.target.page repair looks up the manifest by actionId
+        # against the POSTED spec's action id, finds nothing (stale), and
+        # silently skips the repair — no warning — leaving the provisional
+        # page id live. Mirrors namespace_ids exactly; do not invent a
+        # different mechanism.
+        if (entry = emitted_action_index[[dash_name, stem]])
+          entry['hostElementId'] = ns
+          entry['actionId'] = entry['actionId'].to_s.gsub(stem, ns)
+        end
         src_before = el.dig('source', 'elementId')
         el2 = JSON.parse(el.to_json.gsub(stem, ns))
         # v5.1.3: the stem gsub also rewrites a source.elementId that EMBEDS

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -6914,6 +6914,77 @@ unless opts[:pages_mode] == :worksheet
   # for the identical reason).
 end
 
+# ---- nav-action MARK CLICKS (bfxd step 1) ----------------------------------
+# A Tableau <nav-action> fires from a mark click on a WORKSHEET, not from a
+# dashboard-object button. on-select -> navigate is runtime-proven, so these
+# are auto-wirable; only three shapes are not, and each stays residue with its
+# reason named rather than being silently dropped:
+#   - on-hover / tooltip-menu activation: Sigma has no equivalent trigger.
+#   - a WORKSHEET target: Sigma navigates to a PAGE; there is no element-id
+#     index that would let us target a sheet within one.
+#   - a source naming zero or multiple worksheets: no unambiguous host element.
+#
+# Page ids are provisional here for the same reason as the nav-button block
+# above — two id schemes coexist and put-layout.rb repairs navigate.target.page
+# BY NAME after publish using targetPageName.
+unless opts[:pages_mode] == :worksheet
+  Array(opts[:detected_actions]).each do |det|
+    next unless det['kind'] == 'nav-action'
+
+    caption = det['caption'].to_s
+    unless det['trigger'].to_s.strip.casecmp('on select').zero?
+      warnings << "nav-action '#{caption}' activates on #{det['trigger'].inspect} — " \
+                  'Sigma has no equivalent trigger (named residue)'
+      next
+    end
+    sheets = Array(det.dig('source', 'worksheets'))
+    if sheets.length != 1
+      warnings << "nav-action '#{caption}' sources #{sheets.length} worksheet(s) — " \
+                  'no unambiguous host element (named residue)'
+      next
+    end
+    target = Array(det['targets']).first || {}
+    unless target['dashboard'] == true
+      warnings << "nav-action '#{caption}' targets worksheet '#{target['name']}', not a " \
+                  'dashboard — Sigma navigates to a page, and there is no element-id ' \
+                  'index for a sheet within one (named residue)'
+      next
+    end
+
+    host_el = elements.find { |e| e['_worksheet'] == sheets.first }
+    if host_el.nil?
+      warnings << "nav-action '#{caption}' sources worksheet '#{sheets.first}', which " \
+                  'produced no emitted element (named residue)'
+      next
+    end
+
+    slug = target['name'].to_s.downcase.gsub(/[^a-z0-9]+/, '-')
+             .sub(/\A-/, '').sub(/-\z/, '')[0..40].to_s
+    action = {
+      'id'      => ActionLedger.new_id(action_id_registry, host_el['id']),
+      'trigger' => 'on-select',
+      'effects' => [{ 'effect' => 'navigate',
+                      'target' => { 'type' => 'page', 'page' => "page-#{slug}" } }]
+    }
+    errs = ActionLedger.validate_action(action)
+    raise "emitted an invalid nav-action on #{host_el['id']}: #{errs.join('; ')}" if errs.any?
+
+    manifest_entry = {
+      'actionId'       => action['id'],
+      'source'         => { 'kind' => 'nav-action', 'caption' => caption,
+                            'sourceSheet' => sheets.first,
+                            'actionName' => det['actionName'] },
+      'hostElementId'  => host_el['id'],
+      'targetPageName' => target['name'],
+      'trigger'        => action['trigger'],
+      'effects'        => action['effects']
+    }
+    emitted_actions << manifest_entry
+    emitted_action_index[[host_el['_dashboard'], host_el['id']]] = manifest_entry
+    (host_el['actions'] ||= []) << action
+  end
+end
+
 styled_text_all = styled_text_by_dash.values.flatten(1)
 
 # ---- Control targeting: intended-scope closure ------------------------------

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-postpublish-guide.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-postpublish-guide.rb
@@ -529,6 +529,13 @@ module PostpublishGuide
         'trigger'   => activation_of(a),
         'fields'    => [field_caption(src_field, lut)].compact,
         'targets'   => [{ 'name' => field_caption(tgt_param, lut), 'parameter' => true }],
+        # RAW refs, alongside the human captions above. field_caption strips the
+        # derivation qualifier (none:X:nk) and tidies the name, which is right
+        # for rendering and useless for resolution — emission needs to map the
+        # Tableau field to an emitted Sigma columnId, and the caption cannot do
+        # that. Additive: every rendered surface still reads `fields`/`targets`.
+        'sourceFieldRef'     => src_field,
+        'targetParameterRef' => tgt_param,
         'ui_steps'  => '',   # filled in by the wb-ids pass / renderer
         'notes'     => []
       }
@@ -855,8 +862,8 @@ module PostpublishGuide
         e['ui_steps'] =
           if ctl
             "Already replicated: the Sigma control '#{ctl}' replaces parameter '#{pname}' — " \
-            'clicking the control sets the same value. The click-driven flavor ' \
-            '(chart-click-sets-control) is on the Sigma UI roadmap; control-click is the equivalent today.'
+            'clicking the control sets the same value. Click-to-set is auto-wired when the ' \
+            'source column resolves; otherwise set the control by hand.'
           else
             # No exact-name control match; when wb-ids resolves the source
             # dashboard to a page, name that page's controls as candidates so
@@ -868,8 +875,8 @@ module PostpublishGuide
               hint = " (page '#{src['sigma_page']}' has controls: #{cap_list(cands, 5)})" unless cands.empty?
             end
             "The conversion normally replicates this parameter as a control — check the published " \
-            "workbook for a control replacing '#{pname}'#{hint}. The click-driven flavor " \
-            '(chart-click-sets-control) is on the Sigma UI roadmap; control-click is the equivalent today.'
+            "workbook for a control replacing '#{pname}'#{hint}. Click-to-set is auto-wired when the " \
+            'source column resolves; otherwise set the control by hand.'
           end
       end
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-postpublish-guide.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-postpublish-guide.rb
@@ -500,7 +500,7 @@ module PostpublishGuide
         'targets' => [{ 'name' => target_sheet, 'dashboard' => is_dash }],
         'fields'  => [],
         'ui_steps' => STEPS_BUTTON_NAV,
-        'notes'   => ['Sigma buttons support page navigation in the UI; this wiring is not spec-persistable, so it must be added after publish.']
+        'notes'   => []
       }
       entry['actionName'] = name unless name.empty?
       out << entry

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_column_resolver.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_column_resolver.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Resolve a Tableau action's `source-field` ref to the Sigma column NAME that
+# the converter actually emitted.
+#
+# Why this is its own unit: field_caption() in build-postpublish-guide.rb
+# answers a different question (what should a human read?) and its answer is
+# lossy on purpose — it strips the derivation qualifier and tidies the name.
+# Emission needs the opposite: an exact join to a column that exists on the
+# host element. Mixing the two is what made parameter actions unbuildable.
+#
+# Returns nil rather than guessing. A guessed column ships a schema-valid
+# action that silently sets the control to the wrong value — worse than
+# residue, which at least tells the customer to wire it by hand.
+module ActionColumnResolver
+  module_function
+
+  # ref:             raw Tableau ref, e.g. "[federated.f1].[none:Calculation_100:nk]"
+  # mmap:            the master map (regex string => {'name' => <sigma column>})
+  # columns_by_guid: internal calc name => friendly caption
+  def resolve(ref:, mmap:, columns_by_guid:)
+    inner = strip_qualifier(ref)
+    return nil if inner.nil?
+
+    # An internal calc name (Calculation_NNN, optionally blend-suffixed " 1")
+    # is never a master-map key — bridge it to its friendly caption first.
+    caption = columns_by_guid[inner] ||
+              columns_by_guid[inner.sub(/\s+\d+\z/, '')] ||
+              inner
+
+    info = match_column(caption, mmap)
+    info && info['name']
+  end
+
+  # "[federated.f1].[none:Calculation_100:nk]" -> "Calculation_100"
+  # "[Region]"                                 -> "Region"
+  # "[Parameters].[Parameter 1]"               -> "Parameter 1"
+  def strip_qualifier(ref)
+    return nil if ref.nil? || ref.to_s.empty?
+    inner = ref[/\.\[([^\[\]]+)\]\s*\z/, 1] || ref[/\A\[([^\[\]]+)\]\z/, 1] || ref.to_s
+    # none:X:nk, usr:X:qk, and the 4-segment usr:X:nk:1 instance-numbered shape.
+    inner = Regexp.last_match(1) if inner =~ /\A[a-z]+:(.+?):[a-z]+(?::\d+)?\z/i
+    inner = inner.sub(/\A:/, '')
+    inner.strip.empty? ? nil : inner.strip
+  end
+
+  # Mirrors build-charts-from-signals.rb's map_column so a ref resolves to the
+  # same column the chart build emitted — first regex wins, same as there.
+  def match_column(caption, mmap)
+    h = caption.to_s.strip
+    mmap.each { |pat, info| return info if Regexp.new(pat).match?(h) }
+    nil
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_column_resolver.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_column_resolver.rb
@@ -17,15 +17,15 @@ module ActionColumnResolver
 
   # ref:             raw Tableau ref, e.g. "[federated.f1].[none:Calculation_100:nk]"
   # mmap:            the master map (regex string => {'name' => <sigma column>})
-  # columns_by_guid: internal calc name => friendly caption
+  # columns_by_guid: internal calc name => { 'caption' => <friendly caption>, ... }
   def resolve(ref:, mmap:, columns_by_guid:)
     inner = strip_qualifier(ref)
     return nil if inner.nil?
 
     # An internal calc name (Calculation_NNN, optionally blend-suffixed " 1")
     # is never a master-map key — bridge it to its friendly caption first.
-    caption = columns_by_guid[inner] ||
-              columns_by_guid[inner.sub(/\s+\d+\z/, '')] ||
+    caption = (columns_by_guid[inner].is_a?(Hash) && columns_by_guid[inner]['caption']) ||
+              (columns_by_guid[inner.sub(/\s+\d+\z/, '')].is_a?(Hash) && columns_by_guid[inner.sub(/\s+\d+\z/, '')]['caption']) ||
               inner
 
     info = match_column(caption, mmap)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-column-resolver.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-column-resolver.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+# A Tableau source-field ref must resolve to an EMITTED Sigma column, or to
+# nothing at all. A guessed columnId ships a schema-valid action that silently
+# sets the control to the wrong value.
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'action_column_resolver'
+
+$fails = []
+def check(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+MMAP = { '(?i)^region$' => { 'name' => 'Region' },
+         '(?i)^metric button$' => { 'name' => 'Metric Button' } }.freeze
+GUIDS = { 'Calculation_100' => 'Metric Button' }.freeze
+
+puts '== Plain federated refs ================================================='
+check(ActionColumnResolver.resolve(ref: '[federated.abc].[none:Region:nk]',
+                                   mmap: MMAP, columns_by_guid: {}) == 'Region',
+      'a none:X:nk qualified federated ref resolves to the mapped column')
+check(ActionColumnResolver.resolve(ref: '[Region]', mmap: MMAP, columns_by_guid: {}) == 'Region',
+      'a bare bracketed ref resolves')
+
+puts '== Calc refs resolve through columns_by_guid ============================'
+check(ActionColumnResolver.resolve(ref: '[federated.f1].[none:Calculation_100:nk]',
+                                   mmap: MMAP, columns_by_guid: GUIDS) == 'Metric Button',
+      'an internal Calculation_NNN name resolves via columns_by_guid, then the master map')
+
+puts '== Unresolvable refs return nil, never a guess =========================='
+check(ActionColumnResolver.resolve(ref: '[federated.f1].[none:Unmapped:nk]',
+                                   mmap: MMAP, columns_by_guid: {}).nil?,
+      'a field with no master-map entry resolves to nil')
+check(ActionColumnResolver.resolve(ref: nil, mmap: MMAP, columns_by_guid: {}).nil?,
+      'a nil ref resolves to nil')
+check(ActionColumnResolver.resolve(ref: '', mmap: MMAP, columns_by_guid: {}).nil?,
+      'an empty ref resolves to nil')
+
+puts
+if $fails.empty?
+  puts 'OK'
+else
+  puts "FAILED (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-column-resolver.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-column-resolver.rb
@@ -13,7 +13,7 @@ end
 
 MMAP = { '(?i)^region$' => { 'name' => 'Region' },
          '(?i)^metric button$' => { 'name' => 'Metric Button' } }.freeze
-GUIDS = { 'Calculation_100' => 'Metric Button' }.freeze
+GUIDS = { 'Calculation_100' => { 'caption' => 'Metric Button' } }.freeze
 
 puts '== Plain federated refs ================================================='
 check(ActionColumnResolver.resolve(ref: '[federated.abc].[none:Region:nk]',
@@ -35,6 +35,13 @@ check(ActionColumnResolver.resolve(ref: nil, mmap: MMAP, columns_by_guid: {}).ni
       'a nil ref resolves to nil')
 check(ActionColumnResolver.resolve(ref: '', mmap: MMAP, columns_by_guid: {}).nil?,
       'an empty ref resolves to nil')
+
+puts '== Degradation: flat-String columns_by_guid does not raise ============='
+flat_guids = { 'Calculation_100' => 'Metric Button' }
+result = ActionColumnResolver.resolve(ref: '[federated.f1].[none:Calculation_100:nk]',
+                                      mmap: MMAP, columns_by_guid: flat_guids)
+check(result.nil? || result == 'Calculation_100',
+      'flat-String columns_by_guid value degrades to nil or the inner name')
 
 puts
 if $fails.empty?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-nav-action-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-nav-action-emission.rb
@@ -1,0 +1,130 @@
+#!/usr/bin/env ruby
+# A Tableau <nav-action> fires from a MARK CLICK on a worksheet. PR #657 wired
+# only dashboard-object BUTTONS, so every mark-click nav-action stayed residue
+# even though on-select -> navigate is runtime-proven.
+#
+# Deterministic + offline: drives the committed postpublish-actions.twb.
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+require 'open3'
+
+DIR     = __dir__
+GUIDE   = File.join(DIR, 'build-postpublish-guide.rb')
+FIXTURE = File.join(DIR, 'test-fixtures', 'postpublish-actions.twb')
+RUBY    = RbConfig.ruby
+
+$fails = []
+def check(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+Dir.mktmpdir do |d|
+  detected = File.join(d, 'detected-actions.json')
+  _, st = Open3.capture2e(RUBY, GUIDE, '--twb', FIXTURE, '--detect-only', detected)
+  check(st.success?, 'detection succeeded on the fixture')
+  entries = JSON.parse(File.read(detected))
+
+  nav = entries.find { |e| e['kind'] == 'nav-action' }
+  check(!nav.nil?, 'the fixture still contains a nav-action')
+
+  puts '== The stale spec-persistability note is gone ==========================='
+  note = Array(nav['notes']).join(' ')
+  check(!note.include?('not spec-persistable'),
+        'the nav-action entry no longer claims navigation is "not spec-persistable" — ' \
+        "that is the pre-#657 belief, disproven by the live probe (got: #{note.inspect})")
+
+  puts '== The gate conditions are all present on the entry ====================='
+  check(nav['trigger'] == 'on select',
+        "trigger is Tableau's spaced form (got #{nav['trigger'].inspect}) — " \
+        'emission must map it to Sigma\'s hyphenated on-select, not pass it through')
+  check(Array(nav.dig('source', 'worksheets')).first == 'Sales by Region',
+        'the source names a single worksheet, which is the join key to _worksheet')
+  check(nav['targets'].first['dashboard'] == true,
+        'the target is a DASHBOARD (a worksheet target has no element-id index)')
+
+  puts '== The action is actually EMITTED onto the source element ==============='
+  layout = File.join(d, 'layout.json')
+  meta   = File.join(d, 'layout-meta.json')
+  # parse-twb-layout.rb takes positional args (<twb> <out.json>), not
+  # --twb/--out flags — matches its own usage banner and the existing correct
+  # call site in test-action-detection-bridge.rb.
+  _, pst = Open3.capture2e(RUBY, File.join(DIR, 'parse-twb-layout.rb'), FIXTURE, layout)
+  check(pst.success?, 'parse-twb-layout succeeded')
+
+  # build-charts-from-signals.rb requires --master-map (abort otherwise) and
+  # the Phase 1d dashboard-read gate artifact (png-read.json) — same fixture
+  # setup test-action-detection-bridge.rb already uses for this exact .twb.
+  mmap = File.join(d, 'master-map.json')
+  File.write(mmap, JSON.dump(
+               '(?i)^Region$'       => { 'id' => 'm-region',  'name' => 'Region' },
+               '(?i)^Order ID$'     => { 'id' => 'm-orderid', 'name' => 'Order ID' },
+               '(?i)^Category$'     => { 'id' => 'm-cat',     'name' => 'Category' },
+               '(?i)^Sub-Category$' => { 'id' => 'm-subcat',  'name' => 'Sub-Category' },
+               '(?i)^Product Name$' => { 'id' => 'm-prod',    'name' => 'Product Name' }
+             ))
+  File.write(File.join(d, 'get-workbook.json'), JSON.dump(
+               'views' => { 'view' => [
+                 { 'id' => 'v1', 'name' => 'Sales by Region' },
+                 { 'id' => 'v2', 'name' => 'Region Detail' },
+                 { 'id' => 'v3', 'name' => 'Metric Buttons' },
+                 { 'id' => 'v4', 'name' => 'Filter Panel Sheet' }
+               ] }
+             ))
+  Dir.mkdir(File.join(d, 'views'))
+  %w[v2 v3 v4].each { |v| File.write(File.join(d, 'views', "#{v}.csv"), '') }
+  # 'Sales by Region' (v1) needs REAL rows, not an empty stub: the fixture's
+  # worksheet XML carries no <rows>/<cols> shelf signals (it's a minimal
+  # detection-only fixture), so synthesize_view_from_signals can't reconstruct
+  # it from an empty CSV and the zone would be dropped before any element
+  # exists to host the nav-action — a 0-byte CSV proves detection-bridge
+  # wiring (test-action-detection-bridge.rb's use case) but not emission.
+  File.write(File.join(d, 'views', 'v1.csv'), "Region,Profit Ratio\nWest,0.42\n")
+  File.write(File.join(d, 'png-read.json'), JSON.dump(
+               'source_png' => 'views/v1.png',
+               'tiles' => [
+                 { 'title' => 'Sales by Region',    'kind' => 'bar-chart', 'orientation' => 'vertical' },
+                 { 'title' => 'Region Detail',      'kind' => 'table' },
+                 { 'title' => 'Metric Buttons',     'kind' => 'scatter-chart' },
+                 { 'title' => 'Filter Panel Sheet', 'kind' => 'table' }
+               ],
+               'text_elements' => [], 'filter_shelf' => []
+             ))
+
+  charts = File.join(d, 'chart-specs.json')
+  blog, bst = Open3.capture2e(RUBY, File.join(DIR, 'build-charts-from-signals.rb'),
+                              '--tableau-dir', d, '--layout', layout, '--meta', meta,
+                              '--master-map', mmap, '--master-element-id', 'master',
+                              '--page-per-dashboard',
+                              '--detected-actions', detected,
+                              '--out', charts)
+  check(bst.success?, 'the chart build succeeded with --detected-actions' +
+        (bst.success? ? '' : " (log:\n#{blog})"))
+
+  emitted = JSON.parse(File.read(charts.sub(/\.json$/, '-actions-emitted.json')))
+  navs = emitted.select { |e| e.dig('source', 'kind') == 'nav-action' }
+  check(navs.length == 1, "exactly one nav-action was emitted (got #{navs.length})")
+
+  if (n = navs.first)
+    check(n['trigger'] == 'on-select',
+          "the emitted trigger is Sigma's hyphenated on-select (got #{n['trigger'].inspect})")
+    check(n['effects'].first['effect'] == 'navigate', 'the effect is navigate')
+    check(n['targetPageName'] == 'Detail Page',
+          'targetPageName carries the raw dashboard name for put-layout.rb to resolve by name')
+    check(n.dig('source', 'actionName') == '[Action4_DDDD]',
+          'actionName is carried so ActionLedger.key_of can disambiguate same-captioned actions')
+    ids = emitted.map { |e| e['actionId'] }
+    check(ids.uniq.length == ids.length,
+          'every emitted action id is unique across the whole workbook')
+  end
+end
+
+puts
+if $fails.empty?
+  puts 'OK'
+else
+  puts "FAILED (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-nav-action-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-nav-action-emission.rb
@@ -121,6 +121,130 @@ Dir.mktmpdir do |d|
 end
 
 puts
+puts '== Regression: emitted_action_index survives the --page-per-dashboard rename pass =='
+puts '   (build-charts-from-signals.rb els.map! ~:8594-8626, sibling to namespace_ids'
+puts '   ~:8558-8586 — the reviewer-confirmed gap.)'
+# A LITERAL "same worksheet reused verbatim on two dashboards" case can never
+# exercise this path: element building is dashboard-major and single-pass
+# (one `layout.each do |dash|` loop, :4283-~6500), so the FIRST dashboard (in
+# `layout`/`dash_order` order) that carries a worksheet is BOTH what
+# `elements.find` returns as host_el AND what the per-dashboard dedup pass
+# visits first (and therefore leaves unrenamed) — they can never diverge.
+#
+# What DOES trigger the dedup rename on host_el itself is an id-STEM
+# COLLISION with an unrelated, EARLIER-dashboard element. Element ids are
+# `"el-#{caption.downcase.gsub(/\W+/, '-')[0..40]}"` (build-charts-from-
+# signals.rb ~:2593/4516/4904) — a run of ANY non-word characters collapses
+# to ONE hyphen, so "Sales by Region" (single space) and "Sales  by  Region"
+# (double space) slug to the IDENTICAL "el-sales-by-region", while remaining
+# DIFFERENT strings for the exact `_worksheet` match our emission code uses.
+# So: put the double-spaced DECOY on Overview (dash_order[0] — claims the
+# stem first, stays unrenamed) and the real, single-spaced "Sales by Region"
+# — our nav-action's actual host — on Detail Page (dash_order[1] — the dedup
+# pass finds the stem already claimed and RENAMES it). This is exactly the
+# mechanism the review traced: host_el's own embedded actions[].id survives
+# (whole-object gsub), but the OUT-OF-BAND emitted_actions manifest entry
+# does not update unless els.map! also syncs emitted_action_index.
+Dir.mktmpdir do |d2|
+  layout2 = File.join(d2, 'layout.json')
+  out2, st2 = Open3.capture2e(RUBY, File.join(DIR, 'parse-twb-layout.rb'), FIXTURE, layout2)
+  check(st2.success?, "setup: parse-twb-layout succeeded (log:\n#{out2})")
+
+  layout_data = JSON.parse(File.read(layout2))
+  overview = layout_data.find { |dd| dd['dashboard'] == 'Overview' }
+  detail   = layout_data.find { |dd| dd['dashboard'] == 'Detail Page' }
+  check(!overview.nil? && !detail.nil?, 'setup: fixture has both Overview and Detail Page dashboards')
+
+  sales_zone = (overview['zones'] || []).find { |z| z['caption'] == 'Sales by Region' }
+  check(!sales_zone.nil?, 'setup: Overview has the Sales by Region zone to clone')
+
+  if sales_zone
+    # Clone BEFORE renaming the original: this becomes the REAL host zone,
+    # placed on Detail Page (dash_order[1] — processed, and renamed, second).
+    real_zone = JSON.parse(sales_zone.to_json)
+    real_zone['id'] = 'zone-real-9002'
+    detail['zones'] << real_zone
+
+    # The decoy stays on Overview (dash_order[0]) under the id-colliding
+    # double-spaced caption, so it claims "el-sales-by-region" first.
+    sales_zone['caption'] = 'Sales  by  Region'
+  end
+
+  File.write(layout2, JSON.generate(layout_data))
+
+  # get-workbook.json needs a view per exact caption — 'Sales by Region'
+  # (the real host, on Detail Page) resolves via v1; the decoy needs its own.
+  File.write(File.join(d2, 'get-workbook.json'), JSON.dump(
+               'views' => { 'view' => [
+                 { 'id' => 'v1', 'name' => 'Sales by Region' },
+                 { 'id' => 'v2', 'name' => 'Region Detail' },
+                 { 'id' => 'v3', 'name' => 'Metric Buttons' },
+                 { 'id' => 'v4', 'name' => 'Filter Panel Sheet' },
+                 { 'id' => 'v5', 'name' => 'Sales  by  Region' }
+               ] }
+             ))
+  Dir.mkdir(File.join(d2, 'views'))
+  %w[v2 v3 v4].each { |v| File.write(File.join(d2, 'views', "#{v}.csv"), '') }
+  File.write(File.join(d2, 'views', 'v1.csv'), "Region,Profit Ratio\nWest,0.42\n")
+  File.write(File.join(d2, 'views', 'v5.csv'), "Region,Profit Ratio\nEast,0.37\n")
+
+  mmap2 = File.join(d2, 'master-map.json')
+  File.write(mmap2, JSON.dump(
+               '(?i)^Region$' => { 'id' => 'm-region', 'name' => 'Region' }
+             ))
+  File.write(File.join(d2, 'png-read.json'), JSON.dump(
+               'source_png' => 'views/v1.png',
+               'tiles' => [{ 'title' => 'Sales by Region', 'kind' => 'bar-chart', 'orientation' => 'vertical' }],
+               'text_elements' => [], 'filter_shelf' => []
+             ))
+
+  detected2 = File.join(d2, 'detected-actions.json')
+  File.write(detected2, JSON.generate([
+    { 'kind' => 'nav-action', 'caption' => 'GoTo Detail (rename-path)',
+      'source' => { 'dashboard' => 'Detail Page', 'worksheets' => ['Sales by Region'] },
+      'trigger' => 'on select',
+      'targets' => [{ 'name' => 'Overview', 'dashboard' => true }],
+      'actionName' => '[Action99_RENAME]' }
+  ]))
+
+  charts2 = File.join(d2, 'chart-specs.json')
+  blog2, bst2 = Open3.capture2e(RUBY, File.join(DIR, 'build-charts-from-signals.rb'),
+                                '--tableau-dir', d2, '--layout', layout2,
+                                '--master-map', mmap2, '--master-element-id', 'master',
+                                '--page-per-dashboard',
+                                '--detected-actions', detected2,
+                                '--out', charts2)
+  check(bst2.success?, 'the rename-path chart build succeeded' +
+        (bst2.success? ? '' : " (log:\n#{blog2})"))
+
+  if bst2.success?
+    spec2 = JSON.parse(File.read(charts2))
+    manifest2 = JSON.parse(File.read(charts2.sub(/\.json$/, '-actions-emitted.json')))
+    nav2 = manifest2.find { |e| e.dig('source', 'kind') == 'nav-action' }
+    check(!nav2.nil?, 'the rename-path nav-action was emitted (not residue)')
+
+    if nav2
+      # This mirrors put-layout.rb:224's EXACT lookup
+      # (`manifest.find { |m| m['actionId'] == a['id'] }` against the posted
+      # spec) — a nil here IS the silent-skip bug: put-layout.rb's repair
+      # block would `next` with no warning, leaving the provisional page id
+      # live in the published workbook.
+      posted_el = spec2['pages'].flat_map { |p| p['elements'] || [] }
+                    .find { |e| (e['actions'] || []).any? { |a| a['id'] == nav2['actionId'] } }
+      check(!posted_el.nil?,
+            "manifest actionId #{nav2['actionId'].inspect} matches an action actually embedded in the " \
+            'POSTED spec (put-layout.rb\'s exact lookup — nil here is the silent-skip bug)')
+      check(!posted_el.nil? && posted_el['id'] == nav2['hostElementId'],
+            "manifest hostElementId (#{nav2['hostElementId'].inspect}) matches the posted element's " \
+            "actual id (#{posted_el && posted_el['id'].inspect}) after the rename")
+      check(!posted_el.nil? && posted_el['id'] != 'el-sales-by-region',
+            'sanity: the host element id stem WAS actually renamed by the dedup pass ' \
+            "(got #{posted_el && posted_el['id'].inspect}) — otherwise this test exercises nothing")
+    end
+  end
+end
+
+puts
 if $fails.empty?
   puts 'OK'
 else

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# Parameter actions: on-select -> set-control-value {type: "column"}.
+#
+# The blocker was never just "field_caption is the wrong lookup" — the RAW ref
+# is discarded at the detector, so by the time emission sees the entry there is
+# nothing left to resolve a columnId from. This test locks the raw refs in.
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+require 'open3'
+
+DIR     = __dir__
+GUIDE   = File.join(DIR, 'build-postpublish-guide.rb')
+FIXTURE = File.join(DIR, 'test-fixtures', 'postpublish-actions.twb')
+RUBY    = RbConfig.ruby
+
+$fails = []
+def check(cond, msg)
+  $fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+Dir.mktmpdir do |d|
+  detected = File.join(d, 'detected-actions.json')
+  _, st = Open3.capture2e(RUBY, GUIDE, '--twb', FIXTURE, '--detect-only', detected)
+  check(st.success?, 'detection succeeded on the fixture')
+  entries = JSON.parse(File.read(detected))
+  pa = entries.find { |e| e['kind'] == 'parameter-action' }
+  check(!pa.nil?, 'the fixture still contains a parameter-action')
+
+  puts '== The RAW refs survive detection ======================================='
+  check(pa['sourceFieldRef'] == '[federated.f1].[none:Calculation_100:nk]',
+        'sourceFieldRef carries the raw source-field, not the tidied caption ' \
+        "(got #{pa['sourceFieldRef'].inspect})")
+  check(pa['targetParameterRef'] == '[Parameters].[Parameter 1]',
+        'targetParameterRef carries the raw target-parameter ' \
+        "(got #{pa['targetParameterRef'].inspect})")
+
+  puts '== The human captions are UNCHANGED (additive only) ====================='
+  check(pa['fields'] == ['Metric Button'],
+        "the rendered caption is untouched (got #{pa['fields'].inspect})")
+  check(pa['targets'].first['name'] == 'Metric Picker',
+        "the target caption is untouched (got #{pa['targets'].first['name'].inspect})")
+
+  puts '== The stale roadmap claim is gone ======================================'
+  check(!pa['ui_steps'].to_s.include?('on the Sigma UI roadmap'),
+        'ui_steps no longer says chart-click-sets-control is "on the Sigma UI roadmap" — ' \
+        'it is spec-authorable and runtime-proven')
+end
+
+puts
+if $fails.empty?
+  puts 'OK'
+else
+  puts "FAILED (#{$fails.length}):"
+  $fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
@@ -137,8 +137,20 @@ Dir.mktmpdir do |d|
   # DETERMINISTIC by design (Correction 2): the fixture above always resolves
   # the source column AND wires the target control's filters[], so emission is
   # never optional here — a residue fallback would hide a real regression.
+  #
+  # On failure, name the reason from the REAL build log (`blog`, captured
+  # above via Open3.capture2e — stdout+stderr merged), not from `spec`:
+  # build-charts-from-signals.rb never writes a `warnings` key into the
+  # output JSON (warnings only ever go to stderr via `warn`, :8960-8962) — a
+  # `spec['warnings']` read is always nil and always prints an empty array,
+  # which is exactly the silent-drop failure mode this whole feature exists
+  # to avoid. Every one of the six parameter-action rejection paths' messages
+  # starts with "parameter-action '<caption>'" (build-charts-from-signals.rb
+  # :7909, :7915, :7921, :7929, :7946, :7951), so grepping the log for that
+  # substring surfaces the actual named-residue reason.
   check(pas.length == 1, "exactly one parameter-action was emitted (got #{pas.length})" +
-        (pas.empty? ? " — warnings: #{(spec['warnings'] || []).inspect}" : ''))
+        (pas.empty? ? " — build log's parameter-action line(s): " \
+                       "#{blog.lines.grep(/parameter-action/).map(&:strip).inspect}" : ''))
 
   pa_entry = pas.first
   if pa_entry

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
@@ -3,7 +3,13 @@
 #
 # The blocker was never just "field_caption is the wrong lookup" — the RAW ref
 # is discarded at the detector, so by the time emission sees the entry there is
-# nothing left to resolve a columnId from. This test locks the raw refs in.
+# nothing left to resolve a columnId from. This test locks the raw refs in,
+# THEN drives the real build pipeline end to end so emission is not just typed
+# but actually exercised — deterministically, on every run (no either/or
+# branch): a fixture --master-map makes the source field resolve to a real
+# emitted column, and a synthetic filter-calc in layout-meta.json wires the
+# target control's filters[] so it is not dropped as a dead control (see the
+# comment inline below for why that's the honest way to make it deterministic).
 require 'json'
 require 'tmpdir'
 require 'rbconfig'
@@ -46,6 +52,145 @@ Dir.mktmpdir do |d|
   check(!pa['ui_steps'].to_s.include?('on the Sigma UI roadmap'),
         'ui_steps no longer says chart-click-sets-control is "on the Sigma UI roadmap" — ' \
         'it is spec-authorable and runtime-proven')
+
+  puts '== The parameter action is EMITTED ======================================'
+  layout = File.join(d, 'layout.json')
+  # parse-twb-layout.rb takes positional args (<twb> <out.json>), not
+  # --twb/--out flags — matches its own usage banner and the existing correct
+  # call sites in test-action-detection-bridge.rb / test-nav-action-emission.rb.
+  _, pst = Open3.capture2e(RUBY, File.join(DIR, 'parse-twb-layout.rb'), FIXTURE, layout)
+  check(pst.success?, 'parse-twb-layout succeeded')
+
+  meta = layout.sub(/\.json$/, '-meta.json')
+  # DETERMINISM: the target control ("Metric Picker") is a Tableau parameter
+  # with no quick-filter zone and no calc that references it in the fixture —
+  # so its auto-generated control would carry an EMPTY filters[] and be turned
+  # into named residue by the filters[] guard (constraint 2), making emission
+  # conditional on facts of the fixture rather than deterministic. Wire it the
+  # same way a real workbook would: inject a synthetic boolean filter-calc
+  # ("[Metric Button] = [Metric Picker]") into the parsed meta so
+  # param_filter_targets finds it and the auto-emitted control is born with a
+  # real, non-empty filters[] — the SAME mechanism (data-scoping wiring,
+  # build-charts-from-signals.rb ~:7280) a hand-authored .twb would trigger.
+  # This does not touch the shared fixture .twb; only this test's own parsed
+  # copy of it.
+  meta_data = JSON.parse(File.read(meta))
+  meta_data['worksheets']['Metric Buttons']['calculations'] = [
+    { 'caption' => 'Metric Filter Calc', 'formula' => '[Metric Button] = [Metric Picker]' }
+  ]
+  File.write(meta, JSON.generate(meta_data))
+
+  # build-charts-from-signals.rb requires --master-map (abort otherwise) and
+  # the Phase 1d dashboard-read gate artifacts (get-workbook.json / views/*.csv
+  # / png-read.json) — same fixture setup test-action-detection-bridge.rb and
+  # test-nav-action-emission.rb already use for this exact .twb. The
+  # 'Metric Button' entry is what makes ActionColumnResolver.resolve return a
+  # real, non-nil column NAME instead of falling to residue.
+  mmap = File.join(d, 'master-map.json')
+  File.write(mmap, JSON.dump(
+               '(?i)^Region$'        => { 'id' => 'm-region',        'name' => 'Region' },
+               '(?i)^Metric Button$' => { 'id' => 'm-metric-button', 'name' => 'Metric Button' }
+             ))
+  File.write(File.join(d, 'get-workbook.json'), JSON.dump(
+               'views' => { 'view' => [
+                 { 'id' => 'v1', 'name' => 'Sales by Region' },
+                 { 'id' => 'v2', 'name' => 'Region Detail' },
+                 { 'id' => 'v3', 'name' => 'Metric Buttons' },
+                 { 'id' => 'v4', 'name' => 'Filter Panel Sheet' }
+               ] }
+             ))
+  Dir.mkdir(File.join(d, 'views'))
+  %w[v2 v4].each { |v| File.write(File.join(d, 'views', "#{v}.csv"), '') }
+  # 'Sales by Region' and 'Metric Buttons' both need REAL rows, not empty
+  # stubs: neither worksheet's XML carries <rows>/<cols> shelf signals (this is
+  # a minimal detection-only fixture), so synthesize_view_from_signals can't
+  # reconstruct them from an empty CSV — the zone (and the parameter-action's
+  # HOST element) would be dropped before anything exists to hang the action
+  # on. 'Metric Buttons' header 'Metric Button' is the resolved column the
+  # parameter action's clicked mark must bind to.
+  File.write(File.join(d, 'views', 'v1.csv'), "Region,Profit Ratio\nWest,0.42\n")
+  File.write(File.join(d, 'views', 'v3.csv'), "Metric Button,Metric Count\nSales,5\n")
+  File.write(File.join(d, 'png-read.json'), JSON.dump(
+               'source_png' => 'views/v1.png',
+               'tiles' => [
+                 { 'title' => 'Sales by Region',    'kind' => 'bar-chart', 'orientation' => 'vertical' },
+                 { 'title' => 'Region Detail',      'kind' => 'table' },
+                 { 'title' => 'Metric Buttons',     'kind' => 'scatter-chart' },
+                 { 'title' => 'Filter Panel Sheet', 'kind' => 'table' }
+               ],
+               'text_elements' => [], 'filter_shelf' => []
+             ))
+
+  charts = File.join(d, 'chart-specs.json')
+  blog, bst = Open3.capture2e(RUBY, File.join(DIR, 'build-charts-from-signals.rb'),
+                              '--tableau-dir', d, '--layout', layout, '--meta', meta,
+                              '--master-map', mmap, '--master-element-id', 'master',
+                              '--page-per-dashboard', '--auto-controls',
+                              '--detected-actions', detected,
+                              '--out', charts)
+  check(bst.success?, 'the chart build succeeded' + (bst.success? ? '' : " (log:\n#{blog})"))
+
+  emitted = JSON.parse(File.read(charts.sub(/\.json$/, '-actions-emitted.json')))
+  pas = emitted.select { |e| e.dig('source', 'kind') == 'parameter-action' }
+  spec = JSON.parse(File.read(charts))
+
+  # DETERMINISTIC by design (Correction 2): the fixture above always resolves
+  # the source column AND wires the target control's filters[], so emission is
+  # never optional here — a residue fallback would hide a real regression.
+  check(pas.length == 1, "exactly one parameter-action was emitted (got #{pas.length})" +
+        (pas.empty? ? " — warnings: #{(spec['warnings'] || []).inspect}" : ''))
+
+  pa_entry = pas.first
+  if pa_entry
+    eff = pa_entry['effects'].first
+    check(pa_entry['trigger'] == 'on-select', "trigger is on-select (got #{pa_entry['trigger'].inspect})")
+    check(eff['effect'] == 'set-control-value', 'the effect is set-control-value')
+    check(eff.dig('value', 'type') == 'column', 'the value binds to the clicked column')
+    check(eff.dig('value', 'column') == 'Metric Button',
+          "the value binds to the resolved column 'Metric Button' (got #{eff.dig('value', 'column').inspect})")
+    check(!eff['control'].to_s.empty?, 'the effect names a control')
+
+    puts '== TRAP 2: control is a controlId, NOT an element id ===================='
+    all_element_ids = []
+    walk = lambda do |n|
+      case n
+      when Hash
+        all_element_ids << n['id'] if n['id'] && n['kind']
+        n.each_value { |v| walk.call(v) }
+      when Array then n.each { |v| walk.call(v) }
+      end
+    end
+    walk.call(spec)
+    check(!all_element_ids.include?(eff['control']),
+          "effects[0].control #{eff['control'].inspect} is NOT an element id — " \
+          '/verify accepts the wrong form; the live create rejects it')
+
+    puts '== TRAP 3: the target control MUST carry filters[] ======================'
+    controls = []
+    cwalk = lambda do |n|
+      case n
+      when Hash
+        controls << n if n['controlId']
+        n.each_value { |v| cwalk.call(v) }
+      when Array then n.each { |v| cwalk.call(v) }
+      end
+    end
+    cwalk.call(spec)
+    target_ctl = controls.find { |c| c['controlId'] == eff['control'] }
+    check(!target_ctl.nil?,
+          "the referenced controlId #{eff['control'].inspect} exists in the spec")
+    check(target_ctl && !Array(target_ctl['filters']).empty?,
+          'the target control carries a non-empty filters[] — without it the effect ' \
+          'is a SILENT no-op (there is no direct chart->chart filter in Sigma)')
+  end
+
+  puts '== Conservation: nothing vanished ======================================='
+  detected_count = entries.length
+  emitted_keys = emitted.map { |e| [e.dig('source', 'kind'), e.dig('source', 'actionName')] }
+  check(emitted_keys.uniq.length == emitted_keys.length,
+        'no two emitted entries share an identity key')
+  check(emitted.length <= detected_count,
+        "emitted (#{emitted.length}) never exceeds detected (#{detected_count})")
 end
 
 puts

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
@@ -291,9 +291,9 @@ Dir.mktmpdir do |d3|
   # worksheet 'Sales by Region' emits only Region / Profit Ratio / Region Not
   # Null. Exactly the case proven to ship a wrong binding before the guard.
   mmap3 = stage_fixture(d3,
-                        '(?i)^Region$'        => { 'id' => 'm-region',        'name' => 'Region' },
-                        '(?i)^Order ID$'      => { 'id' => 'm-orderid',       'name' => 'Order ID' },
-                        '(?i)^Metric Button$' => { 'id' => 'm-metric-button', 'name' => 'Metric Button' })
+                        { '(?i)^Region$'        => { 'id' => 'm-region',        'name' => 'Region' },
+                          '(?i)^Order ID$'      => { 'id' => 'm-orderid',       'name' => 'Order ID' },
+                          '(?i)^Metric Button$' => { 'id' => 'm-metric-button', 'name' => 'Metric Button' } })
 
   detected3 = File.join(d3, 'detected-actions.json')
   File.write(detected3, JSON.generate([

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
@@ -158,9 +158,28 @@ Dir.mktmpdir do |d|
     check(pa_entry['trigger'] == 'on-select', "trigger is on-select (got #{pa_entry['trigger'].inspect})")
     check(eff['effect'] == 'set-control-value', 'the effect is set-control-value')
     check(eff.dig('value', 'type') == 'column', 'the value binds to the clicked column')
-    check(eff.dig('value', 'column') == 'Metric Button',
-          "the value binds to the resolved column 'Metric Button' (got #{eff.dig('value', 'column').inspect})")
+    # The design's VERIFIED SIGMA SHAPES section pins
+    # `value: {type: "column", column: <columnId>}` — a columnId, NOT a bare
+    # column name. The id is the HOST element's own column id, which is what
+    # makes the binding real: a name that no column of the clicked element
+    # carries would set the control to nothing (or to the wrong thing).
+    check(eff.dig('value', 'column') == 'x-el-metric-buttons',
+          "the value binds to the HOST element's columnId, not a bare name " \
+          "(got #{eff.dig('value', 'column').inspect})")
     check(!eff['control'].to_s.empty?, 'the effect names a control')
+
+    puts '== HOST-COLUMN BINDING: value.column is a column OF THE HOST ============'
+    host_el_spec = spec['pages'].flat_map { |p| p['elements'] || [] }
+                     .find { |e| e['id'] == pa_entry['hostElementId'] }
+    check(!host_el_spec.nil?,
+          "the manifest's hostElementId #{pa_entry['hostElementId'].inspect} names a real posted element")
+    host_col = host_el_spec && Array(host_el_spec['columns']).find { |c| c['id'] == eff.dig('value', 'column') }
+    check(!host_col.nil?,
+          "value.column #{eff.dig('value', 'column').inspect} is an id carried by the HOST element " \
+          "(host columns: #{host_el_spec ? Array(host_el_spec['columns']).map { |c| c['id'] }.inspect : 'n/a'})")
+    check(host_col && host_col['name'] == 'Metric Button',
+          "that host column is the one the Tableau source-field resolved to, 'Metric Button' " \
+          "(got #{host_col && host_col['name'].inspect})")
 
     puts '== TRAP 2: control is a controlId, NOT an element id ===================='
     all_element_ids = []
@@ -203,6 +222,249 @@ Dir.mktmpdir do |d|
         'no two emitted entries share an identity key')
   check(emitted.length <= detected_count,
         "emitted (#{emitted.length}) never exceeds detected (#{detected_count})")
+end
+
+# ---------------------------------------------------------------------------
+# Stage the Phase-1d gate artifacts every build in this file needs. Factored
+# out because the two regression blocks below need the SAME four-view fixture
+# the main block builds by hand, and a third verbatim copy of it would be the
+# thing that drifts.
+# ---------------------------------------------------------------------------
+def stage_fixture(d, mmap_entries, tiles: nil)
+  File.write(File.join(d, 'get-workbook.json'), JSON.dump(
+               'views' => { 'view' => [
+                 { 'id' => 'v1', 'name' => 'Sales by Region' },
+                 { 'id' => 'v2', 'name' => 'Region Detail' },
+                 { 'id' => 'v3', 'name' => 'Metric Buttons' },
+                 { 'id' => 'v4', 'name' => 'Filter Panel Sheet' },
+                 { 'id' => 'v5', 'name' => 'Metric  Buttons' }
+               ] }
+             ))
+  Dir.mkdir(File.join(d, 'views'))
+  %w[v2 v4].each { |v| File.write(File.join(d, 'views', "#{v}.csv"), '') }
+  File.write(File.join(d, 'views', 'v1.csv'), "Region,Profit Ratio\nWest,0.42\n")
+  File.write(File.join(d, 'views', 'v3.csv'), "Metric Button,Metric Count\nSales,5\n")
+  File.write(File.join(d, 'views', 'v5.csv'), "Metric Button,Metric Count\nProfit,7\n")
+  File.write(File.join(d, 'png-read.json'), JSON.dump(
+               'source_png' => 'views/v1.png',
+               'tiles' => tiles || [
+                 { 'title' => 'Sales by Region',    'kind' => 'bar-chart', 'orientation' => 'vertical' },
+                 { 'title' => 'Region Detail',      'kind' => 'table' },
+                 { 'title' => 'Metric Buttons',     'kind' => 'scatter-chart' },
+                 { 'title' => 'Filter Panel Sheet', 'kind' => 'table' }
+               ],
+               'text_elements' => [], 'filter_shelf' => []
+             ))
+  mmap = File.join(d, 'master-map.json')
+  File.write(mmap, JSON.dump(mmap_entries))
+  mmap
+end
+
+# The synthetic boolean filter-calc that gives the "Metric Picker" parameter
+# control a real, non-empty filters[] — see the main block's comment for why
+# this is the honest way to make emission deterministic instead of
+# fixture-dependent.
+def wire_metric_picker_filters!(meta_path)
+  meta_data = JSON.parse(File.read(meta_path))
+  meta_data['worksheets']['Metric Buttons']['calculations'] = [
+    { 'caption' => 'Metric Filter Calc', 'formula' => '[Metric Button] = [Metric Picker]' }
+  ]
+  File.write(meta_path, JSON.generate(meta_data))
+end
+
+puts
+puts '== HOST-COLUMN BINDING: a field the HOST does not carry is NAMED RESIDUE =='
+puts '   (build-charts-from-signals.rb parameter-action block — the third'
+puts '   documented hard constraint. `mmap` is workbook-GLOBAL; {type:"column"}'
+puts '   is per-element, so a globally-resolvable field that is not on the'
+puts '   clicked chart binds to nothing and sets the control to the wrong'
+puts '   value through a schema-valid action every gate passes.)'
+Dir.mktmpdir do |d3|
+  layout3 = File.join(d3, 'layout.json')
+  plog3, pst3 = Open3.capture2e(RUBY, File.join(DIR, 'parse-twb-layout.rb'), FIXTURE, layout3)
+  check(pst3.success?, "setup: parse-twb-layout succeeded (log:\n#{plog3})")
+  meta3 = layout3.sub(/\.json$/, '-meta.json')
+  wire_metric_picker_filters!(meta3)
+
+  # [Order ID] IS in the master map (so ActionColumnResolver.resolve returns a
+  # real, non-nil column NAME — this is NOT the resolver-nil path) but the host
+  # worksheet 'Sales by Region' emits only Region / Profit Ratio / Region Not
+  # Null. Exactly the case proven to ship a wrong binding before the guard.
+  mmap3 = stage_fixture(d3,
+                        '(?i)^Region$'        => { 'id' => 'm-region',        'name' => 'Region' },
+                        '(?i)^Order ID$'      => { 'id' => 'm-orderid',       'name' => 'Order ID' },
+                        '(?i)^Metric Button$' => { 'id' => 'm-metric-button', 'name' => 'Metric Button' })
+
+  detected3 = File.join(d3, 'detected-actions.json')
+  File.write(detected3, JSON.generate([
+    { 'kind' => 'parameter-action', 'caption' => 'Pick By Order',
+      'source' => { 'dashboard' => 'Overview', 'worksheets' => ['Sales by Region'] },
+      'trigger' => 'on select',
+      'targets' => [{ 'name' => 'Metric Picker' }],
+      'sourceFieldRef' => '[federated.f1].[Order ID]',
+      'targetParameterRef' => '[Parameters].[Parameter 1]',
+      'actionName' => '[Action90_OFFHOST]' }
+  ]))
+
+  charts3 = File.join(d3, 'chart-specs.json')
+  blog3, bst3 = Open3.capture2e(RUBY, File.join(DIR, 'build-charts-from-signals.rb'),
+                                '--tableau-dir', d3, '--layout', layout3, '--meta', meta3,
+                                '--master-map', mmap3, '--master-element-id', 'master',
+                                '--page-per-dashboard', '--auto-controls',
+                                '--detected-actions', detected3,
+                                '--out', charts3)
+  check(bst3.success?, 'the off-host chart build succeeded' + (bst3.success? ? '' : " (log:\n#{blog3})"))
+
+  if bst3.success?
+    manifest3 = JSON.parse(File.read(charts3.sub(/\.json$/, '-actions-emitted.json')))
+    check(manifest3.none? { |e| e.dig('source', 'kind') == 'parameter-action' },
+          'the off-host parameter-action was NOT emitted — a guessed column ships a schema-valid ' \
+          "action that silently sets the control wrong (manifest: #{manifest3.map { |e| e.dig('source', 'caption') }.inspect})")
+
+    residue_line = blog3.lines.grep(/parameter-action 'Pick By Order'/).map(&:strip)
+    check(residue_line.any?, 'the rejection is NAMED in the build log, never silent ' \
+                             "(parameter-action lines: #{blog3.lines.grep(/parameter-action/).map(&:strip).inspect})")
+    joined3 = residue_line.join(' ')
+    check(joined3.include?('(named residue)'),
+          "the reason uses the house '(named residue)' phrasing (got #{joined3.inspect})")
+    check(joined3.include?('NOT a column of its host element'),
+          'the reason names the real cause — the resolved column is not on the host element ' \
+          "(got #{joined3.inspect})")
+    check(joined3.include?('el-sales-by-region'),
+          "the reason names the host element whose columns were checked (got #{joined3.inspect})")
+
+    # No action of ANY kind may have reached the spec for this rejected entry.
+    spec3 = JSON.parse(File.read(charts3))
+    set_ctl = spec3['pages'].flat_map { |p| p['elements'] || [] }
+                .flat_map { |e| Array(e['actions']) }
+                .flat_map { |a| Array(a['effects']) }
+                .select { |ef| ef['effect'] == 'set-control-value' }
+    check(set_ctl.empty?,
+          "no set-control-value effect reached the spec either (got #{set_ctl.inspect})")
+  end
+end
+
+puts
+puts '== Cross-kind: two action KINDS on ONE host both survive the rename pass =='
+puts '   (emitted_action_index was last-writer-wins across kinds — :6923 nav and'
+puts '   :7987 param wrote the SAME [dashboard, host] key, so the second emitter'
+puts '   EVICTED the first. The els.map! rename then synced only the survivor and'
+puts '   the evicted entry shipped a stale actionId; put-layout.rb:224 looks the'
+puts '   manifest up BY actionId, misses, and silently skips the whole'
+puts '   navigate.target.page repair — no warning, provisional page id left live.'
+puts '   Counts still match, so no gate catches it.)'
+Dir.mktmpdir do |d4|
+  layout4 = File.join(d4, 'layout.json')
+  plog4, pst4 = Open3.capture2e(RUBY, File.join(DIR, 'parse-twb-layout.rb'), FIXTURE, layout4)
+  check(pst4.success?, "setup: parse-twb-layout succeeded (log:\n#{plog4})")
+  meta4 = layout4.sub(/\.json$/, '-meta.json')
+  wire_metric_picker_filters!(meta4)
+
+  # Force the host through the --page-per-dashboard dedup RENAME, the same way
+  # test-nav-action-emission.rb's regression block does: element ids are
+  # "el-#{caption.downcase.gsub(/\W+/, '-')[0..40]}", so the double-spaced
+  # decoy "Metric  Buttons" slugs to the IDENTICAL "el-metric-buttons" while
+  # staying a DIFFERENT string for the exact `_worksheet` match emission uses.
+  # Decoy on Overview (dash_order[0] — claims the stem, stays unrenamed); the
+  # real 'Metric Buttons' zone moves to Detail Page (dash_order[1] — the dedup
+  # pass finds the stem claimed and renames it).
+  layout_data = JSON.parse(File.read(layout4))
+  overview = layout_data.find { |dd| dd['dashboard'] == 'Overview' }
+  detail   = layout_data.find { |dd| dd['dashboard'] == 'Detail Page' }
+  check(!overview.nil? && !detail.nil?, 'setup: fixture has both Overview and Detail Page dashboards')
+  mb_zone = overview && (overview['zones'] || []).find { |z| z['caption'] == 'Metric Buttons' }
+  check(!mb_zone.nil?, 'setup: Overview has the Metric Buttons zone to move')
+  if mb_zone
+    real_zone = JSON.parse(mb_zone.to_json)
+    real_zone['id'] = 'zone-real-9101'
+    detail['zones'] << real_zone
+    mb_zone['caption'] = 'Metric  Buttons'
+    mb_zone['name'] = 'Metric  Buttons' if mb_zone.key?('name')
+  end
+  File.write(layout4, JSON.generate(layout_data))
+
+  mmap4 = stage_fixture(d4,
+                        { '(?i)^Region$'        => { 'id' => 'm-region',        'name' => 'Region' },
+                          '(?i)^Metric Button$' => { 'id' => 'm-metric-button', 'name' => 'Metric Button' } },
+                        tiles: [
+                          { 'title' => 'Sales by Region',    'kind' => 'bar-chart', 'orientation' => 'vertical' },
+                          { 'title' => 'Region Detail',      'kind' => 'table' },
+                          { 'title' => 'Metric Buttons',     'kind' => 'scatter-chart' },
+                          { 'title' => 'Metric  Buttons',    'kind' => 'scatter-chart' },
+                          { 'title' => 'Filter Panel Sheet', 'kind' => 'table' }
+                        ])
+
+  # BOTH kinds sourced from the SAME worksheet — the collision the scalar
+  # index could not survive. nav-action is emitted first (block at ~:6871),
+  # parameter-action second (~:7903), so the param entry is the one that used
+  # to evict the nav entry.
+  detected4 = File.join(d4, 'detected-actions.json')
+  File.write(detected4, JSON.generate([
+    { 'kind' => 'nav-action', 'caption' => 'GoTo Overview (cross-kind)',
+      'source' => { 'dashboard' => 'Detail Page', 'worksheets' => ['Metric Buttons'] },
+      'trigger' => 'on select',
+      'targets' => [{ 'name' => 'Overview', 'dashboard' => true }],
+      'actionName' => '[Action91_NAV]' },
+    { 'kind' => 'parameter-action', 'caption' => 'Pick Metric (cross-kind)',
+      'source' => { 'dashboard' => 'Detail Page', 'worksheets' => ['Metric Buttons'] },
+      'trigger' => 'on select',
+      'targets' => [{ 'name' => 'Metric Picker' }],
+      'sourceFieldRef' => '[federated.f1].[none:Calculation_100:nk]',
+      'targetParameterRef' => '[Parameters].[Parameter 1]',
+      'actionName' => '[Action92_PARAM]' }
+  ]))
+
+  charts4 = File.join(d4, 'chart-specs.json')
+  blog4, bst4 = Open3.capture2e(RUBY, File.join(DIR, 'build-charts-from-signals.rb'),
+                                '--tableau-dir', d4, '--layout', layout4, '--meta', meta4,
+                                '--master-map', mmap4, '--master-element-id', 'master',
+                                '--page-per-dashboard', '--auto-controls',
+                                '--detected-actions', detected4,
+                                '--out', charts4)
+  check(bst4.success?, 'the cross-kind chart build succeeded' + (bst4.success? ? '' : " (log:\n#{blog4})"))
+
+  if bst4.success?
+    spec4     = JSON.parse(File.read(charts4))
+    manifest4 = JSON.parse(File.read(charts4.sub(/\.json$/, '-actions-emitted.json')))
+    posted_els = spec4['pages'].flat_map { |p| p['elements'] || [] }
+
+    nav4 = manifest4.find { |e| e.dig('source', 'actionName') == '[Action91_NAV]' }
+    par4 = manifest4.find { |e| e.dig('source', 'actionName') == '[Action92_PARAM]' }
+    check(!nav4.nil?, 'the nav-action entry SURVIVED in the manifest (it used to be evicted)')
+    check(!par4.nil?, 'the parameter-action entry is in the manifest')
+
+    # Sanity: the rename actually happened, otherwise this block proves nothing.
+    check(posted_els.any? { |e| e['id'] == 'el-metric-buttons-detail-page' },
+          'sanity: the host element id stem WAS renamed by the dedup pass ' \
+          "(posted chart ids: #{posted_els.select { |e| e['id'].to_s.start_with?('el-metric-buttons') }.map { |e| e['id'] }.inspect})")
+
+    [['nav-action', nav4], ['parameter-action', par4]].each do |kind, entry|
+      next if entry.nil?
+      # put-layout.rb:224's EXACT lookup. A nil here IS the silent-skip bug.
+      posted_el = posted_els.find { |e| (e['actions'] || []).any? { |a| a['id'] == entry['actionId'] } }
+      check(!posted_el.nil?,
+            "#{kind}: manifest actionId #{entry['actionId'].inspect} matches an action actually " \
+            'embedded in the POSTED spec (put-layout.rb\'s exact lookup — nil here is the silent skip)')
+      check(!posted_el.nil? && posted_el['id'] == entry['hostElementId'],
+            "#{kind}: manifest hostElementId (#{entry['hostElementId'].inspect}) matches the posted " \
+            "element's actual id (#{posted_el && posted_el['id'].inspect}) after the rename")
+    end
+
+    # Both actions live on the SAME host element — that is the whole point.
+    check(nav4 && par4 && nav4['hostElementId'] == par4['hostElementId'],
+          'both kinds report the same host element ' \
+          "(#{nav4 && nav4['hostElementId'].inspect} vs #{par4 && par4['hostElementId'].inspect})")
+
+    # The set-control-value's column id embeds the host stem, so the manifest
+    # copy must track the rename too or the readback probe diffs a pre-rename
+    # id against the posted one.
+    if par4
+      posted_par = posted_els.flat_map { |e| Array(e['actions']) }.find { |a| a['id'] == par4['actionId'] }
+      check(posted_par && posted_par['effects'] == par4['effects'],
+            "parameter-action: the manifest's effects match the POSTED effects byte-for-byte " \
+            "(manifest #{par4['effects'].inspect} vs posted #{posted_par && posted_par['effects'].inspect})")
+    end
+  end
 end
 
 puts


### PR DESCRIPTION
> **DRAFT — BLOCKED ON LIVE VERIFICATION. Do not merge yet.**
> Both emitters are on by default and neither has been exercised against a live Sigma org. See "What must happen before merge" below.

Emitter half of the Tableau-actions wrap-up (`beads-sigma-bfxd` steps 1 and 2). Builds on #662, which landed the hardening and the E2E harness. tableau-to-sigma 1.9.0 → 1.11.0.

## What this adds

**nav-action mark clicks** — `on-select → navigate` on the source element. Previously only dashboard-object *buttons* got a navigate action; a Tableau `<nav-action>` fires from a mark click and was left as manual residue. Gated on `on select` activation, a single-worksheet source, and a dashboard target. on-hover, tooltip-menu, worksheet targets, and multi-sheet sources all stay residue **with the reason named**.

**Parameter actions** — `on-select → set-control-value`, bound to the host element's column **id**. Three constraints, each confirmed by breaking it: `control` takes a `controlId` (not the element id); a control with empty `filters[]` makes the effect a silent no-op; and the clicked column must exist on the host element or it becomes residue, never a guess.

**`ActionColumnResolver`** — resolves a raw Tableau field ref to an emitted Sigma column, returning `nil` rather than guessing. A guessed column ships a schema-valid action that silently sets a control to the wrong value, which is worse than residue.

Also preserves the raw `sourceFieldRef` / `targetParameterRef` at the detector — previously discarded, which is why parameter actions had been unbuildable.

## What must happen before merge

The design's method rule requires every emitter PR to land with a real create + GET readback diff + runtime click, and states that `/verify` output is not evidence — three shapes on this workstream passed `/verify` and were then dropped or rejected. That run has **not** happened. Three open questions:

1. **Is `value.column` a columnId or a column name?** Currently emits a host column id, on the strength of a prior probe record. If that's wrong, every emitted parameter action is wrong — and the offline suite still passes, because it asserts the shape we chose.
2. **Does create validate `navigate.target.page` against pages in the posted spec?** Emitters emit a provisional `page-<slug>`; the orchestrated pipeline assigns `page-dash-<N>`; `put-layout.rb` repairs by name only *after* create. If create validates, a qualifying nav-action hard-fails at publish. This is new by default — at merge-base the only emitter sat behind an off-by-default flag.
3. **Does the readback assign effect ids?** The probe is id-agnostic either way.

Run `scripts/probe-actions-readback.rb` and `scripts/probe-actions-runtime.mjs` (both landed in #662) against a live org to settle all three.

## Review history

Two blockers were found by the final whole-branch review and fixed in one wave:

- `emitted_action_index` was last-writer-wins across action kinds. One worksheet carrying both a nav-action and a parameter action lost the first entry, and `put-layout.rb` then silently skipped its `navigate.target.page` repair. It had been parked as "no runtime failure constructible"; the reviewer constructed one.
- The parameter emitter shipped a column that need not exist on the host element, contradicting its own documented guard — proven with a source-field of `[Order ID]` on a host carrying Region / Profit Ratio / Region Not Null, emitted schema-valid with no warning and every gate green.

Ledger conservation verified with all three emitters firing: `detectedCount 12 == 3 emitted + 9 residue`, disjoint.

Filter actions (step 3) are **not** here. The old "un-pick the `is_action` rejection at 5 sites" plan is wrong — three of those sites must keep rejecting, or an action filter becomes a static element filter that hard-filters the chart to the action's default. Corrected analysis is in the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)