### PR TITLE
Migrate Cognos converter to released workbook code

### DIFF
--- a/corpus/cognos/sales-overview-charts-report/MANIFEST.md
+++ b/corpus/cognos/sales-overview-charts-report/MANIFEST.md
@@ -20,8 +20,11 @@ Note the workbook references `<DM_ID>` — remap with the skill's
 
 ## Features exercised
 
-- report XML → workbook: 8 KPI charts, 2 bar, 1 line, 1 pie, 1 combo,
-  1 tiledmap → region-map, 3 tables (17 elements on 1 page)
+- report XML → current workbook code: outer `document` wrapper, flat
+  `document.elements`, metadata-only pages, and required authoritative layout
+  using the live `<Element>` / `<Container>` vocabulary
+- 8 KPI charts, 2 bar, 1 line, 1 pie, 1 combo, 1 tiledmap → region-map,
+  3 tables, plus auto navigation on both source pages (19 elements on 2 pages)
 - col-formula prefix `[TABLE_TAIL/Col]`, chart slot → axis mapping
 - non-simple ?param? filters flagged (42 warnings: re-create as Sigma
   element/page filters)
@@ -33,15 +36,18 @@ Note the workbook references `<DM_ID>` — remap with the skill's
   "artifacts": [
     {"path": "../../../plugins/cognos-to-sigma/skills/cognos-to-sigma/fixtures/sales-overview-charts.report.xml", "format": "xml"},
     {"path": "../../../plugins/cognos-to-sigma/skills/cognos-to-sigma/fixtures/go-sales-performance.report.xml", "format": "xml"},
-    {"path": "../../../plugins/cognos-to-sigma/skills/cognos-to-sigma/fixtures/banking-risk-crosstab.report.xml", "format": "xml"}
+    {"path": "../../../plugins/cognos-to-sigma/skills/cognos-to-sigma/fixtures/banking-risk-crosstab.report.xml", "format": "xml"},
+    {"path": "checks.sh", "format": "shell"}
   ],
   "goldens": {
     "workbook.json": {
-      "pages": 1,
-      "elements": 17,
-      "columns": 28,
       "warnings": 42
     }
   }
 }
 ```
+
+`checks.sh` validates the current wrapped/flat workbook contract and the
+2-page / 19-element / 28-column expectations. The generic corpus summarizer
+still understands only legacy `pages[].elements`, so those shape-aware counts
+live in the Cognos case check instead of being weakened to a legacy golden.

--- a/corpus/cognos/sales-overview-charts-report/checks.sh
+++ b/corpus/cognos/sales-overview-charts-report/checks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+result = json.loads(Path("golden/workbook.json").read_text())
+workbook = result["workbook"]
+assert set(workbook) == {"name", "document"}, "workbook must use outer metadata + document wrapper"
+doc = workbook["document"]
+pages = doc["pages"]
+elements = doc["elements"]
+layout = doc["layout"]
+
+assert len(pages) == 2, f"expected 2 metadata pages, got {len(pages)}"
+assert all("elements" not in page for page in pages), "pages must be metadata-only"
+assert len(elements) == 19, f"expected 19 flat elements, got {len(elements)}"
+assert sum(len(element.get("columns", [])) for element in elements) == 28, "expected 28 columns"
+assert all(f'<Page' in layout and f'id="{page["id"]}"' in layout for page in pages), "layout must contain every page"
+assert "<LayoutElement" not in layout and "<GridContainer" not in layout, "layout must not emit compatibility aliases"
+assert "<Element " in layout, "layout must use the live Element tag"
+for element in elements:
+    needle = f'elementId="{element["id"]}"'
+    assert layout.count(needle) == 1, f'{element["id"]} must appear exactly once in layout'
+assert any(element.get("kind") == "navigation" for element in elements), "multi-page report needs navigation"
+assert result["stats"]["pages"] == 2
+print("  ok   current workbook wrapper/flat-elements/layout contract")
+PY

--- a/corpus/cognos/sales-overview-charts-report/golden/workbook.json
+++ b/corpus/cognos/sales-overview-charts-report/golden/workbook.json
@@ -1,566 +1,610 @@
 {
   "workbook": {
     "name": "GO modern sample report (Light)",
-    "schemaVersion": 1,
-    "pages": [
-      {
-        "id": "id0001",
-        "name": "Retailer Page",
-        "elements": [
-          {
-            "id": "id0002",
-            "kind": "kpi-chart",
-            "name": "Revenue",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0005",
-                "name": "Revenue",
-                "formula": "Sum([Sales/revenue])",
-                "format": {
-                  "kind": "number",
-                  "formatString": "$,.3s"
-                }
-              }
-            ],
-            "order": [
-              "id0005"
-            ],
-            "value": {
-              "columnId": "id0005"
-            }
-          },
-          {
-            "id": "id0006",
-            "kind": "kpi-chart",
-            "name": "Product cost",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0007",
-                "name": "Product Cost",
-                "formula": "Sum([Sales/product Cost])",
-                "format": {
-                  "kind": "number",
-                  "formatString": "$,.3s"
-                }
-              }
-            ],
-            "order": [
-              "id0007"
-            ],
-            "value": {
-              "columnId": "id0007"
-            }
-          },
-          {
-            "id": "id0008",
-            "kind": "kpi-chart",
-            "name": "Gross profit",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0009",
-                "name": "Gross Profit",
-                "formula": "Sum([Sales/gross Profit])",
-                "format": {
-                  "kind": "number",
-                  "formatString": "$,.3s"
-                }
-              }
-            ],
-            "order": [
-              "id0009"
-            ],
-            "value": {
-              "columnId": "id0009"
-            }
-          },
-          {
-            "id": "id0010",
-            "kind": "kpi-chart",
-            "name": "Gross margin",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0011",
-                "name": "Gross Margin",
-                "formula": "Sum([Sales/gross Margin])",
-                "format": {
-                  "kind": "number",
-                  "formatString": ",.0%"
-                }
-              }
-            ],
-            "order": [
-              "id0011"
-            ],
-            "value": {
-              "columnId": "id0011"
-            }
-          },
-          {
-            "id": "id0012",
-            "kind": "kpi-chart",
-            "name": "Revenue",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0013",
-                "name": "Revenue",
-                "formula": "Sum([Sales/revenue])",
-                "format": {
-                  "kind": "number",
-                  "formatString": "$,.3s"
-                }
-              }
-            ],
-            "order": [
-              "id0013"
-            ],
-            "value": {
-              "columnId": "id0013"
-            }
-          },
-          {
-            "id": "id0014",
-            "kind": "kpi-chart",
-            "name": "Revenue vs Target",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0015",
-                "name": "Revenue",
-                "formula": "Sum([Sales/revenue])"
-              },
-              {
-                "id": "id0016",
-                "name": "Revenue Vs Target",
-                "formula": "Sum([Sales/revenue]) - Sum([Sales Targets/sales Target])",
-                "format": {
-                  "kind": "number",
-                  "formatString": "$,.4s"
-                }
-              }
-            ],
-            "order": [
-              "id0015",
-              "id0016"
-            ],
-            "value": {
-              "columnId": "id0016"
-            }
-          },
-          {
-            "id": "id0017",
-            "kind": "kpi-chart",
-            "name": "Quantity",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0018",
-                "name": "Quantity",
-                "formula": "Sum([Sales/quantity])"
-              }
-            ],
-            "order": [
-              "id0018"
-            ],
-            "value": {
-              "columnId": "id0018"
-            }
-          },
-          {
-            "id": "id0019",
-            "kind": "kpi-chart",
-            "name": "Return quantity",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0020",
-                "name": "Return Quantity",
-                "formula": "Sum([Returned Items/return Quantity])"
-              }
-            ],
-            "order": [
-              "id0020"
-            ],
-            "value": {
-              "columnId": "id0020"
-            }
-          },
-          {
-            "id": "id0021",
-            "kind": "table",
-            "name": "Retailers Sales — Top 10 Country for Sales",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0022"
-            },
-            "columns": [
-              {
-                "id": "id0023",
-                "name": "Retailer Country",
-                "formula": "[Retailers Sales/retailer Country]"
-              },
-              {
-                "id": "id0024",
-                "name": "Revenue",
-                "formula": "Sum([Sales/revenue])"
-              }
-            ],
-            "order": [
-              "id0023",
-              "id0024"
-            ],
-            "groupings": [
-              {
-                "id": "id0025",
-                "groupBy": [
-                  "id0023"
-                ],
-                "calculations": [
-                  "id0024"
-                ]
-              }
-            ]
-          },
-          {
-            "id": "id0026",
-            "kind": "table",
-            "name": "Products Sales — Top 10 Product Table",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0027"
-            },
-            "columns": [
-              {
-                "id": "id0028",
-                "name": "Product",
-                "formula": "[Products Sales/product]"
-              },
-              {
-                "id": "id0029",
-                "name": "Revenue",
-                "formula": "Sum([Sales/revenue])"
-              }
-            ],
-            "order": [
-              "id0028",
-              "id0029"
-            ],
-            "groupings": [
-              {
-                "id": "id0030",
-                "groupBy": [
-                  "id0028"
-                ],
-                "calculations": [
-                  "id0029"
-                ]
-              }
-            ]
-          },
-          {
-            "id": "id0031",
-            "kind": "region-map",
-            "name": "Map1",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0032",
-                "name": "Retailer Country",
-                "formula": "[Retailers Sales/retailer Country]"
-              },
-              {
-                "id": "id0033",
-                "name": "Revenue",
-                "formula": "Sum([Sales/revenue])",
-                "format": {
-                  "kind": "number",
-                  "formatString": "$,.2s"
-                }
-              }
-            ],
-            "order": [
-              "id0032",
-              "id0033"
-            ],
-            "region": {
-              "id": "id0032",
-              "regionType": "country"
-            },
-            "color": {
-              "by": "scale",
-              "column": "id0033"
-            }
-          },
-          {
-            "id": "id0034",
-            "kind": "combo-chart",
-            "name": "Clustered combination2",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0035",
-                "name": "Month",
-                "formula": "[Time Sales/month]"
-              }
-            ],
-            "order": [
-              "id0035"
-            ],
-            "xAxis": {
-              "columnId": "id0035"
-            }
-          },
-          {
-            "id": "id0036",
-            "kind": "bar-chart",
-            "name": "Clustered combination3",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0037",
-                "name": "Month",
-                "formula": "[Time Sales/month]"
-              },
-              {
-                "id": "id0038",
-                "name": "Revenue",
-                "formula": "Sum([Sales/revenue])",
-                "format": {
-                  "kind": "number",
-                  "formatString": "$,.2s"
-                }
-              },
-              {
-                "id": "id0039",
-                "name": "Order Method Type",
-                "formula": "[Order Methods Sales/order Method Type]"
-              }
-            ],
-            "order": [
-              "id0037",
-              "id0038",
-              "id0039"
-            ],
-            "xAxis": {
-              "columnId": "id0037"
-            },
-            "yAxis": {
-              "columnIds": [
-                "id0038"
-              ]
-            },
-            "color": {
-              "by": "category",
-              "column": "id0039"
-            },
-            "stacking": "stacked"
-          },
-          {
-            "id": "id0040",
-            "kind": "pie-chart",
-            "name": "Pie1",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0041",
-                "name": "Product Line",
-                "formula": "[Products Sales/product Line]"
-              },
-              {
-                "id": "id0042",
-                "name": "Revenue",
-                "formula": "Sum([Sales/revenue])"
-              }
-            ],
-            "order": [
-              "id0041",
-              "id0042"
-            ],
-            "color": {
-              "id": "id0041"
-            },
-            "value": {
-              "id": "id0042"
-            }
-          },
-          {
-            "id": "id0043",
-            "kind": "bar-chart",
-            "name": "Clustered column",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0044",
-                "name": "Date",
-                "formula": "[Time Returns/date]"
-              },
-              {
-                "id": "id0045",
-                "name": "Quantity",
-                "formula": "Sum([Sales/quantity])"
-              }
-            ],
-            "order": [
-              "id0044",
-              "id0045"
-            ],
-            "xAxis": {
-              "columnId": "id0044",
-              "sort": {
-                "by": "id0044",
-                "direction": "ascending"
-              }
-            },
-            "yAxis": {
-              "columnIds": [
-                "id0045"
-              ]
-            },
-            "stacking": "none"
-          },
-          {
-            "id": "id0046",
-            "kind": "line-chart",
-            "name": "Line",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0047",
-                "name": "Quarter",
-                "formula": "[Time Returns/quarter]"
-              },
-              {
-                "id": "id0048",
-                "name": "Return Quantity",
-                "formula": "Sum([Returned Items/return Quantity])"
-              },
-              {
-                "id": "id0049",
-                "name": "Order Method Type",
-                "formula": "[Order Methods Returns/order Method Type]"
-              }
-            ],
-            "order": [
-              "id0047",
-              "id0048",
-              "id0049"
-            ],
-            "xAxis": {
-              "columnId": "id0047"
-            },
-            "yAxis": {
-              "columnIds": [
-                "id0048"
-              ]
-            },
-            "color": {
-              "by": "category",
-              "column": "id0049"
-            }
-          },
-          {
-            "id": "id0050",
-            "kind": "table",
-            "name": "Tree map (was treemap)",
-            "source": {
-              "kind": "data-model",
-              "dataModelId": "id0003",
-              "elementId": "id0004"
-            },
-            "columns": [
-              {
-                "id": "id0051",
-                "name": "Product Type",
-                "formula": "[Products Returns/product Type]"
-              },
-              {
-                "id": "id0052",
-                "name": "Quantity",
-                "formula": "Sum([Sales/quantity])"
-              }
-            ],
-            "order": [
-              "id0051",
-              "id0052"
-            ]
+    "document": {
+      "schemaVersion": 1,
+      "kind": "workbook",
+      "pages": [
+        {
+          "id": "ZvjTJOMjdd",
+          "name": "Retailer Page"
+        },
+        {
+          "id": "urNQFo7k7z",
+          "name": "Product Page"
+        }
+      ],
+      "elements": [
+        {
+          "id": "bIzdpyWKNo",
+          "kind": "navigation",
+          "mode": "auto",
+          "pageLabels": {
+            "ZvjTJOMjdd": "Retailer Page",
+            "urNQFo7k7z": "Product Page"
           }
-        ]
-      }
-    ],
-    "controls": []
-  },
-  "stats": {
-    "queries": 5,
-    "tables": 3,
-    "pivots": 0,
-    "kpis": 8,
-    "charts": 5,
-    "maps": 1,
-    "columns": 28,
-    "filters": 0,
-    "controls": 0
+        },
+        {
+          "id": "rFPFJOtvuM",
+          "kind": "kpi-chart",
+          "name": "Revenue",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "qEIHxjzdLE",
+              "name": "Revenue",
+              "formula": "Sum([Sales/revenue])",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.3s"
+              }
+            }
+          ],
+          "order": [
+            "qEIHxjzdLE"
+          ],
+          "value": {
+            "columnId": "qEIHxjzdLE"
+          }
+        },
+        {
+          "id": "vaZeN3wDyJ",
+          "kind": "kpi-chart",
+          "name": "Product cost",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "Shk9WdFgGI",
+              "name": "Product Cost",
+              "formula": "Sum([Sales/product Cost])",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.3s"
+              }
+            }
+          ],
+          "order": [
+            "Shk9WdFgGI"
+          ],
+          "value": {
+            "columnId": "Shk9WdFgGI"
+          }
+        },
+        {
+          "id": "PO1kuddVvh",
+          "kind": "kpi-chart",
+          "name": "Gross profit",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "JsEzIzMtBP",
+              "name": "Gross Profit",
+              "formula": "Sum([Sales/gross Profit])",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.3s"
+              }
+            }
+          ],
+          "order": [
+            "JsEzIzMtBP"
+          ],
+          "value": {
+            "columnId": "JsEzIzMtBP"
+          }
+        },
+        {
+          "id": "twJIniT5dY",
+          "kind": "kpi-chart",
+          "name": "Gross margin",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "XEvqkFMwuV",
+              "name": "Gross Margin",
+              "formula": "Sum([Sales/gross Margin])",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0%"
+              }
+            }
+          ],
+          "order": [
+            "XEvqkFMwuV"
+          ],
+          "value": {
+            "columnId": "XEvqkFMwuV"
+          }
+        },
+        {
+          "id": "3uvQi4HgPo",
+          "kind": "table",
+          "name": "Retailers Sales — Top 10 Country for Sales",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Retailers Sales"
+          },
+          "columns": [
+            {
+              "id": "G8dRTZTdP9",
+              "name": "Retailer Country",
+              "formula": "[Retailers Sales/retailer Country]"
+            },
+            {
+              "id": "cJI9LHLaq3",
+              "name": "Revenue",
+              "formula": "Sum([Sales/revenue])"
+            }
+          ],
+          "order": [
+            "G8dRTZTdP9",
+            "cJI9LHLaq3"
+          ],
+          "groupings": [
+            {
+              "id": "yq0jmF3sDn",
+              "groupBy": [
+                "G8dRTZTdP9"
+              ],
+              "calculations": [
+                "cJI9LHLaq3"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "oDWmkb3mYJ",
+          "kind": "region-map",
+          "name": "Map1",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "aJck4d6HCi",
+              "name": "Retailer Country",
+              "formula": "[Retailers Sales/retailer Country]"
+            },
+            {
+              "id": "ff0WuzbWyB",
+              "name": "Revenue",
+              "formula": "Sum([Sales/revenue])",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.2s"
+              }
+            }
+          ],
+          "order": [
+            "aJck4d6HCi",
+            "ff0WuzbWyB"
+          ],
+          "region": {
+            "id": "aJck4d6HCi",
+            "regionType": "country"
+          },
+          "legend": {
+            "position": "bottom"
+          },
+          "color": {
+            "by": "scale",
+            "column": "ff0WuzbWyB"
+          }
+        },
+        {
+          "id": "bTUQKBDAIX",
+          "kind": "combo-chart",
+          "name": "Clustered combination2",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "niCQt7CRp8",
+              "name": "Month",
+              "formula": "[Time Sales/month]"
+            }
+          ],
+          "order": [
+            "niCQt7CRp8"
+          ],
+          "legend": {
+            "visibility": "hidden",
+            "position": "bottom"
+          },
+          "xAxis": {
+            "columnId": "niCQt7CRp8"
+          }
+        },
+        {
+          "id": "sxRmbuuggH",
+          "kind": "bar-chart",
+          "name": "Clustered combination3",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "biut46HUD6",
+              "name": "Month",
+              "formula": "[Time Sales/month]"
+            },
+            {
+              "id": "65YHF7CjQj",
+              "name": "Revenue",
+              "formula": "Sum([Sales/revenue])",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.2s"
+              }
+            },
+            {
+              "id": "eZQyzKcmtF",
+              "name": "Order Method Type",
+              "formula": "[Order Methods Sales/order Method Type]"
+            }
+          ],
+          "order": [
+            "biut46HUD6",
+            "65YHF7CjQj",
+            "eZQyzKcmtF"
+          ],
+          "legend": {
+            "visibility": "hidden",
+            "position": "bottom"
+          },
+          "xAxis": {
+            "columnId": "biut46HUD6"
+          },
+          "yAxis": {
+            "columnIds": [
+              "65YHF7CjQj"
+            ]
+          },
+          "color": {
+            "by": "category",
+            "column": "eZQyzKcmtF"
+          },
+          "stacking": "stacked"
+        },
+        {
+          "id": "FtQbXI9Ntm",
+          "kind": "pie-chart",
+          "name": "Pie1",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "sqq36KzEx9",
+              "name": "Product Line",
+              "formula": "[Products Sales/product Line]"
+            },
+            {
+              "id": "Hm56xNy2BU",
+              "name": "Revenue",
+              "formula": "Sum([Sales/revenue])"
+            }
+          ],
+          "order": [
+            "sqq36KzEx9",
+            "Hm56xNy2BU"
+          ],
+          "legend": {
+            "visibility": "hidden",
+            "position": "bottom"
+          },
+          "color": {
+            "id": "sqq36KzEx9"
+          },
+          "value": {
+            "id": "Hm56xNy2BU"
+          }
+        },
+        {
+          "id": "zc7OYMnjUT",
+          "kind": "navigation",
+          "mode": "auto",
+          "pageLabels": {
+            "ZvjTJOMjdd": "Retailer Page",
+            "urNQFo7k7z": "Product Page"
+          }
+        },
+        {
+          "id": "Erb92pxTDu",
+          "kind": "kpi-chart",
+          "name": "Revenue",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "ZyOjiupPwd",
+              "name": "Revenue",
+              "formula": "Sum([Sales/revenue])",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.3s"
+              }
+            }
+          ],
+          "order": [
+            "ZyOjiupPwd"
+          ],
+          "value": {
+            "columnId": "ZyOjiupPwd"
+          }
+        },
+        {
+          "id": "QlpSiG8VyK",
+          "kind": "kpi-chart",
+          "name": "Revenue vs Target",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "fw6Xou50Bz",
+              "name": "Revenue",
+              "formula": "Sum([Sales/revenue])"
+            },
+            {
+              "id": "iufDsKrcjg",
+              "name": "Revenue Vs Target",
+              "formula": "Sum([Sales/revenue]) - Sum([Sales Targets/sales Target])",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.4s"
+              }
+            }
+          ],
+          "order": [
+            "fw6Xou50Bz",
+            "iufDsKrcjg"
+          ],
+          "value": {
+            "columnId": "iufDsKrcjg"
+          }
+        },
+        {
+          "id": "hzswQtn1K2",
+          "kind": "kpi-chart",
+          "name": "Quantity",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "dWuXE2vA9i",
+              "name": "Quantity",
+              "formula": "Sum([Sales/quantity])"
+            }
+          ],
+          "order": [
+            "dWuXE2vA9i"
+          ],
+          "value": {
+            "columnId": "dWuXE2vA9i"
+          }
+        },
+        {
+          "id": "kw3cFdIyJM",
+          "kind": "kpi-chart",
+          "name": "Return quantity",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "oUKfXShsJQ",
+              "name": "Return Quantity",
+              "formula": "Sum([Returned Items/return Quantity])"
+            }
+          ],
+          "order": [
+            "oUKfXShsJQ"
+          ],
+          "value": {
+            "columnId": "oUKfXShsJQ"
+          }
+        },
+        {
+          "id": "jLNiTqnVe1",
+          "kind": "table",
+          "name": "Products Sales — Top 10 Product Table",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Products Sales"
+          },
+          "columns": [
+            {
+              "id": "vk8BXEbPbI",
+              "name": "Product",
+              "formula": "[Products Sales/product]"
+            },
+            {
+              "id": "6N9Frtpgfj",
+              "name": "Revenue",
+              "formula": "Sum([Sales/revenue])"
+            }
+          ],
+          "order": [
+            "vk8BXEbPbI",
+            "6N9Frtpgfj"
+          ],
+          "groupings": [
+            {
+              "id": "xwASv6suRa",
+              "groupBy": [
+                "vk8BXEbPbI"
+              ],
+              "calculations": [
+                "6N9Frtpgfj"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "ZxICZLyYRx",
+          "kind": "bar-chart",
+          "name": "Clustered column",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "fSFD2i2scO",
+              "name": "Date",
+              "formula": "[Time Returns/date]"
+            },
+            {
+              "id": "FayxS011Xq",
+              "name": "Quantity",
+              "formula": "Sum([Sales/quantity])"
+            }
+          ],
+          "order": [
+            "fSFD2i2scO",
+            "FayxS011Xq"
+          ],
+          "xAxis": {
+            "columnId": "fSFD2i2scO",
+            "sort": {
+              "by": "fSFD2i2scO",
+              "direction": "ascending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "FayxS011Xq"
+            ]
+          },
+          "stacking": "none"
+        },
+        {
+          "id": "TehrtOId8h",
+          "kind": "line-chart",
+          "name": "Line",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "80sHQfzgYU",
+              "name": "Quarter",
+              "formula": "[Time Returns/quarter]"
+            },
+            {
+              "id": "sICJW9EruW",
+              "name": "Return Quantity",
+              "formula": "Sum([Returned Items/return Quantity])"
+            },
+            {
+              "id": "lJ1Pw8ReP3",
+              "name": "Order Method Type",
+              "formula": "[Order Methods Returns/order Method Type]"
+            }
+          ],
+          "order": [
+            "80sHQfzgYU",
+            "sICJW9EruW",
+            "lJ1Pw8ReP3"
+          ],
+          "legend": {
+            "visibility": "hidden",
+            "position": "bottom"
+          },
+          "xAxis": {
+            "columnId": "80sHQfzgYU"
+          },
+          "yAxis": {
+            "columnIds": [
+              "sICJW9EruW"
+            ]
+          },
+          "color": {
+            "by": "category",
+            "column": "lJ1Pw8ReP3"
+          }
+        },
+        {
+          "id": "pVbLQzVV1V",
+          "kind": "table",
+          "name": "Tree map (was treemap)",
+          "source": {
+            "kind": "data-model",
+            "dataModelId": "<DM_ID>",
+            "elementId": "Sales"
+          },
+          "columns": [
+            {
+              "id": "41CIHdsf3G",
+              "name": "Product Type",
+              "formula": "[Products Returns/product Type]"
+            },
+            {
+              "id": "ncNupj9tFT",
+              "name": "Quantity",
+              "formula": "Sum([Sales/quantity])"
+            }
+          ],
+          "order": [
+            "41CIHdsf3G",
+            "ncNupj9tFT"
+          ],
+          "groupings": [
+            {
+              "id": "FEqYHaBp1D",
+              "groupBy": [
+                "41CIHdsf3G"
+              ],
+              "calculations": [
+                "ncNupj9tFT"
+              ]
+            }
+          ]
+        }
+      ],
+      "layout": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"ZvjTJOMjdd\">\n  <Element elementId=\"bIzdpyWKNo\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n  <Element elementId=\"rFPFJOtvuM\" gridColumn=\"1 / 7\" gridRow=\"4 / 10\"/>\n  <Element elementId=\"vaZeN3wDyJ\" gridColumn=\"7 / 13\" gridRow=\"4 / 10\"/>\n  <Element elementId=\"PO1kuddVvh\" gridColumn=\"13 / 19\" gridRow=\"4 / 10\"/>\n  <Element elementId=\"twJIniT5dY\" gridColumn=\"19 / 25\" gridRow=\"4 / 10\"/>\n  <Element elementId=\"3uvQi4HgPo\" gridColumn=\"1 / 25\" gridRow=\"10 / 22\"/>\n  <Element elementId=\"oDWmkb3mYJ\" gridColumn=\"1 / 25\" gridRow=\"22 / 34\"/>\n  <Element elementId=\"bTUQKBDAIX\" gridColumn=\"1 / 13\" gridRow=\"34 / 45\"/>\n  <Element elementId=\"sxRmbuuggH\" gridColumn=\"13 / 25\" gridRow=\"34 / 45\"/>\n  <Element elementId=\"FtQbXI9Ntm\" gridColumn=\"1 / 25\" gridRow=\"45 / 57\"/>\n</Page>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"urNQFo7k7z\">\n  <Element elementId=\"zc7OYMnjUT\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n  <Element elementId=\"Erb92pxTDu\" gridColumn=\"1 / 7\" gridRow=\"4 / 10\"/>\n  <Element elementId=\"QlpSiG8VyK\" gridColumn=\"7 / 13\" gridRow=\"4 / 10\"/>\n  <Element elementId=\"hzswQtn1K2\" gridColumn=\"13 / 19\" gridRow=\"4 / 10\"/>\n  <Element elementId=\"kw3cFdIyJM\" gridColumn=\"19 / 25\" gridRow=\"4 / 10\"/>\n  <Element elementId=\"jLNiTqnVe1\" gridColumn=\"1 / 25\" gridRow=\"10 / 22\"/>\n  <Element elementId=\"ZxICZLyYRx\" gridColumn=\"1 / 13\" gridRow=\"22 / 33\"/>\n  <Element elementId=\"TehrtOId8h\" gridColumn=\"13 / 25\" gridRow=\"22 / 33\"/>\n  <Element elementId=\"pVbLQzVV1V\" gridColumn=\"1 / 25\" gridRow=\"33 / 45\"/>\n</Page>"
+    }
   },
   "warnings": [
     "filter \"[C].[C_Fred_Data_Module].[Retailers_Sales].[Retailer_country] = ?Store?\" on query \"qRetailerPage\": not a simple =/in filter — re-create as a Sigma element/page filter.",
@@ -602,8 +646,26 @@
     "filter \"[C].[C_Fred_Data_Module].[Time_Sales_Targets].[Year_]  = ?Year?\" on query \"qProductPage\": not a simple =/in filter — re-create as a Sigma element/page filter.",
     "filter \"[C].[C_Fred_Data_Module].[Retailers_Sales].[Retailer_country] = ?Store?\" on query \"qProductPage\": not a simple =/in filter — re-create as a Sigma element/page filter.",
     "filter \"[C].[C_Fred_Data_Module].[Time_Sales_Targets].[Year_]  = ?Year?\" on query \"qProductPage\": not a simple =/in filter — re-create as a Sigma element/page filter.",
-    "chart \"Tree map\" is a Cognos treemap (com.ibm.vis.treemap) — Sigma has no native equivalent; emitted its data as a table. Re-pick a Sigma chart in the workbook.",
+    "⛔ WORKBOOK FEATURE GAP [visual com.ibm.vis.treemap]: chart \"Tree map\" is a Cognos treemap; no grounded Sigma mapping is cataloged. Its data was preserved as a table.",
     "filter \"[C].[C_Fred_Data_Module].[Retailers_Sales].[Retailer_country] = ?Store?\" on query \"qProductPage\": not a simple =/in filter — re-create as a Sigma element/page filter.",
     "filter \"[C].[C_Fred_Data_Module].[Time_Sales_Targets].[Year_]  = ?Year?\" on query \"qProductPage\": not a simple =/in filter — re-create as a Sigma element/page filter."
-  ]
+  ],
+  "stats": {
+    "queries": 5,
+    "tables": 3,
+    "pivots": 0,
+    "kpis": 8,
+    "charts": 5,
+    "maps": 1,
+    "columns": 28,
+    "filters": 0,
+    "controls": 0,
+    "refMarks": 0,
+    "scaleColors": 1,
+    "pages": 2,
+    "progress": 0,
+    "repeaters": 0,
+    "panels": 0,
+    "pageBreaks": 0
+  }
 }

--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos \u2192 Sigma",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Migrate IBM Cognos Analytics to Sigma \u2014 Data Module JSON \u2192 Sigma data model, and report-spec XML \u2192 Sigma workbook. Translates the Cognos expression DSL (total..for \u2192 window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -259,13 +259,16 @@ display name) to the converter via `--metrics`. SAFE: KPI/crosstab measures are 
 measures and any non-match fall back to inline; no `--metrics` is byte-identical.
 **Re-vendor after editing `converter/*.ts`:** `tools/vendor-converters.sh <mcp> cognos`
 rebuilds `converter/cli.mjs` (production runs the bundle). This is **enforced** — `tools/check-cognos-bundle.rb`
-(governance hook + CI) fails if a `converter/*.ts` edit ships without re-bundling. Verified: `scripts/test-metric-reference.mjs`. Then post-and-readback POSTs
-the workbook and re-runs the error-column gate. **`apply-layout.mjs` then gives the page a
-clean 24-col grid** (controls on top, content stacked full-width with per-kind heights) —
-Sigma auto-arrange otherwise squishes every element to the same height. It writes the
-`document.layout` XML (matched to readback ids) and confirms it survives readback — the
-workbook body is `document`-wrapped as of 2026-08-03 (`schemaVersion`/`pages`/`kind`/
-`layout` all nest there; DM specs are unaffected and stay flat).
+(governance hook + CI) fails if a `converter/*.ts` edit ships without re-bundling. Verified: `scripts/test-metric-reference.mjs`. The converter emits the current
+workbook-code shape directly: outer metadata (`name`) plus a `document` wrapper
+with **flat `document.elements`**, **metadata-only `document.pages`**, and a
+required authoritative `document.layout` that is the sole
+page/panel/repeater-membership map. `post-and-readback.mjs` rejects a legacy
+page-nested or layout-less workbook before POST and runs the same gate on GET.
+**`apply-layout.mjs` verifies that authored layout; it no longer synthesizes a
+replacement that would erase source page/panel/tab intent.** Both use CodeRep
+helpers. Data-model specs are unaffected and keep their existing flat
+transport body with `pages[].elements`.
 **It then runs the shared layout-quality lint as a gate** (`scripts/lib/layout_lint.rb`,
 vendored byte-identical; cognos shells out to ruby) on the final readback spec — flags
 raw-id element display names, controls orphaned outside containers, and generic Sigma
@@ -324,14 +327,26 @@ A workbook that POSTs 200 and passes parity ($-total / row-count) can still be v
   **charts (RAVE2 `<vizControl>`) → Sigma chart elements** (bar/column/line/area/pie/donut/
   combo/scatter via the slot model — see `refs/format-shapes.md`) and **maps (`tiledmap`) →
   Sigma region-map / point-map**.
+- Released workbook-code mappings: Cognos **waterfalls → `waterfall-chart`**;
+  explicit legend visibility/position → `legend`; non-empty hierarchy
+  `drillBehavior` → `controlType: drill`; report pages/tabs → metadata pages +
+  auto navigation; `pageBreak` → `page-break`; progress/bullet/gauge visuals →
+  `progress` backed by a hidden aggregate source; page headers →
+  `document.panels`; named blocks/styles → styled container sections;
+  repeaters → `repeated-container` cards.
 
 **Flagged with a warning (and a readable placeholder), never faked:** macros whose prompt
 value set isn't recoverable from the report, **running-total / moving-* / rank / lag / lead**
 (window funcs with no clean single-column analog), **GetResourceString** (localization),
 composite/non-equi **joins**, **summary filters** (post-aggregation), table **sort order**
 (not part of the workbook spec — apply in the UI), and Cognos viz types with no native Sigma
-element (network, word-cloud, packed-bubble, treemap → flagged table). Drill-through→actions
-and Framework Manager `.cpf` remain roadmap.
+element (network, word-cloud, packed-bubble, treemap → flagged table).
+**Box charts are workspace-gated** and stay a loud, data-preserving table
+fallback until entitlement is proven. Cross-report drill-through stays a loud
+gap (Sigma's drill control is hierarchy drill, not a cross-document action).
+Cognos page footers also stay loud because released workbook panels support
+header/sidebar, not footer. Framework Manager `.cpf` remains roadmap. See
+`refs/cognos-coverage.md` for the executable catalog and gap ledger.
 
 ## Security: Row- & Column-Level Security (RLS/CLS)
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/PROVENANCE.json
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/PROVENANCE.json
@@ -1,14 +1,15 @@
 {
-  "source": "in-skill converter/cli.ts (cli.ts + cognos-report.ts + cognos.ts + metric-binding.ts + sigma-ids.ts)",
+  "source": "in-skill converter/cli.ts (cli.ts + cognos-report.ts + cognos.ts + metric-binding.ts + sigma-ids.ts + workbook-features.ts)",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "cli.mjs",
-  "source_sha256": "26cb0f41485300760aa8ba2b52a167280bfa988955a47663898f8ffaa191b434",
+  "source_sha256": "8be3266e7b3674cfd64fd411d04f8e078e7b998fd26a7a33db71c49b85b8ab62",
   "sources": [
     "cli.ts",
     "cognos-report.ts",
     "cognos.ts",
     "metric-binding.ts",
-    "sigma-ids.ts"
+    "sigma-ids.ts",
+    "workbook-features.ts"
   ],
   "note": "cli.mjs is GENERATED from converter/*.ts — do not hand-edit. After editing any converter/*.ts, re-run tools/vendor-converters.sh <sigma-data-model-mcp> cognos (rebuilds cli.mjs + refreshes source_sha256). CI gate: tools/check-cognos-bundle.rb."
 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.mjs
@@ -25,9 +25,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/util.js
+// node_modules/fast-xml-parser/src/util.js
 var require_util = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/util.js"(exports) {
+  "node_modules/fast-xml-parser/src/util.js"(exports) {
     "use strict";
     var nameStartChar = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
     var nameChar = nameStartChar + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
@@ -78,15 +78,30 @@ var require_util = __commonJS({
         return "";
       }
     };
+    var DANGEROUS_PROPERTY_NAMES = [
+      // '__proto__',
+      // 'constructor',
+      // 'prototype',
+      "hasOwnProperty",
+      "toString",
+      "valueOf",
+      "__defineGetter__",
+      "__defineSetter__",
+      "__lookupGetter__",
+      "__lookupSetter__"
+    ];
+    var criticalProperties = ["__proto__", "constructor", "prototype"];
     exports.isName = isName;
     exports.getAllMatches = getAllMatches;
     exports.nameRegexp = nameRegexp;
+    exports.DANGEROUS_PROPERTY_NAMES = DANGEROUS_PROPERTY_NAMES;
+    exports.criticalProperties = criticalProperties;
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/validator.js
+// node_modules/fast-xml-parser/src/validator.js
 var require_validator = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/validator.js"(exports) {
+  "node_modules/fast-xml-parser/src/validator.js"(exports) {
     "use strict";
     var util = require_util();
     var defaultOptions = {
@@ -396,9 +411,16 @@ var require_validator = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
+// node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
 var require_OptionsBuilder = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
+  "node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
+    var { DANGEROUS_PROPERTY_NAMES, criticalProperties } = require_util();
+    var defaultOnDangerousProperty = (name) => {
+      if (DANGEROUS_PROPERTY_NAMES.includes(name)) {
+        return "__" + name;
+      }
+      return name;
+    };
     var defaultOptions = {
       preserveOrder: false,
       attributeNamePrefix: "@_",
@@ -420,11 +442,11 @@ var require_OptionsBuilder = __commonJS({
         leadingZeros: true,
         eNotation: true
       },
-      tagValueProcessor: function(tagName, val2) {
-        return val2;
+      tagValueProcessor: function(tagName, val) {
+        return val;
       },
-      attributeValueProcessor: function(attrName, val2) {
-        return val2;
+      attributeValueProcessor: function(attrName, val) {
+        return val;
       },
       stopNodes: [],
       //nested tags will not be parsed even for errors
@@ -440,20 +462,84 @@ var require_OptionsBuilder = __commonJS({
       transformAttributeName: false,
       updateTag: function(tagName, jPath, attrs) {
         return tagName;
-      }
+      },
       // skipEmptyListItem: false
+      captureMetaData: false,
+      maxNestedTags: 100,
+      strictReservedNames: true,
+      onDangerousProperty: defaultOnDangerousProperty
     };
+    function validatePropertyName(propertyName, optionName) {
+      if (typeof propertyName !== "string") {
+        return;
+      }
+      const normalized = propertyName.toLowerCase();
+      if (DANGEROUS_PROPERTY_NAMES.some((dangerous) => normalized === dangerous.toLowerCase())) {
+        throw new Error(
+          `[SECURITY] Invalid ${optionName}: "${propertyName}" is a reserved JavaScript keyword that could cause prototype pollution`
+        );
+      }
+      if (criticalProperties.some((dangerous) => normalized === dangerous.toLowerCase())) {
+        throw new Error(
+          `[SECURITY] Invalid ${optionName}: "${propertyName}" is a reserved JavaScript keyword that could cause prototype pollution`
+        );
+      }
+    }
+    function normalizeProcessEntities(value) {
+      if (typeof value === "boolean") {
+        return {
+          enabled: value,
+          // true or false
+          maxEntitySize: 1e4,
+          maxExpansionDepth: 10,
+          maxTotalExpansions: 1e3,
+          maxExpandedLength: 1e5,
+          allowedTags: null,
+          tagFilter: null
+        };
+      }
+      if (typeof value === "object" && value !== null) {
+        return {
+          enabled: value.enabled !== false,
+          maxEntitySize: Math.max(1, value.maxEntitySize ?? 1e4),
+          maxExpansionDepth: Math.max(1, value.maxExpansionDepth ?? 1e4),
+          maxTotalExpansions: Math.max(1, value.maxTotalExpansions ?? Infinity),
+          maxExpandedLength: Math.max(1, value.maxExpandedLength ?? 1e5),
+          maxEntityCount: Math.max(1, value.maxEntityCount ?? 1e3),
+          allowedTags: value.allowedTags ?? null,
+          tagFilter: value.tagFilter ?? null
+        };
+      }
+      return normalizeProcessEntities(true);
+    }
     var buildOptions = function(options) {
-      return Object.assign({}, defaultOptions, options);
+      const built = Object.assign({}, defaultOptions, options);
+      const propertyNameOptions = [
+        { value: built.attributeNamePrefix, name: "attributeNamePrefix" },
+        { value: built.attributesGroupName, name: "attributesGroupName" },
+        { value: built.textNodeName, name: "textNodeName" },
+        { value: built.cdataPropName, name: "cdataPropName" },
+        { value: built.commentPropName, name: "commentPropName" }
+      ];
+      for (const { value, name } of propertyNameOptions) {
+        if (value) {
+          validatePropertyName(value, name);
+        }
+      }
+      if (built.onDangerousProperty === null) {
+        built.onDangerousProperty = defaultOnDangerousProperty;
+      }
+      built.processEntities = normalizeProcessEntities(built.processEntities);
+      return built;
     };
     exports.buildOptions = buildOptions;
     exports.defaultOptions = defaultOptions;
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
+// node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
 var require_xmlNode = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module) {
+  "node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module) {
     "use strict";
     var XmlNode = class {
       constructor(tagname) {
@@ -461,9 +547,9 @@ var require_xmlNode = __commonJS({
         this.child = [];
         this[":@"] = {};
       }
-      add(key, val2) {
+      add(key, val) {
         if (key === "__proto__") key = "#__proto__";
-        this.child.push({ [key]: val2 });
+        this.child.push({ [key]: val });
       }
       addChild(node) {
         if (node.tagname === "__proto__") node.tagname = "#__proto__";
@@ -478,93 +564,283 @@ var require_xmlNode = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
+// node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
 var require_DocTypeReader = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module) {
+  "node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module) {
     var util = require_util();
-    function readDocType(xmlData, i) {
-      const entities = {};
-      if (xmlData[i + 3] === "O" && xmlData[i + 4] === "C" && xmlData[i + 5] === "T" && xmlData[i + 6] === "Y" && xmlData[i + 7] === "P" && xmlData[i + 8] === "E") {
-        i = i + 9;
-        let angleBracketsCount = 1;
-        let hasBody = false, comment = false;
-        let exp = "";
-        for (; i < xmlData.length; i++) {
-          if (xmlData[i] === "<" && !comment) {
-            if (hasBody && isEntity(xmlData, i)) {
-              i += 7;
-              [entityName, val, i] = readEntityExp(xmlData, i + 1);
-              if (val.indexOf("&") === -1)
-                entities[validateEntityName(entityName)] = {
-                  regx: RegExp(`&${entityName};`, "g"),
-                  val
-                };
-            } else if (hasBody && isElement(xmlData, i)) i += 8;
-            else if (hasBody && isAttlist(xmlData, i)) i += 8;
-            else if (hasBody && isNotation(xmlData, i)) i += 9;
-            else if (isComment) comment = true;
-            else throw new Error("Invalid DOCTYPE");
-            angleBracketsCount++;
-            exp = "";
-          } else if (xmlData[i] === ">") {
-            if (comment) {
-              if (xmlData[i - 1] === "-" && xmlData[i - 2] === "-") {
-                comment = false;
+    var DocTypeReader = class {
+      constructor(options) {
+        this.suppressValidationErr = !options;
+        this.options = options || {};
+      }
+      readDocType(xmlData, i) {
+        const entities = /* @__PURE__ */ Object.create(null);
+        let entityCount = 0;
+        if (xmlData[i + 3] === "O" && xmlData[i + 4] === "C" && xmlData[i + 5] === "T" && xmlData[i + 6] === "Y" && xmlData[i + 7] === "P" && xmlData[i + 8] === "E") {
+          i = i + 9;
+          let angleBracketsCount = 1;
+          let hasBody = false, comment = false;
+          let exp = "";
+          for (; i < xmlData.length; i++) {
+            if (xmlData[i] === "<" && !comment) {
+              if (hasBody && hasSeq(xmlData, "!ENTITY", i)) {
+                i += 7;
+                let entityName, val;
+                [entityName, val, i] = this.readEntityExp(xmlData, i + 1, this.suppressValidationErr);
+                if (val.indexOf("&") === -1) {
+                  if (this.options.enabled !== false && this.options.maxEntityCount != null && entityCount >= this.options.maxEntityCount) {
+                    throw new Error(
+                      `Entity count (${entityCount + 1}) exceeds maximum allowed (${this.options.maxEntityCount})`
+                    );
+                  }
+                  const escaped = entityName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                  entities[entityName] = {
+                    regx: RegExp(`&${escaped};`, "g"),
+                    val
+                  };
+                  entityCount++;
+                }
+              } else if (hasBody && hasSeq(xmlData, "!ELEMENT", i)) {
+                i += 8;
+                const { index } = this.readElementExp(xmlData, i + 1);
+                i = index;
+              } else if (hasBody && hasSeq(xmlData, "!ATTLIST", i)) {
+                i += 8;
+              } else if (hasBody && hasSeq(xmlData, "!NOTATION", i)) {
+                i += 9;
+                const { index } = this.readNotationExp(xmlData, i + 1, this.suppressValidationErr);
+                i = index;
+              } else if (hasSeq(xmlData, "!--", i)) {
+                comment = true;
+              } else {
+                throw new Error(`Invalid DOCTYPE`);
+              }
+              angleBracketsCount++;
+              exp = "";
+            } else if (xmlData[i] === ">") {
+              if (comment) {
+                if (xmlData[i - 1] === "-" && xmlData[i - 2] === "-") {
+                  comment = false;
+                  angleBracketsCount--;
+                }
+              } else {
                 angleBracketsCount--;
               }
+              if (angleBracketsCount === 0) {
+                break;
+              }
+            } else if (xmlData[i] === "[") {
+              hasBody = true;
             } else {
-              angleBracketsCount--;
+              exp += xmlData[i];
             }
-            if (angleBracketsCount === 0) {
-              break;
-            }
-          } else if (xmlData[i] === "[") {
-            hasBody = true;
-          } else {
-            exp += xmlData[i];
+          }
+          if (angleBracketsCount !== 0) {
+            throw new Error(`Unclosed DOCTYPE`);
+          }
+        } else {
+          throw new Error(`Invalid Tag instead of DOCTYPE`);
+        }
+        return { entities, i };
+      }
+      readEntityExp(xmlData, i) {
+        i = skipWhitespace(xmlData, i);
+        let entityName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i]) && xmlData[i] !== '"' && xmlData[i] !== "'") {
+          entityName += xmlData[i];
+          i++;
+        }
+        validateEntityName(entityName);
+        i = skipWhitespace(xmlData, i);
+        if (!this.suppressValidationErr) {
+          if (xmlData.substring(i, i + 6).toUpperCase() === "SYSTEM") {
+            throw new Error("External entities are not supported");
+          } else if (xmlData[i] === "%") {
+            throw new Error("Parameter entities are not supported");
           }
         }
-        if (angleBracketsCount !== 0) {
-          throw new Error(`Unclosed DOCTYPE`);
+        let entityValue = "";
+        [i, entityValue] = this.readIdentifierVal(xmlData, i, "entity");
+        if (this.options.enabled !== false && this.options.maxEntitySize != null && entityValue.length > this.options.maxEntitySize) {
+          throw new Error(
+            `Entity "${entityName}" size (${entityValue.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`
+          );
         }
-      } else {
-        throw new Error(`Invalid Tag instead of DOCTYPE`);
+        i--;
+        return [entityName, entityValue, i];
       }
-      return { entities, i };
-    }
-    function readEntityExp(xmlData, i) {
-      let entityName2 = "";
-      for (; i < xmlData.length && (xmlData[i] !== "'" && xmlData[i] !== '"'); i++) {
-        entityName2 += xmlData[i];
+      readNotationExp(xmlData, i) {
+        i = skipWhitespace(xmlData, i);
+        let notationName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+          notationName += xmlData[i];
+          i++;
+        }
+        !this.suppressValidationErr && validateEntityName(notationName);
+        i = skipWhitespace(xmlData, i);
+        const identifierType = xmlData.substring(i, i + 6).toUpperCase();
+        if (!this.suppressValidationErr && identifierType !== "SYSTEM" && identifierType !== "PUBLIC") {
+          throw new Error(`Expected SYSTEM or PUBLIC, found "${identifierType}"`);
+        }
+        i += identifierType.length;
+        i = skipWhitespace(xmlData, i);
+        let publicIdentifier = null;
+        let systemIdentifier = null;
+        if (identifierType === "PUBLIC") {
+          [i, publicIdentifier] = this.readIdentifierVal(xmlData, i, "publicIdentifier");
+          i = skipWhitespace(xmlData, i);
+          if (xmlData[i] === '"' || xmlData[i] === "'") {
+            [i, systemIdentifier] = this.readIdentifierVal(xmlData, i, "systemIdentifier");
+          }
+        } else if (identifierType === "SYSTEM") {
+          [i, systemIdentifier] = this.readIdentifierVal(xmlData, i, "systemIdentifier");
+          if (!this.suppressValidationErr && !systemIdentifier) {
+            throw new Error("Missing mandatory system identifier for SYSTEM notation");
+          }
+        }
+        return { notationName, publicIdentifier, systemIdentifier, index: --i };
       }
-      entityName2 = entityName2.trim();
-      if (entityName2.indexOf(" ") !== -1) throw new Error("External entites are not supported");
-      const startChar = xmlData[i++];
-      let val2 = "";
-      for (; i < xmlData.length && xmlData[i] !== startChar; i++) {
-        val2 += xmlData[i];
+      readIdentifierVal(xmlData, i, type) {
+        let identifierVal = "";
+        const startChar = xmlData[i];
+        if (startChar !== '"' && startChar !== "'") {
+          throw new Error(`Expected quoted string, found "${startChar}"`);
+        }
+        i++;
+        while (i < xmlData.length && xmlData[i] !== startChar) {
+          identifierVal += xmlData[i];
+          i++;
+        }
+        if (xmlData[i] !== startChar) {
+          throw new Error(`Unterminated ${type} value`);
+        }
+        i++;
+        return [i, identifierVal];
       }
-      return [entityName2, val2, i];
-    }
-    function isComment(xmlData, i) {
-      if (xmlData[i + 1] === "!" && xmlData[i + 2] === "-" && xmlData[i + 3] === "-") return true;
-      return false;
-    }
-    function isEntity(xmlData, i) {
-      if (xmlData[i + 1] === "!" && xmlData[i + 2] === "E" && xmlData[i + 3] === "N" && xmlData[i + 4] === "T" && xmlData[i + 5] === "I" && xmlData[i + 6] === "T" && xmlData[i + 7] === "Y") return true;
-      return false;
-    }
-    function isElement(xmlData, i) {
-      if (xmlData[i + 1] === "!" && xmlData[i + 2] === "E" && xmlData[i + 3] === "L" && xmlData[i + 4] === "E" && xmlData[i + 5] === "M" && xmlData[i + 6] === "E" && xmlData[i + 7] === "N" && xmlData[i + 8] === "T") return true;
-      return false;
-    }
-    function isAttlist(xmlData, i) {
-      if (xmlData[i + 1] === "!" && xmlData[i + 2] === "A" && xmlData[i + 3] === "T" && xmlData[i + 4] === "T" && xmlData[i + 5] === "L" && xmlData[i + 6] === "I" && xmlData[i + 7] === "S" && xmlData[i + 8] === "T") return true;
-      return false;
-    }
-    function isNotation(xmlData, i) {
-      if (xmlData[i + 1] === "!" && xmlData[i + 2] === "N" && xmlData[i + 3] === "O" && xmlData[i + 4] === "T" && xmlData[i + 5] === "A" && xmlData[i + 6] === "T" && xmlData[i + 7] === "I" && xmlData[i + 8] === "O" && xmlData[i + 9] === "N") return true;
-      return false;
+      readElementExp(xmlData, i) {
+        i = skipWhitespace(xmlData, i);
+        let elementName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+          elementName += xmlData[i];
+          i++;
+        }
+        if (!this.suppressValidationErr && !util.isName(elementName)) {
+          throw new Error(`Invalid element name: "${elementName}"`);
+        }
+        i = skipWhitespace(xmlData, i);
+        let contentModel = "";
+        if (xmlData[i] === "E" && hasSeq(xmlData, "MPTY", i)) {
+          i += 4;
+        } else if (xmlData[i] === "A" && hasSeq(xmlData, "NY", i)) {
+          i += 2;
+        } else if (xmlData[i] === "(") {
+          i++;
+          while (i < xmlData.length && xmlData[i] !== ")") {
+            contentModel += xmlData[i];
+            i++;
+          }
+          if (xmlData[i] !== ")") {
+            throw new Error("Unterminated content model");
+          }
+        } else if (!this.suppressValidationErr) {
+          throw new Error(`Invalid Element Expression, found "${xmlData[i]}"`);
+        }
+        return {
+          elementName,
+          contentModel: contentModel.trim(),
+          index: i
+        };
+      }
+      readAttlistExp(xmlData, i) {
+        i = skipWhitespace(xmlData, i);
+        let elementName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+          elementName += xmlData[i];
+          i++;
+        }
+        validateEntityName(elementName);
+        i = skipWhitespace(xmlData, i);
+        let attributeName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+          attributeName += xmlData[i];
+          i++;
+        }
+        if (!validateEntityName(attributeName)) {
+          throw new Error(`Invalid attribute name: "${attributeName}"`);
+        }
+        i = skipWhitespace(xmlData, i);
+        let attributeType = "";
+        if (xmlData.substring(i, i + 8).toUpperCase() === "NOTATION") {
+          attributeType = "NOTATION";
+          i += 8;
+          i = skipWhitespace(xmlData, i);
+          if (xmlData[i] !== "(") {
+            throw new Error(`Expected '(', found "${xmlData[i]}"`);
+          }
+          i++;
+          let allowedNotations = [];
+          while (i < xmlData.length && xmlData[i] !== ")") {
+            let notation = "";
+            while (i < xmlData.length && xmlData[i] !== "|" && xmlData[i] !== ")") {
+              notation += xmlData[i];
+              i++;
+            }
+            notation = notation.trim();
+            if (!validateEntityName(notation)) {
+              throw new Error(`Invalid notation name: "${notation}"`);
+            }
+            allowedNotations.push(notation);
+            if (xmlData[i] === "|") {
+              i++;
+              i = skipWhitespace(xmlData, i);
+            }
+          }
+          if (xmlData[i] !== ")") {
+            throw new Error("Unterminated list of notations");
+          }
+          i++;
+          attributeType += " (" + allowedNotations.join("|") + ")";
+        } else {
+          while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+            attributeType += xmlData[i];
+            i++;
+          }
+          const validTypes = ["CDATA", "ID", "IDREF", "IDREFS", "ENTITY", "ENTITIES", "NMTOKEN", "NMTOKENS"];
+          if (!this.suppressValidationErr && !validTypes.includes(attributeType.toUpperCase())) {
+            throw new Error(`Invalid attribute type: "${attributeType}"`);
+          }
+        }
+        i = skipWhitespace(xmlData, i);
+        let defaultValue = "";
+        if (xmlData.substring(i, i + 8).toUpperCase() === "#REQUIRED") {
+          defaultValue = "#REQUIRED";
+          i += 8;
+        } else if (xmlData.substring(i, i + 7).toUpperCase() === "#IMPLIED") {
+          defaultValue = "#IMPLIED";
+          i += 7;
+        } else {
+          [i, defaultValue] = this.readIdentifierVal(xmlData, i, "ATTLIST");
+        }
+        return {
+          elementName,
+          attributeName,
+          attributeType,
+          defaultValue,
+          index: i
+        };
+      }
+    };
+    var skipWhitespace = (data, index) => {
+      while (index < data.length && /\s/.test(data[index])) {
+        index++;
+      }
+      return index;
+    };
+    function hasSeq(data, seq, i) {
+      for (let j = 0; j < seq.length; j++) {
+        if (seq[j] !== data[i + j + 1]) return false;
+      }
+      return true;
     }
     function validateEntityName(name) {
       if (util.isName(name))
@@ -572,13 +848,13 @@ var require_DocTypeReader = __commonJS({
       else
         throw new Error(`Invalid entity name ${name}`);
     }
-    module.exports = readDocType;
+    module.exports = DocTypeReader;
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/strnum/strnum.js
+// node_modules/strnum/strnum.js
 var require_strnum = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/strnum/strnum.js"(exports, module) {
+  "node_modules/strnum/strnum.js"(exports, module) {
     var hexRegex = /^[-+]?0x[a-fA-F0-9]+$/;
     var numRegex = /^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/;
     var consider = {
@@ -664,9 +940,9 @@ var require_strnum = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/ignoreAttributes.js
+// node_modules/fast-xml-parser/src/ignoreAttributes.js
 var require_ignoreAttributes = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/ignoreAttributes.js"(exports, module) {
+  "node_modules/fast-xml-parser/src/ignoreAttributes.js"(exports, module) {
     function getIgnoreAttributesFn(ignoreAttributes) {
       if (typeof ignoreAttributes === "function") {
         return ignoreAttributes;
@@ -689,13 +965,13 @@ var require_ignoreAttributes = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
+// node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
 var require_OrderedObjParser = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module) {
+  "node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module) {
     "use strict";
     var util = require_util();
     var xmlNode = require_xmlNode();
-    var readDocType = require_DocTypeReader();
+    var DocTypeReader = require_DocTypeReader();
     var toNumber = require_strnum();
     var getIgnoreAttributesFn = require_ignoreAttributes();
     var OrderedObjParser = class {
@@ -725,8 +1001,8 @@ var require_OrderedObjParser = __commonJS({
           "copyright": { regex: /&(copy|#169);/g, val: "\xA9" },
           "reg": { regex: /&(reg|#174);/g, val: "\xAE" },
           "inr": { regex: /&(inr|#8377);/g, val: "\u20B9" },
-          "num_dec": { regex: /&#([0-9]{1,7});/g, val: (_, str) => String.fromCharCode(Number.parseInt(str, 10)) },
-          "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val: (_, str) => String.fromCharCode(Number.parseInt(str, 16)) }
+          "num_dec": { regex: /&#([0-9]{1,7});/g, val: (_, str) => fromCodePoint(str, 10, "&#") },
+          "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val: (_, str) => fromCodePoint(str, 16, "&#x") }
         };
         this.addExternalEntities = addExternalEntities;
         this.parseXml = parseXml;
@@ -739,38 +1015,54 @@ var require_OrderedObjParser = __commonJS({
         this.saveTextToParentTag = saveTextToParentTag;
         this.addChild = addChild;
         this.ignoreAttributesFn = getIgnoreAttributesFn(this.options.ignoreAttributes);
+        this.entityExpansionCount = 0;
+        this.currentExpandedLength = 0;
+        if (this.options.stopNodes && this.options.stopNodes.length > 0) {
+          this.stopNodesExact = /* @__PURE__ */ new Set();
+          this.stopNodesWildcard = /* @__PURE__ */ new Set();
+          for (let i = 0; i < this.options.stopNodes.length; i++) {
+            const stopNodeExp = this.options.stopNodes[i];
+            if (typeof stopNodeExp !== "string") continue;
+            if (stopNodeExp.startsWith("*.")) {
+              this.stopNodesWildcard.add(stopNodeExp.substring(2));
+            } else {
+              this.stopNodesExact.add(stopNodeExp);
+            }
+          }
+        }
       }
     };
     function addExternalEntities(externalEntities) {
       const entKeys = Object.keys(externalEntities);
       for (let i = 0; i < entKeys.length; i++) {
         const ent = entKeys[i];
+        const escaped = ent.replace(/[.\-+*:]/g, "\\.");
         this.lastEntities[ent] = {
-          regex: new RegExp("&" + ent + ";", "g"),
+          regex: new RegExp("&" + escaped + ";", "g"),
           val: externalEntities[ent]
         };
       }
     }
-    function parseTextData(val2, tagName, jPath, dontTrim, hasAttributes, isLeafNode, escapeEntities) {
-      if (val2 !== void 0) {
+    function parseTextData(val, tagName, jPath, dontTrim, hasAttributes, isLeafNode, escapeEntities) {
+      if (val !== void 0) {
         if (this.options.trimValues && !dontTrim) {
-          val2 = val2.trim();
+          val = val.trim();
         }
-        if (val2.length > 0) {
-          if (!escapeEntities) val2 = this.replaceEntitiesValue(val2);
-          const newval = this.options.tagValueProcessor(tagName, val2, jPath, hasAttributes, isLeafNode);
+        if (val.length > 0) {
+          if (!escapeEntities) val = this.replaceEntitiesValue(val, tagName, jPath);
+          const newval = this.options.tagValueProcessor(tagName, val, jPath, hasAttributes, isLeafNode);
           if (newval === null || newval === void 0) {
-            return val2;
-          } else if (typeof newval !== typeof val2 || newval !== val2) {
+            return val;
+          } else if (typeof newval !== typeof val || newval !== val) {
             return newval;
           } else if (this.options.trimValues) {
-            return parseValue(val2, this.options.parseTagValue, this.options.numberParseOptions);
+            return parseValue(val, this.options.parseTagValue, this.options.numberParseOptions);
           } else {
-            const trimmedVal = val2.trim();
-            if (trimmedVal === val2) {
-              return parseValue(val2, this.options.parseTagValue, this.options.numberParseOptions);
+            const trimmedVal = val.trim();
+            if (trimmedVal === val) {
+              return parseValue(val, this.options.parseTagValue, this.options.numberParseOptions);
             } else {
-              return val2;
+              return val;
             }
           }
         }
@@ -806,12 +1098,12 @@ var require_OrderedObjParser = __commonJS({
             if (this.options.transformAttributeName) {
               aName = this.options.transformAttributeName(aName);
             }
-            if (aName === "__proto__") aName = "#__proto__";
+            aName = sanitizeName(aName, this.options);
             if (oldVal !== void 0) {
               if (this.options.trimValues) {
                 oldVal = oldVal.trim();
               }
-              oldVal = this.replaceEntitiesValue(oldVal);
+              oldVal = this.replaceEntitiesValue(oldVal, tagName, jPath);
               const newVal = this.options.attributeValueProcessor(attrName, oldVal, jPath);
               if (newVal === null || newVal === void 0) {
                 attrs[aName] = oldVal;
@@ -846,6 +1138,9 @@ var require_OrderedObjParser = __commonJS({
       let currentNode = xmlObj;
       let textData = "";
       let jPath = "";
+      this.entityExpansionCount = 0;
+      this.currentExpandedLength = 0;
+      const docTypeReader = new DocTypeReader(this.options.processEntities);
       for (let i = 0; i < xmlData.length; i++) {
         const ch = xmlData[i];
         if (ch === "<") {
@@ -890,7 +1185,7 @@ var require_OrderedObjParser = __commonJS({
               if (tagData.tagName !== tagData.tagExp && tagData.attrExpPresent) {
                 childNode[":@"] = this.buildAttributesMap(tagData.tagExp, jPath, tagData.tagName);
               }
-              this.addChild(currentNode, childNode, jPath);
+              this.addChild(currentNode, childNode, jPath, i);
             }
             i = tagData.closeIndex + 1;
           } else if (xmlData.substr(i + 1, 3) === "!--") {
@@ -902,19 +1197,19 @@ var require_OrderedObjParser = __commonJS({
             }
             i = endIndex;
           } else if (xmlData.substr(i + 1, 2) === "!D") {
-            const result = readDocType(xmlData, i);
+            const result = docTypeReader.readDocType(xmlData, i);
             this.docTypeEntities = result.entities;
             i = result.i;
           } else if (xmlData.substr(i + 1, 2) === "![") {
             const closeIndex = findClosingIndex(xmlData, "]]>", i, "CDATA is not closed.") - 2;
             const tagExp = xmlData.substring(i + 9, closeIndex);
             textData = this.saveTextToParentTag(textData, currentNode, jPath);
-            let val2 = this.parseTextData(tagExp, currentNode.tagname, jPath, true, false, true, true);
-            if (val2 == void 0) val2 = "";
+            let val = this.parseTextData(tagExp, currentNode.tagname, jPath, true, false, true, true);
+            if (val == void 0) val = "";
             if (this.options.cdataPropName) {
               currentNode.add(this.options.cdataPropName, [{ [this.options.textNodeName]: tagExp }]);
             } else {
-              currentNode.add(this.options.textNodeName, val2);
+              currentNode.add(this.options.textNodeName, val);
             }
             i = closeIndex + 2;
           } else {
@@ -925,7 +1220,14 @@ var require_OrderedObjParser = __commonJS({
             let attrExpPresent = result.attrExpPresent;
             let closeIndex = result.closeIndex;
             if (this.options.transformTagName) {
-              tagName = this.options.transformTagName(tagName);
+              const newTagName = this.options.transformTagName(tagName);
+              if (tagExp === tagName) {
+                tagExp = newTagName;
+              }
+              tagName = newTagName;
+            }
+            if (this.options.strictReservedNames && (tagName === this.options.commentPropName || tagName === this.options.cdataPropName || tagName === this.options.textNodeName || tagName === this.options.attributesGroupName)) {
+              throw new Error(`Invalid tag name: ${tagName}`);
             }
             if (currentNode && textData) {
               if (currentNode.tagname !== "!xml") {
@@ -940,7 +1242,8 @@ var require_OrderedObjParser = __commonJS({
             if (tagName !== xmlObj.tagname) {
               jPath += jPath ? "." + tagName : tagName;
             }
-            if (this.isItStopNode(this.options.stopNodes, jPath, tagName)) {
+            const startIndex = i;
+            if (this.isItStopNode(this.stopNodesExact, this.stopNodesWildcard, jPath, tagName)) {
               let tagContent = "";
               if (tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1) {
                 if (tagName[tagName.length - 1] === "/") {
@@ -968,7 +1271,7 @@ var require_OrderedObjParser = __commonJS({
               }
               jPath = jPath.substr(0, jPath.lastIndexOf("."));
               childNode.add(this.options.textNodeName, tagContent);
-              this.addChild(currentNode, childNode, jPath);
+              this.addChild(currentNode, childNode, jPath, startIndex);
             } else {
               if (tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1) {
                 if (tagName[tagName.length - 1] === "/") {
@@ -979,16 +1282,32 @@ var require_OrderedObjParser = __commonJS({
                   tagExp = tagExp.substr(0, tagExp.length - 1);
                 }
                 if (this.options.transformTagName) {
-                  tagName = this.options.transformTagName(tagName);
+                  const newTagName = this.options.transformTagName(tagName);
+                  if (tagExp === tagName) {
+                    tagExp = newTagName;
+                  }
+                  tagName = newTagName;
                 }
                 const childNode = new xmlNode(tagName);
                 if (tagName !== tagExp && attrExpPresent) {
                   childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
                 }
-                this.addChild(currentNode, childNode, jPath);
+                this.addChild(currentNode, childNode, jPath, startIndex);
                 jPath = jPath.substr(0, jPath.lastIndexOf("."));
+              } else if (this.options.unpairedTags.indexOf(tagName) !== -1) {
+                const childNode = new xmlNode(tagName);
+                if (tagName !== tagExp && attrExpPresent) {
+                  childNode[":@"] = this.buildAttributesMap(tagExp, jPath);
+                }
+                this.addChild(currentNode, childNode, jPath, startIndex);
+                jPath = jPath.substr(0, jPath.lastIndexOf("."));
+                i = result.closeIndex;
+                continue;
               } else {
                 const childNode = new xmlNode(tagName);
+                if (this.tagsNodeStack.length > this.options.maxNestedTags) {
+                  throw new Error("Maximum nested tags exceeded");
+                }
                 this.tagsNodeStack.push(currentNode);
                 if (tagName !== tagExp && attrExpPresent) {
                   childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
@@ -1006,59 +1325,110 @@ var require_OrderedObjParser = __commonJS({
       }
       return xmlObj.child;
     };
-    function addChild(currentNode, childNode, jPath) {
+    function addChild(currentNode, childNode, jPath, startIndex) {
+      if (!this.options.captureMetaData) startIndex = void 0;
       const result = this.options.updateTag(childNode.tagname, jPath, childNode[":@"]);
       if (result === false) {
       } else if (typeof result === "string") {
         childNode.tagname = result;
-        currentNode.addChild(childNode);
+        currentNode.addChild(childNode, startIndex);
       } else {
-        currentNode.addChild(childNode);
+        currentNode.addChild(childNode, startIndex);
       }
     }
-    var replaceEntitiesValue = function(val2) {
-      if (this.options.processEntities) {
-        for (let entityName2 in this.docTypeEntities) {
-          const entity = this.docTypeEntities[entityName2];
-          val2 = val2.replace(entity.regx, entity.val);
+    var replaceEntitiesValue = function(val, tagName, jPath) {
+      if (val.indexOf("&") === -1) {
+        return val;
+      }
+      const entityConfig = this.options.processEntities;
+      if (!entityConfig.enabled) {
+        return val;
+      }
+      if (entityConfig.allowedTags) {
+        if (!entityConfig.allowedTags.includes(tagName)) {
+          return val;
         }
-        for (let entityName2 in this.lastEntities) {
-          const entity = this.lastEntities[entityName2];
-          val2 = val2.replace(entity.regex, entity.val);
+      }
+      if (entityConfig.tagFilter) {
+        if (!entityConfig.tagFilter(tagName, jPath)) {
+          return val;
         }
-        if (this.options.htmlEntities) {
-          for (let entityName2 in this.htmlEntities) {
-            const entity = this.htmlEntities[entityName2];
-            val2 = val2.replace(entity.regex, entity.val);
+      }
+      for (let entityName in this.docTypeEntities) {
+        const entity = this.docTypeEntities[entityName];
+        const matches = val.match(entity.regx);
+        if (matches) {
+          this.entityExpansionCount += matches.length;
+          if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
+            throw new Error(
+              `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
+            );
+          }
+          const lengthBefore = val.length;
+          val = val.replace(entity.regx, entity.val);
+          if (entityConfig.maxExpandedLength) {
+            this.currentExpandedLength += val.length - lengthBefore;
+            if (this.currentExpandedLength > entityConfig.maxExpandedLength) {
+              throw new Error(
+                `Total expanded content size exceeded: ${this.currentExpandedLength} > ${entityConfig.maxExpandedLength}`
+              );
+            }
           }
         }
-        val2 = val2.replace(this.ampEntity.regex, this.ampEntity.val);
       }
-      return val2;
+      if (val.indexOf("&") === -1) return val;
+      for (const entityName of Object.keys(this.lastEntities)) {
+        const entity = this.lastEntities[entityName];
+        const matches = val.match(entity.regex);
+        if (matches) {
+          this.entityExpansionCount += matches.length;
+          if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
+            throw new Error(
+              `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
+            );
+          }
+        }
+        val = val.replace(entity.regex, entity.val);
+      }
+      if (val.indexOf("&") === -1) return val;
+      if (this.options.htmlEntities) {
+        for (const entityName of Object.keys(this.htmlEntities)) {
+          const entity = this.htmlEntities[entityName];
+          const matches = val.match(entity.regex);
+          if (matches) {
+            this.entityExpansionCount += matches.length;
+            if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
+              throw new Error(
+                `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
+              );
+            }
+          }
+          val = val.replace(entity.regex, entity.val);
+        }
+      }
+      val = val.replace(this.ampEntity.regex, this.ampEntity.val);
+      return val;
     };
-    function saveTextToParentTag(textData, currentNode, jPath, isLeafNode) {
+    function saveTextToParentTag(textData, parentNode, jPath, isLeafNode) {
       if (textData) {
-        if (isLeafNode === void 0) isLeafNode = Object.keys(currentNode.child).length === 0;
+        if (isLeafNode === void 0) isLeafNode = parentNode.child.length === 0;
         textData = this.parseTextData(
           textData,
-          currentNode.tagname,
+          parentNode.tagname,
           jPath,
           false,
-          currentNode[":@"] ? Object.keys(currentNode[":@"]).length !== 0 : false,
+          parentNode[":@"] ? Object.keys(parentNode[":@"]).length !== 0 : false,
           isLeafNode
         );
         if (textData !== void 0 && textData !== "")
-          currentNode.add(this.options.textNodeName, textData);
+          parentNode.add(this.options.textNodeName, textData);
         textData = "";
       }
       return textData;
     }
-    function isItStopNode(stopNodes, jPath, currentTagName) {
-      const allNodesExp = "*." + currentTagName;
-      for (const stopNodePath in stopNodes) {
-        const stopNodeExp = stopNodes[stopNodePath];
-        if (allNodesExp === stopNodeExp || jPath === stopNodeExp) return true;
-      }
+    function isItStopNode(stopNodesExact, stopNodesWildcard, jPath, currentTagName) {
+      if (stopNodesWildcard && stopNodesWildcard.has(currentTagName)) return true;
+      if (stopNodesExact && stopNodesExact.has(jPath)) return true;
       return false;
     }
     function tagExpWithClosingIndex(xmlData, i, closingChar = ">") {
@@ -1166,27 +1536,43 @@ var require_OrderedObjParser = __commonJS({
         }
       }
     }
-    function parseValue(val2, shouldParse, options) {
-      if (shouldParse && typeof val2 === "string") {
-        const newval = val2.trim();
+    function parseValue(val, shouldParse, options) {
+      if (shouldParse && typeof val === "string") {
+        const newval = val.trim();
         if (newval === "true") return true;
         else if (newval === "false") return false;
-        else return toNumber(val2, options);
+        else return toNumber(val, options);
       } else {
-        if (util.isExist(val2)) {
-          return val2;
+        if (util.isExist(val)) {
+          return val;
         } else {
           return "";
         }
       }
     }
+    function fromCodePoint(str, base, prefix) {
+      const codePoint = Number.parseInt(str, base);
+      if (codePoint >= 0 && codePoint <= 1114111) {
+        return String.fromCodePoint(codePoint);
+      } else {
+        return prefix + str + ";";
+      }
+    }
+    function sanitizeName(name, options) {
+      if (util.criticalProperties.includes(name)) {
+        throw new Error(`[SECURITY] Invalid name: "${name}" is a reserved JavaScript keyword that could cause prototype pollution`);
+      } else if (util.DANGEROUS_PROPERTY_NAMES.includes(name)) {
+        return options.onDangerousProperty(name);
+      }
+      return name;
+    }
     module.exports = OrderedObjParser;
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/node2json.js
+// node_modules/fast-xml-parser/src/xmlparser/node2json.js
 var require_node2json = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
+  "node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
     "use strict";
     function prettify(node, options) {
       return compress(node, options);
@@ -1206,26 +1592,26 @@ var require_node2json = __commonJS({
         } else if (property === void 0) {
           continue;
         } else if (tagObj[property]) {
-          let val2 = compress(tagObj[property], options, newJpath);
-          const isLeaf = isLeafTag(val2, options);
+          let val = compress(tagObj[property], options, newJpath);
+          const isLeaf = isLeafTag(val, options);
           if (tagObj[":@"]) {
-            assignAttributes(val2, tagObj[":@"], newJpath, options);
-          } else if (Object.keys(val2).length === 1 && val2[options.textNodeName] !== void 0 && !options.alwaysCreateTextNode) {
-            val2 = val2[options.textNodeName];
-          } else if (Object.keys(val2).length === 0) {
-            if (options.alwaysCreateTextNode) val2[options.textNodeName] = "";
-            else val2 = "";
+            assignAttributes(val, tagObj[":@"], newJpath, options);
+          } else if (Object.keys(val).length === 1 && val[options.textNodeName] !== void 0 && !options.alwaysCreateTextNode) {
+            val = val[options.textNodeName];
+          } else if (Object.keys(val).length === 0) {
+            if (options.alwaysCreateTextNode) val[options.textNodeName] = "";
+            else val = "";
           }
           if (compressedObj[property] !== void 0 && compressedObj.hasOwnProperty(property)) {
             if (!Array.isArray(compressedObj[property])) {
               compressedObj[property] = [compressedObj[property]];
             }
-            compressedObj[property].push(val2);
+            compressedObj[property].push(val);
           } else {
             if (options.isArray(property, newJpath, isLeaf)) {
-              compressedObj[property] = [val2];
+              compressedObj[property] = [val];
             } else {
-              compressedObj[property] = val2;
+              compressedObj[property] = val;
             }
           }
         }
@@ -1271,9 +1657,9 @@ var require_node2json = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
+// node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
 var require_XMLParser = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module) {
+  "node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module) {
     var { buildOptions } = require_OptionsBuilder();
     var OrderedObjParser = require_OrderedObjParser();
     var { prettify } = require_node2json();
@@ -1329,9 +1715,9 @@ var require_XMLParser = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
+// node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
 var require_orderedJs2Xml = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module) {
+  "node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module) {
     var EOL = "\n";
     function toXml(jArray, options) {
       let indentation = "";
@@ -1343,6 +1729,14 @@ var require_orderedJs2Xml = __commonJS({
     function arrToStr(arr3, options, jPath, indentation) {
       let xmlStr = "";
       let isPreviousElementTag = false;
+      if (!Array.isArray(arr3)) {
+        if (arr3 !== void 0 && arr3 !== null) {
+          let text = arr3.toString();
+          text = replaceEntitiesValue(text, options);
+          return text;
+        }
+        return "";
+      }
       for (let i = 0; i < arr3.length; i++) {
         const tagObj = arr3[i];
         const tagName = propName(tagObj);
@@ -1413,7 +1807,7 @@ var require_orderedJs2Xml = __commonJS({
       const keys = Object.keys(obj);
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
-        if (!obj.hasOwnProperty(key)) continue;
+        if (!Object.prototype.hasOwnProperty.call(obj, key)) continue;
         if (key !== ":@") return key;
       }
     }
@@ -1421,7 +1815,7 @@ var require_orderedJs2Xml = __commonJS({
       let attrStr = "";
       if (attrMap && !options.ignoreAttributes) {
         for (let attr in attrMap) {
-          if (!attrMap.hasOwnProperty(attr)) continue;
+          if (!Object.prototype.hasOwnProperty.call(attrMap, attr)) continue;
           let attrVal = options.attributeValueProcessor(attr, attrMap[attr]);
           attrVal = replaceEntitiesValue(attrVal, options);
           if (attrVal === true && options.suppressBooleanAttributes) {
@@ -1454,9 +1848,9 @@ var require_orderedJs2Xml = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
+// node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
 var require_json2xml = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module) {
+  "node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module) {
     "use strict";
     var buildFromOrderedJs = require_orderedJs2Xml();
     var getIgnoreAttributesFn = require_ignoreAttributes();
@@ -1532,24 +1926,26 @@ var require_json2xml = __commonJS({
     };
     Builder.prototype.j2x = function(jObj, level, ajPath) {
       let attrStr = "";
-      let val2 = "";
+      let val = "";
       const jPath = ajPath.join(".");
       for (let key in jObj) {
         if (!Object.prototype.hasOwnProperty.call(jObj, key)) continue;
         if (typeof jObj[key] === "undefined") {
           if (this.isAttribute(key)) {
-            val2 += "";
+            val += "";
           }
         } else if (jObj[key] === null) {
           if (this.isAttribute(key)) {
-            val2 += "";
+            val += "";
+          } else if (key === this.options.cdataPropName) {
+            val += "";
           } else if (key[0] === "?") {
-            val2 += this.indentate(level) + "<" + key + "?" + this.tagEndChar;
+            val += this.indentate(level) + "<" + key + "?" + this.tagEndChar;
           } else {
-            val2 += this.indentate(level) + "<" + key + "/" + this.tagEndChar;
+            val += this.indentate(level) + "<" + key + "/" + this.tagEndChar;
           }
         } else if (jObj[key] instanceof Date) {
-          val2 += this.buildTextValNode(jObj[key], key, "", level);
+          val += this.buildTextValNode(jObj[key], key, "", level);
         } else if (typeof jObj[key] !== "object") {
           const attr = this.isAttribute(key);
           if (attr && !this.ignoreAttributesFn(attr, jPath)) {
@@ -1557,9 +1953,9 @@ var require_json2xml = __commonJS({
           } else if (!attr) {
             if (key === this.options.textNodeName) {
               let newval = this.options.tagValueProcessor(key, "" + jObj[key]);
-              val2 += this.replaceEntitiesValue(newval);
+              val += this.replaceEntitiesValue(newval);
             } else {
-              val2 += this.buildTextValNode(jObj[key], key, "", level);
+              val += this.buildTextValNode(jObj[key], key, "", level);
             }
           }
         } else if (Array.isArray(jObj[key])) {
@@ -1570,8 +1966,8 @@ var require_json2xml = __commonJS({
             const item = jObj[key][j];
             if (typeof item === "undefined") {
             } else if (item === null) {
-              if (key[0] === "?") val2 += this.indentate(level) + "<" + key + "?" + this.tagEndChar;
-              else val2 += this.indentate(level) + "<" + key + "/" + this.tagEndChar;
+              if (key[0] === "?") val += this.indentate(level) + "<" + key + "?" + this.tagEndChar;
+              else val += this.indentate(level) + "<" + key + "/" + this.tagEndChar;
             } else if (typeof item === "object") {
               if (this.options.oneListGroup) {
                 const result = this.j2x(item, level + 1, ajPath.concat(key));
@@ -1595,7 +1991,7 @@ var require_json2xml = __commonJS({
           if (this.options.oneListGroup) {
             listTagVal = this.buildObjectNode(listTagVal, key, listTagAttr, level);
           }
-          val2 += listTagVal;
+          val += listTagVal;
         } else {
           if (this.options.attributesGroupName && key === this.options.attributesGroupName) {
             const Ks = Object.keys(jObj[key]);
@@ -1604,18 +2000,18 @@ var require_json2xml = __commonJS({
               attrStr += this.buildAttrPairStr(Ks[j], "" + jObj[key][Ks[j]]);
             }
           } else {
-            val2 += this.processTextOrObjNode(jObj[key], key, level, ajPath);
+            val += this.processTextOrObjNode(jObj[key], key, level, ajPath);
           }
         }
       }
-      return { attrStr, val: val2 };
+      return { attrStr, val };
     };
-    Builder.prototype.buildAttrPairStr = function(attrName, val2) {
-      val2 = this.options.attributeValueProcessor(attrName, "" + val2);
-      val2 = this.replaceEntitiesValue(val2);
-      if (this.options.suppressBooleanAttributes && val2 === "true") {
+    Builder.prototype.buildAttrPairStr = function(attrName, val) {
+      val = this.options.attributeValueProcessor(attrName, "" + val);
+      val = this.replaceEntitiesValue(val);
+      if (this.options.suppressBooleanAttributes && val === "true") {
         return " " + attrName;
-      } else return " " + attrName + '="' + val2 + '"';
+      } else return " " + attrName + '="' + val + '"';
     };
     function processTextOrObjNode(object, key, level, ajPath) {
       const result = this.j2x(object, level + 1, ajPath.concat(key));
@@ -1625,8 +2021,8 @@ var require_json2xml = __commonJS({
         return this.buildObjectNode(result.val, key, result.attrStr, level);
       }
     }
-    Builder.prototype.buildObjectNode = function(val2, key, attrStr, level) {
-      if (val2 === "") {
+    Builder.prototype.buildObjectNode = function(val, key, attrStr, level) {
+      if (val === "") {
         if (key[0] === "?") return this.indentate(level) + "<" + key + attrStr + "?" + this.tagEndChar;
         else {
           return this.indentate(level) + "<" + key + attrStr + this.closeTag(key) + this.tagEndChar;
@@ -1638,12 +2034,12 @@ var require_json2xml = __commonJS({
           piClosingChar = "?";
           tagEndExp = "";
         }
-        if ((attrStr || attrStr === "") && val2.indexOf("<") === -1) {
-          return this.indentate(level) + "<" + key + attrStr + piClosingChar + ">" + val2 + tagEndExp;
+        if ((attrStr || attrStr === "") && val.indexOf("<") === -1) {
+          return this.indentate(level) + "<" + key + attrStr + piClosingChar + ">" + val + tagEndExp;
         } else if (this.options.commentPropName !== false && key === this.options.commentPropName && piClosingChar.length === 0) {
-          return this.indentate(level) + `<!--${val2}-->` + this.newLine;
+          return this.indentate(level) + `<!--${val}-->` + this.newLine;
         } else {
-          return this.indentate(level) + "<" + key + attrStr + piClosingChar + this.tagEndChar + val2 + this.indentate(level) + tagEndExp;
+          return this.indentate(level) + "<" + key + attrStr + piClosingChar + this.tagEndChar + val + this.indentate(level) + tagEndExp;
         }
       }
     };
@@ -1658,15 +2054,15 @@ var require_json2xml = __commonJS({
       }
       return closeTag;
     };
-    Builder.prototype.buildTextValNode = function(val2, key, attrStr, level) {
+    Builder.prototype.buildTextValNode = function(val, key, attrStr, level) {
       if (this.options.cdataPropName !== false && key === this.options.cdataPropName) {
-        return this.indentate(level) + `<![CDATA[${val2}]]>` + this.newLine;
+        return this.indentate(level) + `<![CDATA[${val}]]>` + this.newLine;
       } else if (this.options.commentPropName !== false && key === this.options.commentPropName) {
-        return this.indentate(level) + `<!--${val2}-->` + this.newLine;
+        return this.indentate(level) + `<!--${val}-->` + this.newLine;
       } else if (key[0] === "?") {
         return this.indentate(level) + "<" + key + attrStr + "?" + this.tagEndChar;
       } else {
-        let textValue = this.options.tagValueProcessor(key, val2);
+        let textValue = this.options.tagValueProcessor(key, val);
         textValue = this.replaceEntitiesValue(textValue);
         if (textValue === "") {
           return this.indentate(level) + "<" + key + attrStr + this.closeTag(key) + this.tagEndChar;
@@ -1698,9 +2094,9 @@ var require_json2xml = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/fxp.js
+// node_modules/fast-xml-parser/src/fxp.js
 var require_fxp = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/fxp.js"(exports, module) {
+  "node_modules/fast-xml-parser/src/fxp.js"(exports, module) {
     "use strict";
     var validator = require_validator();
     var XMLParser2 = require_XMLParser();
@@ -1713,12 +2109,12 @@ var require_fxp = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
+// cli.ts
 import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/sigma-ids.ts
+// sigma-ids.ts
 var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 var _usedIds = /* @__PURE__ */ new Set();
 var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
@@ -1895,7 +2291,7 @@ function buildDerivedElements(elements) {
   return derived;
 }
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos.ts
+// cognos.ts
 function applyLearnedRules(expr, rules) {
   let s = expr || "";
   for (const r of rules || []) {
@@ -2259,10 +2655,10 @@ function parseJoinExpr(expr) {
 }
 var trunc = (s, n = 80) => s && s.length > n ? s.slice(0, n) + "\u2026" : s || "";
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+// cognos-report.ts
 var import_fast_xml_parser = __toESM(require_fxp(), 1);
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/metric-binding.ts
+// metric-binding.ts
 var canon = (f) => (f || "").replace(/\s+/g, "");
 function metricRefOrInline(inline, masterName, metrics) {
   if (typeof inline !== "string" || !metrics || metrics.length === 0) return inline;
@@ -2273,7 +2669,72 @@ function metricRefOrInline(inline, masterName, metrics) {
   return inline;
 }
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+// workbook-features.ts
+var VIZ_KIND = {
+  "com.ibm.vis.clusteredbar": "bar-chart",
+  "com.ibm.vis.stackedbar": "bar-chart",
+  "com.ibm.vis.clusteredcolumn": "bar-chart",
+  "com.ibm.vis.stackedcolumn": "bar-chart",
+  "com.ibm.vis.line": "line-chart",
+  "com.ibm.vis.spline": "line-chart",
+  "com.ibm.vis.area": "area-chart",
+  "com.ibm.vis.stackedarea": "area-chart",
+  "com.ibm.vis.pie": "pie-chart",
+  "com.ibm.vis.donut": "donut-chart",
+  "com.ibm.vis.clusteredcombination": "combo-chart",
+  "com.ibm.vis.stackedcombination": "combo-chart",
+  "com.ibm.vis.bubble": "scatter-chart",
+  "com.ibm.vis.scatter": "scatter-chart",
+  // Released in workbook code: required shape is source + columns + yAxis.
+  "com.ibm.vis.waterfall": "waterfall-chart",
+  "com.ibm.vis.waterfallchart": "waterfall-chart"
+};
+var VIZ_NO_ANALOG = {
+  "com.ibm.vis.network": "network diagram",
+  "com.ibm.vis.wordcloud": "word cloud",
+  "com.ibm.vis.packedbubble": "packed bubble",
+  "com.ibm.vis.treemap": "treemap"
+};
+var VIZ_GATED = {
+  "com.ibm.vis.box": "box plot",
+  "com.ibm.vis.boxplot": "box plot",
+  "com.ibm.vis.boxandwhisker": "box-and-whisker plot"
+};
+function workbookGap(feature, detail) {
+  return `\u26D4 WORKBOOK FEATURE GAP [${feature}]: ${detail}`;
+}
+
+// ../scripts/lib/code_rep.mjs
+var isObj = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+function flattenElements(doc) {
+  if (!isObj(doc) || !Array.isArray(doc.pages)) return doc;
+  const nested = [];
+  const pages = doc.pages.map((page) => {
+    const copy = { ...page };
+    if (Array.isArray(copy.elements)) nested.push(...copy.elements);
+    delete copy.elements;
+    return copy;
+  });
+  const elements = [];
+  const seen = /* @__PURE__ */ new Set();
+  for (const element of [...Array.isArray(doc.elements) ? doc.elements : [], ...nested]) {
+    const id = isObj(element) ? element.id : null;
+    if (id && seen.has(id)) continue;
+    if (id) seen.add(id);
+    elements.push(element);
+  }
+  return { ...doc, pages, elements };
+}
+function canonicalizeLayout(layoutXml) {
+  return String(layoutXml || "").replace(/<([/]?)LayoutElement\b/g, "<$1Element").replace(/<([/]?)GridContainer\b/g, "<$1Container");
+}
+function wrap(doc, extra = {}) {
+  const flattened = flattenElements(doc);
+  const canonical = isObj(flattened) && "layout" in flattened ? { ...flattened, layout: canonicalizeLayout(flattened.layout) } : flattened;
+  return { ...extra, document: canonical };
+}
+
+// cognos-report.ts
 var xmlParser = new import_fast_xml_parser.XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: "@_",
@@ -2309,6 +2770,71 @@ function findAll(node, tag, out = []) {
     }
   }
   return out;
+}
+var xmlEsc = (s) => s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+function buildAuthoritativeLayout(pages, byPage, containerChildren) {
+  const blocks = pages.map((page) => {
+    const elements = byPage.get(page.id) || [];
+    const nested = new Set([...containerChildren.values()].flat());
+    const lines = [];
+    let row = 1;
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+      if (nested.has(element.id)) continue;
+      const children = containerChildren.get(element.id);
+      if (children?.length) {
+        const height2 = Math.max(6, children.length * 11);
+        const inner = children.map(
+          (id, n) => `    <Element elementId="${xmlEsc(id)}" gridColumn="1 / 25" gridRow="${1 + n * 11} / ${1 + (n + 1) * 11}"/>`
+        ).join("\n");
+        lines.push(`  <Container elementId="${xmlEsc(element.id)}" type="grid" gridColumn="1 / 25" gridRow="${row} / ${row + height2}" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+${inner}
+  </Container>`);
+        row += height2;
+        continue;
+      }
+      if (element.kind === "page-break") {
+        lines.push(`  <Element elementId="${xmlEsc(element.id)}" gridColumn="1 / 25" gridRow="${row} / ${row + 1}"/>`);
+        row += 1;
+        continue;
+      }
+      if (element.kind === "kpi-chart") {
+        const run = [];
+        let j = i;
+        while (j < elements.length && !nested.has(elements[j].id) && elements[j].kind === "kpi-chart" && run.length < 4) {
+          run.push(elements[j]);
+          j++;
+        }
+        const span = Math.floor(24 / run.length);
+        run.forEach((kpi, n) => {
+          const c0 = 1 + n * span;
+          const c1 = n === run.length - 1 ? 25 : c0 + span;
+          lines.push(`  <Element elementId="${xmlEsc(kpi.id)}" gridColumn="${c0} / ${c1}" gridRow="${row} / ${row + 6}"/>`);
+        });
+        row += 6;
+        i = j - 1;
+        continue;
+      }
+      const next = elements[i + 1];
+      const isChart = element.kind.endsWith("-chart") && element.kind !== "kpi-chart";
+      const nextIsChart = !!next && !nested.has(next.id) && next.kind.endsWith("-chart") && next.kind !== "kpi-chart";
+      if (isChart && nextIsChart) {
+        lines.push(`  <Element elementId="${xmlEsc(element.id)}" gridColumn="1 / 13" gridRow="${row} / ${row + 11}"/>`);
+        lines.push(`  <Element elementId="${xmlEsc(next.id)}" gridColumn="13 / 25" gridRow="${row} / ${row + 11}"/>`);
+        row += 11;
+        i += 1;
+        continue;
+      }
+      const height = element.kind === "control" || element.kind === "navigation" || element.kind === "text" ? 3 : element.visibleAsSource === false ? 1 : 12;
+      lines.push(`  <Element elementId="${xmlEsc(element.id)}" gridColumn="1 / 25" gridRow="${row} / ${row + height}"/>`);
+      row += height;
+    }
+    return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${xmlEsc(page.id)}">
+${lines.join("\n")}
+</Page>`;
+  });
+  return `<?xml version="1.0" encoding="utf-8"?>
+${blocks.join("\n")}`;
 }
 function convertCognosReportToSigma(xml2, options = {}) {
   resetIds();
@@ -2458,10 +2984,39 @@ function convertCognosReportToSigma(xml2, options = {}) {
     if (nf) return { kind: "number", formatString: scaled(nf) ? `$,.${dec(nf, 1) + 2}s` : `,.${dec(nf, 2)}f` };
     return void 0;
   };
-  const pages = [];
   const reportPages = findAll(report.layouts || report, "reportPage").concat(findAll(report.layouts || report, "page"));
+  const pageNodes = reportPages.length ? reportPages : [{ "@_name": "Report" }];
+  const pages = pageNodes.map((p) => ({
+    id: sigmaShortId(),
+    name: p["@_name"] || "Report"
+  }));
+  const pageIdBySourceNode = /* @__PURE__ */ new WeakMap();
+  pageNodes.forEach((pageNode, i) => {
+    if (!pageNode || typeof pageNode !== "object") return;
+    for (const tag of ["singleton", "list", "crosstab", "vizControl", "pageBreak", "repeater", "repeaterTable", "block"]) {
+      for (const node of findAll(pageNode, tag)) {
+        if (node && typeof node === "object") pageIdBySourceNode.set(node, pages[i].id);
+      }
+    }
+  });
+  const elementsByPage = new Map(pages.map((p) => [p.id, []]));
+  const elementsBySourceNode = /* @__PURE__ */ new WeakMap();
+  const containerChildren = /* @__PURE__ */ new Map();
   const lists = findAll(report, "list");
   const pageEls = [];
+  const addToPage = (pageId, element) => {
+    elementsByPage.get(pageId).push(element);
+    if (element.kind !== "control") pageEls.push(element);
+  };
+  const addElement = (sourceNode, element) => {
+    const pageId = sourceNode && typeof sourceNode === "object" ? pageIdBySourceNode.get(sourceNode) || pages[0].id : pages[0].id;
+    addToPage(pageId, element);
+    if (sourceNode && typeof sourceNode === "object") {
+      const current = elementsBySourceNode.get(sourceNode) || [];
+      current.push(element);
+      elementsBySourceNode.set(sourceNode, current);
+    }
+  };
   const dmSource = (q) => ({ kind: "data-model", dataModelId: options.dataModelId || "<DM_ID \u2014 wire after posting the data model>", elementId: q.subject ? sigmaDisplayName(q.subject) : "<element>" });
   const bindMeasure = (formula, q) => {
     const map = options.metrics || {};
@@ -2572,7 +3127,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
       value: { columnId: valId }
     };
     applyQueryFilters(el, q);
-    pageEls.push(el);
+    addElement(sg, el);
   }
   for (const L of lists) {
     const qName = L["@_refQuery"];
@@ -2645,7 +3200,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
       el.groupings = [{ id: sigmaShortId(), groupBy: dimIds, calculations: measureIds }];
     }
     applyQueryFilters(el, q);
-    pageEls.push(el);
+    addElement(L, el);
   }
   const isTotal = (r) => /^(Total|Summary|Aggregate|Average|Count|Maximum|Minimum)\(/i.test(r || "");
   for (const X of findAll(report, "crosstab")) {
@@ -2689,7 +3244,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
       values
     };
     applyQueryFilters(el, q);
-    pageEls.push(el);
+    addElement(X, el);
   }
   const dsToQuery = /* @__PURE__ */ new Map();
   for (const ds of findAll(report, "reportDataStore")) {
@@ -2698,28 +3253,6 @@ function convertCognosReportToSigma(xml2, options = {}) {
     if (nm && rq) dsToQuery.set(nm, rq);
   }
   const ROLLUP_AGG = { total: "Sum", sum: "Sum", average: "Avg", avg: "Avg", count: "Count", countdistinct: "CountDistinct", maximum: "Max", minimum: "Min" };
-  const VIZ_KIND = {
-    "com.ibm.vis.clusteredbar": "bar-chart",
-    "com.ibm.vis.stackedbar": "bar-chart",
-    "com.ibm.vis.clusteredcolumn": "bar-chart",
-    "com.ibm.vis.stackedcolumn": "bar-chart",
-    "com.ibm.vis.line": "line-chart",
-    "com.ibm.vis.spline": "line-chart",
-    "com.ibm.vis.area": "area-chart",
-    "com.ibm.vis.stackedarea": "area-chart",
-    "com.ibm.vis.pie": "pie-chart",
-    "com.ibm.vis.donut": "donut-chart",
-    "com.ibm.vis.clusteredcombination": "combo-chart",
-    "com.ibm.vis.stackedcombination": "combo-chart",
-    "com.ibm.vis.bubble": "scatter-chart",
-    "com.ibm.vis.scatter": "scatter-chart"
-  };
-  const VIZ_NOANALOG = {
-    "com.ibm.vis.network": "network diagram",
-    "com.ibm.vis.wordcloud": "word cloud",
-    "com.ibm.vis.packedbubble": "packed bubble",
-    "com.ibm.vis.treemap": "treemap"
-  };
   const isMapViz = (t) => /tiledmap|choropleth|\bmap\b/.test(t);
   const chartSource = dmSource;
   const COGNOS_SCHEME = {
@@ -2752,14 +3285,42 @@ function convertCognosReportToSigma(xml2, options = {}) {
         for (const p of arr2(v)) {
           const nm = String(p?.["@_name"] || "");
           if (/palette|colou?r.?scheme|colou?rmodel/i.test(nm)) {
-            const val2 = txt(p);
-            if (val2) return val2;
+            const val = txt(p);
+            if (val) return val;
           }
         }
       }
     }
     const pal = findAll(V, "vcSlotData").map((s) => s["@_refPaletteDefinition"] || s["@_refPalette"]).find(Boolean) || V["@_refPaletteDefinition"] || V["@_refPalette"];
     return pal ? String(pal) : void 0;
+  };
+  const legendFromViz = (V) => {
+    let seen = false;
+    let visibility;
+    let position;
+    for (const tag of ["vizPropertyBooleanValue", "vizPropertyEnumValue", "vizPropertyStringValue"]) {
+      for (const prop of findAll(V, tag)) {
+        const name = String(prop["@_name"] || "");
+        if (!/legend/i.test(name)) continue;
+        seen = true;
+        const value = String(prop["@_value"] ?? txt(prop)).toLowerCase();
+        if (/visible|show|display/i.test(name)) visibility = /^(false|hidden|none|off|0)$/.test(value) ? "hidden" : "shown";
+        if (/position|placement|location/i.test(name)) {
+          const side = ["top", "bottom", "left", "right"].find((x) => value.includes(x));
+          if (side) position = side;
+        }
+      }
+    }
+    return seen ? { ...visibility ? { visibility } : {}, ...position ? { position } : {} } : void 0;
+  };
+  const styleFromNode = (node) => {
+    const css = findAll(node, "CSS").map((x) => String(x["@_value"] || txt(x))).join(";");
+    const style = {};
+    const background = css.match(/background(?:-color)?\s*:\s*(#[0-9a-f]{3,8})/i)?.[1];
+    if (background) style.backgroundColor = background;
+    const radius = css.match(/border-radius\s*:\s*([^;]+)/i)?.[1]?.trim();
+    if (radius && radius !== "0" && radius !== "0px") style.borderRadius = "round";
+    return Object.keys(style).length ? style : void 0;
   };
   const buildRefMarks = (V, q, vizName) => {
     const nodes = [...findAll(V, "baseline"), ...findAll(V, "vizBaseline")];
@@ -2844,6 +3405,40 @@ function convertCognosReportToSigma(xml2, options = {}) {
     const cats = slot("categories"), series = slot("series"), vals = slot("values");
     const sizes = slot("size"), xs = slot("x"), ys = slot("y"), colorSlot = slot("color");
     const kind = VIZ_KIND[vizType];
+    if (/progress|bullet|gauge/.test(vizType)) {
+      const valueEntry = vals[0] || sizes[0] || ys[0];
+      const valueId = addCol(valueEntry, true);
+      const valueCol = cols.find((c) => c.id === valueId);
+      if (!valueCol) {
+        warnings.push(workbookGap("progress", `chart "${vizName}" had no resolvable value measure; no progress element was emitted.`));
+        continue;
+      }
+      const sourceName = `${vizName} (progress source)`;
+      const source = {
+        id: sigmaShortId(),
+        kind: "table",
+        name: sourceName,
+        source: chartSource(q),
+        columns: cols,
+        order: cols.map((c) => c.id),
+        visibleAsSource: false
+      };
+      const percent = valueEntry?.format?.formatString?.includes("%");
+      const progress = {
+        id: sigmaShortId(),
+        kind: "progress",
+        name: vizName,
+        min: "0",
+        max: percent ? "1" : "100",
+        value: { columnId: valueId },
+        mode: percent ? "percent" : "value",
+        shape: /ring|radial|gauge/.test(vizType) ? "ring" : "bar"
+      };
+      progress.value = `[${sourceName}/${valueCol.name}]`;
+      addElement(V, source);
+      addElement(V, progress);
+      continue;
+    }
     if (isMapViz(vizType)) {
       const lat = slot("latlonglocations.latitude")[0] || slot("latitude")[0];
       const lon = slot("latlonglocations.longitude")[0] || slot("longitude")[0];
@@ -2853,6 +3448,8 @@ function convertCognosReportToSigma(xml2, options = {}) {
         const sizeId = addCol(slot("latlongsize")[0] || sizes[0], true);
         const colorId = addCol(slot("latlongcolor")[0] || colorSlot[0], true);
         const el2 = { id: sigmaShortId(), kind: "point-map", name: vizName, source: chartSource(q), columns: cols, order: [] };
+        const legend2 = legendFromViz(V);
+        if (legend2) el2.legend = legend2;
         if (latId) el2.latitude = { id: latId };
         if (lonId) el2.longitude = { id: lonId };
         if (sizeId) el2.size = { id: sizeId };
@@ -2863,7 +3460,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
           continue;
         }
         applyQueryFilters(el2, q);
-        pageEls.push(el2);
+        addElement(V, el2);
       } else if (region) {
         const regId = addCol(region, false);
         const colorId = addCol(slot("locationcolor")[0] || colorSlot[0] || slot("locationheight")[0], true);
@@ -2872,10 +3469,12 @@ function convertCognosReportToSigma(xml2, options = {}) {
           continue;
         }
         const el2 = { id: sigmaShortId(), kind: "region-map", name: vizName, source: chartSource(q), columns: cols, order: cols.map((c) => c.id), region: { id: regId, regionType: "country" } };
+        const legend2 = legendFromViz(V);
+        if (legend2) el2.legend = legend2;
         if (colorId) el2.color = { by: "scale", column: colorId };
         warnings.push(`chart "${vizName}" \u2192 region-map: defaulted regionType to "country" \u2014 set it to match your data (country / us-state / us-county / us-zipcode / us-cbsa / us-postal-place / ca-province).`);
         applyQueryFilters(el2, q);
-        pageEls.push(el2);
+        addElement(V, el2);
       } else {
         for (const c of findAll(V, "vcSlotDsColumn")) if (c["@_refDsColumn"]) addCol({ ref: c["@_refDsColumn"], rollup: c["@_rollupMethod"] }, !!c["@_rollupMethod"]);
         if (!cols.length) {
@@ -2884,25 +3483,37 @@ function convertCognosReportToSigma(xml2, options = {}) {
         }
         warnings.push(`chart "${vizName}" is a Cognos map (${vizType}) with no lat/long or named-location slot \u2014 emitted its data as a table; add geographic columns + a map in the workbook.`);
         const fb = { id: sigmaShortId(), kind: "table", name: `${vizName} (was map)`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) };
+        const measures = cols.filter((c) => /^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(c.formula)).map((c) => c.id);
+        const dimensions = cols.filter((c) => !measures.includes(c.id)).map((c) => c.id);
+        if (measures.length && dimensions.length) fb.groupings = [{ id: sigmaShortId(), groupBy: dimensions, calculations: measures }];
         applyQueryFilters(fb, q);
-        pageEls.push(fb);
+        addElement(V, fb);
       }
       continue;
     }
     if (!kind) {
-      const label = VIZ_NOANALOG[vizType] || vizType.replace("com.ibm.vis.", "");
+      const gated = VIZ_GATED[vizType];
+      const label = gated || VIZ_NO_ANALOG[vizType] || vizType.replace("com.ibm.vis.", "");
       for (const c of findAll(V, "vcSlotDsColumn")) if (c["@_refDsColumn"]) addCol({ ref: c["@_refDsColumn"], rollup: c["@_rollupMethod"] }, !!c["@_rollupMethod"]);
       if (!cols.length) {
         warnings.push(`<vizControl> "${vizName}" (${vizType}) had no resolvable columns \u2014 skipped.`);
         continue;
       }
-      warnings.push(`chart "${vizName}" is a Cognos ${label} (${vizType}) \u2014 Sigma has no native equivalent; emitted its data as a table. Re-pick a Sigma chart in the workbook.`);
+      warnings.push(workbookGap(
+        gated ? "box-chart (workspace gated)" : `visual ${vizType}`,
+        gated ? `chart "${vizName}" is a Cognos ${label}; Sigma box-chart is workspace-gated, so the converter preserved its data as a table instead of risking a masked entitlement failure. Enable and verify box-chart before replacing it.` : `chart "${vizName}" is a Cognos ${label}; no grounded Sigma mapping is cataloged. Its data was preserved as a table.`
+      ));
       const fb = { id: sigmaShortId(), kind: "table", name: `${vizName} (was ${label})`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) };
+      const measures = cols.filter((c) => /^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(c.formula)).map((c) => c.id);
+      const dimensions = cols.filter((c) => !measures.includes(c.id)).map((c) => c.id);
+      if (measures.length && dimensions.length) fb.groupings = [{ id: sigmaShortId(), groupBy: dimensions, calculations: measures }];
       applyQueryFilters(fb, q);
-      pageEls.push(fb);
+      addElement(V, fb);
       continue;
     }
     const el = { id: sigmaShortId(), kind, name: vizName, source: chartSource(q), columns: [], order: [] };
+    const legend = legendFromViz(V);
+    if (legend) el.legend = legend;
     if (kind === "pie-chart" || kind === "donut-chart") {
       const colorId = addCol(cats[0] || colorSlot[0], false);
       const valId = addCol(vals[0] || sizes[0], true);
@@ -2948,8 +3559,8 @@ function convertCognosReportToSigma(xml2, options = {}) {
         el.order = scols.map((c) => c.id);
         const sRefMarks2 = buildRefMarks(V, q, vizName);
         if (sRefMarks2.length) el.refMarks = sRefMarks2;
-        pageEls.push(src);
-        pageEls.push(el);
+        addElement(V, src);
+        addElement(V, el);
         continue;
       }
       if (xId) el.xAxis = { columnId: xId };
@@ -2959,7 +3570,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
       if (sRefMarks.length) el.refMarks = sRefMarks;
     } else {
       const xId = addCol(cats[0], false, true);
-      if (xId) {
+      if (xId && kind !== "waterfall-chart") {
         el.xAxis = { columnId: xId };
         if (cats[0]?.sort) el.xAxis.sort = { by: xId, direction: /desc/i.test(cats[0].sort) ? "descending" : "ascending" };
       }
@@ -2993,6 +3604,12 @@ function convertCognosReportToSigma(xml2, options = {}) {
         if (/\bbar\b/.test(vizType) && !/column/.test(vizType)) el.orientation = "horizontal";
       }
       if (kind === "combo-chart" && yIds.length > 1) warnings.push(`chart "${vizName}" \u2192 combo-chart: all measures placed on the primary axis as the same mark \u2014 set per-series shape / secondary axis in the workbook.`);
+      if (kind === "waterfall-chart" && cats.length > 1) {
+        warnings.push(workbookGap(
+          "waterfall category hierarchy",
+          `chart "${vizName}" has ${cats.length} Cognos category levels, but released waterfall-chart code exposes no xAxis hierarchy. All category columns were retained; verify the rendered step labels.`
+        ));
+      }
     }
     el.columns = cols;
     el.order = cols.map((c) => c.id);
@@ -3001,14 +3618,151 @@ function convertCognosReportToSigma(xml2, options = {}) {
       continue;
     }
     applyQueryFilters(el, q);
-    pageEls.push(el);
+    addElement(V, el);
+  }
+  for (const pageBreak of findAll(report, "pageBreak")) {
+    addElement(pageBreak, { id: sigmaShortId(), kind: "page-break" });
+  }
+  for (const drill of findAll(report, "drillBehavior")) {
+    if (!drill || typeof drill !== "object" || Object.keys(drill).length === 0) continue;
+    const id = sigmaShortId();
+    addToPage(pages[0].id, {
+      id,
+      kind: "control",
+      controlId: `drill-${id}`,
+      name: "Drill",
+      controlType: "drill"
+    });
+  }
+  for (const reportDrill of findAll(report, "reportDrill")) {
+    const name = reportDrill["@_name"] || "unnamed report drill";
+    const path = findAll(reportDrill, "reportPath")[0]?.["@_path"];
+    warnings.push(workbookGap(
+      "cross-report drill-through",
+      `"${name}" targets ${path || "another Cognos report"}. The released Sigma drill control is hierarchy drill, not cross-document navigation; wire a converted target page/document explicitly.`
+    ));
+  }
+  for (const repeater of [...findAll(report, "repeater"), ...findAll(report, "repeaterTable")]) {
+    const qName = repeater["@_refQuery"];
+    const q = queries.get(qName);
+    if (!q) {
+      warnings.push(workbookGap("repeater", `refQuery="${qName || "(missing)"}" has no matching query; repeater was not emitted.`));
+      continue;
+    }
+    const refs = [...new Set(findAll(repeater, "dataItemValue").map((x) => x["@_refDataItem"]).filter(Boolean))];
+    const sourceName = `${repeater["@_name"] || qName} source`;
+    const sourceColumns = refs.flatMap((ref) => {
+      const di = q.items.get(ref);
+      if (!di) return [];
+      const translated = translate(di.expression, q);
+      translated.warns.forEach((w) => warnings.push(`"${qName}.${ref}": ${w}`));
+      return [{ id: sigmaShortId(), name: sigmaDisplayName(di.name), formula: translated.formula }];
+    });
+    const source = {
+      id: sigmaShortId(),
+      kind: "table",
+      name: sourceName,
+      source: dmSource(q),
+      columns: sourceColumns,
+      order: sourceColumns.map((c) => c.id),
+      visibleAsSource: false
+    };
+    addElement(repeater, source);
+    const rc = {
+      id: sigmaShortId(),
+      kind: "repeated-container",
+      name: repeater["@_name"] || `${qName} repeater`,
+      source: { kind: "table", elementId: source.id },
+      arrangement: "list",
+      cardSize: "small",
+      noDataText: "No rows",
+      cardStyle: styleFromNode(repeater)
+    };
+    addElement(repeater, rc);
+    const children = [];
+    for (const ref of refs) {
+      const di = q.items.get(ref);
+      if (!di) continue;
+      const child = {
+        id: sigmaShortId(),
+        kind: "text",
+        body: `{{[${sourceName} repeated container/${sigmaDisplayName(di.name)}]}}`
+      };
+      addElement(repeater, child);
+      children.push(child.id);
+    }
+    if (children.length) containerChildren.set(rc.id, children);
+    else warnings.push(workbookGap(
+      "repeater content",
+      `"${rc.name}" had no resolvable dataItemValue children. The repeated-container shell was preserved, but its card content must be authored.`
+    ));
+  }
+  const claimedPanelChildren = /* @__PURE__ */ new Set();
+  for (const block of findAll(report, "block")) {
+    if (!block["@_name"]) continue;
+    const children = [];
+    for (const tag of ["singleton", "list", "crosstab", "vizControl", "repeater", "repeaterTable"]) {
+      for (const node of findAll(block, tag)) {
+        for (const element of elementsBySourceNode.get(node) || []) {
+          if (!claimedPanelChildren.has(element.id)) {
+            children.push(element.id);
+            claimedPanelChildren.add(element.id);
+          }
+        }
+      }
+    }
+    if (!children.length) continue;
+    const panel = {
+      id: sigmaShortId(),
+      kind: "container",
+      name: sigmaDisplayName(block["@_name"]),
+      ...styleFromNode(block) ? { style: styleFromNode(block) } : {}
+    };
+    addElement(block, panel);
+    containerChildren.set(panel.id, children);
   }
   const controlEls = [...controls.values()];
-  pages.push({ id: sigmaShortId(), name: reportPages[0]?.["@_name"] || "Report", elements: [...controlEls, ...pageEls] });
+  controlEls.forEach((control) => addToPage(pages[0].id, control));
+  if (pages.length > 1 && report["@_viewPagesAsTabs"]) {
+    const pageLabels = Object.fromEntries(pages.map((p) => [p.id, p.name]));
+    for (const page of pages) {
+      const nav = {
+        id: sigmaShortId(),
+        kind: "navigation",
+        mode: "auto",
+        pageLabels
+      };
+      elementsByPage.get(page.id).unshift(nav);
+    }
+  }
   for (const fnode of findAll(report, "summaryFilter")) {
     const fexpr = txt(fnode.filterExpression || fnode.expression);
     if (fexpr) warnings.push(`summary filter: "${fexpr.slice(0, 80)}" \u2014 post-aggregation filter; re-create as a Sigma filter on the aggregated column.`);
   }
+  const panels = [];
+  pageNodes.forEach((pageNode, i) => {
+    const header = findAll(pageNode, "pageHeader")[0];
+    if (header) {
+      const style = styleFromNode(header);
+      panels.push({
+        id: sigmaShortId(),
+        type: "header",
+        title: `${pages[i].name} header`,
+        pages: [pages[i].id],
+        config: {
+          scroll: "none",
+          borderStyle: "none",
+          ...style?.backgroundColor ? { backgroundColor: style.backgroundColor } : {}
+        }
+      });
+    }
+    if (findAll(pageNode, "pageFooter").length) {
+      warnings.push(workbookGap(
+        "page footer panel",
+        `page "${pages[i].name}" has a Cognos pageFooter, but released workbook panels support header/sidebar only. Preserve footer content as ordinary page elements or a page-break print section.`
+      ));
+    }
+  });
   const stats = {
     queries: queries.size,
     tables: pageEls.filter((e) => e.kind === "table").length,
@@ -3020,16 +3774,31 @@ function convertCognosReportToSigma(xml2, options = {}) {
     filters: pageEls.reduce((n, e) => n + (e.filters?.length || 0), 0),
     controls: controls.size,
     refMarks: pageEls.reduce((n, e) => n + (e.refMarks?.length || 0), 0),
-    scaleColors: pageEls.filter((e) => e.color?.by === "scale").length
+    scaleColors: pageEls.filter((e) => e.color?.by === "scale").length,
+    pages: pages.length,
+    progress: pageEls.filter((e) => e.kind === "progress").length,
+    repeaters: pageEls.filter((e) => e.kind === "repeated-container").length,
+    panels: pageEls.filter((e) => e.kind === "container").length,
+    pagePanels: panels.length,
+    pageBreaks: pageEls.filter((e) => e.kind === "page-break").length
+  };
+  const elements = pages.flatMap((page) => elementsByPage.get(page.id) || []);
+  const document = {
+    schemaVersion: 1,
+    kind: "workbook",
+    pages,
+    elements,
+    layout: buildAuthoritativeLayout(pages, elementsByPage, containerChildren),
+    ...panels.length ? { panels } : {}
   };
   return {
-    workbook: { name: reportName, schemaVersion: 1, pages, controls: controlEls },
+    workbook: wrap(document, { name: reportName }),
     warnings,
     stats
   };
 }
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
+// cli.ts
 function loadLearnedRules() {
   try {
     const p = join(homedir(), ".cognos-to-sigma", "learned-rules.json");

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
@@ -29,6 +29,9 @@ import { XMLParser } from 'fast-xml-parser';
 import { resetIds, sigmaShortId, sigmaDisplayName } from './sigma-ids.js';
 import { translateCognosExpr, type CognosQuerySubject } from './cognos.js';
 import { metricRefOrInline, type BindMetric } from './metric-binding.js';
+import { VIZ_GATED, VIZ_KIND, VIZ_NO_ANALOG, workbookGap } from './workbook-features.js';
+// @ts-expect-error The vendored runtime adapter is plain ESM; esbuild bundles it.
+import * as CodeRep from '../scripts/lib/code_rep.mjs';
 
 const xmlParser = new XMLParser({
   ignoreAttributes: false, attributeNamePrefix: '@_', trimValues: true,
@@ -47,7 +50,7 @@ interface WbControl {
   source?: Record<string, any>; value?: string | null;                                     // segmented (parameter)
 }
 interface WbElement {
-  id: string; kind: string; name: string; source: Record<string, any>;
+  id: string; kind: string; name?: string; source?: Record<string, any>;
   columns?: WbColumn[]; order?: string[]; filters?: any[];
   groupings?: Array<{ id: string; groupBy: string[]; calculations: string[] }>;            // grouped table
   rowsBy?: Array<{ id: string }>; columnsBy?: Array<{ id: string }>; values?: string[];   // pivot
@@ -60,6 +63,13 @@ interface WbElement {
   visibleAsSource?: boolean;                                                                // hidden grouped source (scatter)
   refMarks?: WbRefMark[];                                                                    // reference / baseline lines
   dataLabel?: { labels: string };                                                            // value labels (bar)
+  legend?: { visibility?: 'shown' | 'hidden'; position?: 'top' | 'bottom' | 'left' | 'right' };
+  style?: Record<string, any>;
+  body?: string;
+  mode?: string; options?: any[]; pageLabels?: Record<string, string>;
+  tabs?: Array<{ name: string }>;
+  min?: string; max?: string; shape?: string;
+  arrangement?: string; cardSize?: string; cardStyle?: Record<string, any>; noDataText?: string;
 }
 // A Sigma reference line. `value` MUST be the wrapped {type:formula,formula:"…"}
 // form — a bare number 400s at POST. label.visibility must be 'shown' (not
@@ -71,9 +81,17 @@ interface WbRefMark {
   line?: { color?: string; width?: number };
   label?: { visibility: 'shown'; text: string };
 }
-interface WbPage { id: string; name: string; elements: WbElement[]; }
+interface WbPage { id: string; name: string; visibility?: 'shown' | 'hidden'; }
 export interface CognosReportResult {
-  workbook: { name: string; schemaVersion: number; pages: WbPage[]; controls?: WbControl[] };
+  workbook: {
+    name: string;
+    document: {
+      schemaVersion: number; kind: 'workbook'; pages: WbPage[];
+      elements: Array<WbElement | WbControl>; layout: string;
+      panels?: Array<Record<string, any>>;
+      settings?: Record<string, any>;
+    };
+  };
   warnings: string[];
   stats: Record<string, number>;
 }
@@ -100,6 +118,78 @@ function findAll(node: any, tag: string, out: any[] = []): any[] {
     }
   }
   return out;
+}
+
+const xmlEsc = (s: string): string => s.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+  .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/**
+ * The current workbook representation has a flat document.elements collection.
+ * Page ownership exists only in the authoritative document.layout XML, so every
+ * emitted element (including hidden source tables and containers) is placed
+ * exactly once. Pages themselves remain metadata-only.
+ */
+function buildAuthoritativeLayout(
+  pages: WbPage[],
+  byPage: Map<string, Array<WbElement | WbControl>>,
+  containerChildren: Map<string, string[]>,
+): string {
+  const blocks = pages.map((page) => {
+    const elements = byPage.get(page.id) || [];
+    const nested = new Set([...containerChildren.values()].flat());
+    const lines: string[] = [];
+    let row = 1;
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i] as WbElement;
+      if (nested.has(element.id)) continue;
+      const children = containerChildren.get(element.id);
+      if (children?.length) {
+        const height = Math.max(6, children.length * 11);
+        const inner = children.map((id, n) =>
+          `    <Element elementId="${xmlEsc(id)}" gridColumn="1 / 25" gridRow="${1 + n * 11} / ${1 + (n + 1) * 11}"/>`,
+        ).join('\n');
+        lines.push(`  <Container elementId="${xmlEsc(element.id)}" type="grid" gridColumn="1 / 25" gridRow="${row} / ${row + height}" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">\n${inner}\n  </Container>`);
+        row += height;
+        continue;
+      }
+      if (element.kind === 'page-break') {
+        lines.push(`  <Element elementId="${xmlEsc(element.id)}" gridColumn="1 / 25" gridRow="${row} / ${row + 1}"/>`);
+        row += 1;
+        continue;
+      }
+      if (element.kind === 'kpi-chart') {
+        const run: WbElement[] = [];
+        let j = i;
+        while (j < elements.length && !nested.has((elements[j] as WbElement).id)
+          && (elements[j] as WbElement).kind === 'kpi-chart' && run.length < 4) {
+          run.push(elements[j] as WbElement); j++;
+        }
+        const span = Math.floor(24 / run.length);
+        run.forEach((kpi, n) => {
+          const c0 = 1 + n * span;
+          const c1 = n === run.length - 1 ? 25 : c0 + span;
+          lines.push(`  <Element elementId="${xmlEsc(kpi.id)}" gridColumn="${c0} / ${c1}" gridRow="${row} / ${row + 6}"/>`);
+        });
+        row += 6; i = j - 1;
+        continue;
+      }
+      const next = elements[i + 1] as WbElement | undefined;
+      const isChart = element.kind.endsWith('-chart') && element.kind !== 'kpi-chart';
+      const nextIsChart = !!next && !nested.has(next.id) && next.kind.endsWith('-chart') && next.kind !== 'kpi-chart';
+      if (isChart && nextIsChart) {
+        lines.push(`  <Element elementId="${xmlEsc(element.id)}" gridColumn="1 / 13" gridRow="${row} / ${row + 11}"/>`);
+        lines.push(`  <Element elementId="${xmlEsc(next.id)}" gridColumn="13 / 25" gridRow="${row} / ${row + 11}"/>`);
+        row += 11; i += 1;
+        continue;
+      }
+      const height = element.kind === 'control' || element.kind === 'navigation' || element.kind === 'text'
+        ? 3 : element.visibleAsSource === false ? 1 : 12;
+      lines.push(`  <Element elementId="${xmlEsc(element.id)}" gridColumn="1 / 25" gridRow="${row} / ${row + height}"/>`);
+      row += height;
+    }
+    return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${xmlEsc(page.id)}">\n${lines.join('\n')}\n</Page>`;
+  });
+  return `<?xml version="1.0" encoding="utf-8"?>\n${blocks.join('\n')}`;
 }
 
 // ── convert ─────────────────────────────────────────────────────────────────
@@ -283,10 +373,40 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     return undefined;
   };
 
-  const pages: WbPage[] = [];
   const reportPages = findAll(report.layouts || report, 'reportPage').concat(findAll(report.layouts || report, 'page'));
+  const pageNodes = reportPages.length ? reportPages : [{ '@_name': 'Report' }];
+  const pages: WbPage[] = pageNodes.map((p) => ({
+    id: sigmaShortId(),
+    name: p['@_name'] || 'Report',
+  }));
+  const pageIdBySourceNode = new WeakMap<object, string>();
+  pageNodes.forEach((pageNode, i) => {
+    if (!pageNode || typeof pageNode !== 'object') return;
+    for (const tag of ['singleton', 'list', 'crosstab', 'vizControl', 'pageBreak', 'repeater', 'repeaterTable', 'block']) {
+      for (const node of findAll(pageNode, tag)) {
+        if (node && typeof node === 'object') pageIdBySourceNode.set(node, pages[i].id);
+      }
+    }
+  });
+  const elementsByPage = new Map<string, Array<WbElement | WbControl>>(pages.map((p) => [p.id, []]));
+  const elementsBySourceNode = new WeakMap<object, WbElement[]>();
+  const containerChildren = new Map<string, string[]>();
   const lists = findAll(report, 'list');
   const pageEls: WbElement[] = [];
+  const addToPage = (pageId: string, element: WbElement | WbControl) => {
+    elementsByPage.get(pageId)!.push(element);
+    if ((element as WbElement).kind !== 'control') pageEls.push(element as WbElement);
+  };
+  const addElement = (sourceNode: any, element: WbElement) => {
+    const pageId = sourceNode && typeof sourceNode === 'object'
+      ? pageIdBySourceNode.get(sourceNode) || pages[0].id : pages[0].id;
+    addToPage(pageId, element);
+    if (sourceNode && typeof sourceNode === 'object') {
+      const current = elementsBySourceNode.get(sourceNode) || [];
+      current.push(element);
+      elementsBySourceNode.set(sourceNode, current);
+    }
+  };
 
   // Every element sources the migrated DM element. The converter emits the query
   // SUBJECT display name as the elementId placeholder — remap-wb-to-dm-ids.mjs
@@ -412,7 +532,7 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       columns: cols, order: cols.map((c) => c.id), value: { columnId: valId },
     };
     applyQueryFilters(el, q);
-    pageEls.push(el);
+    addElement(sg, el);
   }
 
   for (const L of lists) {
@@ -479,7 +599,7 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       el.groupings = [{ id: sigmaShortId(), groupBy: dimIds, calculations: measureIds }];
     }
     applyQueryFilters(el, q);
-    pageEls.push(el);
+    addElement(L, el);
   }
 
   // 2b) crosstabs → pivot-table elements (rows edge → rowsBy, columns edge → columnsBy, measure → values)
@@ -512,7 +632,7 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       columns: cols, order: cols.map((c) => c.id), rowsBy, columnsBy, values,
     };
     applyQueryFilters(el, q);
-    pageEls.push(el);
+    addElement(X, el);
   }
 
   // 2c) charts (RAVE2 <vizControl>) → Sigma chart elements
@@ -524,21 +644,8 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     if (nm && rq) dsToQuery.set(nm, rq);
   }
   const ROLLUP_AGG: Record<string, string> = { total: 'Sum', sum: 'Sum', average: 'Avg', avg: 'Avg', count: 'Count', countdistinct: 'CountDistinct', maximum: 'Max', minimum: 'Min' };
-  // Cognos vizControl type → Sigma chart kind (only types with a clean native analog)
-  const VIZ_KIND: Record<string, string> = {
-    'com.ibm.vis.clusteredbar': 'bar-chart', 'com.ibm.vis.stackedbar': 'bar-chart',
-    'com.ibm.vis.clusteredcolumn': 'bar-chart', 'com.ibm.vis.stackedcolumn': 'bar-chart',
-    'com.ibm.vis.line': 'line-chart', 'com.ibm.vis.spline': 'line-chart',
-    'com.ibm.vis.area': 'area-chart', 'com.ibm.vis.stackedarea': 'area-chart',
-    'com.ibm.vis.pie': 'pie-chart', 'com.ibm.vis.donut': 'donut-chart',
-    'com.ibm.vis.clusteredcombination': 'combo-chart', 'com.ibm.vis.stackedcombination': 'combo-chart',
-    'com.ibm.vis.bubble': 'scatter-chart', 'com.ibm.vis.scatter': 'scatter-chart',
-  };
-  // types Sigma has no native element for — emit the data as a table + a loud flag (don't fake the viz)
-  const VIZ_NOANALOG: Record<string, string> = {
-    'com.ibm.vis.network': 'network diagram', 'com.ibm.vis.wordcloud': 'word cloud',
-    'com.ibm.vis.packedbubble': 'packed bubble', 'com.ibm.vis.treemap': 'treemap',
-  };
+  // Enumerated chart mappings and gated/no-analog fallbacks live in the
+  // grounded workbook feature catalog (`workbook-features.ts`).
   const isMapViz = (t: string) => /tiledmap|choropleth|\bmap\b/.test(t);
   const chartSource = dmSource;
 
@@ -586,6 +693,36 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     const pal = (findAll(V, 'vcSlotData').map((s: any) => s['@_refPaletteDefinition'] || s['@_refPalette']).find(Boolean))
       || V['@_refPaletteDefinition'] || V['@_refPalette'];
     return pal ? String(pal) : undefined;
+  };
+
+  const legendFromViz = (V: any): WbElement['legend'] | undefined => {
+    let seen = false;
+    let visibility: 'shown' | 'hidden' | undefined;
+    let position: 'top' | 'bottom' | 'left' | 'right' | undefined;
+    for (const tag of ['vizPropertyBooleanValue', 'vizPropertyEnumValue', 'vizPropertyStringValue']) {
+      for (const prop of findAll(V, tag)) {
+        const name = String(prop['@_name'] || '');
+        if (!/legend/i.test(name)) continue;
+        seen = true;
+        const value = String(prop['@_value'] ?? txt(prop)).toLowerCase();
+        if (/visible|show|display/i.test(name)) visibility = /^(false|hidden|none|off|0)$/.test(value) ? 'hidden' : 'shown';
+        if (/position|placement|location/i.test(name)) {
+          const side = (['top', 'bottom', 'left', 'right'] as const).find((x) => value.includes(x));
+          if (side) position = side;
+        }
+      }
+    }
+    return seen ? { ...(visibility ? { visibility } : {}), ...(position ? { position } : {}) } : undefined;
+  };
+
+  const styleFromNode = (node: any): Record<string, any> | undefined => {
+    const css = findAll(node, 'CSS').map((x: any) => String(x['@_value'] || txt(x))).join(';');
+    const style: Record<string, any> = {};
+    const background = css.match(/background(?:-color)?\s*:\s*(#[0-9a-f]{3,8})/i)?.[1];
+    if (background) style.backgroundColor = background;
+    const radius = css.match(/border-radius\s*:\s*([^;]+)/i)?.[1]?.trim();
+    if (radius && radius !== '0' && radius !== '0px') style.borderRadius = 'round';
+    return Object.keys(style).length ? style : undefined;
   };
 
   // RAVE2 reference lines / baselines → Sigma refMarks. Cognos expresses these as
@@ -677,6 +814,36 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     const sizes = slot('size'), xs = slot('x'), ys = slot('y'), colorSlot = slot('color');
     const kind = VIZ_KIND[vizType];
 
+    // Progress/bullet/gauge visuals now have a native workbook-code element.
+    // It has no source/columns of its own, so retain a hidden aggregate source
+    // table and bind the progress formula to that table's display name.
+    if (/progress|bullet|gauge/.test(vizType)) {
+      const valueEntry = vals[0] || sizes[0] || ys[0];
+      const valueId = addCol(valueEntry, true);
+      const valueCol = cols.find((c) => c.id === valueId);
+      if (!valueCol) {
+        warnings.push(workbookGap('progress', `chart "${vizName}" had no resolvable value measure; no progress element was emitted.`));
+        continue;
+      }
+      const sourceName = `${vizName} (progress source)`;
+      const source: WbElement = {
+        id: sigmaShortId(), kind: 'table', name: sourceName, source: chartSource(q),
+        columns: cols, order: cols.map((c) => c.id), visibleAsSource: false,
+      };
+      const percent = valueEntry?.format?.formatString?.includes('%');
+      const progress: WbElement = {
+        id: sigmaShortId(), kind: 'progress', name: vizName,
+        min: '0', max: percent ? '1' : '100',
+        value: { columnId: valueId },
+        mode: percent ? 'percent' : 'value', shape: /ring|radial|gauge/.test(vizType) ? 'ring' : 'bar',
+      };
+      // The progress schema's value is a formula string, not a column pointer.
+      (progress as any).value = `[${sourceName}/${valueCol.name}]`;
+      addElement(V, source);
+      addElement(V, progress);
+      continue;
+    }
+
     // maps: Cognos tiledmap → Sigma point-map (lat/long slots) or region-map (named-location slots)
     if (isMapViz(vizType)) {
       const lat = slot('latlonglocations.latitude')[0] || slot('latitude')[0];
@@ -687,6 +854,7 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
         const sizeId = addCol(slot('latlongsize')[0] || sizes[0], true);
         const colorId = addCol(slot('latlongcolor')[0] || colorSlot[0], true);
         const el: WbElement = { id: sigmaShortId(), kind: 'point-map', name: vizName, source: chartSource(q), columns: cols, order: [] };
+        const legend = legendFromViz(V); if (legend) el.legend = legend;
         if (latId) el.latitude = { id: latId };
         if (lonId) el.longitude = { id: lonId };
         if (sizeId) el.size = { id: sizeId };
@@ -694,41 +862,53 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
         el.order = cols.map((c) => c.id);
         if (!cols.length) { warnings.push(`<vizControl> map "${vizName}" had no resolvable lat/long columns — skipped.`); continue; }
         applyQueryFilters(el, q);
-        pageEls.push(el);
+        addElement(V, el);
       } else if (region) {
         const regId = addCol(region, false);
         const colorId = addCol(slot('locationcolor')[0] || colorSlot[0] || slot('locationheight')[0], true);
         if (!regId) { warnings.push(`<vizControl> map "${vizName}" had no resolvable location column — skipped.`); continue; }
         const el: WbElement = { id: sigmaShortId(), kind: 'region-map', name: vizName, source: chartSource(q), columns: cols, order: cols.map((c) => c.id), region: { id: regId, regionType: 'country' } };
+        const legend = legendFromViz(V); if (legend) el.legend = legend;
         if (colorId) el.color = { by: 'scale', column: colorId };
         warnings.push(`chart "${vizName}" → region-map: defaulted regionType to "country" — set it to match your data (country / us-state / us-county / us-zipcode / us-cbsa / us-postal-place / ca-province).`);
         applyQueryFilters(el, q);
-        pageEls.push(el);
+        addElement(V, el);
       } else {
         // a map with neither coordinate nor named-location slots → table fallback
         for (const c of findAll(V, 'vcSlotDsColumn')) if (c['@_refDsColumn']) addCol({ ref: c['@_refDsColumn'], rollup: c['@_rollupMethod'] }, !!c['@_rollupMethod']);
         if (!cols.length) { warnings.push(`<vizControl> map "${vizName}" (${vizType}) had no resolvable columns — skipped.`); continue; }
         warnings.push(`chart "${vizName}" is a Cognos map (${vizType}) with no lat/long or named-location slot — emitted its data as a table; add geographic columns + a map in the workbook.`);
         const fb: WbElement = { id: sigmaShortId(), kind: 'table', name: `${vizName} (was map)`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) };
+        const measures = cols.filter((c) => /^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(c.formula)).map((c) => c.id);
+        const dimensions = cols.filter((c) => !measures.includes(c.id)).map((c) => c.id);
+        if (measures.length && dimensions.length) fb.groupings = [{ id: sigmaShortId(), groupBy: dimensions, calculations: measures }];
         applyQueryFilters(fb, q);
-        pageEls.push(fb);
+        addElement(V, fb);
       }
       continue;
     }
 
     if (!kind) {
       // no native Sigma chart → table fallback + flag (collect every slot column, incl. map latlong/etc.)
-      const label = VIZ_NOANALOG[vizType] || vizType.replace('com.ibm.vis.', '');
+      const gated = VIZ_GATED[vizType];
+      const label = gated || VIZ_NO_ANALOG[vizType] || vizType.replace('com.ibm.vis.', '');
       for (const c of findAll(V, 'vcSlotDsColumn')) if (c['@_refDsColumn']) addCol({ ref: c['@_refDsColumn'], rollup: c['@_rollupMethod'] }, !!c['@_rollupMethod']);
       if (!cols.length) { warnings.push(`<vizControl> "${vizName}" (${vizType}) had no resolvable columns — skipped.`); continue; }
-      warnings.push(`chart "${vizName}" is a Cognos ${label} (${vizType}) — Sigma has no native equivalent; emitted its data as a table. Re-pick a Sigma chart in the workbook.`);
+      warnings.push(workbookGap(gated ? 'box-chart (workspace gated)' : `visual ${vizType}`,
+        gated
+          ? `chart "${vizName}" is a Cognos ${label}; Sigma box-chart is workspace-gated, so the converter preserved its data as a table instead of risking a masked entitlement failure. Enable and verify box-chart before replacing it.`
+          : `chart "${vizName}" is a Cognos ${label}; no grounded Sigma mapping is cataloged. Its data was preserved as a table.`));
       const fb: WbElement = { id: sigmaShortId(), kind: 'table', name: `${vizName} (was ${label})`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) };
+      const measures = cols.filter((c) => /^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(c.formula)).map((c) => c.id);
+      const dimensions = cols.filter((c) => !measures.includes(c.id)).map((c) => c.id);
+      if (measures.length && dimensions.length) fb.groupings = [{ id: sigmaShortId(), groupBy: dimensions, calculations: measures }];
       applyQueryFilters(fb, q);
-      pageEls.push(fb);
+      addElement(V, fb);
       continue;
     }
 
     const el: WbElement = { id: sigmaShortId(), kind, name: vizName, source: chartSource(q), columns: [], order: [] };
+    const legend = legendFromViz(V); if (legend) el.legend = legend;
 
     if (kind === 'pie-chart' || kind === 'donut-chart') {
       const colorId = addCol(cats[0] || colorSlot[0], false);
@@ -775,8 +955,8 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
         el.columns = scols; el.order = scols.map((c) => c.id);
         const sRefMarks = buildRefMarks(V, q, vizName);   // e.g. a target line at y=<value>
         if (sRefMarks.length) el.refMarks = sRefMarks;
-        pageEls.push(src);
-        pageEls.push(el);
+        addElement(V, src);
+        addElement(V, el);
         continue;   // self-contained: skip the shared el.columns=cols assignment below
       }
       // <2 measures or no category dim: fall back to a plain ungrouped scatter.
@@ -786,9 +966,11 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       const sRefMarks = buildRefMarks(V, q, vizName);
       if (sRefMarks.length) el.refMarks = sRefMarks;
     } else {
-      // cartesian: bar / line / area / combo
+      // cartesian: bar / line / area / combo. The released waterfall schema
+      // deliberately has no xAxis property; retain its category columns while
+      // binding only the required yAxis.
       const xId = addCol(cats[0], false, true);
-      if (xId) {
+      if (xId && kind !== 'waterfall-chart') {
         el.xAxis = { columnId: xId };
         if (cats[0]?.sort) el.xAxis.sort = { by: xId, direction: /desc/i.test(cats[0].sort) ? 'descending' : 'ascending' };
       }
@@ -825,17 +1007,126 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
         if (/\bbar\b/.test(vizType) && !/column/.test(vizType)) el.orientation = 'horizontal'; // Cognos "bar" = horizontal
       }
       if (kind === 'combo-chart' && yIds.length > 1) warnings.push(`chart "${vizName}" → combo-chart: all measures placed on the primary axis as the same mark — set per-series shape / secondary axis in the workbook.`);
+      if (kind === 'waterfall-chart' && cats.length > 1) {
+        warnings.push(workbookGap('waterfall category hierarchy',
+          `chart "${vizName}" has ${cats.length} Cognos category levels, but released waterfall-chart code exposes no xAxis hierarchy. All category columns were retained; verify the rendered step labels.`));
+      }
     }
 
     el.columns = cols; el.order = cols.map((c) => c.id);
     if (!cols.length) { warnings.push(`<vizControl> "${vizName}" (${vizType}) had no resolvable slot columns — skipped.`); continue; }
     applyQueryFilters(el, q);
-    pageEls.push(el);
+    addElement(V, el);
   }
 
-  // attach controls as page-level elements too
+  // Released non-chart workbook features.
+  for (const pageBreak of findAll(report, 'pageBreak')) {
+    addElement(pageBreak, { id: sigmaShortId(), kind: 'page-break' });
+  }
+
+  for (const drill of findAll(report, 'drillBehavior')) {
+    if (!drill || typeof drill !== 'object' || Object.keys(drill).length === 0) continue;
+    const id = sigmaShortId();
+    addToPage(pages[0].id, {
+      id, kind: 'control', controlId: `drill-${id}`, name: 'Drill',
+      controlType: 'drill',
+    } as WbControl);
+  }
+  for (const reportDrill of findAll(report, 'reportDrill')) {
+    const name = reportDrill['@_name'] || 'unnamed report drill';
+    const path = findAll(reportDrill, 'reportPath')[0]?.['@_path'];
+    warnings.push(workbookGap('cross-report drill-through',
+      `"${name}" targets ${path || 'another Cognos report'}. The released Sigma drill control is hierarchy drill, not cross-document navigation; wire a converted target page/document explicitly.`));
+  }
+
+  // Cognos repeaters become first-class repeated containers. The binding name
+  // uses the data-model source element's display name, matching Sigma's derived
+  // "<source name> repeated container" namespace.
+  for (const repeater of [...findAll(report, 'repeater'), ...findAll(report, 'repeaterTable')]) {
+    const qName = repeater['@_refQuery'];
+    const q = queries.get(qName);
+    if (!q) {
+      warnings.push(workbookGap('repeater', `refQuery="${qName || '(missing)'}" has no matching query; repeater was not emitted.`));
+      continue;
+    }
+    const refs = [...new Set(findAll(repeater, 'dataItemValue').map((x: any) => x['@_refDataItem']).filter(Boolean))] as string[];
+    const sourceName = `${repeater['@_name'] || qName} source`;
+    const sourceColumns: WbColumn[] = refs.flatMap((ref) => {
+      const di = q.items.get(ref);
+      if (!di) return [];
+      const translated = translate(di.expression, q);
+      translated.warns.forEach((w) => warnings.push(`"${qName}.${ref}": ${w}`));
+      return [{ id: sigmaShortId(), name: sigmaDisplayName(di.name), formula: translated.formula }];
+    });
+    const source: WbElement = {
+      id: sigmaShortId(), kind: 'table', name: sourceName, source: dmSource(q),
+      columns: sourceColumns, order: sourceColumns.map((c) => c.id), visibleAsSource: false,
+    };
+    addElement(repeater, source);
+    const rc: WbElement = {
+      id: sigmaShortId(), kind: 'repeated-container', name: repeater['@_name'] || `${qName} repeater`,
+      source: { kind: 'table', elementId: source.id }, arrangement: 'list', cardSize: 'small',
+      noDataText: 'No rows', cardStyle: styleFromNode(repeater),
+    };
+    addElement(repeater, rc);
+    const children: string[] = [];
+    for (const ref of refs) {
+      const di = q.items.get(ref);
+      if (!di) continue;
+      const child: WbElement = {
+        id: sigmaShortId(), kind: 'text',
+        body: `{{[${sourceName} repeated container/${sigmaDisplayName(di.name)}]}}`,
+      };
+      addElement(repeater, child);
+      children.push(child.id);
+    }
+    if (children.length) containerChildren.set(rc.id, children);
+    else warnings.push(workbookGap('repeater content',
+      `"${rc.name}" had no resolvable dataItemValue children. The repeated-container shell was preserved, but its card content must be authored.`));
+  }
+
+  // Named Cognos blocks are semantic panels. Preserve panels that actually own
+  // converted visual children; unnamed layout-only blocks remain structural
+  // noise and are not emitted.
+  const claimedPanelChildren = new Set<string>();
+  for (const block of findAll(report, 'block')) {
+    if (!block['@_name']) continue;
+    const children: string[] = [];
+    for (const tag of ['singleton', 'list', 'crosstab', 'vizControl', 'repeater', 'repeaterTable']) {
+      for (const node of findAll(block, tag)) {
+        for (const element of elementsBySourceNode.get(node) || []) {
+          if (!claimedPanelChildren.has(element.id)) {
+            children.push(element.id);
+            claimedPanelChildren.add(element.id);
+          }
+        }
+      }
+    }
+    if (!children.length) continue;
+    const panel: WbElement = {
+      id: sigmaShortId(), kind: 'container', name: sigmaDisplayName(block['@_name']),
+      ...(styleFromNode(block) ? { style: styleFromNode(block) } : {}),
+    };
+    addElement(block, panel);
+    containerChildren.set(panel.id, children);
+  }
+
+  // attach parameter controls to the first page. Controls remain ordinary flat
+  // document elements; the layout is their sole page-membership authority.
   const controlEls = [...controls.values()];
-  pages.push({ id: sigmaShortId(), name: reportPages[0]?.['@_name'] || 'Report', elements: [...controlEls as any, ...pageEls] });
+  controlEls.forEach((control) => addToPage(pages[0].id, control));
+
+  // Cognos' report-page tab mode maps directly to Sigma's released auto
+  // navigation element. Place one at the start of every page.
+  if (pages.length > 1 && report['@_viewPagesAsTabs']) {
+    const pageLabels = Object.fromEntries(pages.map((p) => [p.id, p.name]));
+    for (const page of pages) {
+      const nav: WbElement = {
+        id: sigmaShortId(), kind: 'navigation', mode: 'auto', pageLabels,
+      };
+      elementsByPage.get(page.id)!.unshift(nav);
+    }
+  }
 
   // detail filters are converted per element (applyQueryFilters); summary filters
   // (post-aggregation HAVING-style) still surface as warnings to re-create.
@@ -843,6 +1134,29 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     const fexpr = txt(fnode.filterExpression || fnode.expression);
     if (fexpr) warnings.push(`summary filter: "${fexpr.slice(0, 80)}" — post-aggregation filter; re-create as a Sigma filter on the aggregated column.`);
   }
+
+  // Page headers are now first-class document.panels definitions. Cognos page
+  // footers do not map to the workbook panel union (header/sidebar only), so
+  // they stay loud rather than being mislabeled as a sidebar.
+  const panels: Array<Record<string, any>> = [];
+  pageNodes.forEach((pageNode, i) => {
+    const header = findAll(pageNode, 'pageHeader')[0];
+    if (header) {
+      const style = styleFromNode(header);
+      panels.push({
+        id: sigmaShortId(), type: 'header', title: `${pages[i].name} header`,
+        pages: [pages[i].id],
+        config: {
+          scroll: 'none', borderStyle: 'none',
+          ...(style?.backgroundColor ? { backgroundColor: style.backgroundColor } : {}),
+        },
+      });
+    }
+    if (findAll(pageNode, 'pageFooter').length) {
+      warnings.push(workbookGap('page footer panel',
+        `page "${pages[i].name}" has a Cognos pageFooter, but released workbook panels support header/sidebar only. Preserve footer content as ordinary page elements or a page-break print section.`));
+    }
+  });
 
   const stats = {
     queries: queries.size,
@@ -856,9 +1170,24 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     controls: controls.size,
     refMarks: pageEls.reduce((n, e) => n + (e.refMarks?.length || 0), 0),
     scaleColors: pageEls.filter((e) => e.color?.by === 'scale').length,
+    pages: pages.length,
+    progress: pageEls.filter((e) => e.kind === 'progress').length,
+    repeaters: pageEls.filter((e) => e.kind === 'repeated-container').length,
+    panels: pageEls.filter((e) => e.kind === 'container').length,
+    pagePanels: panels.length,
+    pageBreaks: pageEls.filter((e) => e.kind === 'page-break').length,
+  };
+  const elements = pages.flatMap((page) => elementsByPage.get(page.id) || []);
+  const document = {
+    schemaVersion: 1,
+    kind: 'workbook' as const,
+    pages,
+    elements,
+    layout: buildAuthoritativeLayout(pages, elementsByPage, containerChildren),
+    ...(panels.length ? { panels } : {}),
   };
   return {
-    workbook: { name: reportName, schemaVersion: 1, pages, controls: controlEls },
+    workbook: CodeRep.wrap(document, { name: reportName }) as CognosReportResult['workbook'],
     warnings, stats,
   };
 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/package-lock.json
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/package-lock.json
@@ -15,6 +15,7 @@
         "cognos-to-sigma": "cli.ts"
       },
       "devDependencies": {
+        "@types/node": "^26.2.0",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0"
       }
@@ -461,6 +462,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -580,6 +591,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/package.json
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/package.json
@@ -4,7 +4,9 @@
   "description": "IBM Cognos Analytics → Sigma converter (Data Module JSON → data model; report-spec XML → workbook). Destined to vendor into sigma-data-model-mcp as convert_cognos_to_sigma tools.",
   "type": "module",
   "license": "MIT",
-  "bin": { "cognos-to-sigma": "cli.ts" },
+  "bin": {
+    "cognos-to-sigma": "cli.ts"
+  },
   "scripts": {
     "convert": "node --import tsx/esm cli.ts",
     "test": "node --import tsx/esm test.ts"
@@ -13,6 +15,7 @@
     "fast-xml-parser": "^4.5.0"
   },
   "devDependencies": {
+    "@types/node": "^26.2.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"
   }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/test.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/test.ts
@@ -5,6 +5,8 @@ import { dirname, join } from 'node:path';
 import { convertCognosToSigma } from './cognos.js';
 import { convertCognosReportToSigma } from './cognos-report.js';
 import { sigmaDisplayName } from './sigma-ids.js';
+// @ts-expect-error Vendored runtime adapter is plain ESM.
+import * as CodeRep from '../scripts/lib/code_rep.mjs';
 
 const FIX = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures');
 let fail = 0;
@@ -33,14 +35,23 @@ for (const [input, expected] of NAME_CASES) {
 // control with values+default, KPI singletons, element filters ───────────────────
 {
   const r = convertCognosReportToSigma(readFileSync(join(FIX, 'go-sales-performance.report.xml'), 'utf8'), { dataModelId: 'dm' });
-  const els = r.workbook.pages[0].elements as any[];
-  const ctl = (r.workbook.controls || []).find((c: any) => c.controlId === 'pColumn') as any;
+  const doc = CodeRep.document(r.workbook);
+  const els = CodeRep.workbookElements(r.workbook) as any[];
+  const controls = els.filter((e: any) => e.kind === 'control');
+  const ctl = controls.find((c: any) => c.controlId === 'pColumn') as any;
   const checks: Array<[string, boolean]> = [
+    ['workbook uses document wrapper', !!r.workbook.document && !('pages' in (r.workbook as any))],
+    ['pages are metadata-only', doc.pages.every((p: any) => !('elements' in p))],
+    ['elements are flat', Array.isArray(doc.elements) && doc.elements.length === els.length],
+    ['authoritative layout places every element',
+      els.every((e: any) => (doc.layout.match(new RegExp(`elementId="${e.id}"`, 'g')) || []).length === 1)],
+    ['layout uses live Element tags',
+      /<Element\b/.test(doc.layout) && !/<(?:LayoutElement|GridContainer)\b/.test(doc.layout)],
     ['pColumn control is segmented', ctl?.controlType === 'segmented'],
     ['pColumn has explicit values', JSON.stringify(ctl?.source?.values) === JSON.stringify(['Revenue', 'Gross Profit'])],
     ['pColumn defaults to Revenue', ctl?.value === 'Revenue'],
     ['pQuarter control registered with Q1-Q4 + default Q4',
-      (r.workbook.controls || []).some((c: any) => c.controlId === 'pQuarter' && c.value === 'Q4' && c.source?.values?.length === 4)],
+      controls.some((c: any) => c.controlId === 'pQuarter' && c.value === 'Q4' && c.source?.values?.length === 4)],
     ['Switch wired by controlId [pColumn]',
       els.some((e) => e.columns?.some((c: any) => /Switch\(\[pColumn\], "Gross Profit", \[Sheet 1\/Gross Profit\], \[Sheet 1\/Revenue\]\)/.test(c.formula)))],
     ['6 KPI singletons converted', els.filter((e) => e.kind === 'kpi-chart').length === 6],
@@ -60,6 +71,78 @@ for (const [input, expected] of NAME_CASES) {
     else { fail++; console.log(`✗ go-sales: ${label}`); }
   }
 }
+
+// ── workbook-code release surface: flat elements + required layout and the
+// newly released grounded mappings (waterfall/legend/drill/navigation/
+// page-break/progress/panels/styles/repeaters); gated box stays loud. ──────────
+{
+  const xml = `<report viewPagesAsTabs="topLeft">
+    <reportName>Release features</reportName>
+    <layouts><layout><reportPages>
+      <page name="Overview"><pageHeader><style><CSS value="background-color:#445566"/></style></pageHeader><pageBody><contents>
+        <block name="Revenue panel"><style><CSS value="background-color:#112233;border-radius:8px"/></style>
+          <vizControl name="Revenue bridge" type="com.ibm.vis.waterfall">
+            <vcDataSet refDataStore="ds"/>
+            <vcSlotData idSlot="categories"><vcSlotDsColumn refDsColumn="Category"/></vcSlotData>
+            <vcSlotData idSlot="values"><vcSlotDsColumn refDsColumn="Revenue" rollupMethod="total"/></vcSlotData>
+            <vizPropertyValues><vizPropertyBooleanValue name="legendVisible">true</vizPropertyBooleanValue>
+              <vizPropertyEnumValue name="legendPosition">right</vizPropertyEnumValue></vizPropertyValues>
+          </vizControl>
+        </block>
+        <pageBreak/>
+        <repeater name="Category cards" refQuery="q"><dataItemValue refDataItem="Category"/></repeater>
+        <drillBehavior enabled="true"/>
+      </contents></pageBody></page>
+      <page name="Detail"><pageBody><contents>
+        <vizControl name="Target progress" type="com.ibm.vis.progressbar">
+          <vcDataSet refDataStore="ds"/>
+          <vcSlotData idSlot="values"><vcSlotDsColumn refDsColumn="Revenue" rollupMethod="total"/></vcSlotData>
+        </vizControl>
+        <vizControl name="Distribution" type="com.ibm.vis.boxplot">
+          <vcDataSet refDataStore="ds"/>
+          <vcSlotData idSlot="categories"><vcSlotDsColumn refDsColumn="Category"/></vcSlotData>
+          <vcSlotData idSlot="values"><vcSlotDsColumn refDsColumn="Revenue" rollupMethod="total"/></vcSlotData>
+        </vizControl>
+      </contents></pageBody></page>
+    </reportPages></layout></layouts>
+    <queries><query name="q"><selection>
+      <dataItem name="Category" aggregate="none"><expression>[C].[M].[Sales].[Category]</expression></dataItem>
+      <dataItem name="Revenue" aggregate="total"><expression>[C].[M].[Sales].[Revenue]</expression></dataItem>
+    </selection></query></queries>
+    <reportDataStores><reportDataStore name="ds"><dsV5ListQuery refQuery="q"/></reportDataStore></reportDataStores>
+  </report>`;
+  const r = convertCognosReportToSigma(xml, { dataModelId: 'dm' });
+  const doc = CodeRep.document(r.workbook);
+  const els = CodeRep.workbookElements(r.workbook) as any[];
+  const checks: Array<[string, boolean]> = [
+    ['two Cognos pages stay two metadata-only pages', doc.pages.length === 2 && doc.pages.every((p: any) => !p.elements)],
+    ['auto navigation emitted per tabbed report page', els.filter((e: any) => e.kind === 'navigation' && e.mode === 'auto').length === 2],
+    ['waterfall uses released kind + yAxis', els.some((e: any) => e.kind === 'waterfall-chart' && e.yAxis?.columnIds?.length === 1)],
+    ['legend settings grounded from viz properties', els.some((e: any) => e.kind === 'waterfall-chart' && e.legend?.visibility === 'shown' && e.legend?.position === 'right')],
+    ['drillBehavior uses released drill control', els.some((e: any) => e.kind === 'control' && e.controlType === 'drill')],
+    ['page break emitted', els.some((e: any) => e.kind === 'page-break')],
+    ['progress emitted with hidden aggregate source', els.some((e: any) => e.kind === 'progress' && typeof e.value === 'string')
+      && els.some((e: any) => e.name === 'Target progress (progress source)' && e.visibleAsSource === false)],
+    ['named block becomes styled panel', els.some((e: any) => e.kind === 'container' && e.name === 'Revenue Panel' && e.style?.backgroundColor === '#112233')],
+    ['page header becomes document panel', doc.panels?.some((p: any) => p.type === 'header'
+      && p.pages?.[0] === doc.pages[0].id && p.config?.backgroundColor === '#445566')],
+    ['repeater becomes repeated-container with child binding', els.some((e: any) => e.kind === 'repeated-container')
+      && els.some((e: any) => e.name === 'Category cards source' && e.visibleAsSource === false)
+      && els.some((e: any) => e.kind === 'text' && /Category cards source repeated container/.test(e.body || ''))],
+    ['box chart remains loud and data-preserving', els.some((e: any) => e.kind === 'table' && /was box plot/.test(e.name || '') && e.groupings?.length)
+      && r.warnings.some((w) => w.includes('⛔ WORKBOOK FEATURE GAP [box-chart (workspace gated)]'))],
+    ['layout is authoritative for every flat element',
+      els.every((e: any) => (doc.layout.match(new RegExp(`elementId="${e.id}"`, 'g')) || []).length === 1)],
+    ['panel layout uses live Element/Container tags',
+      /<Element\b/.test(doc.layout) && /<Container\b/.test(doc.layout)
+        && !/<(?:LayoutElement|GridContainer)\b/.test(doc.layout)],
+  ];
+  for (const [label, ok] of checks) {
+    if (ok) console.log(`✓ release: ${label}`);
+    else { fail++; console.log(`✗ release: ${label}`); }
+  }
+}
+
 for (const f of readdirSync(FIX)) {
   try {
     if (f.endsWith('.module.json')) {
@@ -68,6 +151,13 @@ for (const f of readdirSync(FIX)) {
       console.log(`✓ ${f.padEnd(34)} module → ${r.stats.elements} elems · ${r.stats.columns} cols · ${r.stats.metrics} metrics · ${r.stats.relationships} rels`);
     } else if (f.endsWith('.report.xml')) {
       const r = convertCognosReportToSigma(readFileSync(join(FIX, f), 'utf8'), { dataModelId: 'dm' });
+      const doc = CodeRep.document(r.workbook);
+      if (!Array.isArray(doc.elements) || doc.pages.some((p: any) => 'elements' in p) || !doc.layout) {
+        throw new Error('legacy workbook representation');
+      }
+      if (/<(?:LayoutElement|GridContainer)\b/.test(doc.layout)) {
+        throw new Error('legacy workbook layout tags');
+      }
       console.log(`✓ ${f.padEnd(34)} report → ${r.stats.tables} tables · ${r.stats.pivots} pivots · ${r.stats.kpis} kpis · ${r.stats.charts} charts · ${r.stats.maps} maps · ${r.stats.columns} cols · ${r.stats.filters} filters · ${r.stats.controls} controls`);
     }
   } catch (e: any) { fail++; console.log(`✗ ${f} — ${e.message}`); }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/workbook-features.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/workbook-features.ts
@@ -1,0 +1,63 @@
+/**
+ * Grounded Cognos → Sigma workbook feature catalog.
+ *
+ * Keep enumerable source mappings here instead of scattering optimistic string
+ * matches through the converter. `refs/cognos-coverage.md` documents the source
+ * evidence and release/gating status for each target.
+ */
+export const VIZ_KIND: Record<string, string> = {
+  'com.ibm.vis.clusteredbar': 'bar-chart',
+  'com.ibm.vis.stackedbar': 'bar-chart',
+  'com.ibm.vis.clusteredcolumn': 'bar-chart',
+  'com.ibm.vis.stackedcolumn': 'bar-chart',
+  'com.ibm.vis.line': 'line-chart',
+  'com.ibm.vis.spline': 'line-chart',
+  'com.ibm.vis.area': 'area-chart',
+  'com.ibm.vis.stackedarea': 'area-chart',
+  'com.ibm.vis.pie': 'pie-chart',
+  'com.ibm.vis.donut': 'donut-chart',
+  'com.ibm.vis.clusteredcombination': 'combo-chart',
+  'com.ibm.vis.stackedcombination': 'combo-chart',
+  'com.ibm.vis.bubble': 'scatter-chart',
+  'com.ibm.vis.scatter': 'scatter-chart',
+  // Released in workbook code: required shape is source + columns + yAxis.
+  'com.ibm.vis.waterfall': 'waterfall-chart',
+  'com.ibm.vis.waterfallchart': 'waterfall-chart',
+};
+
+export const VIZ_NO_ANALOG: Record<string, string> = {
+  'com.ibm.vis.network': 'network diagram',
+  'com.ibm.vis.wordcloud': 'word cloud',
+  'com.ibm.vis.packedbubble': 'packed bubble',
+  'com.ibm.vis.treemap': 'treemap',
+};
+
+// Sigma exposes box-chart in the workbook schema only where the workspace
+// feature is enabled. A converter cannot know entitlement before POST, so box
+// plots remain a loud, table-preserving fallback instead of a masked failure.
+export const VIZ_GATED: Record<string, string> = {
+  'com.ibm.vis.box': 'box plot',
+  'com.ibm.vis.boxplot': 'box plot',
+  'com.ibm.vis.boxandwhisker': 'box-and-whisker plot',
+};
+
+export const RELEASED_WORKBOOK_FEATURES = {
+  wrapper: { source: 'report', target: 'document', status: 'released' },
+  flatElements: { source: 'page contents', target: 'document.elements', status: 'released' },
+  layout: { source: 'report page membership', target: 'document.layout', status: 'required' },
+  waterfall: { source: 'com.ibm.vis.waterfall*', target: 'waterfall-chart', status: 'released' },
+  legend: { source: 'vizProperty*Value(name=*legend*)', target: 'legend', status: 'released' },
+  drill: { source: 'drillBehavior', target: 'control/controlType=drill', status: 'released' },
+  navigation: { source: 'viewPagesAsTabs', target: 'navigation/mode=auto', status: 'released' },
+  tabs: { source: 'reportPages/page', target: 'pages + navigation', status: 'released' },
+  pageBreak: { source: 'pageBreak', target: 'page-break', status: 'released' },
+  progress: { source: 'com.ibm.vis.progress*', target: 'progress', status: 'released' },
+  panels: { source: 'pageHeader', target: 'document.panels[type=header]', status: 'released' },
+  styles: { source: 'style/CSS', target: 'panel.config or container.style', status: 'released' },
+  repeaters: { source: 'repeater/repeaterTable', target: 'repeated-container', status: 'released' },
+  box: { source: 'com.ibm.vis.box*', target: 'box-chart', status: 'workspace-gated' },
+} as const;
+
+export function workbookGap(feature: string, detail: string): string {
+  return `⛔ WORKBOOK FEATURE GAP [${feature}]: ${detail}`;
+}

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/cognos-coverage.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/cognos-coverage.md
@@ -1,12 +1,10 @@
 # Cognos → Sigma — dashboard/report classifier coverage matrix
 
-> **Grounding note (beads-sigma-kvza).** Unlike the other migration skills (whose
-> classifiers LOAD JSON catalogs via `coverage_catalog.{py,rb}`), cognos-to-sigma's
-> classifier is **TypeScript bundled to `converter/cli.mjs`** (from `converter/cognos-report.ts`).
-> There is no TS catalog loader, so cognos's maps are grounded as **cited constants in
-> the TS source** with a **loud fallback** on anything unmapped — and documented here.
-> A machine-loaded TS catalog would be the same shape and belongs with the converter
-> (lanq) track. Every mapped Sigma target is a real, current Sigma construct.
+> **Grounding note.** Cognos' executable catalog is
+> `converter/workbook-features.ts`, bundled into `converter/cli.mjs` and consumed
+> directly by `cognos-report.ts`. It records released, gated, and no-analog
+> targets. Anything outside that catalog takes the loud
+> `⛔ WORKBOOK FEATURE GAP […]` path; it never silently selects a chart.
 
 Cognos was already the most loud of the classifiers (an unknown visual degrades to a
 **warned table**, never a silent chart; number formats are read from the report's
@@ -15,7 +13,7 @@ name). This pass closed the one remaining silent default: an **unmapped Cognos
 aggregate / rollup no longer silently becomes `Sum`** — it warns first.
 
 ## Visualization / chart kind
-Source: `cognos-report.ts` `VIZ_KIND` (+ `VIZ_NOANALOG`). Cognos `com.ibm.vis.*` → Sigma element kind.
+Source: `workbook-features.ts` `VIZ_KIND` (+ `VIZ_NO_ANALOG` / `VIZ_GATED`). Cognos `com.ibm.vis.*` → Sigma element kind.
 Authoritative source: <https://www.ibm.com/docs/en/cognos-analytics> (visualization types).
 
 | Cognos vizType | Sigma target | on-unmapped |
@@ -27,7 +25,40 @@ Authoritative source: <https://www.ibm.com/docs/en/cognos-analytics> (visualizat
 | `com.ibm.vis.donut` | `donut-chart` | — |
 | `com.ibm.vis.clusteredcombination` / `stackedcombination` | `combo-chart` | — |
 | `com.ibm.vis.bubble` / `scatter` | `scatter-chart` | — |
-| _unknown vizType_ | — (no native equivalent) | **loud warn + emit the data as a `table`** (`cognos-report.ts` `if (!kind)`) — never a silent concrete chart |
+| `com.ibm.vis.waterfall` / `waterfallchart` | `waterfall-chart` (`source`, `columns`, required `yAxis`) | category columns retained; multi-level category hierarchy is a loud render-review gap because the released schema exposes no `xAxis` |
+| `com.ibm.vis.box*` | `box-chart` only when the workspace feature is enabled | **gated**: loud warning + data-preserving table; never emit a box chart into an unknown entitlement |
+| _unknown vizType_ | — (no grounded equivalent) | **loud `⛔ WORKBOOK FEATURE GAP` + emit the data as a `table`** — never a silent concrete chart |
+
+## Workbook-code representation and released features
+
+Source: `cognos-report.ts`, grounded status: `workbook-features.ts`
+`RELEASED_WORKBOOK_FEATURES`.
+
+| Cognos source | Sigma target | Guard / gap behavior |
+|---|---|---|
+| report workbook | outer `{name, document}` | CodeRep wrapper required before POST and again on readback |
+| report pages | metadata-only `document.pages[]` | elements in a page object fail the contract gate |
+| page contents | flat `document.elements[]` | page ownership comes only from layout |
+| report page membership | required `document.layout` | every page gets one `<Page>` and every element is placed exactly once; missing/unknown/duplicate ids fail before POST and on readback |
+| `viewPagesAsTabs` + multiple `<page>` nodes | metadata pages + `navigation {mode:auto}` | one navigation element per page, with source page labels |
+| `vizProperty*Value name="*legend*"` | chart/map `legend.visibility` / `legend.position` | only explicit source properties are emitted |
+| non-empty `<drillBehavior>` | `controlType: drill` control | cross-report `<reportDrill>` is **not** mislabeled as hierarchy drill; it remains a loud gap requiring explicit page/document navigation |
+| `<pageBreak>` | `page-break` | layout always assigns exactly one grid row |
+| progress/bullet/gauge viz | `progress` + hidden aggregate source table | value binds to the hidden source; percent mode retains 0–1 semantics |
+| `<pageHeader>` | `document.panels[] {type:header, pages:[…]}` | safe CSS background maps to panel config; page ids are contract-gated |
+| named `<block>` with converted children | styled `container` section | safe CSS background/radius properties only; children are authoritative live `<Container>` members |
+| `<repeater>` / `<repeaterTable>` | hidden local source table + `repeated-container` + text bindings | local source name grounds Sigma's derived `"<source> repeated container"` namespace; unresolved query/content is loud |
+
+### Remaining loud gaps
+
+- Cross-report drill-through targets require the destination report to be
+  converted and then wired as Sigma navigation/open-url.
+- Cognos page footers remain loud: released workbook panels support page
+  header/sidebar, not footer.
+- Unknown visual kinds preserve their data as a table and carry a loud gap.
+- Box plots remain workspace-gated until entitlement is proven.
+- Waterfalls with multiple Cognos category levels require render verification
+  because released workbook code does not expose a waterfall category axis.
 
 ## Aggregation
 Source: `cognos-report.ts` `AGG` (list footer/dataItem) + `ROLLUP_AGG` (chart rollup). Cognos aggregate/rollup → Sigma aggregate function.

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
@@ -1,31 +1,19 @@
 #!/usr/bin/env node
-// apply-layout.mjs — give a migrated Cognos workbook a CLEAN container-banded
-// dashboard grid (layout-playbook.md, verified 2026-06-10).
+// apply-layout.mjs — authoritative-layout readback gate for Cognos workbooks.
 //
-// Sigma auto-arrange stacks every element at the SAME height (KPIs as tall as
-// tables, charts squished). Flat LayoutElement lists also produce dead zones /
-// detached controls — so every multi-element page is grouped into full-width
-// BAND CONTAINERS:
-//   1. header band — dark, full-width, page/workbook title text
-//   2. control band — controls side-by-side (global filters)
-//   3. KPI band(s) — runs of kpi-charts as rows of up to 3 TALL tiles (Sigma
-//      hides the KPI title below ~5 grid rows)
-//   4. chart rows — consecutive charts paired 2-across, even heights
-//   5. tables / maps / pivots — full-width band each
-// Spec side each band needs a `kind: container` placeholder element; layout
-// side a <GridContainer> (NOT <LayoutElement type="grid">, which silently
-// drops children) whose child <LayoutElement>s use CONTAINER-RELATIVE
-// coordinates (rows restart at 1). Layout elementIds must match the POSTED
-// (reassigned) ids, so this GETs the readback spec first.
+// The converter now authors document.layout together with metadata-only pages
+// and flat document.elements. Page membership exists only in that layout, so
+// synthesizing a replacement after POST would destroy source page/panel/tab/
+// repeater intent. This command GETs the posted spec and fails unless the
+// authored layout survived exactly as a complete, authoritative membership map.
 //
 // Usage:
 //   eval "$(scripts/get-token.sh)"
 //   node scripts/apply-layout.mjs --workbook <workbookId>
 //
-// Idempotent (band elements are re-derived each run). Run it as the last step
-// of the build/verify phase.
+// Run it as the last step of the build/verify phase.
 import { api, parseArgs } from './lib/sigma-rest.mjs';
-import { document as docOf, metadata as metaOf, wrap as wrapDoc } from './lib/code_rep.mjs';
+import { assertWorkbookContract } from './lib/workbook_contract.mjs';
 import { pythonArgv } from './lib/py_resolve.mjs';
 import { spawnSync } from 'node:child_process';
 import { writeFileSync, mkdirSync } from 'node:fs';
@@ -37,149 +25,19 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const a = parseArgs(process.argv.slice(2));
 if (!a.workbook) { console.error('need --workbook <workbookId>'); process.exit(2); }
 
-const HEADER_STYLE = { backgroundColor: '#0F172A', borderRadius: 'round' };
-const HDR_H = 3;   // header band height (grid rows)
-const CTRL_H = 3;  // control band height
-const KPI_H = 6;   // KPI tile height — >= 5 so the title renders
-const CHART_H = 11; // paired chart row height
-// full-width per-kind heights for non-chart content
-const H = (k) => (k.endsWith('-map') || k === 'pivot-table' || k === 'table') ? 12
-  : k === 'text' ? 3 : 11;
-
-const le = (id, c0, c1, r0, r1) =>
-  `  <LayoutElement elementId="${id}" gridColumn="${c0} / ${c1}" gridRow="${r0} / ${r1}"/>`;
-const gcXml = (id, r0, r1, inner) =>
-  `<GridContainer elementId="${id}" type="grid" gridColumn="1 / 25" gridRow="${r0} / ${r1}" ` +
-  `gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">\n${inner}\n</GridContainer>`;
-
-const isChart = (k) => k.endsWith('-chart') && k !== 'kpi-chart';
-
-function pageLayout(page, fallbackTitle) {
-  // strip band elements injected by a previous run (idempotency)
-  page.elements = (page.elements || []).filter((e) =>
-    !(String(e.id || '').startsWith('band-') && (e.kind === 'container' || e.kind === 'text')));
-  const els = page.elements.filter((e) => e.id);
-  if (!els.length) return null;
-  const pfx = `band-${page.id}`;
-  const bandEls = [];   // container/header spec elements to inject
-  const bands = [];     // page-level GridContainer XML blocks
-  let row = 1;
-
-  // (1) header band
-  const title = page.name || fallbackTitle || 'Dashboard';
-  bandEls.push({ id: `${pfx}-hdr`, kind: 'container', style: { ...HEADER_STYLE } });
-  bandEls.push({ id: `${pfx}-hdrtext`, kind: 'text',
-                 body: `# <span style="color: #FFFFFF">${title}</span>` });
-  bands.push(gcXml(`${pfx}-hdr`, row, row + HDR_H, le(`${pfx}-hdrtext`, 1, 25, 1, 1 + HDR_H)));
-  row += HDR_H;
-
-  // (2) control band: up to 4 across per row, one container for all of them
-  const controls = els.filter((e) => e.kind === 'control');
-  const content = els.filter((e) => e.kind !== 'control');
-  if (controls.length) {
-    const lines = [];
-    const perRow = Math.min(controls.length, 4);
-    const span = Math.floor(24 / perRow);
-    controls.forEach((c, i) => {
-      const col0 = 1 + (i % perRow) * span;
-      const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
-      const r = 1 + Math.floor(i / perRow) * CTRL_H;
-      lines.push(le(c.id, col0, col1, r, r + CTRL_H));
-    });
-    const h = Math.ceil(controls.length / perRow) * CTRL_H;
-    bandEls.push({ id: `${pfx}-ctl`, kind: 'container' });
-    bands.push(gcXml(`${pfx}-ctl`, row, row + h, lines.join('\n')));
-    row += h;
-  }
-
-  // (3..5) content bands
-  let bandN = 0;
-  const pushBand = (h, lines) => {
-    bandN += 1;
-    const cid = `${pfx}-${bandN}`;
-    bandEls.push({ id: cid, kind: 'container' });
-    bands.push(gcXml(cid, row, row + h, lines.join('\n')));
-    row += h;
-  };
-  for (let i = 0; i < content.length; i++) {
-    const e = content[i];
-    if (e.kind === 'kpi-chart') {
-      // KPI panel: the whole run in ONE band container, rows of up to 3 TALL tiles
-      let j = i; while (j < content.length && content[j].kind === 'kpi-chart') j++;
-      const run = content.slice(i, j);
-      // exec headers commonly have 4 KPIs — keep them on ONE row (span 6 each)
-      // instead of 3+1 (a lonely wrapped tile reads as a layout bug); else cap at 3.
-      const perRow = run.length === 4 ? 4 : Math.min(run.length, 3);
-      const span = Math.floor(24 / perRow);
-      const lines = run.map((k, n) => {
-        const col0 = 1 + (n % perRow) * span;
-        const col1 = (n % perRow === perRow - 1) ? 25 : col0 + span;
-        const r = 1 + Math.floor(n / perRow) * KPI_H;
-        return le(k.id, col0, col1, r, r + KPI_H);
-      });
-      pushBand(Math.ceil(run.length / perRow) * KPI_H, lines);
-      i = j - 1;
-      continue;
-    }
-    if (isChart(e.kind) && i + 1 < content.length && isChart(content[i + 1].kind)) {
-      // chart row: two charts side-by-side, even heights (the 2x2 grid pattern)
-      pushBand(CHART_H, [le(e.id, 1, 13, 1, 1 + CHART_H),
-                         le(content[i + 1].id, 13, 25, 1, 1 + CHART_H)]);
-      i += 1;
-      continue;
-    }
-    // lone chart / table / map / pivot / text: full-width band
-    const h = isChart(e.kind) ? CHART_H : H(e.kind);
-    pushBand(h, [le(e.id, 1, 25, 1, 1 + h)]);
-  }
-
-  page.elements = page.elements.concat(bandEls);
-  return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${page.id}">\n${bands.join('\n')}\n</Page>`;
-}
-
 const got = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
 if (!got.json) { console.error(`GET spec failed (HTTP ${got.status}): ${got.text.slice(0, 300)}`); process.exit(1); }
-// Workbook code-rep GETs nest pages/schemaVersion/layout under a top-level
-// `document` key (live since 2026-08) — flatten metadata+document onto ONE
-// object so every `spec.pages`/`spec.layout` read below (and the eventual
-// PUT, wrapped back at the wire boundary) sees the same flat shape this file
-// always worked with.
-const spec = { ...metaOf(got.json), ...docOf(got.json) };
-// The layout is a SINGLE top-level `spec.layout` XML holding one <Page> block per page
-// (NOT pages[].layout — that's silently dropped). Strip read-only fields before the PUT.
-const pageBlocks = [];
-for (const p of spec.pages || []) {
-  delete p.layout;
-  if ((p.name || '') === 'Data') continue; // hidden master page — auto-arrange is fine
-  const xml = pageLayout(p, spec.name);
-  if (xml) pageBlocks.push(xml);
-}
-if (!pageBlocks.length) { console.log('no layoutable pages — nothing to lay out'); process.exit(0); }
-// beads-sigma-kvza.3: the band layout is SYNTHESIZED from element order — the Cognos
-// report's pixel geometry is not read — so say so LOUDLY rather than let it read as
-// source-faithful placement.
-console.warn(`⚠ layout: synthesized a banded grid for ${pageBlocks.length} page(s) from element order — Cognos report pixel geometry is not read, so placement is NOT source-faithful; review it.`);
-spec.layout = `<?xml version="1.0" encoding="utf-8"?>\n${pageBlocks.join('\n')}`;
-for (const k of ['workbookId', 'url', 'ownerId', 'createdBy', 'updatedBy', 'createdAt', 'updatedAt', 'latestDocumentVersion', 'documentVersion']) delete spec[k];
-if (a.folder && !spec.folderId) spec.folderId = a.folder;
-
-// Workbook code-rep PUTs require the nested `document` envelope (verified
-// live 2026-08-03/04: a flat body 400s) — wrap the flattened `spec` back up
-// before sending it over the wire.
-const putBody = wrapDoc(docOf(spec), metaOf(spec));
-const put = await api('PUT', `/v2/workbooks/${a.workbook}/spec`, putBody);
-if (!put.ok) { console.error(`PUT failed (HTTP ${put.status}): ${put.text.slice(0, 400)}`); process.exit(1); }
-
-// verify the layout (containers included) survived readback
-const rb = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
-// Same nested-`document` unwrap as the GET above — every downstream read of
-// this readback (layout string, the lint payload, the visual-QA page list)
-// expects a flat spec, not the live nested shape.
-const rbSpec = { ...metaOf(rb.json), ...docOf(rb.json) };
-const rbLayout = rbSpec.layout || '';
-const ok = /<LayoutElement/.test(rbLayout) && /<GridContainer/.test(rbLayout);
-console.log(JSON.stringify({ workbookId: a.workbook, pagesLaidOut: pageBlocks.length, layoutOnReadback: ok }, null, 2));
-if (!ok) { console.error('FAIL: container layout did not survive readback (check elementId matches — a GridContainer with an unknown elementId is silently dropped)'); process.exit(1); }
+let rbSpec;
+try { rbSpec = assertWorkbookContract(got.json, { requireWrapper: true }); }
+catch (error) { console.error(`FAIL: authoritative layout readback gate: ${error.message}`); process.exit(1); }
+const rb = got;
+const pageBlocks = rbSpec.pages || [];
+console.log(JSON.stringify({
+  workbookId: a.workbook,
+  pagesLaidOut: pageBlocks.length,
+  elementsLaidOut: (rbSpec.elements || []).length,
+  layoutOnReadback: true,
+}, null, 2));
 
 // Layout-quality lint (gate) — shared scripts/lib/layout_lint.rb, vendored
 // byte-identical across the migration plugins. Runs on the final readback spec:
@@ -199,16 +57,13 @@ if (!a['skip-layout-lint'] && rb.json) {
   }
   console.error('layout lint: clean');
 }
-console.error(`container-banded layout applied (${pageBlocks.length} page block(s))`);
+console.error(`authoritative layout verified (${pageBlocks.length} page block(s))`);
 
 // Visual-QA gate — render each CONTENT page to a FULL-PAGE PNG so the layout can
 // be reviewed against refs/layout-visual-qa.md (matching qlik/tableau Phase 5b).
 // NON-FATAL: a transient export failure must not sink a green migration — the
-// REVIEW is the gate. Page ids come from the post-PUT readback spec (rb.json) we
-// already hold: those are the AUTHORITATIVE posted ids (the Cognos POST reassigns
-// page/element ids, so the local pre-POST spec would carry stale ids — and this
-// readback is the same JSON the layout gate above already depends on, not the
-// flaky-YAML /spec case). The Sigma token is passed explicitly to the python
+// REVIEW is the gate. Page ids come from the authoritative GET readback we
+// already hold. The Sigma token is passed explicitly to the python
 // child via env (inherited SIGMA_API_TOKEN; same one the api() helper uses).
 // --skip-visual-qa bypasses.
 if (!a['skip-visual-qa'] && rb.json) {

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/workbook_contract.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/workbook_contract.mjs
@@ -1,0 +1,61 @@
+// Cognos workbook-code release gate. Data-model specs intentionally do not use
+// this contract: their pages[*].elements nesting remains unchanged.
+import * as CodeRep from './code_rep.mjs';
+
+const count = (text, needle) => text.split(needle).length - 1;
+
+export function workbookContractErrors(spec, { requireWrapper = false } = {}) {
+  const errors = [];
+  if (requireWrapper && (!spec || typeof spec.document !== 'object' || Array.isArray(spec.document))) {
+    errors.push('top-level `document` wrapper is required');
+  }
+  const rawDoc = spec && typeof spec.document === 'object' && !Array.isArray(spec.document)
+    ? spec.document : spec;
+  for (const page of (Array.isArray(rawDoc?.pages) ? rawDoc.pages : [])) {
+    if (Array.isArray(page?.elements)) errors.push(`page ${page.id || '(missing id)'} is not metadata-only (remove page.elements)`);
+  }
+  const doc = CodeRep.document(spec);
+  const pages = Array.isArray(doc.pages) ? doc.pages : [];
+  const elements = CodeRep.workbookElements(doc);
+  const layout = typeof doc.layout === 'string' ? doc.layout : '';
+
+  if (!Array.isArray(doc.pages)) errors.push('document.pages must be an array');
+  if (!Array.isArray(doc.elements)) errors.push('document.elements must be a flat array');
+  pages.forEach((page) => { if (!page?.id) errors.push('every page needs an id'); });
+  if (!layout.trim()) errors.push('document.layout is required and must be authoritative');
+
+  const pageIds = pages.map((page) => page?.id).filter(Boolean);
+  if (new Set(pageIds).size !== pageIds.length) errors.push('page ids must be unique');
+  for (const pageId of pageIds) {
+    if (!new RegExp(`<Page\\b[^>]*\\bid="${String(pageId).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`).test(layout)) {
+      errors.push(`layout has no <Page> block for ${pageId}`);
+    }
+  }
+  if (doc.panels !== undefined && !Array.isArray(doc.panels)) errors.push('document.panels must be an array');
+  for (const panel of (Array.isArray(doc.panels) ? doc.panels : [])) {
+    if (!panel?.id || !['header', 'sidebar'].includes(panel.type)) {
+      errors.push('every document panel needs an id and type header|sidebar');
+    }
+    for (const pageId of (Array.isArray(panel?.pages) ? panel.pages : [])) {
+      if (!pageIds.includes(pageId)) errors.push(`panel ${panel.id || '(missing id)'} references unknown page ${pageId}`);
+    }
+  }
+
+  const elementIds = elements.map((element) => element?.id).filter(Boolean);
+  if (new Set(elementIds).size !== elementIds.length) errors.push('flat document element ids must be unique');
+  for (const elementId of elementIds) {
+    const n = count(layout, `elementId="${elementId}"`);
+    if (n !== 1) errors.push(`element ${elementId} must appear exactly once in layout (found ${n})`);
+  }
+  const known = new Set(elementIds);
+  for (const match of layout.matchAll(/\belementId="([^"]+)"/g)) {
+    if (!known.has(match[1])) errors.push(`layout references unknown element ${match[1]}`);
+  }
+  return errors;
+}
+
+export function assertWorkbookContract(spec, options = {}) {
+  const errors = workbookContractErrors(spec, options);
+  if (errors.length) throw new Error(`workbook code contract failed:\n- ${errors.join('\n- ')}`);
+  return CodeRep.document(spec);
+}

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
@@ -577,6 +577,7 @@ run('node', [join(HERE, 'post-and-readback.mjs'), '--type', 'workbook', '--spec'
 const wbMap = JSON.parse(readFileSync(wbMapPath, 'utf8'));
 state.workbookId = wbMap.workbookId;
 state.wbElements = wbMap.elements || [];
+if (wbMap.layoutOnReadback !== true) die('workbook POST readback did not prove the authoritative layout survived');
 line(`workbookId = ${state.workbookId} (${state.wbElements.length} element(s), 0 error columns)`);
 writeFileSync(statePath, JSON.stringify(state, null, 2));
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/post-and-readback.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/post-and-readback.mjs
@@ -11,6 +11,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { api, extractId, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
 import * as CodeRep from './lib/code_rep.mjs';
+import { assertWorkbookContract } from './lib/workbook_contract.mjs';
 
 const a = parseArgs(process.argv.slice(2));
 if (!a.type || !a.spec || !a.folder) { console.error('need --type datamodel|workbook --spec <spec.json> --folder <folderId>'); process.exit(2); }
@@ -27,8 +28,13 @@ const name = a.name || spec.name || `cognos ${a.type} ${Date.now()}`;
 // workbook branch wraps; the datamodel body construction below is untouched
 // (still `{folderId, ...spec, name}`, name last so it can't be silently
 // overridden by a spec.name).
+let workbookDoc;
+if (a.type === 'workbook') {
+  try { workbookDoc = assertWorkbookContract(spec, { requireWrapper: true }); }
+  catch (error) { console.error(`REFUSE POST: ${error.message}`); process.exit(1); }
+}
 const body = a.type === 'workbook'
-  ? CodeRep.wrap(CodeRep.document(spec), { folderId: a.folder, ...CodeRep.metadata(spec), name })
+  ? CodeRep.wrap(workbookDoc, { folderId: a.folder, ...CodeRep.metadata(spec), name })
   : { folderId: a.folder, ...spec, name };
 const post = await api('POST', postPath, body);
 const id = extractId(post, idField);
@@ -44,7 +50,22 @@ for (const c of (Array.isArray(list) ? list : [])) {
   if (String(t).toLowerCase() === 'error') errors.push(c.name || c.columnName || c.columnId);
 }
 const elements = elementsOf((await api('GET', a.type === 'datamodel' ? `/v2/dataModels/${id}/elements` : `/v2/workbooks/${id}/elements`)).json);
-const result = { [idField]: id, elements, errors };
+let layoutOnReadback;
+if (a.type === 'workbook') {
+  const readback = await api('GET', `/v2/workbooks/${id}/spec`);
+  if (!readback.ok || !readback.json) {
+    console.error(`FAIL: workbook spec readback failed (HTTP ${readback.status}): ${readback.text.slice(0, 500)}`);
+    process.exit(1);
+  }
+  try {
+    assertWorkbookContract(readback.json, { requireWrapper: true });
+    layoutOnReadback = true;
+  } catch (error) {
+    console.error(`FAIL: posted workbook did not survive the code/layout readback gate: ${error.message}`);
+    process.exit(1);
+  }
+}
+const result = { [idField]: id, elements, errors, ...(a.type === 'workbook' ? { layoutOnReadback } : {}) };
 if (a.out) writeFileSync(a.out, JSON.stringify(result, null, 2));
 console.log(JSON.stringify(result, null, 2));
 if (errors.length) { console.error(`FAIL: ${errors.length} error-typed column(s): ${errors.join(', ')}`); process.exit(1); }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/remap-wb-to-dm-ids.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/remap-wb-to-dm-ids.mjs
@@ -12,18 +12,21 @@
 //   node scripts/remap-wb-to-dm-ids.mjs --wb wb-spec.json --dm-id <dataModelId> [--out wb.remapped.json]
 import { readFileSync, writeFileSync } from 'node:fs';
 import { api, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
+import * as CodeRep from './lib/code_rep.mjs';
+import { assertWorkbookContract } from './lib/workbook_contract.mjs';
 
 const a = parseArgs(process.argv.slice(2));
 if (!a.wb || !a['dm-id']) { console.error('need --wb <spec.json> --dm-id <dataModelId>'); process.exit(2); }
 const dmId = a['dm-id'];
 const wb = JSON.parse(readFileSync(a.wb, 'utf8'));
+const doc = assertWorkbookContract(wb);
 
 const els = elementsOf((await api('GET', `/v2/dataModels/${dmId}/elements`)).json);
 if (!els.length) { console.error(`No elements found on data model ${dmId} (token? wrong id?)`); process.exit(1); }
 const byName = new Map(els.map((e) => [e.name.toLowerCase(), e.id]));
 
 let remapped = 0; const unresolved = [];
-for (const p of wb.pages || []) for (const e of p.elements || []) {
+for (const e of CodeRep.workbookElements(doc)) {
   const s = e.source; if (!s || !('elementId' in s)) continue;
   s.dataModelId = dmId;
   const want = String(s.elementId || '').toLowerCase();
@@ -32,6 +35,6 @@ for (const p of wb.pages || []) for (const e of p.elements || []) {
 }
 
 const out = a.out || a.wb.replace(/\.json$/, '.remapped.json');
-writeFileSync(out, JSON.stringify(wb, null, 2));
+writeFileSync(out, JSON.stringify(CodeRep.wrap(doc, CodeRep.metadata(wb)), null, 2));
 console.log(JSON.stringify({ dataModelId: dmId, dmElements: els.length, remapped, unresolved, out }, null, 2));
 if (unresolved.length) { console.error(`WARN: ${unresolved.length} elementId(s) unresolved — DM has no element named: ${unresolved.join(', ')}`); process.exit(1); }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-apply-layout.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-apply-layout.mjs
@@ -1,11 +1,7 @@
 #!/usr/bin/env node
-// Regression test for apply-layout.mjs's workbook code-rep `document` envelope
-// handling (2026-08, task 3.9). Before this fix: the pre-PUT GET was unwrapped
-// but the PUT itself still sent the flattened working spec FLAT (no `document`
-// wrapper — a live 400), and the post-PUT verification GET (whose result also
-// feeds the layout-lint payload and the visual-QA page list) read straight off
-// the still-nested response, so `rb.json.layout` / `rb.json.pages` were
-// silently undefined/empty even on a 200.
+// Regression test for the authoritative workbook layout gate. The gate must
+// consume the current wrapped/flat representation and must not synthesize or
+// PUT a replacement layout after creation.
 //
 // Runs IN-PROCESS (stubs `globalThis.fetch` + `process.exit`, then dynamically
 // imports apply-layout.mjs) rather than spawning `node apply-layout.mjs` as a
@@ -25,18 +21,19 @@ const SCRIPT = pathToFileURL(join(HERE, 'apply-layout.mjs')).href;
 const fails = [];
 const check = (cond, msg) => { console.error(`  ${cond ? 'PASS' : 'FAIL'}  ${msg}`); if (!cond) fails.push(msg); };
 
-// The LIVE shape: non-metadata fields (schemaVersion/pages) nested under `document`.
+// The LIVE shape: metadata-only pages + flat elements + required layout.
 const NESTED_DOC = {
   workbookId: 'wb-test',
   name: 'Test WB',
   folderId: 'home-1',
   document: {
     schemaVersion: 3,
-    pages: [{ id: 'pg1', name: 'Page 1', elements: [{ id: 'c1', kind: 'bar-chart' }] }],
+    pages: [{ id: 'pg1', name: 'Page 1' }],
+    elements: [{ id: 'c1', kind: 'bar-chart' }],
+    layout: '<?xml version="1.0"?><Page id="pg1"><Element elementId="c1" gridColumn="1 / 25" gridRow="1 / 12"/></Page>',
   },
 };
 
-let putBody = null;
 let getCount = 0;
 let putCount = 0;
 
@@ -47,16 +44,10 @@ globalThis.fetch = async (url, init = {}) => {
   if (!u.endsWith('/v2/workbooks/wb-test/spec')) return new Response('not found', { status: 404 });
   if (method === 'GET') {
     getCount += 1;
-    // 1st GET (pre-layout): the live nested readback. 2nd GET (post-PUT verify):
-    // echo back whatever was PUT — still nested — so the survives-readback
-    // check and the layout-lint/visual-QA reads exercise the SAME unwrap this
-    // fix adds, not a pre-flattened fixture.
-    const payload = getCount === 1 ? NESTED_DOC : putBody;
-    return new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    return new Response(JSON.stringify(NESTED_DOC), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
   if (method === 'PUT') {
     putCount += 1;
-    putBody = JSON.parse(init.body);
     return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
   return new Response('unsupported method', { status: 405 });
@@ -88,23 +79,15 @@ globalThis.fetch = realFetch;
 
 check(exitCode === null && !threw,
   `apply-layout.mjs runs to completion without exiting/throwing (exit=${exitCode}, threw=${threw ? threw.message : 'no'})`);
-check(putCount === 1, `exactly one PUT issued (got ${putCount})`);
-check(!!putBody && typeof putBody.document === 'object' && putBody.document !== null,
-  'PUT body carries a top-level `document` key (the wrap the bug omitted)');
-check(!!putBody && putBody.pages === undefined,
-  'PUT body has NO top-level `pages` (must be nested, not flat)');
-check(!!putBody && Array.isArray(putBody.document?.pages) && putBody.document.pages.length === 1,
-  'wrapped document carries the one page');
-check(!!putBody && typeof putBody.document?.layout === 'string' && putBody.document.layout.includes('<GridContainer'),
-  'wrapped document carries the synthesized layout XML');
-check(!!putBody && putBody.name === 'Test WB', 'name stays OUTSIDE document as metadata');
+check(putCount === 0, `no replacement PUT issued (got ${putCount})`);
 
 const out = logs.join('\n');
 let parsed = null;
 try { parsed = JSON.parse(out); } catch { /* left null */ }
 check(!!parsed && parsed.layoutOnReadback === true,
-  `layout survives the (nested, now-unwrapped) post-PUT readback (got stdout: ${out.slice(0, 200)})`);
-check(getCount === 2, `exactly 2 GETs issued (pre-PUT + post-PUT verify; got ${getCount})`);
+  `authoritative nested readback passes (got stdout: ${out.slice(0, 200)})`);
+check(!!parsed && parsed.elementsLaidOut === 1, 'gate counted the flat document element');
+check(getCount === 1, `exactly one authoritative GET issued (got ${getCount})`);
 
 console.log();
 if (fails.length) { console.log(`${fails.length} FAILURE(S):`); fails.forEach((f) => console.log(`  - ${f}`)); process.exit(1); }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-control-lint-gate.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-control-lint-gate.rb
@@ -26,32 +26,34 @@ def lint(spec)
   end
 end
 
-good = {
-  'pages' => [{
-    'name' => 'P1', 'id' => 'pg1',
-    'elements' => [
-      { 'id' => 'base', 'kind' => 'table', 'name' => 'Report',
-        'columns' => [{ 'id' => 'c_dim', 'formula' => '[Dim]' }] },
-      { 'id' => 'kpi1', 'kind' => 'kpi-chart', 'name' => 'Total',
-        'source' => { 'kind' => 'source', 'source' => { 'elementId' => 'base' } } },
-      { 'id' => 'ctl1', 'kind' => 'control', 'controlId' => 'dim', 'controlType' => 'list',
-        'filters' => [{ 'source' => { 'elementId' => 'base' }, 'columnId' => 'c_dim' }] }
-    ]
-  }]
-}
+def workbook(elements)
+  ids = elements.map { |e| %(<Element elementId="#{e.fetch('id')}"/>) }.join
+  {
+    'name' => 'Control lint fixture',
+    'document' => {
+      'pages' => [{ 'name' => 'P1', 'id' => 'pg1' }],
+      'elements' => elements,
+      'layout' => %(<Page id="pg1">#{ids}</Page>)
+    }
+  }
+end
 
-partial = {
-  'pages' => [{
-    'name' => 'P1', 'id' => 'pg1',
-    'elements' => [
-      { 'id' => 'base', 'kind' => 'table', 'name' => 'Report',
-        'columns' => [{ 'id' => 'c_dim', 'formula' => '[Dim]' }] },
-      { 'id' => 'kpi1', 'kind' => 'kpi-chart', 'name' => 'Total' }, # NOT sourced from base
-      { 'id' => 'ctl1', 'kind' => 'control', 'controlId' => 'dim', 'controlType' => 'list',
-        'filters' => [{ 'source' => { 'elementId' => 'base' }, 'columnId' => 'c_dim' }] }
-    ]
-  }]
-}
+good = workbook([
+  { 'id' => 'base', 'kind' => 'table', 'name' => 'Report',
+    'columns' => [{ 'id' => 'c_dim', 'formula' => '[Dim]' }] },
+  { 'id' => 'kpi1', 'kind' => 'kpi-chart', 'name' => 'Total',
+    'source' => { 'kind' => 'source', 'source' => { 'elementId' => 'base' } } },
+  { 'id' => 'ctl1', 'kind' => 'control', 'controlId' => 'dim', 'controlType' => 'list',
+    'filters' => [{ 'source' => { 'elementId' => 'base' }, 'columnId' => 'c_dim' }] }
+])
+
+partial = workbook([
+  { 'id' => 'base', 'kind' => 'table', 'name' => 'Report',
+    'columns' => [{ 'id' => 'c_dim', 'formula' => '[Dim]' }] },
+  { 'id' => 'kpi1', 'kind' => 'kpi-chart', 'name' => 'Total' }, # NOT sourced from base
+  { 'id' => 'ctl1', 'kind' => 'control', 'controlId' => 'dim', 'controlType' => 'list',
+    'filters' => [{ 'source' => { 'elementId' => 'base' }, 'columnId' => 'c_dim' }] }
+])
 
 check(File.exist?(CL), 'control_lint.rb is vendored into cognos scripts/lib')
 check(lint(good) == 0, 'correctly-wired control (reaches KPI via source) -> gate PASSES (exit 0)')

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-metric-reference.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-metric-reference.mjs
@@ -15,6 +15,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
+import * as CodeRep from './lib/code_rep.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL = dirname(__dirname);
@@ -39,8 +40,7 @@ function build(metricsMap) {
   return JSON.parse(out);
 }
 
-const formulasOf = (wb) => (wb.pages || [])
-  .flatMap((p) => p.elements || [])
+const formulasOf = (wb) => CodeRep.workbookElements(wb)
   .flatMap((e) => (e.columns || []).map((c) => String(c.formula)));
 
 // 1) no --metrics → inline aggregates, no metric refs (byte-identical fallback)

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-post-and-readback.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-post-and-readback.mjs
@@ -14,6 +14,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as CodeRep from './lib/code_rep.mjs';
+import { workbookContractErrors } from './lib/workbook_contract.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -29,10 +30,16 @@ const check = (cond, msg) => { if (!cond) fail++; console.log(`  ${cond ? 'PASS'
 
 // workbook post body is nested
 {
-  const doc = { schemaVersion: 1, pages: [], kind: 'workbook' };
+  const doc = { schemaVersion: 1, pages: [{ id: 'p1' }], elements: [{ id: 'e1', kind: 'text', body: 'x' }],
+    layout: '<Page id="p1"><Element elementId="e1"/></Page>', kind: 'workbook' };
   const body = CodeRep.wrap(doc, { name: 'n', folderId: 'f' });
   check(JSON.stringify(body.document) === JSON.stringify(doc), 'workbook POST body: document key holds the doc verbatim');
   check(!('pages' in body), 'workbook POST body: pages must not remain top-level');
+  check(workbookContractErrors(body, { requireWrapper: true }).length === 0,
+    'workbook POST body: flat elements + metadata-only pages + authoritative layout pass');
+  const bad = { name: 'bad', document: { schemaVersion: 1, pages: [{ id: 'p1', elements: [{ id: 'e1' }] }] } };
+  check(workbookContractErrors(bad, { requireWrapper: true }).some((e) => /metadata-only/.test(e)),
+    'workbook POST body: legacy page-nested elements fail loudly');
 }
 
 // the DM branch must be left alone — that surface is not changing
@@ -48,6 +55,8 @@ const check = (cond, msg) => { if (!cond) fail++; console.log(`  ${cond ? 'PASS'
 const src = readFileSync(join(__dirname, 'post-and-readback.mjs'), 'utf8');
 check(/CodeRep\.(document|wrap|metadata)/.test(src),
       'post-and-readback.mjs must call CodeRep for its workbook branch');
+check(/assertWorkbookContract/.test(src),
+      'post-and-readback.mjs must gate the required authoritative layout before and after POST');
 
 // The property the check above does NOT protect: that CodeRep is reachable
 // ONLY from the workbook side of the `a.type === 'workbook' ? ... : ...`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Migrates Cognos workbook output to flat elements and canonical authoritative layout with grounded released-feature mappings.

## Scope
- Plugin: `cognos-to-sigma`
- [x] Exactly one plugin
- [x] Plugin version `1.2.15 → 1.2.16`

## Validation
- [x] Shared-copy, lint, and version gates
- [x] Converter, TypeScript, readback, layout, parity, and bundle checks
- [x] Cognos corpus: 2/2
- [x] Working tree clean

Cross-report drill-through, page footers, unsupported visual types, and gated box charts remain explicit gaps.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7f13445-765b-464d-8cb1-9a6d12b52e8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7f13445-765b-464d-8cb1-9a6d12b52e8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

