### PR TITLE
fix(domo-to-sigma): salvage gate-1 parity oracle from superseded PR #661

### DIFF
--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-parity-oracle.rb
@@ -40,6 +40,7 @@ require 'json'
 require 'set'
 require 'optparse'
 require 'time'
+require 'date'
 
 opts = {}
 OptionParser.new do |p|
@@ -51,6 +52,9 @@ OptionParser.new do |p|
   p.on('--out PATH') { |v| opts[:out] = v }
   p.on('--exclusions PATH') { |v| opts[:excl] = v }
   p.on('--allow-cross-day', 'proceed even if the two sides straddle a UTC date boundary') { opts[:xday] = true }
+  p.on('--allow-stale-warehouse REASON', 'proceed even though the landed warehouse copy holds ' \
+       'OLDER data than Domo (see the freshness guard) — only safe when no plan tile has a date ' \
+       'dimension or a relative window') { |v| opts[:allow_stale] = v }
 end.parse!
 abort('--workdir required') unless opts[:wd] && Dir.exist?(opts[:wd])
 wd = opts[:wd]
@@ -101,6 +105,90 @@ def card_id_for(element_id)
   return [nil, false] unless m
   [m[1], !m[2].nil?]
 end
+
+# Parse the handful of date shapes the two sides actually emit. Domo's card-data
+# returns ISO days ("2026-07-13") and month buckets ("2026-Mar"); Sigma's CSV
+# export returns ISO ("2026-07-11", "2026-02"). Anything unrecognised is nil, and
+# a nil simply excludes that tile from the freshness check — never a false alarm.
+# A CONSTANT, not a local: a leading-underscore local is invisible inside `def`.
+MONTH_ABBR = %w[Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec]
+             .each_with_index.to_h { |m, i| [m, i + 1] }.freeze
+def parse_date(v)
+  s = v.to_s.strip
+  if (m = /\A(\d{4})-(\d{2})-(\d{2})/.match(s))
+    return (Date.new(m[1].to_i, m[2].to_i, m[3].to_i) rescue nil)
+  end
+  if (m = /\A(\d{4})-(\d{2})\z/.match(s))
+    return (Date.new(m[1].to_i, m[2].to_i, 1) rescue nil)
+  end
+  if (m = /\A(\d{4})-([A-Z][a-z]{2})\z/.match(s)) && MONTH_ABBR[m[2]]
+    return (Date.new(m[1].to_i, MONTH_ABBR[m[2]], 1) rescue nil)
+  end
+  nil
+end
+
+# Canonicalise Domo's month-bucket rendering to the ISO form Sigma exports.
+# Domo renders a CalendarMonth dimension as "2026-Apr"; Sigma's CSV export gives
+# "2026-04". Same month, different rendering — comparing the strings fails the
+# tile with every measure identical. Measured on 2 tiles (Unsubscribes, Bounces
+# Trend) on the 2026-08-07 run.
+#
+# This is normalisation, not masking: it only rewrites a value that parses as
+# EXACTLY `YYYY-Mon`, and only into the same month's ISO form. A value that means
+# something different is left alone, so a genuine dimension difference still
+# fails. Anything not matching that one pattern is untouched.
+#
+# THREE grains are handled, each VERIFIED against the live corpus rather than
+# assumed, because a wrong rule here would silently fail a tile forever:
+#
+#   month    "2026-Apr"      -> "2026-04"     (Unsubscribes, Bounces Trend)
+#   quarter  "2025-Q3"       -> "2025-07"     first month of the quarter
+#                                             (Projected Sales; 3/3 samples)
+#   week     "Week-28 2026"  -> "2026-07-05"  SUNDAY-anchored week start, where
+#                                             week 1 begins on the Sunday on or
+#                                             before Jan 1 (Click-Through Rate,
+#                                             Traffic Trend; 4/4 samples)
+#
+# THE WEEK RULE IS NOT ISO. ISO calls 2026-07-05 week 27; Domo calls it week 28.
+# Using isocalendar() would have been off by one on every week-grained tile and
+# looked like a data difference. Checked, not guessed.
+def canonicalise_dim(rows)
+  return [rows, 0] unless rows.is_a?(Array)
+  n = 0
+  out = rows.map do |r|
+    a = Array(r).dup
+    s = a.first.to_s
+    if (m = /\A(\d{4})-([A-Z][a-z]{2})\z/.match(s)) && MONTH_ABBR[m[2]]
+      a[0] = format('%s-%02d', m[1], MONTH_ABBR[m[2]])
+      n += 1
+    elsif (m = /\A(\d{4})-Q([1-4])\z/.match(s))
+      a[0] = format('%s-%02d', m[1], ((m[2].to_i - 1) * 3) + 1)
+      n += 1
+    elsif (m = /\AWeek-(\d{1,2})\s+(\d{4})\z/.match(s))
+      wk = m[1].to_i
+      yr = m[2].to_i
+      jan1 = Date.new(yr, 1, 1)
+      # Sunday on or before Jan 1 == start of Domo's week 1.
+      wk1 = jan1 - ((jan1.wday) % 7)
+      a[0] = (wk1 + ((wk - 1) * 7)).to_s
+      n += 1
+    end
+    a
+  end
+  [out, n]
+end
+
+# The newest date appearing in a row set's FIRST column, or nil if that column is
+# not uniformly a date.
+def max_date(rows)
+  return nil unless rows.is_a?(Array) && !rows.empty?
+  ds = rows.map { |r| parse_date(Array(r).first) }
+  return nil if ds.any?(&:nil?)
+  ds.max
+end
+
+stale_evidence = []
+canonicalised = 0
 
 # PRIOR exclusions, loaded BEFORE the loop and honoured over verification.
 #
@@ -238,6 +326,12 @@ charts.each do |c|
     next
   end
 
+  # Canonicalise the dimension BEFORE the row is recorded — doing it afterwards
+  # mutates a local the emitted hash no longer references, which is exactly the
+  # bug this comment exists to stop recurring.
+  exp_rows, canon_n = canonicalise_dim(exp_rows)
+  canonicalised += canon_n
+
   verified << {
     'chart'          => name,
     'sigma_element_id' => eid,
@@ -256,6 +350,76 @@ charts.each do |c|
     # element's plotted order. `columns` is still carried for diagnostics.
     'actual'         => { 'rows' => act['rows'], 'columns' => act['columns'] },
   }
+
+  # ---- warehouse-freshness evidence, collected as we go -------------------
+  # See the guard below. Recorded per tile whose first column parses as a date
+  # on BOTH sides, which is the only shape where "whose data is newer" is a
+  # meaningful question.
+  ed = max_date(exp_rows)
+  ad = max_date(act['rows'])
+  stale_evidence << { 'chart' => name, 'element_id' => eid,
+                      'domo_max' => ed.to_s, 'sigma_max' => ad.to_s,
+                      'days' => (ed - ad).to_i } if ed && ad && ed > ad
+end
+
+# ---- WAREHOUSE FRESHNESS GUARD ---------------------------------------------
+# THERE ARE THREE CLOCKS HERE AND THE SAME-DAY GUARD ABOVE ONLY WATCHES TWO.
+#
+# That guard refuses when the two COLLECTORS ran on different UTC days. But the
+# Sigma side does not read Domo — it reads a warehouse COPY that
+# domo-import-to-snowflake landed at some earlier moment. If that snapshot is
+# older than Domo's live data, both collectors can run in the same second and
+# still be comparing different data.
+#
+# MEASURED 2026-08-07, the run this guard exists because of. The landed table
+# carried Domo's own _BATCH_LAST_RUN_ = 2026-08-05T14:41:55Z with a newest fact
+# date of 2026-08-04, while Domo rendered through 2026-08-06. Two days stale, and
+# gate 1 reported 24.6% (14/57) — which read exactly like 43 broken tiles:
+#   * 3 trend tiles offset by 2 days, with measures aligning 1:1 by POSITION
+#   * every %-change KPI SIGN-INVERTED (+0.198 -> -0.312), because a 7-day
+#     window over data ending 2 days earlier reshuffles which rows fall in the
+#     current vs prior period, and a ratio near 1 flips
+#   * windowed counts off by ~3%
+#   * and the 14 that passed were exactly the non-windowed / static-dataset
+#     tiles, passing byte-exactly (3180018 == 3180018)
+# Nothing about that failure points at the warehouse being behind. Someone would
+# reasonably spend a day auditing the converter, whose formulas were correct.
+#
+# DETECTION USES DATA THE JOIN ALREADY HOLDS — no extra API call, no reliance on
+# _BATCH_LAST_RUN_ existing. For every tile whose first column is uniformly a
+# date on both sides, compare the newest date. Domo newer than Sigma means the
+# warehouse cannot possibly match, whatever the conversion does.
+#
+# TWO tiles must agree before refusing. One tile could legitimately differ (a
+# top-N or a filter truncating Sigma's range); a second independent tile showing
+# the same direction is no longer explainable that way. Reporting every tile
+# either way, so the operator sees the spread rather than one number.
+unless stale_evidence.empty?
+  worst = stale_evidence.max_by { |e| e['days'] }
+  if stale_evidence.size >= 2 && !opts[:allow_stale]
+    warn ''
+    warn 'REFUSING to emit a parity plan: the WAREHOUSE COPY IS STALE relative to Domo.'
+    warn ''
+    stale_evidence.sort_by { |e| -e['days'] }.first(8).each do |e|
+      warn format('    %-26s domo through %s, sigma through %s  (%+d days)',
+                  e['element_id'], e['domo_max'], e['sigma_max'], -e['days'])
+    end
+    warn "    ... and #{stale_evidence.size - 8} more" if stale_evidence.size > 8
+    warn ''
+    warn "#{stale_evidence.size} date-dimensioned tile(s) show Domo holding data newer than the"
+    warn "warehouse, by up to #{worst['days']} day(s). Scoring this would produce a large, entirely"
+    warn 'misleading FAIL: windowed KPIs shift, %-change ratios can invert sign, and only the'
+    warn 'non-windowed tiles would pass. The conversion is not what is wrong.'
+    warn ''
+    warn 'FIX: re-land the datasets, then re-run the parity phase, so both sides see one snapshot:'
+    warn '    ruby ../domo-import-to-snowflake/scripts/domo_import_to_snowflake.rb --workdir <wd> ...'
+    warn 'Override with --allow-stale-warehouse REASON only if you have established that every'
+    warn 'plan tile is insensitive to the gap (no relative windows, no date dimensions).'
+    exit 9
+  end
+  warn "WARNING: #{stale_evidence.size} tile(s) show Domo newer than the warehouse " \
+       "(worst #{worst['days']} day(s)) — proceeding because " \
+       "#{opts[:allow_stale] ? "--allow-stale-warehouse: #{opts[:allow_stale]}" : 'only one tile is affected'}."
 end
 
 # ---- the invariant ---------------------------------------------------------

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-actuals.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-actuals.rb
@@ -114,6 +114,26 @@ threads = [opts[:pool], 1].max.times.map do
         next
       end
       headers = rows.shift.map { |h| h.to_s.strip }
+
+      # HEADERS BUT NO DATA ROWS is a real defect, not an empty comparison.
+      # Measured on the 2026-08-07 run: FOUR elements exported column headers and
+      # zero rows — a bar chart, a table, a region-map and a scatter. The element
+      # renders nothing in Sigma. Recording it as a successful export made the
+      # join compare N Domo rows against 0 Sigma rows, which scores as an
+      # ordinary DIVERGE and hides the actual finding ("this tile is blank")
+      # among value mismatches. It belongs in `unavailable` so it becomes an
+      # exclusion with a reason an operator can act on.
+      if rows.empty?
+        mutex.synchronize do
+          unavailable << { 'chart' => name, 'element_id' => eid,
+                           'columns' => headers,
+                           'reason' => 'Sigma element exported column headers but ZERO data rows ' \
+                                       "(#{headers.size} column(s): #{headers.join(', ')}) — the " \
+                                       'tile renders nothing; fix the element rather than scoring it' }
+          warn "  NO ROWS #{eid} #{name[0, 30]} (#{headers.size} header(s), 0 rows)"
+        end
+        next
+      end
       mutex.synchronize do
         # Keyed by element id — see the header. A collision here would mean the
         # PLAN listed the same element twice, which is a different (and louder)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-expected.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/collect-parity-expected.rb
@@ -92,6 +92,56 @@ def shape_rows(data)
   rows.map { |r| Array(r) }
 end
 
+# Domo sometimes plots ONE measure on TWO channels, so its row carries the same
+# value twice while Sigma's export carries it once. Measured 2026-08-07:
+#   Top 20 Organic Tweets   ['Text','Favorite Count','Favorite Count']
+#                           -> ["...", 2817, 2817]     Sigma: ["...", 1287]
+#   Page Engagement Rate    ['Date','Engaged Users','Unique Impressions','Engaged Users']
+#                           -> ["2026-07-25", 3288.0, 202283, 3288]
+#   Page View Growth        ['Date','Unique Page Views','Page Views','Unique Page Views']
+# Comparing whole tuples, that arity difference fails the tile before any value
+# is looked at — a pure artifact of how Domo reports channels.
+#
+# THE TEST IS DELIBERATELY STRICTER THAN "SAME COLUMN NAME". A later channel is
+# dropped only when its name matches an earlier one AND every row's value is
+# numerically equal. Name alone would corrupt Domo's table-default COUNT shape,
+# where the row-key column appears as BOTH the dimension and the counted measure
+# — e.g. Least Clicked Campaigns is ['campaign_title','campaign_title'] with
+# values ["Gembucket campaign", 2]. Those are different data under one name and
+# must both survive; the strict test leaves them alone.
+#
+# Returns [rows, columns, mappings, dropped] — dropped names are recorded on the
+# card so the collapse is auditable, never invisible.
+def dedupe_channels(rows, columns, mappings)
+  cols = Array(columns)
+  return [rows, cols, Array(mappings), []] if cols.size < 2 || rows.empty?
+
+  numeric = ->(v) { f = Float(v.to_s) rescue nil; f }
+  drop = []
+  (1...cols.size).each do |j|
+    (0...j).each do |i|
+      next if drop.include?(i)
+      next unless cols[j].to_s == cols[i].to_s
+      same = rows.all? do |r|
+        a = numeric.call(Array(r)[i])
+        b = numeric.call(Array(r)[j])
+        (a && b) ? a == b : Array(r)[i].to_s == Array(r)[j].to_s
+      end
+      if same
+        drop << j
+        break
+      end
+    end
+  end
+  return [rows, cols, Array(mappings), []] if drop.empty?
+
+  keep = (0...cols.size).reject { |k| drop.include?(k) }
+  [rows.map { |r| keep.map { |k| Array(r)[k] } },
+   keep.map { |k| cols[k] },
+   keep.map { |k| Array(mappings)[k] },
+   drop.map { |k| cols[k] }]
+end
+
 # The card's own KPI value — what the migrated `<el>-summary` companion tile
 # plots. `summary` carries BOTH forms:
 #
@@ -154,16 +204,18 @@ threads = [opts[:pool], 1].max.times.map do
                                     'value from a window baked into the plotted measure)',
                         'mappings' => data['mappings'], 'num_rows' => data['numRows'] }
           else
+            rows, cols, maps, dropped = dedupe_channels(rows, data['columns'], data['mappings'])
             results[cid] = {
               'card_id'   => cid,
               'title'     => title,
               'rows'      => rows,
-              'columns'   => data['columns'],
-              'mappings'  => data['mappings'],
+              'columns'   => cols,
+              'mappings'  => maps,
               'num_rows'  => data['numRows'],
               'datasource' => data['datasource'],
               'source'    => 'domo-card-data',
             }
+            results[cid]['dropped_duplicate_channels'] = dropped unless dropped.empty?
           end
           results[cid]['summary_value'] = sv if sv && results[cid]
           warn "  [#{results.size + errors.size}/#{cards.size}] #{title[0, 46]}"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-freshness.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-freshness.rb
@@ -1,0 +1,129 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression: the WAREHOUSE FRESHNESS guard in build-parity-oracle.rb.
+#
+# THERE ARE THREE CLOCKS AND THE SAME-DAY GUARD ONLY WATCHED TWO. That guard
+# refuses when the two collectors ran on different UTC days. But the Sigma side
+# reads a warehouse COPY landed at some earlier moment — so both collectors can
+# run in the same second and still compare different data.
+#
+# MEASURED on the 2026-08-07 live run this guard exists because of. The landed
+# table carried Domo's own _BATCH_LAST_RUN_ = 2026-08-05T14:41:55Z with a newest
+# fact date of 2026-08-04, while Domo rendered through 2026-08-06. Gate 1 then
+# reported 24.6% (14/57), which read exactly like 43 broken tiles:
+#   * trend tiles offset 2 days, measures aligning 1:1 by POSITION
+#   * every %-change KPI SIGN-INVERTED (+0.198 -> -0.312) because a 7-day window
+#     over data ending 2 days earlier reshuffles current vs prior period
+#   * windowed counts off ~3%
+#   * the 14 passes were exactly the non-windowed / static-dataset tiles, exact
+# Re-running the guard over that real workdir finds 8 date-dimensioned tiles ALL
+# reporting exactly -2 days. Nothing in the failure output points at the
+# warehouse; the converter's formulas were correct.
+#
+#   ruby test/test-parity-freshness.rb
+require 'json'
+require 'open3'
+require 'tmpdir'
+
+SKILL   = File.expand_path('..', __dir__)
+SCRIPTS = File.join(SKILL, 'scripts')
+$failures = 0
+def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
+def eq(a, e, m)
+  if a == e then puts "  ok: #{m}"
+  else $failures += 1; puts "  FAIL: #{m}\n        expected #{e.inspect}\n        got      #{a.inspect}" end
+end
+
+# Two date-dimensioned tiles. `domo_max` is the newest Domo date; `sigma_lag`
+# shifts the Sigma side back by that many days, i.e. a stale warehouse.
+def stage(dir, sigma_lag:, tiles: 2)
+  ids = (1..tiles).map { |i| "el-#{100 + i}" }
+  File.write(File.join(dir, 'parity-plan.json'), JSON.generate(
+    'charts' => ids.map do |i|
+      { 'chart' => "Trend #{i}", 'sigma_element_id' => i,
+        'sigma_kind' => 'line-chart', 'sigma_columns' => %w[d m] }
+    end))
+  # 5 daily points ending 2026-08-06 on the Domo side.
+  domo = (0..4).map { |k| [(Date.new(2026, 8, 6) - (4 - k)).to_s, (k + 1) * 10] }
+  sig  = domo.map { |d, v| [(Date.parse(d) - sigma_lag).to_s, v] }
+  File.write(File.join(dir, 'parity-expected.json'), JSON.generate(
+    'fetched_at' => '2026-08-07T12:00:00Z', 'unavailable' => [],
+    'cards' => ids.each_with_index.to_h do |i, n|
+      cid = (101 + n).to_s
+      [cid, { 'card_id' => cid, 'title' => "Trend #{i}", 'rows' => domo }]
+    end))
+  File.write(File.join(dir, 'parity-actuals.json'), JSON.generate(
+    'fetched_at' => '2026-08-07T12:05:00Z', 'unavailable' => [],
+    'charts' => ids.to_h do |i|
+      [i, { 'chart' => "Trend #{i}", 'element_id' => i,
+            'columns' => %w[Date M], 'rows' => sig }]
+    end))
+end
+
+require 'date'
+
+def run(dir, *extra)
+  out, st = Open3.capture2e('ruby', File.join(SCRIPTS, 'build-parity-oracle.rb'),
+                            '--workdir', dir, *extra)
+  [st.exitstatus, out]
+end
+
+# ---- stale warehouse, two tiles agreeing -> REFUSE ------------------------
+Dir.mktmpdir('fresh-stale') do |dir|
+  stage(dir, sigma_lag: 2)
+  code, out = run(dir)
+  eq(code, 9, 'a stale warehouse (2 tiles, -2 days) exits 9')
+  ok(out.include?('WAREHOUSE COPY IS STALE'), 'and says so in as many words')
+  ok(out.include?('-2 days'), 'reporting the measured lag per tile')
+  ok(out.match?(/re-land/i), 'and names the remedy (re-land, then re-run parity)')
+  ok(out.include?('The conversion is not what is wrong'),
+     'and says plainly that the conversion is not the defect — the whole point, since ' \
+     'the failure output otherwise reads as a broken migration')
+  ok(!File.exist?(File.join(dir, 'parity-plan-verified.json')),
+     'and writes NO plan — a stale plan scored later is exactly the misleading FAIL')
+end
+
+# ---- fresh warehouse -> proceed ------------------------------------------
+Dir.mktmpdir('fresh-ok') do |dir|
+  stage(dir, sigma_lag: 0)
+  code, out = run(dir)
+  eq(code, 0, 'a fresh warehouse proceeds')
+  ok(!out.include?('STALE'), 'with no staleness complaint')
+  ok(File.exist?(File.join(dir, 'parity-plan-verified.json')), 'and writes the plan')
+end
+
+# ---- ONE affected tile is a warning, not a refusal -----------------------
+# A single tile could legitimately differ (a top-N, or a filter truncating the
+# Sigma range). Two independent tiles showing the same direction cannot be
+# explained that way. Under-reacting on one tile is deliberate.
+Dir.mktmpdir('fresh-one') do |dir|
+  stage(dir, sigma_lag: 2, tiles: 1)
+  code, out = run(dir)
+  eq(code, 0, 'a single affected tile does NOT refuse (could be a filter or top-N)')
+  ok(out.match?(/WARNING/i) && out.match?(/newer than the warehouse/),
+     'but it is still reported as a warning, never silent')
+end
+
+# ---- the override is honoured, and records the reason --------------------
+Dir.mktmpdir('fresh-override') do |dir|
+  stage(dir, sigma_lag: 2)
+  code, out = run(dir, '--allow-stale-warehouse', 'no relative windows in this plan')
+  eq(code, 0, '--allow-stale-warehouse proceeds')
+  ok(out.include?('no relative windows in this plan'),
+     'and echoes the operator reason rather than waiving silently')
+  ok(File.exist?(File.join(dir, 'parity-plan-verified.json')), 'and writes the plan')
+end
+
+# ---- a NEWER warehouse than Domo must not trip it ------------------------
+# Only Domo-newer-than-Sigma means the warehouse cannot match. The reverse
+# (Sigma holding data Domo's card does not show) is a filter/window difference,
+# not staleness, and firing on it would be a false alarm.
+Dir.mktmpdir('fresh-reverse') do |dir|
+  stage(dir, sigma_lag: -2)
+  code, out = run(dir)
+  eq(code, 0, 'Sigma holding NEWER data than Domo is not staleness — no refusal')
+  ok(!out.include?('STALE'), 'and no staleness complaint')
+end
+
+puts $failures.zero? ? "\nALL PASS" : "\n#{$failures} FAILURE(S)"
+exit($failures.zero? ? 0 : 1)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle-dupenames.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle-dupenames.rb
@@ -27,11 +27,18 @@
 #
 #   ruby test/test-parity-oracle-dupenames.rb
 require 'json'
+require 'time'
 require 'open3'
 require 'tmpdir'
 require 'fileutils'
 
 SKILL   = File.expand_path('..', __dir__)
+# Stamped at RUN time, not hardcoded. The oracle's same-day guard compares the
+# expected side's fetched_at against the actuals side, and the actuals collector
+# stamps NOW — so a literal date here passes on the day it is written and aborts
+# ('REFUSING to join ... different UTC days') every day after. Time-bomb, not a
+# real cross-day case; the guard stays exercised by test-parity-freshness.rb.
+TODAY_UTC = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
 SCRIPTS = File.join(SKILL, 'scripts')
 $failures = 0
 def ok(c, m) if c then puts "  ok: #{m}" else $failures += 1; puts "  FAIL: #{m}" end end
@@ -60,7 +67,7 @@ def stage(dir, exclusions: nil)
         'sigma_kind' => 'kpi-chart', 'sigma_columns' => ['m'] }
     end))
   File.write(File.join(dir, 'parity-expected.json'), JSON.generate(
-    'fetched_at' => '2026-08-07T13:00:00Z', 'unavailable' => [],
+    'fetched_at' => TODAY_UTC, 'unavailable' => [],
     'cards' => IDS.to_h do |i|
       cid, sv = CARDS[i]
       [cid, { 'card_id' => cid, 'title' => "card #{cid}", 'rows' => [['x', 1]],
@@ -177,7 +184,7 @@ Dir.mktmpdir('dupe-rerun') do |dir|
   # el-1393001267-summary expects 100 but Sigma exports 999 -> a REAL divergence.
   # el-1124999128-summary has NO card entry at all -> "no Domo source value".
   File.write(File.join(dir, 'parity-expected.json'), JSON.generate(
-    'fetched_at' => '2026-08-07T13:00:00Z', 'unavailable' => [],
+    'fetched_at' => TODAY_UTC, 'unavailable' => [],
     'cards' => { '1393001267' => { 'card_id' => '1393001267', 'title' => 'a',
                                    'rows' => [['x', 1]], 'summary_value' => 100 },
                  '1037345428' => { 'card_id' => '1037345428', 'title' => 'b',
@@ -224,7 +231,7 @@ Dir.mktmpdir('dupe-eid') do |dir|
       'sigma_kind' => 'kpi-chart', 'sigma_columns' => ['m'] },
   ]))
   File.write(File.join(dir, 'parity-expected.json'), JSON.generate(
-    'fetched_at' => '2026-08-07T13:00:00Z', 'unavailable' => [],
+    'fetched_at' => TODAY_UTC, 'unavailable' => [],
     'cards' => { '777' => { 'card_id' => '777', 'title' => 'Pinned Card',
                             'rows' => [['x', 1]], 'summary_value' => 5 } }))
   run(File.join(SCRIPTS, 'collect-parity-actuals.rb'),

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-parity-oracle.rb
@@ -74,6 +74,65 @@ if sv_src
 end
 
 # ---------------------------------------------------------------------------
+# dedupe_channels — Domo sometimes plots ONE measure on TWO channels, so its row
+# carries the value twice while Sigma's export carries it once. Whole-tuple
+# comparison then fails the tile on arity before any value is looked at.
+#
+# Every shape below is verbatim from the 2026-08-07 live run.
+dc_src = expected_src[/^def dedupe_channels\(rows, columns, mappings\)\n.*?\nend\n/m]
+ok(dc_src, 'extracted dedupe_channels from collect-parity-expected.rb')
+eval(dc_src, TOPLEVEL_BINDING) if dc_src # rubocop:disable Security/Eval
+
+if dc_src
+  # Top 20 Organic Tweets: ['Text','Favorite Count','Favorite Count'] -> 2817 twice
+  rows, cols, maps, dropped = dedupe_channels(
+    [['a', 2817, 2817], ['b', 2320, 2320]],
+    ['Text', 'Favorite Count', 'Favorite Count'], %w[ITEM SERIES SERIES])
+  eq(cols, ['Text', 'Favorite Count'], 'a repeated channel with identical values is collapsed')
+  eq(rows, [['a', 2817], ['b', 2320]], 'and the rows lose exactly that column')
+  eq(maps, %w[ITEM SERIES], 'mappings stay parallel to columns')
+  eq(dropped, ['Favorite Count'], 'and the drop is RECORDED, never invisible')
+
+  # Page Engagement Rate: 3288.0 at one index, 3288 at another — numerically equal.
+  _, cols2, _, dropped2 = dedupe_channels(
+    [['2026-07-25', 3288.0, 202283, 3288]],
+    ['Date', 'Engaged Users', 'Unique Impressions', 'Engaged Users'],
+    %w[ITEM SERIES SERIES SERIES])
+  eq(cols2, ['Date', 'Engaged Users', 'Unique Impressions'],
+     'int/float variance of the same value still counts as a duplicate')
+  eq(dropped2, ['Engaged Users'], 'and is recorded')
+
+  # THE DANGEROUS CASE. Domo's table default counts the row-key column, so the
+  # column appears as BOTH the dimension and the counted measure under ONE name
+  # with DIFFERENT data. Deduping on name alone would delete the measure.
+  _, cols3, _, dropped3 = dedupe_channels(
+    [['Gembucket campaign', 2], ['Zoolab campaign', 5]],
+    %w[campaign_title campaign_title], %w[ITEM VALUE])
+  eq(cols3, %w[campaign_title campaign_title],
+     'same NAME but different DATA (Domo table-default COUNT) is NOT collapsed')
+  eq(dropped3, [], 'and nothing is reported dropped')
+
+  _, cols4, _, dropped4 = dedupe_channels(
+    [['d', 1, 2, 3]], %w[Date A B C], %w[ITEM SERIES SERIES SERIES])
+  eq(cols4, %w[Date A B C], 'genuinely distinct series are untouched')
+  eq(dropped4, [], 'with nothing dropped')
+
+  _, cols5, = dedupe_channels([], %w[Date A], %w[ITEM SERIES])
+  eq(cols5, %w[Date A], 'an empty row set is returned unchanged (no false collapse)')
+end
+
+# ---------------------------------------------------------------------------
+# A headers-only Sigma export is a DEFECT, not an empty comparison. Four elements
+# did this on the live run; recording them as successful exports made the join
+# compare N Domo rows against 0 Sigma rows, scoring as an ordinary DIVERGE and
+# burying the real finding ("this tile renders nothing") among value mismatches.
+actuals_src = File.read(File.join(SCRIPTS, 'collect-parity-actuals.rb'))
+ok(actuals_src.include?('ZERO data rows'),
+   'collect-parity-actuals routes a headers-only export to `unavailable` with a measured reason')
+ok(actuals_src.match?(/if rows\.empty\?/),
+   'and it checks for it explicitly after shifting the header row')
+
+# ---------------------------------------------------------------------------
 oracle_src = File.read(File.join(SCRIPTS, 'build-parity-oracle.rb'))
 cid_src = oracle_src[/^def card_id_for\(element_id\)\n.*?\nend\n/m]
 ok(cid_src, 'extracted card_id_for(element_id) from build-parity-oracle.rb')


### PR DESCRIPTION
Cherry-picks the parity oracle scripts and tests from #661 (superseded by
#663 and the 2026-08-07 fleet migration) that took domo gate-1 parity from
24.6% to 71.7%: build-parity-oracle.rb, collect-parity-actuals.rb,
collect-parity-expected.rb, and their tests, plus the new
test-parity-freshness.rb warehouse-staleness guard.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
