### PR TITLE
fix(e2e): make the layout-contract gate detect placeholder folderIds; fix real schema defects in 2 goldens

### DIFF
--- a/corpus/quicksight/workbook-code-release/check_workbook.py
+++ b/corpus/quicksight/workbook-code-release/check_workbook.py
@@ -27,7 +27,9 @@ for element in elements:
 waterfall = by_kind["waterfall-chart"][0]
 assert waterfall["splitBy"]["id"]
 assert waterfall["waterfallShape"]["connectorLine"] == "shown"
-assert waterfall["legend"] == {"visibility": "hidden", "position": "right"}
+assert waterfall["legend"] == {"visibility": "hidden"}  # live API: cannot mix
+# visibility:'hidden' with legend content (position) -- oneOf branch is either
+# {visibility:'hidden'} alone, or {position,...} with no visibility field.
 assert by_kind["progress"][0]["max"] == "500"
 assert len(by_kind["navigation"]) == 2
 assert by_kind["control"][0]["controlType"] == "drill"

--- a/corpus/quicksight/workbook-code-release/golden/workbook.json
+++ b/corpus/quicksight/workbook-code-release/golden/workbook.json
@@ -143,8 +143,7 @@
           "value": "#2563EB"
         },
         "legend": {
-          "visibility": "hidden",
-          "position": "right"
+          "visibility": "hidden"
         }
       },
       {

--- a/corpus/tableau/structural-workarounds/wb-spec.json
+++ b/corpus/tableau/structural-workarounds/wb-spec.json
@@ -11,22 +11,26 @@
       { "id": "master", "kind": "table", "name": "Master",
         "source": { "kind": "table", "elementId": "dm-base" },
         "columns": [
-          { "id": "m-region", "name": "Region" },
-          { "id": "m-sales", "name": "Sales" },
-          { "id": "m-orderdate", "name": "Order Date" },
-          { "id": "m-custid", "name": "Customer Id" }
+          { "id": "m-region", "name": "Region", "formula": "[Master/Region]" },
+          { "id": "m-sales", "name": "Sales", "formula": "[Master/Sales]" },
+          { "id": "m-orderdate", "name": "Order Date", "formula": "[Master/Order Date]" },
+          { "id": "m-custid", "name": "Customer Id", "formula": "[Master/Customer Id]" }
         ] },
       { "id": "el-attainment-by-region", "kind": "bar-chart", "name": "Attainment by Region",
         "source": { "kind": "table", "elementId": "master" },
         "columns": [
           { "id": "x-1", "name": "Region", "formula": "[Master/Region]" },
           { "id": "y-1", "name": "Sales", "formula": "Sum([Master/Sales])" } ],
+        "xAxis": { "columnId": "x-1" },
+        "yAxis": { "columnIds": ["y-1"] },
         "filters": [ { "id": "flt-el-attainment-0", "columnId": "x-1", "kind": "list", "mode": "include", "values": ["North", "South"] } ] },
       { "id": "el-sales-trend", "kind": "line-chart", "name": "Sales Trend",
         "source": { "kind": "table", "elementId": "master" },
         "columns": [
           { "id": "x-2", "name": "Order Date", "formula": "DateTrunc(\"month\", [Master/Order Date])" },
-          { "id": "y-2", "name": "Sales", "formula": "Sum([Master/Sales])" } ] },
+          { "id": "y-2", "name": "Sales", "formula": "Sum([Master/Sales])" } ],
+        "xAxis": { "columnId": "x-2" },
+        "yAxis": { "columnIds": ["y-2"] } },
       { "id": "el-ctl-region", "kind": "control", "controlId": "ctl-region", "name": "Region",
         "controlType": "list", "mode": "include", "selectionMode": "multiple", "values": [],
         "source": { "kind": "source", "source": { "kind": "table", "elementId": "master" }, "columnId": "m-region" },

--- a/shared/scripts/verify-layout-contract-e2e.rb
+++ b/shared/scripts/verify-layout-contract-e2e.rb
@@ -54,8 +54,20 @@ INCIDENT = /incident-id|An error has occurred/i
 # spec (real converter output with its own folderId) is untouched — this only
 # backfills what's missing, so a minimal structural fixture can isolate the
 # layout-tag question without embedding an org id.
+#
+# Some converter goldens under corpus/ (e.g. gooddata) are shared with the
+# OFFLINE, creds-free corpus runner (corpus/run-corpus.sh), which stores
+# goldens id-NORMALIZED (see corpus/README.md — "Goldens are id-normalized"):
+# a real folderId a converter emitted gets rewritten to a stable placeholder
+# token like "inode-FOLDER00" for byte-diffing. That's correct for the
+# offline use case but is NOT a real UUID, so a *present-but-placeholder*
+# folderId must be treated the same as a *missing* one here — otherwise this
+# harness ships the placeholder straight to the live API, which 400s with
+# "Expecting UUID at 0.folderId". Detect "present but not UUID-shaped" and
+# backfill it too, rather than only checking presence.
 DEFAULT_SCHEMA_VERSION = 1
 DEFAULT_KIND = 'workbook'
+UUID_RE = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
 @home_folder_id = nil
 def home_folder_id
@@ -71,9 +83,16 @@ end
 
 def ensure_postable!(spec, path)
   filled = []
-  unless spec['folderId']
+  existing = spec['folderId']
+  if existing.nil?
     spec['folderId'] = home_folder_id
     filled << 'folderId'
+  elsif !(existing.is_a?(String) && existing.match?(UUID_RE))
+    log "  fixture folderId #{existing.inspect} is not a live UUID " \
+        '(looks like an offline corpus normalization placeholder) — ' \
+        'replacing with the resolved home folder, not posting it verbatim'
+    spec['folderId'] = home_folder_id
+    filled << 'folderId (placeholder replaced)'
   end
   unless spec['name']
     spec['name'] = "layout-contract-probe — #{File.basename(path)} — #{Time.now.utc.strftime('%Y%m%dT%H%M%SZ')}"


### PR DESCRIPTION
Live-probed all four "known failures" against the layout-contract E2E gate
(shared/scripts/verify-layout-contract-e2e.rb) to find out why zero goldens
posted successfully.

- Harness: ensure_postable! only backfilled a *missing* folderId. Several
  corpus goldens (gooddata, mode) carry a folderId that IS present but is an
  offline-corpus id-normalization placeholder (e.g. "inode-FOLDER00", see
  corpus/README.md), which the live API rejects as "Expecting UUID". Detect
  a present-but-non-UUID folderId and replace it too, same as a missing one.
  Re-proven must-fail-first still fails on layout_contract_bad.json.

- quicksight golden: legend `{visibility:'hidden', position:'right'}` mixes
  two mutually exclusive oneOf branches per the OpenAPI legend schema (hidden
  takes no other fields) and the live API rejects it accordingly. Fixed to
  `{visibility:'hidden'}`; updated the (unwired, standalone) check_workbook.py
  assertion to match.

- tableau golden: the confusing `Invalid kind: "table"` error was never about
  kind — `columns[].formula` is a required field the schema enforces, and the
  root `master` table's columns were missing it entirely. Once fixed, the
  next elements (bar-chart/line-chart) were missing their required `yAxis`.
  Fixed all three; the golden now fails on an honest, correctly-attributed
  `Dependency not found: 'dm-base'` (master's source is a dangling reference
  with no live data model behind it — a separate, out-of-scope limitation).

Remaining failures (gooddata, powerbi, quicksight, tableau) are all now
individually attributed rather than masked by one harness bug or one
misleading message — see the handoff report for the full breakdown,
including two org-capability gaps (settings.navigation) and a converter
defect (repeated-container cannot host a table/bar-chart/kpi-chart child,
confirmed live; only static kinds like text are accepted).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
