### PR TITLE
fix: CI RANGE_BASE ancestor validation + changed_has() SIGPIPE race

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -94,9 +94,20 @@ jobs:
           else
             BASE="$PUSH_BEFORE_SHA"
           fi
-          # New-branch pushes carry an all-zero 'before'; fall back to the
-          # default-branch merge-base so the branch's commits are still checked.
-          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+          # New-branch pushes carry an all-zero 'before'; a force-push (rebase,
+          # history rewrite) leaves 'before' pointing at a commit that still
+          # exists in the fetched history but is no longer an ancestor of the
+          # new head — git rev-list/diff over such a range walks the full
+          # history divergence instead of the intended small range (#680:
+          # observed 734 unrelated files on a rebased PR, because the old
+          # check here only asked "does this object exist", never "is it an
+          # ancestor of HEAD"). Validate ancestry, not just object existence,
+          # before trusting BASE; fall back to the default-branch merge-base
+          # in either failure mode so the branch's real commits are still
+          # checked. This also protects the PR branch above in the (unlikely)
+          # case its own fallback lands on a non-ancestor $PR_BASE_SHA.
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null \
+             || ! git merge-base --is-ancestor "$BASE" "$HEAD_SHA" 2>/dev/null; then
             git fetch --quiet origin "$DEFAULT_BRANCH" || true
             BASE="$(git merge-base "origin/$DEFAULT_BRANCH" "$HEAD_SHA" 2>/dev/null || true)"
           fi

--- a/tools/check-converter-provenance.sh
+++ b/tools/check-converter-provenance.sh
@@ -254,7 +254,21 @@ HEAD="${2:?usage: check-converter-provenance.sh <BASE> <HEAD>}"
 changed="$(git diff --name-only "$BASE" "$HEAD")" || { echo "git diff $BASE..$HEAD failed — cannot check provenance pairing"; exit 1; }
 fail=0
 
-changed_has() { printf '%s\n' "$changed" | grep -qxF "$1"; }
+# Subprocess-free membership test (#681): the old `printf ... | grep -qxF`
+# form re-piped the full $changed list through grep on every lookup. grep -q
+# exits the instant it finds a match, closing its end of the pipe; on a long
+# list printf/the shell is often still mid-write when that happens, the next
+# write() gets SIGPIPE, and `set -uo pipefail` (above) turns that signal into
+# a false "not found" — non-deterministic, and it only fires once the list is
+# long enough that the writer outlives the reader (latent on small diffs,
+# firing on the large ranges #680's force-push bug produces). A case/glob
+# match against the newline-delimited list needs no subprocess and can't race.
+changed_has() {
+  case $'\n'"$changed"$'\n' in
+    *$'\n'"$1"$'\n'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 at_head() { git cat-file -e "$HEAD:$1" 2>/dev/null; }
 prov_kind() { # reads the HEAD copy; anything unparsable counts as vendored
   git show "$HEAD:$1" 2>/dev/null | python3 -c '

--- a/tools/test-converter-provenance.sh
+++ b/tools/test-converter-provenance.sh
@@ -279,6 +279,22 @@ bash "$GUARD" --online "$TMP/no-such-checkout-dir" >"$TMP/out" 2>&1; RC=$?
 [ "$RC" -eq 0 ]; check $? "--online soft-passes when the checkout path doesn't exist (got $RC)"
 grep -q "soft-passing" "$TMP/out"; check $? "soft-pass explains why (no checkout to compare against)"
 
+echo "Part G — changed_has() SIGPIPE/pipefail race fix (#681)"
+# The old changed_has() re-piped the full $changed list through `grep -qxF`
+# on every lookup: grep -q exits the instant it matches, closing its end of
+# the pipe; on a long list the still-writing printf can get SIGPIPE, and
+# `set -uo pipefail` (this script's own shebang option) turns that signal
+# into a false "not found" — non-deterministic, firing only once the list is
+# long enough that the writer outlives the reader. String-pin that the pipe
+# form is gone and the subprocess-free case/glob replacement is in place
+# (functional correctness of the replacement is already exercised at every
+# scale by Parts A-C above, which all drive changed_has() through real
+# lookups and all pass).
+! grep -qF 'printf '"'"'%s\n'"'"' "$changed" | grep -qxF' "$GUARD"
+check $? "the SIGPIPE-racy 'printf | grep -qxF' pipe form is gone from the guard (comment mentions may remain)"
+grep -qF 'case $'"'"'\n'"'"'"$changed"$'"'"'\n'"'"' in' "$GUARD"
+check $? "changed_has() now uses a subprocess-free case/glob membership test"
+
 echo
 if [ "$fails" -gt 0 ]; then
   echo "$fails FAILURE(S)"

--- a/tools/test-hygiene-range.sh
+++ b/tools/test-hygiene-range.sh
@@ -69,6 +69,8 @@ grep -q 'UNDER-SCAN' "$TMP/coverage.sh"
 check $? "coverage assertion names the failure mode"
 awk '/- name: Resolve push\/PR diff range/,/^        run: \|/' "$YML" | grep -q 'PR_COMMITS:'
 check $? "PR_COMMITS is wired into the step env (assertion has its denominator)"
+grep -qF 'git merge-base --is-ancestor "$BASE" "$HEAD_SHA"' "$TMP/resolve.sh"
+check $? "#680: BASE is ancestor-validated, not just checked for object existence"
 
 # --- fixture: 4-commit PR, base drifts by one commit after PR creation -------
 UP="$TMP/upstream"
@@ -183,6 +185,48 @@ check $? "refused step exports no RANGE_BASE for the guards to consume"
 run_resolve_dead push ""
 [ "$RANGE_RC" -eq 0 ] && grep -q "no diff range to check" "$RANGE_OUT"
 check $? "same dead fixture on a PUSH event still skips green (silent skip is push-only)"
+
+echo "Part E — force-push: before-sha exists but is not an ancestor of the new head (#680)"
+# github.event.before survives a force-push as a real, fetchable commit object
+# (still reachable via some surviving ref — here modeled explicitly with a
+# marker ref, matching how a stale PR-ref/reflog keeps it alive in the real
+# GitHub case) but is no longer an ancestor of the rewritten branch tip. The
+# old check here only asked "does this object exist" (`git cat-file -e`),
+# which a force-pushed-away commit still passes, so RANGE_BASE stayed pinned
+# to it and the diff range walked the full history divergence instead of the
+# PR's real (small) change — issue #680's "observed: 734 unrelated files".
+gitu checkout -q -b force-pushed main
+printf 'real change\n' > "$UP/force-pushed-real.txt"
+gitu add force-pushed-real.txt && gitu commit -q -m "the actual PR change"
+E_OLDTIP="$(git -C "$UP" rev-parse HEAD)"          # github.event.before, pre-force-push
+gitu update-ref refs/heads/old-tip-marker "$E_OLDTIP"  # keeps it fetchable post-rebase
+gitu checkout -q main
+for i in 1 2 3 4 5 6; do
+  printf 'unrelated %s\n' "$i" > "$UP/unrelated-e$i.txt"
+  gitu add "unrelated-e$i.txt" && gitu commit -q -m "unrelated merged PR $i"
+done
+E_NEWMAIN="$(git -C "$UP" rev-parse main)"
+gitu checkout -q force-pushed
+gitu rebase -q main >/dev/null 2>&1
+E_NEWTIP="$(git -C "$UP" rev-parse force-pushed)"  # github.sha, post-force-push
+
+git -C "$CI" fetch -q origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1
+git -C "$CI" cat-file -e "$E_OLDTIP" 2>/dev/null
+check $? "fixture sanity: force-pushed-away tip is still a resolvable object in the fetched history"
+! git -C "$CI" merge-base --is-ancestor "$E_OLDTIP" "$E_NEWTIP" 2>/dev/null
+check $? "fixture sanity: that tip is NOT an ancestor of the new head (the bug's precondition)"
+NAIVE_N="$(git -C "$CI" rev-list --count "$E_OLDTIP..$E_NEWTIP" 2>/dev/null || echo 0)"
+[ "$NAIVE_N" -gt 1 ]; check $? "naively trusting before-sha would over-scan (got $NAIVE_N commits, want >1)"
+
+run_resolve push "$E_NEWTIP" "$E_OLDTIP"
+[ "$RANGE_RC" -eq 0 ]; check $? "shipped step exits 0 on the force-push shape (got $RANGE_RC)"
+[ "$RANGE_BASE" != "$E_OLDTIP" ]
+check $? "shipped step does NOT trust the non-ancestor before-sha as RANGE_BASE"
+EXPECT_BASE="$(git -C "$CI" merge-base "origin/main" "$E_NEWTIP" 2>/dev/null)"
+[ "$RANGE_BASE" = "$EXPECT_BASE" ]
+check $? "shipped step falls back to the default-branch merge-base (got $RANGE_BASE, want $EXPECT_BASE)"
+N_NEW_E="$(git -C "$CI" rev-list --count "$RANGE_BASE..$E_NEWTIP")"
+[ "$N_NEW_E" -eq 1 ]; check $? "corrected range covers only the real PR commit (got $N_NEW_E)"
 
 echo
 if [ "$fails" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Two confirmed CI infrastructure bugs, both in the shared "Resolve push/PR diff range" step's blast radius:

- **Fixes #680** — `hygiene.yml`'s diff-range resolution derived `RANGE_BASE` from `github.event.before` and only checked that the object existed, never that it was an ancestor of the new head. After a force-push (rebase), the old tip is still a resolvable commit object but no longer an ancestor, so `BASE..HEAD` walked the full history divergence instead of the PR's real change (observed: 734 unrelated files on PR #651). Now validates ancestry with `git merge-base --is-ancestor` and falls back to the default-branch merge-base on failure, same as the existing all-zero/missing-object fallback.
- **Fixes #681** — `tools/check-converter-provenance.sh`'s `changed_has()` re-piped the full changed-file list through `grep -qxF` on every lookup. `grep -q` exits as soon as it matches; on a long list the still-writing `printf` can take SIGPIPE, and `set -uo pipefail` turns that signal into a false "not found" — non-deterministic, and it only fires once the list is long enough that the writer outlives the reader (latent on small diffs, firing on the large ranges #680 produces). Replaced with a subprocess-free `case`/glob membership test (bash 3.2-safe, no subshell, no pipe).

Also extended the permanent self-tests to encode both bugs as regressions:
- `tools/test-hygiene-range.sh` Part E — force-push fixture (before-sha exists but isn't an ancestor); confirmed to **fail** against the pre-fix step and pass after.
- `tools/test-converter-provenance.sh` Part G — string-pin on the fixed `changed_has()`; confirmed to **fail** against the pre-fix helper and pass after.

## Verification

**#680 — before/after, exact scale from the issue (734 unrelated commits on main after the branch cut):**
```
=== BEFORE FIX (github.event.before, poisoned by force-push) ===
diff range 8492d5e..09d2194 covers 735 commit(s)
RANGE_BASE=8492d5e (the force-pushed-away tip)
diff file count: 734

=== AFTER FIX (ancestor-validated, merge-base fallback) ===
diff range 23d4640..09d2194 covers 1 commit(s)
RANGE_BASE=23d4640 (merge-base with origin/main)
diff file count: 1
```

**#681 — before/after at real scale (734 converter-bundle pairs, every single one genuinely paired):**
```
OLD (buggy) guard, 3 runs against the identical 734-pair fixture:
  run 1: rc=1  234 false "unpaired" errors
  run 2: rc=1  232 false "unpaired" errors
  run 3: rc=1  229 false "unpaired" errors    <- non-deterministic count, same input

NEW (fixed) guard, 3 runs against the identical fixture:
  run 1: rc=0  converter-provenance guard OK
  run 2: rc=0  converter-provenance guard OK
  run 3: rc=0  converter-provenance guard OK
```
Fast isolated harness at the same flaky boundary position, looped 200x:
```
BEFORE FIX: 200 iterations -> pass=194 fail=6   (non-deterministic)
AFTER FIX:  200 iterations -> pass=200 fail=0
```

**Gates still catch real violations** (planted in a throwaway clone — never committed here): a `quicksight-to-sigma` converter bundle changed without its `PROVENANCE.json`, and `domo-to-sigma` changed without a `plugin.json` version bump. Both fixed gates still fail loudly:
```
::error file=plugins/quicksight-to-sigma/.../converter/quicksight.mjs::vendored converter changed without its sibling PROVENANCE.json ...
::error file=plugins/domo-to-sigma/.claude-plugin/plugin.json::'domo-to-sigma' changed ... but version did not increase (0.16.6 -> 0.16.6) ...
```

**Full existing self-test suite** (`tools/test-*.sh`, 9 files) and `.githooks/run-governance-checks.sh` all stay green after the fix.

## Test plan

- [x] Reproduced #680 with a force-push fixture matching the exact reported scale (734 files); confirmed the fix resolves the correct 1-file range instead
- [x] Reproduced #681 non-determinism both at real 734-pair scale (3 runs, varying false-positive counts) and via a fast 200-iteration harness (6/200 spurious failures before, 0/200 after)
- [x] Added permanent regression tests for both bugs; verified each new test fails against the pre-fix code and passes after
- [x] Planted a real unpaired-converter violation and a real unbumped-plugin violation in a throwaway clone; confirmed both fixed gates still fail loudly
- [x] Ran the full `tools/test-*.sh` suite and `.githooks/run-governance-checks.sh` — all green
- [x] No hardcoded org/connection/workbook IDs introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)