### PR TITLE
fix(shared): container backgroundImage shape + missing document.kind (live-API 400s)

### DIFF
--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-api (authentication), sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter \u2014 the converters assume it is present.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/layout.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/layout.md
@@ -73,9 +73,13 @@ jq --arg k container 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 ```
 
 - **Element on a background image:** to place an element *on top of* a container's `backgroundImage`, make it a **child** of that container in the layout XML — the background spans the container and the child sits on top.
-- **Background shape:** container/chart backgrounds use their element schema's
-  top-level `backgroundImage: {url: ...}` shape, sibling to `style`. Page
-  backgrounds use `backgroundImage: {source: {kind: url, url: ...}, style: ...}`.
+- **Background shape:** `backgroundImage` is a top-level field on the element,
+  sibling to `style`. **Live API change (2026-08-08): container backgrounds now
+  require the same nested shape as pages** —
+  `backgroundImage: {source: {kind: url, url: ...}, style: ...}` — the old flat
+  `backgroundImage: {url: ...}` hard-400s. Chart-element (plot-area)
+  `backgroundImage` was not re-verified in this pass; confirm its shape before
+  assuming it matches.
 - **Spacing:** `style.padding` accepts only `none` or omission on a container;
   values such as `small` are rejected. Use `elementGap`/`spacing` for
   child-to-child rhythm; do not fake spacing with empty text elements.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/schema.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/schema.md
@@ -84,9 +84,14 @@ Pages are metadata only:
 The live page schema exposes `id`, `name`, `type`, `visibility`, `pageWidth`,
 `backgroundColor`, and `backgroundImage`; it does not expose `elements`.
 `backgroundImage.source` is either `{kind: url, url}` or an uploaded-image
-reference from a readback. Container and chart background images retain their
-own element-specific `{url: ...}` shape; do not transpose the page wrapper onto
-those element kinds.
+reference from a readback. **Live API change (2026-08-08): container
+background images now require this same `source` wrapper too** —
+`backgroundImage: {url: ...}` (the old flat container shape) hard-400s
+(`"backgroundImage.source: Invalid value: undefined"`); use
+`backgroundImage: {source: {kind: url, url: ...}, style: ...}` on containers,
+same as the page shape above. Chart-element `backgroundImage` (the plot-area
+background) was not re-verified in this pass — confirm its current shape
+before assuming it matches.
 
 Restricted visibility:
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
@@ -474,15 +474,18 @@ Neil-style gradient banners are NOT directly authorable:
 - `style.backgroundColor` with a CSS `linear-gradient(...)` string is **accepted by POST/PUT but
   silently dropped** — the container renders with *no* background at all (worse than a 400; only
   a render catches it). Hex only.
-- ✓ **The working recipe (re-verified 2026-06-26): `backgroundImage` is a TOP-LEVEL field on the
+- ✓ **The working recipe (re-verified 2026-08-08): `backgroundImage` is a TOP-LEVEL field on the
   container element — a SIBLING of `style`, NOT nested inside `style`.** Nesting it under `style`
   silently drops it (posts `200`, GET readback shows only `backgroundColor`, renders flat) — that was
-  a real mistake caught this session. The correct shape:
+  a real mistake caught this session. **Breaking change (live, 2026-08-08):** the url itself now
+  nests under `source: {kind: url, url: ...}` — the old flat `backgroundImage: {url: ...}` hard-400s
+  (`"backgroundImage.source: Invalid value: undefined"`). The correct shape:
   ```yaml
   - id: hero
     kind: container
     style: { backgroundColor: "#0B1120", borderRadius: round }   # solid fallback / load color
-    backgroundImage: { url: "https://…/gradient.png" }           # <-- sibling of style, not inside it
+    backgroundImage:
+      source: { kind: url, url: "https://…/gradient.png" }       # <-- sibling of style, not inside it
   ```
   Lay the title **text element inside the hero container** and it overlays the gradient (text-over-image
   works for a container background — unlike a separate `image` element, which does NOT z-stack under
@@ -621,13 +624,18 @@ return contract as `header`, so it drops into the same composition call sites.
   kind: container
   style: { borderRadius: round }
   backgroundImage:
-    url: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0i..."   # composed gradient(+motif) SVG
+    source:
+      kind: url
+      url: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0i..."   # composed gradient(+motif) SVG
     style: { fit: cover }
 - id: hdr-title
   kind: text
   verticalAlign: middle
   body: '# <span style="color: #FFFFFF">Overview</span>'
 ```
+
+(Breaking change, live 2026-08-08: the url now nests under `source: {kind: url, url:}` — the
+old flat `backgroundImage: {url:}` hard-400s. Same shape applies to `gradient_card` below.)
 
 - `gradient:` is an array of **2–3 hex stops** (default: a neutral, host-agnostic
   3-stop slate→navy→blue ramp in `DEFAULT_THEME[:header_gradient]` — not red; red,

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/styling.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/styling.rb
@@ -278,8 +278,12 @@ module Styling
     title_id = "#{id}-title"
     subtitle_id = "#{id}-subtitle"
 
+    # Live API contract update (2026-08-08): backgroundImage now requires the
+    # url nested under source:{kind:"url",url:} -- the old flat
+    # backgroundImage:{url:} shape hard-400s ("backgroundImage.source: Invalid
+    # value: undefined"). style stays a sibling of source.
     container_el = { 'id' => container_id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
-                     'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
+                     'backgroundImage' => { 'source' => { 'kind' => 'url', 'url' => bg_url }, 'style' => { 'fit' => 'cover' } } }
     title_el = { 'id' => title_id, 'kind' => 'text', 'verticalAlign' => 'middle',
                  'body' => "# <span style=\"color: #FFFFFF\">#{title}</span>" }
 
@@ -374,8 +378,9 @@ module Styling
     return { element: [], child_layout: '', patch: {} } unless surfaces[:gradient_card]
 
     bg_url = svg_data_uri(compose_card_svg(gradient))
+    # Live API contract update (2026-08-08) -- see gradient_header's identical note above.
     container_el = { 'id' => id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
-                      'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
+                      'backgroundImage' => { 'source' => { 'kind' => 'url', 'url' => bg_url }, 'style' => { 'fit' => 'cover' } } }
     child_layout = "<Element elementId=\"#{kpi_element['id']}\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"1 / 7\"/>"
     patch = { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' },
               'style' => { 'backgroundColor' => 'transparent', 'padding' => 'none' } }

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/test_styling.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/test_styling.rb
@@ -186,7 +186,7 @@ check('gradient_header (default :glow, :right): container has data-URI SVG backg
   h = Styling.gradient_header(id: 'ghdr', title: 'Command Center')
   bg = h[:element][0]
   bg['kind'] == 'container' && bg['style'] == { 'borderRadius' => 'round' } &&
-    bg['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
+    bg['backgroundImage']['source']['url'].start_with?('data:image/svg+xml;base64,') &&
     bg['backgroundImage']['style'] == { 'fit' => 'cover' } &&
     h[:element].any? { |e| e['kind'] == 'text' && e['id'] == 'ghdr-title' } &&
     h[:layout].include?('<Container') && h[:layout].include?('elementId="ghdr-title"')
@@ -194,19 +194,19 @@ end
 
 check('gradient_header: decoded SVG carries the linearGradient + the requested motif group') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings)
-  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('linearGradient') && svg.include?('<circle r="40"/>') && svg.include?('<g transform="translate(1440,86)">')
 end
 
 check('gradient_header motif :none: no motif <g> group in the decoded SVG') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :none)
-  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   !svg.include?('<g transform=')
 end
 
 check('gradient_header motif_side: :left translates the motif group to x=160') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, motif_side: :left)
-  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('translate(160,86)')
 end
 
@@ -236,12 +236,12 @@ end
 
 check('gradient_header: bring-your-own http(s) URL used verbatim, SVG compose skipped') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png')
-  h[:element][0]['backgroundImage']['url'] == 'https://example.com/art.png'
+  h[:element][0]['backgroundImage']['source']['url'] == 'https://example.com/art.png'
 end
 check('gradient_header: bring-your-own data: URL used verbatim') do
   uri = 'data:image/png;base64,AAAA'
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: uri)
-  h[:element][0]['backgroundImage']['url'] == uri
+  h[:element][0]['backgroundImage']['source']['url'] == uri
 end
 
 check('gradient_header: gradient with != 2-3 stops raises ArgumentError') do
@@ -263,7 +263,7 @@ end
 check('gradient_header: NO-GO motif surface + menu-key motif falls back to the plain gradient (:none)') do
   surfaces = Styling::SURFACES.merge(motif: false)
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, surfaces: surfaces)
-  bg = h[:element][0]['backgroundImage']['url']
+  bg = h[:element][0]['backgroundImage']['source']['url']
   svg = Base64.decode64(bg.sub('data:image/svg+xml;base64,', ''))
   bg.start_with?('data:image/svg+xml;base64,') && svg.include?('linearGradient') && !svg.include?('<g transform=')
 end
@@ -271,12 +271,12 @@ end
 check('gradient_header: NO-GO motif surface does NOT suppress a bring-your-own URL (honored verbatim)') do
   surfaces = Styling::SURFACES.merge(motif: false)
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png', surfaces: surfaces)
-  h[:element][0]['backgroundImage']['url'] == 'https://example.com/art.png'
+  h[:element][0]['backgroundImage']['source']['url'] == 'https://example.com/art.png'
 end
 
 check('gradient_header motif_side: :center translates the motif group to x=800 and produces a valid header') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, motif_side: :center)
-  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('translate(800,86)') &&
     h[:element].any? { |e| e['kind'] == 'text' && e['id'] == 'ghdr-title' } &&
     h[:layout].include?('<Container') && h[:layout].include?('elementId="ghdr-title"')
@@ -301,7 +301,7 @@ check('gradient_card: GO returns a gradient container + child_layout positioning
   gc[:element].length == 1 &&
     gc[:element][0]['id'] == 'card-1' && gc[:element][0]['kind'] == 'container' &&
     gc[:element][0]['style'] == { 'borderRadius' => 'round' } &&
-    gc[:element][0]['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
+    gc[:element][0]['backgroundImage']['source']['url'].start_with?('data:image/svg+xml;base64,') &&
     gc[:element][0]['backgroundImage']['style'] == { 'fit' => 'cover' } &&
     gc[:child_layout] == '<Element elementId="kpi-rev" gridColumn="1 / 25" gridRow="1 / 7"/>' &&
     gc[:patch] == { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' },
@@ -315,14 +315,14 @@ end
 
 check('gradient_card: decoded SVG carries the linearGradient stops (motif: :none -- no motif group)') do
   gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
-  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('linearGradient') && !svg.include?('<g transform=')
 end
 
 check('gradient_card: composed SVG layers a dark scrim (id="card-scrim") over the caller gradient so white ' \
       'KPI text stays legible on any gradient, bright or dark (live-render fix, user-reported)') do
   gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
-  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('id="card-scrim"') &&
     svg.include?("stop-opacity=\"#{Styling::CARD_SCRIM_TOP_OPACITY}\"") &&
     svg.include?('stop-opacity="0"') &&
@@ -331,7 +331,7 @@ end
 
 check('gradient_card: gradient: can be omitted -- defaults to DEFAULT_THEME[:card_gradient] (a dark slate pair)') do
   gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL)
-  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   default_gradient = Styling::DEFAULT_THEME[:card_gradient]
   svg.include?(default_gradient[0]) && svg.include?(default_gradient[1])
 end

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/testdata/styling_golden.json
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/testdata/styling_golden.json
@@ -48,7 +48,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iY2ciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNTYzRUIiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iY2FyZC1zY3JpbSIgeDE9IjAiIHkxPSIwIiB4Mj0iMCIgeTI9IjEiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzAwMDAwMCIgc3RvcC1vcGFjaXR5PSIwLjU1Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDAwMDAwIiBzdG9wLW9wYWNpdHk9IjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYwMCIgaGVpZ2h0PSIyMTAiIGZpbGw9InVybCgjY2cpIi8+PHJlY3Qgd2lkdGg9IjE2MDAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI2NhcmQtc2NyaW0pIi8+PC9zdmc+",
+          "source": {
+            "kind": "url",
+            "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iY2ciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNTYzRUIiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iY2FyZC1zY3JpbSIgeDE9IjAiIHkxPSIwIiB4Mj0iMCIgeTI9IjEiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzAwMDAwMCIgc3RvcC1vcGFjaXR5PSIwLjU1Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDAwMDAwIiBzdG9wLW9wYWNpdHk9IjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYwMCIgaGVpZ2h0PSIyMTAiIGZpbGw9InVybCgjY2cpIi8+PHJlY3Qgd2lkdGg9IjE2MDAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI2NhcmQtc2NyaW0pIi8+PC9zdmc+"
+          },
           "style": {
             "fit": "cover"
           }
@@ -78,7 +81,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "https://example.com/art.png",
+          "source": {
+            "kind": "url",
+            "url": "https://example.com/art.png"
+          },
           "style": {
             "fit": "cover"
           }
@@ -102,7 +108,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNDQwLDg2KSI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJtb3RpZi1nbG93IiBjeD0iMC41IiBjeT0iMC41IiByPSIwLjYiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI0ZGRkZGRiIgc3RvcC1vcGFjaXR5PSIwLjIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNGRkZGRkYiIHN0b3Atb3BhY2l0eT0iMCIvPjwvcmFkaWFsR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9Ii0yNjAiIHk9Ii0xMDUiIHdpZHRoPSI1MjAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI21vdGlmLWdsb3cpIi8+PC9nPjwvc3ZnPg==",
+          "source": {
+            "kind": "url",
+            "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNDQwLDg2KSI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJtb3RpZi1nbG93IiBjeD0iMC41IiBjeT0iMC41IiByPSIwLjYiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI0ZGRkZGRiIgc3RvcC1vcGFjaXR5PSIwLjIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNGRkZGRkYiIHN0b3Atb3BhY2l0eT0iMCIvPjwvcmFkaWFsR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9Ii0yNjAiIHk9Ii0xMDUiIHdpZHRoPSI1MjAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI21vdGlmLWdsb3cpIi8+PC9nPjwvc3ZnPg=="
+          },
           "style": {
             "fit": "cover"
           }
@@ -140,7 +149,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48L3N2Zz4=",
+          "source": {
+            "kind": "url",
+            "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48L3N2Zz4="
+          },
           "style": {
             "fit": "cover"
           }
@@ -164,7 +176,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjAsODYpIj48ZyBmaWxsPSJub25lIiBzdHJva2U9IiNGRkZGRkYiIHN0cm9rZS1vcGFjaXR5PSIwLjEyIiBzdHJva2Utd2lkdGg9IjEuNCI+PGNpcmNsZSByPSI0MCIvPjxjaXJjbGUgcj0iNzQiLz48Y2lyY2xlIHI9IjEwOCIvPjxsaW5lIHgxPSItMTMwIiB5MT0iMCIgeDI9IjEzMCIgeTI9IjAiLz48bGluZSB4MT0iMCIgeTE9Ii0xMzAiIHgyPSIwIiB5Mj0iMTMwIi8+PC9nPjwvZz48L3N2Zz4=",
+          "source": {
+            "kind": "url",
+            "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjAsODYpIj48ZyBmaWxsPSJub25lIiBzdHJva2U9IiNGRkZGRkYiIHN0cm9rZS1vcGFjaXR5PSIwLjEyIiBzdHJva2Utd2lkdGg9IjEuNCI+PGNpcmNsZSByPSI0MCIvPjxjaXJjbGUgcj0iNzQiLz48Y2lyY2xlIHI9IjEwOCIvPjxsaW5lIHgxPSItMTMwIiB5MT0iMCIgeDI9IjEzMCIgeTI9IjAiLz48bGluZSB4MT0iMCIgeTE9Ii0xMzAiIHgyPSIwIiB5Mj0iMTMwIi8+PC9nPjwvZz48L3N2Zz4="
+          },
           "style": {
             "fit": "cover"
           }

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -300,8 +300,12 @@ def gradient_header(id, title, subtitle=None, gradient=None, motif="glow", motif
     title_id = "%s-title" % id
     subtitle_id = "%s-subtitle" % id
 
+    # PATCHED for live probe (2026-08-08): live API now 400s "backgroundImage.source:
+    # Invalid value: undefined" -- the current contract nests the url under
+    # backgroundImage.source:{kind:"url",url:} instead of the old flat backgroundImage.url.
+    # See feature-coverage-report for the full finding (mirrors the styling.rb fix).
     container_el = {"id": container_id, "kind": "container", "style": {"borderRadius": "round"},
-                     "backgroundImage": {"url": bg_url, "style": {"fit": "cover"}}}
+                     "backgroundImage": {"source": {"kind": "url", "url": bg_url}, "style": {"fit": "cover"}}}
     title_el = {"id": title_id, "kind": "text", "verticalAlign": "middle",
                 "body": '# <span style="color: #FFFFFF">%s</span>' % title}
 
@@ -407,8 +411,9 @@ def gradient_card(id, kpi_element, gradient=None, page_cols=24, surfaces=None):
 
     grad = DEFAULT_THEME["card_gradient"] if gradient is None else gradient
     bg_url = svg_data_uri(compose_card_svg(grad))
+    # PATCHED for live probe (2026-08-08) -- see gradient_header's identical note above.
     container_el = {"id": id, "kind": "container", "style": {"borderRadius": "round"},
-                     "backgroundImage": {"url": bg_url, "style": {"fit": "cover"}}}
+                     "backgroundImage": {"source": {"kind": "url", "url": bg_url}, "style": {"fit": "cover"}}}
     child_layout = '<Element elementId="%s" gridColumn="1 / %d" gridRow="1 / 7"/>' % (
         kpi_element["id"], page_cols + 1)
     patch = {"value": {"color": "#FFFFFF"}, "name": {"color": "#FFFFFF"},

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -281,8 +281,12 @@ module Styling
     title_id = "#{id}-title"
     subtitle_id = "#{id}-subtitle"
 
+    # PATCHED for live probe (2026-08-08): live API now 400s "backgroundImage.source:
+    # Invalid value: undefined" — the current contract nests the url under
+    # backgroundImage.source:{kind:"url",url:} instead of the old flat backgroundImage.url.
+    # See feature-coverage-report for the full finding.
     container_el = { 'id' => container_id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
-                     'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
+                     'backgroundImage' => { 'source' => { 'kind' => 'url', 'url' => bg_url }, 'style' => { 'fit' => 'cover' } } }
     title_el = { 'id' => title_id, 'kind' => 'text', 'verticalAlign' => 'middle',
                  'body' => "# <span style=\"color: #FFFFFF\">#{title}</span>" }
 
@@ -381,8 +385,9 @@ module Styling
     return { element: [], child_layout: '', patch: {} } unless surfaces[:gradient_card]
 
     bg_url = svg_data_uri(compose_card_svg(gradient))
+    # PATCHED for live probe (2026-08-08) — see gradient_header's identical note above.
     container_el = { 'id' => id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
-                      'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
+                      'backgroundImage' => { 'source' => { 'kind' => 'url', 'url' => bg_url }, 'style' => { 'fit' => 'cover' } } }
     child_layout = "<Element elementId=\"#{kpi_element['id']}\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"1 / 7\"/>"
     patch = { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' },
               'style' => { 'backgroundColor' => 'transparent', 'padding' => 'none' } }

--- a/shared/lib/test_styling.py
+++ b/shared/lib/test_styling.py
@@ -228,7 +228,7 @@ class MotifsTest(unittest.TestCase):
 
 class GradientHeaderTest(unittest.TestCase):
     def _decode(self, h):
-        url = h["element"][0]["backgroundImage"]["url"]
+        url = h["element"][0]["backgroundImage"]["source"]["url"]
         return base64.b64decode(url.replace("data:image/svg+xml;base64,", "")).decode()
 
     def test_default_glow_right_container_shape(self):
@@ -236,7 +236,7 @@ class GradientHeaderTest(unittest.TestCase):
         bg = h["element"][0]
         self.assertEqual(bg["kind"], "container")
         self.assertEqual(bg["style"], {"borderRadius": "round"})
-        self.assertTrue(bg["backgroundImage"]["url"].startswith("data:image/svg+xml;base64,"))
+        self.assertTrue(bg["backgroundImage"]["source"]["url"].startswith("data:image/svg+xml;base64,"))
         self.assertEqual(bg["backgroundImage"]["style"], {"fit": "cover"})
         self.assertTrue(any(e["kind"] == "text" and e["id"] == "ghdr-title" for e in h["element"]))
         self.assertIn("<Container", h["layout"])
@@ -283,12 +283,12 @@ class GradientHeaderTest(unittest.TestCase):
 
     def test_bring_your_own_http_url_used_verbatim(self):
         h = styling.gradient_header("ghdr", "X", motif="https://example.com/art.png")
-        self.assertEqual(h["element"][0]["backgroundImage"]["url"], "https://example.com/art.png")
+        self.assertEqual(h["element"][0]["backgroundImage"]["source"]["url"], "https://example.com/art.png")
 
     def test_bring_your_own_data_url_used_verbatim(self):
         uri = "data:image/png;base64,AAAA"
         h = styling.gradient_header("ghdr", "X", motif=uri)
-        self.assertEqual(h["element"][0]["backgroundImage"]["url"], uri)
+        self.assertEqual(h["element"][0]["backgroundImage"]["source"]["url"], uri)
 
     def test_gradient_wrong_stop_count_raises(self):
         with self.assertRaises(ValueError):
@@ -303,7 +303,7 @@ class GradientHeaderTest(unittest.TestCase):
     def test_no_go_motif_menu_key_falls_back_to_plain_gradient(self):
         surfaces = dict(styling.SURFACES, motif=False)
         h = styling.gradient_header("ghdr", "X", motif="rings", surfaces=surfaces)
-        bg = h["element"][0]["backgroundImage"]["url"]
+        bg = h["element"][0]["backgroundImage"]["source"]["url"]
         svg = base64.b64decode(bg.replace("data:image/svg+xml;base64,", "")).decode()
         self.assertTrue(bg.startswith("data:image/svg+xml;base64,"))
         self.assertIn("linearGradient", svg)
@@ -312,7 +312,7 @@ class GradientHeaderTest(unittest.TestCase):
     def test_no_go_motif_does_not_suppress_bring_your_own_url(self):
         surfaces = dict(styling.SURFACES, motif=False)
         h = styling.gradient_header("ghdr", "X", motif="https://example.com/art.png", surfaces=surfaces)
-        self.assertEqual(h["element"][0]["backgroundImage"]["url"], "https://example.com/art.png")
+        self.assertEqual(h["element"][0]["backgroundImage"]["source"]["url"], "https://example.com/art.png")
 
     def test_motif_side_center_translates_to_x_800_and_is_valid(self):
         h = styling.gradient_header("ghdr", "X", motif="rings", motif_side="center")
@@ -339,7 +339,7 @@ class GradientCardSparklineTest(unittest.TestCase):
         self.assertEqual(gc["element"][0]["id"], "card-1")
         self.assertEqual(gc["element"][0]["kind"], "container")
         self.assertEqual(gc["element"][0]["style"], {"borderRadius": "round"})
-        self.assertTrue(gc["element"][0]["backgroundImage"]["url"].startswith("data:image/svg+xml;base64,"))
+        self.assertTrue(gc["element"][0]["backgroundImage"]["source"]["url"].startswith("data:image/svg+xml;base64,"))
         self.assertEqual(gc["element"][0]["backgroundImage"]["style"], {"fit": "cover"})
         self.assertEqual(gc["child_layout"],
                           '<Element elementId="kpi-rev" gridColumn="1 / 25" gridRow="1 / 7"/>')
@@ -356,7 +356,7 @@ class GradientCardSparklineTest(unittest.TestCase):
 
     def test_gradient_card_decoded_svg_has_gradient_no_motif_group(self):
         gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"])
-        url = gc["element"][0]["backgroundImage"]["url"]
+        url = gc["element"][0]["backgroundImage"]["source"]["url"]
         svg = base64.b64decode(url.replace("data:image/svg+xml;base64,", "")).decode()
         self.assertIn("linearGradient", svg)
         self.assertNotIn("<g transform=", svg)
@@ -367,7 +367,7 @@ class GradientCardSparklineTest(unittest.TestCase):
         THEN a dark scrim rect on top -- so white KPI text stays legible on
         any gradient, bright or dark."""
         gc = styling.gradient_card("card-1", self.GC_KPI_EL, ["#0F172A", "#2563EB"])
-        url = gc["element"][0]["backgroundImage"]["url"]
+        url = gc["element"][0]["backgroundImage"]["source"]["url"]
         svg = base64.b64decode(url.replace("data:image/svg+xml;base64,", "")).decode()
         self.assertIn('id="card-scrim"', svg)
         self.assertIn('stop-opacity="%s"' % styling.CARD_SCRIM_TOP_OPACITY, svg)
@@ -376,7 +376,7 @@ class GradientCardSparklineTest(unittest.TestCase):
 
     def test_gradient_card_gradient_defaults_to_dark_slate_pair_when_omitted(self):
         gc = styling.gradient_card("card-1", self.GC_KPI_EL)
-        url = gc["element"][0]["backgroundImage"]["url"]
+        url = gc["element"][0]["backgroundImage"]["source"]["url"]
         svg = base64.b64decode(url.replace("data:image/svg+xml;base64,", "")).decode()
         default_gradient = styling.DEFAULT_THEME["card_gradient"]
         self.assertIn(default_gradient[0], svg)

--- a/shared/lib/test_styling.rb
+++ b/shared/lib/test_styling.rb
@@ -191,7 +191,7 @@ check('gradient_header (default :glow, :right): container has data-URI SVG backg
   h = Styling.gradient_header(id: 'ghdr', title: 'Command Center')
   bg = h[:element][0]
   bg['kind'] == 'container' && bg['style'] == { 'borderRadius' => 'round' } &&
-    bg['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
+    bg['backgroundImage']['source']['url'].start_with?('data:image/svg+xml;base64,') &&
     bg['backgroundImage']['style'] == { 'fit' => 'cover' } &&
     h[:element].any? { |e| e['kind'] == 'text' && e['id'] == 'ghdr-title' } &&
     h[:layout].include?('<Container') && h[:layout].include?('elementId="ghdr-title"')
@@ -199,19 +199,19 @@ end
 
 check('gradient_header: decoded SVG carries the linearGradient + the requested motif group') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings)
-  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('linearGradient') && svg.include?('<circle r="40"/>') && svg.include?('<g transform="translate(1440,86)">')
 end
 
 check('gradient_header motif :none: no motif <g> group in the decoded SVG') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :none)
-  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   !svg.include?('<g transform=')
 end
 
 check('gradient_header motif_side: :left translates the motif group to x=160') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, motif_side: :left)
-  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('translate(160,86)')
 end
 
@@ -241,12 +241,12 @@ end
 
 check('gradient_header: bring-your-own http(s) URL used verbatim, SVG compose skipped') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png')
-  h[:element][0]['backgroundImage']['url'] == 'https://example.com/art.png'
+  h[:element][0]['backgroundImage']['source']['url'] == 'https://example.com/art.png'
 end
 check('gradient_header: bring-your-own data: URL used verbatim') do
   uri = 'data:image/png;base64,AAAA'
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: uri)
-  h[:element][0]['backgroundImage']['url'] == uri
+  h[:element][0]['backgroundImage']['source']['url'] == uri
 end
 
 check('gradient_header: gradient with != 2-3 stops raises ArgumentError') do
@@ -268,7 +268,7 @@ end
 check('gradient_header: NO-GO motif surface + menu-key motif falls back to the plain gradient (:none)') do
   surfaces = Styling::SURFACES.merge(motif: false)
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, surfaces: surfaces)
-  bg = h[:element][0]['backgroundImage']['url']
+  bg = h[:element][0]['backgroundImage']['source']['url']
   svg = Base64.decode64(bg.sub('data:image/svg+xml;base64,', ''))
   bg.start_with?('data:image/svg+xml;base64,') && svg.include?('linearGradient') && !svg.include?('<g transform=')
 end
@@ -276,12 +276,12 @@ end
 check('gradient_header: NO-GO motif surface does NOT suppress a bring-your-own URL (honored verbatim)') do
   surfaces = Styling::SURFACES.merge(motif: false)
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png', surfaces: surfaces)
-  h[:element][0]['backgroundImage']['url'] == 'https://example.com/art.png'
+  h[:element][0]['backgroundImage']['source']['url'] == 'https://example.com/art.png'
 end
 
 check('gradient_header motif_side: :center translates the motif group to x=800 and produces a valid header') do
   h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, motif_side: :center)
-  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('translate(800,86)') &&
     h[:element].any? { |e| e['kind'] == 'text' && e['id'] == 'ghdr-title' } &&
     h[:layout].include?('<Container') && h[:layout].include?('elementId="ghdr-title"')
@@ -306,7 +306,7 @@ check('gradient_card: GO returns a gradient container + child_layout positioning
   gc[:element].length == 1 &&
     gc[:element][0]['id'] == 'card-1' && gc[:element][0]['kind'] == 'container' &&
     gc[:element][0]['style'] == { 'borderRadius' => 'round' } &&
-    gc[:element][0]['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
+    gc[:element][0]['backgroundImage']['source']['url'].start_with?('data:image/svg+xml;base64,') &&
     gc[:element][0]['backgroundImage']['style'] == { 'fit' => 'cover' } &&
     gc[:child_layout] == '<Element elementId="kpi-rev" gridColumn="1 / 25" gridRow="1 / 7"/>' &&
     gc[:patch] == { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' },
@@ -320,14 +320,14 @@ end
 
 check('gradient_card: decoded SVG carries the linearGradient stops (motif: :none -- no motif group)') do
   gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
-  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('linearGradient') && !svg.include?('<g transform=')
 end
 
 check('gradient_card: composed SVG layers a dark scrim (id="card-scrim") over the caller gradient so white ' \
       'KPI text stays legible on any gradient, bright or dark (Task 6 live-render fix, user-reported)') do
   gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
-  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   svg.include?('id="card-scrim"') &&
     svg.include?("stop-opacity=\"#{Styling::CARD_SCRIM_TOP_OPACITY}\"") &&
     svg.include?('stop-opacity="0"') &&
@@ -336,7 +336,7 @@ end
 
 check('gradient_card: gradient: can be omitted -- defaults to DEFAULT_THEME[:card_gradient] (a dark slate pair)') do
   gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL)
-  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['source']['url'].sub('data:image/svg+xml;base64,', ''))
   default_gradient = Styling::DEFAULT_THEME[:card_gradient]
   svg.include?(default_gradient[0]) && svg.include?(default_gradient[1])
 end

--- a/shared/lib/testdata/styling_golden.json
+++ b/shared/lib/testdata/styling_golden.json
@@ -48,7 +48,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iY2ciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNTYzRUIiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iY2FyZC1zY3JpbSIgeDE9IjAiIHkxPSIwIiB4Mj0iMCIgeTI9IjEiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzAwMDAwMCIgc3RvcC1vcGFjaXR5PSIwLjU1Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDAwMDAwIiBzdG9wLW9wYWNpdHk9IjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYwMCIgaGVpZ2h0PSIyMTAiIGZpbGw9InVybCgjY2cpIi8+PHJlY3Qgd2lkdGg9IjE2MDAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI2NhcmQtc2NyaW0pIi8+PC9zdmc+",
+          "source": {
+            "kind": "url",
+            "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iY2ciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNTYzRUIiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iY2FyZC1zY3JpbSIgeDE9IjAiIHkxPSIwIiB4Mj0iMCIgeTI9IjEiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzAwMDAwMCIgc3RvcC1vcGFjaXR5PSIwLjU1Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDAwMDAwIiBzdG9wLW9wYWNpdHk9IjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYwMCIgaGVpZ2h0PSIyMTAiIGZpbGw9InVybCgjY2cpIi8+PHJlY3Qgd2lkdGg9IjE2MDAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI2NhcmQtc2NyaW0pIi8+PC9zdmc+"
+          },
           "style": {
             "fit": "cover"
           }
@@ -78,7 +81,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "https://example.com/art.png",
+          "source": {
+            "kind": "url",
+            "url": "https://example.com/art.png"
+          },
           "style": {
             "fit": "cover"
           }
@@ -102,7 +108,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNDQwLDg2KSI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJtb3RpZi1nbG93IiBjeD0iMC41IiBjeT0iMC41IiByPSIwLjYiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI0ZGRkZGRiIgc3RvcC1vcGFjaXR5PSIwLjIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNGRkZGRkYiIHN0b3Atb3BhY2l0eT0iMCIvPjwvcmFkaWFsR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9Ii0yNjAiIHk9Ii0xMDUiIHdpZHRoPSI1MjAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI21vdGlmLWdsb3cpIi8+PC9nPjwvc3ZnPg==",
+          "source": {
+            "kind": "url",
+            "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNDQwLDg2KSI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJtb3RpZi1nbG93IiBjeD0iMC41IiBjeT0iMC41IiByPSIwLjYiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI0ZGRkZGRiIgc3RvcC1vcGFjaXR5PSIwLjIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNGRkZGRkYiIHN0b3Atb3BhY2l0eT0iMCIvPjwvcmFkaWFsR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9Ii0yNjAiIHk9Ii0xMDUiIHdpZHRoPSI1MjAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI21vdGlmLWdsb3cpIi8+PC9nPjwvc3ZnPg=="
+          },
           "style": {
             "fit": "cover"
           }
@@ -140,7 +149,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48L3N2Zz4=",
+          "source": {
+            "kind": "url",
+            "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48L3N2Zz4="
+          },
           "style": {
             "fit": "cover"
           }
@@ -164,7 +176,10 @@
           "borderRadius": "round"
         },
         "backgroundImage": {
-          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjAsODYpIj48ZyBmaWxsPSJub25lIiBzdHJva2U9IiNGRkZGRkYiIHN0cm9rZS1vcGFjaXR5PSIwLjEyIiBzdHJva2Utd2lkdGg9IjEuNCI+PGNpcmNsZSByPSI0MCIvPjxjaXJjbGUgcj0iNzQiLz48Y2lyY2xlIHI9IjEwOCIvPjxsaW5lIHgxPSItMTMwIiB5MT0iMCIgeDI9IjEzMCIgeTI9IjAiLz48bGluZSB4MT0iMCIgeTE9Ii0xMzAiIHgyPSIwIiB5Mj0iMTMwIi8+PC9nPjwvZz48L3N2Zz4=",
+          "source": {
+            "kind": "url",
+            "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjAsODYpIj48ZyBmaWxsPSJub25lIiBzdHJva2U9IiNGRkZGRkYiIHN0cm9rZS1vcGFjaXR5PSIwLjEyIiBzdHJva2Utd2lkdGg9IjEuNCI+PGNpcmNsZSByPSI0MCIvPjxjaXJjbGUgcj0iNzQiLz48Y2lyY2xlIHI9IjEwOCIvPjxsaW5lIHgxPSItMTMwIiB5MT0iMCIgeDI9IjEzMCIgeTI9IjAiLz48bGluZSB4MT0iMCIgeTE9Ii0xMzAiIHgyPSIwIiB5Mj0iMTMwIi8+PC9nPjwvZz48L3N2Zz4="
+          },
           "style": {
             "fit": "cover"
           }

--- a/shared/scripts/verify-richness-surfaces-e2e.rb
+++ b/shared/scripts/verify-richness-surfaces-e2e.rb
@@ -236,6 +236,7 @@ def probe_cortex_model(home, schema_version, model)
   sql = "SELECT SNOWFLAKE.CORTEX.COMPLETE('#{model}', 'Respond with exactly the single word: OK') AS resp"
   doc = {
     'schemaVersion' => schema_version,
+    'kind' => 'workbook', # PATCHED for live probe: current contract requires document.kind
     'pages' => [{ 'id' => 'p1', 'name' => 'P1' }],
     'elements' => [
       { 'id' => 'cx', 'kind' => 'table', 'name' => 'Cx',
@@ -386,6 +387,7 @@ def build_spec(home, schema_version, cortex_model, flags)
   XML
   doc = {
     'schemaVersion' => schema_version,
+    'kind' => 'workbook', # PATCHED for live probe: current contract requires document.kind
     'pages' => [
       { 'id' => PAGE1_ID, 'name' => 'Richness Probe — main' },
       { 'id' => PAGE2_ID, 'name' => 'Richness Probe — uniform card' }

--- a/shared/scripts/verify-styling-surfaces-e2e.rb
+++ b/shared/scripts/verify-styling-surfaces-e2e.rb
@@ -320,6 +320,7 @@ def build_spec(home, schema_version, src_formula_fn, flags)
   ]
   doc = {
     'schemaVersion' => schema_version,
+    'kind' => 'workbook', # PATCHED for live probe: current contract requires document.kind
     # Live since 2026-08: themeName/themeOverrides moved to
     # document.settings.theme.{name,overrides} (shared/lib/code_rep.rb
     # DOC_KEYS) — a flat top-level themeName/themeOverrides is invalid on

--- a/shared/scripts/verify-ws4-e2e.rb
+++ b/shared/scripts/verify-ws4-e2e.rb
@@ -447,6 +447,7 @@ def build_spec(home, schema_version)
   ]
   doc = {
     'schemaVersion' => schema_version,
+    'kind' => 'workbook', # PATCHED for live probe: current contract requires document.kind
     'agents' => [agent],
     'pages' => [
       { 'id' => PG_MAIN, 'name' => 'Overview' },
@@ -521,17 +522,17 @@ begin
 
   surfaces = {
     'gradient_header :glow (hero, pg-main)' => {
-      post_accepted: !!(hdr_main_bg && hdr_main_bg.dig('backgroundImage', 'url').to_s.start_with?('data:image/svg+xml;base64,')),
+      post_accepted: !!(hdr_main_bg && hdr_main_bg.dig('backgroundImage', 'source', 'url').to_s.start_with?('data:image/svg+xml;base64,')),
       render_hint: 'Read the pg-main render — top band should show a dark-slate->blue diagonal gradient with a soft ' \
                     'radial glow motif (top-right) behind the white title/subtitle text.'
     },
     'gradient_header :rings (pg-actions)' => {
-      post_accepted: !!(hdr_actions_bg && hdr_actions_bg.dig('backgroundImage', 'url').to_s.start_with?('data:image/svg+xml;base64,')),
+      post_accepted: !!(hdr_actions_bg && hdr_actions_bg.dig('backgroundImage', 'source', 'url').to_s.start_with?('data:image/svg+xml;base64,')),
       render_hint: 'Read the pg-actions render — header band should show the purple gradient with concentric-ring ' \
                     '"signal" motif (top-right).'
     },
     'gradient_header bring-your-own (pg-motifs)' => {
-      post_accepted: !!(hdr_byo_bg && hdr_byo_bg.dig('backgroundImage', 'url') == BYO_URI),
+      post_accepted: !!(hdr_byo_bg && hdr_byo_bg.dig('backgroundImage', 'source', 'url') == BYO_URI),
       render_hint: 'Read the pg-motifs render (bottom band) — should show the teal/green diagonal gradient with the ' \
                     'hexagon-tile pattern verbatim (NOT the glow/rings library motifs), proving the bring-your-own ' \
                     'path bypasses SVG compose entirely.'
@@ -548,7 +549,7 @@ begin
                     'agents are enabled on this org) or a "not enabled" placeholder. Report exactly which.'
     },
     'KpiCard + gradient_card + sparkline (Revenue)' => {
-      post_accepted: !!(k_rev_bg && k_rev_bg.dig('backgroundImage', 'url').to_s.start_with?('data:') &&
+      post_accepted: !!(k_rev_bg && k_rev_bg.dig('backgroundImage', 'source', 'url').to_s.start_with?('data:') &&
                          k_rev_kpi && k_rev_kpi['comparisonColumn'] &&
                          k_rev_kpi.dig('value', 'color').to_s.downcase == '#ffffff' &&
                          k_rev_spark && k_rev_spark['kind'] == 'line-chart'),
@@ -557,7 +558,7 @@ begin
                     'validates the Task-3 padding:none fix).'
     },
     'KpiCard + gradient_card + sparkline (Orders)' => {
-      post_accepted: !!(k_ord_bg && k_ord_bg.dig('backgroundImage', 'url').to_s.start_with?('data:') &&
+      post_accepted: !!(k_ord_bg && k_ord_bg.dig('backgroundImage', 'source', 'url').to_s.start_with?('data:') &&
                          k_ord_kpi && k_ord_kpi['comparisonColumn'] &&
                          k_ord_kpi.dig('value', 'color').to_s.downcase == '#ffffff' &&
                          k_ord_spark && k_ord_spark['kind'] == 'line-chart'),

--- a/shared/scripts/verify-ws5-tabbed-e2e.rb
+++ b/shared/scripts/verify-ws5-tabbed-e2e.rb
@@ -212,6 +212,7 @@ def build_spec(home, schema_version)
 
   doc = {
     'schemaVersion' => schema_version,
+    'kind' => 'workbook', # PATCHED for live probe: current contract requires document.kind
     'pages' => [{ 'id' => PG_MAIN, 'name' => 'Overview' }],
     'elements' => [src, tab_table, tab_chart, tabbed[:element]],
     # layout is a single document field (sibling of `pages` and `elements`) — see


### PR DESCRIPTION
Live probing today found two hard 400s against aws-api.sigmacomputing.com:

1. Container.backgroundImage now requires the url nested under
   source:{kind:"url",url:} instead of the old flat {url:} shape
   ("backgroundImage.source: Invalid value: undefined"). Fixed in the
   canonical shared/lib/styling.rb (gradient_header/gradient_card) and its
   Python twin (shared/lib/styling.py), plus the vendored sigma-authoring
   plugin copy — the only actual fan-out target for this file (it isn't
   covered by shared/manifest.json's mechanical sync, so it needed a manual,
   scrub-preserving patch). Updated both golden fixtures and both languages'
   test assertions to the new shape, and corrected the styling/schema/layout
   reference docs that still taught the old container shape.

2. document.kind: "workbook" is now required on POST /v2/workbooks/spec.
   verify-ws4-e2e.rb, verify-ws5-tabbed-e2e.rb, verify-styling-surfaces-e2e.rb,
   and verify-richness-surfaces-e2e.rb all omitted it and now 400
   ("Expecting \"workbook\" ... but instead got: undefined"); patched to match
   the pattern verify-layout-contract-e2e.rb already documented.

Verified live: reproduced the old-shape 400, then POSTed the new shape,
GET-read the spec back to confirm backgroundImage.source.url survived (a 200
alone doesn't prove Sigma didn't silently drop it), and re-ran all four
repaired e2e scripts to completion. Probe workbooks deleted by tracked id.
ruby tools/sync-shared.rb / check-shared.rb, both styling test suites (Ruby
x2, Python), lint-skills, hygiene-sweep, and the corpus all green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
