### PR TITLE
fix(tableau-to-sigma): three cold-run DM-generation bugs from #685

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/hydrate-custom-sql.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/hydrate-custom-sql.rb
@@ -229,6 +229,55 @@ module HydrateCustomSql
     (conn.attributes['class'].to_s == 'sqlproxy')
   end
 
+  # Per-datasource sqlproxy detection (issue #685-A). twb_has_sqlproxy? answers
+  # a WORKBOOK-scoped question ("does this .twb contain ANY sqlproxy datasource
+  # anywhere") — using it to gate the embedded-extract landing/remap flow for
+  # the ENTIRE workbook silently disables landing for an unrelated, perfectly
+  # landable SIBLING datasource (a workbook mixing an embedded Hyper extract
+  # with an unrelated sqlproxy-backed published datasource, e.g. Superstore's
+  # "Commission Model" dashboard). Returns the datasource `name` (falling back
+  # to `caption`) of every top-level datasource that is sqlproxy with no real
+  # relation — the ones hydrate_pds! / the PDS-chase path still own.
+  def sqlproxy_only_datasource_names(twb_path)
+    return [] unless File.exist?(twb_path)
+    doc = REXML::Document.new(File.read(twb_path, encoding: 'UTF-8'))
+    names = []
+    doc.each_element('/workbook/datasources/datasource') do |ds|
+      conn = ds.elements['connection']
+      next unless conn && sqlproxy_connection?(conn) && !has_real_relation?(conn)
+      nm = ds.attributes['name'].to_s
+      names << (nm.empty? ? ds.attributes['caption'].to_s : nm)
+    end
+    names
+  rescue StandardError
+    []
+  end
+
+  # Every <connection class='...'> value carried by a top-level datasource that
+  # is NOT itself sqlproxy-only (see sqlproxy_only_datasource_names above) —
+  # i.e. exactly the answer migrate-tableau.rb's embedded-extract-landing gate
+  # needs ("is everything OUTSIDE the sqlproxy-handled datasources an embedded
+  # extract, and therefore landable") without an unrelated sqlproxy sibling's
+  # 'sqlproxy' class polluting the eligibility check. A pure-sqlproxy workbook
+  # correctly returns [] (nothing left to land; falls through to hydration).
+  def non_sqlproxy_conn_classes(twb_path)
+    return [] unless File.exist?(twb_path)
+    doc = REXML::Document.new(File.read(twb_path, encoding: 'UTF-8'))
+    classes = []
+    doc.each_element('/workbook/datasources/datasource') do |ds|
+      conn = ds.elements['connection']
+      next unless conn
+      next if sqlproxy_connection?(conn) && !has_real_relation?(conn)
+      REXML::XPath.each(ds, './/connection') do |c|
+        cls = c.attributes['class'].to_s
+        classes << cls unless cls.empty?
+      end
+    end
+    classes.uniq
+  rescue StandardError
+    []
+  end
+
   # Connection classes whose dbname is NOT a warehouse database: sqlproxy's is a
   # published-DS contentUrl, hyper/file classes carry a file path, and a virtual
   # connection's is the VC name. None of them may seed a warehouse table path.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -34,6 +34,7 @@ require 'open3'
 require 'zlib' # CRC32 — a cross-run-STABLE hash for case-disambiguating column ids (#455)
 require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 require_relative 'lib/theme_derive' # shared theme derivation/emission (v5.0)
+require_relative 'lib/sql_ident_check' # #685-C: calc-masquerading-as-physical fixup reuses its scanner/catalog check
 
 module MechanicalSpecs
   module_function
@@ -162,6 +163,26 @@ module MechanicalSpecs
 
   def all_elements(model)
     (model['pages'] || []).flat_map { |p| p['elements'] || [] }
+  end
+
+  # Issue #685-A part 2: the converter's extractPath fallback (converter/
+  # tableau.mjs) names an unresolvable relation literally "UNKNOWN" and gives
+  # it a malformed, DATABASE-SEGMENT-MISSING path (e.g. ["TJ","UNKNOWN"]) — an
+  # intentional placeholder for embedded-extract elements the Ruby-side
+  # extract-landing manifest remap is EXPECTED to overwrite afterward
+  # (remap_from_manifest!). When that attribution never happens (no manifest,
+  # --skip-extract-landing was waived, or 0% column-caption overlap with any
+  # manifest entry) the placeholder survives fixup and would otherwise reach a
+  # live POST, which 404s late with an unnamed "Source not found: warehouse
+  # table '<schema>.UNKNOWN'" error. Callers must check this AFTER remap_from_
+  # manifest!/fixup_dm_spec have had their chance and fail loud + named instead
+  # of POSTing a broken path. Returns the offending elements (empty = clean).
+  def unresolved_warehouse_elements(model)
+    all_elements(model).select do |e|
+      next false unless e.dig('source', 'kind') == 'warehouse-table'
+      path = Array(e.dig('source', 'path'))
+      e['name'].to_s.upcase == 'UNKNOWN' || path.any? { |seg| seg.to_s.upcase == 'UNKNOWN' }
+    end
   end
 
   def elem_name(e)
@@ -692,6 +713,39 @@ module MechanicalSpecs
     # every embedded datasource) are unattributable and stay as NAMED residue,
     # never a guess.
     claimed_ids = rename_pairs.map { |r| r[4].object_id }
+
+    # #685-C secondary pattern: PRECISE attribution first, via source.elementId.
+    # A kind:'table' derived VIEW carries an explicit pointer to its base
+    # element — when that base was claimed above, the view's refs can be
+    # repointed using THAT SPECIFIC claim, never the (possibly ambiguous)
+    # identifier-STRING match below. This matters when Tableau's OWN duplicate-
+    # datasource shape reuses the identical internal relation name across TWO
+    # DIFFERENT datasources (a workbook + its "(2)" duplicate both name their
+    # table "Orders") — the string old_last="ORDERS" is then genuinely
+    # ambiguous (two DIFFERENT landed tables both trace back to "ORDERS"), so
+    # the string-based repair below correctly refuses to guess — but the
+    # VIEW's elementId link removes the ambiguity entirely for elements that
+    # carry one (live-caught: Executive Dashboard's "Orders View").
+    by_id = all_elements(model).each_with_object({}) { |e, h| h[e['id']] = e }
+    by_orig_object_id = rename_pairs.each_with_object({}) { |r, h| h[r[4].object_id] = r }
+    precisely_repaired = Set.new
+    all_elements(model).each do |other|
+      next if claimed_ids.include?(other.object_id)
+      next unless other.dig('source', 'kind') == 'table'
+      base_el = (bid = other.dig('source', 'elementId')) && by_id[bid]
+      rp = base_el && by_orig_object_id[base_el.object_id]
+      next unless rp
+      old_last, old_name, new_last, = rp
+      [old_last, old_name].each do |old|
+        next if old.to_s.empty?
+        pfx_old = /\[#{Regexp.escape(old)}\//
+        (Array(other['columns']) + Array(other['metrics'])).each do |c|
+          c['formula'] = c['formula'].gsub(pfx_old, "[#{new_last}/") if c['formula'].is_a?(String)
+        end
+      end
+      precisely_repaired << other.object_id
+    end
+
     { 0 => 2, 1 => 3 }.each do |old_idx, new_idx|
       rename_pairs.group_by { |r| r[old_idx] }.each do |old, rs|
         next if old.to_s.empty?
@@ -705,7 +759,7 @@ module MechanicalSpecs
         pfx_old = /\[#{Regexp.escape(old)}\//
         repl = "[#{news.first}/"
         all_elements(model).each do |other|
-          next if claimed_ids.include?(other.object_id)
+          next if claimed_ids.include?(other.object_id) || precisely_repaired.include?(other.object_id)
           (Array(other['columns']) + Array(other['metrics'])).each do |c|
             c['formula'] = c['formula'].gsub(pfx_old, repl) if c['formula'].is_a?(String)
           end
@@ -1404,6 +1458,135 @@ module MechanicalSpecs
     added
   end
 
+  # Issue #685-B: the mechanical converter's base-column passthrough formula
+  # embeds a Tableau field's raw CAPTION, unescaped, inside a Sigma
+  # `[Table/Column]` bracket-path formula. Tableau captions routinely contain
+  # "/" (a very common naming convention — "Country/Region", "State/Province"
+  # — present in several of Tableau's OWN sample workbooks). A caption
+  # containing "/" (or "[" / "]") is ambiguous to Sigma's bracket-path parser
+  # (it reads as a multi-segment nested path, not a table/column pair) and the
+  # column compiles server-side to `type="error"`. It ALSO silently corrupts
+  # every Ruby-side consumer that recovers the physical name via
+  # `formula.split('/').last` (col_display, fixup_dm_spec's own phantom-column
+  # check below) — for "[T/Country/Region]" that yields "Region", the wrong,
+  # truncated segment, which is how a --column-mapping remediation went
+  # silently inert in the field: the phantom-check's derived physical name was
+  # already wrong (but coincidentally matched an unrelated real column), so
+  # the mapping was never even consulted.
+  #
+  # Rewrites every base (pure passthrough) column formula so the CAPTION
+  # segment is bracket-path-safe: folded to the SAME upper-snake physical-name
+  # form used everywhere else in this file (remap_from_manifest!'s colmap,
+  # synthesize_fixed_lods!'s `phys` — one convention, not a second one-off
+  # escaping scheme), while preserving the ORIGINAL caption as the column's
+  # display `name` — the user-visible label is unaffected; only the internal
+  # formula reference is desensitized. Runs unconditionally (no manifest /
+  # catalog / --column-mapping required) so every downstream consumer sees an
+  # unambiguous formula from the start. Returns the number of formulas rewritten.
+  BRACKET_PATH_SPECIAL_RE = %r{[/\[\]]}.freeze
+
+  def sanitize_bracket_path_captions!(model)
+    rewritten = 0
+    all_elements(model).each do |el|
+      next unless el.dig('source', 'kind') == 'warehouse-table'
+      tbl = (el.dig('source', 'path') || []).last.to_s
+      next if tbl.empty?
+      pfx = /\A\[#{Regexp.escape(tbl)}\/(.+)\]\z/
+      (el['columns'] || []).each do |c|
+        f = c['formula'].to_s
+        m = f.match(pfx)
+        next unless m
+        caption = m[1]
+        next unless caption =~ BRACKET_PATH_SPECIAL_RE
+        safe = caption.gsub(/[^0-9A-Za-z]+/, '_').gsub(/\A_+|_+\z/, '').upcase
+        c['name'] = caption if c['name'].to_s.empty?
+        c['formula'] = "[#{tbl}/#{safe}]"
+        rewritten += 1
+      end
+    end
+    rewritten
+  end
+
+  # Issue #685-C: a generated Custom-SQL helper element (window/LOD/Top-N
+  # builder) can reference a Tableau CALCULATED field — e.g. "Days to Ship" =
+  # DATEDIFF('day',[Order Date],[Ship Date]) — as though it were a physical
+  # warehouse column. The calc has no physical counterpart, so the bare
+  # identifier (DAYS_TO_SHIP) 404s the live catalog. The pre-POST
+  # check-sql-idents gate correctly catches this (exit 20) BEFORE a wasted
+  # POST — that gate is correct and stays exactly as strict; this fixup runs
+  # BEFORE the gate and removes the phantom reference AT THE SOURCE, but only
+  # when it can do so with confidence:
+  #   * the offending identifier's NORMALIZED form matches a KNOWN Tableau
+  #     calculated field (from calc-fields.json), AND
+  #   * that calc's formula is a single, confidently-translatable shape
+  #     (DATEDIFF('unit', [Field1], [Field2])) whose two operand fields ARE
+  #     themselves physical columns on the statement's own FROM table.
+  # When either condition fails, the statement is left COMPLETELY UNTOUCHED —
+  # refuse, don't guess. The (unweakened) gate remains the backstop for every
+  # other shape.
+  #
+  # calc_fields: [{ 'name' => 'Days to Ship',
+  #                 'formula' => "DATEDIFF('day',[Order Date],[Ship Date])" }, ...]
+  #   (the shape scripts/extract-calc-fields.rb's calc-fields.json carries
+  #   under its top-level "calcs" key).
+  # real_columns: { "TABLE" => [phys col, ...], ... } — the live catalog. nil
+  #   or empty => no-op (never guess blind about what's physical).
+  # Returns { rewritten: <n identifiers substituted>, elements: [<element
+  # name>, ...] }. Mutates model in place.
+  DATEDIFF_CALC_RE = /\A\s*DATEDIFF\s*\(\s*'([^']+)'\s*,\s*\[([^\]]+)\]\s*,\s*\[([^\]]+)\]\s*\)\s*\z/i.freeze
+
+  def fix_calc_masquerading_as_physical!(model, calc_fields, real_columns)
+    result = { rewritten: 0, elements: [] }
+    return result if real_columns.nil? || real_columns.empty?
+    norm_tables = {}
+    real_columns.each { |t, cols| norm_tables[t.to_s.split('.').last.upcase] = Array(cols).map(&:to_s) }
+    return result if norm_tables.empty?
+    calc_by_norm = {}
+    Array(calc_fields).each do |cf|
+      nm = cf['name'] || cf[:name]
+      formula = cf['formula'] || cf[:formula]
+      calc_by_norm[SqlIdentCheck.normalize(nm)] = formula.to_s if nm && formula
+    end
+    return result if calc_by_norm.empty?
+
+    all_elements(model).each do |el|
+      next unless el.dig('source', 'kind') == 'sql'
+      stmt = el.dig('source', 'statement').to_s
+      next if stmt.empty?
+      tbl_name = SqlIdentCheck.scan(stmt)[:tables].first&.dig(:name).to_s.split('.').last.upcase
+      real_cols = norm_tables[tbl_name]
+      next unless real_cols
+      chk = SqlIdentCheck.check(stmt, { tbl_name => real_cols })
+      touched = false
+      chk[:unknown].each do |u|
+        formula = calc_by_norm[SqlIdentCheck.normalize(u[:identifier])]
+        next unless formula
+        m = formula.match(DATEDIFF_CALC_RE)
+        next unless m
+        unit, f1, f2 = m[1], m[2], m[3]
+        p1 = real_cols.find { |c| SqlIdentCheck.normalize(c) == SqlIdentCheck.normalize(f1) }
+        p2 = real_cols.find { |c| SqlIdentCheck.normalize(c) == SqlIdentCheck.normalize(f2) }
+        next unless p1 && p2 # both operands must themselves be REAL physical columns
+        # Word-boundary substitution only. `\b` never fires between two word
+        # characters (letters/digits/underscore), so this can never match
+        # INSIDE a longer token like the output alias
+        # DAYS_TO_SHIP_CURRENT_MONTH_AVERAGE — only the bare, standalone
+        # phantom reference is touched.
+        ident_re = /\b#{Regexp.escape(u[:identifier])}\b/
+        next unless stmt.match?(ident_re)
+        new_stmt = stmt.gsub(ident_re, "DATEDIFF('#{unit}', #{p1}, #{p2})")
+        next if new_stmt == stmt
+        stmt = new_stmt
+        touched = true
+        result[:rewritten] += 1
+      end
+      next unless touched
+      el['source']['statement'] = stmt
+      result[:elements] << (el['name'] || el['id']).to_s
+    end
+    result
+  end
+
   # DM-spec fixup (mechanical). See module doc. Returns
   #   { fixed: <n formulas rewritten>, dropped: [<dropped calc display names>] }.
   # real_columns: optional { "TABLE" => Set/Array of UPPER physical column names }
@@ -1434,6 +1617,11 @@ module MechanicalSpecs
     # Keyed by the UPPER extract caption; value = the real warehouse column.
     colmap = {}
     (column_mapping || {}).each { |src, dest| colmap[src.to_s.strip.upcase] = dest.to_s.strip }
+    # Bracket-path caption escaping FIRST (#685-B): a caption containing "/"
+    # (or "[" / "]") must be desensitized in the FORMULA before anything below
+    # tries to recover a physical name from it (formula.split('/').last would
+    # otherwise silently truncate "Country/Region" to "Region").
+    sanitize_bracket_path_captions!(model)
     # Caption hygiene FIRST (bead 320u): Sigma trims display names server-side,
     # so trailing-space captions must be trimmed everywhere refs are built.
     trim_spec_whitespace!(model)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -120,6 +120,15 @@ Encoding.default_external = Encoding::UTF_8
 # 19 = scoped-run mismatch: a --dashboard / mission.json stated scope named a
 #      dashboard that matches NOTHING in the workbook — the banner lists the
 #      workbook's dashboards (E9.6: never a silent full-workbook run);
+# 20 = the pre-POST Custom-SQL identifier gate (check-sql-idents.rb) found a
+#      statement referencing an identifier that does not exist on its FROM
+#      table — waive with --skip-sql-ident-gate "<reason>";
+# 21 = an element still carries the mechanical converter's placeholder
+#      warehouse-table name/path ("UNKNOWN") after every attribution chance
+#      (extract-landing manifest remap, phantom-column filter) has already
+#      run — POSTing it would 404 late with an unnamed "Source not found"
+#      error (#685-A). Land the embedded extract (or repoint the element by
+#      hand with --table-mapping) and re-run;
 # 3 = parity/guard fail; 4 = workbook layer needs the agent path; other = error.
 #
 # SINGLE-INVOCATION (speed review #2, wave 1):
@@ -2444,9 +2453,29 @@ if mechanical
   # a stray class='MapBox' (from a geo mark) otherwise would — dropping the
   # embedded path, the landing manifest, and the source.path remap.
   nondata_classes = %w[mapbox tableau-map wms wms-server]
-  if have_twb && !HydrateCustomSql.twb_has_sqlproxy?(twb)
+  # #685-A: sqlproxy detection must be scoped PER-DATASOURCE, not per-workbook.
+  # twb_has_sqlproxy?(twb) is a workbook-wide "does ANY datasource here use
+  # sqlproxy" question — gating this whole embedded-extract-landing block on
+  # its negation used to disable landing/remap for the ENTIRE workbook the
+  # moment ONE unrelated datasource was sqlproxy-backed (e.g. Superstore's
+  # "Commission Model" dashboard, fed by a published/file-based datasource
+  # with no landing path), even though a perfectly landable SIBLING datasource
+  # (the embedded "Sample - Superstore" Hyper extract) sat right next to it.
+  # non_sqlproxy_conn_classes scopes the eligibility scan to datasources that
+  # are NOT themselves sqlproxy-only, so the sqlproxy sibling's class can never
+  # leak into "is everything else here an embedded extract" — the sqlproxy
+  # datasource itself is still handled separately by the PDS-hydration block
+  # below (HydrateCustomSql.twb_has_sqlproxy? there is unchanged; both blocks
+  # can now fire in the SAME run for a mixed workbook).
+  if have_twb
+    sqlproxy_ds_names = HydrateCustomSql.sqlproxy_only_datasource_names(twb)
+    if sqlproxy_ds_names.any?
+      line "sqlproxy datasource(s) detected (#{sqlproxy_ds_names.join(', ')}) — scoping embedded-extract " \
+           'detection to the REMAINING datasource(s) only (#685-A: a sqlproxy datasource must not disable ' \
+           'landing/remap for an unrelated, landable sibling datasource)'
+    end
     conn_classes = begin
-      File.read(twb, encoding: 'UTF-8').scan(/<connection[^>]*\bclass='([^']+)'/).flatten.uniq
+      HydrateCustomSql.non_sqlproxy_conn_classes(twb)
         .reject { |c| c == 'federated' || nondata_classes.include?(c.to_s.downcase) }
     rescue StandardError
       []
@@ -4154,6 +4183,28 @@ elsif mechanical
     pf = MechanicalSpecs.fixup_dm_spec(dm, real_cols, column_mapping: opts[:column_mapping])
     line "phantom-column filter: dropped #{pf[:phantom]} non-existent base column(s) using #{real_cols.size} live table catalog(s)" if pf[:phantom].to_i.positive?
     line "column-rename remap: rewired #{pf[:remapped]} base column(s) to their warehouse names (--column-mapping)" if pf[:remapped].to_i.positive?
+    # Calc-field-as-physical-column guard (#685-C): a generated Custom-SQL
+    # window/LOD helper can reference a Tableau CALCULATED field's sanitized
+    # caption (e.g. DAYS_TO_SHIP for "Days to Ship" = DATEDIFF('day',[Order
+    # Date],[Ship Date])) as though it were a physical warehouse column. Fix
+    # it here, BEFORE the sql-ident gate / POST, using the SAME live catalogs
+    # just loaded — never weakens that gate; only prevents feeding it something
+    # it would rightly reject.
+    begin
+      _calc_path = File.join(WORK, 'calc-fields.json')
+      if File.exist?(_calc_path)
+        _calc_doc = JSON.parse(File.read(_calc_path, encoding: 'UTF-8'))
+        _calcs = Array(_calc_doc['calcs'])
+        cf = MechanicalSpecs.fix_calc_masquerading_as_physical!(dm, _calcs, real_cols)
+        if cf[:rewritten].to_i.positive?
+          line "calc-as-physical guard: substituted #{cf[:rewritten]} calculated-field reference(s) " \
+               "with their own translated SQL in #{cf[:elements].uniq.join(', ')} (#685-C)"
+        end
+      end
+    rescue StandardError => e
+      line "WARN: calc-as-physical guard failed (#{e.class}: #{e.message.to_s[0, 100]}) — " \
+           'a phantom physical-column reference (if any) is left for check-sql-idents to catch'
+    end
     # Retain the multi-metric recipe's point-in-time columns on the fact (the
     # discriminator / rollup flag + year the source didn't plot) so the
     # real-entity filter can run instead of being skipped as a dangling ref.
@@ -4274,6 +4325,32 @@ rescue StandardError => e
 end
 unless reuse_dm_id
   dm['folderId'] = opts[:folder] if opts[:folder]
+  # Unresolved-warehouse-table GATE (#685-A part 2): remap_from_manifest! and
+  # fixup_dm_spec have both had their chance by now. An element STILL carrying
+  # the converter's "UNKNOWN" placeholder name/path means nothing could
+  # attribute it to a real warehouse table (no landing manifest, --skip-
+  # extract-landing was waived, or 0% column-caption overlap with any manifest
+  # entry) — POSTing it 404s late and cryptically ("Source not found:
+  # warehouse table '<schema>.UNKNOWN'"). Fail loud and NAMED here instead.
+  unresolved = MechanicalSpecs.unresolved_warehouse_elements(dm)
+  if unresolved.any?
+    puts
+    puts '========== UNRESOLVED WAREHOUSE TABLE (exit 21) =========='
+    puts "The mechanical converter could not resolve a real warehouse table for #{unresolved.size} " \
+         'element(s) below — every attribution chance (extract-landing manifest remap, phantom-column'
+    puts 'filter) has already run. POSTing this DM would fail LATE with an unnamed "Source not found"'
+    puts 'error instead. Offending element(s):'
+    unresolved.each { |e| puts "  - #{e['name'].inspect}  path=#{(e.dig('source', 'path') || []).inspect}" }
+    puts
+    puts 'Likely causes, in order of likelihood:'
+    puts '  * an embedded-extract datasource that never got landed — check for a landing-manifest.json'
+    puts '    in this workdir (refs/extract-landing.md); land it (scripts/land-extracts.py), then re-run;'
+    puts '  * --skip-extract-landing was used and the DM table paths were knowingly left on you;'
+    puts "  * the manifest could not attribute this element by column-caption overlap (0% overlap) —"
+    puts '    repoint it by hand with --table-mapping.'
+    puts '==========================================================='
+    exit 21
+  end
   File.write(dm_spec_path, JSON.pretty_generate(dm))
   # In mechanical mode validate-spec.rb is advisory only: it flags cross-element
   # sibling refs that Sigma actually resolves via relationships (documented

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bracket-path-caption-escape.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bracket-path-caption-escape.rb
@@ -1,0 +1,123 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for issue #685-B (World Indicators cold-run failure, 2026-08-08).
+#
+# THE BUG: the mechanical converter's base-column passthrough formula embeds a
+# Tableau field's raw CAPTION, unescaped, inside a Sigma `[Table/Column]`
+# bracket-path formula. Tableau captions routinely contain "/" (a very common
+# naming convention — "Country/Region", "State/Province" — present in several
+# of Tableau's OWN sample workbooks, not just customer content). When the
+# caption itself contains "/", the emitted formula ("[WORLDIND_.../Country/Region]")
+# is ambiguous to Sigma's bracket-path parser (it reads as a 3-segment nested
+# path, not a 2-segment table/column pair) and compiles server-side to
+# `type="error"`.
+#
+# This ALSO silently corrupted every Ruby-side consumer of the formula that
+# recovers the physical column name via `formula.split('/').last`
+# (MechanicalSpecs.col_display, and fixup_dm_spec's phantom-column check) —
+# for "[T/Country/Region]" that yields "Region" (the wrong, truncated
+# segment), which is how `--column-mapping "Country/Region=COUNTRY_REGION"`
+# went silently inert in the live run: the phantom-check's `phys` variable
+# was already "REGION" (which happened to coincide with an ACTUAL separate
+# "Region" column on this table), so the mapping's lookup key never matched
+# and colmap was never even consulted.
+#
+# THE FIX: MechanicalSpecs.sanitize_bracket_path_captions! rewrites every base
+# passthrough column's formula to use a SANITIZED (bracket-path-safe) form of
+# the caption — "/", "[", "]" folded to "_" — while preserving the ORIGINAL
+# caption as the column's display `name`. Runs unconditionally (no manifest /
+# catalog / --column-mapping required) as the first step of fixup_dm_spec, so
+# every downstream consumer sees an unambiguous formula from the start.
+#
+# Deterministic + offline: hand-built DM fixture using the real column shape
+# from the live run (Tableau's own "World Indicators" sample workbook), no
+# network / creds.
+#
+# Usage:  ruby scripts/test-bracket-path-caption-escape.rb
+
+require_relative 'mechanical-specs'
+
+fails = []
+def check(cond, msg, fails) fails << msg unless cond; puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}" end
+
+def base_element(path_last, columns)
+  {
+    'id' => 'el-fact', 'kind' => 'table', 'name' => nil,
+    'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'conn-1',
+                  'path' => ['DB', 'SCHEMA', path_last] },
+    'columns' => columns
+  }
+end
+
+puts "Part A — a caption containing '/' is desensitized in the FORMULA, preserved as the display name"
+model = { 'pages' => [{ 'elements' => [
+  base_element('WORLDIND_2F6653_WORLD_INDICATORS', [
+    { 'id' => 'c-1', 'name' => nil, 'formula' => '[WORLDIND_2F6653_WORLD_INDICATORS/Country/Region]' },
+    { 'id' => 'c-2', 'name' => nil, 'formula' => '[WORLDIND_2F6653_WORLD_INDICATORS/GDP]' }
+  ])
+] }] }
+n = MechanicalSpecs.sanitize_bracket_path_captions!(model)
+col1 = model['pages'][0]['elements'][0]['columns'][0]
+col2 = model['pages'][0]['elements'][0]['columns'][1]
+check(n == 1, "exactly one formula rewritten (got #{n})", fails)
+check(col1['formula'] == '[WORLDIND_2F6653_WORLD_INDICATORS/COUNTRY_REGION]',
+      "'/' in the caption is folded to '_' in the FORMULA segment (got #{col1['formula']})", fails)
+check(col1['name'] == 'Country/Region',
+      "original caption 'Country/Region' preserved as the display name (got #{col1['name'].inspect})", fails)
+check(col2['formula'] == '[WORLDIND_2F6653_WORLD_INDICATORS/GDP]',
+      'a caption with no special characters is left byte-identical', fails)
+check(col2['name'].nil?, 'an untouched column is not force-given a name', fails)
+
+puts 'Part B — col_display now recovers the FULL original caption (no more truncation to "Region")'
+check(MechanicalSpecs.col_display(col1) == 'Country/Region',
+      "col_display returns the preserved display name, not a split-mangled fragment (got #{MechanicalSpecs.col_display(col1).inspect})", fails)
+
+puts "Part C — '[' and ']' are also neutralized (any bracket-path-special character)"
+model2 = { 'pages' => [{ 'elements' => [
+  base_element('T', [{ 'id' => 'c-3', 'name' => nil, 'formula' => '[T/Weird [Bracket] Name]' }])
+] }] }
+MechanicalSpecs.sanitize_bracket_path_captions!(model2)
+c3 = model2['pages'][0]['elements'][0]['columns'][0]
+check(c3['formula'] !~ %r{[\[\]]/?.*[\[\]].*\]\z} || c3['formula'] == '[T/Weird _Bracket_ Name]',
+      "embedded brackets in the caption are folded, not left to reopen the path (got #{c3['formula']})", fails)
+check(c3['name'] == 'Weird [Bracket] Name', 'original caption (with brackets) preserved as display name', fails)
+
+puts 'Part D — fixup_dm_spec runs the sanitizer unconditionally (no real_columns / column_mapping needed)'
+model3 = { 'pages' => [{ 'elements' => [
+  base_element('WORLDIND_2F6653_WORLD_INDICATORS', [
+    { 'id' => 'c-4', 'name' => nil, 'formula' => '[WORLDIND_2F6653_WORLD_INDICATORS/Country/Region]' }
+  ])
+] }] }
+MechanicalSpecs.fixup_dm_spec(model3)
+c4 = model3['pages'][0]['elements'][0]['columns'][0]
+check(c4['formula'] == '[WORLDIND_2F6653_WORLD_INDICATORS/COUNTRY_REGION]',
+      "fixup_dm_spec (called with NO real_columns/column_mapping — the live-run first-pass call shape) " \
+      "still sanitizes the caption (got #{c4['formula']})", fails)
+check(c4['name'] == 'Country/Region', 'fixup_dm_spec preserves the display caption', fails)
+
+puts 'Part E — the phantom-column check now sees the CORRECT physical name (COUNTRY_REGION, not REGION)'
+# A landed table carrying a genuinely SEPARATE "Region" column (the coincidence
+# that masked the bug in the live run) PLUS the real "Country/Region" ->
+# COUNTRY_REGION landed column. Post-sanitization, the phantom check must key
+# off COUNTRY_REGION and find it real (no false drop, no --column-mapping needed).
+model4 = { 'pages' => [{ 'elements' => [
+  base_element('WORLDIND_2F6653_WORLD_INDICATORS', [
+    { 'id' => 'c-5', 'name' => nil, 'formula' => '[WORLDIND_2F6653_WORLD_INDICATORS/Country/Region]' },
+    { 'id' => 'c-6', 'name' => nil, 'formula' => '[WORLDIND_2F6653_WORLD_INDICATORS/Region]' }
+  ])
+] }] }
+real = { 'WORLDIND_2F6653_WORLD_INDICATORS' => %w[COUNTRY_REGION REGION GDP] }
+fx = MechanicalSpecs.fixup_dm_spec(model4, real)
+check(fx[:dropped].empty?, "no column wrongly dropped as phantom (got #{fx[:dropped].inspect})", fails)
+kept = model4['pages'][0]['elements'][0]['columns']
+check(kept.size == 2, 'both the slash-caption column and the plain Region column survive, distinct', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-as-physical-guard.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-as-physical-guard.rb
@@ -8,7 +8,7 @@
 #   SELECT SHIP_DATE AS SHIP_DATE, AVG(CASE WHEN DATETRUNC('month', SHIP_DATE)
 #     = DATETRUNC('month',DATE('12/01/2021')) THEN DAYS_TO_SHIP END)
 #     AS DAYS_TO_SHIP_CURRENT_MONTH_AVERAGE
-#   FROM CSA.TJ.EXECDASH_2FB33B_ORDERS GROUP BY 1
+#   FROM WHDB.WHSCHEMA.FIXTURE_ORDERS GROUP BY 1
 #
 # "Days to Ship" is actually a Tableau CALCULATED field —
 # DATEDIFF('day',[Order Date],[Ship Date]) — with NO physical counterpart on
@@ -43,7 +43,7 @@ def check(cond, msg, fails) fails << msg unless cond; puts "  #{cond ? 'PASS' : 
 STATEMENT = <<~SQL.strip
   SELECT SHIP_DATE AS SHIP_DATE, AVG(CASE WHEN DATETRUNC('month', SHIP_DATE) = DATETRUNC('month',DATE('12/01/2021'))
           THEN DAYS_TO_SHIP
-          END) AS DAYS_TO_SHIP_CURRENT_MONTH_AVERAGE FROM CSA.TJ.EXECDASH_2FB33B_ORDERS GROUP BY 1
+          END) AS DAYS_TO_SHIP_CURRENT_MONTH_AVERAGE FROM WHDB.WHSCHEMA.FIXTURE_ORDERS GROUP BY 1
 SQL
 
 CALC_FIELDS = [
@@ -51,7 +51,7 @@ CALC_FIELDS = [
     'depends_on' => ['Ship Date', 'Order Date'] }
 ]
 
-REAL_COLUMNS = { 'EXECDASH_2FB33B_ORDERS' => %w[ORDER_ID ORDER_DATE SHIP_DATE SHIP_MODE] }
+REAL_COLUMNS = { 'FIXTURE_ORDERS' => %w[ORDER_ID ORDER_DATE SHIP_DATE SHIP_MODE] }
 
 def build_model(statement)
   {
@@ -89,13 +89,13 @@ fixed_check = SqlIdentCheck.check(fixed_stmt, REAL_COLUMNS)
 check(fixed_check[:ok], "check-sql-idents passes on the fixed statement (unknown: #{fixed_check[:unknown].inspect})", fails)
 
 puts 'Part D — the gate is NOT weakened: a genuinely-unresolvable identifier still fails'
-untranslatable_stmt = 'SELECT SOME_TOTALLY_MADE_UP_COLUMN FROM CSA.TJ.EXECDASH_2FB33B_ORDERS'
+untranslatable_stmt = 'SELECT SOME_TOTALLY_MADE_UP_COLUMN FROM WHDB.WHSCHEMA.FIXTURE_ORDERS'
 still_fails = SqlIdentCheck.check(untranslatable_stmt, REAL_COLUMNS)
 check(!still_fails[:ok], 'an unrelated, genuinely-unknown identifier still fails the gate after our fixup exists', fails)
 
 puts 'Part E — a calc formula NOT confidently translatable is left completely alone (never guessed)'
 weird_calc = [{ 'name' => 'Weird Calc', 'formula' => 'IF [X] THEN [Y] ELSE [Z] END' }]
-weird_stmt = 'SELECT CASE WHEN 1=1 THEN WEIRD_CALC END AS W FROM CSA.TJ.EXECDASH_2FB33B_ORDERS'
+weird_stmt = 'SELECT CASE WHEN 1=1 THEN WEIRD_CALC END AS W FROM WHDB.WHSCHEMA.FIXTURE_ORDERS'
 weird_model = build_model(weird_stmt)
 weird_result = MechanicalSpecs.fix_calc_masquerading_as_physical!(weird_model, weird_calc, REAL_COLUMNS)
 check(weird_result[:rewritten].zero?, 'no substitution attempted for a non-DATEDIFF calc shape (refuse, never guess)', fails)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-as-physical-guard.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-as-physical-guard.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for issue #685-C (Executive Dashboard cold-run failure, 2026-08-08).
+#
+# THE BUG: a generated Custom-SQL window/LOD helper element referenced
+# DAYS_TO_SHIP as though it were a physical warehouse column:
+#
+#   SELECT SHIP_DATE AS SHIP_DATE, AVG(CASE WHEN DATETRUNC('month', SHIP_DATE)
+#     = DATETRUNC('month',DATE('12/01/2021')) THEN DAYS_TO_SHIP END)
+#     AS DAYS_TO_SHIP_CURRENT_MONTH_AVERAGE
+#   FROM CSA.TJ.EXECDASH_2FB33B_ORDERS GROUP BY 1
+#
+# "Days to Ship" is actually a Tableau CALCULATED field —
+# DATEDIFF('day',[Order Date],[Ship Date]) — with NO physical counterpart on
+# the landed table. The pre-POST check-sql-idents gate correctly caught this
+# (exit 20: "DAYS_TO_SHIP -> no catalog match") BEFORE a wasted live POST —
+# that gate is CORRECT and must stay exactly as strict (this test proves it
+# still fires on a genuinely bad statement, per "verification gates must fail
+# first" — Ruby test-driven, not the live gate itself, but the same
+# SqlIdentCheck the live gate calls).
+#
+# THE FIX: MechanicalSpecs.fix_calc_masquerading_as_physical! runs BEFORE the
+# gate/POST and removes the phantom reference at the source — when the
+# offending name resolves to a KNOWN Tableau calculated field (from
+# calc-fields.json) whose formula is a confidently-translatable simple shape
+# (DATEDIFF over fields that ARE physical on the statement's FROM table), it
+# substitutes the calc's own SQL translation in place of the bare identifier.
+# Anything NOT confidently translatable is left completely alone — the gate
+# stays the unweakened backstop for every other case.
+#
+# Deterministic + offline: hand-built DM + calc-fields fixture matching the
+# live run's real shape (Tableau's own "Sample - Superstore" sample data),
+# no network / creds.
+#
+# Usage:  ruby scripts/test-calc-as-physical-guard.rb
+
+require_relative 'mechanical-specs'
+require_relative 'lib/sql_ident_check'
+
+fails = []
+def check(cond, msg, fails) fails << msg unless cond; puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}" end
+
+STATEMENT = <<~SQL.strip
+  SELECT SHIP_DATE AS SHIP_DATE, AVG(CASE WHEN DATETRUNC('month', SHIP_DATE) = DATETRUNC('month',DATE('12/01/2021'))
+          THEN DAYS_TO_SHIP
+          END) AS DAYS_TO_SHIP_CURRENT_MONTH_AVERAGE FROM CSA.TJ.EXECDASH_2FB33B_ORDERS GROUP BY 1
+SQL
+
+CALC_FIELDS = [
+  { 'name' => 'Days to Ship', 'formula' => "DATEDIFF('day',[Order Date],[Ship Date])",
+    'depends_on' => ['Ship Date', 'Order Date'] }
+]
+
+REAL_COLUMNS = { 'EXECDASH_2FB33B_ORDERS' => %w[ORDER_ID ORDER_DATE SHIP_DATE SHIP_MODE] }
+
+def build_model(statement)
+  {
+    'pages' => [{ 'elements' => [
+      { 'id' => 'el-helper', 'kind' => 'table', 'name' => 'ORDERS FIXED SHIP_DATE',
+        'source' => { 'connectionId' => 'conn-1', 'kind' => 'sql', 'statement' => statement },
+        'columns' => [
+          { 'id' => 'c-1', 'name' => 'SHIP_DATE', 'formula' => '[Custom SQL/SHIP_DATE]' },
+          { 'id' => 'c-2', 'name' => 'Days to Ship | Current Month Average',
+            'formula' => '[Custom SQL/DAYS_TO_SHIP_CURRENT_MONTH_AVERAGE]' }
+        ] }
+    ] }]
+  }
+end
+
+puts 'Part A — reproduce the live failure: check-sql-idents (unmodified) rejects the raw statement'
+raw_check = SqlIdentCheck.check(STATEMENT, REAL_COLUMNS)
+check(!raw_check[:ok], 'the unfixed statement fails the identifier gate (DAYS_TO_SHIP has no catalog match)', fails)
+check(raw_check[:unknown].any? { |u| u[:identifier] == 'DAYS_TO_SHIP' },
+      "the gate names DAYS_TO_SHIP specifically (got #{raw_check[:unknown].map { |u| u[:identifier] }.inspect})", fails)
+
+puts 'Part B — MechanicalSpecs.fix_calc_masquerading_as_physical! substitutes the calc\'s own SQL translation'
+model = build_model(STATEMENT)
+result = MechanicalSpecs.fix_calc_masquerading_as_physical!(model, CALC_FIELDS, REAL_COLUMNS)
+fixed_stmt = model['pages'][0]['elements'][0]['source']['statement']
+check(result[:rewritten] == 1, "exactly one identifier substituted (got #{result[:rewritten]})", fails)
+check(!fixed_stmt.include?('DAYS_TO_SHIP') || fixed_stmt.include?('DAYS_TO_SHIP_CURRENT_MONTH_AVERAGE'),
+      "the bare DAYS_TO_SHIP physical-column reference is gone (kept only as the OUTPUT alias) " \
+      "(got #{fixed_stmt.inspect})", fails)
+check(fixed_stmt.include?("DATEDIFF('day', ORDER_DATE, SHIP_DATE)"),
+      "the calc's own DATEDIFF formula is inlined against REAL physical columns (got #{fixed_stmt.inspect})", fails)
+
+puts 'Part C — the fixed statement now PASSES the SAME (unweakened) identifier gate'
+fixed_check = SqlIdentCheck.check(fixed_stmt, REAL_COLUMNS)
+check(fixed_check[:ok], "check-sql-idents passes on the fixed statement (unknown: #{fixed_check[:unknown].inspect})", fails)
+
+puts 'Part D — the gate is NOT weakened: a genuinely-unresolvable identifier still fails'
+untranslatable_stmt = 'SELECT SOME_TOTALLY_MADE_UP_COLUMN FROM CSA.TJ.EXECDASH_2FB33B_ORDERS'
+still_fails = SqlIdentCheck.check(untranslatable_stmt, REAL_COLUMNS)
+check(!still_fails[:ok], 'an unrelated, genuinely-unknown identifier still fails the gate after our fixup exists', fails)
+
+puts 'Part E — a calc formula NOT confidently translatable is left completely alone (never guessed)'
+weird_calc = [{ 'name' => 'Weird Calc', 'formula' => 'IF [X] THEN [Y] ELSE [Z] END' }]
+weird_stmt = 'SELECT CASE WHEN 1=1 THEN WEIRD_CALC END AS W FROM CSA.TJ.EXECDASH_2FB33B_ORDERS'
+weird_model = build_model(weird_stmt)
+weird_result = MechanicalSpecs.fix_calc_masquerading_as_physical!(weird_model, weird_calc, REAL_COLUMNS)
+check(weird_result[:rewritten].zero?, 'no substitution attempted for a non-DATEDIFF calc shape (refuse, never guess)', fails)
+check(weird_model['pages'][0]['elements'][0]['source']['statement'] == weird_stmt,
+      'statement left byte-identical when the fixup cannot confidently translate it', fails)
+still_fails2 = SqlIdentCheck.check(weird_model['pages'][0]['elements'][0]['source']['statement'], REAL_COLUMNS)
+check(!still_fails2[:ok], 'the untranslated phantom reference is still caught by the (unweakened) gate', fails)
+
+puts 'Part F — no real_columns supplied (catalog unknown): no-op, never guesses blind'
+noop_model = build_model(STATEMENT)
+noop_result = MechanicalSpecs.fix_calc_masquerading_as_physical!(noop_model, CALC_FIELDS, nil)
+check(noop_result[:rewritten].zero?, 'without a live catalog, the fixup makes no changes', fails)
+check(noop_model['pages'][0]['elements'][0]['source']['statement'] == STATEMENT,
+      'statement left untouched absent real_columns', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-manifest-remap.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-manifest-remap.rb
@@ -191,7 +191,7 @@ puts "Part H — #685-C secondary: derived-view refs repaired via elementId even
      '"Orders View" prefix-mismatch)'
 dup_el = lambda do |id, caps|
   { 'id' => id, 'kind' => 'table', 'name' => nil,
-    'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'conn-1', 'path' => %w[CSA TJ ORDERS] },
+    'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'conn-1', 'path' => %w[WHDB WHSCHEMA ORDERS] },
     'columns' => caps.each_with_index.map { |c, i| { 'id' => "#{id}-#{i}", 'name' => c, 'formula' => "[ORDERS/#{c}]" } } }
 end
 orders_a = dup_el.call('el-orders-a', ['Row ID', 'Order Date', 'Ship Date', 'Sales'])
@@ -204,10 +204,10 @@ view_a = {
 dup_model = { 'pages' => [{ 'elements' => [orders_a, orders_b, view_a] }] }
 dup_manifest = [
   { 'slug' => 'wb', 'datasource' => 'federated.orders_a', 'caption' => 'Sample - Superstore',
-    'hyper' => 'a.hyper', 'hyper_table' => 'Orders', 'sf_table' => 'CSA.TJ.EXECDASH_ORDERS', 'rows' => 100,
+    'hyper' => 'a.hyper', 'hyper_table' => 'Orders', 'sf_table' => 'WHDB.WHSCHEMA.FIXTURE_ORDERS', 'rows' => 100,
     'columns' => { 'Row ID' => 'ROW_ID', 'Order Date' => 'ORDER_DATE', 'Ship Date' => 'SHIP_DATE', 'Sales' => 'SALES' } },
   { 'slug' => 'wb', 'datasource' => 'federated.orders_b', 'caption' => 'Sample - Superstore (2)',
-    'hyper' => 'b.hyper', 'hyper_table' => 'Orders', 'sf_table' => 'CSA.TJ.EXECDASH_SAMPLE_SUPERSTORE_2',
+    'hyper' => 'b.hyper', 'hyper_table' => 'Orders', 'sf_table' => 'WHDB.WHSCHEMA.FIXTURE_ORDERS_DUP',
     'rows' => 100,
     'columns' => { 'Order ID' => 'ORDER_ID', 'Customer Name' => 'CUSTOMER_NAME', 'Sales' => 'SALES',
                    'Discount' => 'DISCOUNT' } }
@@ -219,12 +219,12 @@ Dir.mktmpdir do |dir|
 end
 els_h = dup_model['pages'][0]['elements']
 view_ref = els_h.find { |e| e['id'] == 'el-view-a' }['columns'][0]['formula']
-check(view_ref == '[EXECDASH_ORDERS/Row ID]',
+check(view_ref == '[FIXTURE_ORDERS/Row ID]',
       "derived view's ref repointed to ITS OWN base's landed table via elementId (not the ambiguous " \
       "shared string 'ORDERS') (got #{view_ref})", fails)
-check(els_h.find { |e| e['id'] == 'el-orders-a' }.dig('source', 'path') == %w[CSA TJ EXECDASH_ORDERS],
+check(els_h.find { |e| e['id'] == 'el-orders-a' }.dig('source', 'path') == %w[WHDB WHSCHEMA FIXTURE_ORDERS],
       'the first duplicate claims its own manifest entry', fails)
-check(els_h.find { |e| e['id'] == 'el-orders-b' }.dig('source', 'path') == %w[CSA TJ EXECDASH_SAMPLE_SUPERSTORE_2],
+check(els_h.find { |e| e['id'] == 'el-orders-b' }.dig('source', 'path') == %w[WHDB WHSCHEMA FIXTURE_ORDERS_DUP],
       'the second (duplicate-named) datasource claims its OWN, different manifest entry', fails)
 
 puts

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-manifest-remap.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-manifest-remap.rb
@@ -185,6 +185,48 @@ check(!names_left.include?('el-orphan'), 'orphan removed from the page', fails)
 check(names_left.include?('el-used') && names_left.include?('el-sql2'),
       'referenced-but-broken and source-relative elements KEPT', fails)
 
+puts "Part H — #685-C secondary: derived-view refs repaired via elementId even when the STRING " \
+     "identifier is ambiguous (Tableau's own duplicate-datasource shape: two DIFFERENT datasources " \
+     "reuse the identical internal relation name 'Orders' — the Executive Dashboard cold-run's " \
+     '"Orders View" prefix-mismatch)'
+dup_el = lambda do |id, caps|
+  { 'id' => id, 'kind' => 'table', 'name' => nil,
+    'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'conn-1', 'path' => %w[CSA TJ ORDERS] },
+    'columns' => caps.each_with_index.map { |c, i| { 'id' => "#{id}-#{i}", 'name' => c, 'formula' => "[ORDERS/#{c}]" } } }
+end
+orders_a = dup_el.call('el-orders-a', ['Row ID', 'Order Date', 'Ship Date', 'Sales'])
+orders_b = dup_el.call('el-orders-b', %w[Order\ ID Customer\ Name Sales Discount])
+view_a = {
+  'id' => 'el-view-a', 'kind' => 'table', 'name' => 'Orders View',
+  'source' => { 'kind' => 'table', 'elementId' => 'el-orders-a' },
+  'columns' => [{ 'id' => 'c-va1', 'name' => nil, 'formula' => '[ORDERS/Row ID]' }]
+}
+dup_model = { 'pages' => [{ 'elements' => [orders_a, orders_b, view_a] }] }
+dup_manifest = [
+  { 'slug' => 'wb', 'datasource' => 'federated.orders_a', 'caption' => 'Sample - Superstore',
+    'hyper' => 'a.hyper', 'hyper_table' => 'Orders', 'sf_table' => 'CSA.TJ.EXECDASH_ORDERS', 'rows' => 100,
+    'columns' => { 'Row ID' => 'ROW_ID', 'Order Date' => 'ORDER_DATE', 'Ship Date' => 'SHIP_DATE', 'Sales' => 'SALES' } },
+  { 'slug' => 'wb', 'datasource' => 'federated.orders_b', 'caption' => 'Sample - Superstore (2)',
+    'hyper' => 'b.hyper', 'hyper_table' => 'Orders', 'sf_table' => 'CSA.TJ.EXECDASH_SAMPLE_SUPERSTORE_2',
+    'rows' => 100,
+    'columns' => { 'Order ID' => 'ORDER_ID', 'Customer Name' => 'CUSTOMER_NAME', 'Sales' => 'SALES',
+                   'Discount' => 'DISCOUNT' } }
+]
+Dir.mktmpdir do |dir|
+  mpath = File.join(dir, 'landing-manifest.json')
+  File.write(mpath, JSON.generate(dup_manifest))
+  MechanicalSpecs.remap_from_manifest!(dup_model, mpath)
+end
+els_h = dup_model['pages'][0]['elements']
+view_ref = els_h.find { |e| e['id'] == 'el-view-a' }['columns'][0]['formula']
+check(view_ref == '[EXECDASH_ORDERS/Row ID]',
+      "derived view's ref repointed to ITS OWN base's landed table via elementId (not the ambiguous " \
+      "shared string 'ORDERS') (got #{view_ref})", fails)
+check(els_h.find { |e| e['id'] == 'el-orders-a' }.dig('source', 'path') == %w[CSA TJ EXECDASH_ORDERS],
+      'the first duplicate claims its own manifest entry', fails)
+check(els_h.find { |e| e['id'] == 'el-orders-b' }.dig('source', 'path') == %w[CSA TJ EXECDASH_SAMPLE_SUPERSTORE_2],
+      'the second (duplicate-named) datasource claims its OWN, different manifest entry', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sqlproxy-per-datasource.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sqlproxy-per-datasource.rb
@@ -1,0 +1,133 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for issue #685-A (Superstore cold-run failure, 2026-08-08).
+#
+# THE BUG: migrate-tableau.rb's embedded-extract-landing gate used
+# `HydrateCustomSql.twb_has_sqlproxy?(twb)` — a WORKBOOK-scoped question ("does
+# this .twb contain ANY sqlproxy datasource anywhere") — to decide whether to
+# run extract-landing + MechanicalSpecs.remap_from_manifest! for the ENTIRE
+# workbook. A workbook mixing an unrelated sqlproxy-backed published datasource
+# (e.g. a "Commission Model" dashboard fed by a published DS) with a perfectly
+# landable embedded Hyper extract (e.g. "Sample - Superstore") saw the sqlproxy
+# sibling disable landing/remap for BOTH datasources — the landable one never
+# got remapped, so its DM element kept the converter's placeholder name/path
+# ("UNKNOWN" / ["TJ","UNKNOWN"], missing the database segment) all the way to
+# a live POST ("Source not found: warehouse table 'TJ.UNKNOWN'").
+#
+# THE FIX: sqlproxy detection must be scoped PER-DATASOURCE. This test guards
+# two new HydrateCustomSql functions:
+#   sqlproxy_only_datasource_names(twb) — which datasource(s) are sqlproxy
+#     placeholders with no real relation (the ones hydrate-custom-sql.rb's
+#     PDS-chase path still owns).
+#   non_sqlproxy_conn_classes(twb) — the connection classes carried by every
+#     OTHER (non-sqlproxy) datasource, i.e. exactly what migrate-tableau.rb
+#     needs to decide "is the REMAINING workbook fully embedded-extract and
+#     therefore landable" WITHOUT an unrelated sqlproxy sibling polluting the
+#     answer with a stray 'sqlproxy' class.
+#
+# Deterministic + offline: hand-built .twb fixture mirroring the real
+# Superstore shape (never the customer's own workbook — Tableau's own sample
+# content), no network / creds.
+#
+# Usage:  ruby scripts/test-sqlproxy-per-datasource.rb
+
+require 'tempfile'
+require_relative 'hydrate-custom-sql'
+
+fails = []
+def check(cond, msg, fails) fails << msg unless cond; puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}" end
+
+H = HydrateCustomSql
+
+# Mirrors the real Superstore shape: an embedded Hyper extract federation
+# ("Sample - Superstore") feeding 5 landable dashboards, PLUS an unrelated
+# sqlproxy-backed "Commission Model" published datasource (file-based PDS,
+# no landing path) feeding a separate dashboard. Bug #685-A: the sqlproxy
+# sibling must not blind the orchestrator to the landable one.
+MIXED_TWB = <<~XML
+  <workbook>
+    <datasources>
+      <datasource caption='Sample - Superstore' name='federated.superstore'>
+        <connection class='federated'>
+          <named-connections>
+            <named-connection name='hyper.orders'>
+              <connection class='hyper' dbname='Data/Superstore.hyper' />
+            </named-connection>
+          </named-connections>
+          <relation name='Orders' table='[Orders]' type='table' />
+        </connection>
+      </datasource>
+      <datasource caption='Commission Model' name='sqlproxy.commission'>
+        <connection class='sqlproxy' dbname='CommissionModelPDS'>
+          <relation name='sqlproxy' table='[sqlproxy]' type='table' />
+        </connection>
+      </datasource>
+    </datasources>
+  </workbook>
+XML
+
+# A control: a workbook whose ONLY datasource is sqlproxy — nothing landable,
+# non_sqlproxy_conn_classes must correctly come back empty (not a false trip).
+PURE_SQLPROXY_TWB = <<~XML
+  <workbook>
+    <datasources>
+      <datasource caption='Commission Model' name='sqlproxy.commission'>
+        <connection class='sqlproxy' dbname='CommissionModelPDS'>
+          <relation name='sqlproxy' table='[sqlproxy]' type='table' />
+        </connection>
+      </datasource>
+    </datasources>
+  </workbook>
+XML
+
+puts 'Part A — mixed workbook: sqlproxy detection is per-datasource, not per-workbook'
+Tempfile.create(['mixed', '.twb']) do |f|
+  f.write(MIXED_TWB); f.flush
+  check(H.twb_has_sqlproxy?(f.path), 'workbook-level twb_has_sqlproxy? stays true (unchanged behavior)', fails)
+  names = H.sqlproxy_only_datasource_names(f.path)
+  check(names == ['sqlproxy.commission'],
+        "sqlproxy_only_datasource_names identifies ONLY the Commission Model datasource (got #{names.inspect})", fails)
+  classes = H.non_sqlproxy_conn_classes(f.path)
+  # 'federated' is the outer wrapper class on the landable datasource itself
+  # (rejected by the CALLER, same as today's blunt regex scan) — the point of
+  # this test is that 'sqlproxy' (from the UNRELATED Commission Model
+  # datasource) never appears here at all.
+  check(classes.sort == %w[federated hyper],
+        "non_sqlproxy_conn_classes sees the landable sibling's classes UNPOLLUTED by the " \
+        "unrelated sqlproxy datasource's class (got #{classes.inspect})", fails)
+  check(!classes.include?('sqlproxy'),
+        'the sqlproxy class from the unrelated Commission Model datasource never leaks into the ' \
+        'embedded-extract eligibility check', fails)
+end
+
+puts 'Part B — pure-sqlproxy workbook: no landable classes (not a false trip)'
+Tempfile.create(['pure_sqlproxy', '.twb']) do |f|
+  f.write(PURE_SQLPROXY_TWB); f.flush
+  check(H.twb_has_sqlproxy?(f.path), 'workbook-level twb_has_sqlproxy? true', fails)
+  check(H.sqlproxy_only_datasource_names(f.path) == ['sqlproxy.commission'],
+        'the sole datasource is correctly identified as sqlproxy-only', fails)
+  check(H.non_sqlproxy_conn_classes(f.path) == [],
+        'no non-sqlproxy classes remain — a pure-sqlproxy workbook has nothing to land ' \
+        '(falls through to the hydration path, not landing)', fails)
+end
+
+puts 'Part C — live-table-only workbook: unaffected (no sqlproxy anywhere)'
+Tempfile.create(['live', '.twb']) do |f|
+  f.write("<workbook><datasources><datasource caption='L'><connection class='snowflake'>" \
+          "<relation name='O' table='[A].[B].[O]' type='table'/></connection></datasource></datasources></workbook>")
+  f.flush
+  check(!H.twb_has_sqlproxy?(f.path), 'workbook-level twb_has_sqlproxy? false', fails)
+  check(H.sqlproxy_only_datasource_names(f.path) == [], 'no sqlproxy datasources found', fails)
+  check(H.non_sqlproxy_conn_classes(f.path) == ['snowflake'],
+        'the single live-table datasource\'s class passes through unchanged', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-unresolved-warehouse-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-unresolved-warehouse-gate.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for issue #685-A part 2 (Superstore cold-run failure, 2026-08-08).
+#
+# THE BUG: when the extract-landing manifest remap (MechanicalSpecs.
+# remap_from_manifest!) never runs / never attributes an element, the
+# converter's placeholder warehouse-table name+path ("UNKNOWN" /
+# ["TJ","UNKNOWN"], missing the database segment) survives all the way to a
+# live DM POST, which fails late with an unnamed, cryptic error:
+#   POST failed: {"errors"=>[{"summary"=>"Source not found: warehouse table
+#   'TJ.UNKNOWN' on connection '...'"}]}
+#
+# THE FIX: MechanicalSpecs.unresolved_warehouse_elements(model) detects any
+# warehouse-table element still carrying that placeholder AFTER remap/fixup
+# have run, so migrate-tableau.rb can fail loud + named (exit 21) BEFORE the
+# POST instead of after it. A broken path reaching a live POST is worse than
+# an early, named error.
+#
+# Deterministic + offline: hand-built DM fixtures, no network / creds.
+#
+# Usage:  ruby scripts/test-unresolved-warehouse-gate.rb
+
+require_relative 'mechanical-specs'
+
+fails = []
+def check(cond, msg, fails) fails << msg unless cond; puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}" end
+
+def wt_element(id, name, path)
+  { 'id' => id, 'kind' => 'table', 'name' => name,
+    'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'conn-1', 'path' => path },
+    'columns' => [{ 'id' => "#{id}-c1", 'name' => 'X', 'formula' => "[#{name}/X]" }] }
+end
+
+puts "Part A — the exact reported shape: name='UNKNOWN', path=['TJ','UNKNOWN'] (database segment missing)"
+model = { 'pages' => [{ 'elements' => [wt_element('el-1', 'UNKNOWN', %w[TJ UNKNOWN])] }] }
+bad = MechanicalSpecs.unresolved_warehouse_elements(model)
+check(bad.size == 1, "the placeholder element is flagged (got #{bad.size})", fails)
+check(bad.first['id'] == 'el-1', 'the correct element is identified', fails)
+
+puts 'Part B — a clean, fully-resolved element is NOT flagged'
+clean_model = { 'pages' => [{ 'elements' => [
+  wt_element('el-2', 'Superstore Orders', %w[CSA TJ SUPERSTORE_C462BF_ORDERS])
+] }] }
+check(MechanicalSpecs.unresolved_warehouse_elements(clean_model).empty?,
+      'a real, correctly-remapped element passes clean', fails)
+
+puts "Part C — a REAL table that merely happens to be named similarly is not falsely tripped"
+# 'Unknown Region' is a legitimate, if unfortunately-named, real business
+# dimension — only the EXACT sentinel 'UNKNOWN' (case-insensitive, whole
+# segment) trips the gate, never a substring/prefix match.
+similar_model = { 'pages' => [{ 'elements' => [
+  wt_element('el-3', 'Unknown Region Dim', %w[CSA TJ UNKNOWN_REGION_DIM])
+] }] }
+check(MechanicalSpecs.unresolved_warehouse_elements(similar_model).empty?,
+      "a real table merely CONTAINING 'unknown' as a substring is not a false positive", fails)
+
+puts 'Part D — a kind:sql (Custom SQL) element is never in scope (the placeholder is warehouse-table only)'
+sql_model = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-4', 'kind' => 'table', 'name' => 'UNKNOWN',
+    'source' => { 'connectionId' => 'c', 'kind' => 'sql', 'statement' => 'SELECT 1' },
+    'columns' => [] }
+] }] }
+check(MechanicalSpecs.unresolved_warehouse_elements(sql_model).empty?,
+      'a kind:sql element named UNKNOWN is out of scope for this gate', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## Summary

Fixes #685 — three independent, live-verified converter bugs found by cold Tableau→Sigma migrations on 2026-08-08 (0 of 3 produced a workbook; all three failed in data-model generation, before workbook build). Auth and Snowflake extract-landing were reliable throughout — these are converter-side DM-generation defects.

- **Superstore** — `Source not found: warehouse table 'TJ.UNKNOWN'`. Workbook-scoped sqlproxy detection disabled extract-landing + `remap_from_manifest!` for the whole workbook whenever ANY datasource was sqlproxy-backed, even an unrelated one, leaving a perfectly landable sibling extract with the converter's placeholder name/path all the way to a live POST.
  - Two new `HydrateCustomSql` functions (`sqlproxy_only_datasource_names` / `non_sqlproxy_conn_classes`) scope the embedded-extract eligibility check per-datasource.
  - A new pre-POST gate (`MechanicalSpecs.unresolved_warehouse_elements`, exit 21) fails loud and named if the placeholder ever survives remap + fixup, instead of letting a broken path reach POST.

- **World Indicators** — 1 of 26 columns compiled to `type=error`. The base-column passthrough formula embedded a raw Tableau caption unescaped inside a `[Table/Column]` bracket-path formula; a caption containing "/" ("Country/Region", a common Tableau convention present in Tableau's own sample workbooks) collided with the bracket-path separator. This also silently broke every Ruby-side consumer recovering a physical name via `formula.split('/').last`, explaining why a `--column-mapping` remediation went inert in the field.
  - `MechanicalSpecs.sanitize_bracket_path_captions!` now runs unconditionally as the first step of `fixup_dm_spec`, folding `/`, `[`, `]` in the caption segment to the same upper-snake physical-name convention used elsewhere in the file, while preserving the original caption as the display name.

- **Executive Dashboard** — pre-POST SQL-identifier gate correctly caught (exit 20) a generated Custom-SQL helper referencing `DAYS_TO_SHIP` as a physical column, when "Days to Ship" is actually a calculated field (`DATEDIFF('day',[Order Date],[Ship Date])`) with no physical counterpart. The gate is untouched and stays exactly as strict.
  - `MechanicalSpecs.fix_calc_masquerading_as_physical!` runs before the gate/POST and substitutes the calc's own SQL translation for confidently-recognized shapes (DATEDIFF over fields that ARE physical on the statement's FROM table); anything else is left completely untouched.
  - Also fixed the secondary "element-name-prefix mismatch" pattern seen in 2/3 runs: `remap_from_manifest!`'s derived-view ref repair now attributes via `source.elementId` first (unambiguous) before falling back to the identifier-string match, which was refusing to repair views whose base table's original name was reused by a Tableau "(2)" duplicate datasource in the same workbook.

Plugin version bumped 1.9.6 → 1.9.7 (patch, per the version-bump gate).

## Test plan

- [x] TDD: each new regression test written first and confirmed failing for the right reason before any fix code
- [x] `test-sqlproxy-per-datasource.rb` — new, per-datasource sqlproxy scoping
- [x] `test-unresolved-warehouse-gate.rb` — new, exit-21 placeholder gate
- [x] `test-bracket-path-caption-escape.rb` — new, bracket-path caption sanitization
- [x] `test-calc-as-physical-guard.rb` — new, calc-as-physical fixup (also proves the SQL-ident gate is neither weakened nor bypassed)
- [x] `test-manifest-remap.rb` — extended with Part H for the elementId-based derived-ref repair
- [x] Full `plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-*.rb` suite: 260 files, 259 pass, 1 fails only for the documented environmental reason (`test-calc-discovery.rb` needs `TABLEAU_AUTH_TOKEN` + a live `.twb`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)