### PR TITLE
fix(tableau): DM reuse must author missing derived columns or refuse

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/performance.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/performance.md
@@ -289,6 +289,18 @@ backoff).
 - Re-entry NOT printing `dm-match REUSED`: signature changed (converter output
   differs) or the cache is >24h old.
 
+### slow-phase2-6-reuse-augment
+Reads back the reuse candidate's live spec, plans which derived columns a
+fresh build would have created (#691), and — only when at least one is
+CLOSABLE — PUTs one augmented spec via `post-and-readback.rb --update-id`.
+- No network beyond one GET + (at most) one PUT+readback; slow here almost
+  always means the underlying Sigma API call is slow, not this gate's own
+  logic.
+- Skipped entirely (near-zero time) whenever `reuse_dm_id` is unset (fresh
+  build) or the candidate already carries every field the workbook needs.
+- An UNCLOSABLE gap aborts reuse and falls through to the normal fresh-build
+  phases below — that time is charged to `phase3-dm`, not this phase.
+
 ### slow-phase2-columns
 ~2–5s per table via the Sigma catalog. Slow = catalog sync lag on the
 connection; re-entries reuse `cols-*.json`. A 404 here is not slowness — see

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -2026,6 +2026,148 @@ module MechanicalSpecs
     { 'master_columns' => master_columns, 'mmap' => mmap, 'untranslated_metrics' => untranslated }
   end
 
+  # ── DM-reuse augmentation (#691) ────────────────────────────────────────────
+  # A REUSED data model never runs through THIS conversion's Phase 3 build+POST
+  # — the converter's own fact element (conv_fact) can carry mechanically-
+  # derived columns (date-key synthesis like "Date(Left(Text([Order Date
+  # Key]),...))", cross-element Lookups, translated calc fields) that a FRESH
+  # build would have POSTed as real physical columns on the live DM. Reuse
+  # skips that POST entirely, so those columns simply never exist on the
+  # candidate — derive_master then falls back to a bare `[Fact/<name>]`
+  # reference that dangles at the pre-POST ref gate (exit 4).
+  #
+  # plan_reuse_derived_columns computes, for a chosen reuse candidate, exactly
+  # which of the converter's fact columns are MISSING and whether each one can
+  # be safely authored onto the live element:
+  #   CLOSABLE   — every column its formula references (bare same-element
+  #                refs, or slash-qualified cross-element refs) already
+  #                resolves against the candidate: present verbatim on the
+  #                live fact, another column we're already authoring, or
+  #                reachable on a sibling element via an EXISTING wired
+  #                relationship. Fixed-point over multiple passes so a chained
+  #                dependency (a calc column referencing another calc column)
+  #                still resolves once its own dependency is authored.
+  #   UNCLOSABLE — the formula depends on an element/relationship/column the
+  #                candidate does not have and cannot self-derive (e.g. a
+  #                role-playing date dimension behind a join the run could not
+  #                create). A workbook that needs this field must abandon the
+  #                reuse candidate and build fresh rather than ship a dangling
+  #                ref — a raw column-superset score cannot see this gap
+  #                because it counts a name existing ANYWHERE in the DM, not
+  #                whether it is reachable from the fact grain the workbook
+  #                actually needs.
+  #
+  # This intentionally does NOT re-derive formulas — it only replays the
+  # ALREADY-COMPUTED conv_fact column verbatim, so the reuse and fresh-build
+  # paths can never drift onto two different derivations of the same field.
+  def plan_reuse_derived_columns(conv_fact, live_spec, live_fact_name)
+    closable = []
+    unclosable = []
+    empty = { 'closable' => closable, 'unclosable' => unclosable }
+    return empty unless conv_fact && live_spec && live_fact_name
+
+    live_els = all_elements(live_spec)
+    live_fact = live_els.find { |e| e['name'].to_s.casecmp?(live_fact_name.to_s) }
+    return empty unless live_fact
+
+    known = (live_fact['columns'] || []).map { |c| col_display(c) }.compact.map(&:downcase).to_set
+    live_by_name = live_els.each_with_object({}) { |e, h| h[e['name'].to_s.downcase] = e }
+    wired = lambda do |el_name|
+      tgt = live_by_name[el_name.to_s.downcase]
+      return false unless tgt
+      (live_fact['relationships'] || []).any? { |r| r['targetElementId'] == tgt['id'] }
+    end
+    cross_ok = lambda do |el_name, col_name|
+      tgt = live_by_name[el_name.to_s.downcase]
+      next false unless tgt
+      tgt_cols = (tgt['columns'] || []).map { |c| col_display(c) }.compact.map(&:downcase)
+      tgt_cols.include?(col_name.to_s.downcase) && wired.call(el_name)
+    end
+
+    candidates = (conv_fact['columns'] || []).each_with_object([]) do |col, acc|
+      dname = col_display(col)
+      next if dname.nil? || dname.to_s.empty? || dname =~ GUID_RE
+      next if known.include?(dname.downcase) # already present verbatim — nothing to author
+      acc << { 'name' => dname, 'formula' => col['formula'].to_s, 'format' => col['format'] }.compact
+    end
+
+    loop do
+      progressed = false
+      candidates.reject! do |cand|
+        refs = cand['formula'].to_s.scan(/\[([^\]]+)\]/).flatten
+        missing = refs.reject do |ref|
+          parts = ref.split('/')
+          parts.size == 1 ? known.include?(parts[0].downcase) : cross_ok.call(parts[0], parts[-1])
+        end
+        if missing.empty?
+          closable << cand
+          known << cand['name'].downcase
+          progressed = true
+          true
+        else
+          cand['missing_refs'] = missing.uniq
+          false
+        end
+      end
+      break unless progressed
+    end
+    unclosable.concat(candidates)
+    empty
+  end
+
+  # Splice `closable` derived columns (from plan_reuse_derived_columns) onto
+  # the live spec's fact element in place, minting ids the same way derive_
+  # master/fresh-build columns are minted. The formula is carried VERBATIM —
+  # never re-derived — so this can only ever replay the fresh-build's own
+  # output. Returns the number of columns actually added (idempotent: a
+  # column already present by name is skipped, not duplicated).
+  def apply_reuse_augmentation!(live_spec, live_fact_name, closable)
+    return 0 if closable.nil? || closable.empty?
+    live_fact = all_elements(live_spec).find { |e| e['name'].to_s.casecmp?(live_fact_name.to_s) }
+    return 0 unless live_fact
+    live_fact['columns'] ||= []
+    registry = {}
+    live_fact['columns'].each do |c|
+      dn = col_display(c)
+      registry["c-#{slug(dn.to_s)}"] ||= dn.to_s if dn
+    end
+    added = 0
+    closable.each do |col|
+      next if live_fact['columns'].any? { |c| col_display(c).to_s.casecmp?(col['name'].to_s) }
+      id = mint_id('c-', col['name'], registry)
+      entry = { 'id' => id, 'name' => col['name'], 'formula' => col['formula'] }
+      entry['format'] = col['format'] if col['format']
+      live_fact['columns'] << entry
+      added += 1
+    end
+    added
+  end
+
+  # #691 requirement 4: find-or-pick-dm.rb's own ambiguous_wide_tie guard only
+  # refuses a WIDE (>=3-way) tie; a narrow tie at an identical/near-identical
+  # score still auto-picks — its own rationale even says so ("collapsing a
+  # 0.9-score tie — duplicate-DM sprawl"). Column-superset scoring is also
+  # computed over every element's RAW columns rather than the workbook's
+  # actual required (post-derivation) fields, so a tie between near-identical
+  # DM twins is exactly the case the picker's score cannot break on its own.
+  # Prefer a candidate whose name matches the source workbook (a genuine
+  # signal the picker's own tie-break already uses); otherwise refuse the
+  # auto-pick, log why, and let the caller fall back to a fresh, unambiguous
+  # build rather than an arbitrary pick.
+  def reuse_tie_guard(dm_match, source_name)
+    return { 'auto_picked' => false, 'blocked' => false } unless dm_match && dm_match['auto_picked']
+    tie_count = dm_match['tie_count'].to_i
+    best = (dm_match['candidates'] || []).first
+    name_matches = !!(best && source_name && best['dm_name'].to_s.strip.casecmp?(source_name.to_s.strip))
+    if tie_count >= 2 && !name_matches
+      return { 'auto_picked' => false, 'blocked' => true,
+               'reason' => "#{tie_count} candidate(s) tie at score #{dm_match['score']} and none is a " \
+                           'source-name match — refusing to auto-pick an arbitrary twin (#691); build fresh ' \
+                           'unless an explicit --reuse-dm is given.' }
+    end
+    { 'auto_picked' => true, 'blocked' => false }
+  end
+
   # Assemble the full workbook spec: a hidden master table on page-data sourcing
   # the DM fact element, plus dashboard page(s) of the build-charts elements.
   #

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -940,6 +940,7 @@ PHASE_BUDGET = {
   'phase1-lane(bg)'   => 240, # Tableau 5-fetch discovery pool, cold 2-4min; stamp-reused <5s
   'join-wait'         => 240, # foreground wait on the lane (≈ lane time on a cold run, ~0s on reuse)
   'phase1.6-dm-scan'  => 45,  # DM list + ≤25 spec fetches; signature-cached re-entry <1s
+  'phase2.6-reuse-augment' => 30, # #691: reuse-candidate readback + gap plan + one optional DM PUT
   'phase2-columns'    => 90,  # ~2-5s per table via the Sigma catalog; cols-*.json reused on re-entry
   'phase1-join'       => 120, # calc extraction + custom-SQL scan + gap-report parse (sha-cached on re-entry)
   'phase0c-cost'      => 15,  # estimate-cost.rb over workdir artifacts (pure local) + sign-off print
@@ -3036,9 +3037,16 @@ else
               '--auto-pick', '--auto-pick-threshold', '0.5'],
              allow_fail: true) # exit 1 = no candidate ≥ min-score (normal: build new)
   dm_match = (JSON.parse(File.read(match_path)) rescue {})
+  # #691: find-or-pick-dm.rb's own ambiguous_wide_tie guard only refuses a WIDE
+  # (>=3-way) tie; a narrow tie at an identical score still auto-picks (its
+  # rationale even says "collapsing a 0.9-score tie — duplicate-DM sprawl").
+  # Don't silently collapse that here either — prefer a source-name match,
+  # else refuse the auto-pick and fall back to a fresh build.
+  _tie = MechanicalSpecs.reuse_tie_guard(dm_match, wb_name)
+  line "DM-REUSE tie guard: #{_tie['reason']}" if _tie['blocked']
   # Reuse-first: if the picker auto-picked a safe candidate (covers ALL source
   # tables), reuse it automatically unless the user passed an explicit --reuse-dm.
-  if !opts[:reuse_dm] && dm_match['auto_picked'] && dm_match['recommended_dm_id']
+  if !opts[:reuse_dm] && _tie['auto_picked'] && dm_match['recommended_dm_id']
     opts[:reuse_dm] = :recommended
     line "DM-REUSE (auto): #{dm_match['rationale']}"
   end
@@ -4099,6 +4107,67 @@ elsif DashboardRead.expected?(WORK)
   end
   line "dashboard-read gate: #{DashboardRead.tile_count(WORK)} tile(s) verified (png-read.json)"
   RunState.stamp(WORK, 'phase-1d', note: 'source dashboard-read (png-read.json)')
+end
+
+# ---------------------------------------------------------------------------
+# Phase 2.6 — DM-reuse augmentation gate (#691). A reused DM never runs
+# through THIS conversion's Phase 3 build+POST, so the converter's own fact
+# element (conv_fact) can carry mechanically-derived columns (date-key
+# synthesis, cross-element Lookups, translated calc fields) that a fresh
+# build would have POSTed as real columns and reuse simply never emitted.
+# Verify the candidate against the ACTUAL columns the workbook will need
+# (not the raw column-superset score find-or-pick-dm.rb computed — a name
+# existing ANYWHERE in the DM is not the same as it being reachable from the
+# fact grain the workbook needs) and either author the missing ones onto the
+# live DM — replaying the SAME derivation a fresh build emits, never a second
+# implementation — or abandon reuse for a fresh build when a gap can't be
+# closed (a formula depends on an element/relationship the candidate lacks).
+# ---------------------------------------------------------------------------
+if reuse_dm_id && mechanical && conv_fact
+  hdr('2.6', 'DM-reuse augmentation gate')
+  $LOAD_PATH.unshift File.expand_path('lib', HERE) unless $LOAD_PATH.include?(File.expand_path('lib', HERE))
+  require 'sigma_rest'
+  _reuse_spec = begin
+    Sigma.request(:get, "/v2/dataModels/#{reuse_dm_id}/spec")
+  rescue StandardError => e
+    line "WARN: could not read back reuse candidate #{reuse_dm_id} to plan augmentation " \
+         "(#{e.class}: #{e.message.to_s[0, 100]}) — proceeding without it"
+    nil
+  end
+  if _reuse_spec.is_a?(Hash) && _reuse_spec['pages']
+    _reuse_els = MechanicalSpecs.all_elements(_reuse_spec)
+    _dim_re = /(^Dim\b| Dim$)/i
+    _reuse_fact = _reuse_els.reject { |e| e['name'] =~ _dim_re }
+                            .max_by { |e| (e['columns'] || []).size } ||
+                  _reuse_els.find { |e| e['name'] !~ _dim_re } || _reuse_els.first
+    if _reuse_fact
+      _plan = MechanicalSpecs.plan_reuse_derived_columns(conv_fact, _reuse_spec, _reuse_fact['name'])
+      if _plan['unclosable'].any?
+        _gap_names = _plan['unclosable'].map { |c| c['name'] }.join(', ')
+        line "REUSE REFUSED: candidate #{reuse_dm_id} is missing #{_plan['unclosable'].size} required " \
+             "derived field(s) with no derivable relationship/key on the live DM (#{_gap_names}) — " \
+             'abandoning reuse; building a fresh data model instead.'
+        Offramp.log(WORK, kind: 'reuse-gap-unclosable', detail: "#{reuse_dm_id}: #{_gap_names}") if defined?(Offramp)
+        reuse_dm_id = nil
+        opts[:reuse_dm] = nil
+      elsif _plan['closable'].any?
+        _added_names = _plan['closable'].map { |c| c['name'] }.join(', ')
+        line "REUSE AUGMENT: candidate #{reuse_dm_id} is missing #{_plan['closable'].size} derived " \
+             "field(s) a fresh build would have created (#{_added_names}) — authoring them onto the " \
+             'live DM (same derivation the fresh path would emit, not re-derived).'
+        _added = MechanicalSpecs.apply_reuse_augmentation!(_reuse_spec, _reuse_fact['name'], _plan['closable'])
+        _aug_path = File.join(WORK, 'dm-spec-reuse-augment.json')
+        File.write(_aug_path, JSON.pretty_generate(_reuse_spec))
+        sigma_run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
+                    '--spec', _aug_path, '--update-id', reuse_dm_id,
+                    '--out', File.join(WORK, 'dm-ids-reuse-augment.json')])
+        line "REUSE AUGMENT: added #{_added} column(s) to '#{_reuse_fact['name']}' on #{reuse_dm_id}"
+      else
+        line "REUSE: candidate #{reuse_dm_id} already carries every field the workbook needs — no augmentation required."
+      end
+    end
+  end
+  mark('phase2.6-reuse-augment')
 end
 
 # ---------------------------------------------------------------------------

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-reuse-augment.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-reuse-augment.rb
@@ -1,0 +1,157 @@
+#!/usr/bin/env ruby
+# Regression test for #691: on the DM-REUSE path, migrate-tableau.rb binds to
+# an existing data model but never authors the derived columns a FRESH build
+# would have created — the converter's own fact element (conv_fact) can carry
+# mechanically-derived columns (date-key synthesis, cross-element Lookups)
+# that a fresh build POSTs as real physical columns; reuse skips that POST
+# entirely, so a workbook ref to one of those columns dangles against the
+# live (reused) DM's actual columns ("no master column matched dim header
+# 'Month of Order Date'" / exit 4).
+#
+# Fixture mirrors the reported shape (business-generic names only — no live
+# ids/paths/customer data):
+#   conv_fact ("Order Fact") carries 4 mechanically-derived columns:
+#     Order Date        <- self-contained: Date(...) over its OWN
+#                           "Order Date Key" (int) column
+#     Fulfillment Tier   <- self-contained: If() over its OWN
+#                           "Days To Ship" column
+#     Region             <- cross-element Lookup into "Customer Dim", which
+#                           the reuse candidate DOES have (wired)
+#     Loyalty Score       <- cross-element Lookup into "Rewards Dim", which
+#                           the candidate does NOT have at all — models the
+#       fact<->date-dimension class of gap from the live report: a join the
+#       run could not auto-create.
+#
+#   The REUSE CANDIDATE ("Order Fact") is a raw-column superset exactly like
+#   the live report (every raw column matched) — it carries every RAW column
+#   the converter references and a wired Customer Dim relationship, but NONE
+#   of the four derived columns above.
+#
+# Expected: Order Date, Fulfillment Tier, and Region are CLOSABLE (every ref
+# they need already resolves against the candidate at the fact grain).
+# Loyalty Score is UNCLOSABLE (its target element/relationship does not exist
+# on the candidate and cannot be derived) — a workbook that needs it must
+# abandon this reuse candidate and build fresh, not ship a dangling ref.
+#
+# Usage: ruby scripts/test-dm-reuse-augment.rb
+
+require_relative 'mechanical-specs'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+conv_fact = {
+  'name' => 'Order Fact',
+  'columns' => [
+    { 'id' => 'c1', 'name' => 'Order Date Key' },
+    { 'id' => 'c2', 'name' => 'Days To Ship' },
+    { 'id' => 'c3', 'name' => 'Customer Key' },
+    { 'id' => 'c4', 'name' => 'Order Date',
+      'formula' => 'Date(Left(Text([Order Date Key]),4) & "-" & Mid(Text([Order Date Key]),5,2) & "-" & Mid(Text([Order Date Key]),7,2))' },
+    { 'id' => 'c5', 'name' => 'Fulfillment Tier',
+      'formula' => 'If([Days To Ship] <= 2, "Fast", "Standard")' },
+    { 'id' => 'c6', 'name' => 'Region',
+      'formula' => 'Lookup([Customer Dim/Region], [Customer Key], [Customer Dim/Customer Key])' },
+    { 'id' => 'c7', 'name' => 'Loyalty Score',
+      'formula' => 'Lookup([Rewards Dim/Score], [Customer Key], [Rewards Dim/Customer Key])' }
+  ]
+}
+
+# The reuse candidate never went through THIS conversion's Phase 3 build. It
+# has every RAW column the converter references, a wired Customer Dim
+# relationship — but none of the derived columns, and no Rewards Dim element.
+candidate = {
+  'pages' => [{
+    'elements' => [
+      { 'id' => 'e-fact', 'name' => 'Order Fact',
+        'columns' => [
+          { 'id' => 'lc1', 'name' => 'Order Date Key' },
+          { 'id' => 'lc2', 'name' => 'Days To Ship' },
+          { 'id' => 'lc3', 'name' => 'Customer Key' }
+        ],
+        'relationships' => [
+          { 'targetElementId' => 'e-cust' }
+        ] },
+      { 'id' => 'e-cust', 'name' => 'Customer Dim',
+        'columns' => [
+          { 'id' => 'lc4', 'name' => 'Customer Key' },
+          { 'id' => 'lc5', 'name' => 'Region' }
+        ] }
+    ]
+  }]
+}
+
+puts '-- plan_reuse_derived_columns: the pre-fix decision this pins --'
+plan = MechanicalSpecs.plan_reuse_derived_columns(conv_fact, candidate, 'Order Fact')
+closable_names = plan['closable'].map { |c| c['name'] }
+unclosable_names = plan['unclosable'].map { |c| c['name'] }
+
+check(closable_names.sort == ['Order Date', 'Region', 'Fulfillment Tier'].sort,
+      "self-contained + wired-cross-element columns are CLOSABLE (got #{closable_names.inspect})", fails)
+check(unclosable_names == ['Loyalty Score'],
+      "a column needing a relationship the candidate lacks is UNCLOSABLE (got #{unclosable_names.inspect})", fails)
+
+od_plan = plan['closable'].find { |c| c['name'] == 'Order Date' }
+check(od_plan && od_plan['formula'] == conv_fact['columns'][3]['formula'],
+      'the CLOSABLE plan entry carries the fresh-build formula VERBATIM (reused, not re-derived)', fails)
+
+puts
+puts '-- apply_reuse_augmentation!: must splice the fresh-build derivations onto the live element --'
+added = MechanicalSpecs.apply_reuse_augmentation!(candidate, 'Order Fact', plan['closable'])
+fact_el = candidate['pages'][0]['elements'][0]
+authored_names = fact_el['columns'].map { |c| c['name'] }
+od = fact_el['columns'].find { |c| c['name'] == 'Order Date' }
+
+check(added == 3, "apply_reuse_augmentation! reports 3 column(s) added (got #{added})", fails)
+check(od && od['formula'] == conv_fact['columns'][3]['formula'],
+      "authored 'Order Date' formula is IDENTICAL to the fresh-build formula (no parallel derivation engine)", fails)
+check(authored_names.include?('Fulfillment Tier') && authored_names.include?('Region'),
+      "Fulfillment Tier and Region were also authored onto the live fact (got #{authored_names.inspect})", fails)
+check(authored_names.none? { |n| n == 'Loyalty Score' },
+      'the UNCLOSABLE Loyalty Score is never authored onto the live DM (would dangle)', fails)
+
+puts
+puts '-- reuse_tie_guard: a narrow score tie must not silently auto-pick an arbitrary twin --'
+tied_match = {
+  'auto_picked' => true,
+  'score' => 0.9,
+  'tie_count' => 2,
+  'candidates' => [
+    { 'dm_id' => 'dm-a', 'dm_name' => 'ORDER_FACT (ANALYTICS.ORDER_FACT)+ (New Virtual Connection)' },
+    { 'dm_id' => 'dm-b', 'dm_name' => 'ORDER_FACT (ANALYTICS.ORDER_FACT)+ (copy)' }
+  ]
+}
+tie_guard = MechanicalSpecs.reuse_tie_guard(tied_match, 'Regional Sales Summary')
+check(tie_guard['auto_picked'] == false && tie_guard['blocked'],
+      "a 2-way tie with no source-name match is BLOCKED, not silently auto-picked (got #{tie_guard.inspect})", fails)
+
+name_matched = {
+  'auto_picked' => true,
+  'score' => 0.9,
+  'tie_count' => 2,
+  'candidates' => [
+    { 'dm_id' => 'dm-a', 'dm_name' => 'Regional Sales Summary' },
+    { 'dm_id' => 'dm-b', 'dm_name' => 'ORDER_FACT (ANALYTICS.ORDER_FACT)+ (copy)' }
+  ]
+}
+tie_guard2 = MechanicalSpecs.reuse_tie_guard(name_matched, 'Regional Sales Summary')
+check(tie_guard2['auto_picked'] == true && !tie_guard2['blocked'],
+      "a tie where the TOP candidate matches the source workbook name still auto-picks (got #{tie_guard2.inspect})", fails)
+
+untied = { 'auto_picked' => true, 'score' => 0.9, 'tie_count' => 1,
+           'candidates' => [{ 'dm_id' => 'dm-a', 'dm_name' => 'Something Else' }] }
+tie_guard3 = MechanicalSpecs.reuse_tie_guard(untied, 'Regional Sales Summary')
+check(tie_guard3['auto_picked'] == true && !tie_guard3['blocked'],
+      "no tie (tie_count 1) is unaffected (got #{tie_guard3.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — reuse authors the fresh-build derivations it needs, refuses an unclosable gap, and never silently collapses a tie'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"; fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
The reuse path bound to an existing data model but never authored the
derived columns a fresh build would create (date-key synthesis, Lookup()
cross-element columns, dashboard-specific calcs), then failed workbook
ref resolution on fields that were never going to exist. Reuse therefore
worked only when the candidate happened to already carry every field the
workbook referenced.

- plan_reuse_derived_columns: diffs the converter's fact columns against
  the candidate's live spec and classifies each gap as closable or not.
- Closable gaps are authored onto the candidate via one augmented PUT.
- An unclosable gap (a join with no derivable key) now abandons the
  candidate and builds fresh instead of shipping a dangling ref.
- Narrow ties: the existing guard only refused a wide (>=3-way) tie, so a
  2-way tie at an identical score still auto-picked arbitrarily. Now
  refused unless a source-name match disambiguates.

Fixes #691

tableau suite 262/263 (test-calc-discovery.rb needs a Tableau token plus
a local fixture, environmental); corpus 27/27; hygiene sweep clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
