### PR TITLE
Fix Tableau workbook readers, metric census, and GUID dates

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/workbook-reader-classification.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/workbook-reader-classification.json
@@ -60,6 +60,11 @@
       "reason": "Validates both workbook and data-model specs"
     },
     {
+      "path": "scripts/lib/lod_audit.rb",
+      "classification": "dual",
+      "reason": "Audits nested data-model elements and flat workbook elements for emitted LOD translations"
+    },
+    {
       "path": "scripts/lib/workbook_code.rb",
       "classification": "adapter",
       "reason": "Canonical workbook adapter with legacy nested-artifact compatibility"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/workbook-reader-classification.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/workbook-reader-classification.json
@@ -1,0 +1,118 @@
+{
+  "contract": {
+    "workbook": "document.elements is flat; layout owns page membership",
+    "dataModel": "pages[].elements remains nested"
+  },
+  "readers": [
+    {
+      "path": "scripts/auto-parity-plan.rb",
+      "classification": "workbook",
+      "reason": "Phase 6 workbook readback and page-scoped parity"
+    },
+    {
+      "path": "scripts/export-chart-png.rb",
+      "classification": "workbook",
+      "reason": "GET workbook spec before chart exports"
+    },
+    {
+      "path": "scripts/remap-wb-spec-to-dm-ids.rb",
+      "classification": "workbook",
+      "reason": "Rewrites workbook sources after a DM re-POST; DM id-map readers remain nested"
+    },
+    {
+      "path": "scripts/migration-notes.rb",
+      "classification": "workbook",
+      "reason": "Reads final workbook element ids; chart-spec input remains a transitional nested build artifact"
+    },
+    {
+      "path": "scripts/lib/action_gates.rb",
+      "classification": "workbook",
+      "reason": "Validates actions on workbook elements"
+    },
+    {
+      "path": "scripts/lib/control_field_census.rb",
+      "classification": "workbook",
+      "reason": "Compares posted and read-back workbook controls"
+    },
+    {
+      "path": "scripts/lib/datasource_filter_check.rb",
+      "classification": "workbook",
+      "reason": "Checks workbook elements for applied filters and controls"
+    },
+    {
+      "path": "scripts/lib/style_normalize.rb",
+      "classification": "workbook",
+      "reason": "Mutates workbook element styling before POST"
+    },
+    {
+      "path": "scripts/scan-customer-style.rb",
+      "classification": "workbook",
+      "reason": "Scans live workbook specs for style patterns"
+    },
+    {
+      "path": "scripts/post-and-readback.rb",
+      "classification": "dual",
+      "reason": "Workbook paths use flat helpers; data-model paths intentionally use pages[].elements"
+    },
+    {
+      "path": "scripts/validate-spec.rb",
+      "classification": "dual",
+      "reason": "Validates both workbook and data-model specs"
+    },
+    {
+      "path": "scripts/lib/workbook_code.rb",
+      "classification": "adapter",
+      "reason": "Canonical workbook adapter with legacy nested-artifact compatibility"
+    },
+    {
+      "path": "scripts/build-dashboard-layout.rb",
+      "classification": "transitional",
+      "reason": "Uses WorkbookCode.legacy_view for in-memory layout transforms and canonicalizes before emission"
+    },
+    {
+      "path": "scripts/build-workbook-spec.rb",
+      "classification": "transitional",
+      "reason": "Consumes nested DM id maps and pre-release workbook build artifacts"
+    },
+    {
+      "path": "scripts/build-story-pages.rb",
+      "classification": "transitional",
+      "reason": "Mutates the legacy in-memory workbook builder shape before canonicalization"
+    },
+    {
+      "path": "scripts/mechanical-specs.rb",
+      "classification": "data-model",
+      "reason": "All model pages[].elements access is to data-model specs"
+    },
+    {
+      "path": "scripts/find-or-pick-dm.rb",
+      "classification": "data-model",
+      "reason": "Scores data-model readbacks; nested page elements are correct"
+    },
+    {
+      "path": "scripts/validate-sigma-formula.rb",
+      "classification": "data-model",
+      "reason": "Resolves formulas against data-model elements"
+    },
+    {
+      "path": "scripts/inspect-dm-shape.rb",
+      "classification": "data-model",
+      "reason": "Inspects data-model spec shape"
+    },
+    {
+      "path": "scripts/lib/column_census.rb",
+      "classification": "data-model",
+      "reason": "Compares posted and read-back data-model elements"
+    },
+    {
+      "path": "scripts/lib/dm_quarantine.rb",
+      "classification": "data-model",
+      "reason": "Quarantines invalid data-model elements"
+    },
+    {
+      "path": "scripts/lib/equivalence_probe.rb",
+      "classification": "data-model",
+      "reason": "Builds semantic-equivalence probes from data-model elements"
+    }
+  ]
+}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
@@ -309,17 +309,26 @@ if unresolved.empty? && metric_fails.empty? && extra_fails.empty?
   exit 0
 end
 
-warn '[FAIL] workbook ref-resolution gate'
 if unresolved.any?
-  warn "       #{unresolved.size} of #{refs.size} referenced column(s) do NOT exist in the live DM " \
+  # Keep the progress count on the [FAIL] head. The retry breaker consumes
+  # this exact shape to distinguish a converging repair (18 -> 17 misses)
+  # from a repeating or growing failure.
+  warn "[FAIL] workbook ref-resolution gate — #{unresolved.size} of #{refs.size} referenced " \
+       "column(s) do NOT exist in the live DM " \
        "(#{available.size} columns):"
   unresolved.values.first(40).each do |r|
     warn "         ✗ #{r[:display]}   (referenced via #{r[:elements].to_a.map { |e| "[#{e}/…]" }.join(', ')})"
   end
   warn "         … and #{unresolved.size - 40} more." if unresolved.size > 40
+elsif metric_fails.any?
+  warn "[FAIL] workbook ref-resolution gate — #{metric_fails.size} of #{metric_refs.size} referenced " \
+       'metric(s) failed the DM metrics census:'
+else
+  warn '[FAIL] workbook ref-resolution gate'
 end
 if metric_fails.any?
-  warn "       #{metric_fails.size} of #{metric_refs.size} referenced metric(s) failed the DM metrics census:"
+  warn "       #{metric_fails.size} of #{metric_refs.size} referenced metric(s) failed the DM metrics census:" \
+    if unresolved.any?
   metric_fails.values.first(40).each { |failure| warn "         ✗ #{failure}" }
   warn "         … and #{metric_fails.size - 40} more." if metric_fails.size > 40
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
@@ -40,6 +40,8 @@
 # Usage:
 #   ruby assert-wb-refs-resolve.rb --wb-spec <spec.json> \
 #     ( --dm-ids <dm-ids.json> | --dm-id <dataModelId> ) \
+#     [--metrics <metrics.json>]  # optional explicit DM metrics census;
+#                                 # auto-loads beside --dm-ids when present
 #     [--workdir DIR]             # workdir for the off-ramp trail (the
 #                                 # orchestrator passes it; a waived run
 #                                 # records itself to offramps.jsonl)
@@ -60,6 +62,7 @@ OptionParser.new do |p|
   p.on('--wb-spec PATH')  { |v| opts[:spec] = v }
   p.on('--dm-ids PATH')   { |v| opts[:dm_ids] = v }
   p.on('--dm-id ID')      { |v| opts[:dm_id] = v }
+  p.on('--metrics PATH', 'DM metrics census for [Metrics/<name>] references') { |v| opts[:metrics] = v }
   p.on('--workdir DIR', 'workdir for the off-ramp trail (a waiver is recorded there)') { |v| opts[:workdir] = v }
   p.on('--skip-ref-check REASON',
        'waive the ref-resolution gate — REQUIRED reason; name it in your report') { |v| opts[:skip] = v }
@@ -95,6 +98,15 @@ end
 available  = Set.new
 error_cols = Set.new # normalized labels whose type compiled to "error" (live mode)
 dm_el_ids  = Set.new # DM element ids (offline mode; for source.elementId checks)
+metrics_census = nil # nil means no census was available; an empty Set is a valid empty census
+add_metrics = lambda do |records|
+  next unless records.is_a?(Array)
+  metrics_census ||= Set.new
+  records.each do |metric|
+    name = metric.is_a?(Hash) ? metric['name'] : metric
+    metrics_census << name.to_s.strip unless name.to_s.strip.empty?
+  end
+end
 if opts[:dm_ids]
   idmap = JSON.parse(File.read(opts[:dm_ids], encoding: 'bom|utf-8'))
   dm_elements = if idmap['pages'].is_a?(Array)
@@ -105,7 +117,9 @@ if opts[:dm_ids]
   dm_elements.each do |el|
     dm_el_ids << el['id'] if el['id']
     (el['columnLabels'] || []).each { |l| available << norm(l) }
+    add_metrics.call(el['metrics']) if el.key?('metrics')
   end
+  add_metrics.call(idmap['metrics']) if idmap.key?('metrics')
 else
   # Live fetch via the shared REST lib (self-mints a token). Paginated — big
   # DMs (the collapse case declared 599 columns) overflow a single page.
@@ -130,6 +144,36 @@ else
   # A column that resolves cleanly in ANY element is usable even if a same-
   # named column errored elsewhere — only fail labels that ONLY error.
   error_cols.subtract(clean)
+
+  # Metrics do not appear in /columns. Read the full data-model spec and build
+  # a separate census from element metrics[]; never infer metrics from labels.
+  dm_spec = (Sigma.request(:get, "/v2/dataModels/#{opts[:dm_id]}/spec") rescue nil)
+  dm_doc = dm_spec.is_a?(Hash) && dm_spec['document'].is_a?(Hash) ? dm_spec['document'] : dm_spec
+  if dm_doc.is_a?(Hash)
+    add_metrics.call(dm_doc['metrics']) if dm_doc.key?('metrics')
+    Array(dm_doc['pages']).each do |page_record|
+      next unless page_record.is_a?(Hash)
+      Array(page_record['elements']).each do |element|
+        add_metrics.call(element['metrics']) if element.is_a?(Hash) && element.key?('metrics')
+      end
+    end
+  end
+end
+
+metrics_file = opts[:metrics]
+if metrics_file.nil? && opts[:dm_ids]
+  sidecar = File.join(File.dirname(File.expand_path(opts[:dm_ids])), 'metrics.json')
+  metrics_file = sidecar if File.exist?(sidecar)
+end
+if metrics_file
+  begin
+    metrics_doc = JSON.parse(File.read(metrics_file, encoding: 'bom|utf-8'))
+    metrics_records = metrics_doc.is_a?(Hash) ? metrics_doc['metrics'] : metrics_doc
+    abort "metrics census #{metrics_file} carries no metrics array" unless metrics_records.is_a?(Array)
+    add_metrics.call(metrics_records)
+  rescue JSON::ParserError, Errno::ENOENT => e
+    abort "metrics census #{metrics_file} unreadable: #{e.message}"
+  end
 end
 
 if available.empty?
@@ -159,6 +203,8 @@ end
 # --- extract every [Element/Column] ref, element by element (doc order) -----
 REF = /\[([^\]\/]+)\/([^\]]+)\]/.freeze
 refs = {}       # normalized column -> {display, elements:Set}  (unresolved-vs-DM report)
+metric_refs = Set.new
+metric_fails = {}
 extra_fails = [] # forward-order / dangling-source / type=error findings
 walk = lambda do |obj, &blk|
   case obj
@@ -186,6 +232,22 @@ wb_elements.each_with_index do |el, i|
   end
 
   walk.call(el) do |prefix, col_raw|
+    if prefix.strip == 'Metrics'
+      metric_name = col_raw.to_s.strip
+      metric_refs << metric_name
+      if metrics_census.nil?
+        metric_fails[metric_name] =
+          "no DM metrics census is available for [Metrics/#{metric_name}] — pass --metrics <workdir>/metrics.json, " \
+          'keep metrics.json beside --dm-ids, or use a full DM spec/readback carrying metrics[]'
+      elsif !metrics_census.include?(metric_name)
+        known = metrics_census.to_a.sort
+        metric_fails[metric_name] =
+          "metric #{metric_name.inspect} is not in the DM metrics census " \
+          "(#{known.empty? ? 'the census is EMPTY' : "known metrics: #{known.join(', ')}"})"
+      end
+      next
+    end
+
     # A 3-part relationship ref [Element/RelName/Field] resolves THROUGH the DM
     # relationship — the actual column to check is the FINAL segment (Field); the
     # middle segment is a relationship name (existence validated DM-side by the
@@ -240,18 +302,27 @@ wb_elements.each_with_index do |el, i|
   end
 end
 
-if unresolved.empty? && extra_fails.empty?
-  puts "[PASS] workbook ref-resolution gate: all #{refs.size} referenced column(s) resolve " \
-       "against the live DM (#{available.size} columns) or the spec's own elements."
+if unresolved.empty? && metric_fails.empty? && extra_fails.empty?
+  puts "[PASS] workbook ref-resolution gate: all #{refs.size} referenced column(s) and " \
+       "#{metric_refs.size} referenced metric(s) resolve against the live DM " \
+       "(#{available.size} columns, #{metrics_census&.size || 0} metrics) or the spec's own elements."
   exit 0
 end
 
-warn "[FAIL] workbook ref-resolution gate — #{unresolved.size} of #{refs.size} referenced " \
-     "column(s) do NOT exist in the live DM (#{available.size} columns):"
-unresolved.values.first(40).each do |r|
-  warn "         ✗ #{r[:display]}   (referenced via #{r[:elements].to_a.map { |e| "[#{e}/…]" }.join(', ')})"
+warn '[FAIL] workbook ref-resolution gate'
+if unresolved.any?
+  warn "       #{unresolved.size} of #{refs.size} referenced column(s) do NOT exist in the live DM " \
+       "(#{available.size} columns):"
+  unresolved.values.first(40).each do |r|
+    warn "         ✗ #{r[:display]}   (referenced via #{r[:elements].to_a.map { |e| "[#{e}/…]" }.join(', ')})"
+  end
+  warn "         … and #{unresolved.size - 40} more." if unresolved.size > 40
 end
-warn "         … and #{unresolved.size - 40} more." if unresolved.size > 40
+if metric_fails.any?
+  warn "       #{metric_fails.size} of #{metric_refs.size} referenced metric(s) failed the DM metrics census:"
+  metric_fails.values.first(40).each { |failure| warn "         ✗ #{failure}" }
+  warn "         … and #{metric_fails.size - 40} more." if metric_fails.size > 40
+end
 if extra_fails.any?
   warn "       plus #{extra_fails.size} structural failure(s):"
   extra_fails.first(20).each { |f| warn "         ✗ #{f}" }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-lod-calcs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-lod-calcs.rb
@@ -31,6 +31,8 @@
 #     [--wb-spec PATH]          # default <WORK>/wb-spec.resolved.json,
 #                               #   else <WORK>/wb-spec.json
 #     [--manual-residues PATH]  # default <WORK>/manual-residues.json
+#     [--gaps-report PATH]      # default <WORK>/workbook-content-gaps-report.json;
+#                               #   proves fields unused by every source worksheet
 #     [--out PATH]              # default <WORK>/lod-audit.json
 #   ruby scripts/audit-lod-calcs.rb --workdir <WORK> --resolve <INDEX> \
 #     --how <manual|waived> --reason "<evidence>"
@@ -60,6 +62,7 @@ OptionParser.new do |p|
   p.on('--dm-spec PATH')        { |v| opts[:dm_spec] = v }
   p.on('--wb-spec PATH')        { |v| opts[:wb_spec] = v }
   p.on('--manual-residues PATH') { |v| opts[:residues] = v }
+  p.on('--gaps-report PATH')    { |v| opts[:gaps_report] = v }
   p.on('--out PATH')            { |v| opts[:out] = v }
   p.on('--resolve INDEX', Integer) { |v| opts[:resolve] = v }
   p.on('--how HOW', 'manual|waived') { |v| opts[:how] = v }
@@ -121,9 +124,12 @@ else
   dm  = read_json.call(opts[:dm_spec] || File.join(work, 'dm-spec.json'))
   wb  = read_json.call(opts[:wb_spec] || File.join(work, wb_default))
   mr  = read_json.call(opts[:residues] || File.join(work, 'manual-residues.json'))
+  gaps = read_json.call(opts[:gaps_report] || File.join(work, 'workbook-content-gaps-report.json'))
+  unused_fields = gaps.is_a?(Hash) ? Array(gaps.dig('field_statistics', 'unused_field_names')) : []
   prior = read_json.call(out_path)
 
-  entries = LodAudit.derive(calcs, dm_spec: dm, wb_spec: wb, manual_residues: mr, prior: prior)
+  entries = LodAudit.derive(calcs, dm_spec: dm, wb_spec: wb, manual_residues: mr,
+                            prior: prior, unused_fields: unused_fields)
   LodAudit.write(out_path, entries)
   entries.each_with_index do |e, i|
     tag = LodAudit.resolved?(e) ? 'ok    ' : 'BLOCK '
@@ -179,6 +185,8 @@ res_n = entries.count { |e| e['resolution'].is_a?(Hash) }
 puts "audit-lod-calcs: #{entries.size} LOD calc(s) — " \
      "#{entries.count { |e| e['class'] == 'lod-synth' }} synth, " \
      "#{entries.count { |e| e['class'] == 'manual-residue' }} manual-residue, " \
-     "#{entries.count { |e| e['class'] == 'reference-derived' }} reference-derived" \
+     "#{entries.count { |e| e['class'] == 'reference-derived' }} reference-derived, " \
+     "#{entries.count { |e| e['class'] == 'unused-source' }} unused-source, " \
+     '0 unresolved' \
      "#{res_n.positive? ? ", #{res_n} resolved-by-hand" : ''}. Ledger: #{out_path}"
 exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
@@ -35,6 +35,7 @@ require 'optparse'
 require 'net/http'
 require 'uri'
 require 'set'
+require_relative 'lib/workbook_code'
 
 opts = { renames: {} }
 OptionParser.new do |p|
@@ -77,15 +78,17 @@ view_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v }
 
 # Load Sigma side
 spec = JSON.parse(File.read(opts[:wb]))
+workbook_pages = WorkbookCode.pages(spec)
+workbook_elements = WorkbookCode.elements(spec)
 
 # Per-dashboard scope: narrow the pages we plan parity over to the matching
-# page(s). The master-detection + chart-matching loops below iterate `pages`
-# instead of `spec['pages']`, so a scoped run gates ONLY the target tab's tiles
-# (per-tab parity, not all-or-nothing). No flag ⇒ every page (current behavior).
-pages = spec['pages']
+# page(s). Workbook pages are metadata-only; layout owns page membership, so
+# scoped element selection must use WorkbookCode.elements_for_page rather than
+# reading a nonexistent pages[].elements array.
+pages = workbook_pages
 if opts[:dashboards] && !opts[:dashboards].empty?
   want = opts[:dashboards].map(&:downcase)
-  pages = spec['pages'].select do |pg|
+  pages = workbook_pages.select do |pg|
     nm = pg['name'].to_s.downcase
     pid = pg['id'].to_s.downcase
     want.any? { |w| !w.empty? && (nm == w || nm.include?(w) || pid == w) }
@@ -93,6 +96,12 @@ if opts[:dashboards] && !opts[:dashboards].empty?
   abort("--dashboard/--page matched no workbook page in #{opts[:wb]}") if pages.empty?
   warn "scoped parity to page(s): #{pages.map { |p| p['name'] }.join(', ')}"
 end
+scoped_elements =
+  if opts[:dashboards] && !opts[:dashboards].empty?
+    pages.flat_map { |page| WorkbookCode.elements_for_page(spec, page) }.uniq { |element| element['id'] }
+  else
+    workbook_elements
+  end
 
 # Build the set of master-element-IDs we should treat as "the master" for
 # chart matching. Either explicit via --master-id (repeatable) OR auto-detect
@@ -106,24 +115,17 @@ master_ids =
   if opts[:master_ids] && !opts[:master_ids].empty?
     opts[:master_ids]
   else
-    detected = []
-    spec['pages'].each do |pg|
-      pg['elements'].each do |e|
-        if e['kind'] == 'table' &&
-           e['visibleAsSource'] == false &&
-           e.dig('source', 'kind') == 'data-model'
-          detected << e['id']
-        end
+    detected = workbook_elements.each_with_object([]) do |element, out|
+      if element['kind'] == 'table' &&
+         element['visibleAsSource'] == false &&
+         element.dig('source', 'kind') == 'data-model'
+        out << element['id']
       end
     end
     # Legacy fallback for specs that pre-date the master/visibleAsSource shape:
     # any element whose ID literally starts with `master`.
     if detected.empty?
-      spec['pages'].each do |pg|
-        pg['elements'].each do |e|
-          detected << e['id'] if e['id'].to_s.start_with?('master')
-        end
-      end
+      workbook_elements.each { |element| detected << element['id'] if element['id'].to_s.start_with?('master') }
     end
     detected.uniq
   end
@@ -131,8 +133,8 @@ if master_ids.empty?
   # A hand-authored spec may have NO intermediate master tables at all — every
   # chart sources the data model directly. That's a valid documented shape,
   # not an error (the chart loop below matches DM-sourced charts on its own).
-  has_dm_charts = spec['pages'].any? do |pg|
-    (pg['elements'] || []).any? { |e| e.dig('source', 'kind') == 'data-model' && e['kind'] != 'table' }
+  has_dm_charts = scoped_elements.any? do |element|
+    element.dig('source', 'kind') == 'data-model' && element['kind'] != 'table'
   end
   abort('auto-parity-plan.rb: no master element(s) detected; pass --master-id explicitly') unless has_dm_charts
   warn 'no master tables detected — matching data-model-sourced charts directly'
@@ -144,28 +146,23 @@ master_id_set = master_ids.to_set
 # Transitive: hidden helper tables that THEMSELVES source a master (e.g. the
 # scatter grouped-source tables, bead z1d0) count as masters for chart
 # matching — the scatter chart sources the helper, not the master.
-spec['pages'].each do |pg|
-  pg['elements'].each do |e|
-    next unless e['kind'] == 'table' && e['visibleAsSource'] == false
-    next unless e['source'] && master_id_set.include?(e['source']['elementId'])
-    master_id_set << e['id']
-  end
+workbook_elements.each do |element|
+  next unless element['kind'] == 'table' && element['visibleAsSource'] == false
+  next unless element['source'] && master_id_set.include?(element['source']['elementId'])
+  master_id_set << element['id']
 end
-sigma_charts = []
-pages.each do |pg|
-  pg['elements'].each do |e|
-    next if master_id_set.include?(e['id'])
-    # A chart counts when it sources a detected master — OR sources the data
-    # model DIRECTLY (source.kind=='data-model' on the chart itself, the
-    # documented hand-authored shape). The master-only check silently produced
-    # a "0 CSV tiles" census on every exit-4 workbook, forcing an
-    # --allow-missing-tiles waiver for tiles that were fully verifiable
-    # (field-caught round 2, two independent runs).
-    from_master = e['source'] && master_id_set.include?(e['source']['elementId'])
-    from_dm     = e.dig('source', 'kind') == 'data-model' && !%w[table control text image container].include?(e['kind'].to_s)
-    next unless from_master || from_dm
-    sigma_charts << e
-  end
+sigma_charts = scoped_elements.each_with_object([]) do |element, out|
+  next if master_id_set.include?(element['id'])
+  # A chart counts when it sources a detected master — OR sources the data
+  # model DIRECTLY (source.kind=='data-model' on the chart itself, the
+  # documented hand-authored shape). The master-only check silently produced
+  # a "0 CSV tiles" census on every exit-4 workbook, forcing an
+  # --allow-missing-tiles waiver for tiles that were fully verifiable
+  # (field-caught round 2, two independent runs).
+  from_master = element['source'] && master_id_set.include?(element['source']['elementId'])
+  from_dm = element.dig('source', 'kind') == 'data-model' &&
+            !%w[table control text image container].include?(element['kind'].to_s)
+  out << element if from_master || from_dm
 end
 
 # Match Sigma chart → Tableau view

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/export-chart-png.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/export-chart-png.rb
@@ -72,7 +72,7 @@ end
 # bare spec['pages'] read here was always nil, so `elements` came back empty
 # and every run hit the "no matching elements" abort below.
 spec = Sigma::CodeRep.document(spec)
-elements = (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+elements = Sigma::CodeRep.workbook_elements(spec)
 targets = if opts[:element_ids]
             elements.select { |e| opts[:element_ids].include?(e['id']) }
           else

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
@@ -483,12 +483,13 @@ when 'apply-patch'
             YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
           end
         end
-      # Workbook code-rep GETs nest pages/layout/schemaVersion under `document`
-      # (live since 2026-08); flatten metadata+document onto ONE hash so every
-      # live['pages']/merged['layout'] read below stays correct whether `live`
-      # came from a live nested GET or a legacy flat --live-spec fixture (the
-      # adapter's document()/metadata() both tolerate an already-flat input).
-      live = WorkbookCode.legacy_view(live)
+      # Workbook code-rep GETs carry flat document.elements. Keep that canonical
+      # flat shape while merging a partial fidelity patch: converting the live
+      # spec to pages[].elements first would make a flat patch.elements array a
+      # second namespace, and canonicalize() would let those partial records
+      # (id/style but no kind) shadow the complete page-owned records.
+      canonical_live = WorkbookCode.canonicalize(live)
+      live = WorkbookCode.metadata(canonical_live).merge(WorkbookCode.document(canonical_live))
       unless live['pages'].is_a?(Array) && live['pages'].any?
         die 'live spec has no `pages` — refusing to PUT a spec that would blank the workbook', 4
       end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_gates.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_gates.rb
@@ -17,6 +17,7 @@
 require 'json'
 $LOAD_PATH.unshift File.expand_path(__dir__)
 require 'action_ledger'
+require_relative 'workbook_code'
 
 module ActionGates
   module_function
@@ -30,27 +31,25 @@ module ActionGates
   def action_schema_violations(spec)
     errs = []
     seen = {}
-    (spec['pages'] || []).each do |page|
-      (page['elements'] || []).each do |el|
-        (el['actions'] || []).each do |action|
-          ActionLedger.validate_action(action).each do |e|
-            errs << "#{page['id']}/#{el['id']}: #{e}"
-          end
-          id = action['id']
-          next if id.to_s.empty?
-          if seen[id]
-            errs << "duplicate action id #{id.inspect} on #{el['id']} (already on #{seen[id]}) " \
-                    '— action ids must be unique across the WHOLE workbook'
-          end
-          seen[id] = el['id']
+    WorkbookCode.elements_with_pages(spec).each do |element, page|
+      (element['actions'] || []).each do |action|
+        ActionLedger.validate_action(action).each do |error|
+          errs << "#{page&.dig('id') || '(unplaced)'}/#{element['id']}: #{error}"
         end
+        id = action['id']
+        next if id.to_s.empty?
+        if seen[id]
+          errs << "duplicate action id #{id.inspect} on #{element['id']} (already on #{seen[id]}) " \
+                  '— action ids must be unique across the WHOLE workbook'
+        end
+        seen[id] = element['id']
       end
     end
     errs
   end
 
   def action_count(spec)
-    (spec['pages'] || []).sum { |pg| (pg['elements'] || []).sum { |el| Array(el['actions']).size } }
+    WorkbookCode.elements(spec).sum { |element| Array(element['actions']).size }
   end
 
   # Ledger/spec contradiction check — the built `spec` (--spec) is the one

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/column_census.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/column_census.rb
@@ -28,10 +28,14 @@ module ColumnCensus
   #                     ([{elementId, columnId, label, formula, type:{type}}])
   #
   # Returns an Array of per-element discrepancy Hashes (empty == clean):
-  #   { 'element' => name, 'posted' => N, 'resolved' => M,
-  #     'missing' => [posted column names absent from the readback],
+  #   { 'element' => name,
+  #     'posted_columns' => N, 'resolved_columns' => M,
+  #     'missing_columns' => [posted column names absent from /columns],
+  #     'posted_metrics' => N, 'resolved_metrics' => M,
+  #     'missing_metrics' => [posted metric names absent from readback metrics[]],
   #     'error_columns' => [readback labels whose type compiled to "error"],
   #     'note' => optional }
+  # Legacy posted/resolved/missing aliases describe COLUMNS only.
   def census(posted_spec, readback_spec, columns_entries)
     labels_by_el = Hash.new { |h, k| h[k] = [] }
     errors_by_el = Hash.new { |h, k| h[k] = [] }
@@ -43,16 +47,20 @@ module ColumnCensus
 
     rb_ids_by_name = Hash.new { |h, k| h[k] = [] }
     rb_ids = Set.new
+    metrics_by_el = Hash.new { |h, k| h[k] = [] }
     flatten_elements(readback_spec).each do |e|
       rb_ids << e['id'] if e['id']
       rb_ids_by_name[e['name']] << e['id'] if e['name'] && e['id']
+      metrics_by_el[e['id']].concat(Array(e['metrics']).map do |metric|
+        metric.is_a?(Hash) ? metric['name'] : metric
+      end.compact) if e['id']
     end
 
     problems = []
     flatten_elements(posted_spec).each do |pel|
-      posted_names = ((pel['columns'] || []) + (pel['metrics'] || []))
-                     .map { |c| c['name'] }.compact
-      next if posted_names.empty? # nothing was posted for this element
+      posted_columns = Array(pel['columns']).map { |column| column['name'] }.compact
+      posted_metrics = Array(pel['metrics']).map { |metric| metric['name'] }.compact
+      next if posted_columns.empty? && posted_metrics.empty?
 
       # Match by NAME first (ids are reassigned on DM POST), then by id.
       server_ids = rb_ids_by_name[pel['name']]
@@ -60,25 +68,41 @@ module ColumnCensus
 
       if server_ids.empty?
         problems << { 'element' => pel['name'] || pel['id'] || '?',
-                      'posted' => posted_names.size, 'resolved' => 0,
-                      'missing' => posted_names, 'error_columns' => [],
+                      'posted' => posted_columns.size, 'resolved' => 0,
+                      'missing' => posted_columns,
+                      'posted_columns' => posted_columns.size, 'resolved_columns' => 0,
+                      'missing_columns' => posted_columns,
+                      'posted_metrics' => posted_metrics.size, 'resolved_metrics' => 0,
+                      'missing_metrics' => posted_metrics, 'error_columns' => [],
                       'note' => 'element missing from readback entirely' }
         next
       end
 
-      resolved = server_ids.flat_map { |sid| labels_by_el[sid] }
+      resolved_columns = server_ids.flat_map { |sid| labels_by_el[sid] }
+      resolved_metrics = server_ids.flat_map { |sid| metrics_by_el[sid] }.uniq
       err_cols = server_ids.flat_map { |sid| errors_by_el[sid] }.uniq
-      resolved_set = resolved.to_set
+      resolved_set = resolved_columns.to_set
       # Sigma relabels joined-dim columns with a disambiguation suffix —
       # "Customer Id" may read back as "Customer Id (CUSTOMER_DIM)". Accept
       # the suffixed label as a resolution of the posted name.
-      desuffixed = resolved.map { |l| l.sub(/ \([^()]*\)\z/, '') }.to_set
-      missing = posted_names.reject { |n| resolved_set.include?(n) || desuffixed.include?(n) }
+      desuffixed = resolved_columns.map { |label| label.sub(/ \([^()]*\)\z/, '') }.to_set
+      missing_columns = posted_columns.reject do |name|
+        resolved_set.include?(name) || desuffixed.include?(name)
+      end
+      resolved_metrics_set = resolved_metrics.to_set
+      missing_metrics = posted_metrics.reject { |name| resolved_metrics_set.include?(name) }
 
-      next if missing.empty? && err_cols.empty?
+      next if missing_columns.empty? && missing_metrics.empty? && err_cols.empty?
       problems << { 'element' => pel['name'] || pel['id'] || '?',
-                    'posted' => posted_names.size, 'resolved' => resolved.size,
-                    'missing' => missing, 'error_columns' => err_cols }
+                    'posted' => posted_columns.size, 'resolved' => resolved_columns.size,
+                    'missing' => missing_columns,
+                    'posted_columns' => posted_columns.size,
+                    'resolved_columns' => resolved_columns.size,
+                    'missing_columns' => missing_columns,
+                    'posted_metrics' => posted_metrics.size,
+                    'resolved_metrics' => resolved_metrics.size,
+                    'missing_metrics' => missing_metrics,
+                    'error_columns' => err_cols }
     end
     problems
   end
@@ -88,12 +112,20 @@ module ColumnCensus
   def report_lines(problems, cap: 20)
     problems.flat_map do |p|
       head = "#{p['element']}: posted #{p['posted']} column(s), readback resolved #{p['resolved']}"
+      if p['posted_metrics'].to_i.positive? || p['missing_metrics']&.any?
+        head += "; posted #{p['posted_metrics']} metric(s), readback spec resolved #{p['resolved_metrics']}"
+      end
       head += " — #{p['note']}" if p['note']
       lines = [head]
-      if (m = p['missing']).any?
+      if (m = p['missing_columns'] || p['missing']).any?
         shown = m.first(cap).join(', ')
         tail = m.size > cap ? " ... and #{m.size - cap} more" : ''
-        lines << "  missing #{m.size}: #{shown}#{tail}"
+        lines << "  missing columns #{m.size}: #{shown}#{tail}"
+      end
+      if (m = p['missing_metrics'] || []).any?
+        shown = m.first(cap).join(', ')
+        tail = m.size > cap ? " ... and #{m.size - cap} more" : ''
+        lines << "  missing metrics #{m.size}: #{shown}#{tail}"
       end
       if (e = p['error_columns']).any?
         lines << "  type=error #{e.size}: #{e.first(cap).join(', ')}#{e.size > cap ? " ... and #{e.size - cap} more" : ''}"
@@ -104,7 +136,12 @@ module ColumnCensus
 
   def posted_column_count(posted_spec)
     flatten_elements(posted_spec)
-      .sum { |el| ((el['columns'] || []) + (el['metrics'] || [])).count { |c| c['name'] } }
+      .sum { |element| Array(element['columns']).count { |column| column['name'] } }
+  end
+
+  def posted_metric_count(posted_spec)
+    flatten_elements(posted_spec)
+      .sum { |element| Array(element['metrics']).count { |metric| metric['name'] } }
   end
 
   def flatten_elements(spec)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_field_census.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_field_census.rb
@@ -28,6 +28,7 @@
 # wires it to the live readback on the workbook path and WARNs loudly on any
 # dropped field (a WARN, not a hard stop: the workbook is live and correct
 # except for the ignored field; the operator sets it in the UI).
+require_relative 'workbook_code'
 
 module ControlFieldCensus
   # Keys never expected to survive: builder-internal annotations (underscore-
@@ -109,7 +110,7 @@ module ControlFieldCensus
 
   def controls(spec)
     return [] unless spec.is_a?(Hash)
-    (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
-                         .select { |e| e.is_a?(Hash) && e['kind'].to_s == 'control' }
+    WorkbookCode.elements(spec)
+                .select { |element| element.is_a?(Hash) && element['kind'].to_s == 'control' }
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/datasource_filter_check.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/datasource_filter_check.rb
@@ -26,6 +26,7 @@
 #   DatasourceFilterCheck.violations(datasource_filters:, filter_shelf:, spec:, master_id: 'master')
 require 'json'
 require 'set'
+require_relative 'workbook_code'
 
 module DatasourceFilterCheck
   module_function
@@ -34,16 +35,13 @@ module DatasourceFilterCheck
     s.to_s.downcase.strip.gsub(/\s+/, ' ')
   end
 
-  # Every element regardless of spec shape: pages[].elements[] or a flat list.
+  # Every workbook element regardless of envelope. Canonical workbooks use
+  # flat document.elements; WorkbookCode retains a legacy nested fallback for
+  # pre-release fixtures.
   def all_elements(spec)
     return [] unless spec.is_a?(Hash) || spec.is_a?(Array)
-    if spec.is_a?(Array)
-      spec
-    elsif spec['pages'].is_a?(Array)
-      spec['pages'].flat_map { |pg| Array(pg.is_a?(Hash) ? pg['elements'] : nil) }
-    else
-      Array(spec['elements'])
-    end.select { |e| e.is_a?(Hash) }
+    records = spec.is_a?(Array) ? spec : WorkbookCode.elements(spec)
+    records.select { |element| element.is_a?(Hash) }
   end
 
   # columnIds (across every element) whose column display name matches `caption`.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/join_plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/join_plan.rb
@@ -346,7 +346,7 @@ module JoinPlan
   # Role parentheticals are stripped BEFORE folding (see strip_role_paren).
   def relationship_probe_key(key, captions)
     # Duplicate logical-table roles suffix the field id itself, e.g.
-    #   <guid> (DATE_DIM (CSA.DATE_DIM)1)
+    #   <guid> (DATE_DIM (DEMO_SCHEMA.DATE_DIM)1)
     # That whole token is not GUID-shaped, but the datasource's column census
     # carries an exact caption for it. Prefer exact caption evidence before
     # falling back to the plain-GUID and display-name paths.
@@ -375,7 +375,7 @@ module JoinPlan
   # blocking, the safe direction.
   # Tableau appends a numeric role suffix after the closing physical-path
   # parenthesis when the same logical table appears more than once:
-  #   DATE_DIM (CSA.DATE_DIM)1
+  #   DATE_DIM (DEMO_SCHEMA.DATE_DIM)1
   # The suffix identifies the role, not a warehouse table.
   VC_LABEL_RE = /\(\s*([A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+){1,2})\s*\)\d*\s*\z/
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/join_plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/join_plan.rb
@@ -345,6 +345,13 @@ module JoinPlan
   # ('Entity Id' -> ENTITY_ID; an already-physical 'ENTITY_ID' is a no-op).
   # Role parentheticals are stripped BEFORE folding (see strip_role_paren).
   def relationship_probe_key(key, captions)
+    # Duplicate logical-table roles suffix the field id itself, e.g.
+    #   <guid> (DATE_DIM (CSA.DATE_DIM)1)
+    # That whole token is not GUID-shaped, but the datasource's column census
+    # carries an exact caption for it. Prefer exact caption evidence before
+    # falling back to the plain-GUID and display-name paths.
+    caption = captions[key.to_s.downcase]
+    return physical_name(strip_role_paren(caption)) if caption
     guid_like?(key) ? physical_probe_key(key, captions) : physical_name(strip_role_paren(key))
   end
 
@@ -366,7 +373,11 @@ module JoinPlan
   # the run's resolved db/schema. When neither resolution works we return nil
   # and the caller keeps the old FQN — the probe errors and the gate keeps
   # blocking, the safe direction.
-  VC_LABEL_RE = /\(\s*([A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+){1,2})\s*\)\s*\z/
+  # Tableau appends a numeric role suffix after the closing physical-path
+  # parenthesis when the same logical table appears more than once:
+  #   DATE_DIM (CSA.DATE_DIM)1
+  # The suffix identifies the role, not a warehouse table.
+  VC_LABEL_RE = /\(\s*([A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+){1,2})\s*\)\d*\s*\z/
 
   def vc_physical_fqn(label, db, schema)
     m = label.to_s.match(VC_LABEL_RE)
@@ -399,9 +410,19 @@ module JoinPlan
     idx = {}
     doc.elements.each('//column[@caption]') do |c|
       name = c.attributes['name'].to_s.sub(/\A\[/, '').sub(/\]\z/, '')
-      next unless guid_like?(name)
+      # A duplicate logical-table role preserves the physical GUID at the
+      # start, then appends " (role-name)N". Index both the exact role token
+      # and its base GUID, but reject unrelated strings that merely begin with
+      # 36 GUID-looking characters.
+      base = name[0, 36]
+      suffix = name[36..].to_s
+      next unless guid_like?(base)
+      next unless suffix.empty? || suffix.match?(/\A\s+\(.+\)\d*\z/)
       cap = c.attributes['caption'].to_s
-      idx[name.downcase] ||= cap unless cap.empty?
+      unless cap.empty?
+        idx[name.downcase] ||= cap
+        idx[base.downcase] ||= cap
+      end
     end
     idx
   rescue StandardError

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/lod_audit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/lod_audit.rb
@@ -34,6 +34,10 @@
 #                     passthrough of a column that appears ONLY in the LOD's
 #                     filter condition does NOT qualify — that is a fuzzy alias
 #                     (#452), classified suspect-alias below.
+#   unused-source     resolved — no translation was emitted, and the source
+#                     workbook field census proves that no worksheet references
+#                     the calc. This is scope evidence, not a waiver; an emitted
+#                     suspect alias still blocks even when listed as unused.
 #   suspect-alias     UNRESOLVED — an emitted column carries the calc's name but
 #                     its formula either references a base/physical column that
 #                     is NOT in the LOD expression's own reference set, OR is a
@@ -56,6 +60,7 @@
 require 'json'
 require_relative 'calc_coverage'
 require_relative 'sql_ident_check'
+require_relative 'workbook_code'
 
 module LodAudit
   GRAIN_NOTE = 'A {FIXED/INCLUDE/EXCLUDE} calc must translate to the documented LOD strategy ' \
@@ -167,24 +172,28 @@ module LodAudit
   def emitted_columns(spec, spec_label)
     return [] unless spec.is_a?(Hash)
     out = []
-    (spec['pages'] || []).each do |pg|
-      (pg['elements'] || []).each do |el|
-        el_name = (el['name'] || el['id']).to_s
-        grouped = el['groupings'].is_a?(Array) && !el['groupings'].empty?
-        stmt = el.dig('source', 'kind') == 'sql' ? el.dig('source', 'statement').to_s : ''
-        sql_grouped = stmt =~ /\bGROUP\s+BY\b/i ? true : false
-        (Array(el['columns']) + Array(el['metrics'])).each do |col|
-          next unless col.is_a?(Hash)
-          out << {
-            'spec'        => spec_label,
-            'element'     => el_name,
-            'name'        => col_display(col),
-            'formula'     => col['formula'].to_s,
-            'grouped'     => grouped,
-            'sql_grouped' => sql_grouped,
-            'sql_stmt'    => stmt
-          }
-        end
+    elements =
+      if spec_label == 'wb-spec'
+        WorkbookCode.elements(spec)
+      else
+        (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+      end
+    elements.each do |el|
+      el_name = (el['name'] || el['id']).to_s
+      grouped = el['groupings'].is_a?(Array) && !el['groupings'].empty?
+      stmt = el.dig('source', 'kind') == 'sql' ? el.dig('source', 'statement').to_s : ''
+      sql_grouped = stmt =~ /\bGROUP\s+BY\b/i ? true : false
+      (Array(el['columns']) + Array(el['metrics'])).each do |col|
+        next unless col.is_a?(Hash)
+        out << {
+          'spec'        => spec_label,
+          'element'     => el_name,
+          'name'        => col_display(col),
+          'formula'     => col['formula'].to_s,
+          'grouped'     => grouped,
+          'sql_grouped' => sql_grouped,
+          'sql_stmt'    => stmt
+        }
       end
     end
     out
@@ -202,16 +211,21 @@ module LodAudit
   # manual_residues: parsed manual-residues.json (or nil). prior: previously
   # written ledger doc/entries — unresolved entries carry their recorded
   # resolution forward across re-derivation (same calc + formula).
-  def derive(calcs, dm_spec: nil, wb_spec: nil, manual_residues: nil, prior: nil)
+  def derive(calcs, dm_spec: nil, wb_spec: nil, manual_residues: nil, prior: nil,
+             unused_fields: nil)
     cols = emitted_columns(dm_spec, 'dm-spec') + emitted_columns(wb_spec, 'wb-spec')
     residues = residue_index(manual_residues)
     tindex = spec_table_index(dm_spec, wb_spec)
-    entries = Array(calcs).map { |c| classify(c, cols, residues, tindex) }
+    unused = Array(unused_fields).each_with_object({}) do |field, index|
+      key = norm(field)
+      index[key] ||= field.to_s unless key.empty?
+    end
+    entries = Array(calcs).map { |c| classify(c, cols, residues, tindex, unused) }
     carry_resolutions(entries, prior)
     entries
   end
 
-  def classify(calc, cols, residues, table_index = {})
+  def classify(calc, cols, residues, table_index = {}, unused_fields = {})
     name_n = norm(calc['calc'])
     ref_ns = Array(calc['reference_set']).map { |r| norm(r) }.reject(&:empty?)
     allowed = ref_ns + [name_n]
@@ -303,6 +317,13 @@ module LodAudit
       entry['class']  = 'reference-derived'
       entry['status'] = 'resolved'
       entry['evidence'] = evidence(derived.first)
+    elsif matches.empty? && unused_fields.key?(name_n)
+      entry['class']  = 'unused-source'
+      entry['status'] = 'resolved'
+      entry['evidence'] = {
+        'kind' => 'source-unused-field-census',
+        'field' => unused_fields[name_n]
+      }
     else
       entry['class']  = 'silently-dropped'
       entry['status'] = 'unresolved'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/style_normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/style_normalize.rb
@@ -55,6 +55,8 @@
 # NOT here: SN-1 title-hide ships separately via put-layout — the live API
 # rejects name:{text, visibility:'hidden'} (probed 2026-07-11: 400 "cannot mix
 # visibility:'hidden' with title content").
+require_relative 'workbook_code'
+
 module StyleNormalize
   RULE_TOTALS  = 'SN-2-pivot-totals'
   RULE_GRAMMAR = 'SN-3-format-grammar'
@@ -106,24 +108,18 @@ module StyleNormalize
     @warnings = []
     changes = []
     return changes unless spec.is_a?(Hash)
+    document = WorkbookCode.document(spec)
     zones = chart_zones_by_key(layout)
-    pages = spec['pages']
-    pages = [] unless pages.is_a?(Array)
-    pages.each do |page|
-      next unless page.is_a?(Hash)
-      elements = page['elements']
-      next unless elements.is_a?(Array)
-      elements.each do |el|
-        next unless el.is_a?(Hash)
-        normalize_pivot_totals!(el, zones, changes)
-        normalize_scheme_defaults!(spec, el, changes)
-        columns = el['columns']
-        next unless columns.is_a?(Array)
-        columns.each_with_index do |col, i|
-          next unless col.is_a?(Hash)
-          repair_format_grammar!(el, col, i, changes)
-          normalize_percent_precision!(el, col, i, changes)
-        end
+    WorkbookCode.elements(document).each do |el|
+      next unless el.is_a?(Hash)
+      normalize_pivot_totals!(el, zones, changes)
+      normalize_scheme_defaults!(document, el, changes)
+      columns = el['columns']
+      next unless columns.is_a?(Array)
+      columns.each_with_index do |col, i|
+        next unless col.is_a?(Hash)
+        repair_format_grammar!(el, col, i, changes)
+        normalize_percent_precision!(el, col, i, changes)
       end
     end
     changes

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/workbook_code.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/workbook_code.rb
@@ -36,6 +36,19 @@ module WorkbookCode
     end
   end
 
+  def elements_with_pages(spec)
+    doc = document(spec)
+    legacy_pages = Array(doc['pages']).select { |page| page.is_a?(Hash) && page.key?('elements') }
+    if legacy_pages.any?
+      return legacy_pages.flat_map do |page|
+        Array(page['elements']).select { |element| element.is_a?(Hash) }
+                               .map { |element| [element, page] }
+      end
+    end
+
+    Sigma::CodeRep.workbook_elements_with_pages(doc)
+  end
+
   def pages(spec)
     Array(document(spec)['pages']).select { |page| page.is_a?(Hash) }
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -32,6 +32,8 @@ require 'set'
 require 'json'
 require 'open3'
 require 'zlib' # CRC32 — a cross-run-STABLE hash for case-disambiguating column ids (#455)
+require 'rexml/document'
+require 'rexml/xpath'
 require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 require_relative 'lib/theme_derive' # shared theme derivation/emission (v5.0)
 require_relative 'lib/sql_ident_check' # #685-C: calc-masquerading-as-physical fixup reuses its scanner/catalog check
@@ -1168,6 +1170,210 @@ module MechanicalSpecs
       end
     end
     out
+  end
+
+  # ---- GUID-backed date recovery (#700) -------------------------------------
+  # Recover converter-omitted virtual-connection dates only when Tableau type,
+  # parse format, owning relation, live physical column, and warehouse type all
+  # agree. Returns { recovered:, messages: }; "GAP:" messages are refusals.
+  def recover_guid_backed_date_fields!(model, twb_xml, real_cols, warehouse_catalogs,
+                                       column_mapping: nil)
+    result = { recovered: 0, messages: [] }
+    xml = twb_xml.to_s.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+    begin
+      document = REXML::Document.new(xml)
+    rescue REXML::ParseException => e
+      result[:messages] << "GAP: GUID date recovery could not parse the Tableau workbook: #{e.message.to_s.lines.first.to_s.strip}"
+      return result
+    end
+
+    warehouse_elements = all_elements(model).select do |element|
+      element.dig('source', 'kind') == 'warehouse-table'
+    end
+    by_table = warehouse_elements.group_by do |element|
+      Array(element.dig('source', 'path')).last.to_s.upcase
+    end
+
+    guid_of = lambda do |raw|
+      raw.to_s[/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i]&.downcase
+    end
+    table_token = lambda do |raw|
+      value = raw.to_s
+      bracketed = value.scan(/\[([^\]]+)\]/).flatten.last
+      value = bracketed unless bracketed.to_s.empty?
+      value = value.sub(/\s*\([^()]*\)\s*\z/, '').strip
+      value.split('.').last.to_s.gsub(/\A["`\[]|["`\]]\z/, '').upcase
+    end
+
+    relation_evidence = Hash.new { |hash, key| hash[key] = [] }
+    REXML::XPath.each(document, "//relation[@type='table']") do |relation|
+      owners = [relation.attributes['name'], relation.attributes['table']]
+               .map { |raw| table_token.call(raw) }.reject(&:empty?).uniq
+      owners.select! { |owner| by_table.key?(owner) }
+      REXML::XPath.each(relation, './columns/column') do |column|
+        guid = guid_of.call(column.attributes['name'])
+        next unless guid
+        relation_evidence[guid] << {
+          owners: owners,
+          format: column.attributes['date-parse-format'].to_s.strip
+        }
+      end
+    end
+
+    # parent-name is a second structural owner signal for vendor-wrapped
+    # relation attributes.
+    metadata_owners = Hash.new { |hash, key| hash[key] = [] }
+    REXML::XPath.each(document, '//metadata-record') do |record|
+      guid = guid_of.call(record.elements['local-name']&.text)
+      next unless guid
+      owner = table_token.call(record.elements['parent-name']&.text)
+      metadata_owners[guid] << owner if by_table.key?(owner)
+    end
+
+    fields = {}
+    REXML::XPath.each(document, '//column[@caption]') do |column|
+      guid = guid_of.call(column.attributes['name'])
+      next unless guid
+      next unless column.attributes['datatype'].to_s.casecmp?('date')
+      caption = column.attributes['caption'].to_s.strip
+      next if caption.empty?
+      fields[[guid, caption]] ||= { guid: guid, caption: caption }
+    end
+
+    normalized_mapping = {}
+    (column_mapping || {}).each do |source, destination|
+      normalized_mapping[source.to_s.strip.upcase] = destination.to_s.strip
+    end
+
+    physical_type_compatible = lambda do |format, type|
+      raw = type.to_s.downcase
+      next false if raw.empty? || raw =~ /bool|binary|variant|object|array/
+      next true if raw =~ /date|time|char|string|text/
+      format == 'yyyyMMdd' && raw =~ /int|number|numeric|decimal|float|double|real/
+    end
+
+    formula_for = lambda do |format, type, physical_display|
+      ref = "[#{physical_display}]"
+      next "Date(#{ref})" if type.to_s =~ /date|time/i
+      if format == 'yyyyMMdd'
+        text = "Text(#{ref})"
+        next %(Date(Left(#{text}, 4) & "-" & Mid(#{text}, 5, 2) & "-" & Right(#{text}, 2)))
+      end
+      strftime = {
+        'yyyy-MM-dd' => '%Y-%m-%d',
+        'MM/dd/yyyy' => '%m/%d/%Y',
+        'dd/MM/yyyy' => '%d/%m/%Y'
+      }[format]
+      strftime && %(Date(DateParse(Text(#{ref}), "#{strftime}")))
+    end
+
+    fields.each_value do |field|
+      guid = field[:guid]
+      caption = field[:caption]
+      evidence = relation_evidence[guid]
+      formats = evidence.map { |entry| entry[:format] }.reject(&:empty?).uniq
+      if formats.empty?
+        result[:messages] << "GAP: GUID-backed date #{caption.inspect} has no date-parse-format; NOT synthesized"
+        next
+      end
+      if formats.size != 1
+        result[:messages] << "GAP: GUID-backed date #{caption.inspect} has ambiguous date-parse-format values " \
+                             "#{formats.inspect}; NOT synthesized"
+        next
+      end
+      format = formats.first
+
+      owners = evidence.flat_map { |entry| entry[:owners] }
+      owners.concat(metadata_owners[guid])
+      owners = owners.reject(&:empty?).uniq
+      if owners.size != 1 || Array(by_table[owners.first]).size != 1
+        result[:messages] << "GAP: GUID-backed date #{caption.inspect} has ambiguous owning table evidence " \
+                             "#{owners.inspect}; NOT synthesized"
+        next
+      end
+      owner = owners.first
+      fact = by_table.fetch(owner).first
+
+      catalog = Array(warehouse_catalogs && (warehouse_catalogs[owner] || warehouse_catalogs[owner.upcase]))
+      live_names = Array(real_cols && (real_cols[owner] || real_cols[owner.upcase])).map { |name| name.to_s.upcase }
+      mapped = normalized_mapping[caption.upcase] || normalized_mapping[guid.upcase]
+      inferred = caption.gsub(/[^0-9A-Za-z]+/, '_').gsub(/\A_+|_+\z/, '').upcase
+      wanted = mapped.to_s.empty? ? [inferred, "#{inferred}_KEY"] : [mapped]
+      physical_candidates = catalog.select do |entry|
+        entry.is_a?(Hash) && wanted.any? { |name| entry['name'].to_s.casecmp?(name.to_s) }
+      end
+      physical_candidates.select! { |entry| live_names.include?(entry['name'].to_s.upcase) }
+      if physical_candidates.size != 1
+        reason = physical_candidates.empty? ? 'no verified physical warehouse column' : 'ambiguous physical warehouse columns'
+        result[:messages] << "GAP: GUID-backed date #{caption.inspect} has #{reason} on #{owner} " \
+                             "(expected #{wanted.join(' or ')}); NOT synthesized"
+        next
+      end
+      physical = physical_candidates.first
+      physical_name = physical['name'].to_s
+      physical_type = physical['type'].to_s
+      unless physical_type_compatible.call(format, physical_type)
+        result[:messages] << "GAP: GUID-backed date #{caption.inspect} maps to #{owner}.#{physical_name} with " \
+                             "incompatible warehouse type #{physical_type.inspect} for #{format.inspect}; NOT synthesized"
+        next
+      end
+
+      physical_display = display_name(physical_name)
+      physical_display = "#{caption} Key" if physical_display.casecmp?(caption)
+      date_formula = formula_for.call(format, physical_type, physical_display)
+      unless date_formula
+        result[:messages] << "GAP: GUID-backed date #{caption.inspect} uses unsupported date-parse-format " \
+                             "#{format.inspect}; NOT synthesized"
+        next
+      end
+
+      columns = (fact['columns'] ||= [])
+      existing_physical = columns.find do |column|
+        col_display(column).to_s.casecmp?(physical_display) ||
+          column['formula'].to_s.casecmp?("[#{owner}/#{display_name(physical_name)}]")
+      end
+      changed = false
+      unless existing_physical
+        existing_ids = columns.map { |column| column['id'] }.compact.to_set
+        physical_id = "c-#{slug(physical_display)}"
+        suffix = 2
+        while existing_ids.include?(physical_id)
+          physical_id = "c-#{slug(physical_display)}-#{suffix}"
+          suffix += 1
+        end
+        existing_physical = {
+          'id' => physical_id,
+          'name' => physical_display,
+          'formula' => "[#{owner}/#{display_name(physical_name)}]"
+        }
+        columns << existing_physical
+        fact['order'] << physical_id if fact['order']
+        changed = true
+      end
+
+      existing_date = columns.find { |column| col_display(column).to_s.casecmp?(caption) }
+      unless existing_date
+        existing_ids = columns.map { |column| column['id'] }.compact.to_set
+        date_id = "c-#{slug(caption)}"
+        suffix = 2
+        while existing_ids.include?(date_id)
+          date_id = "c-#{slug(caption)}-#{suffix}"
+          suffix += 1
+        end
+        columns << { 'id' => date_id, 'name' => caption, 'formula' => date_formula }
+        fact['order'] << date_id if fact['order']
+        changed = true
+      end
+
+      if changed
+        result[:recovered] += 1
+        source = mapped.to_s.empty? ? 'catalog match' : '--column-mapping'
+        result[:messages] << "GUID-backed date recovered: #{caption.inspect} on #{owner} via #{source} " \
+                             "#{physical_name} (#{physical_type}, #{format})"
+      end
+    end
+
+    result
   end
 
   # ---- computed-key join recovery (bead ovud; role-instanced, R3-1) -----------

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -5172,6 +5172,7 @@ begin
   ref_cmd = ['ruby', File.join(HERE, 'assert-wb-refs-resolve.rb'),
              '--wb-spec', wb_spec_path, '--dm-ids', dm_ids_path,
              '--workdir', WORK] # PR-14: a waived run records itself to offramps.jsonl
+  ref_cmd += ['--metrics', metrics_path] if metrics_path && File.exist?(metrics_path)
   ref_cmd += ['--skip-ref-check', opts[:skip_ref_check]] if opts[:skip_ref_check]
   run_wb!(ref_cmd)
   par_cmd = ['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -4249,6 +4249,23 @@ elsif mechanical
     dim_catalogs[tname.upcase] = cj['columns']
   end
   unless real_cols.empty?
+    # #700: the converter intentionally omits Tableau GUID-backed virtual-
+    # connection dates because their physical identity is not present in the
+    # converter output. Recover them BEFORE the phantom filter, and only when
+    # the TWB date metadata, owning relation, live physical column, and
+    # warehouse type all agree. --column-mapping is an explicit physical-name
+    # signal, but it does not weaken any of the other evidence requirements.
+    if have_twb
+      date_recovery = MechanicalSpecs.recover_guid_backed_date_fields!(
+        dm, File.binread(twb), real_cols, dim_catalogs,
+        column_mapping: opts[:column_mapping]
+      )
+      date_recovery[:messages].each do |message|
+        line message
+        Offramp.log(WORK, kind: 'guid-date-recovery-gap', detail: message.sub(/\AGAP:\s*/, '')) \
+          if message.start_with?('GAP:') && defined?(Offramp)
+      end
+    end
     pf = MechanicalSpecs.fixup_dm_spec(dm, real_cols, column_mapping: opts[:column_mapping])
     line "phantom-column filter: dropped #{pf[:phantom]} non-existent base column(s) using #{real_cols.size} live table catalog(s)" if pf[:phantom].to_i.positive?
     line "column-rename remap: rewired #{pf[:remapped]} base column(s) to their warehouse names (--column-mapping)" if pf[:remapped].to_i.positive?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migration-notes.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migration-notes.rb
@@ -18,6 +18,7 @@
 require 'json'
 require 'set'
 require 'optparse'
+require_relative 'lib/workbook_code'
 
 opts = {}
 OptionParser.new do |p|
@@ -80,7 +81,7 @@ ctx = { name_to_cap: name_to_cap, cap_by_norm: cap_by_norm, param_switch: param_
         param_filter: param_filter, inert: inert, met_norm: met_norm, col_norm: col_norm,
         nk: method(:nk), calc_internal: calc_internal }
 
-kept = Set.new((wb['pages'] || []).flat_map { |pg| (pg['elements'] || []).map { |e| e['id'] } })
+kept = Set.new(WorkbookCode.elements(wb).map { |element| element['id'] })
 ref_re = /\[master\/([^\]]+)\]/i
 collect = lambda do |o, acc|
   case o
@@ -93,18 +94,17 @@ end
 
 PRIORITY = %w[absent-from-sql unresolved-calc aggregate-metric inert-in-source param-measure-picker param-driven].freeze
 rows = []
-(specs['pages'] || []).each do |pg|
-  (pg['elements'] || []).each do |e|
-    next if kept.include?(e['id'])
-    refs = collect.call(e, []).uniq.reject { |r| col_lc.include?(r.downcase) }
-    cats = refs.map { |r| classify(r, ctx) }
-    cats << ['unresolved-calc', 'no resolvable reason captured'] if cats.empty?
-    distinct = cats.map(&:first).uniq.sort_by { |c| PRIORITY.index(c) || 99 }
-    primary = distinct.first
-    reason = (cats.find { |c| c[0] == primary } || cats[0])[1]
-    rows << { page: pg['name'] || pg['id'], tile: e['id'], kind: e['kind'] || e['type'],
-              category: primary, also: distinct[1..] || [], reason: reason, refs: refs.first(5) }
-  end
+WorkbookCode.elements_with_pages(specs).each do |element, page|
+  next if kept.include?(element['id'])
+  refs = collect.call(element, []).uniq.reject { |ref| col_lc.include?(ref.downcase) }
+  cats = refs.map { |ref| classify(ref, ctx) }
+  cats << ['unresolved-calc', 'no resolvable reason captured'] if cats.empty?
+  distinct = cats.map(&:first).uniq.sort_by { |category| PRIORITY.index(category) || 99 }
+  primary = distinct.first
+  reason = (cats.find { |category| category[0] == primary } || cats[0])[1]
+  rows << { page: page && (page['name'] || page['id']), tile: element['id'],
+            kind: element['kind'] || element['type'], category: primary,
+            also: distinct[1..] || [], reason: reason, refs: refs.first(5) }
 end
 
 by_cat = Hash.new(0); rows.each { |r| by_cat[r[:category]] += 1 }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -762,6 +762,11 @@ else
         'elements' => (p['elements'] || []).map do |e|
           el = { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] }
           el['columnLabels'] = labels_by_el[e['id']] if labels_by_el.key?(e['id'])
+          if e.key?('metrics')
+            el['metrics'] = Array(e['metrics']).map do |metric|
+              { 'id' => metric['id'], 'name' => metric['name'] }.compact
+            end
+          end
           el
         end
       }
@@ -853,14 +858,15 @@ if opts[:type] == 'datamodel' && res.is_a?(Net::HTTPSuccess)
     warn '========================================'
   elsif census_problems.any?
     warn "\n========================================"
-    warn "WARN — column census: #{census_problems.size} element(s) lost columns between POST and readback:"
+    warn "WARN — column/metric census: #{census_problems.size} element(s) lost columns or metrics between POST and readback:"
     ColumnCensus.report_lines(census_problems).each { |l| warn "  #{l}" }
-    warn 'These columns were POSTed but the live DM did not resolve them (silent drop —'
-    warn 'no HTTP error, no type=error entry). Downstream [Master/...] refs to missing'
-    warn 'columns will be caught by the pre-POST ref gate (assert-wb-refs-resolve.rb).'
+    warn 'Columns are compared only with GET /columns; metrics are compared only with the'
+    warn 'full DM readback metrics[] census. Downstream [Master/...] and [Metrics/...] refs'
+    warn 'to missing entries will be caught by assert-wb-refs-resolve.rb.'
     warn '========================================'
   elsif posted_spec
-    warn "column census: #{ColumnCensus.posted_column_count(posted_spec)} posted column(s) all resolved in readback"
+    warn "column/metric census: #{ColumnCensus.posted_column_count(posted_spec)} posted column(s) and " \
+         "#{ColumnCensus.posted_metric_count(posted_spec)} posted metric(s) all resolved in their readback namespaces"
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-join-keys.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-join-keys.rb
@@ -65,6 +65,7 @@ require 'json'
 require 'csv'
 require 'optparse'
 require 'securerandom'
+require_relative 'lib/workbook_code'
 
 # K12(a): how long to wait for a probe's CSV export before giving up. Bounded by
 # wall-clock, not iteration count. The previous ~30s ceiling was routinely
@@ -202,7 +203,12 @@ def sigma_sql_rows(conn_id, folder_id, sql, columns, workdir: nil)
   # same way mechanical-specs.rb does.
   spec['folderId'] = folder_id if folder_id
   begin
-    r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+    # Workbook code-rep POSTs require the nested `document` envelope and flat
+    # document.elements. Keep this throwaway probe on the same canonical write
+    # boundary as production workbooks; the legacy flat pages[].elements body
+    # is rejected by the current API.
+    post_body = WorkbookCode.canonicalize(spec)
+    r = Sigma.request(:post, '/v2/workbooks/spec', body: JSON.generate(post_body))
   rescue Sigma::Error => e
     # Keep the HTTP status AND the response-body excerpt on one line so the
     # recorded probe_error names the real cause, not a bare "400 Bad Request".

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-join-keys.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/probe-join-keys.rb
@@ -30,8 +30,9 @@
 # Usage:
 #   ruby scripts/probe-join-keys.rb --workdir <WORK> [--plan PATH]
 #     --connection-id <id> [--folder-id <id>]     # live probe via Sigma;
-#                            # no --folder-id → folderId omitted from the POST
-#                            # (probe lands in My Documents, the API default)
+#                            # omitted flag → infer folderId from the workdir's
+#                            # wb-spec.json or dm-spec.json; current API
+#                            # requires an explicit UUID on workbook creation
 #     [--fixture DIR]        # offline: DIR/entry-<index>.json per ledger entry:
 #                            #   {"total": N, "distinct": M,
 #                            #    "duplicates": [{"keys": {"COL": "v", ...}, "count": 3}, ...]}
@@ -91,6 +92,30 @@ end.parse!
 plan_path = opts[:plan] || (opts[:workdir] && File.join(opts[:workdir], 'join-plan.json'))
 abort 'usage: probe-join-keys.rb --workdir <WORK> [--plan PATH] (--connection-id <id> | --fixture DIR | --resolve N --how H --reason R)' unless plan_path
 abort "FATAL: #{plan_path} not found — run the DM build first (migrate-tableau.rb derives the ledger)" unless File.exist?(plan_path)
+
+# The current workbook-create contract requires folderId. Migration runs
+# already persist the selected destination on wb-spec.json and dm-spec.json,
+# so the generated probe command can stay concise while still emitting the
+# required UUID. Refuse before any live POST if neither source exists; guessing
+# a destination would violate the probe-cleanup/audit contract.
+if opts[:conn] && opts[:folder].to_s.empty? && opts[:workdir]
+  %w[wb-spec.json dm-spec.json].each do |name|
+    path = File.join(opts[:workdir], name)
+    next unless File.exist?(path)
+    begin
+      candidate = JSON.parse(File.read(path))['folderId'].to_s
+      unless candidate.empty?
+        opts[:folder] = candidate
+        break
+      end
+    rescue JSON::ParserError
+      next
+    end
+  end
+end
+if opts[:conn] && opts[:folder].to_s.empty?
+  abort 'FATAL: live join probes require --folder-id <UUID>, or a workdir wb-spec.json/dm-spec.json carrying folderId'
+end
 
 doc = JSON.parse(File.read(plan_path))
 entries = doc.is_a?(Hash) ? (doc['entries'] || []) : doc
@@ -197,11 +222,9 @@ def sigma_sql_rows(conn_id, folder_id, sql, columns, workdir: nil)
       'columns' => columns.map { |c| { 'id' => "c-#{c.downcase.gsub(/[^a-z0-9]+/, '-')}", 'name' => c, 'formula' => "[Custom SQL/#{c}]" } }
     }] }]
   }
-  # folderId only when the caller supplied one. An explicit `folderId: null`
-  # is a live 400 (Twin B e2e); an OMITTED key lands the probe in My Documents
-  # — the API default validate-spec.rb documents, stamped conditionally the
-  # same way mechanical-specs.rb does.
-  spec['folderId'] = folder_id if folder_id
+  # The caller has either supplied or workdir-inferred the destination. The
+  # current API rejects both a missing folderId and an explicit null.
+  spec['folderId'] = folder_id
   begin
     # Workbook code-rep POSTs require the nested `document` envelope and flat
     # document.elements. Keep this throwaway probe on the same canonical write

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/remap-wb-spec-to-dm-ids.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/remap-wb-spec-to-dm-ids.rb
@@ -26,6 +26,7 @@
 
 require 'json'
 require 'optparse'
+require_relative 'lib/workbook_code'
 
 opts = { renames: {} }
 OptionParser.new do |p|
@@ -71,19 +72,17 @@ spec = JSON.parse(File.read(opts[:spec]))
 #    references that POST 4xx with "data model not found".
 n_src = 0
 n_dm  = 0
-(spec['pages'] || []).each do |pg|
-  (pg['elements'] || []).each do |el|
-    src = el['source']
-    next unless src.is_a?(Hash)
-    if (eid = src['elementId']) && id_remap.key?(eid)
-      src['elementId'] = id_remap[eid]
-      n_src += 1
-    end
-    if (dm = src['dataModelId']) && (dm == old_dm_id || id_remap.values.include?(src['elementId']))
-      if src['dataModelId'] != new_dm_id
-        src['dataModelId'] = new_dm_id
-        n_dm += 1
-      end
+WorkbookCode.elements(spec).each do |element|
+  src = element['source']
+  next unless src.is_a?(Hash)
+  if (eid = src['elementId']) && id_remap.key?(eid)
+    src['elementId'] = id_remap[eid]
+    n_src += 1
+  end
+  if (dm = src['dataModelId']) && (dm == old_dm_id || id_remap.values.include?(src['elementId']))
+    if src['dataModelId'] != new_dm_id
+      src['dataModelId'] = new_dm_id
+      n_dm += 1
     end
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-customer-style.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-customer-style.rb
@@ -30,7 +30,7 @@ require 'net/http'
 require 'uri'
 require 'fileutils'
 require 'optparse'
-require_relative 'lib/code_rep'
+require_relative 'lib/workbook_code'
 
 opts = { sample: 20, sort: 'updatedAt:desc', keep_raw: false }
 OptionParser.new do |p|
@@ -141,7 +141,7 @@ wb_ids.each_with_index do |wb_id, i|
   # Workbook code-rep GETs nest schemaVersion/pages under `document` (live
   # since 2026-08) — bare spec['schemaVersion']/spec['pages'] reads here were
   # always nil/empty, so every workbook silently scanned as 0 pages/elements.
-  spec = Sigma::CodeRep.metadata(spec).merge(Sigma::CodeRep.document(spec))
+  spec = Sigma::CodeRep.metadata(spec).merge(WorkbookCode.document(spec))
   File.write(File.join(opts[:out_dir], 'raw-specs', "#{wb_id}.yaml"), spec.to_yaml) if opts[:keep_raw]
 
   profile['sample_size'] += 1
@@ -151,7 +151,7 @@ wb_ids.each_with_index do |wb_id, i|
 
   wb_charts = 0
   pages.each do |page|
-    els = page['elements'] || []
+    els = WorkbookCode.elements_for_page(spec, page)
     chart_els = els.select { |e| e['kind'] && e['kind'] != 'text' && e['kind'] != 'container' }
     profile['elements_per_page'] << chart_els.size
     controls_count = els.count { |e| e['kind'] == 'control' || e['kind'].to_s.start_with?('control-') }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-census.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-column-census.rb
@@ -27,9 +27,14 @@ def posted_spec(names_by_element)
 end
 
 # Readback: server REASSIGNS element ids (DM POST always does) — names survive.
-def readback_spec(el_names)
+def readback_spec(el_names, metrics_by_element: {})
   { 'pages' => [{ 'id' => 'srv-pg', 'name' => 'Model', 'elements' =>
-    el_names.map.with_index { |n, i| { 'id' => "srv-el-#{i}", 'kind' => 'table', 'name' => n } } }] }
+    el_names.map.with_index do |n, i|
+      { 'id' => "srv-el-#{i}", 'kind' => 'table', 'name' => n,
+        'metrics' => Array(metrics_by_element[n]).map.with_index do |metric, mi|
+          { 'id' => "srv-metric-#{mi}", 'name' => metric }
+        end }
+    end }] }
 end
 
 def entries_for(labels_by_server_id, error_labels: [])
@@ -97,13 +102,23 @@ problems = ColumnCensus.census(posted, rb, entries_for({ 'kept-id' => %w[Sales] 
 check(problems.empty?, 'nameless element matched by surviving id', fails)
 
 puts
-puts 'Part G — metrics counted alongside columns'
+puts 'Part G — metrics resolve only against readback metrics[]'
 posted = { 'pages' => [{ 'elements' => [{ 'id' => 'e1', 'name' => 'Fact', 'kind' => 'table',
                                           'columns' => [{ 'id' => 'c1', 'name' => 'Sales' }],
                                           'metrics' => [{ 'id' => 'm1', 'name' => 'Total Sales' }] }] }] }
-rb = readback_spec(['Fact'])
+rb = readback_spec(['Fact'], metrics_by_element: { 'Fact' => ['Total Sales'] })
 problems = ColumnCensus.census(posted, rb, entries_for({ 'srv-el-0' => ['Sales'] }))
-check(problems.size == 1 && problems.first['missing'] == ['Total Sales'], 'missing metric caught', fails)
+check(problems.empty?, 'metric present in readback metrics[] passes even though absent from /columns', fails)
+check(ColumnCensus.posted_column_count(posted) == 1, 'posted_column_count excludes metrics', fails)
+check(ColumnCensus.posted_metric_count(posted) == 1, 'posted_metric_count counts metrics separately', fails)
+
+rb = readback_spec(['Fact'])
+problems = ColumnCensus.census(posted, rb, entries_for({ 'srv-el-0' => ['Sales', 'Total Sales'] }))
+check(problems.size == 1 && problems.first['missing_metrics'] == ['Total Sales'],
+      'same-named /columns entry does not satisfy a posted metric', fails)
+check(problems.first['missing_columns'].empty?, 'metric miss is not reported as a column miss', fails)
+check(ColumnCensus.report_lines(problems).any? { |line| line.include?('missing metrics 1: Total Sales') },
+      'report clearly labels a missing metric', fails)
 
 puts
 if fails.empty?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fidelity-loop.rb
@@ -168,6 +168,25 @@ Dir.mktmpdir do |dir|
      'nested `document.layout` preserved through the merge')
   ok(nested_doc && nested_doc.dig('settings', 'theme', 'overrides', 'categoricalScheme') == ['#0e7c7b'],
      'patch still applies inside the canonical nested live spec')
+
+  # #698 / live RCF regression: workbook patches use flat document.elements.
+  # A partial element patch must merge into the complete flat record, never
+  # shadow it with an id/style-only record after a legacy pages[] conversion.
+  nested_live['document']['elements'] << { 'id' => 'k2', 'kind' => 'bar-chart' }
+  nested_live['document']['layout'] = '<Page id="PG"><Element elementId="k1"/><Element elementId="k2"/></Page>'
+  File.write(File.join(dir, 'nested-live.json'), JSON.generate(nested_live))
+  File.write(File.join(dir, 'element-patch.json'),
+             JSON.generate('elements' => [{ 'id' => 'k1', 'style' => { 'backgroundColor' => '#ffffff' } }]))
+  out, st = run('apply-patch', '--patch', File.join(dir, 'element-patch.json'),
+                '--dry-run', '--live-spec', File.join(dir, 'nested-live.json'),
+                '--out', File.join(dir, 'element-merged.json'), dir: dir)
+  element_doc = JSON.parse(File.read(File.join(dir, 'element-merged.json')))['document']
+  element_k1 = element_doc['elements'].find { |element| element['id'] == 'k1' }
+  ok(st.exitstatus.zero?, 'flat document.elements fidelity patch exits 0')
+  ok(element_k1['kind'] == 'kpi-chart' && element_k1.dig('style', 'backgroundColor') == '#ffffff',
+     'partial flat element patch preserves required kind and merges style')
+  ok(element_doc['elements'].any? { |element| element['id'] == 'k2' && element['kind'] == 'bar-chart' },
+     'partial flat element patch preserves unpatched sibling elements')
 end
 
 puts 'RCF page picking (#422):'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-guid-date-recovery.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-guid-date-recovery.rb
@@ -1,0 +1,188 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require_relative 'mechanical-specs'
+
+fails = []
+def check(condition, message, fails)
+  fails << message unless condition
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+end
+
+GUID = 'c2ec6b07-897e-39ab-9422-aa895d35a627'
+
+def model(table: 'ORDER_FACT')
+  fact = {
+    'id' => 'el-fact',
+    'kind' => 'table',
+    'name' => 'Order Fact',
+    'source' => { 'kind' => 'warehouse-table', 'path' => ['DB', 'SCHEMA', table] },
+    'columns' => [{ 'id' => 'c-order-id', 'name' => 'Order Id', 'formula' => "[#{table}/Order Id]" }],
+    'order' => ['c-order-id']
+  }
+  derived = {
+    'id' => 'el-derived',
+    'kind' => 'table',
+    'name' => 'Order Fact View',
+    'source' => { 'kind' => 'table', 'elementId' => 'el-fact' },
+    'columns' => [],
+    'order' => []
+  }
+  { 'pages' => [{ 'id' => 'page-model', 'elements' => [fact, derived] }] }
+end
+
+def twb(caption: 'Order Date', format: 'yyyyMMdd', second_owner: false)
+  relation = lambda do |name|
+    <<~XML
+      <relation name='#{name}' table='[#{name}]' type='table'>
+        <columns>
+          <column datatype='date' date-parse-format='#{format}' name='#{GUID}' />
+        </columns>
+      </relation>
+    XML
+  end
+  <<~XML
+    <workbook>
+      <datasource>
+        <connection>
+          <relation type='collection'>
+            #{relation.call('ORDER_FACT')}
+            #{second_owner ? relation.call('ORDER_FACT_ALT') : ''}
+          </relation>
+          <metadata-records>
+            <metadata-record class='column'>
+              <remote-name>#{GUID}</remote-name>
+              <local-name>[#{GUID}]</local-name>
+              <parent-name>[ORDER_FACT]</parent-name>
+              <local-type>date</local-type>
+            </metadata-record>
+          </metadata-records>
+        </connection>
+        <column caption='#{caption} ' datatype='date' name='[#{GUID}]' role='dimension' />
+      </datasource>
+    </workbook>
+  XML
+end
+
+def fact(model)
+  MechanicalSpecs.all_elements(model).find { |element| element['id'] == 'el-fact' }
+end
+
+puts 'Part A — GUID-backed yyyyMMdd field is recovered before phantom filtering'
+m = model
+catalogs = {
+  'ORDER_FACT' => [
+    { 'name' => 'ORDER_ID', 'type' => 'NUMBER' },
+    { 'name' => 'ORDER_DATE_KEY', 'type' => 'NUMBER' }
+  ]
+}
+result = MechanicalSpecs.recover_guid_backed_date_fields!(
+  m, twb, { 'ORDER_FACT' => %w[ORDER_ID ORDER_DATE_KEY] }, catalogs
+)
+names = fact(m)['columns'].map { |column| column['name'] }
+date = fact(m)['columns'].find { |column| column['name'] == 'Order Date' }
+check(result[:recovered] == 1, "one field recovered (got #{result.inspect})", fails)
+check(names.include?('Order Date Key'), 'verified physical ORDER_DATE_KEY is emitted', fails)
+check(date && date['formula'].include?('Date(Left(Text([Order Date Key])'),
+      "date-typed Order Date is synthesized from the key (got #{date.inspect})", fails)
+
+fixup = MechanicalSpecs.fixup_dm_spec(
+  m, { 'ORDER_FACT' => %w[ORDER_ID ORDER_DATE_KEY] }
+)
+names_after = fact(m)['columns'].map { |column| column['name'] }
+check(fixup[:phantom].zero? && names_after.include?('Order Date Key') && names_after.include?('Order Date'),
+      'recovered key/date survive the phantom filter', fails)
+
+puts
+puts 'Part B — --column-mapping injects an omitted mapped date field'
+mapped = model(table: 'INVOICE_FACT')
+mapped_catalog = {
+  'INVOICE_FACT' => [
+    { 'name' => 'ORDER_ID', 'type' => 'NUMBER' },
+    { 'name' => 'INVOICE_DT_INT', 'type' => 'INTEGER' }
+  ]
+}
+mapped_result = MechanicalSpecs.recover_guid_backed_date_fields!(
+  mapped,
+  twb(caption: 'Invoice Date').gsub('ORDER_FACT', 'INVOICE_FACT'),
+  { 'INVOICE_FACT' => %w[ORDER_ID INVOICE_DT_INT] },
+  mapped_catalog,
+  column_mapping: { 'Invoice Date' => 'INVOICE_DT_INT' }
+)
+mapped_names = fact(mapped)['columns'].map { |column| column['name'] }
+mapped_date = fact(mapped)['columns'].find { |column| column['name'] == 'Invoice Date' }
+check(mapped_result[:recovered] == 1, "mapped omitted field recovered (got #{mapped_result.inspect})", fails)
+check(mapped_names.include?('Invoice Dt Int'), 'mapped physical column is injected', fails)
+check(mapped_date && mapped_date['formula'].include?('[Invoice Dt Int]'),
+      'mapped date synthesis references the injected physical column', fails)
+
+puts
+puts 'Part C — recovery is idempotent'
+before = JSON.generate(mapped)
+second = MechanicalSpecs.recover_guid_backed_date_fields!(
+  mapped,
+  twb(caption: 'Invoice Date').gsub('ORDER_FACT', 'INVOICE_FACT'),
+  { 'INVOICE_FACT' => %w[ORDER_ID INVOICE_DT_INT] },
+  mapped_catalog,
+  column_mapping: { 'Invoice Date' => 'INVOICE_DT_INT' }
+)
+check(second[:recovered].zero?, "second run reports no recovery (got #{second.inspect})", fails)
+check(JSON.generate(mapped) == before, 'second run leaves the model byte-identical', fails)
+
+puts
+puts 'Part D — synthesis refuses insufficient or incompatible evidence'
+no_format = model
+r1 = MechanicalSpecs.recover_guid_backed_date_fields!(
+  no_format, twb(format: ''), { 'ORDER_FACT' => %w[ORDER_ID ORDER_DATE_KEY] }, catalogs
+)
+check(r1[:recovered].zero? && fact(no_format)['columns'].size == 1,
+      'missing parse format does not synthesize a date', fails)
+
+ambiguous = model
+ambiguous['pages'][0]['elements'].insert(
+  1,
+  {
+    'id' => 'el-alt',
+    'kind' => 'table',
+    'name' => 'Order Fact Alt',
+    'source' => { 'kind' => 'warehouse-table', 'path' => %w[DB SCHEMA ORDER_FACT_ALT] },
+    'columns' => [],
+    'order' => []
+  }
+)
+r2 = MechanicalSpecs.recover_guid_backed_date_fields!(
+  ambiguous,
+  twb(second_owner: true),
+  { 'ORDER_FACT' => %w[ORDER_ID ORDER_DATE_KEY],
+    'ORDER_FACT_ALT' => %w[ORDER_ID ORDER_DATE_KEY] },
+  catalogs.merge('ORDER_FACT_ALT' => catalogs['ORDER_FACT'])
+)
+check(r2[:recovered].zero? && r2[:messages].any? { |message| message.include?('ambiguous owning table') },
+      "ambiguous owner refuses clearly (got #{r2.inspect})", fails)
+
+incompatible = model
+bad_catalog = {
+  'ORDER_FACT' => [
+    { 'name' => 'ORDER_ID', 'type' => 'NUMBER' },
+    { 'name' => 'ORDER_DATE_KEY', 'type' => 'BOOLEAN' }
+  ]
+}
+r3 = MechanicalSpecs.recover_guid_backed_date_fields!(
+  incompatible,
+  twb,
+  { 'ORDER_FACT' => %w[ORDER_ID ORDER_DATE_KEY] },
+  bad_catalog
+)
+check(r3[:recovered].zero? && r3[:messages].any? { |message| message.include?('incompatible warehouse type') },
+      "incompatible physical type refuses clearly (got #{r3.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — GUID-backed date recovery is evidence-gated, mapped, and idempotent'
+  exit 0
+else
+  puts "FAILURES (#{fails.size}):"
+  fails.each { |failure| puts "  - #{failure}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-join-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-join-plan.rb
@@ -144,7 +144,7 @@ check(e['status'] == 'unprobed' && e['grain_assumption'] == 'right unique on key
 
 puts "\n== object-graph duplicate-table role resolves its suffixed GUID + physical VC table =="
 role_guid = '737611ae-3a14-349a-8fa8-d92dd0bb0432'
-role_name = 'DATE_DIM (CSA.DATE_DIM)1'
+role_name = 'DATE_DIM (DEMO_SCHEMA.DATE_DIM)1'
 role_xml = <<~XML
   <workbook>
     <datasource>
@@ -154,15 +154,15 @@ role_xml = <<~XML
         <objects>
           <object id='fact'>
             <properties>
-              <relation name='ORDER_FACT (CSA.ORDER_FACT)'
-                        table='[fact-inode].[ORDER_FACT (CSA.ORDER_FACT)]'
+              <relation name='EVENT_FACT (DEMO_SCHEMA.EVENT_FACT)'
+                        table='[fact-inode].[EVENT_FACT (DEMO_SCHEMA.EVENT_FACT)]'
                         type='table' />
             </properties>
           </object>
           <object id='date-role'>
             <properties>
               <relation name='#{role_name}'
-                        table='[date-inode].[DATE_DIM (CSA.DATE_DIM)]'
+                        table='[date-inode].[DATE_DIM (DEMO_SCHEMA.DATE_DIM)]'
                         type='table' />
             </properties>
           </object>
@@ -181,7 +181,7 @@ role_xml = <<~XML
     </datasource>
   </workbook>
 XML
-entries = JoinPlan.derive(nil, role_xml, db: 'CSA', schema: 'TJ')
+entries = JoinPlan.derive(nil, role_xml, db: 'DEMO_DB', schema: 'DEMO_SCHEMA')
 check(entries.size == 1, "duplicate-table role yields one relationship entry (got #{entries.size})", fails)
 e = entries.first || {}
 check(e['right'] == role_name, 'ledger preserves the Tableau role name for provenance', fails)
@@ -189,7 +189,7 @@ check(e['keys'] == ["#{role_guid} (#{role_name})"],
       'ledger preserves the role-suffixed GUID key for provenance', fails)
 check(e['probe_keys'] == ['DATE_KEY'],
       "role-suffixed GUID resolves through its exact caption (got #{e['probe_keys'].inspect})", fails)
-check(e['right_table'] == 'CSA.TJ.DATE_DIM',
+check(e['right_table'] == 'DEMO_DB.DEMO_SCHEMA.DATE_DIM',
       "numeric Tableau role suffix does not corrupt the physical VC FQN (got #{e['right_table'].inspect})", fails)
 
 puts "\n== function-wrapped (computed-key) join side still records the join =="

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-join-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-join-plan.rb
@@ -142,6 +142,56 @@ check(e['right_table'] == 'ANALYTICS.PUBLIC.STATE_REF',
 check(e['status'] == 'unprobed' && e['grain_assumption'] == 'right unique on keys',
       'relationship joins carry the same grain assumption (Tableau culls per-viz; Sigma fans out)', fails)
 
+puts "\n== object-graph duplicate-table role resolves its suffixed GUID + physical VC table =="
+role_guid = '737611ae-3a14-349a-8fa8-d92dd0bb0432'
+role_name = 'DATE_DIM (CSA.DATE_DIM)1'
+role_xml = <<~XML
+  <workbook>
+    <datasource>
+      <column caption='Date Key' datatype='integer'
+              name='[#{role_guid} (#{role_name})]' />
+      <object-graph>
+        <objects>
+          <object id='fact'>
+            <properties>
+              <relation name='ORDER_FACT (CSA.ORDER_FACT)'
+                        table='[fact-inode].[ORDER_FACT (CSA.ORDER_FACT)]'
+                        type='table' />
+            </properties>
+          </object>
+          <object id='date-role'>
+            <properties>
+              <relation name='#{role_name}'
+                        table='[date-inode].[DATE_DIM (CSA.DATE_DIM)]'
+                        type='table' />
+            </properties>
+          </object>
+        </objects>
+        <relationships>
+          <relationship>
+            <expression op='='>
+              <expression op='[fact-date-key]' />
+              <expression op='[#{role_guid} (#{role_name})]' />
+            </expression>
+            <first-end-point object-id='fact' />
+            <second-end-point object-id='date-role' />
+          </relationship>
+        </relationships>
+      </object-graph>
+    </datasource>
+  </workbook>
+XML
+entries = JoinPlan.derive(nil, role_xml, db: 'CSA', schema: 'TJ')
+check(entries.size == 1, "duplicate-table role yields one relationship entry (got #{entries.size})", fails)
+e = entries.first || {}
+check(e['right'] == role_name, 'ledger preserves the Tableau role name for provenance', fails)
+check(e['keys'] == ["#{role_guid} (#{role_name})"],
+      'ledger preserves the role-suffixed GUID key for provenance', fails)
+check(e['probe_keys'] == ['DATE_KEY'],
+      "role-suffixed GUID resolves through its exact caption (got #{e['probe_keys'].inspect})", fails)
+check(e['right_table'] == 'CSA.TJ.DATE_DIM',
+      "numeric Tableau role suffix does not corrupt the physical VC FQN (got #{e['right_table'].inspect})", fails)
+
 puts "\n== function-wrapped (computed-key) join side still records the join =="
 fn_xml = File.read(FIX1).sub("op='[REV_PRIMARY].[ENTITY_ID]'", "op='DATE([REV_PRIMARY].[ENTITY_ID])'")
 entries = JoinPlan.derive(nil, fn_xml)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-audit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-audit.rb
@@ -113,6 +113,23 @@ check(by['Dropped Seats'] && by['Dropped Seats']['class'] == 'silently-dropped',
 check(by['Declared Residue'] && by['Declared Residue']['class'] == 'manual-residue' && by['Declared Residue']['status'] == 'resolved',
       'explicit manual-residues.json entry → resolved manual-residue', fails)
 
+puts 'Part B1 — source census proves an un-emitted LOD is unused (resolved without waiver)'
+unused_entries = LodAudit.derive(
+  calcs,
+  dm_spec: JSON.parse(JSON.generate(DM_SPEC)),
+  wb_spec: nil,
+  manual_residues: JSON.parse(JSON.generate(MANUAL_RESIDUES)),
+  unused_fields: ['[Dropped Seats]', '[Aliased Seats]']
+)
+unused_by = unused_entries.each_with_object({}) { |entry, index| index[entry['calc']] = entry }
+check(unused_by['Dropped Seats']['class'] == 'unused-source' &&
+      unused_by['Dropped Seats']['status'] == 'resolved',
+      'un-emitted calc named by the source unused-field census → resolved unused-source', fails)
+check(unused_by['Dropped Seats'].dig('evidence', 'kind') == 'source-unused-field-census',
+      'unused-source resolution carries explicit census evidence', fails)
+check(unused_by['Aliased Seats']['class'] == 'suspect-alias',
+      'unused-field census never masks an emitted suspect alias', fails)
+
 puts 'Part B2 — reference-derived: a formula built strictly from the LOD refs resolves'
 wb = { 'pages' => [{ 'elements' => [
   { 'id' => 'el-kpi', 'kind' => 'kpi-chart', 'name' => 'Seats KPI',
@@ -135,6 +152,21 @@ wb3 = { 'pages' => [{ 'elements' => [
 e3 = LodAudit.derive(calcs, dm_spec: nil, wb_spec: wb3, manual_residues: nil)
 d3 = e3.find { |x| x['calc'] == 'Dropped Seats' }
 check(d3 && d3['class'] == 'lod-synth', 'grouped helper element → lod-synth even with rewired refs', fails)
+
+puts 'Part B3b — current flat workbook document.elements is audited too'
+wb3_flat = {
+  'document' => {
+    'schemaVersion' => 1,
+    'kind' => 'workbook',
+    'pages' => [{ 'id' => 'p1', 'name' => 'Page 1' }],
+    'elements' => wb3['pages'][0]['elements'],
+    'layout' => '<Page id="p1"><Element elementId="el-h"/></Page>'
+  }
+}
+e3_flat = LodAudit.derive(calcs, dm_spec: nil, wb_spec: wb3_flat, manual_residues: nil)
+d3_flat = e3_flat.find { |x| x['calc'] == 'Dropped Seats' }
+check(d3_flat && d3_flat['class'] == 'lod-synth',
+      'flat workbook grouped helper is visible to the LOD audit', fails)
 
 puts 'Part B4 — passthrough-only ref is NOT evidence (still dropped)'
 wb4 = { 'pages' => [{ 'elements' => [
@@ -264,6 +296,19 @@ Dir.mktmpdir do |dir|
                                  '--resolve', idx['Active Seats'].to_s, '--how', 'waived', '--reason', 'x')
   check(!st4.success? && e4s.include?('only suspect-alias/silently-dropped'),
         'resolving a resolved entry is refused', fails)
+end
+
+puts 'Part D2 — audit script consumes source unused-field census'
+Dir.mktmpdir do |dir|
+  dropped_only = { 'calcs' => [CALC_FIELDS['calcs'].find { |calc| calc['name'] == 'Dropped Seats' }] }
+  gaps = { 'field_statistics' => { 'unused_field_names' => ['[Dropped Seats]'] } }
+  File.write(File.join(dir, 'calc-fields.json'), JSON.pretty_generate(dropped_only))
+  File.write(File.join(dir, 'workbook-content-gaps-report.json'), JSON.pretty_generate(gaps))
+
+  out, err, st = Open3.capture3(RbConfig.ruby, SCRIPT, '--workdir', dir)
+  check(st.success?, "unused-only LOD audit exits 0 (got #{st.exitstatus}: #{err.lines.first})", fails)
+  check(out.include?('[unused-source]') && out.include?('0 unresolved'),
+        'script reports unused-source as resolved without a manual/waived resolution', fails)
 end
 
 puts 'Part B6 — wave-2 §6.6: wrong-FROM grouped Custom-SQL helper is NOT synth evidence'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-metric-reference.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-metric-reference.rb
@@ -190,7 +190,7 @@ check(f5 == '[Metrics/Gross Revenue]',
 #    exits 1 (the fix stops the EMISSION; the gate keeps catching real misses).
 GATE = File.join(DIR, 'assert-wb-refs-resolve.rb')
 require 'open3'
-def run_gate(formula)
+def run_gate(formula, metric: true)
   Dir.mktmpdir do |d|
     wb = { 'schemaVersion' => 1, 'name' => 'gate-probe', 'pages' => [
       { 'id' => 'pg1', 'name' => 'P1', 'elements' => [
@@ -198,9 +198,12 @@ def run_gate(formula)
           'columns' => [{ 'id' => 'c1', 'name' => 'Probe Measure', 'formula' => formula }] }
       ] }
     ] }
+    dm_element = { 'id' => 'el1', 'name' => 'Freight Fact',
+                   'columnLabels' => ['Depot', 'Linehaul Cost'] }
+    dm_element['metrics'] = [{ 'id' => 'metric-linehaul-cost', 'name' => 'Linehaul Cost' }] if metric
     ids = { 'dataModelId' => 'dm-fixture', 'pages' => [
       { 'id' => 'dp1', 'name' => 'Data', 'elements' => [
-        { 'id' => 'el1', 'name' => 'Freight Fact', 'columnLabels' => ['Depot', 'Linehaul Cost'] }
+        dm_element
       ] }
     ] }
     File.write(File.join(d, 'wb-spec.json'), JSON.dump(wb))
@@ -214,7 +217,10 @@ gout, gcode = run_gate('[Metrics/Ghost Rate]')
 check(gcode == 1 && gout.include?('Ghost Rate'),
       "ref gate fails closed on a genuinely-absent metric (exit #{gcode})", fails)
 _gout2, gcode2 = run_gate('[Metrics/Linehaul Cost]')
-check(gcode2 == 0, "ref gate control: a readback-backed name still passes (exit #{gcode2})", fails)
+check(gcode2 == 0, "ref gate control: a readback metric still passes (exit #{gcode2})", fails)
+gout3, gcode3 = run_gate('[Metrics/Linehaul Cost]', metric: false)
+check(gcode3 == 1 && gout3.include?('no DM metrics census'),
+      "ref gate refuses to resolve [Metrics/name] from columnLabels alone (exit #{gcode3})", fails)
 
 if fails.empty?
   puts 'ALL PASS — tableau workbook measures bind to [Metrics/<name>] (byte-identical fallback; F4 collision shape stays inline)'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-metrics-namespace.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-metrics-namespace.rb
@@ -25,8 +25,8 @@
 #   T3 no-trip:  census names resolve via context / sidecar / --metrics /
 #                local element metrics (Parts A-D)
 #   T4 clear:    --type datamodel self-census admit + reject (Part I)
-#   T5 contract: NO census anywhere → the pre-W2.8 unknown-prefix ERROR is
-#                byte-compatible, plus a routing hint (Part H)
+#   T5 contract: NO census anywhere → a named metrics-census ERROR plus a
+#                routing hint (Part H); never fall back to column namespaces
 #   T6 degrade:  unparseable sidecar → WARN, never abort; validation proceeds
 #                census-less (Part J)
 #
@@ -148,11 +148,12 @@ Dir.mktmpdir do |dir|
   check(out.include?('prefix "Bogus" unknown'), 'bogus prefix still errors as unknown', fails)
 end
 
-puts 'Part H — NO census anywhere → unchanged unknown-prefix ERROR, with the routing hint'
+puts 'Part H — NO census anywhere → explicit metrics-census ERROR, with the routing hint'
 Dir.mktmpdir do |dir|
   out, code = run_validate(dir, wb_spec('[Metrics/Gross Revenue]'), ctx: dm_context) # no metrics, no sidecar
   check(code == 1, "no census → still exit 1 (got #{code})", fails)
-  check(out.include?('prefix "Metrics" unknown'), 'unknown-prefix error preserved', fails)
+  check(out.include?('no DM metrics census'),
+        'missing census is named explicitly (never resolved through columns)', fails)
   check(out.include?('--metrics'), 'error hints at the census routing (--metrics / sidecar)', fails)
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-plan-freshness.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-plan-freshness.rb
@@ -23,16 +23,18 @@ def check(cond, msg, fails)
 end
 
 WB_SPEC = {
-  'pages' => [{
-    'id' => 'p1', 'name' => 'Data',
+  'document' => {
+    'pages' => [{ 'id' => 'p1', 'name' => 'Data' }],
     'elements' => [
       { 'id' => 'master', 'kind' => 'table', 'source' => { 'kind' => 'data-model', 'dataModelId' => 'dm', 'elementId' => 'e' },
         'columns' => [{ 'id' => 'm-region', 'name' => 'Region' }, { 'id' => 'm-rev', 'name' => 'Net Revenue' }] },
       { 'id' => 'el-chart', 'kind' => 'bar-chart', 'name' => 'Chart',
+        'source' => { 'kind' => 'table', 'elementId' => 'master' },
         'xAxis' => { 'columnId' => 'm-region' }, 'yAxis' => { 'columnIds' => ['m-rev'] },
         'columns' => [{ 'id' => 'm-region', 'name' => 'Region' }, { 'id' => 'm-rev', 'name' => 'Net Revenue' }] }
-    ]
-  }]
+    ],
+    'layout' => '<Page id="p1"><Element elementId="master"/><Element elementId="el-chart"/></Page>'
+  }
 }
 
 plan = nil

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-join-keys.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-join-keys.rb
@@ -11,12 +11,12 @@
 # missing fixture → status error + exit 3; probe SQL recorded on the entry.
 #
 # Live-path coverage (stubbed sigma_rest, same -I <stub> -r sigma_rest seam as
-# test-parity-render-verify-fallback.rb): no --folder-id → the probe-workbook
-# POST body carries NO folderId key (an explicit null is a live 400, Twin B
-# e2e); the body uses the current nested document envelope with flat elements;
-# --folder-id supplied → stamped; a POST 400 → probe_error records the HTTP
-# status + response-body excerpt and the console prints a --folder-id hint when
-# the error mentions the folder.
+# test-parity-render-verify-fallback.rb): no --folder-id → infer the required
+# UUID from the migration workdir's wb-spec.json; no flag or artifact refuses
+# before a POST; the body uses the current nested document envelope with flat
+# elements; --folder-id supplied → stamped; a POST 400 → probe_error records
+# the HTTP status + response-body excerpt and the console prints a --folder-id
+# hint when the error mentions the folder.
 #
 # W2.9 identifier-legality gate — six-trajectory matrix (the oracle itself is
 # unit-covered in test-sql-ident-check.rb Part J; derivation stripping in
@@ -321,9 +321,10 @@ Dir.mktmpdir do |dir|
   check(ledger(dir)[0]['status'] == 'error', 'ledger status error (gate still blocks)', fails)
 end
 
-puts "\n== live probe, no --folder-id → POST body has NO folderId key =="
+puts "\n== live probe, no --folder-id → infer required folderId from wb-spec.json =="
 Dir.mktmpdir do |dir|
   workdir_with(dir, [entry])
+  File.write(File.join(dir, 'wb-spec.json'), JSON.generate('folderId' => 'fld-inferred'))
   log = File.join(dir, 'stub.log')
   _out, err, st = run_probe_live(dir, { 'SIGMA_STUB_LOG' => log }, '--connection-id', 'conn-1')
   check(st.success?, "live-stub unique → exit 0 (got #{st.exitstatus}: #{err.lines.first})", fails)
@@ -331,8 +332,8 @@ Dir.mktmpdir do |dir|
   posts = spec_posts(log)
   check(posts.size == 2, "two probe-workbook POSTs (dup sample + totals; got #{posts.size})", fails)
   bodies = posts.map { |r| JSON.parse(r['body']) }
-  check(bodies.all? { |b| !b.key?('folderId') },
-        'no --folder-id → POST body carries NO folderId key (explicit null is a live 400)', fails)
+  check(bodies.all? { |b| b['folderId'] == 'fld-inferred' },
+        'no --folder-id → POST body carries the workdir-inferred destination UUID', fails)
   check(bodies.all? { |b|
           doc = b['document']
           doc.is_a?(Hash) && doc['schemaVersion'] == 1 && doc['kind'] == 'workbook' &&
@@ -342,6 +343,18 @@ Dir.mktmpdir do |dir|
             !b.key?('schemaVersion') && !b.key?('pages')
         },
         'probe POST uses nested document, flat elements, and layout-owned page membership', fails)
+end
+
+puts "\n== live probe, no --folder-id and no workdir destination → refuse before POST =="
+Dir.mktmpdir do |dir|
+  workdir_with(dir, [entry])
+  log = File.join(dir, 'stub.log')
+  _out, err, st = run_probe_live(dir, { 'SIGMA_STUB_LOG' => log }, '--connection-id', 'conn-1')
+  check(!st.success?, 'missing required destination exits nonzero', fails)
+  check(err.include?('require --folder-id') && err.include?('wb-spec.json/dm-spec.json'),
+        'failure names both the explicit flag and workdir inference path', fails)
+  check(!File.exist?(log) || spec_posts(log).empty?,
+        'missing destination refuses before any live probe-workbook POST', fails)
 end
 
 puts "\n== live probe, --folder-id supplied → folderId stamped on the POST body =="
@@ -358,7 +371,8 @@ end
 puts "\n== live probe POST 400 → probe_error carries status + body excerpt + --folder-id hint =="
 Dir.mktmpdir do |dir|
   workdir_with(dir, [entry])
-  out, _err, st = run_probe_live(dir, { 'SIGMA_STUB_400' => '1' }, '--connection-id', 'conn-1')
+  out, _err, st = run_probe_live(dir, { 'SIGMA_STUB_400' => '1' },
+                                 '--connection-id', 'conn-1', '--folder-id', 'fld-bad')
   check(st.exitstatus == 3, "probe error → exit 3 (got #{st.exitstatus})", fails)
   e = ledger(dir)[0]
   check(e['status'] == 'error', 'ledger status error (gate still blocks)', fails)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-join-keys.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-join-keys.rb
@@ -13,9 +13,10 @@
 # Live-path coverage (stubbed sigma_rest, same -I <stub> -r sigma_rest seam as
 # test-parity-render-verify-fallback.rb): no --folder-id → the probe-workbook
 # POST body carries NO folderId key (an explicit null is a live 400, Twin B
-# e2e); --folder-id supplied → stamped; a POST 400 → probe_error records the
-# HTTP status + response-body excerpt and the console prints a --folder-id
-# hint when the error mentions the folder.
+# e2e); the body uses the current nested document envelope with flat elements;
+# --folder-id supplied → stamped; a POST 400 → probe_error records the HTTP
+# status + response-body excerpt and the console prints a --folder-id hint when
+# the error mentions the folder.
 #
 # W2.9 identifier-legality gate — six-trajectory matrix (the oracle itself is
 # unit-covered in test-sql-ident-check.rb Part J; derivation stripping in
@@ -332,7 +333,15 @@ Dir.mktmpdir do |dir|
   bodies = posts.map { |r| JSON.parse(r['body']) }
   check(bodies.all? { |b| !b.key?('folderId') },
         'no --folder-id → POST body carries NO folderId key (explicit null is a live 400)', fails)
-  check(bodies.all? { |b| b['schemaVersion'] == 1 && b['pages'] }, 'probe spec envelope otherwise intact', fails)
+  check(bodies.all? { |b|
+          doc = b['document']
+          doc.is_a?(Hash) && doc['schemaVersion'] == 1 && doc['kind'] == 'workbook' &&
+            doc['pages'].is_a?(Array) && doc['pages'].none? { |page| page.key?('elements') } &&
+            doc['elements'].is_a?(Array) && doc['elements'].one? &&
+            doc['elements'][0]['id'] == 'probe' && !doc['layout'].to_s.empty? &&
+            !b.key?('schemaVersion') && !b.key?('pages')
+        },
+        'probe POST uses nested document, flat elements, and layout-owned page membership', fails)
 end
 
 puts "\n== live probe, --folder-id supplied → folderId stamped on the POST body =="

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-join-keys.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-probe-join-keys.rb
@@ -244,7 +244,8 @@ puts "\n== W2.9: live path — refused identifier sends NOTHING (zero POSTs) =="
 Dir.mktmpdir do |dir|
   workdir_with(dir, [entry('probe_keys' => ['PRODUCT_KEY_(PRODUCT_DIM)'])])
   log = File.join(dir, 'stub.log')
-  _out, _err, st = run_probe_live(dir, { 'SIGMA_STUB_LOG' => log }, '--connection-id', 'conn-1')
+  _out, _err, st = run_probe_live(dir, { 'SIGMA_STUB_LOG' => log },
+                                  '--connection-id', 'conn-1', '--folder-id', 'fld-123')
   check(st.exitstatus == 3, "live refused → exit 3 (got #{st.exitstatus})", fails)
   check(!File.exist?(log) || spec_posts(log).empty?,
         'refused identifier → ZERO probe-workbook POSTs (never live SQL)', fails)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
@@ -27,7 +27,8 @@ end
 
 DM = { 'dataModelId' => 'dm1', 'pages' => [{ 'elements' => [
   { 'id' => 'e1', 'name' => 'Master',
-    'columnLabels' => ['Net Revenue', 'Region', 'Customer Id (CUSTOMER_DIM)'] }
+    'columnLabels' => ['Net Revenue', 'Region', 'Customer Id (CUSTOMER_DIM)'],
+    'metrics' => [{ 'id' => 'metric-gross-margin', 'name' => 'Gross Margin Pct' }] }
 ] }] }
 
 # all refs resolve (incl. suffix-normalized "Customer Id")
@@ -36,6 +37,32 @@ rc, = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [
   { 'formula' => '[Master/Customer Id]' }
 ] }] }] }, DM)
 check(rc == 0, 'all-resolving spec passes (exit 0), suffix-normalized match works')
+
+# [Metrics/name] is a literal namespace. It resolves ONLY against the DM
+# metrics census from the full spec/readback, never against columnLabels.
+rc, = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [
+  { 'formula' => '[Metrics/Gross Margin Pct]' }
+] }] }] }, DM)
+check(rc == 0, 'metric-only DM name resolves through the metrics census')
+
+rc, out = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [
+  { 'formula' => '[Metrics/Net Revenue]' }
+] }] }] }, DM)
+check(rc == 1, '[Metrics/name] does not resolve through a same-named DM column')
+check(out.include?('not in the DM metrics census'), 'column-only metric miss names the metrics census')
+
+rc, out = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [
+  { 'formula' => '[Metrics/Ghost Rate]' }
+] }] }] }, DM)
+check(rc == 1 && out.include?('Ghost Rate'), 'genuinely absent metric fails closed')
+
+dm_without_metrics = Marshal.load(Marshal.dump(DM))
+dm_without_metrics['pages'][0]['elements'][0].delete('metrics')
+rc, out = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [
+  { 'formula' => '[Metrics/Gross Margin Pct]' }
+] }] }] }, dm_without_metrics)
+check(rc == 1, 'missing metric census fails closed')
+check(out.include?('no DM metrics census'), 'missing census failure is explicit')
 
 # dropped columns (multi-DS collapse) → fail with exit 1
 rc, out = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tests/test_auto_parity_plan_shape.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tests/test_auto_parity_plan_shape.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'minitest/autorun'
+require_relative '../lib/code_rep'
+
+SCRIPT = File.expand_path('../auto-parity-plan.rb', __dir__)
+CLASSIFICATION = File.expand_path('../../refs/workbook-reader-classification.json', __dir__)
+
+class TestAutoParityPlanShape < Minitest::Test
+  def test_flat_workbook_elements_and_layout_owned_page_membership
+    spec = {
+      'document' => {
+        'pages' => [{ 'id' => 'overview', 'name' => 'Executive Overview' }],
+        'elements' => [
+          { 'id' => 'master', 'kind' => 'table' },
+          { 'id' => 'trend', 'kind' => 'line-chart' }
+        ],
+        'layout' => <<~XML
+          <Page id="overview">
+            <Element elementId="master"/>
+            <Element elementId="trend"/>
+          </Page>
+        XML
+      }
+    }
+
+    assert_equal %w[master trend],
+                 Sigma::CodeRep.workbook_elements(spec).map { |element| element['id'] }
+    assert_equal %w[master trend],
+                 Sigma::CodeRep.workbook_elements_with_pages(spec)
+                               .select { |_, page| page && page['id'] == 'overview' }
+                               .map { |element, _| element['id'] }
+    refute spec['document']['pages'].first.key?('elements')
+  end
+
+  def test_auto_parity_plan_uses_workbook_helpers
+    source = File.read(SCRIPT)
+
+    assert_match(/(?:Sigma::CodeRep|WorkbookCode)\.workbook_elements|WorkbookCode\.elements/,
+                 source,
+                 'auto-parity-plan must enumerate flat document.elements through a workbook helper')
+    assert_match(/workbook_elements_with_pages|elements_for_page/,
+                 source,
+                 'page-scoped parity must derive page ownership from layout')
+    refute_match(/\b(?:pg|page)\[['"]elements['"]\]/, source,
+                 'workbook pages are metadata-only and must not be read as element owners')
+  end
+
+  def test_reader_classification_is_machine_readable_and_complete_for_confirmed_readers
+    doc = JSON.parse(File.read(CLASSIFICATION))
+    entries = Array(doc['readers'])
+    by_path = entries.each_with_object({}) { |entry, out| out[entry.fetch('path')] = entry }
+
+    %w[
+      scripts/auto-parity-plan.rb
+      scripts/export-chart-png.rb
+      scripts/remap-wb-spec-to-dm-ids.rb
+      scripts/migration-notes.rb
+      scripts/lib/action_gates.rb
+      scripts/lib/control_field_census.rb
+      scripts/lib/datasource_filter_check.rb
+      scripts/lib/style_normalize.rb
+      scripts/scan-customer-style.rb
+    ].each do |path|
+      assert_equal 'workbook', by_path.fetch(path).fetch('classification'), path
+    end
+
+    entries.each do |entry|
+      assert_includes %w[workbook data-model dual transitional adapter],
+                      entry.fetch('classification')
+      assert File.exist?(File.expand_path("../../#{entry.fetch('path')}", __dir__)),
+             "classified path does not exist: #{entry.fetch('path')}"
+    end
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-spec.rb
@@ -347,12 +347,16 @@ spec.fetch('pages', []).each do |page|
           # W2.8: governed-metric refs resolve against the METRICS CENSUS, not
           # element prefixes. A census HIT is valid — and is NOT an element
           # ref, so the cross-element render-500 guard below must not judge
-          # it. A census MISS is a hard ERROR (error-when-checkable), unless
-          # an element literally named "Metrics" makes the prefix known — then
-          # the pre-census checks judge the ref exactly as before.
-          if prefix == 'Metrics' && metrics_census
+          # it. Metrics is a reserved namespace: an element or column literally
+          # named "Metrics" can never satisfy [Metrics/<name>].
+          if prefix == 'Metrics'
             mname = ref.split('/', 2)[1].to_s
-            prefix_is_element = own_prefixes.include?(prefix) || all_known_set.include?(prefix)
+            if metrics_census.nil?
+              errors << "#{name}.#{col['name']}: ref [#{ref}] — no DM metrics census is available. " \
+                        'Pass --metrics <workdir>/metrics.json (or keep metrics.json beside --dm-context); ' \
+                        'column names and elements named "Metrics" are not valid metric evidence.'
+              next
+            end
             # F4 PRECEDENCE (review-caught): judge the structural exclusion
             # BEFORE census membership. Every pre-fix workdir carries a stale
             # machine-written metrics.json sidecar that still lists the
@@ -362,7 +366,7 @@ spec.fetch('pages', []).each do |page|
             # 1 without). Dual-carrier names were already cleared at the
             # census build, so anything still excluded rides ONLY a
             # collision-shaped element and cannot survive readback.
-            if metrics_excluded.key?(mname) && !prefix_is_element
+            if metrics_excluded.key?(mname)
               # F4: the metric IS defined — on a collision-shaped element, so
               # the live readback drops it and the ref cannot survive the
               # post-POST gate. Same admissibility rule as the binder.
@@ -374,19 +378,16 @@ spec.fetch('pages', []).each do |page|
               next
             end
             next if metrics_census.include?(mname)
-            unless prefix_is_element
-              listed = metrics_census.to_a.sort
-              errors << "#{name}.#{col['name']}: ref [#{ref}] — metric #{mname.empty? ? '(empty name)' : "\"#{mname}\""} is not in the DM metrics census " \
-                        "(#{listed.empty? ? 'the census is EMPTY' : "known metrics: #{listed.join(', ')}"}). " \
-                        'The governed-metric binder emits census names only — if the census is stale, re-run with the run\'s ' \
-                        'metrics.json (--metrics PATH, or the sidecar beside --dm-context).'
-              next
-            end
+            listed = metrics_census.to_a.sort
+            errors << "#{name}.#{col['name']}: ref [#{ref}] — metric #{mname.empty? ? '(empty name)' : "\"#{mname}\""} is not in the DM metrics census " \
+                      "(#{listed.empty? ? 'the census is EMPTY' : "known metrics: #{listed.join(', ')}"}). " \
+                      'The governed-metric binder emits census names only — if the census is stale, re-run with the run\'s ' \
+                      'metrics.json (--metrics PATH, or the sidecar beside --dm-context).'
+            next
           end
           unless own_prefixes.include?(prefix) || all_known_set.include?(prefix)
-            hint = prefix == 'Metrics' && !metrics_census ? ' — governed-metric refs need the DM metrics census: pass --metrics <workdir>/metrics.json (or keep metrics.json beside --dm-context)' : ''
             errors << "#{name}.#{col['name']}: ref [#{ref}] — prefix \"#{prefix}\" unknown " \
-                      "(known: #{(own_prefixes + all_known_set).to_a.sort.join(', ')})#{hint}"
+                      "(known: #{(own_prefixes + all_known_set).to_a.sort.join(', ')})"
           end
           # v5.3 RENDER-500 guard: a formula referencing a workbook element
           # that is NOT this element's source opaquely 500s EVERY png


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Fixes #698, #699, and #700 for `tableau-to-sigma`:

- Read current workbook code-rep from flat `document.elements`, with page membership owned by layout; retain nested `pages[].elements` only for data models and transitional build artifacts.
- Resolve `[Metrics/name]` only against the data-model metrics census, never `/columns`; missing metric census and missing metrics fail explicitly.
- Recover GUID-backed Tableau dates before phantom filtering only when date type, parse format, owning table, live physical column, and warehouse type agree. `--column-mapping` can supply the physical-name evidence without weakening the other gates.

Live validation also exposed and fixed current workbook envelopes for join probes, required probe-folder inference, duplicate logical-table roles, flat-workbook LOD auditing, and source-census-proven unused LOD fields.

## Scope

- Plugin touched: `tableau-to-sigma` only
- Version: `1.9.10` → `1.9.11`
- 34 files changed; no shared library edits; phase numbers unchanged

## Reader classification

Machine-readable classification: `refs/workbook-reader-classification.json`.

- Workbook readers moved to `WorkbookCode`/`Sigma::CodeRep` flat-element helpers: parity planning, chart export, DM-id remap, migration notes, action/control/filter gates, style normalization, customer-style scan, and LOD audit workbook path.
- Dual readers branch explicitly by artifact type: `post-and-readback.rb`, `validate-spec.rb`, and `lib/lod_audit.rb`.
- Data-model readers remain nested: mechanical specs, DM reuse/scoring, formula validation, column census, quarantine, and equivalence probes.
- Transitional builders keep their in-memory compatibility view and canonicalize at the emission boundary.

## Test evidence

- Complete Tableau Ruby suite: **264 run, 0 failed**.
- Corpus: **27/27 cases pass**.
- Shared drift: **700 copies match canonical**.
- Skill lint, hygiene sweep + harnesses, provenance guard, tree-litter guard, plugin-version gate: green.
- CI: **10/10 checks successful**, including Linux full Ruby suite, macOS BSD smoke, Windows smoke, syntax, corpus, shared drift, and both private hygiene jobs.
- New/expanded regressions cover flat/page-scoped parity, metric namespace separation, missing metric census, GUID-date mapping/idempotence/refusal, flat fidelity patches, current probe envelope/folder contract, duplicate table roles, and flat/unused-source LOD audit behavior.

## Live Orders Executive Overview evidence

Connection: `ymb68310`.

- Data model: `1c18aa2a-5e50-46e2-9376-836a3ed912b9`
- Workbook: `c61c5d5a-d004-45b0-9b47-93ba7796ad57`
- Fresh build used no DM reuse.
- Live DM readback: `Order Date Key` is integer; synthesized `Order Date` is datetime. The downstream view also reads `Order Date` as datetime.
- Reference gate: 102 column refs and 5 metric refs resolved against 121 columns / 26 metrics. A planted `[Metrics/PLANTED Missing Metric]` failed with exit 1 against the live metrics census.
- Flat readback + `--dashboard "Executive Overview"` auto-parity planning matched all 9 charts, proving page-scoped layout ownership.
- Final parity: **9/9 charts pass**, value score 1.0; source anchors **22/22**; numeric coverage **9/9**; trend values and axis/tick/month formatting agree.
- Join cardinality: **7/7 relationship targets warehouse-proven unique**.
- Blind visual grade: all six dimensions pass; visual similarity 0.796.
- Final migration status: `STATUS: GREEN`; all gates pass. No reference or parity waivers were used.

## Cleanup evidence

- Probe registry: no outstanding artifacts.
- Workbook delete succeeded; readback returns `409 inode_archived` and is absent from the active workspace.
- Data-model delete succeeded; readback returns `409 inode_archived` and is absent from the active workspace.

## Remaining risks / blocked feature

- The run verdict is **PARTIAL** despite green gates because Tableau parameter control `Year Filter` remains a declared scope cut (`needs-wiring`). It is the sole degradation-ledger item.
- Ground-truth coverage used source view-CSV anchors for all 9 tiles rather than mechanically generated warehouse SQL because the object-graph joins and IF/IIF calculations are outside that SQL subset. Cardinality was independently probed for every relationship.
- Source `YTD Revenue` is unreferenced by every worksheet; it is recorded as `unused-source`, not silently dropped or waived.

## Checklist

- [x] One plugin only
- [x] `ruby tools/check-shared.rb`
- [x] `ruby tools/lint-skills.rb`
- [x] `./corpus/run-corpus.sh --check`
- [x] Complete Tableau Ruby suite
- [x] Fresh live migration and cleanup
- [x] Phase numbers unchanged
- [x] Plugin version bumped
- [x] Working tree clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f96ecc6c-8c1c-406d-bdaa-ad729739659e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f96ecc6c-8c1c-406d-bdaa-ad729739659e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

