### PR TITLE
Fix Power BI workbook fidelity and time-intel routing

### DIFF
--- a/corpus/powerbi/workbook-code-release/golden/workbook.json
+++ b/corpus/powerbi/workbook-code-release/golden/workbook.json
@@ -352,9 +352,6 @@
             "backgroundCanvas": "#EEF2F7"
           }
         }
-      },
-      "navigation": {
-        "pageTabsInViewMode": "shown"
       }
     }
   }

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.26",
+  "version": "1.8.27",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.27",
+  "version": "1.8.28",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -1416,7 +1416,8 @@ def prepare_drill_control!(el, rec, fields, masters, master, active_qr, active_c
   end
 end
 
-def prepare_legend_control!(el, rec, fields, masters, master, legend_qr, target_column_id)
+def prepare_legend_control!(el, rec, fields, masters, master, legend_qr, target_column_id,
+                            source_column_id = nil)
   return if legend_qr.nil? || target_column_id.nil? || rec['legend'] == false
   # Sigma legend controls require a categorical color target and do not support
   # waterfall charts. Waterfall splitBy keeps its chart-local legend instead.
@@ -1425,8 +1426,13 @@ def prepare_legend_control!(el, rec, fields, masters, master, legend_qr, target_
 
   fs = field_spec(legend_qr, fields, master)
   master_rec = master && masters[master]
-  source_col = master_rec && match_master_column(master_rec, qr_leaf(legend_qr),
-                                                  legend_qr.to_s.split('.').first)
+  source_col =
+    if source_column_id
+      Array(master_rec && master_rec['columns']).find { |c| c['id'] == source_column_id }
+    else
+      master_rec && match_master_column(master_rec, qr_leaf(legend_qr),
+                                        legend_qr.to_s.split('.').first)
+    end
   if source_col && fs['master'] == master
     el['_legend_control'] = {
       'sourceColumnId' => source_col['id'],
@@ -2203,9 +2209,30 @@ def build_element(rec, fields, masters, extra_data = [], forced_master = nil)
     # the whole categoricalScheme on donut/pie (per-element color.scheme is dropped
     # there — theme palette is the only lever). Coalescing null -> "(Blank)" both
     # matches PBI's label and sorts ahead of letters ("(" < "A"), so every slice
-    # gets the same color PBI gave it. Only wrap a bare column ref.
+    # gets the same color PBI gave it. Materialize the coalesce on the workbook
+    # master when possible: Sigma otherwise preserves the source column's null
+    # color lineage and renders the dominant bucket gray/"Others" even though the
+    # chart-level display formula reads "(Blank)".
     dim_ref = dfs['ref']
-    dim_ref = %(Coalesce(#{dim_ref}, "(Blank)")) if dim_ref.to_s =~ /\A\[[^\]]+\]\z/
+    blank_safe_source_id = nil
+    if dim_ref.to_s =~ /\A\[[^\]]+\]\z/ && master && masters[master]
+      master_rec = masters[master]
+      source_col = match_master_column(master_rec, qr_leaf(dim), dim.to_s.split('.').first)
+      if source_col && source_col['formula']
+        blank_safe_source_id = "#{source_col['id']}-blank"
+        blank_name = "#{source_col['name']} (Blank-safe)"
+        unless Array(master_rec['columns']).any? { |c| c['id'] == blank_safe_source_id }
+          master_rec['columns'] << {
+            'id' => blank_safe_source_id,
+            'formula' => %(Coalesce(#{source_col['formula']}, "(Blank)")),
+            'name' => blank_name
+          }
+        end
+        dim_ref = "[#{master_rec['id']}/#{blank_name}]"
+      else
+        dim_ref = %(Coalesce(#{dim_ref}, "(Blank)"))
+      end
+    end
     cols << { 'id' => dcid, 'formula' => dim_ref, 'name' => qr_leaf(dim, 'Dim') }
     cv = { 'id' => vcid, 'formula' => measure_formula(vfs), 'name' => qr_leaf(val, 'Value') }
     apply_fmt(cv, val, fields, vfmts)
@@ -2223,7 +2250,8 @@ def build_element(rec, fields, masters, extra_data = [], forced_master = nil)
     }
     el['value'] = { 'id' => vcid }
     prepare_drill_control!(el, rec, fields, masters, master, dim, dcid, cols)
-    prepare_legend_control!(el, rec, fields, masters, master, dim, dcid)
+    prepare_legend_control!(el, rec, fields, masters, master, dim, dcid,
+                            blank_safe_source_id)
     # value labels on pie/donut slices — honor an explicit PBI labels-off signal
     # (bead n9u9); default (nil/absent) keeps the labels shown as before.
     unless rec['data_labels'] == false

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -1560,17 +1560,17 @@ def build_element(rec, fields, masters, extra_data = [], forced_master = nil)
 
   # Report-build hardening: in page-base mode every visual sources the PAGE's one
   # base master (forced_master) so a single control target propagates to all —
-  # but only when at least one of the visual's own fields resolves on that base
-  # (else a genuinely different-fact visual would lose all its data; it keeps its
-  # own master and is surfaced as out-of-scope for the page control instead).
-  resolves_on = lambda do |m|
-    (rec['bindings'] || {}).values.flatten.compact.any? do |qr|
-      fs = field_spec(qr, fields)
-      fs['master'] == m || Array(fs['alts']).any? { |a| a['master'] == m }
-    end
+  # but only when ALL of the visual's fields resolve there. A partial match must
+  # retain per-visual master selection or a specialized grouped series (such as
+  # prior-year revenue) is silently dropped.
+  bound_qrs = (rec['bindings'] || {}).values.flatten.compact
+  masters_for = lambda do |qr|
+    fs = field_spec(qr, fields)
+    ([fs['master']] + Array(fs['alts']).map { |a| a['master'] }).compact.uniq
   end
   master =
-    if forced_master && masters[forced_master] && resolves_on.call(forced_master)
+    if forced_master && masters[forced_master] &&
+       PbiReportBuild.all_fields_resolve_on?(bound_qrs, forced_master, masters_for)
       forced_master
     else
       visual_master(rec, fields)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -2921,7 +2921,7 @@ pages_xml = signals['pages'].map do |pg|
     if hdr_text_id
       hdr_el = page_spec && page_spec['elements'].find { |e| e['id'] == hdr_text_id }
       ttl = src_rec.call(hdr_text_id)['text'].to_s.strip
-      hdr_el['body'] = %(# <span style="color: #FFFFFF">#{ttl}</span>) if hdr_el
+      hdr_el['body'] = SigmaLayout.header_text_el(hdr_text_id, ttl)['body'] if hdr_el
       children << SigmaLayout.header_band_xml(hdr_id, hdr_text_id)
     else
       ttl = SigmaLayout.resolve_header_title(pg['page_title'], opts[:source_title], opts[:name]) || 'Dashboard'
@@ -3023,7 +3023,8 @@ pages_xml = signals['pages'].map do |pg|
           SigmaLayout.le(pair['chart'], 1, 19, 1, 9),
           SigmaLayout.le(pair['legend'], 19, 25, 1, 9)
         ].join("\n")
-        SigmaLayout.gc(i[0], i[1], i[2], i[3], i[4], nested)
+        SigmaLayout.gc(i[0], i[1], i[2], i[3], i[4], nested,
+                       row_template: 'repeat(8, 1fr)')
       else
         SigmaLayout.le(i[0], i[1], i[2], i[3], i[4])
       end
@@ -3121,7 +3122,7 @@ pages_xml = signals['pages'].map do |pg|
     items = items.reject { |i| i[0] == hdr_eid }
     next nil if items.empty?
     hdr_el = page_spec['elements'].find { |e| e['id'] == hdr_eid }
-    hdr_el['body'] = %(# <span style="color: #FFFFFF">#{hdr_vis['text']}</span>) if hdr_el
+    hdr_el['body'] = SigmaLayout.header_text_el(hdr_eid, hdr_vis['text'])['body'] if hdr_el
     xml, extra = banded_page(page_id, items, header_el: hdr_eid)
   else
     # No promotable source title — header text falls back, in priority order,

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -2894,6 +2894,25 @@ pages_xml = signals['pages'].map do |pg|
       children << SigmaLayout.header_band_xml(hdr_id, txt_id)
     end
 
+    # A generated Sigma legend control represents the source chart's in-panel
+    # legend, not a page filter. Keep it beside its chart in one container so it
+    # does not become a full-width control strip above the dashboard.
+    legend_pairs = {}
+    Array(page_spec && page_spec['elements']).each do |legend|
+      next unless legend['kind'] == 'control' && legend['controlType'] == 'legend'
+      chart_id = legend.dig('targets', 0, 'source', 'elementId')
+      chart_item = items.find { |it| it[0] == chart_id }
+      legend_item = items.find { |it| it[0] == legend['id'] }
+      next unless chart_item && legend_item
+
+      container_id = "band-#{page_id}-legend-#{chart_id}"
+      items = items.reject { |it| it[0] == chart_id || it[0] == legend['id'] }
+      items << [container_id, chart_item[1], chart_item[2], chart_item[3], chart_item[4]]
+      kind_of[container_id] = 'container'
+      extra << SigmaLayout.container_el(container_id)
+      legend_pairs[container_id] = { 'chart' => chart_id, 'legend' => legend['id'] }
+    end
+
     # 2) bands from the SOURCE rows, columns from the SOURCE x-positions
     min_rows = { 'kpi-chart' => 4, 'control' => 2, 'text' => 2, 'image' => 20,
                  'scatter-chart' => 9, 'region-map' => 9, 'point-map' => 9 }
@@ -2961,7 +2980,18 @@ pages_xml = signals['pages'].map do |pg|
       cursor += band_h
     end
     page_spec['elements'] = page_spec['elements'] + extra if page_spec
-    inner = les.map { |i| SigmaLayout.le(i[0], i[1], i[2], i[3], i[4]) }.join("\n")
+    inner = les.map do |i|
+      pair = legend_pairs[i[0]]
+      if pair
+        nested = [
+          SigmaLayout.le(pair['chart'], 1, 19, 1, 7),
+          SigmaLayout.le(pair['legend'], 19, 25, 1, 7)
+        ].join("\n")
+        SigmaLayout.gc(i[0], i[1], i[2], i[3], i[4], nested)
+      else
+        SigmaLayout.le(i[0], i[1], i[2], i[3], i[4])
+      end
+    end.join("\n")
     next SigmaLayout.page_xml(page_id, children.join("\n"), inner)
   end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -1424,6 +1424,15 @@ def prepare_legend_control!(el, rec, fields, masters, master, legend_qr, target_
   return unless %w[bar-chart line-chart area-chart combo-chart scatter-chart
                    pie-chart donut-chart].include?(el['kind'])
 
+  # Pie/donut legends are presentation-first and already render in-panel in
+  # Sigma. A separate legend control consumes chart canvas height and shrinks the
+  # ring dramatically, so keep these chart-local. Cartesian legends retain the
+  # interactive companion control below.
+  if %w[pie-chart donut-chart].include?(el['kind'])
+    el['legend'] = { 'visibility' => 'shown' }
+    return
+  end
+
   fs = field_spec(legend_qr, fields, master)
   master_rec = master && masters[master]
   source_col =

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -2212,7 +2212,15 @@ def build_element(rec, fields, masters, extra_data = [], forced_master = nil)
     cols << cv
     qr_cids[dim] = dcid if dim
     qr_cids[val] = vcid if val
-    el['color'] = { 'id' => dcid }
+    # Donut/pie colors come from the workbook categoricalScheme and are assigned
+    # positionally. Default Sigma ordering is value-descending; Power BI's
+    # categorical palette follows the category order (with "(Blank)" first).
+    # Seed that order here. An explicit source visual sort, when present, is
+    # applied later by apply_sort and overrides this default.
+    el['color'] = {
+      'id' => dcid,
+      'sort' => { 'by' => dcid, 'direction' => 'ascending' }
+    }
     el['value'] = { 'id' => vcid }
     prepare_drill_control!(el, rec, fields, masters, master, dim, dcid, cols)
     prepare_legend_control!(el, rec, fields, masters, master, dim, dcid)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -3020,7 +3020,10 @@ pages_xml = signals['pages'].map do |pg|
       pair = legend_pairs[i[0]]
       if pair
         nested = [
-          SigmaLayout.le(pair['chart'], 1, 19, 1, 9),
+          # Let the chart size from the full panel. The legend occupies the
+          # rightmost quarter as an overlay; reserving that width made Sigma
+          # shrink six-slice donuts to an unreadably small ring.
+          SigmaLayout.le(pair['chart'], 1, 25, 1, 9),
           SigmaLayout.le(pair['legend'], 19, 25, 1, 9)
         ].join("\n")
         SigmaLayout.gc(i[0], i[1], i[2], i[3], i[4], nested,

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -2984,8 +2984,8 @@ pages_xml = signals['pages'].map do |pg|
       pair = legend_pairs[i[0]]
       if pair
         nested = [
-          SigmaLayout.le(pair['chart'], 1, 19, 1, 7),
-          SigmaLayout.le(pair['legend'], 19, 25, 1, 7)
+          SigmaLayout.le(pair['chart'], 1, 19, 1, 9),
+          SigmaLayout.le(pair['legend'], 19, 25, 1, 9)
         ].join("\n")
         SigmaLayout.gc(i[0], i[1], i[2], i[3], i[4], nested)
       else

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -3121,9 +3121,7 @@ document = {
     'theme' => {
       'name' => 'Light',
       'overrides' => theme_overrides
-    },
-    # PBI page tabs/pageNavigator semantics map to Sigma workbook navigation.
-    'navigation' => { 'pageTabsInViewMode' => 'shown' }
+    }
   }
 }
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -183,9 +183,24 @@ def _textbox_body(visual):
     objs = visual.get("objects", {})
     for key in ("general", "text"):
         for item in objs.get(key, []):
-            t = item.get("properties", {}).get("text", {}).get("expr", {}).get("Literal", {}).get("Value")
+            props = item.get("properties", {})
+            t = props.get("text", {}).get("expr", {}).get("Literal", {}).get("Value")
             if t:
                 return t.strip("'")
+            # Modern PBIR textboxes store rich text as paragraphs[].textRuns[]
+            # instead of a scalar properties.text literal. Preserve paragraph
+            # boundaries so the builder can promote a title + subtitle together.
+            lines = []
+            for paragraph in props.get("paragraphs", []):
+                line = "".join(
+                    run.get("value", "")
+                    for run in paragraph.get("textRuns", [])
+                    if isinstance(run, dict)
+                ).strip()
+                if line:
+                    lines.append(line)
+            if lines:
+                return "\n".join(lines)
     return None
 
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout.rb
@@ -29,10 +29,10 @@ module SigmaLayout
     candidates.map { |c| c.to_s.strip }.find { |c| !c.empty? && !generic_title?(c) }
   end
 
-  def gc(eid, c0, c1, r0, r1, inner)
+  def gc(eid, c0, c1, r0, r1, inner, row_template: 'auto')
     "<Container elementId=\"#{eid}\" type=\"grid\" " \
     "gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\" " \
-    "gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n#{inner}\n</Container>"
+    "gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"#{row_template}\">\n#{inner}\n</Container>"
   end
 
   def le(eid, c0, c1, r0, r1)
@@ -59,8 +59,13 @@ module SigmaLayout
 
   # Spec-side page-title text element (white text over the dark header band).
   def header_text_el(id, title)
+    lines = title.to_s.lines.map(&:strip).reject(&:empty?)
+    heading = lines.shift.to_s
+    subtitle = lines.join(' ')
+    body = %(# <span style="color: #FFFFFF">#{heading}</span>)
+    body += %(\n<span style="color: #94A3B8">#{subtitle}</span>) unless subtitle.empty?
     { 'id' => id, 'kind' => 'text',
-      'body' => %(# <span style="color: #FFFFFF">#{title}</span>) }
+      'body' => body }
   end
 
   # Header band XML: dark full-width container at the top of the page wrapping

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_reportbuild.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_reportbuild.rb
@@ -91,6 +91,15 @@ module PbiReportBuild
     best && best[0]
   end
 
+  # A page-wide base may source a visual only when it can resolve EVERY bound
+  # field. Falling back after a partial match lets the visual choose a specialized
+  # grouped master (for example Year + Revenue + Prior Year) instead of silently
+  # dropping the field that exists only on that master.
+  def all_fields_resolve_on?(query_refs, master, masters_for)
+    refs = Array(query_refs).compact
+    !refs.empty? && refs.all? { |qr| Array(masters_for.call(qr)).include?(master) }
+  end
+
   # Name-shape heuristic for a boolean/indicator slicer when no TMSL dataType is
   # available (the extract carried no --model). Conservative: only true/has
   # prefixes and the ind/indicator/flag suffix — the well-known PBI indicator

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_timeintel_route.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_timeintel_route.rb
@@ -21,6 +21,9 @@
 module PbiTimeIntelRoute
   module_function
 
+  TIME_INTEL_RE =
+    /\b(SAMEPERIODLASTYEAR|TOTALYTD|TOTALQTD|TOTALMTD|DATESYTD|DATEADD|PARALLELPERIOD|PREVIOUSYEAR|PREVIOUSMONTH|PREVIOUSQUARTER)\b/i
+
   # base fact of a synthesized time-intel element = the table its source View
   # denormalizes ("ABSENCE_RECORDS View" -> "ABSENCE_RECORDS"). A plain table name
   # passes through unchanged.
@@ -34,6 +37,22 @@ module PbiTimeIntelRoute
     a = norm(measure_table)
     b = norm(ti_fact)
     !a.empty? && a == b
+  end
+
+  # Classify a remaining measure before selecting a synthesized time-intel
+  # column. Prefer the measure's explicit semantic name over broad expression
+  # heuristics: a "Net Revenue PY" expression commonly contains ALL([Year]), but
+  # that is still a prior-year value, not the synthesized YoY percentage.
+  def measure_shape(measure_name, expression)
+    name = measure_name.to_s
+    expr = expression.to_s
+    return :yoy if name =~ /YoY|Y\/Y|growth/i
+    return :ytd if name =~ /\bYTD\b/i
+    return :prior if name =~ /\b(PY|Prior Year|Last Year|LY)\b/i
+    return :generic if expr =~ TIME_INTEL_RE
+    return :yoy if expr =~ /ALL\s*\([^)]*\[Year\]/i
+
+    nil
   end
 
   def norm(str)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_timeintel_route.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_timeintel_route.rb
@@ -55,6 +55,17 @@ module PbiTimeIntelRoute
     nil
   end
 
+  # A reused Sigma time-intel element may have been renamed since conversion
+  # ("Net Revenue PY" -> "Revenue by Year"), so no source measure name maps back
+  # to its original table. Preserve the source element's fact as the fallback
+  # routing table for co-locating base values and period dimensions.
+  def routing_table(original_table, time_intel_fact)
+    original = original_table.to_s.strip
+    return original unless original.empty?
+
+    time_intel_fact.to_s.strip
+  end
+
   def norm(str)
     str.to_s.gsub(/\s+/, '').downcase
   end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -1463,6 +1463,7 @@ conv_elements.each do |cel|
   hf = headline.call(pick['name'])
   ref['formula'] = hf if hf
   orig = ti_orig_table[mname]
+  route_table = PbiTimeIntelRoute.routing_table(orig, ti_fact)
   # route both the original-table queryRef and a self-named queryRef so whichever
   # form the PBIR binding used resolves to this element.
   field_map["#{orig}.#{mname}"] = ref if orig
@@ -1494,10 +1495,10 @@ conv_elements.each do |cel|
     valleaf  = base_val['name']
     valnorm  = valleaf.gsub(/\s+/, '').downcase
     all_measures.each do |t2, m2, e2|
-      next unless t2 == orig
+      next unless t2 == route_table
       enorm = e2.to_s.gsub(/\s+/, '').downcase
       agg_of_val = enorm =~ /(sum|average|avg|min|max|count|distinctcount)\([^)]*#{Regexp.escape(valnorm)}/
-      reg_alt.call("#{orig}.#{m2}", valleaf) if agg_of_val || m2 == valleaf
+      reg_alt.call("#{route_table}.#{m2}", valleaf) if agg_of_val || m2 == valleaf
     end
   end
   # The grouped element carries period dimension column(s) (Year and/or Month).
@@ -1506,7 +1507,7 @@ conv_elements.each do |cel|
   # date-dim queryRef forms (the calc-table date dim is the usual binding source).
   period_cols.each do |pc|
     %w[DATE_DIM DimDate DimMonth Date].each { |dt| reg_alt.call("#{dt}.#{pc['name']}", pc['name']) }
-    reg_alt.call("#{orig}.#{pc['name']}", pc['name'])
+    reg_alt.call("#{route_table}.#{pc['name']}", pc['name'])
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -1880,7 +1880,9 @@ cols = (Sigma.request(:get, "/v2/workbooks/#{wb_id}/columns") rescue { 'entries'
 err_cols = (cols['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
 total_cols = (cols['entries'] || []).size
 wb_pairs = Sigma::CodeRep.workbook_elements_with_pages(wb_rb)
-chart_els = wb_pairs.select { |_el, page| page && page['id'] != 'page-data' }.map(&:first)
+chart_pairs = wb_pairs.select { |_el, page| page && page['id'] != 'page-data' }
+chart_els = chart_pairs.map(&:first)
+chart_pages = chart_pairs.filter_map { |_el, page| page['id'] }.uniq
 
 # (2) warehouse-vs-snapshot compare (bead fmte). For every table the preflight
 # snapshotted, export the matching Data-page master element (Sigma = LIVE

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -1517,18 +1517,11 @@ end
 # the chart binds, but no field_map entry -> source:{} -> POST fails. Route every
 # remaining time-intel-shaped measure to the best-matching time-intel column.
 if ti_elements.any?
-  ti_re = /\b(SAMEPERIODLASTYEAR|TOTALYTD|TOTALQTD|TOTALMTD|DATESYTD|DATEADD|PARALLELPERIOD|PREVIOUSYEAR|PREVIOUSMONTH|PREVIOUSQUARTER)\b/i
   all_measures.each do |tbl, mname, expr|
     next if field_map.key?("#{tbl}.#{mname}")
-    e = expr.to_s
     # time-intel-shaped: a DAX time-intel function, OR a YoY/growth name, OR a
     # hand-rolled MAX(...)/ALL(...) prior-year ratio.
-    shape =
-      if e =~ ti_re then :generic
-      elsif mname =~ /YoY|Y\/Y|growth/i || e =~ /ALL\s*\([^)]*\[Year\]/i then :yoy
-      elsif mname =~ /\bYTD\b/i then :ytd
-      elsif mname =~ /\b(PY|Prior Year|Last Year|LY)\b/i then :prior
-      end
+    shape = PbiTimeIntelRoute.measure_shape(mname, expr)
     next unless shape
     # choose a target column across the emitted time-intel elements — but ONLY
     # those built from THIS measure's own fact. Cross-fact borrowing produced

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-extract-viz-signals.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-extract-viz-signals.py
@@ -119,6 +119,21 @@ check(epb._role_bindings(pbir_hierarchy) == {"Category": ["D.Month"]},
 check(epb._drill_signal(pbir_hierarchy) == {
           "role": "Category", "levels": ["D.Year", "D.Month"], "active": "D.Month"
       }, "PBIR extractor separately preserves full hierarchy for native drill")
+rich_textbox = {
+    "objects": {
+        "general": [{
+            "properties": {
+                "paragraphs": [
+                    {"textRuns": [{"value": "Retail Performance & Trends"}]},
+                    {"textRuns": [{"value": "Net revenue, profitability, and order mix"}]},
+                ]
+            }
+        }]
+    }
+}
+check(epb._textbox_body(rich_textbox) ==
+      "Retail Performance & Trends\nNet revenue, profitability, and order mix",
+      "PBIR rich-text paragraphs preserve title and subtitle")
 
 print(f"\n{'ALL PASS' if not fails else f'{len(fails)} FAILURE(S)'}")
 for f in fails:

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild.rb
@@ -55,6 +55,20 @@ tie_for = ->(qr) { { 'a' => ['A'], 'b' => ['B'] }[qr] }
 tie_visuals = [{ 'bindings' => { 'X' => ['a'], 'Y' => ['b'] } }]
 ok('page_base_master tie -> first-seen (A)', PbiReportBuild.page_base_master(tie_visuals, tie_for) == 'A')
 
+# A dominant page base must not be forced onto a specialized visual when it
+# resolves only some of that visual's fields.
+special_for = lambda do |qr|
+  {
+    'year' => %w[BASE YEAR_GROUP],
+    'revenue' => %w[BASE YEAR_GROUP],
+    'prior' => ['YEAR_GROUP']
+  }[qr]
+end
+ok('page base is rejected when one visual field needs a specialized master',
+   !PbiReportBuild.all_fields_resolve_on?(%w[year revenue prior], 'BASE', special_for))
+ok('specialized master is eligible when it resolves every visual field',
+   PbiReportBuild.all_fields_resolve_on?(%w[year revenue prior], 'YEAR_GROUP', special_for))
+
 # ---- boolean_leaf?: indicator naming, conservative --------------------------
 B = PbiReportBuild.method(:boolean_leaf?)
 ok('"Is Active" -> boolean',        B.call('Is Active'))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
@@ -31,6 +31,18 @@ ok('whitespace/case tolerant',
 ok('empty fact never matches',
    R.same_fact?('SAFETY_INCIDENTS', '') == false)
 
+# measure_shape: explicit measure semantics beat broad ALL([Year]) heuristics.
+py_dax = 'VAR cy=SELECTEDVALUE(DATE_DIM[Year]) RETURN CALCULATE(SUM(F[Revenue]),ALL(DATE_DIM[Year]),DATE_DIM[Year]=cy-1)'
+yoy_dax = 'VAR maxY=CALCULATE(MAX(DATE_DIM[Year]),ALL(DATE_DIM)) RETURN DIVIDE(curr-prev,prev)'
+ok('explicit PY name routes to DateLookback column despite ALL([Year])',
+   R.measure_shape('Net Revenue PY', py_dax) == :prior)
+ok('explicit YoY name routes to synthesized YoY column',
+   R.measure_shape('YoY %', yoy_dax) == :yoy)
+ok('explicit YTD name routes to cumulative column',
+   R.measure_shape('Net Revenue YTD', 'CALCULATE(SUM(F[Revenue]), ALL(D[Month]))') == :ytd)
+ok('unnamed native time-intel expression retains generic routing',
+   R.measure_shape('Revenue Comparison', 'CALCULATE([Revenue], SAMEPERIODLASTYEAR(D[Date]))') == :generic)
+
 # --- routing simulation: mirror the gate in migrate-powerbi.rb. Only same-fact
 # elements are considered; a SAFETY prior-year measure with only ABSENCE elements
 # must find NO target (→ unresolved → honest coverage degradation).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
@@ -42,6 +42,10 @@ ok('explicit YTD name routes to cumulative column',
    R.measure_shape('Net Revenue YTD', 'CALCULATE(SUM(F[Revenue]), ALL(D[Month]))') == :ytd)
 ok('unnamed native time-intel expression retains generic routing',
    R.measure_shape('Revenue Comparison', 'CALCULATE([Revenue], SAMEPERIODLASTYEAR(D[Date]))') == :generic)
+ok('renamed reused element falls back to its source fact for sibling routing',
+   R.routing_table(nil, 'ORDER_FACT') == 'ORDER_FACT')
+ok('original measure table wins when the converter element name still matches',
+   R.routing_table('SALES_FACT', 'OTHER_FACT') == 'SALES_FACT')
 
 # --- routing simulation: mirror the gate in migrate-powerbi.rb. Only same-fact
 # elements are considered; a SAFETY prior-year measure with only ABSENCE elements

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -116,6 +116,11 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
        legend.dig('targets', 0, 'source', 'elementId') == bar['id'] &&
        legend.dig('targets', 0, 'columnId') == bar.dig('color', 'column') &&
        bar['legend'] == { 'visibility' => 'hidden' })
+  legend_pair = bar && legend &&
+                doc['layout'].match?(
+                  %r{<Container elementId="band-page-p1-legend-#{Regexp.escape(bar['id'])}"[^>]*>.*?<Element elementId="#{Regexp.escape(bar['id'])}"[^>]*/>.*?<Element elementId="#{Regexp.escape(legend['id'])}"[^>]*/>}m
+                )
+  ok('visible legend control stays beside its source chart', legend_pair)
   progress = doc['elements'].find { |e| e['kind'] == 'progress' }
   ok('gauge uses native ring progress', progress && progress['shape'] == 'ring' &&
      progress['mode'] == 'value' && progress['value'].to_s.include?('master-s'))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -129,6 +129,19 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
      donut && donut.dig('color', 'sort') == {
        'by' => donut.dig('color', 'id'), 'direction' => 'ascending'
      })
+  donut_dim = donut && donut['columns'].find { |c| c['id'] == donut.dig('color', 'id') }
+  blank_safe = doc['elements'].find { |e| e['id'] == 'master-s' }
+                              &.fetch('columns', [])
+                              &.find { |c| c['id'] == 'm-region-blank' }
+  donut_legend = doc['elements'].find do |e|
+    e['controlType'] == 'legend' &&
+      e.dig('targets', 0, 'source', 'elementId') == donut&.fetch('id', nil)
+  end
+  ok('donut blank bucket is materialized on the master to avoid gray Others',
+     blank_safe &&
+       blank_safe['formula'] == 'Coalesce([S/Region], "(Blank)")' &&
+       donut_dim&.fetch('formula', nil) == '[master-s/Region (Blank-safe)]' &&
+       donut_legend&.dig('source', 'columnId') == 'm-region-blank')
   progress = doc['elements'].find { |e| e['kind'] == 'progress' }
   ok('gauge uses native ring progress', progress && progress['shape'] == 'ring' &&
      progress['mode'] == 'value' && progress['value'].to_s.include?('master-s'))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'open3'
 require 'tmpdir'
 require 'rbconfig'
+require_relative 'lib/layout_lint'
 
 BUILD = File.join(__dir__, 'build-workbook-from-pbir.rb')
 ASSEMBLE = File.join(__dir__, 'build-workbook-spec.rb')
@@ -146,6 +147,9 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
 
   _vo, ve, vst = Open3.capture3(RUBY, VALIDATE, '--type', 'workbook', out)
   ok('flat workbook passes validate-spec', vst.success? || (warn(ve) && false))
+  layout_violations = LayoutLint.lint(envelope)
+  ok('chart-adjacent legend container passes layout lint',
+     layout_violations.empty? || (warn(layout_violations.join("\n")) && false))
 end
 
 Dir.mktmpdir('pbi-legacy-assembler') do |dir|

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -155,8 +155,12 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
   _vo, ve, vst = Open3.capture3(RUBY, VALIDATE, '--type', 'workbook', out)
   ok('flat workbook passes validate-spec', vst.success? || (warn(ve) && false))
   layout_violations = LayoutLint.lint(envelope)
+  legend_ids = doc['elements'].select { |e| e['controlType'] == 'legend' }.flat_map do |e|
+    [e['id'], e.dig('targets', 0, 'source', 'elementId')]
+  end.compact
+  legend_violations = layout_violations.select { |v| legend_ids.any? { |id| v.include?(id) } }
   ok('chart-adjacent legend container passes layout lint',
-     layout_violations.empty? || (warn(layout_violations.join("\n")) && false))
+     legend_violations.empty? || (warn(legend_violations.join("\n")) && false))
 end
 
 Dir.mktmpdir('pbi-legacy-assembler') do |dir|

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -121,6 +121,8 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
      progress['mode'] == 'value' && progress['value'].to_s.include?('master-s'))
   nav = doc['elements'].find { |e| e['kind'] == 'navigation' }
   ok('page navigator uses native auto navigation', nav && nav['mode'] == 'auto')
+  ok('feature-gated workbook navigation setting is omitted',
+     !doc.fetch('settings', {}).key?('navigation'))
   ok('background and spacing survive', waterfall.dig('style', 'backgroundColor') == '#F8FAFC' &&
      doc.dig('settings', 'theme', 'overrides', 'colorOverrides', 'backgroundCanvas') == '#EEF2F7' &&
      doc.dig('settings', 'theme', 'overrides', 'space', 'unit') == 'small')

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -7,6 +7,7 @@ require 'open3'
 require 'tmpdir'
 require 'rbconfig'
 require_relative 'lib/layout_lint'
+require_relative 'lib/layout'
 
 BUILD = File.join(__dir__, 'build-workbook-from-pbir.rb')
 ASSEMBLE = File.join(__dir__, 'build-workbook-spec.rb')
@@ -121,9 +122,9 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
        bar['legend'] == { 'visibility' => 'hidden' })
   legend_pair = bar && legend &&
                 doc['layout'].match?(
-                  %r{<Container elementId="band-page-p1-legend-#{Regexp.escape(bar['id'])}"[^>]*>.*?<Element elementId="#{Regexp.escape(bar['id'])}"[^>]*/>.*?<Element elementId="#{Regexp.escape(legend['id'])}"[^>]*/>}m
+                  %r{<Container elementId="band-page-p1-legend-#{Regexp.escape(bar['id'])}"[^>]*gridTemplateRows="repeat\(8, 1fr\)"[^>]*>.*?<Element elementId="#{Regexp.escape(bar['id'])}"[^>]*/>.*?<Element elementId="#{Regexp.escape(legend['id'])}"[^>]*/>}m
                 )
-  ok('visible legend control stays beside its source chart', legend_pair)
+  ok('visible legend control stays beside and fills its source chart panel', legend_pair)
   donut = doc['elements'].find { |e| e['kind'] == 'donut-chart' }
   ok('donut category sort pins the positional Power BI palette',
      donut && donut.dig('color', 'sort') == {
@@ -152,6 +153,10 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
   ok('background and spacing survive', waterfall.dig('style', 'backgroundColor') == '#F8FAFC' &&
      doc.dig('settings', 'theme', 'overrides', 'colorOverrides', 'backgroundCanvas') == '#EEF2F7' &&
      doc.dig('settings', 'theme', 'overrides', 'space', 'unit') == 'small')
+  multiline_header = SigmaLayout.header_text_el('header', "Title\nSubtitle")
+  ok('multiline source header preserves a muted subtitle',
+     multiline_header['body'].include?('# <span style="color: #FFFFFF">Title</span>') &&
+       multiline_header['body'].include?('<span style="color: #94A3B8">Subtitle</span>'))
 
   control = doc['elements'].find { |e| e['controlType'] == 'list' }
   target_ids = Array(control && control['filters']).filter_map { |f| f.dig('source', 'elementId') }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -122,7 +122,7 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
        bar['legend'] == { 'visibility' => 'hidden' })
   legend_pair = bar && legend &&
                 doc['layout'].match?(
-                  %r{<Container elementId="band-page-p1-legend-#{Regexp.escape(bar['id'])}"[^>]*gridTemplateRows="repeat\(8, 1fr\)"[^>]*>.*?<Element elementId="#{Regexp.escape(bar['id'])}"[^>]*/>.*?<Element elementId="#{Regexp.escape(legend['id'])}"[^>]*/>}m
+                  %r{<Container elementId="band-page-p1-legend-#{Regexp.escape(bar['id'])}"[^>]*gridTemplateRows="repeat\(8, 1fr\)"[^>]*>.*?<Element elementId="#{Regexp.escape(bar['id'])}" gridColumn="1 / 25"[^>]*/>.*?<Element elementId="#{Regexp.escape(legend['id'])}" gridColumn="19 / 25"[^>]*/>}m
                 )
   ok('visible legend control stays beside and fills its source chart panel', legend_pair)
   donut = doc['elements'].find { |e| e['kind'] == 'donut-chart' }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -65,7 +65,9 @@ signals = {
       visual.call('nav', 'pageNavigator', 'navigation', 'text', {}, 'Pages', 450),
       visual.call('ctl', 'slicer', 'control', 'control', { 'Values' => ['S.Region'] }, 'Region', 600),
       visual.call('tbl', 'tableEx', 'table', 'table',
-                  { 'Values' => ['S.Region', 'S.Amount'] }, 'Details', 750)
+                  { 'Values' => ['S.Region', 'S.Amount'] }, 'Details', 750),
+      visual.call('donut', 'donutChart', 'donut', 'chart',
+                  { 'Category' => ['S.Region'], 'Y' => ['S.Amount'] }, 'Regional Share', 900)
     ]
   }]
 }
@@ -122,6 +124,11 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
                   %r{<Container elementId="band-page-p1-legend-#{Regexp.escape(bar['id'])}"[^>]*>.*?<Element elementId="#{Regexp.escape(bar['id'])}"[^>]*/>.*?<Element elementId="#{Regexp.escape(legend['id'])}"[^>]*/>}m
                 )
   ok('visible legend control stays beside its source chart', legend_pair)
+  donut = doc['elements'].find { |e| e['kind'] == 'donut-chart' }
+  ok('donut category sort pins the positional Power BI palette',
+     donut && donut.dig('color', 'sort') == {
+       'by' => donut.dig('color', 'id'), 'direction' => 'ascending'
+     })
   progress = doc['elements'].find { |e| e['kind'] == 'progress' }
   ok('gauge uses native ring progress', progress && progress['shape'] == 'ring' &&
      progress['mode'] == 'value' && progress['value'].to_s.include?('master-s'))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -141,8 +141,9 @@ Dir.mktmpdir('pbi-workbook-code') do |dir|
   ok('donut blank bucket is materialized on the master to avoid gray Others',
      blank_safe &&
        blank_safe['formula'] == 'Coalesce([S/Region], "(Blank)")' &&
-       donut_dim&.fetch('formula', nil) == '[master-s/Region (Blank-safe)]' &&
-       donut_legend&.dig('source', 'columnId') == 'm-region-blank')
+       donut_dim&.fetch('formula', nil) == '[master-s/Region (Blank-safe)]')
+  ok('donut keeps its legend chart-local so the ring fills the panel',
+     donut_legend.nil? && donut['legend'] == { 'visibility' => 'shown' })
   progress = doc['elements'].find { |e| e['kind'] == 'progress' }
   ok('gauge uses native ring progress', progress && progress['shape'] == 'ring' &&
      progress['mode'] == 'value' && progress['value'].to_s.include?('master-s'))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

A live Device Code Auth migration of `Retail Performance & Trends` exposed fidelity and execution defects in the Power BI skill:

1. Remove workspace-feature-gated `settings.navigation` while preserving native page navigators.
2. Correct `PY`/`YTD`/`YoY` routing and preserve fact provenance under DM reuse.
3. Avoid partial field loss from page-base routing.
4. Fix the Phase 6 chart-page readback census.
5. Keep Cartesian interactive legends beside their charts; keep donut/pie legends chart-local so the ring fills the panel.
6. Preserve Power BI donut palette ordering and materialize blank-safe categories so `(Blank)` gets the intended color.
7. Extract PBIR rich-text paragraphs and preserve title/subtitle styling.

Focused regressions cover the changes. The affected corpus golden was reconverted; its only semantic change is removal of the rejected navigation setting.

## Scope

- Plugin(s) touched: `powerbi-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] `ruby tools/lint-skills.rb` — green
- [x] Complete Power BI Ruby/Python suites — 52/52 green
- [x] `./corpus/run-corpus.sh --check` — 27/27 green
- [x] Focused workbook-code, legend, layout, palette, PBIR text, time-intel, and page-base regressions — green
- [x] CI — all 10 checks green, including the full Tableau Ruby suite
- [x] Final live render checked against the source screenshot
- [x] Phase numbers unchanged
- [x] No unrelated changes
- [x] Plugin version 1.8.26 → 1.8.28

## Live validation

- Reused Sigma data model: `0cd4360f-a52e-4399-ab25-36fbee114402`.
- Workbook: `b99746ae-5ae3-47c7-9cda-213c2cadf876`.
- 10/10 source visuals built; 19/19 bindings resolved; 88/88 columns resolve.
- Online Power BI DAX vs Sigma parity: 14/14 pass in import-snapshot drift mode, 0 divergent.
- Source dataset last refreshed 2026-07-30 and has failed refreshes; live Sigma values are fresher (923 vs 877 fact rows).
- Final render restores the subtitle, source chart families, chart-local donut legend, donut size, and category colors.
- No runtime controls remain; the control-flip gate reports nothing to test.
- `verify-complete.rb`: `✅ DONE`.

## Recorded limitations

- Final completion verdict is YELLOW, not GREEN: import-snapshot drift mode was necessary because the Power BI model is stale, and the user-supplied source screenshot was visible to the driving vision model but not mounted for a context-free blind-grader subagent.
- Telemetry was explicitly declined; nothing was sent.

## If this changes a shared lib

Not applicable.

## If this adds a converter

Not applicable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f96ecc6c-8c1c-406d-bdaa-ad729739659e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f96ecc6c-8c1c-406d-bdaa-ad729739659e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

