### PR TITLE
feat(excel-to-sigma): graduate staging skill with released code_rep wire

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -169,6 +169,13 @@
       "description": "Mode Analytics Reports (SQL Queries + Charts) -> Sigma, with parity verification. No formula translation needed -- Mode's SQL already runs in the target warehouse dialect.",
       "category": "migration",
       "keywords": ["mode", "migration", "bi"]
+    },
+    {
+      "name": "excel-to-sigma",
+      "source": "./plugins/excel-to-sigma",
+      "description": "Excel (.xlsx) planning / data-entry models → Sigma — formal-Table discovery, input-table → warehouse-view → data-model source-swap so forecasters keep entering numbers, plus equity-research / forecast builders. Workbook POSTs use the released document code_rep wrapper.",
+      "category": "migration",
+      "keywords": ["excel", "xlsx", "input-tables", "forecast", "planning", "migration", "bi"]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md — sigma-migration-skills
 
 Migration skills for moving BI tools (**Tableau, Power BI, Qlik, ThoughtSpot,
-QuickSight, Looker, Cognos, MicroStrategy, Sisense, GoodData, Domo, Hex**) to
-**Sigma**: per-tool *converters* (source → Sigma data model + workbook, with
-warehouse parity verification) and read-only *assessments* (tenant inventory →
-migration-readiness readout + shortlist).
+QuickSight, Looker, Cognos, MicroStrategy, Sisense, GoodData, Domo, Hex, Mode,
+Excel**) to **Sigma**: per-tool *converters* (source → Sigma data model +
+workbook, with warehouse parity verification) and read-only *assessments*
+(tenant inventory → migration-readiness readout + shortlist).
 
 This repo is packaged as a Claude Code plugin marketplace, but the skills are
 agent-neutral: each is a `SKILL.md` (instructions) plus `scripts/` (Ruby/Python/
@@ -61,6 +61,7 @@ Maturity labels (`gold` / `live` / `foundation` / `scaffold`) are defined in
 | Convert a Hex project (SQL/METRIC cells, EXPLORE charts, app layout) → Sigma | `hex-to-sigma` | live | `plugins/hex-to-sigma/skills/hex-to-sigma/` |
 | Scope/assess a Hex instance | `hex-assessment` | scaffold | `plugins/hex-to-sigma/skills/hex-assessment/` |
 | Convert a Mode Report (SQL Queries + Charts) → Sigma | `mode-to-sigma` | foundation | `plugins/mode-to-sigma/skills/mode-to-sigma/` |
+| Convert an Excel (.xlsx) planning / data-entry model → Sigma (input tables) | `excel-to-sigma` | foundation | `plugins/excel-to-sigma/skills/excel-to-sigma/` |
 | Author / repair Sigma workbooks (canonical spec) | `sigma-workbooks` | live | `plugins/sigma-authoring/skills/sigma-workbooks/` |
 | Author / repair Sigma data models (canonical spec) | `sigma-data-models` | live | `plugins/sigma-authoring/skills/sigma-data-models/` |
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ shared `~/.sigma-migration/env` under any agent.
 /plugin install domo-to-sigma@sigma-migration-skills
 /plugin install hex-to-sigma@sigma-migration-skills
 /plugin install mode-to-sigma@sigma-migration-skills
+/plugin install excel-to-sigma@sigma-migration-skills
 ```
 
 **Other agents (Cursor, Cortex Code, …)** — clone the repo and point your agent at the
@@ -67,6 +68,7 @@ and the skill drives discovery → translation → build → parity.
 | [`domo-to-sigma`](plugins/domo-to-sigma/) | Domo | `domo-to-sigma`, `domo-assessment`, `domo-import-to-snowflake` |
 | [`hex-to-sigma`](plugins/hex-to-sigma/) | Hex | `hex-to-sigma`, `hex-assessment` (scaffold) |
 | [`mode-to-sigma`](plugins/mode-to-sigma/) | Mode Analytics | `mode-to-sigma` |
+| [`excel-to-sigma`](plugins/excel-to-sigma/) | Excel (`.xlsx` planning / data-entry) | `excel-to-sigma` |
 | [`sigma-authoring`](plugins/sigma-authoring/) | (companion) | `sigma-workbooks`, `sigma-data-models`, … — install alongside every converter |
 
 In Claude Code, installed skills are namespaced — e.g. `/powerbi-to-sigma:powerbi-assessment`.

--- a/docs/phase-schema.md
+++ b/docs/phase-schema.md
@@ -170,3 +170,20 @@ local mapping:
 | C8 Parity hard gate | Phase 5 — Parity (`verify-parity.rb`, hard-gated by `assert-phase6-ran.rb`); the separate visual-render sub-gate (gate 8) is honestly waived in v1 (`--skip-visual-gate` — no Mode UI render capability), but the parity comparison itself is never skipped |
 | C9 Security/RLS | "Security: RLS/CLS" section — Mode has no row/column-level security on query results; access control is Space/Report visibility only |
 | C10 Enhance | — |
+
+### excel-to-sigma
+
+Excel uses "Phase" numbering from its staging repo. Its local mapping:
+
+| Canonical | excel-to-sigma |
+|---|---|
+| C1 Assess | — (no assessment skill yet; pick the `.xlsx` / fleet dir directly) |
+| C2 Discover | Phase 0 — Discover (`xlsx-discover.py`; Phase 0b macros, 0c model map, 0d template fingerprint) |
+| C3 Reuse-check | Phase 2 — reuse / extend an existing DM at the same grain before POSTing a new one |
+| C4 Convert | Phase 1–2 — seed extract + read/output DM; Phase 3–4 input-table + warehouse-view source-swap |
+| C5 Post-DM gate | Phase 2 — POST DM + read back server-assigned ids (`map_dm*`) before workbook build |
+| C6 Build workbook | Phase 5 — workbook builders (`build-input-table-wb.py` / `build-forecast-model.py` / `build-research-model.py`) |
+| C7 Layout | within Phase 5 — stacked notebook-flow `layout` assembled as the last write inside `workbook_wire.wire_workbook` before POST (released `code_rep` document wrapper) |
+| C8 Parity hard gate | Phase 0c/0d simulate-and-freeze + Phase 2/4 section rollups + research `batch-convert.py` AUTO_PARITY; never skipped |
+| C9 Security/RLS | "Security: RLS / CLS" — Excel has no native RLS/CLS to port; detect workbook/sheet protection only |
+| C10 Enhance | — |

--- a/plugins/excel-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/excel-to-sigma/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "excel-to-sigma",
+  "displayName": "Excel \u2192 Sigma",
+  "version": "0.2.0",
+  "description": "Migrate Excel (.xlsx) planning / data-entry models to Sigma \u2014 formal-Table discovery, Excel-formula translation, and the validated input-table \u2192 warehouse-view \u2192 data-model source-swap so forecasters keep entering numbers in Sigma. Workbook POSTs use the released document code_rep wrapper. Graduated from twells89/excel-to-sigma.",
+  "author": {
+    "name": "Thomas Wells"
+  },
+  "license": "MIT",
+  "keywords": [
+    "excel",
+    "xlsx",
+    "input-tables",
+    "forecast",
+    "planning",
+    "sigma",
+    "migration",
+    "bi",
+    "converter"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/excel-to-sigma/.gitignore
+++ b/plugins/excel-to-sigma/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.pyc
+# generated fixtures / scratch (regenerate via the make-sample-*.py scripts)
+skills/excel-to-sigma/scripts/Sample Forecast.xlsx
+skills/excel-to-sigma/scripts/Sample Research Model.xlsx
+*.tmp
+.DS_Store

--- a/plugins/excel-to-sigma/LICENSE
+++ b/plugins/excel-to-sigma/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thomas Wells
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/excel-to-sigma/README.md
+++ b/plugins/excel-to-sigma/README.md
@@ -1,0 +1,55 @@
+# Excel → Sigma
+
+Migrate **Excel (`.xlsx`) planning / budget / forecast models** to Sigma —
+preserving the part that matters most about a spreadsheet: **data entry**.
+
+Part of the [`sigma-migration-skills`](https://github.com/twells89/sigma-migration-skills)
+marketplace (`plugins/excel-to-sigma/`). Graduated from the staging repo
+[`twells89/excel-to-sigma`](https://github.com/twells89/excel-to-sigma); see
+[`SYNC.md`](SYNC.md).
+
+## What it does
+
+Excel planning models aren't dashboards — they're data-entry tools. The faithful
+Sigma translation keeps forecasters typing numbers, which is what **input tables**
+are for. The skill covers:
+
+1. **Discovery** — inventory formal Excel Tables, pivots, charts, and a formula
+   census (flagging the untranslatable).
+2. **Read/output half** — formal Tables → Sigma data-model elements; the
+   income-statement SUMIFS become grouped DM metrics + workbook charts.
+3. **Data-entry half (validated)** — the formal Table forecasters edit becomes a
+   Sigma **input table**; the data model re-points to read it through a
+   **warehouse view**.
+
+```
+Excel formal Table → Sigma input table → (publish) → SIGDS_ writeback
+   → warehouse view → data model (FROM view) → workbook charts/metrics
+```
+
+Workbook POSTs use the released **`code_rep` document wrapper** (same wire
+contract as every sibling converter). Builders author nested drafts;
+`skills/excel-to-sigma/scripts/lib/workbook_wire.py` assembles layout and wraps
+at the POST boundary.
+
+## Status
+
+- ✅ **Input-table data-entry path: validated end-to-end** (2026-06-08) with exact
+  parity on a 540-row forecast model.
+- ✅ Read/output DM + workbook build: validated (2026-06-03).
+- ✅ Workbook builders migrated to released document `code_rep` (2026-08).
+- 🚧 Discovery + Excel-formula translation: spiked, not yet a one-shot converter.
+
+See `skills/excel-to-sigma/SKILL.md` for the full workflow and `QUICKSTART.md` for
+a runnable walkthrough on the bundled sample fixture.
+
+## Requirements
+
+- A Sigma `SIGMA_API_TOKEN` (creds in `~/.sigma-migration/env`).
+- A **write-enabled** Sigma connection for the data-entry half (input tables write
+  back to a `SIGDS_` schema).
+- Python with `openpyxl` (+ `python-dateutil` for the fixture generator).
+
+## License
+
+MIT

--- a/plugins/excel-to-sigma/SYNC.md
+++ b/plugins/excel-to-sigma/SYNC.md
@@ -1,0 +1,15 @@
+# excel-to-sigma — graduated from `twells89/excel-to-sigma`
+
+This plugin was graduated from the staging repo
+https://github.com/twells89/excel-to-sigma into
+`plugins/excel-to-sigma/` so it can share the marketplace wiring, shared
+`code_rep` adapter, and governance gates with the other converters.
+
+- **Prior source of truth (staging):** `twells89/excel-to-sigma` (last synced
+  from `main` @ a83d42d, 2026-07-22).
+- **Current source of truth:** this directory in `sigma-migration-skills`.
+- **code_rep:** `skills/excel-to-sigma/scripts/lib/code_rep.py` is vendored
+  byte-identical from `shared/lib/code_rep.py` (see `shared/manifest.json`).
+  Edit the canonical copy, then `ruby tools/sync-shared.rb`.
+- Workbook builders call `scripts/lib/workbook_wire.py` at the POST / dry-run
+  boundary so nested drafts become the released document envelope.

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/QUICKSTART.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/QUICKSTART.md
@@ -1,0 +1,125 @@
+# Excel → Sigma — Quickstart
+
+End-to-end on the bundled sample fixture. ~10 min; three of the steps are clicks.
+
+## 0. Setup
+```bash
+cd <this skill>/scripts
+python3 -m venv .venv && .venv/bin/pip install openpyxl python-dateutil
+# Sigma creds in ~/.sigma-migration/env  (SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET)
+```
+
+## 1. Make (or bring) an Excel model
+```bash
+.venv/bin/python make-sample-forecast.py        # writes "Sample Forecast.xlsx" (540-row formal Table + dims + a SUMPRODUCT report)
+```
+Or point the next steps at a real `.xlsx`.
+
+## 2. Discover
+```bash
+.venv/bin/python xlsx-discover.py "Sample Forecast.xlsx"
+```
+Lists formal Tables, their grain, pivots/charts, and a formula census. Confirm the
+fact Table + grain with the user.
+
+## 3. Extract the paste-ready seed
+```bash
+.venv/bin/python xlsx-to-input-csv.py "Sample Forecast.xlsx" --table tblForecast --out forecast_input_paste.csv
+```
+Entry columns only, UPPER_SNAKE_CASE headers, dates as ISO. (System columns are
+excluded — Sigma auto-populates them.)
+
+## 4. Build the input-table structure  (API)
+```bash
+.venv/bin/python build-input-table-wb.py --name "Forecast Entry" --connection cb2f5180-… \
+  --columns REGION:text,BRANCH:text,SUB_BRANCH:text,MONTH_DATE:datetime,CATEGORY_CODE:number,FORECAST_AMOUNT:number
+```
+> Builds the empty input-table **structure** (API). Loading the rows is a UI step
+> (CSV paste) until the bulk-seed API lands. **Don't use `--linked` for a shippable
+> table** — linked context columns don't resolve via POST ("multiple values");
+> build linked input tables in the UI. See `refs/input-tables.md`.
+
+## 5. Load data + view  (UI — see refs/input-tables.md)
+1. Open the workbook → the input table → **paste** `forecast_input_paste.csv`.
+2. **Publish** (data commits to the warehouse only on publish).
+3. Input-table element → **Warehouse views → Create new** → copy the
+   `database.schema.view` path.
+
+## 6. Build the DM on the view  (API)
+```bash
+.venv/bin/python build-dm-on-view.py --view SIGMA_WRITE_DB.SIGMA_WRITE.FORECAST_ENTRY \
+  --connection cb2f5180-… --categories-from "Sample Forecast.xlsx"
+# prints the dataModelId
+```
+
+## 7. Verify parity
+Query the DM's report element grouped by Statement Section (Sigma MCP) and compare
+to the targets the discover step computed. The fixture's targets:
+Revenue **10,902,533** · Contract Costs **−5,603,043** · Admin **−2,221,185** ·
+Allocation **−415,557** · Net Contribution **2,662,748**.
+
+> Validated run (2026-06-08): exact parity on all sections. workbook
+> `cb6c53ef-…`, view `SIGMA_WRITE_DB.SIGMA_WRITE.FORECAST_ENTRY`, DM `04e462d8-…`.
+
+---
+
+# Worked example B — actuals + driver-grown + manual P&L (one-shot builder)
+
+For a "report drawn in cells" planning model (live actuals + assumption-driven
+forecast + manual cells) — the FP&A case. `xlsx-discover.py` now prints a
+**cell-level model map** (ACTUAL / DRIVER_GROWTH / MANUAL / FLAT / DERIVED); after
+confirming intent (read-only / editable / what-if — see `refs/model-taxonomy.md`),
+drive the whole build from a **model-plan JSON**:
+
+```bash
+# dry run: local parity + emits dm_spec.json / wb_spec.json / seed CSVs to /tmp/fcst-build
+.venv/bin/python build-forecast-model.py sample-model-plan.json
+# build live (DM + workbook with union[actuals,forecast], KPIs, Actual|Forecast pivot, trend, editable rate+manual tables)
+.venv/bin/python build-forecast-model.py --post sample-model-plan.json
+```
+
+The forecast is computed (`base × (1+rate)^n`); editable rate/manual input tables
+override via `Coalesce(input, default)`, so **parity holds before any seeding**
+(verified: Revenue 6,961,218.48 · EBITDA 62,327.16 · **Net Income −135,372.84**).
+Then: paste `rate_seed.csv` / `manual_seed.csv` into the two editable tables +
+Publish to make them live; run `wb-rep push` for the designed layout (the POST
+lands auto-arranged). See `refs/forecast-recipes.md`.
+
+If `.xlsm`: run `macro-classify.py` first (`refs/macro-handling.md`) — surface
+FLAG/ACTION macros before building.
+
+> Note: delete a test workbook/DM via `DELETE /v2/files/{inodeId}` (not
+> `/v2/workbooks/{id}`, which 404s).
+
+---
+
+## Worked example C — equity-research model (broker / FactSet house template)
+
+For a sell-side research model (line-items × YEARS, statement sections; e.g. a FactSet-style broker model). Generate the synthetic fixture, then convert it:
+
+```bash
+# fake, no-customer-data fixture (Acme Widgets NV): plug-cycle + %-literal + Lag + #REF! + MIXED
+.venv/bin/python make-sample-research-model.py                       # -> scripts/Sample Research Model.xlsx
+
+# infer the two-layer plan (hard-coded grid + ONE canonical formula per derived line)
+.venv/bin/python infer-canonical-formulas.py "Sample Research Model.xlsx" \
+    --sheet="FY results" --first-row=7 --last-row=45 --out plan.json
+
+# build DM (data page) + workbook (computation + transpose + display pivot)
+.venv/bin/python build-research-model.py plan.json --conn <writeConn> --folder <id> --post
+```
+
+The report shows `input / derived / ratio` counts, live-verified vs frozen formula
+cells, and resolved anchors. Verified end-to-end: the synthetic fixture round-trips
+to **100% cell parity**, and a real broker equity-research model rebuilt to **100.00% parity
+(3,263/3,263 cells), ~81% live Sigma formulas** — far simpler than a hand build (one
+column per line, not per-year `User`/`Calc`/`(1)` triplets). See `refs/research-recipes.md`.
+
+**A fleet of similar files** (the ~850-file case) → `batch-convert.py` fingerprints,
+maps to the chart-of-accounts (`coa.json`), converts, parity-gates, and emits a triage
+manifest (AUTO_PARITY / NEEDS_REVIEW / FAILED) + the top unmapped labels to grow the COA:
+
+```bash
+.venv/bin/python batch-convert.py /path/to/models/ --sheet="FY results" --out manifest.json
+```
+See `refs/research-template-coa.md`.

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/SKILL.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: excel-to-sigma
+description: >-
+  Convert an Excel (.xlsx) workbook — especially a planning / budget / forecast
+  data-entry model — into a Sigma data model + workbook. Use when the user has
+  an Excel file (formal Tables, pivots, charts, or a cell-formula budget model)
+  and wants to recreate it in Sigma. Covers formal-Table discovery, Excel-formula
+  translation, and the input-table → warehouse-view → data-model pattern that
+  preserves data entry. Requires a Sigma SIGMA_API_TOKEN and (for the data-entry
+  half) a write-enabled Sigma connection.
+user-invocable: true
+---
+
+# Excel → Sigma Conversion
+
+> Phase numbering is local to this skill; the canonical Assess→Discover→Reuse→
+> Convert→Post-DM→Build→Layout→Parity→Security→Enhance arc and this skill's
+> mapping live in `docs/phase-schema.md` (full clone only).
+
+> **STATUS: input-table data-entry path VALIDATED end-to-end (2026-06-08).** The
+> full chain — Excel formal Table → Sigma input table → warehouse view → data
+> model reading `FROM` that view → section rollups — was proven with **exact
+> parity** on a representative 540-row forecast model. The read/output half (DM +
+> workbook from a landed seed) was validated earlier (2026-06-03). The discovery
+> + formula-translation layer is designed and spiked, not yet a one-shot
+> converter — see `refs/excel-translation.md`. Graduated from
+> `twells89/excel-to-sigma` into this marketplace; workbook POSTs use the
+> released `code_rep` document wrapper (same as every sibling converter).
+
+<!-- mandatory-pre-read -->
+**Read before acting (load more refs only when the phase needs them):**
+- `refs/input-tables.md` — validated input-table workflow + API-vs-UI split (source-swap goes through a warehouse view, not a direct DM source binding).
+- `refs/excel-translation.md` — translation surface, formal-Table MVP rule, grain selection.
+- `refs/sigma-build-gotchas.md` — DM/workbook wire rules incl. released document wrapper.
+<!-- /mandatory-pre-read -->
+
+Phase-scoped (load on demand): `refs/macro-handling.md` (`.xlsm`),
+`refs/model-taxonomy.md` + `refs/forecast-recipes.md` (cell-drawn planning),
+`refs/research-recipes.md` + `refs/research-template-coa.md` (equity-research fleets).
+Companion authoring: `sigma-workbooks` (in `sigma-authoring`) + the Sigma OpenAPI.
+
+---
+
+## The one big idea
+
+Excel planning models are **data-entry tools**, not dashboards. Forecasters type
+numbers into budget sheets; formulas roll them into an income statement. The
+faithful Sigma translation keeps that data entry alive — which is exactly what
+**input tables** are for.
+
+The decisive structural insight (validated): in well-structured enterprise
+workbooks, the value lives in **formal Excel Tables** at a tidy grain. Most of the
+thousands of `INDEX/MATCH/SUMIFS` formulas are **wide→long reshaping**, not
+business logic — they *evaporate* when the data lands at that grain in a Sigma DM.
+What's left ("report" sheets drawn in cells) is rebuilt by hand, same as any
+migration.
+
+So the migration is two halves:
+
+1. **Read / output half** — the formal Table(s) become DM elements; the income-
+   statement SUMIFS become grouped DM metrics + workbook charts. (Build against a
+   seed first; see `refs/excel-translation.md`.)
+2. **Data-entry half** — the formal Table that forecasters edit becomes a Sigma
+   **input table**; the DM re-points to read from it. (See `refs/input-tables.md`.)
+
+---
+
+## Preserve the inputs — never ship a read-only port
+
+**A spreadsheet is an app people type into. If the conversion is read-only, you've
+demoted it.** Don't default every table to a read-only DM element. Classify each
+source table by *how it's used* and route accordingly:
+
+| Source table is… | → Sigma | Editable? |
+|---|---|---|
+| **Entered** (users type values: budget inputs, a tracker, subscriptions) | **input table** (empty / CSV / linked) | ✅ like Excel/Sheets |
+| **Derived** (formula rollups: the income statement, SUMIFS summaries) | read-only DM element + metrics | ❌ recomputes |
+| **Reference dim** (lookup lists users maintain) | input table if maintained, else read-only | depends |
+
+A Phase-0 heuristic: a formal Table that's *fed by* formulas/other sheets and only
+*read* downstream = **derived**; a Table whose cells are typed values with no
+inbound formula = **entered**. Route entered → input-table builder, derived →
+read-only DM/metric builder. When unsure, ask the user how they use that sheet.
+
+### What's actually buildable via API today (validated 2026-06-10 by MCP query)
+
+> **Hard-won correction.** Earlier drafts claimed linked input tables were the
+> "powerful path, fully API, no seed." **That was wrong — validated only by
+> structure (`/elements`), never by querying the data.** A linked input table
+> authored via `POST /v2/workbooks/spec` has **inherited columns that don't
+> resolve** — every row shows **"multiple values"** (publish doesn't fix it;
+> re-POSTing a known-good UI-built spec reproduces the break). The linked-column
+> key-correlation is UI-only state the spec can't carry. See
+> `refs/input-tables.md`.
+
+So, honestly, by usage pattern:
+
+| Need | API today? | How |
+|---|---|---|
+| **Edit-in-place of the migrated rows** (the common spreadsheet case) | ❌ | empty/CSV input table **structure** is API; loading the rows = UI CSV paste now, the **bulk-seed API** later |
+| **Net-new entry at a grain** (blank forecast grid) | ⚠️ partial | a linked-off-spine table's PK/grain + entry columns populate via POST, but the **dimension context columns show "multiple values"** → UX is poor; build in UI for now |
+| **Augment / annotate existing rows** (notes/flags beside live data) | ❌ via API | needs working linked columns → **UI-authored** |
+
+**Bottom line today:** via API you can scaffold input-table *structure* and build
+read-only DMs; making input tables actually *show the migrated data editable*
+needs the UI (CSV paste / UI-built linked tables) until the bulk-seed API lands.
+Don't promise "editable via API" — scaffold the structure, then hand off the
+data-load/link step as a UI action (or wait for the seed API).
+
+Design so the editable surfaces exist from day one; the seed API just fills the
+"edit-in-place" case later. **Don't build a read-only model and call it a
+migration.**
+
+---
+
+## Prerequisites
+
+### Sigma access
+```bash
+# neutral cred file written by the sigma-migration setup (see refs/input-tables.md)
+bash -c 'source ~/.sigma-migration/env; TOKEN=$(curl -s -X POST "$SIGMA_BASE_URL/v2/auth/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=$SIGMA_CLIENT_ID&client_secret=$SIGMA_CLIENT_SECRET" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)[\"access_token\"])"); <cmd>'
+```
+The **data-entry half requires a write-enabled connection** (input tables write
+back to a `SIGDS_` schema). Confirm via `GET /v2/connections` → `writeAccess: true`.
+Verified write connection on tj-wells-1989: `cb2f5180-…` (Snowflake ymb68310).
+
+### Python
+`scripts/` use `openpyxl` (+ `python-dateutil` for the fixture generator). Install
+into a venv: `python3 -m venv .venv && .venv/bin/pip install openpyxl python-dateutil`.
+
+### Optional: `snow` CLI
+Used only to look up the **full path** of a Sigma-created warehouse view
+(`SIGMA_WRITE_DB.<schema>.<view>`) when the UI truncates it. SSO browser-auth;
+`snow sql -c default --format json -q "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME FROM <DB>.INFORMATION_SCHEMA.VIEWS WHERE TABLE_NAME ILIKE '<view>%'"`.
+
+---
+
+## Phase 0 — Discover the workbook (`scripts/xlsx-discover.py`)
+
+Walk the `.xlsx` (OOXML = a ZIP of XML; `openpyxl` reads it). Produce an inventory:
+
+- **Formal Tables** (`xl/tables/*.xml`) — name, sheet, range, columns. These are
+  the migration's Rosetta Stone: each is a DM-element / input-table candidate.
+- **Pivots, charts, slicers** — count + anchor; map to `pivot-table` / chart /
+  control later.
+- **Formula census** — tally functions; flag the untranslatable (`OFFSET`,
+  `INDIRECT`, volatile locators) and the "report drawn in cells" sheets.
+- **Degenerate-column warnings** — constant / decayed columns (broken fiscal
+  defaults, stale lookup spines). **Derive these, don't port them.**
+
+State the inventory back to the user and confirm the **canonical grain** of the
+fact Table before building.
+
+### Phase 0b — Macro inventory & disposition gate (if `.xlsm`/`.xlsb`/`.xls`)
+
+If the file is macro-enabled, run the macro pass **before building** — a dropped
+macro is a silent loss of behavior (see `refs/macro-handling.md`):
+
+```bash
+python scripts/macro-classify.py <file.xlsm>          # report
+python scripts/macro-classify.py --json <file.xlsm>   # contract for build steps
+```
+
+Each procedure is classified (olevba-extracted VBA) and routed: **AUTO** (covered
+by the data/formula conversion or safely dropped), **CONTROL** (controls / editable
+assumptions table), **ACTION** (Sigma Action — *gated on the Actions primitive*;
+scaffold a placeholder + inventory entry now), or **FLAG** (external I/O / opaque —
+human review). **Surface the FLAG and ACTION items to the user and get
+acknowledgement before build.** Never silently omit a macro.
+
+### Phase 0c — Model map & intent (for "report drawn in cells" / planning models)
+
+When there are **no formal Tables** (a cell-drawn P&L/budget/forecast), don't punt
+to "manual rebuild." `xlsx-discover.py` now prints a **cell-level model map**:
+classifies each formula/value as **ACTUAL** (SUMIFS over a data tab → live DM),
+**DRIVER_GROWTH** (`prior×(1±rate)` → closed-form `base×(1+rate)^n`), **MANUAL**
+(literal among formulas → editable input table), **FLAT** (`=prior` → carry), or
+**DERIVED** (totals/margins → workbook calc), and names the actuals-source +
+drivers sheets.
+
+That map *is* the architecture: **union [live ACTUAL] + [forecast]**. Before
+building, **present the map and ask the 3 intent questions** (read-only report /
+editable plan / live what-if; which inputs editable; actuals live or snapshot) —
+see `refs/model-taxonomy.md`. Then build per `refs/forecast-recipes.md` and
+**assert parity to the cent** against the sheet's cached totals (the trust gate).
+
+### Phase 0d — Template-family fingerprint & routing (financial-statement models)
+
+Before choosing a build path, **fingerprint the file** (see `refs/research-template-coa.md`):
+a **broker/FactSet equity-research model** (line-items down rows, YEARS across columns, sections
+like PROFIT AND LOSS / PER SHARE DATA / BALANCE SHEET; often `__FDSCACHE__` + thousands of named
+ranges) routes to the **research archetype**, NOT the FP&A forecast path:
+
+```bash
+python scripts/infer-canonical-formulas.py <file.xlsx> --sheet="FY results" \
+       --first-row=7 --last-row=<end> --out plan.json     # per-file inference + parity gate
+python scripts/build-research-model.py plan.json --conn <writeConn> --folder <id> [--post]
+```
+
+`infer-canonical-formulas.py` extracts the hard-coded grid + one canonical formula per derived
+line, breaks plug-cycles, and simulates-and-freezes to guarantee **displayed parity = 100%**.
+`build-research-model.py` posts the DM (data page) + workbook (computation + transpose + pivot).
+
+**For a fleet of similar files off one template** (the ~850-file case), use
+`scripts/batch-convert.py` — it fingerprints, maps each file's line items to a canonical
+chart-of-accounts (`refs/research-template-coa.md` + `coa.json`), converts, parity-gates, and
+emits a **triage manifest** (AUTO_PARITY / NEEDS_REVIEW / FAILED) with no silent truncation.
+Read `refs/research-template-coa.md` first. Everything else (a cell-drawn P&L with a data tab,
+SUMIFS actuals, driver growth) stays on the FP&A path below.
+
+## Phase 1 — Pick the grain & extract the seed (`scripts/xlsx-to-input-csv.py`)
+
+For the fact Table, emit a **paste-ready CSV** with:
+- **only the data-entry columns**, headers in `UPPER_SNAKE_CASE` matching the
+  Sigma input-table column names exactly (so a clipboard paste aligns 1:1),
+- **no system columns** — `Row ID` / `Created at|by` / `Last updated at|by`
+  auto-populate in Sigma; including them breaks the paste.
+
+Parse Excel date serials → ISO dates here.
+
+## Phase 2 — Build the read/output DM (against a seed) + reuse-check
+
+Before POSTing a new DM, check whether an existing Sigma data model already
+covers the same grain (same formal-Table columns / warehouse view). Prefer
+reusing / extending that DM over spawning another copy — same intent as
+`find-or-pick-dm.rb` in the other converters. When no match, land the seed
+(inline `VALUES` custom-SQL for ≤~1k rows; PUT-to-stage + COPY INTO for larger)
+and POST the DM (fact + dim elements + relationships + a flattened `*_REPORT`
+join element for grouping).
+
+**Post-DM readback (hard gate):** after `POST /v2/dataModels/spec`, GET the
+live spec and map server-assigned element/column ids before any workbook build
+(`build-forecast-model.py` / `build-research-model.py` already do this via
+`map_dm*`). Never trust authored ids past the POST. Full build rules in
+`refs/sigma-build-gotchas.md`.
+
+## Phase 3 — Stand up the input table (`scripts/build-input-table-wb.py`)
+
+Build the **empty input-table structure via API**; load/link the data via UI for
+now (or the bulk-seed API later). See `refs/input-tables.md`.
+
+**Empty input table (API for structure).** POST an **empty input-table element** at
+the fact grain (`source: { kind: empty, connectionId: <write-conn> }`,
+`inputMode: explore`, data columns + system columns
+`ID/CREATED_AT/CREATED_BY/UPDATED_AT/UPDATED_BY`). Then UI: open the input table →
+**paste / upload** the Phase-1 CSV → **Publish** → **Warehouse views → Create
+new**. (The CSV paste is the current bridge for the bulk-seed API.)
+
+> **Do NOT auto-build linked input tables via the spec.** It looks like it works
+> (the POST succeeds, `/elements` shows the columns) but the **inherited columns
+> resolve to "multiple values"** — the linked correlation is UI-only (validated
+> 2026-06-10, publish doesn't fix it). `build-input-table-wb.py --linked` only
+> scaffolds the PK/grain + entry columns; the *linked context columns must be
+> added in the UI*. If a usage pattern needs live context columns beside editable
+> cells, build that table in the UI.
+
+## Phase 4 — Source-swap the DM onto the view (`scripts/build-dm-on-view.py`)
+
+Re-point (or build) the DM's fact element to `SELECT … FROM <warehouse view>` on
+the write connection. Display names stay identical, so the workbook + metrics are
+unchanged. This is **API**. Verify the section rollups hit the same parity targets
+as Phase 2.
+
+## Phase 5 — Build / repoint the workbook, layout last, parity
+
+Build the dashboard pages (Forecast Summary pivot + KPIs, trend charts) per
+`sigma-workbooks`, sourced from the DM. Builders author a nested
+`pages[].elements` draft; **`scripts/lib/workbook_wire.py` assembles layout XML
+as the last write**, then wraps via `code_rep` into the released
+`{ name, folderId, document: { schemaVersion, kind, pages, elements, layout } }`
+body before `POST /v2/workbooks/spec`. Do **not** POST a flat pre-document
+workbook body (live API 400s). Data-model specs stay unwrapped.
+
+Confirm every element compiles and the totals tie out (parity hard gate —
+Phase 0c/0d simulate-and-freeze, Phase 2/4 section rollups, research
+`batch-convert.py` AUTO_PARITY bucket). Never skip the parity comparison.
+
+### Security: RLS / CLS
+
+Excel workbooks have no native row-/column-level security construct to port —
+access control is file-share / workbook-protection only. Detect workbook
+password protection / sheet protection during Phase 0 and note it for the
+customer; do not invent Sigma RLS from spreadsheet structure. If the landed
+warehouse tables already carry RLS policies outside Excel, leave those to the
+warehouse / Sigma admin — this skill does not apply RLS automatically.
+
+---
+
+## Scriptability matrix (verified vs. live OpenAPI + connections; input-table re-verified 2026-06-10)
+
+| Step | Path |
+|---|---|
+| input-table **structure** (columns/types; title `name`, `tableStyle`, `sort` round-trip) | ✅ API (workbook spec) |
+| **linked** input table (inherited columns resolve) | ❌ UI only — spec POST yields "multiple values" (publish doesn't fix); PK/grain + entry cols populate but linked cols don't |
+| seed **data** load into an empty/CSV table (CSV upload / paste) | ⚠️ UI now — no REST endpoint; bulk-seed API in progress |
+| **Publish** (commits writeback) | ⚠️ UI |
+| **warehouse view** on the input table | ⚠️ UI only |
+| DM **source-swap** to `FROM <view>` | ✅ API (DM spec PUT/POST) |
+| read/output DM + workbook build | ✅ API |
+| data validation / column protection / data-entry permission | ⚠️ UI (linked dimension columns are auto-locked) |
+
+With **linked mode** the only mandatory UI steps are **Publish** and **Create
+warehouse view** — everything else, including the grain, is scripted. Bake those
+two into the run as explicit "do this, then tell me the view path" hand-offs.
+
+---
+
+## What this skill does NOT do (yet)
+
+- One-shot `.xlsx` → finished migration. Phase 0–1 (discovery + formula
+  translation) is spiked, not a hardened converter. The data-entry path (Phase
+  3–4) is fully validated.
+- Power Query / ODBC / SharePoint-Online sources — MVP assumes inline data +
+  Snowflake landing (the other source paths are additive; see
+  `refs/excel-translation.md`).
+- `.xlsm` / VBA / macros — **detected + classified + routed** (Phase 0b,
+  `scripts/macro-classify.py` + `refs/macro-handling.md`); never *executed*.
+  Write-back macros (`ACTION`) are gated on the forthcoming Sigma Actions
+  primitive — scaffolded as placeholders + inventory until it ships.
+
+See `refs/excel-translation.md` for the full converter-build design and the
+~60–70% pipeline reuse from `tableau-to-sigma`.

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/refs/excel-translation.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/refs/excel-translation.md
@@ -1,0 +1,85 @@
+# Excel → Sigma translation surface & converter design
+
+Condensed from the converter design notes + the 2026-06-03/06-08 validation spike
+against a real customer forecast model (5-year BU budget, 13 sheets, 3,255
+formulas, 37 external links). The design held, with refinements baked in below.
+
+## Translation surface
+
+| Excel concept | Sigma equivalent | Difficulty |
+|---|---|---|
+| Worksheet | Workbook page | trivial |
+| Formal **Table** (named, structured) | DM element / input table | easy if data lands somewhere reachable |
+| Arbitrary cell range with values | text element OR a landed warehouse table | fundamental impedance mismatch |
+| Cell formula (`=A2*B2`) | calc column on the parent Table | hard at scale (cell-grid vs column-of-rows) |
+| Named range | calc column or control | medium |
+| PivotTable | `pivot-table` (`rowsBy`/`columnsBy`/`values`) | clean 1:1 — pivot cache has the metadata |
+| Chart | chart element of matching `kind` | mostly 1:1; radar/waterfall need substitution |
+| Conditional formatting | `conditionalFormats[]` | clean 1:1 |
+| Slicer | `control` element | clean 1:1 |
+| Data validation (dropdown) | input-table single/multi-select, or `control` | medium |
+| External links (workbook→workbook) | DM relationship / joined element | the biggest robustness win |
+| VBA / macros | out of scope | flag in Phase 0 |
+
+`.xlsx` is OOXML (ZIP of XML). Key members: `xl/tables/*.xml` (formal Tables),
+`xl/pivotTables/*` + `xl/pivotCache/*`, `xl/charts/*.xml`, `xl/styles.xml`
+(number formats / conditional formats), `xl/sharedStrings.xml`. Parse with
+`openpyxl` (mature formula tokenizer) or `Nokogiri`.
+
+## The three structurally hard problems
+
+1. **Cell-grid → column-of-rows.** Only translate cell formulas that live inside
+   formal Tables. Everything else → "manual review". Report sheets are rebuilt by
+   hand in any migration anyway.
+2. **Where does the data live?** MVP assumes **inline values → Snowflake landing**
+   (inline `VALUES` custom-SQL for ≤~1k rows, PUT-stage + COPY INTO for larger).
+   Power Query / ODBC / SharePoint-Online are additive paths once inline works.
+3. **Formula breadth.** Cover the common ~30 functions (IF/IFS/SWITCH/IFERROR,
+   SUM/SUMIFS/COUNTIFS/AVERAGEIFS, VLOOKUP/XLOOKUP/INDEX+MATCH, LEFT/MID/CONCAT,
+   YEAR/MONTH/EOMONTH/EDATE, ROUND/ABS/MOD). Fail-loud on volatile locators
+   (`OFFSET`, `INDIRECT`) — they almost always mark a report layout that needs a
+   manual rebuild. A `convert_excel_formula_to_sigma` MCP tool would mirror the
+   existing `convert_tableau_formula_to_sigma` rules-table pattern.
+
+## Validation findings (fold into the converter)
+
+- **80/20 formula coverage is real.** Of 3,255 formulas, only `OFFSET` (2%) was
+  genuinely untranslatable. The big `MATCH/INDEX/SUMIFS` counts were
+  *wide→long reshaping*, not business logic — they **evaporate** when data lands
+  at a tidy grain. **State this to users: most "formula translation" is grain
+  selection.**
+- **Formal-Table-only MVP rule is right.** The one normalized Table was the
+  Rosetta Stone defining the canonical grain. Report sheets were rebuilt by hand.
+- **External links → warehouse joins** collapsed 55% of formulas to a few DM
+  relationships. Biggest robustness win.
+- **Inline `VALUES` custom-SQL beats CSV-landing for the seed** at ≤~1k rows — no
+  warehouse write, and the source-swap to the real table/view is a one-line spec
+  change.
+- **Cached values are a trap on formula-driven output sheets.** Detached
+  INDEX/MATCH sources cache dimension keys to `0`. The discovery scanner must
+  distinguish *typed* cells from *formula* cells and warn when an output table's
+  keys are computed from now-missing externals.
+- **Derive, don't port, decayed columns** — broken fiscal-month/year defaults,
+  stale date-lookup spines that end before the forecast window. Generate forward.
+
+## Pipeline reuse from `tableau-to-sigma` (~60–70%)
+
+Sigma-side (DM POST, workbook POST, verify, visual gate) is identical. Only the
+input parser, calc discovery, and formula translator differ.
+
+| Phase | Tableau | Excel |
+|---|---|---|
+| 0 Gap/layout scan | `scan-workbook-gaps.rb` / `parse-twb-layout.rb` | `xlsx-discover.py` (this skill) |
+| 1 Calc discovery | Metadata API → `.twb` fallback | OOXML XML walk only |
+| 2 Data landing | VDS / custom-SQL probe | inline VALUES / PUT-stage + COPY INTO |
+| 3 DM build | `build-dm.py` | `build-dm-on-view.py` (this skill) |
+| 4 Workbook build | `build-charts-from-signals.rb` | `sigma-workbooks` recipes |
+| 5 Verify | `verify-workbook.rb` | unchanged |
+
+Everything from validate-spec onward is platform-agnostic.
+
+## MVP scope
+
+`.xlsx` only; formal Tables as sources; pivots/charts from formal Tables; top ~30
+functions translated, rest flagged; inline-data → Snowflake landing; the
+input-table data-entry path from `refs/input-tables.md`.

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/refs/forecast-recipes.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/refs/forecast-recipes.md
@@ -1,0 +1,109 @@
+# Forecast / planning recipes (proven on the FY P&L build, 2026-06-17)
+
+The Sigma spec patterns for an **actuals + driver-grown + manual** model. All
+live-verified to exact parity (Net Income −$135,372.84, EBITDA $62,327.16). Pair
+with `refs/model-taxonomy.md` (which architecture) and `sigma-build-gotchas.md`.
+
+## 1. Closed-form growth — no recursion
+
+Excel's `forecast = prior × (1+rate)` recursion is a **closed form**:
+`forecast[n] = base × (1+rate)^n` where `n` = months after the base (Jun=0). So a
+DM custom-SQL element computes it directly — no window functions, no recursion:
+
+```sql
+-- spine: one row per (line × forecast month) with base/n/kind/default rate
+with spine(line_item, section, month, month_num, month_end, n, kind, default_rate, manual_value, june_base) as (
+  values ('Subscription Revenue','Revenue','Jul-26',7,'2026-07-31'::date,1,'growth',0.03,NULL,503000.00), ...
+)
+select section, line_item, month, month_num, month_end,
+  case kind when 'manual' then manual_value when 'flat' then june_base
+       else june_base * power(1+default_rate, n) end as amount,
+  'Forecast' as period
+from spine
+```
+
+`^` is the power operator in Sigma workbook formulas (`[June Base] * (1 + [Rate]) ^ [N]`); `power()` in warehouse SQL.
+
+## 2. Override pattern — defaults that stay editable
+
+To make rates/manual cells editable *and* correct before any seed, the forecast
+reads `Coalesce([editable input], [default])`:
+
+```
+Eff Rate   = Coalesce([Rate], [Default Rate])          -- from an editable rates input table
+Eff Manual = Coalesce([Manual Entry], [Manual Value])  -- from an editable manual input table
+Amount     = If([Kind] = "manual", [Eff Manual],
+                [Kind] = "flat",   [June Base],
+                [June Base] * (1 + [Eff Rate]) ^ [N])
+```
+
+Unseeded → uses defaults (parity holds); user edits a cell → their value wins and
+everything recomputes. The editable inputs are **input tables** joined to the
+spine (left-outer, on Line Item [+ Month Num for manual]).
+
+## 3. Combine actuals + forecast — `union`
+
+One P&L fact = union of the live actuals and the forecast. **Both legs must be
+wrapped workbook `table` elements** — a `data-model` (or raw input-table) leg
+*inside* a `union`/`join` is rejected:
+`400 "data-model source requires owning element's columns"`. So wrap each DM/spine
+element in a passthrough `table` first (`actuals`, `forecastWrap`/`forecast`).
+
+```yaml
+source:
+  kind: union          # NOTE: union has no `name` field → outputs are referenced
+  sources:             #       as [Union of 2 Sources/Col] downstream
+    - { kind: table, elementId: actuals }
+    - { kind: table, elementId: forecast }
+  matches:
+    - { outputColumnName: Section, sourceColumns: ["[Section]", "[Section]"] }   # bare refs, one per leg
+    - { outputColumnName: Amount,  sourceColumns: ["[Amount]",  "[Amount]"] }
+    # … Line Item, Month, Month Num, Month End, Period
+```
+
+Add a `Period` column on each leg (`"Actual"` / `"Forecast"` literal) so the
+combined fact carries it. Row-flag calc columns on the combined element drive
+cross-section roll-ups:
+`Revenue Amt = If([Section]="Revenue",[Amount],0)`, COGS/OpEx/Below likewise →
+`EBITDA = Sum(Rev)-Sum(COGS)-Sum(OpEx)`, `Net Income = … - Sum(Below)`.
+
+## 4. Actual vs Forecast, visible — pivot column grouping
+
+Mirror Excel's `ACTUALS | FORECAST` header band: outer `columnsBy` on `Period`,
+then `Month`:
+
+```yaml
+columnsBy:
+  - { id: p_period, sort: { direction: ascending } }   # Actual < Forecast
+  - { id: p_month,  sort: { direction: ascending } }
+```
+
+(Row order: carry `Section Order`/`Line Order` columns and sort `rowsBy` with
+`{ by: <orderCol>, aggregation: min, direction: ascending }`.)
+
+A **trend ref-line** at the actual/forecast boundary does *not* work cleanly: a
+`refMark` value is a number/columnId, not a date, and the x-axis is a date — skip
+it; the pivot grouping is the reliable cue.
+
+## 5. Plumbing goes on a hidden page
+
+Intermediate elements (`actuals`, `forecastWrap`/`forecast`, `spineWrap`, the
+`union`) are sources, not visuals. Unplaced elements **auto-append to the canvas**
+(`visibleAsSource:false` does *not* remove them) — put them on a second page with
+`visibility: hidden`. Visuals on the main page source them by `elementId`
+across pages fine.
+
+## 6. Layout + input-table gotchas (cost real time)
+
+- **Layout only sticks via `wb-rep push`.** A direct `POST`/`PUT` of `pages[].layout`
+  is silently replaced by Sigma's auto-arrange. Edit `_layout.xml` in the rep and push.
+- **Input-table data-entry columns lose `name`/`format` on readback.** Any re-pull→push
+  (or GET→PUT) drops them, which then breaks join keys (`Column reference not found:
+  '[Line Item]'`). Re-add `name` (and `format`) on every input-table column before pushing.
+- **Input-table data load is UI-only** (paste/CSV + Publish); no REST endpoint yet.
+  Seed CSVs cover the editable rates (5 rows) + manual cells (24 rows); defaults keep
+  parity until seeded.
+- **Workbook controls are filter controls, not free parameters.** A `controlType:number`
+  referenced in a calc formula is rejected (`Invalid kind: control`); a true parameter
+  needs a data-model control + `parameters` binding. Use an **editable input table** for
+  adjustable rates instead (proven), unless/until you wire DM parameters.

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/refs/input-tables.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/refs/input-tables.md
@@ -1,0 +1,205 @@
+# Input tables — the data-entry half (VALIDATED 2026-06-08)
+
+This is the part that was blocked until input tables shipped. It's now proven
+end-to-end with exact parity. Read this before building the data-entry path.
+
+## The mental model that matters
+
+An Excel planning model is a **data-entry tool**. The faithful Sigma translation
+keeps forecasters typing numbers — that's what input tables are for. But input
+tables are **not** a data-model source kind. They are **workbook/document
+elements** that write back to the warehouse, and the data model reads that
+written-back data **through a warehouse view**.
+
+```
+Excel formal Table (forecasters type ForecastAmount)
+      │  migrate the grain + values
+      ▼
+Sigma input table  (workbook element: kind: input-table, source.kind: empty)
+      │  Sigma writes back on PUBLISH → SIGDS_-prefixed table (NOT directly queryable)
+      ▼
+Warehouse view on the input table   (UI: "Warehouse views → Create new")
+      │
+      ▼
+Data model element  →  source: SELECT … FROM <database>.<schema>.<view>
+      │
+      ▼
+Workbook charts / metrics  (unchanged — display names identical)
+```
+
+> **The original "flip the DM source to the input table, one line" plan was
+> WRONG.** The swap targets a *warehouse view of* the input table. That adds one
+> (UI) step the naive plan didn't account for. Everything else holds.
+
+## The API-vs-UI split (the single most important fact)
+
+Verified against the live Sigma OpenAPI and `/v2/connections` on 2026-06-08:
+
+| Step | Path | Notes |
+|---|---|---|
+| input-table **structure** | ✅ API — `POST /v2/workbooks/spec` | columns, types; titles (`name`) + `tableStyle`/`sort` round-trip. Validation/protection are UI. |
+| **linked** input table (inherited columns resolve) | ❌ **UI only** | spec POST yields inherited columns that show **"multiple values"** (publish doesn't fix; verified 2026-06-10). PK/grain + entry cols populate, but the linked correlation is UI-only state. See "Linked input tables" below. |
+| seed **data** load into an empty/CSV table | ⚠️ **UI now** | CSV upload / clipboard paste; no REST endpoint (only `*/materialization*`, unrelated). **Bulk-seed API in progress.** |
+| **Publish** | ⚠️ UI | data commits to the warehouse only on publish |
+| **warehouse view** | ⚠️ **UI only** | input-table element → Warehouse views → Create new |
+| DM **source-swap** | ✅ API — `POST`/`PUT /v2/dataModels/spec` | `SELECT … FROM <view>` |
+| **"Editable in published version"** data-entry permission | ⚠️ **UI only** | The input-table element spec carries ONLY `id/kind/source/inputMode/columns` — there is NO permission field (verified 2026-06-09 against WANDA's viewer-editable input tables; none expose it). Default = editable in draft only. To let viewers edit in the published workbook: input table → **"Editable in" → Editable in published version – Explore / all users** → **Publish**. Still a Sigma Beta feature. `inputMode` ('explore'/'view') is a separate, unrelated element setting. |
+
+So a converter auto-builds the input-table **structure** and the **DM-on-view**,
+and hands the user three explicit clicks in between. Don't try to script the
+upload or the view — there's no endpoint. (`swapSources` exists on dataModels but
+swaps between *registered sources*, not to an ad-hoc input-table view.)
+
+## Input-table element spec shape (proven)
+
+```yaml
+- id: forecastInput
+  kind: input-table
+  name: Forecast Entry          # element TITLE — persists in the spec & round-trips on GET
+  source:
+    kind: empty
+    connectionId: cb2f5180-…    # MUST be a write-enabled connection (writeAccess: true)
+  inputMode: explore            # 'explore' = editable; 'view' also seen on WANDA
+  tableStyle: { preset: presentation }   # optional — tableStyle + sort round-trip too
+  columns:
+    - id: REGION                # data-entry columns: give a `type`
+      type: text
+    - id: MONTH_DATE
+      type: datetime
+    - id: CATEGORY_CODE
+      type: number
+    - id: FORECAST_AMOUNT
+      type: number
+    - id: ID                    # system columns: NO `type` — Sigma auto-manages them
+    - id: CREATED_AT
+    - id: CREATED_BY
+    - id: UPDATED_AT
+    - id: UPDATED_BY
+```
+
+- A write-enabled connection is required (`GET /v2/connections` → `writeAccess: true`).
+- Column types: `text`, `number`, `datetime`, `checkbox` (and single/multi-select
+  via data validation, configured in UI).
+- The system columns (`ID` = Row ID; `CREATED_*`/`UPDATED_*` = row edit history)
+  auto-populate. **Exclude them from the seed CSV.**
+- **Titles & customizations now round-trip**: the element `name` is the visible
+  title; `tableStyle` and `sort` persist in the spec too (treat like a `table`
+  element). (Data validation / column protection / data-entry permission remain
+  UI — see the matrix above.)
+
+## Linked input tables — UI-authored only (spec POST does NOT work)
+
+> **⚠️ CORRECTION (2026-06-10). An earlier version of this file called linked
+> input tables "the powerful path, API-authorable." That was wrong** — it was
+> validated only by structure (`/elements`), never by querying the data. When you
+> author a linked input table via `POST /v2/workbooks/spec`, the **inherited
+> columns don't resolve: every row shows "multiple values."** Publishing does not
+> fix it, and re-POSTing a known-good UI-built linked table verbatim reproduces the
+> break. The linked-column key-correlation is UI-only server state the spec can't
+> carry. **Build linked input tables in the UI.**
+>
+> What a POST *does* create: the PK column + the grain (PK rows populate from the
+> parent) + editable entry columns. What it *cannot* create: working inherited/
+> linked context columns. So even the "blank forecast grid off a spine" idea gives
+> rows whose dimension context columns read "multiple values" — poor UX; do it in
+> the UI.
+
+The idea below is the *intended* design (and how a UI-built linked table looks),
+but it must be built in the UI, not POSTed:
+
+```yaml
+# 1) the spine: any element whose rows define the grain — a warehouse/data-model
+#    dimension, or a custom-SQL cross-join (CALENDAR × CATEGORY × BU), etc.
+- id: spine
+  kind: table
+  source: { kind: data-model, dataModelId: <dm>, elementId: <el> }   # or warehouse-table / sql
+  columns:
+    - { id: storeKey, formula: '[D_STORE/Store Key]' }
+    - { id: storeName, formula: '[D_STORE/Store Name]' }
+
+# 2) the linked input table — rows come FROM the spine
+- id: forecastEntry
+  kind: input-table
+  source:
+    kind: linked
+    from: spine                 # the PARENT element id (rows are inherited from it)
+  inputMode: explore
+  columns:
+    - id: pk
+      key: storeKey             # PRIMARY KEY → references the PARENT's column id (static row identifier)
+    - id: storeNameLinked
+      formula: '[D_STORE/Store Name]'   # LINKED column — inherits live parent value, NOT editable
+    - id: FORECAST_AMOUNT
+      type: number              # OWN entry column — the only thing forecasters type
+    - id: UPDATED_AT            # system edit-history columns (no type)
+    - id: UPDATED_BY
+```
+
+Why it's still the right *design* (build it in the UI):
+
+- **Grain derives from a spine, not a paste.** Point the linked table at a freshly
+  generated spine (e.g. a custom-SQL `CALENDAR × CATEGORY × BU` cross-join) and the
+  grain is correct by construction — solves the stale-spine problem ("derive, don't
+  port"). Forecasters fill only the measure; dimension columns are read-only.
+- **But the linkage is UI-only.** When built in the UI the inherited columns
+  resolve correctly; when POSTed they show "multiple values" (see correction
+  above). So: generate the spine via API if you like, then **add the linked input
+  table in the UI** pointing at it.
+
+Use **empty + CSV** (below) instead when you're seeding **starting values**
+(e.g. last year's actuals as a baseline to adjust), where the rows aren't simply a
+dimension cross-product. Use **linked** when the grain is a dimension product and
+forecasters enter net-new measures.
+
+## The seed CSV (paste-ready)
+
+Emit only the data-entry columns, headers in `UPPER_SNAKE_CASE` matching the
+input-table column ids exactly:
+
+```
+REGION,BRANCH,SUB_BRANCH,MONTH_DATE,CATEGORY_CODE,FORECAST_AMOUNT
+West,Seattle,SEA-North,2025-09-01,4000,94592
+…
+```
+
+Paste limit is 2,000 rows × 25 columns; CSV upload limit is 200 MB / UTF-8. For
+the 540-row fixture, clipboard paste was used.
+
+## The warehouse view
+
+After publish, the input-table element menu → **Warehouse views → Create new**
+lands a queryable view (e.g. `SIGMA_WRITE_DB.SIGMA_WRITE.FORECAST_ENTRY`). The
+view exposes **only the data columns** (system columns dropped); a Snowflake
+`datetime` lands as `TIMESTAMP_LTZ`. The UI dialog truncates the path — get the
+full one from the dialog tooltip or via `snow`:
+
+```bash
+snow sql -c default --format json -q \
+  "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME \
+   FROM SIGMA_WRITE_DB.INFORMATION_SCHEMA.VIEWS WHERE TABLE_NAME ILIKE 'FORECAST_ENTRY%'"
+```
+
+## Gotchas that cost time (so they don't again)
+
+1. **Data is invisible until Publish.** A pre-publish MCP/REST query of the input
+   table returns **0 rows** — the query layer reads the published version.
+   Publish, then re-query. (This looks like "the upload failed"; it didn't.)
+2. **Don't repoint a DM seeded with different data.** If you built the read-half
+   DM against a different seed (different category codes / grain), build a *fresh*
+   DM for the view rather than repointing — otherwise dimension joins silently
+   miss and parity breaks.
+3. **DM element `name` is not honored on POST** — every element reads back as
+   "Custom SQL". Identify elements by inspecting columns, not name.
+4. **DM element + column IDs are REASSIGNED on POST.** Always `describe` the live
+   data model (Sigma MCP) to get the real element/column ids before querying.
+5. **SIGDS_ tables aren't directly queryable** and must not be modified — always
+   go through the warehouse view.
+
+## Going further: governance for the forecaster experience (UI)
+
+Once the structure exists, configure in the workbook UI:
+- **Data validation** — turn `CATEGORY_CODE` into a single-select against the
+  category list so forecasters pick, not type.
+- **Column protection** — lock the dimension keys + system columns so only
+  `FORECAST_AMOUNT` is editable.
+- **Data entry permissions** — who can write.

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/refs/macro-handling.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/refs/macro-handling.md
@@ -1,0 +1,90 @@
+# Macros (VBA) — detect, classify, route, gate
+
+`.xlsm`/`.xlsb`/`.xls` carry VBA. **Macros are not one thing** — like cells, you
+classify them by *intent* and route each class. Most FP&A macro logic maps to
+things Sigma already has; only a slice truly needs the (forthcoming) **Actions**
+primitive. The non-negotiable rule:
+
+> **Never silent.** Every macro is surfaced with a disposition. A dropped
+> "Commit Forecast" button the user assumes still works is the FP&A equivalent of
+> silently dropping row-level security. Macros are a **STOP/flag gate**, not a
+> quiet delete.
+
+## Extraction
+
+VBA lives in `xl/vbaProject.bin` (an OLE compound stream) — `openpyxl` only sees
+*that it exists*, not the code. Use **`olevba`** (oletools) to pull module source:
+
+```bash
+pip install oletools          # stable; not in the org's last-3-days window
+python scripts/macro-classify.py path/to/model.xlsm          # human report
+python scripts/macro-classify.py --json path/to/model.xlsm   # machine contract
+```
+
+`macro-classify.py` accepts a binary office file (extracts via olevba) **or** a
+raw VBA module (`.bas/.cls/.frm/.vba/.txt`) for testing. It strips comments before
+classifying (comments must never drive a classification — they lie).
+
+## The taxonomy → Sigma mapping
+
+| Class | VBA signals | Sigma target | Status |
+|---|---|---|---|
+| **RECALC_REFRESH** | `RefreshAll`, `.Calculate(Full)`, `.Refresh`, `ScreenUpdating` | none — Sigma is always live | ✅ AUTO (drop) |
+| **TRANSFORM_ROLLUP** | `For…To` loop + `Cells(..).Value =`, `WorksheetFunction`, in-code SUMIFS | data model element / calc columns | ✅ AUTO (result reproduced declaratively) |
+| **NAVIGATION** | `.Activate`, `.Select`, `.Goto`, `.Visible =` | page navigation / visibility | ✅ AUTO (map or drop) |
+| **FORMAT_COSMETIC** | `.Font`, `.Interior`, `.Borders`, `AutoFit`, `.NumberFormat` | conditional formatting / styling | ✅ AUTO (map or drop) |
+| **WHATIF_SCENARIO** | `GoalSeek`, `Solver`, writes into assumption cells, `Select Case scenario` | controls / parameters / editable assumptions table | 🎛 CONTROL |
+| **ACTION_WRITEBACK** | `PasteSpecial xlPasteValues`, `ListRows.Add`, `…End(xlUp).Row + 1` append, name verbs (Commit/Save/Submit/Post/Archive/Snapshot/Freeze) | **Sigma Action → append rows to an input table** | ⏳ ACTION (gated) |
+| **EXTERNAL_IO** | `CreateObject("Outlook")`, `.Send`, `Shell`, `ExportAsFixedFormat`, `FileSystemObject`, `MSXML2/WinHttp`, file `Open…For` | scheduled delivery / external API job | 🚩 FLAG |
+| **OPAQUE** | bespoke math writing cells (`Sin/Cos/Rnd/…`), `Do While`, `GoTo` | — | 🚩 FLAG (human review) |
+| **event-handler** | name `Workbook_*` / `Worksheet_*` (e.g. `Workbook_Open`) | decompose into its called actions; the auto-run wrapper itself drops | (follows contents) |
+
+**Precedence** (when a macro matches several): EXTERNAL_IO ▸ ACTION_WRITEBACK ▸
+WHATIF_SCENARIO ▸ TRANSFORM_ROLLUP ▸ RECALC ▸ NAVIGATION ▸ FORMAT. Bespoke math
+(`Sin/Rnd/…`) overrides a weak/AUTO primary → **OPAQUE** (only EXTERNAL_IO and
+ACTION_WRITEBACK outrank it). Action verbs are matched on the **procedure name**
+only, so a called helper like `PostToGrid` doesn't trip "Post".
+
+## Status meanings
+
+- **AUTO** — reproduced by the data/formula conversion, or safely dropped (Sigma is live). No user action.
+- **CONTROL** — becomes controls / parameters / an editable input table (the driver story in `refs/forecast-recipes.md`).
+- **ACTION** — becomes a Sigma **Action** (button-triggered). **Gated on the Actions primitive** shipping in the workbook spec. Until then: scaffold a placeholder (a labeled button/text element) + an inventory entry; do **not** silently omit.
+- **FLAG** — must be reviewed by a human (external I/O or opaque logic). Surface before build; never auto-port.
+
+## The Actions wiring (forthcoming primitive)
+
+When `actions` lands in the workbook spec, a `build-actions` step consumes the
+`--json` records with `status == "ACTION"`. Most resolve to **Action → insert rows
+into an input table** — which is exactly the editable-table machinery the forecast
+recipes already build, so the future work is the *trigger*, not the data path:
+
+```
+CommitForecast_Click  → Action(on button): insert current forecast rows → "Snapshots" input table (+ timestamp)
+SaveScenario_Click    → Action(on button): insert current assumption rates → "Scenarios" input table
+ApplyScenario(name)   → Action(on select): set assumption controls to the chosen scenario's values
+```
+
+The classifier output is the contract; the wiring drops in behind a feature flag
+without re-running detection. (Same pattern as the Tableau-Actions follow-on.)
+
+## Worked example (`scripts/Sample Macros.bas` — the FP&A model's VBA)
+
+11 procedures → **AUTO 5, CONTROL 2, ACTION 2, FLAG 2**:
+
+| Macro | Class | Status |
+|---|---|---|
+| `Workbook_Open` | RECALC + event | ✅ AUTO |
+| `RefreshActuals_Click` | RECALC_REFRESH | ✅ AUTO |
+| `RebuildPnL` | TRANSFORM_ROLLUP | ✅ AUTO |
+| `GoToForecast_Click` | NAVIGATION | ✅ AUTO |
+| `FormatStatement` | FORMAT_COSMETIC | ✅ AUTO |
+| `ApplyScenario` | WHATIF_SCENARIO | 🎛 CONTROL |
+| `SolveForTarget` (GoalSeek) | WHATIF_SCENARIO | 🎛 CONTROL |
+| `CommitForecast_Click` | ACTION_WRITEBACK | ⏳ ACTION |
+| `SaveScenario_Click` | ACTION_WRITEBACK | ⏳ ACTION |
+| `EmailReport_Click` | EXTERNAL_IO | 🚩 FLAG |
+| `AllocateOverheadByHeadcount` | OPAQUE | 🚩 FLAG |
+
+Extraction validated end-to-end through olevba on a real `.xlsm`; classification
+validated on the full taxonomy above (2026-06-17).

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/refs/model-taxonomy.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/refs/model-taxonomy.md
@@ -1,0 +1,69 @@
+# Spreadsheet model taxonomy + the architecture decision
+
+The hard part of Excel→Sigma isn't the mechanical build — it's **classifying the
+model**: which parts are live actuals, which are driver-grown, which are typed
+inputs, which are derived. That classification is mostly deterministic; the
+*architecture* it implies depends on **how the model is used**, which isn't in the
+file — so you **detect, propose a model map, then ask a few intent questions**.
+
+This is the path that handles "report drawn in cells" workbooks (no formal Table)
+— the common FP&A case the formal-Table router (`refs/excel-translation.md`) skips.
+
+## Detect — the cell-level classifier (`xlsx-discover.py`)
+
+For every formula/value cell on a non-Table sheet, `classify_report_cells` emits:
+
+| Class | Excel signal | Sigma target |
+|---|---|---|
+| **ACTUAL** | `SUMIFS`/`SUMIF`/`SUMPRODUCT` over a transaction tab | live read-only DM element off that source |
+| **DRIVER_GROWTH** | `=prior_cell * (1 ± Assumptions!rate)` | closed-form `base × (1+rate)^n` (rate from the drivers) |
+| **MANUAL** | numeric literal sitting in a row that's otherwise formula-driven | editable input table (one cell per line×period) |
+| **FLAT** | `=single_prior_cell` (carried) | `= base` |
+| **DERIVED** | arithmetic of sibling cells / `IF` margins (totals, %s) | workbook calc columns |
+
+It also reports the **actuals source** sheet (SUMIFS targets) and the
+**driver/assumptions** sheet (the `(1±rate)` refs). Example, FY P&L model:
+
+```
+P&L: DERIVED=111, ACTUAL=60, DRIVER-grown=30, MANUAL=24, FLAT=6
+  → actuals source: Data        (= live read-only DM element)
+  → drivers:        Assumptions  (= editable rates table / controls)
+```
+
+That map *is* the architecture: **union [live ACTUAL] + [forecast]**, where
+forecast = DRIVER_GROWTH + MANUAL + FLAT, and DERIVED becomes workbook calcs.
+
+## The decision — ask intent (don't guess)
+
+The classification is fixed; the *build* hinges on one question. Present the
+detected model map, then ask (use the recommended-default pattern):
+
+**1. How is this model used?** (the load-bearing question)
+
+| Answer | Actuals | Forecast | Drivers |
+|---|---|---|---|
+| **Read-only report** | live DM | computed, baked | reference table |
+| **Editable plan** | live DM | editable input table(s) | reference table |
+| **Live what-if model** (recommended for FP&A) | live DM | computed via closed-form | **editable rates + manual cells** that recompute |
+
+**2. Which detected inputs stay editable?** (pre-fill from MANUAL + driver detection: the growth rates, the manual cells, or both)
+
+**3. Actuals: live or snapshot?** (default **live** — re-query the source, matching Excel's `SUMIFS`)
+
+Keep it to these. Everything else (grain, sections, line order, parity targets)
+is derivable. The questions are *informed by* the model map, so the agent looks
+like it understands the spreadsheet — it does.
+
+## Build + the trust gate
+
+Build per `refs/forecast-recipes.md` for the chosen architecture, then **assert
+parity to the cent** against the spreadsheet's cached totals (e.g. Net Income,
+EBITDA, Total Revenue). The parity gate is what makes the output trustworthy
+regardless of how the questions were answered — never call a migration done
+without it.
+
+## Macros
+
+If `.xlsm`, run the **macro gate** (`refs/macro-handling.md`) in the same discovery
+pass — macros often *are* the "how it's used" answer (a `CommitForecast` button ⇒
+this is an editable plan with scenario history).

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/refs/research-recipes.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/refs/research-recipes.md
@@ -1,0 +1,86 @@
+# Equity-research model recipes (broker / FactSet house-template models)
+
+The archetype for **sell-side equity-research models** — a covered-company model with
+line-items down the rows, **YEARS across the columns**, grouped into statement sections
+(PROFIT AND LOSS, PER SHARE DATA, EVALUATION, BALANCE SHEET, CHANGE IN NET DEBT, …). One
+analyst maintains each; a single sell-side desk covers hundreds off **one house template** (can be ~850). This is a different shape from the FP&A forecast archetype in
+`refs/forecast-recipes.md` (months across, actuals+driver-grown+manual, input-table entry).
+
+**Validated end-to-end on a real broker equity-research model: 100.00% cell parity (3,263/3,263
+cells across 24 years), 0 wrong, with ~81% of derived cells as LIVE Sigma formulas.** Built
+entirely via REST — `infer-canonical-formulas.py` → plan JSON → `build-research-model.py`.
+
+## The one big idea (why the hand build bloats, and the fix)
+
+A hand build of one of these tends to explode: in the validated model, the manual P&L pivot had **97
+columns** — every line item split into `X User` / `X Calc` / `X (1)` triplets with
+`Coalesce([X User],[X Calc])` chains (some circular, one a literal placeholder) — because the
+*same line is a hardcode in some years and a formula in others* (analyst overrides), and they
+tried to honour every per-year exception. Per Share Data, done right, used **one formula per
+line for all years** and stayed small. That is the whole lesson.
+
+**Architecture (the clean version):**
+
+1. **Data page** — *every typed number in the grid* as inline `VALUES` custom-SQL, WIDE:
+   one row per YEAR, one column per line item (`c<row>` safe id). A typed cell is *always*
+   data — a historical actual OR a forecast-year override; you never classify override-vs-actual.
+2. **Computation table** — one calc COLUMN per line item (making each line a column, not a
+   pivot row, is what lets each carry its OWN formula):
+   - input line → `[data/c<row>]`
+   - derived line → `Coalesce([data/c<row>], <ONE canonical formula>)` — the typed override
+     wins automatically; the formula fills the blanks. **Exactly one Coalesce, one formula,
+     all years. No `User`/`Calc`/`(1)` triplets.**
+3. **Long** — a `transpose` (column-to-row) unpivot of the computation table → `(Year, LineId,
+   Value)`.
+4. **Labeled** — join Long ⋈ a line-dim (id → label / section / order).
+5. **Display pivot** — `rowsBy` Section→Line Item (ordered), `columnsBy` Year, `Sum(Value)`.
+
+## Canonical-formula inference (`infer-canonical-formulas.py`)
+
+- **Year-relative normalisation.** Rewrite each Excel formula's refs to `(col_offset, row)` —
+  offset 0 = same year, −1 = prior. Resolve `row` → the line item. Cells that differ only by
+  which year-column collapse to the **same canonical key**; the row's formula is the **modal**
+  key. `=F13-F8` → `[Gross profit] - [Turnover]`; `=F13/E13-1` → `[X]/Lag([X],1,[Year]) - 1`.
+- **Refs are `[c<row>]` safe ids, not labels** — labels carry `/`, `%`, `&` which break Sigma
+  refs. A line-dim maps `c<row>` → the real label for display.
+- **Sigma idioms:** `Lag([c],k,[Year])` for prior-year (% change, CAGR); `[a]/[b]` for ratios;
+  `^` for power; Excel `IF`→`If`, `SUM`→`Sum`; Excel `101%`→`(101*0.01)`.
+
+## The three hard problems and how they're handled
+
+1. **Plug cycles.** History types COGS→computes Gross profit; the forecast types Gross
+   profit→computes COGS. One formula per row makes that a *static* cycle Sigma rejects. Detect
+   cycles (incl. same-period self-refs; `Lag`/`Lead` prior-period refs are NOT cycles) from the
+   **rendered** formulas, and **demote the most-typed cycle member to carried data** ("start
+   from the hard-coded values"). It becomes a `[data/c]` leaf; the rest stay live.
+2. **Blank-as-zero.** Excel treats a blank as 0 in `+`/`−`; Sigma propagates null. So **additive
+   canonicals wrap each ref in `Coalesce(ref, 0)`** — the sum computes live and matches Excel.
+   Ratios/products stay strict (a null there is real).
+3. **Per-year structural differences & the parity gate (the trust anchor).** Simulate the WHOLE
+   model exactly as Sigma evaluates it (topological, null-propagating), compare to Excel's
+   cached values, and **freeze the Excel value into the data page for any cell the live formula
+   doesn't reproduce** (via the `Coalesce`, that cell shows the correct number). Result:
+   **displayed parity = 100%** — every cell is either live-verified or cached-frozen; never a
+   silent wrong number. A line whose one canonical is wrong in >25% of its years is flagged
+   `NEEDS_REVIEW` (a genuine "this line's formula varies" signal), but still shows correct values.
+
+## Build gotchas (verified live via the REST API)
+
+- **`transpose` element takes NO explicit `name`** — Sigma auto-names it `Transpose of <source>`;
+  its own columns must self-reference that auto name (`[Transpose of Calc/Year]`). Passthrough
+  (non-merged) columns come through by their original name; the two new columns are named by
+  `columnLabelForMergedColumns` / `columnLabelForValues`.
+- A **data-model element can't be a `join`/`union` leg** — wrap it in a workbook `table` first
+  (the line-dim → `Dim` wrapper).
+- **No unary `+`** (`=+B8` → strip), **no `#,##0.0` format strings** (Sigma rejects; use its
+  format objects or omit), **column names with `/` break refs** (use `c<row>` ids).
+- **DM element formulas** = `[Custom SQL/<alias>]`; DM element `kind:"table"` + `source.kind:"sql"`.
+- **FactSet cruft to strip** (log, don't silently drop): the `__FDSCACHE__` sheet, thousands of
+  junk named ranges, `#REF!`/`#N/A`, external `[n]!` links. Don't trust cached values for
+  broken-forecast years (they cache to `#REF!`) — rebuild from formula text.
+
+## Verify
+
+Export the `long` element to CSV and compare every `(c<row>, year)` to the Excel cached grid
+(`data_only=True`) within €0.01 / 0.1%. Target: 0 wrong, 0 blank-where-Excel-has-a-value. Also
+confirm the result is far smaller than a hand build (one column per line, not per-year triplets).

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/refs/research-template-coa.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/refs/research-template-coa.md
@@ -1,0 +1,77 @@
+# Template-family detection + chart-of-accounts (the ~850-file fleet)
+
+A broker covers hundreds of companies off **one house model template** (a single sell-side desk can cover ~850). The
+files are "similar but not identical" — same skeleton, different company / segments / periods /
+row counts / (bilingual) labels. This is the *ideal* case: reverse-engineer the template ONCE,
+then run `scripts/batch-convert.py` across the fleet with a triage report. Read this before a
+fleet run; pair with `refs/research-recipes.md` (the per-file conversion).
+
+## Once vs per-file
+
+- **Template-once (curated, versioned):** `scripts/coa.json` — the canonical chart-of-accounts
+  (`{id, section, aliases[] (EN+FR), shape}`), the expected sections/sheets, the fingerprint
+  weights + thresholds. This is the *contract*.
+- **Per-file (automated):** fingerprint, COA mapping, canonical-formula inference + parity
+  (re-run per file — rows/years/overrides differ), triage, build.
+
+The contract is a **prior, not a straitjacket**: a per-file formula that disagrees with a COA
+`shape` is a *flag*, not an auto-reject (over-fit protection — we have few examples).
+
+## Fingerprint (similarity, not equality)
+
+`batch-convert.py::fingerprint` scores each file against the contract — NO absolute cell
+addresses (we have too few examples to hard-code positions):
+- **section-header set** overlap (weight 0.4) — the strongest, most stable signal,
+- **sheet-name set** (0.15) — `FY results` + `Quarterly` (+ the `__FDSCACHE__` marker),
+- **headline-label coverage** vs the COA (0.25) — fraction of non-ratio lines that map,
+- **formula-shape presence** (0.2) — derived canonicals exist.
+→ `SAME` (≥0.75) / `VARIANT` (≥0.45) / `UNKNOWN`. `UNKNOWN` is never guessed at → FAILED.
+
+## Line → COA mapping (confidence tiers)
+
+`coa_map` maps each line to a canonical account: **exact normalized alias** → **fuzzy token
+overlap ≥0.6** (catches `= EBIT (Operating income)` → `ebit`, `Marge brute` → `gross_profit`).
+- **Unmapped lines are CARRIED** (company-specific), never dropped. Ratio / `ow …` sub-items
+  are *detail*, not COA accounts — expected to be unmapped and carried.
+- Segments / geographies (the `Quarterly` bridge) are a **dynamic dimension**, carried as data,
+  not fixed COA.
+
+## Triage buckets (no silent truncation)
+
+Per file → `AUTO_PARITY` / `NEEDS_REVIEW` / `FAILED`:
+- **FAILED** — `UNKNOWN` fingerprint, or a broken invariant (no year axis, no anchor line
+  resolved, <2 known sections). Nothing built.
+- **AUTO_PARITY** — `SAME`, 0 inference review-flags, every headline stable-section line mapped.
+- **NEEDS_REVIEW** — everything else that still converted (VARIANT, inference flags, or an
+  unmapped headline line). Still builds; still 100% displayed parity — just wants eyes.
+
+**No-silent-truncation invariants** (a bounded/dropped result is logged, never silent): year
+axis detected, ≥1 anchor resolved, ≥2 known sections, FactSet cruft counts recorded
+(`named_ranges`, `__FDSCACHE__`). A file that trips one → FAILED with the reason.
+
+## The manifest + the calibration loop
+
+`--out manifest.json` (+ `.csv`) records per file: bucket, fingerprint, periods, line counts,
+`live`/`frozen`, anchors, mapped/unmapped, stripped-cruft counts, reasons — plus a rollup and
+**the top unmapped headline labels across the batch**. That last list is the calibration signal:
+add those labels as `aliases` in `coa.json` and re-run. Run the **first ~30–50 files report-only**,
+grow the COA + tune thresholds, *then* commit builds.
+
+## Scale reality (state it plainly)
+
+Input-table data load / warehouse view / publish are **UI-only**. 850 *editable* models is
+untenable, so the batch default is **READ-ONLY**: the data page is inline `VALUES` in the DM
+(fully API, parity-preserving) — `--post` builds `POST /v2/dataModels/spec` + `/v2/workbooks/spec`
+per file (~1,700 calls; throttle/retry/resume; one folder per sector; guard name collisions).
+Editable entry is **opt-in per file**, routed to the input-table hand-off, and cheap only once
+the bulk-seed API lands. Don't promise editable-at-scale today.
+
+## Run
+
+```bash
+# report-only calibration over a tranche
+python scripts/batch-convert.py /path/to/models/ --sheet="FY results" --out manifest.json
+# after calibration: also build the clean ones (read-only DMs, fully API)
+python scripts/batch-convert.py /path/to/models/ --sheet="FY results" --out manifest.json \
+       --post --conn <writeConn> --folder <folderId> [--post-review]
+```

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/refs/sigma-build-gotchas.md
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/refs/sigma-build-gotchas.md
@@ -1,0 +1,78 @@
+# Sigma build gotchas (data model + workbook spec)
+
+Hard-won rules from building the forecast DM + input-table workbook. These are the
+difference between a 2xx that errors at query time and a working migration. Many
+overlap with the other sigma-migration-skills converters — collected here for the
+Excel path.
+
+## Data model spec (`POST /v2/dataModels/spec`)
+
+- **Envelope:** top-level `schemaVersion: 1`, real-UUID `folderId`, `pages[]` with
+  `id` + `name` + `elements[]`. Each element: `kind: table` (NOT `type`), a
+  `source`, and `columns[]`.
+- **SQL element source:** `source: { kind: sql, connectionId, statement }`.
+- **SQL-element column formulas use the literal `[Custom SQL/ALIAS]` prefix** —
+  NOT `[ElementName/ALIAS]`. The DM spec-resource doc claims element-name; the API
+  rejects it. `ALIAS` is the column alias in your `SELECT`.
+  ```json
+  { "id": "fc6", "formula": "[Custom SQL/FORECAST_AMOUNT]", "name": "Forecast Amount" }
+  ```
+- **Element `name` is NOT honored** — every element reads back as "Custom SQL".
+  Don't rely on it; identify elements by their columns.
+- **Element + column IDs are REASSIGNED on POST.** The ids you send are mapped to
+  internal ids. Before querying or doing any follow-up PUT, `describe` the live
+  model (Sigma MCP `describe` type `datamodel` then `datamodel-element`) and use
+  the readback ids.
+- **Grouping trap:** to let a chart/pivot group by a dimension from another
+  element, emit a **flattened in-SQL join element** (a `WITH … SELECT … JOIN`),
+  NOT cross-element relationship refs — otherwise "Rollup cannot reference more
+  than one external relation."
+
+## Workbook spec (`POST /v2/workbooks/spec`) — released document wrapper
+
+> **Live-verified 2026-08:** the workbook code-rep surface nests non-metadata
+> fields under a top-level `document` key and rejects the old flat body with
+> HTTP 400 (including `/verify`). Same adapter every sibling converter uses
+> (`scripts/lib/code_rep.py`, vendored from `shared/lib/code_rep.py`).
+> **Data-model specs are unchanged** — do NOT wrap `/v2/dataModels/.../spec`.
+
+- **Wire body for create:** top-level `name` + `folderId` (+ optional
+  `description`) outside; inside `document`: `schemaVersion`, `kind: workbook`,
+  metadata-only `pages[]`, flat `elements[]`, and required `layout` XML.
+- Builders may still author the convenient nested `pages[].elements` draft.
+  Call `workbook_wire.wire_workbook(spec)` (which builds a stacked layout if
+  missing, then `code_rep.wrap`) **as the last write before POST**. Dry-run
+  artifacts that would be POSTed must be the wrapped shape too.
+- **Every page needs a string `id`** (POST fails with `each page must have a
+  string "id"` otherwise). Page membership lives in `document.layout`
+  (`<Page id="…"><Element elementId="…"/></Page>`), not in nested
+  `pages[].elements` after wrap.
+- Prefer `<Element>` / `<Container>` tags — `code_rep.wrap` rewrites legacy
+  `<LayoutElement>` / `<GridContainer>` aliases.
+- Theme (if any) goes in `document.settings.theme.{name,overrides}` via
+  `code_rep.set_theme` — never top-level `themeName` / `themeOverrides`.
+- Every element needs a unique `id`; columns need `id` + `name` + `formula`.
+- Send `Content-Type: application/json` (or yaml). Specs round-trip as YAML on GET.
+- On readback, unwrap with `code_rep.document(resp)` / `code_rep.workbook_elements`
+  — never dig `pages[].elements` on a live GET.
+- **Input-table specifics** live in `refs/input-tables.md` (write connection, empty
+  source, system columns without `type`, publish gate).
+
+## Auth
+
+```bash
+bash -c 'source ~/.sigma-migration/env; TOKEN=$(curl -s -X POST "$SIGMA_BASE_URL/v2/auth/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=$SIGMA_CLIENT_ID&client_secret=$SIGMA_CLIENT_SECRET" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)[\"access_token\"])"); <curl using $TOKEN>'
+```
+Tokens expire ~1h. Never `source` settings.json (it's JSON). Don't assign to the
+shell-reserved `UID` var (use `MID` etc.).
+
+## Verification
+
+- Query the built DM element grouped by the rollup dimension via the Sigma MCP and
+  compare to parity targets computed straight from the source data.
+- A successful POST is necessary but not sufficient — Sigma accepts specs whose
+  formulas don't resolve and embeds the error as a SQL string literal at query
+  time. Always run a real query.

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/Sample Macros.bas
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/Sample Macros.bas
@@ -1,0 +1,122 @@
+Attribute VB_Name = "FPAModel"
+' ===== FP&A Monthly P&L — VBA behind the workbook =====
+Option Explicit
+
+' Auto-runs when the workbook opens
+Private Sub Workbook_Open()
+    Application.ScreenUpdating = False
+    ThisWorkbook.RefreshAll
+    Sheets("P&L").Activate
+    Application.ScreenUpdating = True
+End Sub
+
+' "Refresh" button: pull latest GL + recalc
+Sub RefreshActuals_Click()
+    ThisWorkbook.RefreshAll
+    Application.CalculateFull
+    MsgBox "Actuals refreshed.", vbInformation
+End Sub
+
+' Rebuild the P&L actuals columns from the Data tab (SUMIFS in code)
+Sub RebuildPnL()
+    Dim ws As Worksheet, r As Long, lastRow As Long
+    Set ws = Sheets("Data")
+    lastRow = ws.Cells(ws.Rows.Count, "C").End(xlUp).Row
+    Dim li As String, mo As String, amt As Double
+    For r = 5 To lastRow
+        li = ws.Cells(r, 3).Value
+        mo = ws.Cells(r, 2).Value
+        amt = ws.Cells(r, 6).Value
+        ' accumulate into the P&L grid by line item / month
+        Call PostToGrid(li, mo, amt)
+    Next r
+End Sub
+
+' Apply a named scenario: write growth rates into the Assumptions cells
+Sub ApplyScenario(scenarioName As String)
+    Select Case scenarioName
+        Case "Aggressive"
+            Sheets("Assumptions").Range("B5").Value = 0.06  ' subscription growth
+            Sheets("Assumptions").Range("B6").Value = 0.02
+        Case "Conservative"
+            Sheets("Assumptions").Range("B5").Value = 0.01
+            Sheets("Assumptions").Range("B6").Value = 0.01
+    End Select
+    Application.CalculateFull
+End Sub
+
+' "Commit Forecast" button: freeze the current Jul-Dec forecast as values and
+' append them to the Snapshot history tab
+Sub CommitForecast_Click()
+    Dim src As Range, dst As Worksheet, nextRow As Long
+    Set dst = Sheets("Snapshots")
+    nextRow = dst.Cells(dst.Rows.Count, 1).End(xlUp).Row + 1
+    Set src = Sheets("P&L").Range("H7:M33")
+    src.Copy
+    dst.Cells(nextRow, 1).PasteSpecial Paste:=xlPasteValues
+    dst.Cells(nextRow, 1).Value = Now
+    Application.CutCopyMode = False
+    MsgBox "Forecast committed to Snapshots.", vbInformation
+End Sub
+
+' "Save Scenario" button: append current assumptions to the Scenarios table
+Sub SaveScenario_Click()
+    Dim t As ListObject, newRow As ListRow
+    Set t = Sheets("Scenarios").ListObjects("tblScenarios")
+    Set newRow = t.ListRows.Add
+    newRow.Range(1, 1).Value = InputBox("Scenario name?")
+    newRow.Range(1, 2).Value = Sheets("Assumptions").Range("B5").Value
+    newRow.Range(1, 3).Value = Sheets("Assumptions").Range("B6").Value
+End Sub
+
+' "Email to CFO" button: render the P&L to PDF and send via Outlook
+Sub EmailReport_Click()
+    Dim OutApp As Object, OutMail As Object, pdfPath As String
+    pdfPath = Environ("TEMP") & "\PnL.pdf"
+    Sheets("P&L").ExportAsFixedFormat Type:=xlTypePDF, Filename:=pdfPath
+    Set OutApp = CreateObject("Outlook.Application")
+    Set OutMail = OutApp.CreateItem(0)
+    With OutMail
+        .To = "cfo@example.com"
+        .Subject = "Monthly P&L"
+        .Body = "Latest P&L attached."
+        .Attachments.Add pdfPath
+        .Send
+    End With
+End Sub
+
+' Navigation button
+Sub GoToForecast_Click()
+    Sheets("P&L").Activate
+    Sheets("P&L").Range("H5").Select
+End Sub
+
+' Cosmetic formatting of the statement
+Sub FormatStatement()
+    With Sheets("P&L").Range("A6:N33")
+        .Font.Name = "Calibri"
+        .Columns.AutoFit
+    End With
+    Sheets("P&L").Range("A9,A15,A24").Font.Bold = True
+End Sub
+
+' Goal-seek: solve the subscription growth needed to hit a Net Income target
+Sub SolveForTarget()
+    Sheets("P&L").Range("N33").GoalSeek Goal:=2000000, _
+        ChangingCell:=Sheets("Assumptions").Range("B5")
+End Sub
+
+' Opaque bespoke allocation — multi-step imperative logic, no clean declarative equivalent
+Sub AllocateOverheadByHeadcount()
+    Dim depts As Variant, hc As Variant, i As Integer, total As Double
+    depts = Array("Eng", "Sales", "G&A", "Support")
+    hc = Sheets("Headcount").Range("B2:B5").Value
+    For i = 1 To 4
+        total = total + hc(i, 1)
+    Next i
+    For i = 1 To 4
+        Sheets("Alloc").Cells(i + 1, 2).Value = _
+            (hc(i, 1) / total) * Sheets("Assumptions").Range("B12").Value * _
+            (1 + 0.5 * Sin(i)) ' bespoke smoothing factor
+    Next i
+End Sub

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/batch-convert.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/batch-convert.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+batch-convert.py — fleet converter for a family of broker equity-research models
+(the ~850-file case: same house template, "similar but not identical").
+
+Per file: strip FactSet cruft (logged) -> fingerprint the template -> run canonical
+inference (infer-canonical-formulas.py) -> map line items to the canonical
+chart-of-accounts (coa.json) -> parity gate -> bucket into AUTO_PARITY / NEEDS_REVIEW
+/ FAILED. Emits a triage manifest (JSON + CSV) with a rollup and the top unmapped
+labels across the batch (which feed COA-alias growth). NO silent truncation.
+
+Default = report-only (recommended calibration mode for the first tranche): inference
++ triage, nothing built. `--post --conn <id> --folder <id>` also builds AUTO_PARITY (and,
+with `--post-review`, NEEDS_REVIEW) files via build-research-model.py — READ-ONLY DMs
+(inline VALUES), fully API, no UI step (see refs/research-recipes.md).
+
+Usage:
+  batch-convert.py <file-or-dir> [<more> ...] [--sheet "FY results"]
+                   [--out manifest.json] [--post --conn <id> --folder <id> [--post-review]]
+"""
+import sys, os, re, json, glob, hashlib, importlib.util
+from collections import Counter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_mod(fn, name):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(HERE, fn))
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+    return m
+
+
+INF = load_mod("infer-canonical-formulas.py", "inf")
+COA = json.load(open(os.path.join(HERE, "coa.json")))
+
+
+def norm(s):
+    return re.sub(r"[^a-z0-9 ]", " ", (s or "").lower()).strip()
+
+
+def alias_index(coa):
+    idx = {}
+    for acc in coa["accounts"]:
+        for a in acc["aliases"]:
+            idx[norm(a)] = acc["id"]
+    return idx
+
+
+ALIAS = alias_index(COA)
+STABLE_SECTIONS = set(COA["template"]["sections_expected"])
+
+
+def strip_report(path):
+    """Count (never silently drop) the FactSet cruft we ignore."""
+    import openpyxl
+    wb = openpyxl.load_workbook(path, data_only=False, read_only=True)
+    named = len(wb.defined_names)
+    fdscache = any(s.startswith("__") for s in wb.sheetnames)
+    return {"named_ranges": named, "fdscache_sheet": fdscache, "sheets": list(wb.sheetnames)}
+
+
+def is_detail(l):
+    """Ratio / sub-item lines aren't canonical COA accounts (they're carried detail)."""
+    n = norm(l["label"])
+    return l["kind"] == "ratio" or n.startswith(("ow ", "% ")) or n in ("", ".") or "%" in l["label"][:3]
+
+
+def fingerprint(plan, sheets, n_mapped):
+    """Similarity (not equality) to the house template -> SAME / VARIANT / UNKNOWN."""
+    T = COA["template"]; w = T["fingerprint_weights"]
+    file_secs = {norm(l["section"]) for l in plan["lines"]}
+    exp_secs = {norm(s) for s in T["sections_expected"]}
+    sec_score = len(file_secs & exp_secs) / max(len(exp_secs), 1)
+    sheet_score = len({norm(s) for s in sheets} & {norm(s) for s in T["sheets_expected"]}) / \
+                  max(len(T["sheets_expected"]), 1)
+    accountish = [l for l in plan["lines"] if not is_detail(l)]      # headline lines only
+    lab_score = n_mapped / max(len(accountish), 1)
+    # formula-shape signal: how many derived canonicals look like a COA shape (rough: has refs)
+    shp = sum(1 for l in plan["lines"] if l["kind"] in ("derived", "ratio") and l.get("canonical"))
+    shp_score = min(shp / 20.0, 1.0)
+    score = (w["sections"] * sec_score + w["sheets"] * sheet_score +
+             w["label_jaccard"] * lab_score + w["formula_shapes"] * shp_score)
+    cls = "SAME" if score >= T["thresholds"]["same"] else \
+          ("VARIANT" if score >= T["thresholds"]["variant"] else "UNKNOWN")
+    return round(score, 3), cls, {"sections": round(sec_score, 2), "sheets": round(sheet_score, 2),
+                                  "labels": round(lab_score, 2)}
+
+
+def coa_map(plan):
+    """Map each line to a canonical account (exact alias, then fuzzy token overlap).
+    Unmapped lines are CARRIED (company-specific), never dropped."""
+    mapped = {}; unmapped = []
+    for l in plan["lines"]:
+        n = norm(l["label"])
+        acc = ALIAS.get(n)
+        if not acc:                                   # fuzzy: alias fully contained / token overlap
+            toks = set(n.split())
+            best, bestj = None, 0.0
+            for a, aid in ALIAS.items():
+                at = set(a.split())
+                if not at:
+                    continue
+                j = len(toks & at) / len(toks | at)
+                if j > bestj:
+                    bestj, best = j, aid
+            acc = best if bestj >= 0.6 else None
+        if acc:
+            mapped[l["row"]] = acc
+        else:
+            unmapped.append(l["label"])
+    return mapped, unmapped
+
+
+def triage(path, sheet):
+    entry = {"file": os.path.basename(path),
+             "hash": hashlib.sha1(open(path, "rb").read()).hexdigest()[:12]}
+    try:
+        strip = strip_report(path)
+        entry["stripped"] = strip
+        plan = INF.infer(path, sheet=sheet)
+    except BaseException as ex:                          # incl. ValueError from axis detection
+        entry.update(bucket="FAILED", fingerprint_class="UNKNOWN",
+                     reasons=[f"inference error: {ex}"])
+        return entry, None
+    mapped, unmapped = coa_map(plan)
+    sc, cls, det = fingerprint(plan, entry["stripped"]["sheets"], len(mapped))
+    s = plan["summary"]; par = plan["parity"]
+    n_periods = len(plan["periods"])
+    anchors = list(plan["anchors"])
+    # a real gap = a HEADLINE line (not a ratio/sub-item) in a stable section that didn't map
+    unmapped_stable = [l["label"] for l in plan["lines"]
+                       if l["row"] not in mapped and l["section"] in STABLE_SECTIONS
+                       and not is_detail(l)]
+    reasons = []
+    # no-silent-truncation invariants
+    if n_periods == 0:
+        reasons.append("INVARIANT: no year axis detected")
+    if not anchors:
+        reasons.append("INVARIANT: no anchor line (revenue/EBIT/net income/EPS) resolved")
+    sections_found = {l["section"] for l in plan["lines"]} & STABLE_SECTIONS
+    if len(sections_found) < 2:
+        reasons.append(f"INVARIANT: only {len(sections_found)} known section(s) found")
+    entry.update(sheet=plan["sheet"], fingerprint=sc, fingerprint_class=cls, fingerprint_detail=det,
+                 n_periods=n_periods, periods=[p["year"] for p in plan["periods"]][:2] +
+                 [plan["periods"][-1]["year"]] if plan["periods"] else [],
+                 n_lines=len(plan["lines"]), input=s.get("input", 0), derived=s.get("derived", 0),
+                 ratio=s.get("ratio", 0), carried=s.get("carried_plug", 0),
+                 needs_review=s.get("needs_review", 0), live=par.get("live", 0),
+                 frozen=par.get("frozen", 0), anchors=anchors,
+                 n_mapped=len(mapped), n_unmapped=len(unmapped),
+                 unmapped_stable=unmapped_stable[:8], reasons=reasons)
+    # bucket
+    if cls == "UNKNOWN" or any(r.startswith("INVARIANT") for r in reasons):
+        entry["bucket"] = "FAILED"
+    elif (cls == "SAME" and s.get("needs_review", 0) == 0 and not unmapped_stable):
+        entry["bucket"] = "AUTO_PARITY"
+    else:
+        entry["bucket"] = "NEEDS_REVIEW"
+        if cls == "VARIANT":
+            reasons.append("VARIANT fingerprint")
+        if s.get("needs_review", 0):
+            reasons.append(f"{s['needs_review']} line(s) flagged in inference")
+        if unmapped_stable:
+            reasons.append(f"{len(unmapped_stable)} unmapped line(s) in stable sections (carried)")
+    return entry, plan
+
+
+def expand(paths):
+    out = []
+    for p in paths:
+        if os.path.isdir(p):
+            out += sorted(glob.glob(os.path.join(p, "*.xlsx")))
+        else:
+            out += sorted(glob.glob(p)) if any(c in p for c in "*?[") else [p]
+    return [p for p in out if p.lower().endswith(".xlsx") and "~$" not in p]
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    opt = {a.split("=")[0]: (a.split("=", 1)[1] if "=" in a else True)
+           for a in sys.argv[1:] if a.startswith("--")}
+    files = expand(args)
+    if not files:
+        sys.exit(__doc__)
+    sheet = opt.get("--sheet")
+    manifest = []; plans = {}
+    for f in files:
+        entry, plan = triage(f, sheet)
+        manifest.append(entry); plans[entry["file"]] = plan
+        print(f"  [{entry['bucket']:12s}] {entry['file'][:48]:48s} "
+              f"fp={entry.get('fingerprint','-')}/{entry.get('fingerprint_class','-')} "
+              f"periods={entry.get('n_periods','-')} live={entry.get('live','-')} "
+              f"frozen={entry.get('frozen','-')} unmapped={entry.get('n_unmapped','-')}")
+
+    buckets = Counter(e["bucket"] for e in manifest)
+    top_unmapped = Counter()
+    for e in manifest:
+        for lab in (e.get("unmapped_stable") or []):
+            top_unmapped[lab] += 1
+    print(f"\nROLLUP over {len(manifest)} file(s): " +
+          "  ".join(f"{k}={v}" for k, v in buckets.most_common()))
+    if top_unmapped:
+        print("Top unmapped stable-section labels (grow coa.json aliases):")
+        for lab, n in top_unmapped.most_common(10):
+            print(f"   {n:3d}  {lab}")
+
+    out = opt.get("--out")
+    if out and out is not True:
+        json.dump({"buckets": dict(buckets), "top_unmapped": top_unmapped.most_common(20),
+                   "files": manifest}, open(out, "w"), indent=1)
+        csvp = os.path.splitext(out)[0] + ".csv"
+        import csv
+        keys = ["file", "bucket", "fingerprint", "fingerprint_class", "n_periods", "n_lines",
+                "input", "derived", "ratio", "carried", "needs_review", "live", "frozen",
+                "n_mapped", "n_unmapped"]
+        with open(csvp, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=keys, extrasaction="ignore"); w.writeheader()
+            for e in manifest:
+                w.writerow(e)
+        print(f"\nmanifest: {out}  +  {csvp}")
+
+    # optional live build for AUTO_PARITY (+ NEEDS_REVIEW with --post-review)
+    if "--post" in opt:
+        BUILD = load_mod("build-research-model.py", "brm")
+        conn, folder = opt.get("--conn"), opt.get("--folder")
+        want = {"AUTO_PARITY"} | ({"NEEDS_REVIEW"} if "--post-review" in opt else set())
+        e = BUILD.env(); base = e["SIGMA_BASE_URL"]; tok = BUILD.token(e)
+        for entry in manifest:
+            if entry["bucket"] not in want:
+                continue
+            plan = plans[entry["file"]]
+            name = os.path.splitext(entry["file"])[0][:56] + " (auto)"
+            dl = [ln for ln in plan["lines"] if ln["typed"]]
+            dm = BUILD.api(base, tok, "POST", "/v2/dataModels/spec",
+                           BUILD.build_dm(plan, conn, folder, name)[0])
+            full = BUILD.api(base, tok, "GET", f"/v2/dataModels/{dm['dataModelId']}/spec")
+            # Released workbook code_rep: wrap nested draft + layout last before POST.
+            wb_body = BUILD.workbook_wire.wire_workbook(
+                BUILD.build_wb(plan, dm["dataModelId"], BUILD.map_dm(full), dl, folder, name))
+            wb = BUILD.api(base, tok, "POST", "/v2/workbooks/spec", wb_body)
+            print(f"   built {entry['file']}: wb {wb.get('workbookId')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/build-dm-on-view.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/build-dm-on-view.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Phase 4 — POST a data model that reads FROM the input-table warehouse view.
+
+This is the source-swap target: a fact element sourced from
+`SELECT … FROM <view>`, plus (optionally) a category dimension lifted from a
+formal Table in the Excel file and a flattened *_REPORT element (in-SQL join) for
+section rollups.
+
+Auth: reads ~/.sigma-migration/env. Verify parity afterward by querying the
+report element (Sigma MCP) grouped by the rollup dimension.
+
+Usage:
+    python build-dm-on-view.py --view SIGMA_WRITE_DB.SIGMA_WRITE.FORECAST_ENTRY \
+        --connection cb2f5180-… \
+        --fact-cols REGION,BRANCH,SUB_BRANCH,MONTH_DATE,CATEGORY_CODE,FORECAST_AMOUNT \
+        [--categories-from "Sample Forecast.xlsx" --categories-table tblCategory \
+         --join-key CATEGORY_CODE]
+"""
+import argparse
+import json
+import os
+import urllib.request
+import urllib.parse
+
+
+def token():
+    env = {}
+    with open(os.path.expanduser("~/.sigma-migration/env")) as f:
+        for line in f:
+            line = line.strip().replace("export ", "")
+            if "=" in line:
+                k, v = line.split("=", 1)
+                env[k] = v.strip().strip('"').strip("'")
+    data = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": env["SIGMA_CLIENT_ID"],
+        "client_secret": env["SIGMA_CLIENT_SECRET"],
+    }).encode()
+    req = urllib.request.Request(env["SIGMA_BASE_URL"] + "/v2/auth/token", data=data,
+                                 headers={"Content-Type": "application/x-www-form-urlencoded"})
+    return env["SIGMA_BASE_URL"], json.load(urllib.request.urlopen(req))["access_token"]
+
+
+def home_folder(base, tok):
+    req = urllib.request.Request(base + "/v2/whoami",
+                                 headers={"Authorization": f"Bearer {tok}"})
+    uid = json.load(urllib.request.urlopen(req))["userId"]
+    req = urllib.request.Request(base + f"/v2/members/{uid}",
+                                 headers={"Authorization": f"Bearer {tok}"})
+    return json.load(urllib.request.urlopen(req)).get("homeFolderId")
+
+
+def title(alias):
+    return alias.replace("_", " ").title()
+
+
+def cols(aliases, prefix):
+    # SQL-element columns MUST use the literal [Custom SQL/ALIAS] prefix
+    return [{"id": f"{prefix}{i}", "formula": f"[Custom SQL/{a}]", "name": title(a)}
+            for i, a in enumerate(aliases, 1)]
+
+
+def category_values(xlsx, table):
+    """Lift a formal Table into a VALUES list (codes assumed numeric-or-text)."""
+    from openpyxl import load_workbook
+    wb = load_workbook(xlsx, data_only=True)
+    for ws in wb.worksheets:
+        if table in ws.tables:
+            cells = ws[ws.tables[table].ref]
+            headers = [str(c.value) for c in cells[0]]
+            rows = []
+            for r in cells[1:]:
+                vals = []
+                for c in r:
+                    v = c.value
+                    if isinstance(v, (int, float)):
+                        vals.append(str(v))
+                    else:
+                        vals.append("'" + str(v).replace("'", "''") + "'")
+                rows.append("(" + ",".join(vals) + ")")
+            return headers, ",\n".join(rows)
+    raise SystemExit(f"category table '{table}' not found in {xlsx}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--view", required=True, help="fully qualified db.schema.view")
+    ap.add_argument("--connection", required=True)
+    ap.add_argument("--fact-cols", required=True, help="comma list of view column names")
+    ap.add_argument("--folder", default=None)
+    ap.add_argument("--name", default="Forecast (Input Table)")
+    ap.add_argument("--categories-from", default=None)
+    ap.add_argument("--categories-table", default="tblCategory")
+    ap.add_argument("--join-key", default="CATEGORY_CODE")
+    args = ap.parse_args()
+
+    base, tok = token()
+    folder = args.folder or home_folder(base, tok)
+    fact_cols = [c.strip() for c in args.fact_cols.split(",")]
+
+    fact_sql = f"select {', '.join(fact_cols)} from {args.view}"
+    elements = [{
+        "id": "fact", "kind": "table",
+        "source": {"kind": "sql", "connectionId": args.connection, "statement": fact_sql},
+        "columns": cols(fact_cols, "fc"),
+    }]
+
+    if args.categories_from:
+        chdr, cvals = category_values(args.categories_from, args.categories_table)
+        cat_aliases = [h.replace(" ", "_").upper() for h in chdr]
+        cat_sql = ("select " +
+                   ", ".join(f"column{i+1} as {a}" for i, a in enumerate(cat_aliases)) +
+                   f" from values\n{cvals}")
+        elements.append({
+            "id": "category", "kind": "table",
+            "source": {"kind": "sql", "connectionId": args.connection, "statement": cat_sql},
+            "columns": cols(cat_aliases, "ca"),
+        })
+        # flattened report (in-SQL join — avoids the cross-element rollup error)
+        join_cat_cols = [a for a in cat_aliases if a != args.join_key]
+        report_sql = (
+            f"with f as ({fact_sql}),\n"
+            f"c as ({cat_sql})\n"
+            f"select " + ", ".join(f"f.{a}" for a in fact_cols) + ", " +
+            ", ".join(f"c.{a}" for a in join_cat_cols) +
+            f" from f join c on f.{args.join_key} = c.{args.join_key}")
+        elements.append({
+            "id": "report", "kind": "table",
+            "source": {"kind": "sql", "connectionId": args.connection, "statement": report_sql},
+            "columns": cols(fact_cols + join_cat_cols, "fr"),
+        })
+
+    spec = {"name": args.name, "schemaVersion": 1, "folderId": folder,
+            "pages": [{"id": "model", "name": "Model", "elements": elements}]}
+
+    body = json.dumps(spec).encode()
+    req = urllib.request.Request(base + "/v2/dataModels/spec", data=body, method="POST",
+                                 headers={"Authorization": f"Bearer {tok}",
+                                          "Content-Type": "application/json"})
+    resp = json.load(urllib.request.urlopen(req))
+    print("dataModelId:", resp.get("dataModelId"))
+    print("url:", resp.get("url"))
+    print("\nNEXT: `describe` the model via the Sigma MCP (element + column IDs are "
+          "reassigned), then query the report element grouped by your rollup "
+          "dimension and compare to parity targets.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/build-forecast-model.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/build-forecast-model.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+build-forecast-model.py — one-shot builder for an actuals + driver-grown + manual
+planning model (the architecture in refs/forecast-recipes.md). Consumes a model-plan
+JSON (drafted from xlsx-discover.py's model map + the intent answers) and emits:
+  - a Sigma data model (GL actuals VALUES + assumptions + raw forecast spine)
+  - a workbook (union[actuals, forecast] → KPIs, P&L pivot w/ Actual|Forecast cols,
+    monthly summary, trend, GL detail, assumptions; editable rate+manual input tables
+    when intent is editable/what-if)
+  - paste-ready seed CSVs for the editable tables
+  - a LOCAL parity check (asserts the plan reproduces the spreadsheet totals)
+
+Default = dry-run (writes specs to /tmp, runs parity, no API). `--post` builds live.
+
+Intent (plan.intent):
+  read-only          → forecast baked from default rates (no input tables)
+  editable | what-if → rates + manual cells are editable input tables (Coalesce override)
+"""
+import sys, os, json, csv, urllib.request, urllib.parse, urllib.error
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+import workbook_wire  # noqa: E402
+
+CUR = lambda p: {"kind": "number", "formatString": p["currencyFormat"]}
+PCT = lambda p: {"kind": "number", "formatString": p.get("pctFormat", ".1%")}
+DATEF = {"kind": "datetime", "formatString": "%b-%y"}
+def q(s): return "'" + str(s).replace("'", "''") + "'"
+
+def env():
+    e = {}
+    for line in open(os.path.expanduser("~/.sigma-migration/env")):
+        line = line.strip().replace("export ", "")
+        if "=" in line: k, v = line.split("=", 1); e[k] = v.strip().strip('"').strip("'")
+    return e
+def token(e):
+    d = urllib.parse.urlencode({"grant_type": "client_credentials", "client_id": e["SIGMA_CLIENT_ID"], "client_secret": e["SIGMA_CLIENT_SECRET"]}).encode()
+    return json.load(urllib.request.urlopen(urllib.request.Request(e["SIGMA_BASE_URL"] + "/v2/auth/token", data=d, headers={"Content-Type": "application/x-www-form-urlencoded"})))["access_token"]
+def api(base, tok, method, path, body=None):
+    r = urllib.request.Request(base + path, data=(json.dumps(body).encode() if body else None), method=method,
+        headers={"Authorization": f"Bearer {tok}", "Content-Type": "application/json", "Accept": "application/json"})
+    try: return json.load(urllib.request.urlopen(r))
+    except urllib.error.HTTPError as ex: print("HTTP", ex.code, ex.read().decode()[:1500]); raise
+
+# ---------- DM ----------
+def values_sql(rows, cols):
+    body = ",\n".join("(" + ",".join(rows[i]) + ")" for i in range(len(rows)))
+    return f"select * from (values\n{body}\n) as t({', '.join(cols)})"
+
+def build_dm_spec(P):
+    conn = P["connectionId"]
+    # GL detail (actuals, transaction grain)
+    gl = []
+    for r in P["actuals"]:
+        gl.append([f"{q(r['date'])}::date", q(r['month']), q(r['line']), q(r['section']),
+                   str(r['secOrder']), str(r['lineOrder']), q(r['dept']), q(r['vendor']), f"{float(r['amt']):.2f}"])
+    mnum = {m["month"]: m["num"] for m in P["actualMonths"]}; mend = {m["month"]: m["end"] for m in P["actualMonths"]}
+    gl_cols = ["TXN_DATE", "MONTH", "LINE_ITEM", "SECTION", "SEC_ORDER", "LINE_ORDER", "DEPARTMENT", "VENDOR", "AMOUNT"]
+    # add MONTH_NUM / MONTH_END derived
+    for row, r in zip(gl, P["actuals"]):
+        row.insert(2, str(mnum[r['month']])); row.insert(3, f"{q(mend[r['month']])}::date")
+    gl_cols[2:2] = ["MONTH_NUM", "MONTH_END"]
+    glDetail = {"id": "glDetail", "kind": "table", "source": {"kind": "sql", "connectionId": conn, "statement": values_sql(gl, gl_cols)},
+                "columns": dmcols([("TXN_DATE","Txn Date"),("MONTH","Month"),("MONTH_NUM","Month Num"),("MONTH_END","Month End"),("LINE_ITEM","Line Item"),("SECTION","Section"),("SEC_ORDER","Section Order"),("LINE_ORDER","Line Order"),("DEPARTMENT","Department"),("VENDOR","Vendor"),("AMOUNT","Amount")])}
+    # assumptions
+    arows = [[q(a), f"{b}", q(c)] for a, b, c in P["assumptions"]]
+    assumptions = {"id": "assumptions", "kind": "table", "source": {"kind": "sql", "connectionId": conn, "statement": values_sql(arows, ["DRIVER","MONTHLY_RATE","BASIS"])},
+                   "columns": dmcols([("DRIVER","Driver"),("MONTHLY_RATE","Monthly Rate"),("BASIS","Basis")])}
+    # raw forecast spine
+    srows = []
+    for ln in P["lines"]:
+        for i, m in enumerate(P["forecastMonths"]):
+            n = m["num"] - P["actualMonths"][-1]["num"]
+            kind = ln["kind"]
+            drate = f"{ln['rate']}" if kind == "growth" else "NULL"
+            mv = f"{ln['manual'][i]:.2f}" if kind == "manual" else "NULL"
+            jb = f"{ln['juneBase']:.2f}" if kind in ("growth", "flat") else "NULL"
+            srows.append([q(ln["line"]), q(ln["section"]), str(ln["secOrder"]), str(ln["lineOrder"]),
+                          q(m["month"]), str(m["num"]), f"{q(m['end'])}::date", str(n), q(kind), drate, mv, jb])
+    scols = ["LINE_ITEM","SECTION","SEC_ORDER","LINE_ORDER","MONTH","MONTH_NUM","MONTH_END","N","KIND","DEFAULT_RATE","MANUAL_VALUE","JUNE_BASE"]
+    spine = {"id": "spine", "kind": "table", "source": {"kind": "sql", "connectionId": conn, "statement": values_sql(srows, scols)},
+             "columns": dmcols([("LINE_ITEM","Line Item"),("SECTION","Section"),("SEC_ORDER","Section Order"),("LINE_ORDER","Line Order"),("MONTH","Month"),("MONTH_NUM","Month Num"),("MONTH_END","Month End"),("N","N"),("KIND","Kind"),("DEFAULT_RATE","Default Rate"),("MANUAL_VALUE","Manual Value"),("JUNE_BASE","June Base")])}
+    return {"name": P["name"] + " — Model", "schemaVersion": 1, "folderId": P["folderId"],
+            "pages": [{"id": "model", "name": "Model", "elements": [glDetail, assumptions, spine]}]}
+
+def dmcols(pairs):
+    return [{"id": f"c{i}", "name": nm, "formula": f"[Custom SQL/{al}]"} for i, (al, nm) in enumerate(pairs, 1)]
+
+def map_dm_elements(spec):
+    """Identify element ids by a signature column name (names round-trip; ids reassign)."""
+    out = {}
+    for el in spec["pages"][0]["elements"]:
+        names = {c["name"] for c in el["columns"]}
+        if "Vendor" in names: out["glDetail"] = el["id"]
+        elif "Kind" in names: out["spine"] = el["id"]
+        elif "Driver" in names: out["assumptions"] = el["id"]
+    return out
+
+# ---------- parity (local) ----------
+def parity(P):
+    rev = cogs = opex = below = 0.0
+    secsum = {"Revenue": 0.0, "Cost of Revenue": 0.0, "Operating Expenses": 0.0, "Below the Line": 0.0}
+    # actuals
+    for r in P["actuals"]:
+        secsum[r["section"]] += r["amt"]
+    # forecast
+    for ln in P["lines"]:
+        base = ln.get("juneBase", 0)
+        for i, m in enumerate(P["forecastMonths"]):
+            n = m["num"] - P["actualMonths"][-1]["num"]
+            v = ln["manual"][i] if ln["kind"] == "manual" else (base if ln["kind"] == "flat" else base * (1 + ln["rate"]) ** n)
+            secsum[ln["section"]] += v
+    rev, cogs, opex, below = secsum["Revenue"], secsum["Cost of Revenue"], secsum["Operating Expenses"], secsum["Below the Line"]
+    return {"Revenue": rev, "Gross Profit": rev - cogs, "EBITDA": rev - cogs - opex, "Net Income": rev - cogs - opex - below}
+
+# ---------- seed CSVs ----------
+def seed_csvs(P, outdir):
+    rate_p = os.path.join(outdir, "rate_seed.csv"); man_p = os.path.join(outdir, "manual_seed.csv")
+    with open(rate_p, "w", newline="") as f:
+        w = csv.writer(f); w.writerow(["LINE_ITEM", "RATE"])
+        for ln in P["lines"]:
+            if ln["kind"] == "growth": w.writerow([ln["line"], ln["rate"]])
+    with open(man_p, "w", newline="") as f:
+        w = csv.writer(f); w.writerow(["LINE_ITEM", "MONTH", "MONTH_NUM", "MONTH_END", "AMOUNT"])
+        for ln in P["lines"]:
+            if ln["kind"] == "manual":
+                for i, m in enumerate(P["forecastMonths"]): w.writerow([ln["line"], m["month"], m["num"], m["end"], f"{ln['manual'][i]:.2f}"])
+    return rate_p, man_p
+
+# ---------- workbook ----------
+def build_wb_spec(P, dm_id, els):
+    conn = P["connectionId"]; editable = P["intent"] in ("editable", "what-if"); DMP = "Custom SQL"; C = "PnL Combined"
+    U = "Union of 2 Sources"
+    cur = CUR(P)
+    def dm(elid): return {"kind": "data-model", "dataModelId": dm_id, "elementId": els[elid]}
+    elements = []
+    # actuals wrap (live)
+    actuals = {"id": "actuals", "kind": "table", "name": "Actuals", "visibleAsSource": False, "source": dm("glDetail"),
+        "columns": [{"id":"a_sec","name":"Section","formula":f"[{DMP}/Section]"},{"id":"a_so","name":"Section Order","formula":f"[{DMP}/Section Order]"},
+                    {"id":"a_line","name":"Line Item","formula":f"[{DMP}/Line Item]"},{"id":"a_lo","name":"Line Order","formula":f"[{DMP}/Line Order]"},
+                    {"id":"a_m","name":"Month","formula":f"[{DMP}/Month]"},{"id":"a_mn","name":"Month Num","formula":f"[{DMP}/Month Num]"},
+                    {"id":"a_me","name":"Month End","formula":f"[{DMP}/Month End]"},{"id":"a_amt","name":"Amount","formula":f"[{DMP}/Amount]"},
+                    {"id":"a_p","name":"Period","formula":'"Actual"'}]}
+    spineWrap = {"id":"spineWrap","kind":"table","name":"Forecast Spine","visibleAsSource":False,"source":dm("spine"),
+        "columns":[{"id":f"s_{k}","name":nm,"formula":f"[{DMP}/{nm}]"} for k,nm in
+                   [("sec","Section"),("so","Section Order"),("line","Line Item"),("lo","Line Order"),("m","Month"),("mn","Month Num"),("me","Month End"),("n","N"),("k","Kind"),("dr","Default Rate"),("mv","Manual Value"),("jb","June Base")]]}
+    # forecast element
+    if editable:
+        rateInput = {"id":"rateInput","kind":"input-table","name":"Growth Rates (editable)","inputMode":"edit","source":{"kind":"empty","connectionId":conn},
+            "columns":[{"id":"ID"},{"id":"LINE_ITEM","type":"text","name":"Line Item"},{"id":"RATE","type":"number","name":"Rate","format":PCT(P)}],"order":["LINE_ITEM","RATE"]}
+        manualInput = {"id":"manualInput","kind":"input-table","name":"Manual Forecast (editable)","inputMode":"edit","source":{"kind":"empty","connectionId":conn},
+            "columns":[{"id":"ID"},{"id":"LINE_ITEM","type":"text","name":"Line Item"},{"id":"MONTH","type":"text","name":"Month"},{"id":"MONTH_NUM","type":"number","name":"Month Num"},{"id":"MONTH_END","type":"datetime","name":"Month End"},{"id":"AMOUNT","type":"number","name":"Amount","format":cur}],"order":["LINE_ITEM","MONTH","AMOUNT"]}
+        forecast = {"id":"forecast","kind":"table","name":"Forecast","visibleAsSource":False,
+            "source":{"kind":"join","name":"FJ","primarySource":{"kind":"table","elementId":"spineWrap"},
+                "joins":[{"name":"Rates","joinType":"left-outer","left":{"kind":"table","elementId":"spineWrap"},"right":{"kind":"table","elementId":"rateInput"},"columns":[{"left":"[Line Item]","right":"[Line Item]"}]},
+                         {"name":"Manual","joinType":"left-outer","left":{"kind":"table","elementId":"spineWrap"},"right":{"kind":"table","elementId":"manualInput"},"columns":[{"left":"[Line Item]","right":"[Line Item]"},{"left":"[Month Num]","right":"[Month Num]"}]}]},
+            "columns":[{"id":"f_sec","name":"Section","formula":"[FJ/Section]"},{"id":"f_so","name":"Section Order","formula":"[FJ/Section Order]"},
+                {"id":"f_line","name":"Line Item","formula":"[FJ/Line Item]"},{"id":"f_lo","name":"Line Order","formula":"[FJ/Line Order]"},
+                {"id":"f_m","name":"Month","formula":"[FJ/Month]"},{"id":"f_mn","name":"Month Num","formula":"[FJ/Month Num]"},{"id":"f_me","name":"Month End","formula":"[FJ/Month End]"},
+                {"id":"f_n","name":"N","formula":"[FJ/N]"},{"id":"f_k","name":"Kind","formula":"[FJ/Kind]"},{"id":"f_jb","name":"June Base","formula":"[FJ/June Base]"},
+                {"id":"f_er","name":"Eff Rate","formula":"Coalesce([Rates/Rate], [FJ/Default Rate])"},
+                {"id":"f_em","name":"Eff Manual","formula":"Coalesce([Manual/Amount], [FJ/Manual Value])"},
+                {"id":"f_amt","name":"Amount","formula":'If([Kind] = "manual", [Eff Manual], [Kind] = "flat", [June Base], [June Base] * (1 + [Eff Rate]) ^ [N])',"format":cur},
+                {"id":"f_p","name":"Period","formula":'"Forecast"'}]}
+    else:
+        forecast = {"id":"forecast","kind":"table","name":"Forecast","visibleAsSource":False,"source":{"kind":"table","elementId":"spineWrap"},
+            "columns":[{"id":"f_sec","name":"Section","formula":"[Forecast Spine/Section]"},{"id":"f_so","name":"Section Order","formula":"[Forecast Spine/Section Order]"},
+                {"id":"f_line","name":"Line Item","formula":"[Forecast Spine/Line Item]"},{"id":"f_lo","name":"Line Order","formula":"[Forecast Spine/Line Order]"},
+                {"id":"f_m","name":"Month","formula":"[Forecast Spine/Month]"},{"id":"f_mn","name":"Month Num","formula":"[Forecast Spine/Month Num]"},{"id":"f_me","name":"Month End","formula":"[Forecast Spine/Month End]"},
+                {"id":"f_amt","name":"Amount","formula":'If([Forecast Spine/Kind] = "manual", [Forecast Spine/Manual Value], [Forecast Spine/Kind] = "flat", [Forecast Spine/June Base], [Forecast Spine/June Base] * (1 + [Forecast Spine/Default Rate]) ^ [Forecast Spine/N])',"format":cur},
+                {"id":"f_p","name":"Period","formula":'"Forecast"'}]}
+    def m(nm): return {"outputColumnName": nm, "sourceColumns": [f"[{nm}]", f"[{nm}]"]}
+    pnlCombined = {"id":"pnlCombined","kind":"table","name":C,"visibleAsSource":False,
+        "source":{"kind":"union","sources":[{"kind":"table","elementId":"actuals"},{"kind":"table","elementId":"forecast"}],
+                  "matches":[m("Section"),m("Section Order"),m("Line Item"),m("Line Order"),m("Month"),m("Month Num"),m("Month End"),m("Amount"),m("Period")]},
+        "columns":[{"id":"c_sec","name":"Section","formula":f"[{U}/Section]"},{"id":"c_so","name":"Section Order","formula":f"[{U}/Section Order]"},
+            {"id":"c_line","name":"Line Item","formula":f"[{U}/Line Item]"},{"id":"c_lo","name":"Line Order","formula":f"[{U}/Line Order]"},
+            {"id":"c_m","name":"Month","formula":f"[{U}/Month]"},{"id":"c_mn","name":"Month Num","formula":f"[{U}/Month Num]"},{"id":"c_me","name":"Month End","formula":f"[{U}/Month End]"},
+            {"id":"c_amt","name":"Amount","formula":f"[{U}/Amount]","format":cur},{"id":"c_p","name":"Period","formula":f"[{U}/Period]"},
+            {"id":"c_rev","name":"Revenue Amt","formula":f'If([{U}/Section] = "Revenue", [{U}/Amount], 0)'},
+            {"id":"c_cogs","name":"COGS Amt","formula":f'If([{U}/Section] = "Cost of Revenue", [{U}/Amount], 0)'},
+            {"id":"c_opex","name":"OpEx Amt","formula":f'If([{U}/Section] = "Operating Expenses", [{U}/Amount], 0)'},
+            {"id":"c_below","name":"Below Amt","formula":f'If([{U}/Section] = "Below the Line", [{U}/Amount], 0)'}]}
+    REV=f"Sum([{C}/Revenue Amt])"; COGS=f"Sum([{C}/COGS Amt])"; OPEX=f"Sum([{C}/OpEx Amt])"; BELOW=f"Sum([{C}/Below Amt])"
+    def kpi(eid,name,f,fmt): return {"id":eid,"kind":"kpi-chart","name":name,"source":{"kind":"table","elementId":"pnlCombined"},"columns":[{"id":"v","formula":f,"format":fmt}],"value":{"columnId":"v"}}
+    kpis=[kpi("kpiRev","Total Revenue",REV,cur),kpi("kpiEbitda","EBITDA",f"{REV} - {COGS} - {OPEX}",cur),
+          kpi("kpiNI","Net Income",f"{REV} - {COGS} - {OPEX} - {BELOW}",cur),kpi("kpiGM","Gross Margin %",f"({REV} - {COGS}) / {REV}",PCT(P))]
+    pivot={"id":"pnlPivot","kind":"pivot-table","name":"P&L Statement","source":{"kind":"table","elementId":"pnlCombined"},
+        "columns":[{"id":"p_sec","name":"Section","formula":f"[{C}/Section]"},{"id":"p_so","name":"Section Order","formula":f"[{C}/Section Order]"},
+            {"id":"p_line","name":"Line Item","formula":f"[{C}/Line Item]"},{"id":"p_lo","name":"Line Order","formula":f"[{C}/Line Order]"},
+            {"id":"p_per","name":"Period","formula":f"[{C}/Period]"},{"id":"p_m","name":"Month","formula":f"[{C}/Month End]","format":DATEF},
+            {"id":"p_amt","name":"Amount","formula":f"Sum([{C}/Amount])","format":cur}],
+        "values":["p_amt"],
+        "rowsBy":[{"id":"p_sec","sort":{"direction":"ascending","by":"p_so","aggregation":"min"}},{"id":"p_line","sort":{"direction":"ascending","by":"p_lo","aggregation":"min"}}],
+        "columnsBy":[{"id":"p_per","sort":{"direction":"ascending"}},{"id":"p_m","sort":{"direction":"ascending"}}]}
+    glTable={"id":"glTable","kind":"table","name":"GL Transaction Detail (Actuals)","source":dm("glDetail"),
+        "columns":[{"id":"g1","name":"Txn Date","formula":f"[{DMP}/Txn Date]"},{"id":"g2","name":"Month","formula":f"[{DMP}/Month]"},{"id":"g3","name":"Line Item","formula":f"[{DMP}/Line Item]"},{"id":"g4","name":"Department","formula":f"[{DMP}/Department]"},{"id":"g5","name":"Vendor","formula":f"[{DMP}/Vendor]"},{"id":"g6","name":"Amount","formula":f"[{DMP}/Amount]","format":cur}]}
+    assumpTable={"id":"assumpTable","kind":"table","name":"Forecast Assumptions","source":dm("assumptions"),
+        "columns":[{"id":"d1","name":"Driver","formula":f"[{DMP}/Driver]"},{"id":"d2","name":"Monthly Rate","formula":f"[{DMP}/Monthly Rate]","format":PCT(P)},{"id":"d3","name":"Basis","formula":f"[{DMP}/Basis]"}]}
+    main_els=kpis+[pivot,glTable,assumpTable]
+    hidden_els=[actuals,spineWrap,forecast,pnlCombined]
+    if editable: main_els+=[rateInput,manualInput]
+    pages=[{"id":"pnl","name":"P&L","elements":main_els},{"id":"model","name":"Model (sources)","visibility":"hidden","elements":hidden_els}]
+    # Nested draft; wire_workbook flattens + wraps at the POST / dry-run boundary.
+    return {"name":P["name"],"schemaVersion":1,"kind":"workbook","folderId":P["folderId"],"pages":pages}
+
+def main():
+    args=[a for a in sys.argv[1:] if not a.startswith("-")]
+    do_post="--post" in sys.argv
+    if not args: sys.exit("usage: build-forecast-model.py [--post] <model-plan.json>")
+    P=json.load(open(args[0]))
+    outdir="/tmp/fcst-build"; os.makedirs(outdir,exist_ok=True)
+    # parity
+    par=parity(P)
+    print("LOCAL PARITY (from plan):", "  ".join(f"{k}={v:,.2f}" for k,v in par.items()))
+    rate_csv,man_csv=seed_csvs(P,outdir)
+    print(f"seed CSVs: {rate_csv}, {man_csv}")
+    dm_spec=build_dm_spec(P)
+    json.dump(dm_spec,open(f"{outdir}/dm_spec.json","w"),indent=1)
+    if not do_post:
+        # map ids from the local spec (ids as-authored) for a dry-run wb spec
+        els={"glDetail":"glDetail","spine":"spine","assumptions":"assumptions"}
+        wb_spec=workbook_wire.wire_workbook(build_wb_spec(P,"<dm-id>",els))
+        json.dump(wb_spec,open(f"{outdir}/wb_spec.json","w"),indent=1)
+        print(f"DRY RUN — specs written to {outdir}/ (dm_spec.json, wb_spec.json). Re-run with --post to build live.")
+        return
+    e=env(); base=e["SIGMA_BASE_URL"]; tok=token(e)
+    dm=api(base,tok,"POST","/v2/dataModels/spec",dm_spec); dm_id=dm["dataModelId"]
+    print("dataModelId:",dm_id)
+    full=api(base,tok,"GET",f"/v2/dataModels/{dm_id}/spec")
+    els=map_dm_elements(full)
+    # Layout is the last write (assembled inside wire_workbook) before POST.
+    wb_spec=workbook_wire.wire_workbook(build_wb_spec(P,dm_id,els))
+    wb=api(base,tok,"POST","/v2/workbooks/spec",wb_spec)
+    print("workbookId:",wb["workbookId"],"| url:",wb.get("url"))
+    print("NOTE: POST uses a stacked notebook-flow layout via code_rep; refine with wb-rep push if needed.")
+
+if __name__=="__main__":
+    main()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/build-input-table-wb.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/build-input-table-wb.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Phase 3 — POST a workbook with an input table at the fact grain.
+
+Two modes (see refs/input-tables.md):
+
+  LINKED (⚠️ scaffold only — inherited columns do NOT resolve via POST):
+    builds a custom-SQL spine element + a linked input table off it. The PK/grain
+    and entry columns populate, but linked context columns render "multiple values"
+    (verified 2026-06-10; publish doesn't fix). Add the real linked columns in the
+    UI. Prefer building linked input tables entirely in the UI for now.
+    python build-input-table-wb.py --name "Forecast Entry" --connection <writeConn> \
+      --spine-sql spine.sql --spine-cols REGION,BRANCH,SUB_BRANCH,MONTH_DATE,CATEGORY_CODE \
+      --key MONTH_DATE --entry-cols FORECAST_AMOUNT:number
+    (--linked-cols defaults to all spine cols except --key)
+
+  EMPTY (seed starting values via UI CSV paste afterward):
+    python build-input-table-wb.py --name "Forecast Entry" --connection <writeConn> \
+      --columns REGION:text,MONTH_DATE:datetime,CATEGORY_CODE:number,FORECAST_AMOUNT:number
+
+Auth: reads ~/.sigma-migration/env (SIGMA_BASE_URL/CLIENT_ID/CLIENT_SECRET).
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.parse
+from pathlib import Path
+
+SYSTEM_COLS = ["ID", "CREATED_AT", "CREATED_BY", "UPDATED_AT", "UPDATED_BY"]
+
+_LIB = Path(__file__).resolve().parent / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+import workbook_wire  # noqa: E402
+
+
+def token():
+    env = {}
+    with open(os.path.expanduser("~/.sigma-migration/env")) as f:
+        for line in f:
+            line = line.strip().replace("export ", "")
+            if "=" in line:
+                k, v = line.split("=", 1)
+                env[k] = v.strip().strip('"').strip("'")
+    data = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": env["SIGMA_CLIENT_ID"],
+        "client_secret": env["SIGMA_CLIENT_SECRET"],
+    }).encode()
+    req = urllib.request.Request(env["SIGMA_BASE_URL"] + "/v2/auth/token", data=data,
+                                 headers={"Content-Type": "application/x-www-form-urlencoded"})
+    return env["SIGMA_BASE_URL"], json.load(urllib.request.urlopen(req))["access_token"]
+
+
+def home_folder(base, tok):
+    req = urllib.request.Request(base + "/v2/whoami", headers={"Authorization": f"Bearer {tok}"})
+    uid = json.load(urllib.request.urlopen(req))["userId"]
+    req = urllib.request.Request(base + f"/v2/members/{uid}", headers={"Authorization": f"Bearer {tok}"})
+    return json.load(urllib.request.urlopen(req)).get("homeFolderId")
+
+
+def title(alias):
+    return alias.replace("_", " ").title()
+
+
+def build_empty(args):
+    cols = [{"id": "ID"}]
+    for spec in args.columns.split(","):
+        name, _, typ = spec.partition(":")
+        cols.append({"id": name.strip(), "type": (typ or "text").strip()})
+    for sc in SYSTEM_COLS[1:]:
+        cols.append({"id": sc})
+    desc = "Excel→Sigma input table (empty). Paste/upload the seed CSV, publish, then create a warehouse view."
+    elements = [{
+        "id": "inputTable", "kind": "input-table", "name": args.name,
+        "source": {"kind": "empty", "connectionId": args.connection},
+        "inputMode": "explore", "columns": cols,
+    }]
+    nxt = "open the input table → paste the seed CSV → PUBLISH → Warehouse views → Create new → copy the view path."
+    return desc, elements, nxt
+
+
+def build_linked(args):
+    spine_cols = [c.strip() for c in args.spine_cols.split(",")]
+    if args.key not in spine_cols:
+        raise SystemExit(f"--key {args.key} must be one of --spine-cols ({spine_cols})")
+    linked = ([c.strip() for c in args.linked_cols.split(",")]
+              if args.linked_cols else [c for c in spine_cols if c != args.key])
+    stmt = open(args.spine_sql).read() if args.spine_sql else args.spine_statement
+    if not stmt:
+        raise SystemExit("linked mode needs --spine-sql <file> or --spine-statement")
+
+    spine = {
+        "id": "spine", "kind": "table", "name": "Spine",
+        "source": {"kind": "sql", "connectionId": args.connection, "statement": stmt},
+        "columns": [{"id": a, "formula": f"[Custom SQL/{a}]", "name": title(a)} for a in spine_cols],
+    }
+    it_cols = [{"id": "pk", "key": args.key}]                       # primary key → spine column id
+    for a in linked:                                               # linked (inherited, non-editable) columns
+        it_cols.append({"id": f"lk_{a}", "formula": f"[Spine/{title(a)}]"})
+    for spec in args.entry_cols.split(","):                        # own editable entry columns
+        name, _, typ = spec.partition(":")
+        it_cols.append({"id": name.strip(), "type": (typ or "number").strip()})
+    it_cols += [{"id": "UPDATED_AT"}, {"id": "UPDATED_BY"}]
+    elements = [spine, {
+        "id": "inputTable", "kind": "input-table", "name": args.name,
+        "source": {"kind": "linked", "from": "spine"},
+        "inputMode": "explore", "columns": it_cols,
+    }]
+    desc = "Excel→Sigma linked input table SCAFFOLD — PK/grain + entry cols only; linked context cols do NOT resolve via POST (add in UI)."
+    nxt = ("⚠️ Linked CONTEXT columns will show 'multiple values' (POST can't author the "
+           "link — verified). This built the PK/grain + entry columns; add linked columns "
+           "in the UI, or rebuild the whole linked table in the UI. Then Publish + Create warehouse view.")
+    return desc, elements, nxt
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--name", required=True)
+    ap.add_argument("--connection", required=True, help="write-enabled connectionId")
+    ap.add_argument("--folder", default=None)
+    # empty mode
+    ap.add_argument("--columns", help="empty mode: comma list of NAME:type")
+    # linked mode
+    ap.add_argument("--spine-sql", help="linked mode: path to a .sql file for the spine")
+    ap.add_argument("--spine-statement", help="linked mode: inline spine SQL (alt to --spine-sql)")
+    ap.add_argument("--spine-cols", help="linked mode: comma list of spine SELECT aliases")
+    ap.add_argument("--key", help="linked mode: spine alias used as the primary key")
+    ap.add_argument("--linked-cols", help="linked mode: spine aliases to inherit (default: all but --key)")
+    ap.add_argument("--entry-cols", help="linked mode: comma list of NAME:type entry columns")
+    args = ap.parse_args()
+
+    base, tok = token()
+    folder = args.folder or home_folder(base, tok)
+
+    if args.spine_cols or args.spine_sql or args.spine_statement:
+        desc, elements, nxt = build_linked(args)
+    elif args.columns:
+        desc, elements, nxt = build_empty(args)
+    else:
+        raise SystemExit("provide --columns (empty mode) or --spine-cols/--spine-sql + --key + --entry-cols (linked mode)")
+
+    # Nested draft → released document wrapper (code_rep). Layout is assembled
+    # as the last write inside wire_workbook before the POST body is built.
+    spec = {"name": args.name, "description": desc, "folderId": folder,
+            "schemaVersion": 1, "kind": "workbook",
+            "pages": [{"id": "entryPage", "name": args.name, "elements": elements}]}
+    post_body = workbook_wire.wire_workbook(spec)
+
+    body = json.dumps(post_body).encode()
+    req = urllib.request.Request(base + "/v2/workbooks/spec", data=body, method="POST",
+                                 headers={"Authorization": f"Bearer {tok}",
+                                          "Content-Type": "application/json",
+                                          "Accept": "application/json"})
+    resp = json.load(urllib.request.urlopen(req))
+    wbid = resp.get("workbookId")
+    print("workbookId:", wbid)
+    if wbid:
+        req = urllib.request.Request(base + f"/v2/workbooks/{wbid}", headers={"Authorization": f"Bearer {tok}"})
+        print("url:", json.load(urllib.request.urlopen(req)).get("url"))
+        print(f"\nNEXT (UI): {nxt}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/build-research-model.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/build-research-model.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+build-research-model.py — one-shot builder for the EQUITY-RESEARCH archetype
+(broker/FactSet house-template models). Consumes the plan JSON emitted by
+infer-canonical-formulas.py and builds, entirely via the Sigma REST API:
+
+  DATA LAYER      (DM element `data`)     — the hard-coded grid as inline VALUES:
+                                            one row per YEAR, one column per line item
+                                            (safe id c<row>), typed values or NULL.
+  LINE DIM        (DM element `linedim`)  — id -> label / section / order (inline VALUES).
+  COMPUTATION     (wb table `calc`)       — one column per line item:
+                                            input   -> [data/c<row>]
+                                            derived -> Coalesce([data/c<row>], <canonical>)
+                                            (canonical references sibling c<row> columns;
+                                             ONE formula per line, all years — no triplets).
+  LONG            (wb transpose `long`)   — column-to-row unpivot -> (Year, LineId, Value).
+  LABELED         (wb join `labeled`)     — long ⋈ linedim -> adds Label/Section/orders.
+  DISPLAY         (wb pivot)              — rowsBy Section->Label, columnsBy Year, Sum(Value).
+
+This is the "start from the hard-coded values, then build the pivot with the formulas
+in it" architecture — the clean version of a hand build (no User/Calc/(1) sprawl).
+
+Creds: reads SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET from the environment
+if set, else ~/.sigma-migration/env. (Point it at any org via env vars.)
+
+Usage:
+  build-research-model.py <plan.json> --conn <connId> --folder <folderId>
+                          [--name "..."] [--post]         # default = dry-run to /tmp
+"""
+import sys, os, json, urllib.request, urllib.parse, urllib.error
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+import workbook_wire  # noqa: E402
+
+OUTDIR = "/tmp/research-build"
+NUM = {"kind": "number", "formatString": "#,##0.0"}
+
+
+def q(s):
+    return "'" + str(s).replace("'", "''") + "'"
+
+
+def env():
+    e = dict(os.environ)
+    if all(k in e and e[k] for k in ("SIGMA_BASE_URL", "SIGMA_CLIENT_ID", "SIGMA_CLIENT_SECRET")):
+        return e
+    p = os.path.expanduser("~/.sigma-migration/env")
+    if os.path.exists(p):
+        for line in open(p):
+            line = line.strip().replace("export ", "")
+            if "=" in line:
+                k, v = line.split("=", 1); e.setdefault(k, v.strip().strip('"').strip("'"))
+    return e
+
+
+def token(e):
+    d = urllib.parse.urlencode({"grant_type": "client_credentials",
+                                "client_id": e["SIGMA_CLIENT_ID"],
+                                "client_secret": e["SIGMA_CLIENT_SECRET"]}).encode()
+    req = urllib.request.Request(e["SIGMA_BASE_URL"] + "/v2/auth/token", data=d,
+                                 headers={"Content-Type": "application/x-www-form-urlencoded"})
+    return json.load(urllib.request.urlopen(req))["access_token"]
+
+
+def api(base, tok, method, path, body=None):
+    req = urllib.request.Request(base + path, data=(json.dumps(body).encode() if body else None),
+                                 method=method,
+                                 headers={"Authorization": f"Bearer {tok}",
+                                          "Content-Type": "application/json",
+                                          "Accept": "application/json"})
+    try:
+        return json.load(urllib.request.urlopen(req))
+    except urllib.error.HTTPError as ex:
+        print("HTTP", ex.code, ex.read().decode()[:2000]); raise
+
+
+# ---------------------------------------------------------------- DM specs
+def data_sql(plan, data_lines):
+    """Wide VALUES: row per year, col per line (typed or NULL), cast so all-NULL cols type."""
+    years = [p["year"] for p in plan["periods"]]
+    cols = ["YR"] + [ln["col_id"] for ln in data_lines]
+    rows = []
+    for y in years:
+        cells = [str(y)]
+        for ln in data_lines:
+            v = ln["typed"].get(str(y), ln["typed"].get(y))
+            cells.append("NULL" if v is None else f"{float(v):.6f}")
+        rows.append("(" + ",".join(cells) + ")")
+    inner = "select * from (values\n" + ",\n".join(rows) + "\n) as t(" + ", ".join(cols) + ")"
+    casts = ["YR::int as YR"] + [f"{ln['col_id']}::float as {ln['col_id']}" for ln in data_lines]
+    return f"select {', '.join(casts)} from (\n{inner}\n) s"
+
+
+def linedim_sql(plan):
+    rows = []
+    for ln in plan["lines"]:
+        rows.append("(" + ",".join([q(ln["col_id"]), q(ln["label"] or ln["col_id"]),
+                                    q(ln["section"]), str(ln["sec_order"]), str(ln["line_order"]),
+                                    q(ln["kind"])]) + ")")
+    inner = "select * from (values\n" + ",\n".join(rows) + \
+            "\n) as t(LINE_ID, LABEL, SECTION, SEC_ORDER, LINE_ORDER, KIND)"
+    return inner
+
+
+def dmcol(i, alias, name):
+    return {"id": f"k{i}", "name": name, "formula": f"[Custom SQL/{alias}]"}
+
+
+def build_dm(plan, conn, folder, name):
+    data_lines = [ln for ln in plan["lines"] if ln["typed"]]     # only lines with typed values
+    data_el = {"id": "data", "kind": "table",
+               "source": {"kind": "sql", "connectionId": conn, "statement": data_sql(plan, data_lines)},
+               "columns": [dmcol(0, "YR", "Year")] +
+                          [dmcol(i + 1, ln["col_id"], ln["col_id"]) for i, ln in enumerate(data_lines)]}
+    linedim_el = {"id": "linedim", "kind": "table",
+                  "source": {"kind": "sql", "connectionId": conn, "statement": linedim_sql(plan)},
+                  "columns": [dmcol(0, "LINE_ID", "Line Id"), dmcol(1, "LABEL", "Label"),
+                              dmcol(2, "SECTION", "Section"), dmcol(3, "SEC_ORDER", "Sec Order"),
+                              dmcol(4, "LINE_ORDER", "Line Order"), dmcol(5, "KIND", "Kind")]}
+    spec = {"name": name + " — Model", "schemaVersion": 1, "folderId": folder,
+            "pages": [{"id": "m", "name": "Model", "elements": [data_el, linedim_el]}]}
+    return spec, data_lines
+
+
+def map_dm(full):
+    out = {}
+    for el in full["pages"][0]["elements"]:
+        names = {c["name"] for c in el["columns"]}
+        if "Label" in names:
+            out["linedim"] = el["id"]
+        elif "Year" in names:
+            out["data"] = el["id"]
+    return out
+
+
+# ---------------------------------------------------------------- workbook spec
+def build_wb(plan, dm_id, els, data_lines, folder, name):
+    DMP = "Custom SQL"
+    dcols = {ln["col_id"] for ln in data_lines}
+
+    def dm(elid):
+        return {"kind": "data-model", "dataModelId": dm_id, "elementId": els[elid]}
+
+    # ---- calc: one column per line, in the same element (siblings referenced by name) ----
+    calc_cols = [{"id": "yr", "name": "Year", "formula": f"[{DMP}/Year]"}]
+    merge = []
+    for ln in plan["lines"]:
+        cid = ln["col_id"]; merge.append(cid)
+        has_data = cid in dcols
+        if ln["kind"] == "input" or not ln.get("canonical"):
+            f = f"[{DMP}/{cid}]" if has_data else "Null"      # carried / input / quarantined
+        elif has_data:
+            f = f"Coalesce([{DMP}/{cid}], {ln['canonical']})"  # override wins, else compute
+        else:
+            f = ln["canonical"]                                # pure derived, one formula
+        calc_cols.append({"id": cid, "name": cid, "formula": f})
+    calc = {"id": "calc", "kind": "table", "name": "Calc", "visibleAsSource": False,
+            "source": dm("data"), "columns": calc_cols}
+
+    # ---- long: transpose (column-to-row) all line columns -> (Year, LineId, Value) ----
+    # NB: a transpose element takes NO explicit name; Sigma auto-names it "Transpose of <source>"
+    # and its OWN columns must self-reference via that auto name.
+    TR = "Transpose of Calc"
+    long_el = {"id": "long", "kind": "table", "visibleAsSource": False,
+               "source": {"kind": "transpose", "source": {"kind": "table", "elementId": "calc"},
+                          "direction": "column-to-row", "columnsToMerge": merge,
+                          "columnLabelForMergedColumns": "LineId", "columnLabelForValues": "Value"},
+               "columns": [{"id": "l_yr", "name": "Year", "formula": f"[{TR}/Year]"},
+                           {"id": "l_id", "name": "LineId", "formula": f"[{TR}/LineId]"},
+                           {"id": "l_v", "name": "Value", "formula": f"[{TR}/Value]"}]}
+
+    # ---- linedim wrap (a DM leg can't sit inside a join) ----
+    dimw = {"id": "dimw", "kind": "table", "name": "Dim", "visibleAsSource": False,
+            "source": dm("linedim"),
+            "columns": [{"id": "d_id", "name": "Line Id", "formula": f"[{DMP}/Line Id]"},
+                        {"id": "d_lab", "name": "Label", "formula": f"[{DMP}/Label]"},
+                        {"id": "d_sec", "name": "Section", "formula": f"[{DMP}/Section]"},
+                        {"id": "d_so", "name": "Sec Order", "formula": f"[{DMP}/Sec Order]"},
+                        {"id": "d_lo", "name": "Line Order", "formula": f"[{DMP}/Line Order]"}]}
+
+    # ---- labeled: long ⋈ dim on LineId ----
+    labeled = {"id": "labeled", "kind": "table", "name": "Labeled", "visibleAsSource": False,
+               "source": {"kind": "join", "name": "LJ",
+                          "primarySource": {"kind": "table", "elementId": "long"},
+                          "joins": [{"name": "D", "joinType": "left-outer",
+                                     "left": {"kind": "table", "elementId": "long"},
+                                     "right": {"kind": "table", "elementId": "dimw"},
+                                     "columns": [{"left": "[LineId]", "right": "[Line Id]"}]}]},
+               "columns": [{"id": "x_yr", "name": "Year", "formula": "[LJ/Year]"},
+                           {"id": "x_v", "name": "Value", "formula": "[LJ/Value]"},
+                           {"id": "x_lab", "name": "Line Item", "formula": "[D/Label]"},
+                           {"id": "x_sec", "name": "Section", "formula": "[D/Section]"},
+                           {"id": "x_so", "name": "Sec Order", "formula": "[D/Sec Order]"},
+                           {"id": "x_lo", "name": "Line Order", "formula": "[D/Line Order]"}]}
+
+    # ---- display pivot ----
+    pivot = {"id": "pivot", "kind": "pivot-table", "name": name,
+             "source": {"kind": "table", "elementId": "labeled"},
+             "columns": [{"id": "pv_sec", "name": "Section", "formula": "[Labeled/Section]"},
+                         {"id": "pv_so", "name": "Sec Order", "formula": "[Labeled/Sec Order]"},
+                         {"id": "pv_line", "name": "Line Item", "formula": "[Labeled/Line Item]"},
+                         {"id": "pv_lo", "name": "Line Order", "formula": "[Labeled/Line Order]"},
+                         {"id": "pv_yr", "name": "Year", "formula": "[Labeled/Year]"},
+                         {"id": "pv_v", "name": "Value", "formula": "Sum([Labeled/Value])"}],
+             "values": ["pv_v"],
+             "rowsBy": [{"id": "pv_sec", "sort": {"direction": "ascending", "by": "pv_so", "aggregation": "min"}},
+                        {"id": "pv_line", "sort": {"direction": "ascending", "by": "pv_lo", "aggregation": "min"}}],
+             "columnsBy": [{"id": "pv_yr", "sort": {"direction": "ascending"}}]}
+
+    data_tbl = {"id": "datatbl", "kind": "table", "name": "FY results — hard-coded values (data page)",
+                "source": dm("data"),
+                "columns": [{"id": "dt_yr", "name": "Year", "formula": f"[{DMP}/Year]"}] +
+                           [{"id": f"dt_{ln['col_id']}", "name": ln["label"] or ln["col_id"],
+                             "formula": f"[{DMP}/{ln['col_id']}]"} for ln in data_lines[:40]]}
+
+    pages = [
+        {"id": "main", "name": "FY results", "elements": [pivot]},
+        {"id": "datap", "name": "Data page", "elements": [data_tbl]},
+        {"id": "plumb", "name": "plumbing", "visibility": "hidden",
+         "elements": [calc, long_el, dimw, labeled]},
+    ]
+    # Nested draft; wire_workbook flattens + wraps at the POST / dry-run boundary.
+    return {"name": name, "schemaVersion": 1, "kind": "workbook",
+            "folderId": folder, "pages": pages}
+
+
+# ---------------------------------------------------------------- main
+def main():
+    a = [x for x in sys.argv[1:] if not x.startswith("--")]
+    opt = {x.split("=")[0]: (x.split("=", 1)[1] if "=" in x else True) for x in sys.argv[1:] if x.startswith("--")}
+    if not a:
+        sys.exit(__doc__)
+    plan = json.load(open(a[0]))
+    conn = opt.get("--conn"); folder = opt.get("--folder")
+    name = opt.get("--name") or (os.path.splitext(plan["source"])[0][:60] + " (auto)")
+    do_post = "--post" in opt
+    os.makedirs(OUTDIR, exist_ok=True)
+
+    s = plan["summary"]; par = plan["parity"]
+    tot = par.get("live", 0) + par.get("frozen", 0)
+    print(f"Plan: {s.get('input',0)} input, {s.get('derived',0)} derived, {s.get('ratio',0)} ratio, "
+          f"{s.get('needs_review',0)} needs-review; formula cells {par.get('live',0)}/{tot} live-verified, "
+          f"{par.get('frozen',0)} frozen to Excel cached")
+    print(f"Anchors: {list(plan['anchors'])}")
+
+    if not (conn and folder):
+        print("(dry-run needs --conn and --folder to embed real ids; writing spec skeletons anyway)")
+    dm_spec, data_lines = build_dm(plan, conn or "<conn>", folder or "<folder>", name)
+    json.dump(dm_spec, open(f"{OUTDIR}/dm_spec.json", "w"), indent=1)
+    print(f"data columns (lines with typed values): {len(data_lines)} ; total lines: {len(plan['lines'])}")
+
+    if not do_post:
+        wb_spec = workbook_wire.wire_workbook(
+            build_wb(plan, "<dm-id>", {"data": "data", "linedim": "linedim"},
+                     data_lines, folder or "<folder>", name))
+        json.dump(wb_spec, open(f"{OUTDIR}/wb_spec.json", "w"), indent=1)
+        print(f"DRY RUN — {OUTDIR}/dm_spec.json + wb_spec.json. Re-run with --post (and --conn/--folder) to build live.")
+        return
+
+    e = env(); base = e["SIGMA_BASE_URL"]; tok = token(e)
+    dm = api(base, tok, "POST", "/v2/dataModels/spec", dm_spec); dm_id = dm["dataModelId"]
+    print("dataModelId:", dm_id)
+    full = api(base, tok, "GET", f"/v2/dataModels/{dm_id}/spec")
+    els = map_dm(full)
+    # Layout is the last write (assembled inside wire_workbook) before POST.
+    wb_spec = workbook_wire.wire_workbook(
+        build_wb(plan, dm_id, els, data_lines, folder, name))
+    json.dump(wb_spec, open(f"{OUTDIR}/wb_spec_live.json", "w"), indent=1)
+    wb = api(base, tok, "POST", "/v2/workbooks/spec", wb_spec)
+    print("workbookId:", wb.get("workbookId"), "| url:", wb.get("url"))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/coa.json
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/coa.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "Canonical chart-of-accounts for a broker equity-research template (FactSet-style house model). Maps a file's line-item labels to stable canonical accounts so a fleet of ~850 'similar but not identical' files can be reconciled. Curated from a reference model; grow `aliases` from batch-convert.py's 'top unmapped labels' rollup. such desks are often bilingual, so aliases carry EN + FR. `shape` is the expected canonical formula (advisory: a per-file formula that disagrees is a flag, not an auto-reject). Segments/geographies are a DYNAMIC dimension (not in the COA) - carried as data.",
+  "template": {
+    "name": "broker-factset-equity-research",
+    "sheets_expected": ["FY results", "Quarterly"],
+    "sections_expected": ["PROFIT AND LOSS", "PER SHARE DATA", "EVALUATION", "BALANCE SHEET", "CHANGE IN NET DEBT", "COMPUTED ASSUMPTIONS"],
+    "fdscache_marker": "__FDSCACHE__",
+    "fingerprint_weights": {"sections": 0.4, "sheets": 0.15, "label_jaccard": 0.25, "formula_shapes": 0.2},
+    "thresholds": {"same": 0.75, "variant": 0.45}
+  },
+  "accounts": [
+    {"id": "revenue",        "section": "PROFIT AND LOSS", "aliases": ["turnover", "revenue", "sales", "chiffre d'affaires", "chiffre d affaires", "ca"], "shape": "input"},
+    {"id": "cogs",           "section": "PROFIT AND LOSS", "aliases": ["cost of purchased materials & services", "cost of goods sold", "cogs", "cost of sales", "coût des ventes", "cout des ventes"], "shape": "[gross_profit] - [revenue]"},
+    {"id": "gross_profit",   "section": "PROFIT AND LOSS", "aliases": ["gross profit", "marge brute", "gross margin"], "shape": "[revenue] + [cogs]"},
+    {"id": "opex",           "section": "PROFIT AND LOSS", "aliases": ["operating expenses", "opex", "charges d'exploitation", "frais operationnels"], "shape": "input"},
+    {"id": "ebitda",         "section": "PROFIT AND LOSS", "aliases": ["ebitda", "excédent brut d'exploitation", "ebe"], "shape": "[ebita] - [d_and_a]"},
+    {"id": "ebita",          "section": "PROFIT AND LOSS", "aliases": ["ebita", "adj. ebita", "adjusted ebita"], "shape": "derived"},
+    {"id": "d_and_a",        "section": "PROFIT AND LOSS", "aliases": ["depreciation expense", "d&a", "depreciation", "amortization", "dotations aux amortissements", "ow depreciation expense"], "shape": "input"},
+    {"id": "ebit",           "section": "PROFIT AND LOSS", "aliases": ["ebit", "operating income", "résultat d'exploitation", "resultat operationnel"], "shape": "[ebita] + [net_other] + [amortization_intangibles] + [impairment]"},
+    {"id": "net_financial",  "section": "PROFIT AND LOSS", "aliases": ["cost of net financial debt", "net financial", "net financial expenses", "résultat financier", "resultat financier"], "shape": "input"},
+    {"id": "pbt",            "section": "PROFIT AND LOSS", "aliases": ["net income before tax", "pbt", "profit before tax", "résultat avant impôt", "resultat avant impot"], "shape": "[ebit] + [net_financial]"},
+    {"id": "tax",            "section": "PROFIT AND LOSS", "aliases": ["tax", "income tax", "impôt", "impot", "- tax"], "shape": "input"},
+    {"id": "net_income",     "section": "PROFIT AND LOSS", "aliases": ["net income", "résultat net", "resultat net"], "shape": "[pbt] + [tax]"},
+    {"id": "other_income",   "section": "PROFIT AND LOSS", "aliases": ["other income", "+ other income", "autres produits"], "shape": "input"},
+    {"id": "other_expenses", "section": "PROFIT AND LOSS", "aliases": ["other expenses", "- other expenses", "autres charges"], "shape": "input"},
+    {"id": "net_other",      "section": "PROFIT AND LOSS", "aliases": ["net other expenses", "= net other expenses", "net other expenses (impairt.)", "autres produits et charges"], "shape": "[other_income] + [other_expenses]"},
+    {"id": "amortization_intangibles", "section": "PROFIT AND LOSS", "aliases": ["amortization of intangible assets", "- amortization of intangible assets", "amortisation of intangibles", "amortissement des incorporels"], "shape": "input"},
+    {"id": "impairment",     "section": "PROFIT AND LOSS", "aliases": ["impairment of goodwill", "- impairment of goodwill", "impairment", "dépréciation du goodwill"], "shape": "input"},
+    {"id": "non_recurring",  "section": "PROFIT AND LOSS", "aliases": ["non recurring effect", "non recurring effect related to copper", "- non recurring effect", "éléments non récurrents"], "shape": "derived"},
+    {"id": "associates",     "section": "PROFIT AND LOSS", "aliases": ["affiliates / associates", "+ affiliates / associates", "affiliates", "associates", "sociétés mises en équivalence"], "shape": "input"},
+    {"id": "fx",             "section": "PROFIT AND LOSS", "aliases": ["foreign currency exchange", "+ foreign currency exchange", "forex", "change"], "shape": "input"},
+    {"id": "discontinued",   "section": "PROFIT AND LOSS", "aliases": ["discontinued operations", "+ discontinued operations", "activités abandonnées"], "shape": "input"},
+    {"id": "minorities",     "section": "PROFIT AND LOSS", "aliases": ["minorities share", "minorities", "intérêts minoritaires", "interets minoritaires"], "shape": "input"},
+    {"id": "net_attributable","section": "PROFIT AND LOSS","aliases": ["net attributable", "net attributable income", "résultat net part du groupe", "rnpg"], "shape": "[net_income] + [minorities]"},
+
+    {"id": "shares",         "section": "PER SHARE DATA", "aliases": ["number of shares", "average number of shares", "published average number of shares", "nombre d'actions", "nombre d actions"], "shape": "input"},
+    {"id": "eps",            "section": "PER SHARE DATA", "aliases": ["eps", "eps reported", "earnings per share", "bpa", "bénéfice par action"], "shape": "[net_income] / [shares]"},
+    {"id": "eps_adjusted",   "section": "PER SHARE DATA", "aliases": ["eps adjusted", "adjusted eps", "bpa ajusté"], "shape": "derived"},
+    {"id": "dps",            "section": "PER SHARE DATA", "aliases": ["net dividend / share", "dps", "dividend per share", "dividende par action"], "shape": "input"},
+    {"id": "payout",         "section": "PER SHARE DATA", "aliases": ["pay-out", "payout", "payout ratio", "taux de distribution"], "shape": "[dps] / [eps]"},
+
+    {"id": "net_debt",       "section": "BALANCE SHEET", "aliases": ["net financial debt", "net debt", "dette nette", "endettement net"], "shape": "input"},
+    {"id": "equity",         "section": "BALANCE SHEET", "aliases": ["group equity", "equity", "shareholders equity", "capitaux propres", "fonds propres"], "shape": "input"},
+    {"id": "total_assets",   "section": "BALANCE SHEET", "aliases": ["total assets", "total actif", "= total assets"], "shape": "derived"},
+    {"id": "wcr",            "section": "BALANCE SHEET", "aliases": ["wcr", "working capital", "bfr", "besoin en fonds de roulement", "+ wcr"], "shape": "derived"},
+
+    {"id": "free_cash_flow", "section": "CHANGE IN NET DEBT", "aliases": ["free cash flow", "fcf", "= free cash flow", "flux de trésorerie disponible"], "shape": "derived"},
+    {"id": "operating_cf",   "section": "CHANGE IN NET DEBT", "aliases": ["operating cash flow", "= operating cash flow before wc change", "flux de trésorerie opérationnel"], "shape": "derived"},
+    {"id": "capex",          "section": "CHANGE IN NET DEBT", "aliases": ["net capex", "- net capex", "capex", "investissements"], "shape": "input"},
+    {"id": "dividends_paid", "section": "CHANGE IN NET DEBT", "aliases": ["dividends", "- dividends", "dividendes versés", "dividendes verses"], "shape": "input"}
+  ]
+}

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/infer-canonical-formulas.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/infer-canonical-formulas.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+"""
+infer-canonical-formulas.py — the inference core for the EQUITY-RESEARCH archetype
+(FactSet / broker house-template models: line-items down rows, YEARS across columns,
+organised into statement sections — PROFIT AND LOSS, PER SHARE DATA, BALANCE SHEET, …).
+
+It turns a "report drawn in cells" financial model into a clean two-layer plan:
+
+  DATA LAYER   — every TYPED number in the grid (historical actual OR forecast-year
+                 override — a typed cell is *always* data), long grain
+                 (Period, Section, Line Item, orders, Value).
+  FORMULA LAYER— for each DERIVED line item, ONE canonical formula applied to all
+                 periods (the "Per Share Data done right" pattern), NOT the per-year
+                 exception soup that bloats a hand build.
+
+Why one formula, not per-year? The same row is often a hardcode in history and a
+formula in the forecast (analyst overrides). We take the row's MODAL formula (after
+normalising the period dimension away), let typed cells win via Coalesce in the
+build step, and PARITY-GATE the result against Excel's own cached values.
+
+Output: a research-model-plan JSON consumed by build-research-model.py. Also prints a
+human report. Read-only; never writes to the source workbook.
+
+Usage:
+  infer-canonical-formulas.py <file.xlsx> [--sheet "FY results"] [--out plan.json]
+                              [--first-row N] [--last-row N] [--quiet]
+"""
+import sys, os, json, re, math
+from collections import Counter, defaultdict
+
+try:
+    import openpyxl
+    from openpyxl.utils import get_column_letter, column_index_from_string
+    from openpyxl.formula.tokenizer import Tokenizer, Token
+except ImportError:
+    sys.exit("needs openpyxl:  python3 -m venv .venv && .venv/bin/pip install openpyxl")
+
+CELL_RE  = re.compile(r"^(\$?)([A-Z]{1,3})(\$?)(\d+)$")
+RANGE_RE = re.compile(r"^(\$?[A-Z]{1,3}\$?\d+):(\$?[A-Z]{1,3}\$?\d+)$")
+ERR_RE   = re.compile(r"#(REF|N/A|VALUE|DIV/0|NAME|NUM|NULL)!?", re.I)
+YEAR_RE  = re.compile(r"^(19|20)\d{2}$")
+
+
+# ------------------------------------------------------------------ load
+def load(path):
+    f = openpyxl.load_workbook(path, data_only=False)   # formulas
+    v = openpyxl.load_workbook(path, data_only=True)     # cached values
+    return f, v
+
+
+def pick_sheet(wb, name):
+    if name and name in wb.sheetnames:
+        return wb[name]
+    # skip FactSet cache / veryHidden; take the widest visible sheet
+    cand = [ws for ws in wb.worksheets
+            if ws.sheet_state == "visible" and not ws.title.startswith("__")]
+    return max(cand, key=lambda w: (w.max_row or 0) * (w.max_column or 0)) if cand else wb.active
+
+
+# ------------------------------------------------------------------ year axis
+def detect_year_axis(ws_f, ws_v):
+    """Return (header_row, [(col_idx, year_int)], first_year_col, last_year_col).
+    A year column runs while the header cell is a 4-digit year (cached) or an
+    increment formula (=<prev>+1). Stops at the first break (notes columns)."""
+    best = None
+    for r in range(1, min(ws_f.max_row, 15) + 1):
+        cols = []
+        for c in range(2, min(ws_f.max_column, 60) + 1):
+            fv = ws_f.cell(r, c).value
+            cv = ws_v.cell(r, c).value
+            is_year = (isinstance(cv, (int, float)) and YEAR_RE.match(str(int(cv)))) or \
+                      (isinstance(fv, str) and re.match(r"^=\s*\$?[A-Z]+\$?\d+\s*\+\s*1\s*$", fv))
+            if is_year:
+                cols.append(c)
+            elif cols:
+                break            # end of the contiguous year run
+        if len(cols) > (len(best[1]) if best else 0):
+            best = (r, cols)
+    if not best:
+        return None, [], None, None
+    hr, cols = best
+    axis = []
+    for c in cols:
+        cv = ws_v.cell(hr, c).value
+        yr = int(cv) if isinstance(cv, (int, float)) and YEAR_RE.match(str(int(cv))) else None
+        axis.append((c, yr))
+    # fill any None years by walking the increment (=prev+1)
+    for i in range(1, len(axis)):
+        if axis[i][1] is None and axis[i - 1][1] is not None:
+            axis[i] = (axis[i][0], axis[i - 1][1] + 1)
+    return hr, axis, cols[0], cols[-1]
+
+
+# ------------------------------------------------------------------ row / label map
+SECTION_HINTS = ("PROFIT AND LOSS", "PER SHARE DATA", "EVALUATION", "BALANCE SHEET",
+                 "CHANGE IN NET DEBT", "CASH FLOW", "COMPUTED ASSUMPTIONS", "RATIOS",
+                 "INCOME STATEMENT", "VALUATION")
+
+
+def is_section_header(text, has_year_data):
+    if not text or has_year_data:
+        return False
+    t = text.strip()
+    if t.upper() in SECTION_HINTS:
+        return True
+    # ALL-CAPS-ish, multi-word, no leading indentation, few punctuation
+    letters = [ch for ch in t if ch.isalpha()]
+    if len(letters) >= 3 and t == t.upper() and not t.startswith(" ") and ":" not in t:
+        return True
+    return False
+
+
+def build_row_map(ws_f, ws_v, axis, first_row, last_row):
+    """row -> {label, section, sec_order, line_order, uname, cells{col:(kind,val,formula,cached)}}
+    Only rows with >=1 non-empty year cell are data rows."""
+    year_cols = [c for c, _ in axis]
+    rows = {}
+    section, sec_order, line_order = "(none)", 0, 0
+    name_seen = Counter()
+    for r in range(first_row, last_row + 1):
+        label = ws_f.cell(r, 1).value
+        label = str(label).strip() if label is not None else ""
+        # gather year cells
+        cells = {}
+        has_data = False
+        for c in year_cols:
+            fv = ws_f.cell(r, c).value
+            cv = ws_v.cell(r, c).value
+            if fv is None and cv is None:
+                cells[c] = ("EMPTY", None, None, None); continue
+            has_data = True
+            if isinstance(fv, str) and fv.startswith("="):
+                cells[c] = ("FORMULA", None, fv, cv)
+            elif isinstance(fv, (int, float)):
+                cells[c] = ("LITERAL", fv, None, cv)
+            else:
+                # text literal in a data row is rare; treat as label-ish, ignore for value
+                cells[c] = ("TEXT", fv, None, cv)
+        if is_section_header(label, has_data):
+            section = label.strip(); sec_order += 1; line_order = 0
+            continue
+        if not has_data:
+            continue    # sub-header / spacer
+        line_order += 1
+        # unique internal name (Sigma column). disambiguate duplicate labels.
+        base = label if label else f"row{r}"
+        name_seen[base] += 1
+        uname = base if name_seen[base] == 1 else f"{base} ({name_seen[base]})"
+        rows[r] = dict(label=label, section=section, sec_order=sec_order,
+                       line_order=line_order, uname=uname, cells=cells)
+    return rows
+
+
+# ------------------------------------------------------------------ formula normalisation
+def parse_ref(ref):
+    """'B$8' -> (col_idx, row_idx, col_abs, row_abs) ; None if not a simple cell ref."""
+    m = CELL_RE.match(ref)
+    if not m:
+        return None
+    col_abs = (m.group(1) == "$")
+    col_idx = column_index_from_string(m.group(2))
+    row_abs = (m.group(3) == "$")
+    row_idx = int(m.group(4))
+    return col_idx, row_idx, col_abs, row_abs
+
+
+def expand_range_rows(a, b):
+    """A range like B8:B12 within one column -> list of row ints; cross-col -> None."""
+    pa, pb = parse_ref(a), parse_ref(b)
+    if not pa or not pb or pa[0] != pb[0]:
+        return None
+    return list(range(min(pa[1], pb[1]), max(pa[1], pb[1]) + 1))
+
+
+def normalize_formula(formula, self_col, self_row, row_by_num):
+    """Return (canonical_key, sigma_expr_template, deps:set(row), flags:set).
+    canonical_key: period-relative string used for the modal vote (refs -> R<row>@<off>).
+    sigma_expr_template: same but refs -> {{R<row>@<off>}} placeholders, later rendered.
+    Cross-sheet refs / errors / unresolved rows set flags and make the row non-derivable
+    from this cell (caller decides)."""
+    flags = set()
+    deps = set()
+    try:
+        toks = Tokenizer(formula).items
+    except Exception:
+        return None, None, deps, {"unparseable"}
+    out = []
+    for t in toks:
+        val = t.value
+        if t.type == Token.OPERAND and t.subtype == Token.RANGE:
+            if "!" in val:                       # cross-sheet reference
+                flags.add("cross_sheet"); out.append("XREF"); continue
+            if ERR_RE.search(val):
+                flags.add("error_ref"); out.append("ERR"); continue
+            rng = RANGE_RE.match(val)
+            if rng:                              # SUM(B8:B12) style
+                rr = expand_range_rows(rng.group(1), rng.group(2))
+                if rr is None:
+                    flags.add("range_multicol"); out.append("RANGE"); continue
+                parts = []
+                for rw in rr:
+                    if rw in row_by_num:
+                        deps.add(rw); parts.append(f"R{rw}@0")
+                    else:
+                        flags.add("unresolved_ref"); parts.append(f"?{rw}")
+                out.append("(" + "+".join(parts) + ")"); continue
+            p = parse_ref(val)
+            if not p:
+                flags.add("weird_ref"); out.append("REF"); continue
+            col, row, col_abs, row_abs = p
+            if col_abs:                          # absolute column -> fixed base period
+                flags.add("abs_col_ref")
+            off = 0 if col_abs else (col - self_col)
+            if row not in row_by_num:
+                flags.add("unresolved_ref"); out.append(f"?{row}"); continue
+            deps.add(row); out.append(f"R{row}@{off}")
+        elif t.type == Token.OPERAND and t.subtype == Token.ERROR:
+            flags.add("error_ref"); out.append("ERR")
+        elif t.type == Token.OPERAND and t.subtype == Token.NUMBER:
+            out.append(val)
+        elif t.type == Token.OPERAND and t.subtype == Token.TEXT:
+            out.append('"' + val.strip('"') + '"')
+        elif t.type == Token.FUNC:
+            fn = val.rstrip("(").upper()
+            if fn not in ("SUM", "IF", "ROUND", "ABS", "MIN", "MAX", "INT"):
+                flags.add(f"func:{fn}")
+            out.append(val)
+        elif t.type in (Token.PAREN, Token.SEP, Token.OP_IN, Token.OP_PRE, Token.OP_POST):
+            out.append(val)
+        else:
+            out.append(val)
+    key = "".join(out)
+    return key, key, deps, flags
+
+
+# ------------------------------------------------------------------ render to Sigma
+UNRENDERABLE = ("XREF", "ERR", "RANGE", "REF", "?")   # tokens with no safe Sigma form
+
+
+def col_id(row):
+    return f"c{row}"                    # stable, ref-safe id (labels carry /,%,& — unsafe)
+
+
+def _additive(key):
+    """True if the canonical is a pure sum/difference of refs (Excel treats blanks as 0
+    in +/-, so these can be rendered null-safe with Coalesce(ref,0) and stay LIVE)."""
+    t = re.sub(r"R\d+@-?\d+", " ", key)
+    t = re.sub(r"[0-9.]+", " ", t)
+    t = re.sub(r"[+\-() ]", " ", t)
+    return t.strip() == "" and key.strip() != ""
+
+
+def render_sigma(key):
+    """R<row>@<off> -> [c<row>] / Lag([c<row>],k,[Year]) ; Excel IF->If ; Sigma uses ^ for power.
+    Additive formulas wrap refs in Coalesce(ref,0) to match Excel's blank-as-0 (stays live).
+    Returns None if the key holds a token with no safe Sigma rendering (cross-sheet, error, …)."""
+    if any(tok in key for tok in UNRENDERABLE):
+        return None
+    add = _additive(key)
+
+    def repl(m):
+        row = int(m.group(1)); off = int(m.group(2))
+        nm = col_id(row)
+        base = f"[{nm}]" if off == 0 else (
+            f"Lag([{nm}], {-off}, [Year])" if off < 0 else f"Lead([{nm}], {off}, [Year])")
+        return f"Coalesce({base}, 0)" if add else base
+    s = re.sub(r"R(\d+)@(-?\d+)", repl, key)
+    s = re.sub(r"\bIF\(", "If(", s)
+    s = re.sub(r"\bSUM\(", "Sum(", s)
+    s = re.sub(r"([0-9.]+)\s*%", r"(\1 * 0.01)", s)         # Excel 101% -> (101*0.01)
+    # Sigma rejects a unary '+' prefix (Excel '=+B8+B11'): drop '+' at start / after '(' or ','
+    for _ in range(3):
+        s = re.sub(r"(^|[(,])\s*\+", r"\1", s.strip())
+    return s if _safe_sigma(s) else None                     # unsupported -> carry as data
+
+
+_ALLOWED_FUNCS = ("If", "Coalesce", "Lag", "Lead", "Sum", "Min", "Max", "Round", "Abs", "Power")
+
+
+def _safe_sigma(s):
+    """True iff the formula uses only constructs we can build (refs, arithmetic, allowed
+    funcs). Anything else (& concat, text, unknown functions) -> carry as cached data."""
+    t = re.sub(r"\[c\d+\]", " ", s)                          # column refs
+    for fn in _ALLOWED_FUNCS:
+        t = re.sub(rf"\b{fn}\(", " ", t)
+    t = re.sub(r"[0-9]+(\.[0-9]+)?", " ", t)                 # numbers
+    t = re.sub(r"[\s+\-*/^(),.<>=]", " ", t)                 # operators / punctuation
+    return t.strip() == ""
+
+
+# ------------------------------------------------------------------ parity eval
+def eval_key(key, self_col, cached):
+    """Evaluate a canonical key against the cached grid for one period column.
+    cached[(row,col)] -> float. Returns float or None (unevaluatable / missing)."""
+    if any(tok in key for tok in ("XREF", "ERR", "REF", "RANGE", "?")):
+        return None
+    key = re.sub(r"([0-9.]+)\s*%", r"(\1*0.01)", key)        # Excel percent literal
+    if re.search(r"\b(IF|MIN|MAX|ROUND|ABS|INT)\(", key, re.I):
+        return None            # skip strict eval on branching/functions (v1)
+
+    def repl(m):
+        row = int(m.group(1)); off = int(m.group(2))
+        v = cached.get((row, self_col + off))
+        if not isinstance(v, (int, float)):
+            raise ValueError("missing")
+        return repr(float(v))
+    try:
+        expr = re.sub(r"R(\d+)@(-?\d+)", repl, key)
+        expr = expr.replace("^", "**")
+        if not re.fullmatch(r"[0-9eE.+\-*/() ]*", expr):
+            return None
+        return eval(expr, {"__builtins__": {}}, {})   # sanitised: digits/operators only
+    except Exception:
+        return None
+
+
+def approx(a, b, abs_tol=0.01, rel_tol=0.001):
+    if a is None or b is None:
+        return False
+    if abs(a - b) <= abs_tol:
+        return True
+    denom = max(abs(a), abs(b), 1e-9)
+    return abs(a - b) / denom <= rel_tol
+
+
+def _eval_rform(key, pos, computed):
+    """Evaluate a canonical KEY (R<row>@<off> form) at year-position `pos`, using the
+    already-computed grid, with Sigma's null-propagation (any None operand -> None)."""
+    if not key or any(t in key for t in ("XREF", "ERR", "REF", "RANGE", "?")):
+        return None
+    if re.search(r"\b(IF|MIN|MAX|ROUND|ABS|INT)\(", key, re.I):
+        return None
+    key = re.sub(r"([0-9.]+)\s*%", r"(\1*0.01)", key)
+    add = _additive(key)                                   # additive -> blanks are 0 (like Excel)
+    for r, o in re.findall(r"R(\d+)@(-?\d+)", key):
+        v = computed.get(int(r), {}).get(pos + int(o))
+        if not isinstance(v, (int, float)) and not add:
+            return None                                    # null propagates (non-additive)
+
+    def sub(m):
+        v = computed.get(int(m.group(1)), {}).get(pos + int(m.group(2)))
+        return repr(float(v)) if isinstance(v, (int, float)) else ("0.0" if add else "None")
+    expr = re.sub(r"R(\d+)@(-?\d+)", sub, key)
+    expr = expr.replace("^", "**")
+    if not re.fullmatch(r"[0-9eE.+\-*/() ]*", expr):
+        return None
+    try:
+        return eval(expr, {"__builtins__": {}}, {})       # sanitised: digits/operators only
+    except Exception:
+        return None
+
+
+def simulate_and_freeze(plan_lines, rows, axis, cached):
+    """Compute the model the way Sigma will (Coalesce(typed, canonical), topological,
+    null-propagating), compare to Excel cached, and freeze cached values where the live
+    computation doesn't reproduce them. Iterates because a freeze fixes downstream cells.
+    Returns (live_cells, frozen_cells, [rows with genuine numeric disagreement])."""
+    year_cols = [c for c, _ in axis]
+    col_year = dict(axis)
+    pos_of = {c: i for i, c in enumerate(year_cols)}
+    by_row = {p["row"]: p for p in plan_lines}
+    derived = [p for p in plan_lines if p["kind"] in ("derived", "ratio") and p.get("canonical_key")]
+
+    # topological order by SAME-PERIOD deps (offset 0); prior/future handled by year order
+    graph = {p["row"]: {int(m.group(1)) for m in re.finditer(r"R(\d+)@0", p["canonical_key"])}
+                        & set(by_row) for p in derived}
+    order, seen = [], set()
+
+    def visit(r, stack):
+        if r in seen or r not in graph:
+            return
+        for d in graph.get(r, ()):
+            if d not in stack:
+                visit(d, stack | {r})
+        seen.add(r); order.append(r)
+    for p in derived:
+        visit(p["row"], set())
+
+    mism_rows = set()
+    disagree = defaultdict(int)
+    for _ in range(6):                                     # converge (freezes are monotonic)
+        disagree = defaultdict(int)                        # recount each pass; keep the last
+        computed = defaultdict(dict)
+        # seed inputs + already-frozen/override typed values
+        for p in plan_lines:
+            for c in year_cols:
+                yr = col_year[c]
+                if yr in p["typed"]:
+                    computed[p["row"]][pos_of[c]] = float(p["typed"][yr])
+        # compute derived in (year, topo) order
+        new_freeze = 0
+        for pos in range(len(year_cols)):
+            for r in order:
+                p = by_row[r]
+                yr = col_year[year_cols[pos]]
+                if yr in p["typed"]:                       # Coalesce: typed/override/frozen wins
+                    continue
+                computed[r][pos] = _eval_rform(p["canonical_key"], pos, computed)
+        # compare to cached; freeze where live result != Excel value
+        for p in derived:
+            for c in year_cols:
+                cv = cached.get((p["row"], c))
+                if not isinstance(cv, (int, float)):
+                    continue
+                if col_year[c] in p["typed"]:
+                    continue                               # already frozen/typed
+                got = computed[p["row"]].get(pos_of[c])
+                if got is None or not approx(got, cv):
+                    p["typed"][col_year[c]] = round(cv, 6)  # freeze
+                    new_freeze += 1
+                    if got is not None:                    # a genuine numeric disagreement
+                        disagree[p["row"]] += 1
+        if new_freeze == 0:
+            break
+
+    # flag NEEDS_REVIEW only where the one canonical is WIDELY wrong (>25% of formula years),
+    # not for the odd structural-override year (those are just frozen, and correct).
+    for p in derived:
+        fcells = sum(1 for c in year_cols
+                     if rows[p["row"]]["cells"][c][0] == "FORMULA"
+                     and isinstance(rows[p["row"]]["cells"][c][3], (int, float)))
+        if fcells and disagree[p["row"]] / fcells > 0.25:
+            mism_rows.add(p["row"])
+
+    # final tally: for every formula cell with a cached value, live vs frozen
+    live = frozen = 0
+    for p in derived:
+        for c in year_cols:
+            k, lit, fml, cv = rows[p["row"]]["cells"][c]
+            if k != "FORMULA" or not isinstance(cv, (int, float)):
+                continue
+            if col_year[c] in p["typed"]:
+                frozen += 1
+            else:
+                live += 1
+    for r in mism_rows:
+        by_row[r]["reasons"].append("parity: canonical disagreed with Excel in >=1 year "
+                                    "-> Excel value frozen (carried)")
+    return live, frozen, [by_row[r] for r in mism_rows]
+
+
+# ------------------------------------------------------------------ main inference
+def infer(path, sheet=None, first_row=None, last_row=None):
+    wb_f, wb_v = load(path)
+    ws_f = pick_sheet(wb_f, sheet)
+    ws_v = wb_v[ws_f.title]
+    hr, axis, fc, lc = detect_year_axis(ws_f, ws_v)
+    if not axis:
+        raise ValueError(f"could not detect a year axis on sheet {ws_f.title!r}")
+    first_row = first_row or (hr + 1)
+    last_row = last_row or ws_f.max_row
+    rows = build_row_map(ws_f, ws_v, axis, first_row, last_row)
+    row_by_num = rows
+    year_cols = [c for c, _ in axis]
+    col_year = dict(axis)
+
+    # cached grid for parity
+    cached = {}
+    for r, rd in rows.items():
+        for c, (kind, lit, fml, cv) in rd["cells"].items():
+            if isinstance(cv, (int, float)):
+                cached[(r, c)] = float(cv)
+
+    # per-row inference
+    plan_lines = []
+    stats = Counter()
+    for r in sorted(rows):
+        rd = rows[r]
+        keys = Counter()             # canonical key -> count (formula cells only)
+        key_years = defaultdict(list)
+        all_deps = set()
+        row_flags = set()
+        typed = {}                   # year -> value (literals + cross-sheet cached = data)
+        n_formula = n_literal = n_xsheet = n_empty = 0
+        for c in year_cols:
+            kind, lit, fml, cv = rd["cells"][c]
+            yr = col_year[c]
+            if kind == "EMPTY":
+                n_empty += 1; continue
+            if kind in ("LITERAL", "TEXT"):
+                n_literal += 1
+                if isinstance(lit, (int, float)):
+                    typed[yr] = float(lit)
+                continue
+            # FORMULA
+            key, _, deps, flags = normalize_formula(fml, c, r, row_by_num)
+            if "cross_sheet" in flags:
+                n_xsheet += 1
+                if isinstance(cv, (int, float)):
+                    typed[yr] = float(cv)        # linked value -> treat as data input
+                row_flags.add("has_cross_sheet"); continue
+            if key is None or {"error_ref", "unparseable"} & flags:
+                row_flags |= flags; continue     # broken cell: ignore for voting
+            n_formula += 1
+            keys[key] += 1; key_years[key].append(yr)
+            all_deps |= deps
+            row_flags |= {f for f in flags if f.startswith("func:") or f in
+                          ("abs_col_ref", "unresolved_ref", "range_multicol")}
+
+        # decide kind
+        if n_formula == 0:
+            plan_lines.append(dict(row=r, col_id=col_id(r), uname=rd["uname"], label=rd["label"],
+                section=rd["section"], sec_order=rd["sec_order"], line_order=rd["line_order"],
+                kind="input", typed=typed, deps=[], canonical=None, status="OK", reasons=[]))
+            continue
+
+        modal, modal_n = keys.most_common(1)[0]
+        reasons = []
+        if len(keys) > 1:
+            reasons.append(f"disputed:{len(keys)} formula variants "
+                           f"(modal used, minority years {sorted(sum([key_years[k] for k in keys if k!=modal],[]))})")
+        for f in row_flags:
+            if f.startswith("func:"):
+                reasons.append(f"contains {f.split(':')[1]}()")
+            elif f in ("unresolved_ref", "abs_col_ref", "range_multicol"):
+                reasons.append(f)
+        canonical_sigma = render_sigma(modal)
+        if canonical_sigma is None:
+            # no safe Sigma form (cross-sheet/error/multicol range) -> carry cached values as data
+            plan_lines.append(dict(row=r, col_id=col_id(r), uname=rd["uname"], label=rd["label"],
+                section=rd["section"], sec_order=rd["sec_order"], line_order=rd["line_order"],
+                kind="input", typed=typed, deps=[], canonical=None, status="OK",
+                reasons=reasons + ["unrenderable formula -> carried as typed data"]))
+            continue
+        kind = "ratio" if _looks_ratio(modal, rd["label"]) else "derived"
+        plan_lines.append(dict(row=r, col_id=col_id(r), uname=rd["uname"], label=rd["label"],
+            section=rd["section"], sec_order=rd["sec_order"], line_order=rd["line_order"],
+            kind=kind, typed=typed, deps=sorted(all_deps), canonical=canonical_sigma,
+            canonical_key=modal, status="OK", reasons=reasons))
+
+    # DAG: break analyst "plug cycles" by carrying the most-typed member as data
+    by_row = {p["row"]: p for p in plan_lines}
+    carried = break_cycles(plan_lines, by_row)
+    # freeze EVERY cached value on any input/carried line (formula cells included) so the data
+    # page shows all Excel values — and do it BEFORE the simulation so downstream derived lines
+    # can read these carried values and stay live.
+    for p in plan_lines:
+        if p["kind"] == "input":
+            for c in year_cols:
+                cv = cached.get((p["row"], c))
+                if isinstance(cv, (int, float)):
+                    p["typed"].setdefault(col_year[c], round(float(cv), 6))
+
+    # parity gate: simulate the WHOLE model exactly as Sigma will evaluate it (topological,
+    # null-propagating), then freeze the Excel cached value into any cell the live formulas
+    # don't reproduce. Guarantees displayed parity = 100% (live where verified, cached else).
+    parity_live, parity_frozen, mism_rows = simulate_and_freeze(plan_lines, rows, axis, cached)
+    for p in mism_rows:
+        p["status"] = "NEEDS_REVIEW"
+
+    # final accounting (after demotion + parity)
+    stats = Counter()
+    for p in plan_lines:
+        stats[p["kind"]] += 1
+        if "carried as typed data" in " ".join(p.get("reasons", [])):
+            stats["carried_plug"] += 1
+        if p["status"] == "NEEDS_REVIEW":
+            stats["needs_review"] += 1
+
+    anchors = _anchors(plan_lines)
+    # ground-truth anchor values per year (from Excel cached) so the builder can assert live parity
+    expected = []
+    for nm, a in anchors.items():
+        for c in year_cols:
+            v = cached.get((a["row"], c))
+            if isinstance(v, (int, float)):
+                expected.append({"anchor": nm, "col_id": a["col_id"], "year": col_year[c],
+                                 "value": round(v, 4)})
+    plan = dict(
+        source=os.path.basename(path), sheet=ws_f.title,
+        periods=[{"year": y, "col": get_column_letter(c)} for c, y in axis],
+        lines=plan_lines,
+        anchors=anchors,
+        expected_anchors=expected,
+        summary=dict(stats),
+        parity=dict(live=parity_live, frozen=parity_frozen),
+    )
+    return plan
+
+
+def _looks_ratio(key, label):
+    lab = (label or "").lower().strip()
+    if lab.startswith("%") or lab.startswith(". %") or "% " in lab[:6] or "rate" in lab:
+        return True
+    # a single division of two refs, no + or -
+    body = re.sub(r"R\d+@-?\d+", "R", key)
+    return bool(re.fullmatch(r"R/R", body.replace(" ", ""))) or body.strip().endswith("-1")
+
+
+def _sccs(graph):
+    """Tarjan strongly-connected components over {node: [deps]}."""
+    index = {}; low = {}; onstack = {}; stack = []; out = []; counter = [0]
+
+    def strong(v):
+        index[v] = low[v] = counter[0]; counter[0] += 1
+        stack.append(v); onstack[v] = True
+        for w in graph.get(v, []):
+            if w not in index:
+                strong(w); low[v] = min(low[v], low[w])
+            elif onstack.get(w):
+                low[v] = min(low[v], index[w])
+        if low[v] == index[v]:
+            comp = []
+            while True:
+                w = stack.pop(); onstack[w] = False; comp.append(w)
+                if w == v:
+                    break
+            out.append(comp)
+
+    for v in list(graph):
+        if v not in index:
+            strong(v)
+    return out
+
+
+def _same_period_refs(canonical):
+    """Rows referenced at the SAME period by a rendered canonical (the edges Sigma sees).
+    Refs inside Lag(...)/Lead(...) are prior/future period -> NOT static-cycle edges."""
+    if not canonical:
+        return set()
+    stripped = re.sub(r"(Lag|Lead)\([^)]*\)", " ", canonical)   # drop prior/future-period refs
+    return {int(m.group(1)) for m in re.finditer(r"\[c(\d+)\]", stripped)}
+
+
+def break_cycles(plan_lines, by_row):
+    """Break analyst plug-cycles (row A computes from B in some years, B from A in
+    others — e.g. history types COGS→Gross profit, forecast types Gross profit→COGS) AND
+    same-period self-references. A static Sigma column DAG can't hold either, so demote the
+    MOST-TYPED cycle member to carried data ('start from hard-coded values'). The dep graph
+    is read from the RENDERED canonical so it matches exactly what Sigma will evaluate.
+    Returns the set of demoted (carried) rows."""
+    carried = set()
+    for _ in range(500):                                        # iterate until acyclic
+        graph = {p["row"]: [d for d in _same_period_refs(p.get("canonical"))
+                            if d in by_row and by_row[d]["kind"] in ("derived", "ratio")
+                            and by_row[d]["row"] not in carried]
+                 for p in plan_lines
+                 if p["kind"] in ("derived", "ratio") and p["row"] not in carried}
+        cyclic = [comp for comp in _sccs(graph)
+                  if len(comp) > 1 or (comp[0] in graph.get(comp[0], []))]   # incl self-loop
+        if not cyclic:
+            break
+        for comp in cyclic:
+            indeg = Counter(d for r in comp for d in graph.get(r, []) if d in comp)
+            victim = max(comp, key=lambda r: (len(by_row[r]["typed"]), indeg[r], -r))
+            p = by_row[victim]
+            p["kind"] = "input"; p["canonical"] = None; p.pop("canonical_key", None)
+            p["reasons"].append("plug-cycle: carried as typed data (not recomputed live)")
+            carried.add(victim)
+    for p in plan_lines:
+        if any("unresolved_ref" in x for x in p.get("reasons", [])) and p["kind"] != "input":
+            p["status"] = "NEEDS_REVIEW"
+    return carried
+
+
+def _anchors(plan_lines):
+    want = {"turnover": "Turnover", "ebit ": "EBIT", "= ebit": "EBIT",
+            "net income": "Net income", "net attributable": "Net attributable",
+            "eps reported": "EPS reported", "eps adjusted": "EPS adjusted"}
+    found = {}
+    for p in plan_lines:
+        low = (p["label"] or "").lower()
+        for k, nm in want.items():
+            if k in low and nm not in found:
+                found[nm] = {"col_id": p["col_id"], "label": p["label"], "row": p["row"]}
+    return found
+
+
+# ------------------------------------------------------------------ report
+def report(plan):
+    print(f"# Canonical-formula inference — {plan['source']}  (sheet {plan['sheet']!r})")
+    yrs = [str(p["year"]) for p in plan["periods"]]
+    print(f"\nPeriods ({len(yrs)}): {yrs[0]}…{yrs[-1]}")
+    s = plan["summary"]
+    print(f"\nLine items: input={s.get('input',0)}  derived={s.get('derived',0)}  "
+          f"ratio={s.get('ratio',0)}  (of which carried plug-cycles={s.get('carried_plug',0)})  "
+          f"NEEDS_REVIEW={s.get('needs_review',0)}")
+    par = plan["parity"]
+    tot = par["live"] + par["frozen"]
+    rate = (100 * par["live"] / tot) if tot else 0
+    print(f"Formula cells: {par['live']}/{tot} live-verified ({rate:.1f}%); "
+          f"{par['frozen']} frozen to Excel cached value (carried). Displayed parity = 100%.")
+    print(f"Anchors resolved: {plan['anchors']}")
+    rev = [p for p in plan["lines"] if p["status"] == "NEEDS_REVIEW"]
+    if rev:
+        print(f"\nNEEDS_REVIEW ({len(rev)}):")
+        for p in rev[:25]:
+            print(f"  [{p['section']}] {p['label']!r}: {'; '.join(p['reasons'])}")
+    print("\nSample DERIVED canonicals:")
+    shown = 0
+    for p in plan["lines"]:
+        if p["kind"] == "derived" and p["status"] == "OK" and p.get("canonical") and shown < 14:
+            print(f"  {p['label'][:40]:40s} = {p['canonical']}")
+            shown += 1
+
+
+def main():
+    a = [x for x in sys.argv[1:] if not x.startswith("--")]
+    opt = {x.split("=")[0]: (x.split("=", 1)[1] if "=" in x else True) for x in sys.argv[1:] if x.startswith("--")}
+    if not a:
+        sys.exit(__doc__)
+    plan = infer(a[0], sheet=opt.get("--sheet"),
+                 first_row=int(opt["--first-row"]) if "--first-row" in opt else None,
+                 last_row=int(opt["--last-row"]) if "--last-row" in opt else None)
+    if "--quiet" not in opt:
+        report(plan)
+    out = opt.get("--out")
+    if out and out is not True:
+        json.dump(plan, open(out, "w"), indent=1)
+        print(f"\nplan written: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/lib/code_rep.py
@@ -1,0 +1,189 @@
+"""Shape adapter for the Sigma WORKBOOK code representation
+(POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+
+Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+`document` key and rejects the old flat body with HTTP 400 — including on /verify.
+Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+changing, so this adapter is workbook-only and always writes the nested shape.
+Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`.
+
+Reads stay tolerant of the legacy flat shape because flat artifacts still exist
+on disk (committed workbook snapshots, fixtures).
+"""
+
+# Workbook elements are flat document collections; `overlays` and `panels` live
+# beside them. `settings` (theme/navigation) and `agents` belong inside
+# `document` too. Omitting any of these sweeps it onto the metadata envelope,
+# where it is invalid and silently dropped on write.
+DOC_KEYS = (
+    "schemaVersion", "pages", "elements", "overlays", "panels",
+    "kind", "layout", "settings", "agents",
+)
+
+# REMOVED from the API. The workbook theme is now settings.theme.name /
+# settings.theme.overrides (published OpenAPI: createWorkbookSpec has zero
+# occurrences of themeName/themeOverrides). The individual override keys are
+# unchanged - only the container path moved. document() folds the legacy pair
+# forward so specs and fixtures written before the move still produce a valid body.
+LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+
+
+def _fold_legacy_theme(doc, source):
+    """themeName/themeOverrides -> settings.theme.{name,overrides}."""
+    name = doc.get("themeName") or source.get("themeName")
+    overrides = doc.get("themeOverrides") or source.get("themeOverrides")
+    has_ov = isinstance(overrides, dict) and bool(overrides)
+    if not name and not has_ov and not (set(LEGACY_THEME_KEYS) & set(doc)):
+        return doc
+
+    out = {k: v for k, v in doc.items() if k not in LEGACY_THEME_KEYS}
+    settings = dict(out.get("settings") or {})
+    theme = dict(settings.get("theme") or {})
+    if name and not theme.get("name"):
+        theme["name"] = name
+    if has_ov:
+        theme["overrides"] = {**(theme.get("overrides") or {}), **overrides}
+    if not theme:
+        return out
+    settings["theme"] = theme
+    out["settings"] = settings
+    return out
+
+
+def set_theme(doc, name=None, overrides=None):
+    """Emitter helper - set the workbook theme in the CURRENT shape.
+
+    Builders should call this instead of assigning the removed
+    themeName/themeOverrides pair. Mutates and returns doc.
+    """
+    has_ov = isinstance(overrides, dict) and bool(overrides)
+    if not name and not has_ov:
+        return doc
+    settings = doc.setdefault("settings", {})
+    theme = settings.setdefault("theme", {})
+    if name:
+        theme["name"] = name
+    if has_ov:
+        theme["overrides"] = {**(theme.get("overrides") or {}), **overrides}
+    return doc
+
+
+def theme(spec):
+    """Read the theme from either shape. Returns {"name":..., "overrides":{...}}."""
+    t = (document(spec).get("settings") or {}).get("theme") or {}
+    return {"name": t.get("name"), "overrides": t.get("overrides") or {}}
+
+
+def document(response):
+    """Return the workbook document from either the nested or legacy flat shape."""
+    if not isinstance(response, dict):
+        return {}
+    inner = response.get("document")
+    doc = inner if isinstance(inner, dict) else {
+        k: v for k, v in response.items() if k in DOC_KEYS
+    }
+    return _fold_legacy_theme(doc, response)
+
+
+def metadata(response):
+    if not isinstance(response, dict):
+        return {}
+    return {
+        k: v for k, v in response.items()
+        if k != "document" and k not in DOC_KEYS and k not in LEGACY_THEME_KEYS
+    }
+
+
+def workbook_elements(spec):
+    """Return flat elements, with read-only compatibility for old artifacts."""
+    doc = document(spec)
+    elements = doc.get("elements")
+    if isinstance(elements, list):
+        return [element for element in elements if isinstance(element, dict)]
+    return [
+        element
+        for page in doc.get("pages", [])
+        if isinstance(page, dict)
+        for element in page.get("elements", [])
+        if isinstance(element, dict)
+    ]
+
+
+def workbook_page_element_ids(spec):
+    """Return {page_id: [element_id, ...]} derived from layout order."""
+    import re
+
+    result = {}
+    layout = str(document(spec).get("layout") or "")
+    for match in re.finditer(r'<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>', layout, re.S):
+        result[match.group(1)] = list(dict.fromkeys(
+            re.findall(
+                r'<(?:Element|Container|TabbedContainer|LayoutElement|GridContainer)\b'
+                r'[^>]*\belementId="([^"]*)"',
+                match.group(2),
+            )
+        ))
+    return result
+
+
+def workbook_page_by_element(spec):
+    """Return {element_id: page_metadata}; layout is authoritative."""
+    doc = document(spec)
+    pages = [page for page in doc.get("pages", []) if isinstance(page, dict)]
+    pages_by_id = {page["id"]: page for page in pages if page.get("id")}
+    result = {}
+    for page_id, element_ids in workbook_page_element_ids(doc).items():
+        page = pages_by_id.get(page_id, {"id": page_id, "name": page_id})
+        for element_id in element_ids:
+            result.setdefault(element_id, page)
+    return result
+
+
+def workbook_elements_with_pages(spec):
+    page_by_element = workbook_page_by_element(spec)
+    return [
+        (element, page_by_element.get(element.get("id") or element.get("elementId")))
+        for element in workbook_elements(spec)
+    ]
+
+
+def _flatten_elements(doc):
+    if not isinstance(doc, dict) or not isinstance(doc.get("pages"), list):
+        return doc
+
+    nested = []
+    pages = []
+    for page in doc["pages"]:
+        page_copy = dict(page)
+        nested.extend(page_copy.pop("elements", []) or [])
+        pages.append(page_copy)
+
+    elements = []
+    seen = set()
+    for element in list(doc.get("elements") or []) + nested:
+        element_id = element.get("id") if isinstance(element, dict) else None
+        if element_id and element_id in seen:
+            continue
+        if element_id:
+            seen.add(element_id)
+        elements.append(element)
+    return {**doc, "pages": pages, "elements": elements}
+
+
+def canonicalize_layout(layout_xml):
+    """Map legacy layout aliases to the live-verified canonical tag names."""
+    import re
+
+    layout = str(layout_xml or "")
+    layout = re.sub(r'<(/?)LayoutElement\b', r'<\1Element', layout)
+    return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
+
+
+def wrap(doc, extra=None):
+    """Build a current request body with flat elements and canonical layout."""
+    out = dict(extra or {})
+    flattened = _flatten_elements(doc)
+    if isinstance(flattened, dict) and "layout" in flattened:
+        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    out["document"] = flattened
+    return out

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/lib/workbook_wire.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/lib/workbook_wire.py
@@ -1,0 +1,74 @@
+"""Wire helper for excel-to-sigma workbook builders.
+
+Builders still author the convenient nested `pages[].elements` draft shape.
+Before POST /v2/workbooks/spec (and when writing dry-run artifacts that would
+be POSTed), call `wire_workbook(spec)` so the body matches the released
+workbook code representation:
+
+  { name, folderId?, description?, document: { schemaVersion, kind, pages, elements, layout } }
+
+`code_rep.wrap` flattens nested elements and canonicalizes layout tags. This
+helper invents a stacked notebook-flow `layout` when the draft lacks one —
+layout is required on the live surface and owns page membership.
+Data-model specs are unchanged — do not wrap /v2/dataModels/... payloads.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import code_rep  # noqa: E402
+
+GRID_COLS = 24
+DEFAULT_ROW_HEIGHT = 12
+
+
+def stack_layout(pages, row_height: int = DEFAULT_ROW_HEIGHT) -> str:
+    """One full-width stacked tile per element, page order preserved."""
+    blocks = []
+    for page in pages or []:
+        if not isinstance(page, dict) or not page.get("id"):
+            continue
+        pid = page["id"]
+        els = [el for el in (page.get("elements") or []) if isinstance(el, dict) and el.get("id")]
+        lines = [
+            f'<Page type="grid" gridTemplateColumns="repeat({GRID_COLS}, 1fr)" '
+            f'gridTemplateRows="auto" id="{pid}">'
+        ]
+        cursor = 1
+        for el in els:
+            end = cursor + row_height
+            lines.append(
+                f'  <Element elementId="{el["id"]}" '
+                f'gridColumn="1 / {GRID_COLS + 1}" gridRow="{cursor} / {end}"/>'
+            )
+            cursor = end
+        lines.append("</Page>")
+        blocks.append("\n".join(lines))
+    return '<?xml version="1.0" encoding="utf-8"?>\n' + "\n".join(blocks)
+
+
+def wire_workbook(spec: dict) -> dict:
+    """Return a POST-ready workbook body (document wrapper + flat elements)."""
+    if not isinstance(spec, dict):
+        raise TypeError("workbook spec must be a dict")
+
+    # Already wrapped — re-canonicalize through code_rep for safety.
+    if isinstance(spec.get("document"), dict):
+        doc = code_rep.document(spec)
+        return code_rep.wrap(doc, extra=code_rep.metadata(spec))
+
+    draft = dict(spec)
+    draft.setdefault("schemaVersion", 1)
+    draft.setdefault("kind", "workbook")
+    pages = draft.get("pages")
+    if "layout" not in draft and isinstance(pages, list):
+        draft["layout"] = stack_layout(pages)
+
+    meta = code_rep.metadata(draft)
+    doc = code_rep.document(draft)
+    return code_rep.wrap(doc, extra=meta)

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/macro-classify.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/macro-classify.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+macro-classify.py — detect & classify Excel VBA macros, map each to its Sigma
+disposition. Input: a .xlsm/.xlsb/.xls (VBA extracted via olevba) OR a raw VBA
+source file (.bas/.cls/.frm/.vba/.txt). Output: a per-procedure inventory with a
+Sigma target + porting status, plus a STOP-gate summary.
+
+Porting status:
+  AUTO    — reproduced by the data/formula conversion, or safely dropped (Sigma is live)
+  CONTROL — becomes controls / parameters / an editable input table
+  ACTION  — becomes a Sigma Action (button-triggered); GATED on the Actions primitive
+  FLAG    — must be reviewed by a human (external I/O or opaque imperative logic)
+
+Never silent: every macro is surfaced with a disposition. A dropped macro the user
+assumes still works is the FP&A equivalent of dropping row-level security.
+"""
+import sys, os, re
+
+def extract_vba(path):
+    """Return list of (proc_source) blocks' container code. Uses olevba for office
+    binaries; reads text for raw VBA modules."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext in (".bas", ".cls", ".frm", ".vba", ".txt"):
+        return open(path, encoding="utf-8", errors="replace").read()
+    # office container → olevba
+    try:
+        from oletools.olevba import VBA_Parser
+    except ImportError:
+        sys.exit("olevba not installed: pip install oletools  (or pass a .bas source file)")
+    vp = VBA_Parser(path)
+    if not vp.detect_vba_macros():
+        return ""
+    return "\n".join(code for (_f, _s, _name, code) in vp.extract_macros())
+
+PROC_RE = re.compile(r"^[ \t]*(?:Public |Private |Friend )?(?:Static )?(Sub|Function)[ \t]+([A-Za-z0-9_]+)\s*\(", re.M)
+
+def strip_comments(code):
+    """Remove VBA comments (full-line and inline) so they can't drive classification.
+    Respects string literals so a `'` inside "..." is kept."""
+    out = []
+    for line in code.splitlines():
+        in_str = False; cut = len(line)
+        for i, ch in enumerate(line):
+            if ch == '"':
+                in_str = not in_str
+            elif ch == "'" and not in_str:
+                cut = i; break
+        out.append(line[:cut])
+    return "\n".join(out)
+
+def split_procedures(code):
+    """Yield (name, kind, body) for each Sub/Function. Comments stripped first."""
+    code = strip_comments(code)
+    marks = [(m.start(), m.group(1), m.group(2)) for m in PROC_RE.finditer(code)]
+    for i, (start, kind, name) in enumerate(marks):
+        end = marks[i + 1][0] if i + 1 < len(marks) else len(code)
+        yield name, kind, code[start:end]
+
+# (label, status, regex signals, sigma target, note-template)
+# Ordered by precedence — first matching class wins as PRIMARY; all hits reported.
+RULES = [
+    ("EXTERNAL_IO", "FLAG", [
+        r"CreateObject\(\s*[\"']Outlook", r"\.Send\b", r"SendMail", r"\bShell\b",
+        r"ExportAsFixedFormat", r"FileSystemObject", r"Workbooks\.Open", r"\bKill\b",
+        r"\bMkDir\b", r"MSXML2|WinHttp|ServerXMLHTTP", r"\bEnviron\(", r"Open .* For (Output|Append|Input)"],
+     "Sigma scheduled export / delivery, or external API job — usually NOT 1:1",
+     "Reaches outside the workbook (email / file / shell / HTTP / PDF). Review: map to "
+     "Sigma scheduled delivery or an external workflow; do not auto-port."),
+
+    ("ACTION_WRITEBACK", "ACTION", [
+        r"PasteSpecial\s+Paste:=xlPasteValues", r"ListRows\.Add",
+        r"End\(xlUp\)[^\n]*\+\s*1"],   # nextRow = ...End(xlUp).Row + 1  → append target
+     "Sigma Action → append rows to an input table (Scenarios / Snapshots)",
+     "Button workflow that freezes/commits values into a history/scenario table. "
+     "Becomes an Action that inserts rows into an input table. GATED on the Actions primitive."),
+
+    ("WHATIF_SCENARIO", "CONTROL", [
+        r"GoalSeek", r"Solver", r"Range\(\s*[\"']B\d", r"(Scenario|Assumption)",
+        r"Select Case\s+\w*[Ss]cenario"],
+     "Controls / parameters, or an editable assumptions input table",
+     "Drives the model by changing assumption inputs (scenario swap / goal-seek). "
+     "Maps to control parameters or the editable rates table; goal-seek → a what-if control."),
+
+    ("TRANSFORM_ROLLUP", "AUTO", [
+        r"For\b.+\bTo\b", r"Cells\(\s*\w+\s*,.*\)\.Value\s*=", r"SumIf", r"WorksheetFunction"],
+     "Data model element / calc columns (result reproduced declaratively)",
+     "Loops over source rows building a summary/rollup in code. The data conversion "
+     "reproduces the RESULT declaratively; the imperative loop evaporates."),
+
+    ("RECALC_REFRESH", "AUTO", [
+        r"RefreshAll", r"\.Calculate(Full)?\b", r"\.Refresh\b", r"ScreenUpdating"],
+     "None — Sigma is always live",
+     "Recalc/refresh. Obsolete in Sigma (queries are live); safe to drop."),
+
+    ("NAVIGATION", "AUTO", [
+        r"\.Activate\b", r"\.Select\b", r"\.Goto\b", r"\.Visible\s*="],
+     "Page navigation / element visibility (or drop)",
+     "Sheet/cell navigation. Map to Sigma page navigation or drop."),
+
+    ("FORMAT_COSMETIC", "AUTO", [
+        r"\.Font\b", r"\.Interior\b", r"\.Borders\b", r"AutoFit", r"\.NumberFormat\b"],
+     "Conditional formatting / element styling (or drop)",
+     "Cosmetic formatting. Map to conditional formatting / styling or drop."),
+]
+
+RULES_MAP = {label: (status, target, note) for label, status, _s, target, note in RULES}
+RULE_ORDER = {label: i for i, (label, *_) in enumerate(RULES)}
+# bespoke-math fallback → OPAQUE: writes cells using non-declarative math
+OPAQUE_MATH = re.compile(r"(Sin|Cos|Rnd|Sqr|Exp|Tan|Atn)\(|\bDo While\b|\bGoTo\b")
+# only EXTERNAL_IO / ACTION_WRITEBACK outrank a bespoke-math FLAG
+OPAQUE_OVERRIDABLE = {"WHATIF_SCENARIO", "TRANSFORM_ROLLUP", "NAVIGATION", "FORMAT_COSMETIC", "RECALC_REFRESH"}
+ACTION_VERB = re.compile(r"(Commit|Save|Submit|Post|Archive|Snapshot|Freeze)", re.I)
+
+def classify(name, body):
+    hits = {}
+    for label, status, sigs, target, note in RULES:
+        matched = [s for s in sigs if re.search(s, body, re.I)]
+        if matched:
+            hits[label] = (status, target, note, matched)
+    # action-verb signal is matched on the procedure NAME only (avoids e.g. a called
+    # helper "PostToGrid" tripping "Post" inside an unrelated body)
+    if ACTION_VERB.search(name):
+        st, tg, nt = RULES_MAP["ACTION_WRITEBACK"]
+        prev = hits.get("ACTION_WRITEBACK", (st, tg, nt, []))
+        hits["ACTION_WRITEBACK"] = (st, tg, nt, prev[3] + [f"name~{name}"])
+    is_event = bool(re.match(r"(Workbook_|Worksheet_)", name))
+    if hits:
+        primary = min(hits, key=lambda l: RULE_ORDER[l])
+        status, target, note, matched = hits[primary]
+        # OPAQUE override: bespoke math + a weak/auto primary → flag for human review
+        if primary in OPAQUE_OVERRIDABLE and OPAQUE_MATH.search(body):
+            return "OPAQUE", "FLAG", "Human review — bespoke imperative logic", \
+                   "Custom math writing cells (smoothing/allocation/iteration) with no clean declarative " \
+                   "equivalent. Flag for a human to reproduce or confirm intent.", \
+                   sorted({m for *_x, ms in hits.values() for m in ms})[:6]
+        secondary = [l for l in hits if l != primary]
+        tag = primary + (" + event-handler (auto-run)" if is_event else "")
+        return tag, status, target, note, matched + ([f"(also: {', '.join(secondary)})"] if secondary else [])
+    if OPAQUE_MATH.search(body):
+        return "OPAQUE", "FLAG", "Human review — bespoke imperative logic", \
+               "Custom imperative logic, no recognized pattern. Flag for human review.", []
+    return "UNKNOWN", "FLAG", "Human review", "No recognized signals; review manually.", []
+
+STATUS_ICON = {"AUTO": "✅ AUTO", "CONTROL": "🎛  CONTROL", "ACTION": "⏳ ACTION (gated)", "FLAG": "🚩 FLAG"}
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    as_json = "--json" in sys.argv
+    if not args:
+        sys.exit("usage: macro-classify.py [--json] <file.xlsm | module.bas>")
+    path = args[0]
+    code = extract_vba(path)
+    if not code.strip():
+        print("[]" if as_json else f"No VBA macros found in {path}."); return
+    procs = list(split_procedures(code))
+    if as_json:
+        import json
+        recs = []
+        for name, kind, body in procs:
+            cls, status, target, note, sigs = classify(name, body)
+            recs.append({"name": name, "kind": kind, "class": cls, "status": status,
+                         "sigmaTarget": target, "note": note, "signals": sigs})
+        print(json.dumps(recs, indent=2)); return
+    print(f"# Macro inventory — {os.path.basename(path)}  ({len(procs)} procedures)\n")
+    tally = {}
+    for name, kind, body in procs:
+        cls, status, target, note, sigs = classify(name, body)
+        tally[status] = tally.get(status, 0) + 1
+        print(f"## {name}  [{kind}]")
+        print(f"   class    : {cls}")
+        print(f"   status   : {STATUS_ICON.get(status, status)}")
+        print(f"   → Sigma  : {target}")
+        print(f"   note     : {note}")
+        if sigs: print(f"   signals  : {', '.join(sigs[:6])}")
+        print()
+    print("=" * 64)
+    print("DISPOSITION SUMMARY:", "  ".join(f"{STATUS_ICON[k].split()[0]} {k}={v}" for k, v in sorted(tally.items())))
+    gated = tally.get("ACTION", 0); flagged = tally.get("FLAG", 0)
+    if gated:   print(f"\n⏳ {gated} macro(s) need the Sigma Actions primitive — scaffold a placeholder + inventory entry now; wire when it ships.")
+    if flagged: print(f"🚩 {flagged} macro(s) require human review — DO NOT silently drop. Surface these to the user before build.")
+
+if __name__ == "__main__":
+    main()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/make-sample-forecast.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/make-sample-forecast.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Build a synthetic, self-contained Excel forecast/data-entry model that mirrors
+the structure of the real Ledcor file (without using any customer data).
+
+Shape:
+  - "Forecast Entry"  : formal Table `tblForecast` at the canonical grain
+                        Region x Branch x SubBranch x MonthDate x CategoryCode,
+                        measure ForecastAmount. THIS is the sheet that becomes
+                        a Sigma input table.
+  - "Categories"      : formal Table `tblCategory` (dimension)
+  - "Calendar"        : formal Table `tblCalendar` (Sept-start fiscal calendar)
+  - "Forecast Summary": formula-driven rollup (SUMIFS by statement section x
+                        month) -- the read/output half, rebuilt as DM metrics.
+
+This exercises the whole excel-to-sigma surface: one formal Table at a tidy
+grain (clean input-table candidate), two dimension Tables (DM relationships),
+and a report sheet whose SUMIFS "evaporate" into grouped aggregates.
+"""
+import random
+from datetime import date
+from dateutil.relativedelta import relativedelta
+from openpyxl import Workbook
+from openpyxl.worksheet.table import Table, TableStyleInfo
+from openpyxl.utils import get_column_letter
+
+random.seed(42)
+
+# ---- dimensions -----------------------------------------------------------
+# Region / Branch / SubBranch hierarchy
+HIER = [
+    ("West", "Seattle",  "SEA-North"),
+    ("West", "Seattle",  "SEA-South"),
+    ("West", "Portland", "PDX-Metro"),
+    ("East", "Boston",   "BOS-Downtown"),
+    ("East", "NewYork",  "NYC-Manhattan"),
+]
+
+# CategoryCode -> (label, statement section, sort order, typical monthly magnitude)
+CATEGORIES = [
+    (4000, "Product Revenue",     "Revenue",        1, ( 80000, 160000)),
+    (4100, "Service Revenue",     "Revenue",        2, ( 30000,  90000)),
+    (5000, "Materials",           "Contract Costs", 3, (-45000, -20000)),
+    (5100, "Direct Labor",        "Contract Costs", 4, (-60000, -30000)),
+    (5200, "Subcontractors",      "Contract Costs", 5, (-25000,  -8000)),
+    (6000, "Admin Salaries",      "Administration", 6, (-30000, -15000)),
+    (6100, "Rent & Facilities",   "Administration", 7, (-12000,  -6000)),
+    (6200, "Software & IT",       "Administration", 8, ( -8000,  -3000)),
+    (7000, "Corporate Allocation","Allocation",     9, (-10000,  -4000)),
+]
+
+# Sept-start fiscal year: Sep 2025 -> Aug 2026
+FY_START = date(2025, 9, 1)
+MONTHS = [FY_START + relativedelta(months=i) for i in range(12)]
+
+
+def fiscal_bits(d):
+    # Sept = fiscal month 1; fiscal year labelled by the year it ends
+    fmi = (d.month - 9) % 12 + 1
+    fy = d.year + 1 if d.month >= 9 else d.year
+    fq = (fmi - 1) // 3 + 1
+    return fmi, fy, fq
+
+
+def style(ws, table_name, ref):
+    t = Table(displayName=table_name, ref=ref)
+    t.tableStyleInfo = TableStyleInfo(
+        name="TableStyleMedium2", showRowStripes=True, showColumnStripes=False)
+    ws.add_table(t)
+
+
+wb = Workbook()
+
+# ---- Sheet 1: Forecast Entry (the formal Table -> input table) -------------
+ws = wb.active
+ws.title = "Forecast Entry"
+hdr = ["Region", "Branch", "SubBranch", "MonthDate", "CategoryCode", "ForecastAmount"]
+ws.append(hdr)
+nrows = 0
+for region, branch, sub in HIER:
+    for code, label, section, order, (lo, hi) in CATEGORIES:
+        for m in MONTHS:
+            amt = random.randint(lo, hi)
+            # light seasonality on revenue
+            if section == "Revenue" and m.month in (11, 12, 1):
+                amt = int(amt * 1.15)
+            ws.append([region, branch, sub, m, code, amt])
+            nrows += 1
+for c, _ in enumerate(hdr, start=1):
+    ws.column_dimensions[get_column_letter(c)].width = 16
+for r in range(2, nrows + 2):
+    ws.cell(r, 4).number_format = "yyyy-mm-dd"
+    ws.cell(r, 6).number_format = "#,##0"
+style(ws, "tblForecast", f"A1:F{nrows + 1}")
+
+# ---- Sheet 2: Categories (dimension Table) --------------------------------
+ws2 = wb.create_sheet("Categories")
+ws2.append(["CategoryCode", "CategoryLabel", "StatementSection", "SortOrder"])
+for code, label, section, order, _ in CATEGORIES:
+    ws2.append([code, label, section, order])
+for c, w in zip("ABCD", (14, 22, 18, 12)):
+    ws2.column_dimensions[c].width = w
+style(ws2, "tblCategory", f"A1:D{len(CATEGORIES) + 1}")
+
+# ---- Sheet 3: Calendar (dimension Table) ----------------------------------
+ws3 = wb.create_sheet("Calendar")
+ws3.append(["MonthDate", "FiscalMonthIndex", "FiscalYear", "FiscalQuarter"])
+for m in MONTHS:
+    fmi, fy, fq = fiscal_bits(m)
+    ws3.append([m, fmi, fy, fq])
+for r in range(2, len(MONTHS) + 2):
+    ws3.cell(r, 1).number_format = "yyyy-mm-dd"
+for c, w in zip("ABCD", (14, 18, 14, 16)):
+    ws3.column_dimensions[c].width = w
+style(ws3, "tblCalendar", f"A1:D{len(MONTHS) + 1}")
+
+# ---- Sheet 4: Forecast Summary (formula-driven rollup) --------------------
+# Rows = statement sections; columns = the 12 fiscal months; SUMIFS rollups.
+# This is the "report" sheet whose SUMIFS evaporate into grouped DM metrics.
+ws4 = wb.create_sheet("Forecast Summary")
+sections = ["Revenue", "Contract Costs", "Administration", "Allocation"]
+# header row: blank + month labels
+ws4.cell(1, 1, "Statement Section")
+for j, m in enumerate(MONTHS, start=2):
+    c = ws4.cell(1, j, m)
+    c.number_format = "mmm-yy"
+ws4.cell(1, len(MONTHS) + 2, "FY Total")
+
+# category->section lookup lives on the Categories sheet; we SUMIFS through it
+# via a helper: sum ForecastAmount where the category's section matches.
+# Simplest faithful Excel idiom: SUMPRODUCT over the entry table joined to
+# category sections. We approximate with SUMIFS per-category then sum by section
+# in a helper block, but to keep the formula readable we use SUMPRODUCT.
+# tblForecast columns: Region(A) Branch(B) SubBranch(C) MonthDate(D) CategoryCode(E) ForecastAmount(F)
+fe = "'Forecast Entry'"
+cat = "Categories"
+ncat = len(CATEGORIES)
+fr_last = nrows + 1  # last data row in Forecast Entry
+for i, sec in enumerate(sections, start=2):
+    ws4.cell(i, 1, sec)
+    for j, m in enumerate(MONTHS, start=2):
+        col = get_column_letter(j)
+        # SUMPRODUCT: rows where month matches AND category's section == sec
+        # category section resolved via LOOKUP of CategoryCode into Categories table
+        f = (f"=SUMPRODUCT(({fe}.$D$2:$D${fr_last}={col}$1)*"
+             f"(LOOKUP({fe}.$E$2:$E${fr_last},{cat}.$A$2:$A${ncat+1},{cat}.$C$2:$C${ncat+1})=$A{i})*"
+             f"{fe}.$F$2:$F${fr_last})")
+        cell = ws4.cell(i, j, f)
+        cell.number_format = "#,##0"
+    # FY total
+    tcol = get_column_letter(len(MONTHS) + 2)
+    ws4.cell(i, len(MONTHS) + 2, f"=SUM(B{i}:{get_column_letter(len(MONTHS)+1)}{i})").number_format = "#,##0"
+
+# Net Contribution row
+nrow = len(sections) + 2
+ws4.cell(nrow, 1, "Net Contribution")
+for j in range(2, len(MONTHS) + 3):
+    col = get_column_letter(j)
+    ws4.cell(nrow, j, f"=SUM({col}2:{col}{len(sections)+1})").number_format = "#,##0"
+ws4.column_dimensions["A"].width = 20
+
+import os
+out = os.path.join(os.getcwd(), "Sample Forecast.xlsx")
+wb.save(out)
+print(f"wrote {out}")
+print(f"tblForecast rows: {nrows}  (= {len(HIER)} subbranch x {len(CATEGORIES)} cat x {len(MONTHS)} months)")
+print(f"categories: {len(CATEGORIES)}  calendar months: {len(MONTHS)}")

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/make-sample-research-model.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/make-sample-research-model.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+make-sample-research-model.py — generate a SYNTHETIC broker equity-research model
+(no customer data) shaped like a FactSet-style broker house-template file, for use as the
+excel-to-sigma golden fixture + QUICKSTART example.
+
+Fake issuer "Acme Widgets NV", fake broker "Zenith Securities". Sheet "FY results":
+line-items down rows, YEARS across columns, sections PROFIT AND LOSS / PER SHARE DATA /
+BALANCE SHEET. Deliberately reproduces the hard cases so the converter is exercised:
+  - MIXED rows (hardcoded history, formula forecast),
+  - a plug-cycle (COGS types in history, Gross profit types in forecast),
+  - a `%` literal (Excel 105%),
+  - a same-period self-reference and a `#REF!` broken cell (escape-hatch test),
+  - ratio rows (% margin, % growth) and a prior-year %change via a cross-year ref.
+
+Writes scripts/Sample Research Model.xlsx.
+"""
+import os, re, zipfile, shutil
+from openpyxl import Workbook
+from openpyxl.utils import get_column_letter
+
+YEARS = list(range(2018, 2028))          # 10 years; 2018-2023 actual, 2024-2027 estimate
+FIRST_COL = 2                            # B
+
+
+def col(i):
+    return get_column_letter(FIRST_COL + i)
+
+
+def build():
+    wb = Workbook()
+    ws = wb.active; ws.title = "FY results"
+    ws["A3"] = "Acme Widgets NV"
+    ws["A4"] = "12M to Dec"
+    # year header row 5: first two hardcoded, rest = prev+1 (as the real files do)
+    ws[f"{col(0)}5"] = YEARS[0]; ws[f"{col(1)}5"] = YEARS[1]
+    for i in range(2, len(YEARS)):
+        ws[f"{col(i)}5"] = f"={col(i-1)}5+1"
+
+    def put(r, label, values):
+        ws[f"A{r}"] = label
+        for i, v in enumerate(values):
+            if v is None:
+                continue
+            ws[f"{col(i)}{r}"] = v
+
+    # ---- PROFIT AND LOSS ----
+    ws["A7"] = "PROFIT AND LOSS"
+    # Revenue: actuals hardcoded, forecast grows 5% (105% literal, MIXED)
+    rev = [820.0, 905.0, 960.0, 1010.0, 1105.0, 1190.0]
+    put(8, "Revenue", rev + [f"={col(5+k)}8*105%" for k in range(1, 5)])   # 2024-27 formula
+    put(9, "   % growth", [None] + [f"={col(i)}8/{col(i-1)}8-1" for i in range(1, len(YEARS))])
+    # COGS: hardcoded in history (plug: Gross profit derived here); forecast = GrossProfit-Revenue
+    cogs = [-500.0, -545.0, -575.0, -600.0, -650.0, -700.0]
+    put(11, "- COGS", cogs + [f"={col(6+k)}13-{col(6+k)}8" for k in range(4)])   # 2024-27 = GP-Rev
+    # Gross profit: history = Rev+COGS; forecast hardcoded (the plug flips)
+    put(13, "= Gross profit",
+        [f"={col(i)}8+{col(i)}11" for i in range(6)] + [520.0, 560.0, 600.0, 645.0])
+    put(14, "   % margin", [f"={col(i)}13/{col(i)}8" for i in range(len(YEARS))])
+    # Opex, EBITDA, D&A, EBIT
+    put(16, "- Opex", [-230, -250, -262, -275, -300, -322, -338, -352, -366, -380])
+    put(18, "EBITDA", [f"={col(i)}13+{col(i)}16" for i in range(len(YEARS))])
+    put(19, "   % margin", [f"={col(i)}18/{col(i)}8" for i in range(len(YEARS))])
+    put(20, "- D&A", [-45, -48, -50, -52, -55, -58, -60, -62, -64, -66])
+    put(22, "= EBIT", [f"={col(i)}18+{col(i)}20" for i in range(len(YEARS))])
+    put(23, "   % margin", [f"={col(i)}22/{col(i)}8" for i in range(len(YEARS))])
+    # Net financial (self prior-year carry — Lag test), PBT, Tax (rate driver), Net income
+    put(25, "- Net financial", [-18] + [f"={col(i-1)}25" for i in range(1, len(YEARS))])
+    put(27, "= PBT", [f"={col(i)}22+{col(i)}25" for i in range(len(YEARS))])
+    put(28, "   Tax rate", [0.26] * 6 + [0.25, 0.25, 0.24, 0.24])
+    put(29, "- Tax", [f"=-{col(i)}27*{col(i)}28" for i in range(len(YEARS))])
+    put(31, "= Net income", [f"={col(i)}27+{col(i)}29" for i in range(len(YEARS))])
+    put(32, "   % growth", [None] + [f"={col(i)}31/{col(i-1)}31-1" for i in range(1, len(YEARS))])
+
+    # ---- PER SHARE DATA (the "done right" section: one formula per line) ----
+    ws["A35"] = "PER SHARE DATA"
+    put(36, "Number of shares (m)", [100.0] * len(YEARS))
+    put(37, "EPS", [f"={col(i)}31/{col(i)}36" for i in range(len(YEARS))])
+    put(38, "DPS", [0.30, 0.33, 0.35, 0.38, 0.42, 0.46, 0.50, 0.54, 0.58, 0.62])
+    put(39, "Payout (%)", [f"={col(i)}38/{col(i)}37" for i in range(len(YEARS))])
+
+    # ---- BALANCE SHEET (a couple lines + a deliberate #REF! forecast cell) ----
+    ws["A42"] = "BALANCE SHEET"
+    put(43, "Net debt", [310, 295, 280, 260, 240, 215, 190, 160, 130, 95])
+    put(44, "Equity", [640, 690, 745, 810, 890, 980, 1080, 1190, 1310, 1440])
+    # ND/EBITDA ratio, with a broken 2019 cell (#REF!) to exercise the freeze
+    put(45, "Net debt / EBITDA",
+        [f"={col(i)}43/{col(i)}18" for i in range(len(YEARS))])
+    ws[f"{col(1)}45"] = "=#REF!/#REF!"                      # deliberate broken cell
+
+    out = os.path.join(os.path.dirname(__file__), "Sample Research Model.xlsx")
+    wb.save(out)
+    inject_cached(out, compute_values())     # give formula cells cached <v> (like a real FactSet file)
+    print("wrote", out, "— 10 years, 3 sections, plug-cycle + %-literal + Lag + #REF! + MIXED")
+    return out
+
+
+def compute_values():
+    """Evaluate the model in Python so the fixture carries cached values (openpyxl can't
+    write formula+cache; real FactSet files always have them). Returns {cellref: number}."""
+    n = len(YEARS)
+    rev = [820., 905., 960., 1010., 1105., 1190.]
+    for _ in range(4):
+        rev.append(round(rev[-1] * 1.05, 6))
+    opex = [-230, -250, -262, -275, -300, -322, -338, -352, -366, -380]
+    da = [-45, -48, -50, -52, -55, -58, -60, -62, -64, -66]
+    gp_fc = [520., 560., 600., 645.]
+    gp = [rev[i] + (-500, -545, -575, -600, -650, -700)[i] for i in range(6)] + gp_fc
+    cogs = [-500., -545., -575., -600., -650., -700.] + [gp[6 + k] - rev[6 + k] for k in range(4)]
+    ebitda = [gp[i] + opex[i] for i in range(n)]
+    ebit = [ebitda[i] + da[i] for i in range(n)]
+    netfin = [-18.] * n
+    pbt = [ebit[i] + netfin[i] for i in range(n)]
+    taxrate = [0.26] * 6 + [0.25, 0.25, 0.24, 0.24]
+    tax = [-pbt[i] * taxrate[i] for i in range(n)]
+    ni = [pbt[i] + tax[i] for i in range(n)]
+    shares = [100.] * n
+    eps = [ni[i] / shares[i] for i in range(n)]
+    dps = [0.30, 0.33, 0.35, 0.38, 0.42, 0.46, 0.50, 0.54, 0.58, 0.62]
+    payout = [dps[i] / eps[i] for i in range(n)]
+    netdebt = [310, 295, 280, 260, 240, 215, 190, 160, 130, 95]
+    equity = [640, 690, 745, 810, 890, 980, 1080, 1190, 1310, 1440]
+    grow = lambda s: [None] + [s[i] / s[i - 1] - 1 for i in range(1, n)]
+    rows = {8: rev, 9: grow(rev), 11: cogs, 13: gp,
+            14: [gp[i] / rev[i] for i in range(n)], 16: opex, 18: ebitda,
+            19: [ebitda[i] / rev[i] for i in range(n)], 20: da, 22: ebit,
+            23: [ebit[i] / rev[i] for i in range(n)], 25: netfin, 27: pbt,
+            28: taxrate, 29: tax, 31: ni, 32: grow(ni), 36: shares, 37: eps,
+            38: dps, 39: payout, 43: netdebt, 44: equity,
+            45: [netdebt[i] / ebitda[i] for i in range(n)]}
+    rows[45][1] = None                              # the deliberate #REF! cell has no value
+    vals = {5 + 0: None}
+    out = {}
+    for r, series in rows.items():
+        for i, v in enumerate(series):
+            if v is not None:
+                out[f"{col(i)}{r}"] = round(float(v), 6)
+    # year header cells 2020..2027 are =prev+1
+    for i in range(2, len(YEARS)):
+        out[f"{col(i)}5"] = YEARS[i]
+    return out
+
+
+def inject_cached(path, values):
+    """Add a cached <v> to each formula cell so data_only reads return numbers."""
+    tmp = path + ".tmp"
+    with zipfile.ZipFile(path) as zin:
+        names = zin.namelist()
+        sheet = next(n for n in names if re.match(r"xl/worksheets/sheet1\.xml", n))
+        data = {n: zin.read(n) for n in names}
+    xml = data[sheet].decode("utf-8")
+    for ref, val in values.items():
+        # openpyxl writes formula cells as <c r=".."><f>..</f><v /></c> -> fill the empty <v>
+        xml = re.sub(rf'(<c r="{ref}"[^>]*><f[^>]*>.*?</f>)<v ?/>',
+                     rf'\1<v>{val}</v>', xml, count=1)
+    data[sheet] = xml.encode("utf-8")
+    with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zout:
+        for n in names:
+            zout.writestr(n, data[n])
+    shutil.move(tmp, path)
+
+
+if __name__ == "__main__":
+    build()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/sample-model-plan.json
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/sample-model-plan.json
@@ -1,0 +1,1602 @@
+{
+ "name": "FP&A Monthly P&L (built)",
+ "intent": "what-if",
+ "connectionId": "cb2f5180-641f-47bd-8efa-da9d590d855a",
+ "folderId": "57e59735-86b9-40b0-b029-217205406f57",
+ "currencyFormat": "$,.0f",
+ "pctFormat": ".1%",
+ "actualMonths": [
+  {
+   "month": "Jan-26",
+   "num": 1,
+   "end": "2026-01-31"
+  },
+  {
+   "month": "Feb-26",
+   "num": 2,
+   "end": "2026-02-28"
+  },
+  {
+   "month": "Mar-26",
+   "num": 3,
+   "end": "2026-03-31"
+  },
+  {
+   "month": "Apr-26",
+   "num": 4,
+   "end": "2026-04-30"
+  },
+  {
+   "month": "May-26",
+   "num": 5,
+   "end": "2026-05-31"
+  },
+  {
+   "month": "Jun-26",
+   "num": 6,
+   "end": "2026-06-30"
+  }
+ ],
+ "forecastMonths": [
+  {
+   "month": "Jul-26",
+   "num": 7,
+   "end": "2026-07-31"
+  },
+  {
+   "month": "Aug-26",
+   "num": 8,
+   "end": "2026-08-31"
+  },
+  {
+   "month": "Sep-26",
+   "num": 9,
+   "end": "2026-09-30"
+  },
+  {
+   "month": "Oct-26",
+   "num": 10,
+   "end": "2026-10-31"
+  },
+  {
+   "month": "Nov-26",
+   "num": 11,
+   "end": "2026-11-30"
+  },
+  {
+   "month": "Dec-26",
+   "num": 12,
+   "end": "2026-12-31"
+  }
+ ],
+ "lines": [
+  {
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "kind": "growth",
+   "rate": 0.03,
+   "juneBase": 503000.0
+  },
+  {
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "kind": "manual",
+   "manual": [
+    70000.0,
+    64000.0,
+    78000.0,
+    66000.0,
+    74000.0,
+    95000.0
+   ]
+  },
+  {
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "kind": "growth",
+   "rate": 0.015,
+   "juneBase": 55500.0
+  },
+  {
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "kind": "growth",
+   "rate": 0.01,
+   "juneBase": 35000.0
+  },
+  {
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "kind": "manual",
+   "manual": [
+    41000.0,
+    37000.0,
+    45000.0,
+    39000.0,
+    43000.0,
+    52000.0
+   ]
+  },
+  {
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "kind": "manual",
+   "manual": [
+    165000.0,
+    170000.0,
+    168000.0,
+    178000.0,
+    182000.0,
+    175000.0
+   ]
+  },
+  {
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "kind": "growth",
+   "rate": 0.01,
+   "juneBase": 188000.0
+  },
+  {
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "kind": "growth",
+   "rate": 0.005,
+   "juneBase": 93000.0
+  },
+  {
+   "line": "Depreciation & Amort.",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 9,
+   "kind": "flat",
+   "juneBase": 12000.0
+  },
+  {
+   "line": "Interest Expense",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 10,
+   "kind": "manual",
+   "manual": [
+    4500.0,
+    4500.0,
+    4500.0,
+    4400.0,
+    4400.0,
+    4400.0
+   ]
+  }
+ ],
+ "assumptions": [
+  [
+   "Subscription Revenue growth",
+   0.03,
+   "MoM, prior month x (1+rate)"
+  ],
+  [
+   "Hosting & Infrastructure growth",
+   0.015,
+   "Scales with usage"
+  ],
+  [
+   "Customer Support growth",
+   0.01,
+   "Headcount creep"
+  ],
+  [
+   "R&D growth",
+   0.01,
+   "Headcount creep"
+  ],
+  [
+   "G&A growth",
+   0.005,
+   "Inflationary"
+  ]
+ ],
+ "actuals": [
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - Enterprise",
+   "amt": 252000.0
+  },
+  {
+   "date": "2026-01-10",
+   "month": "Jan-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - SMB",
+   "amt": 88685.0
+  },
+  {
+   "date": "2026-01-17",
+   "month": "Jan-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "Annual prepay",
+   "amt": 79315.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - Enterprise",
+   "amt": 261000.0
+  },
+  {
+   "date": "2026-02-11",
+   "month": "Feb-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - SMB",
+   "amt": 70470.0
+  },
+  {
+   "date": "2026-02-18",
+   "month": "Feb-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "Annual prepay",
+   "amt": 103530.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - Enterprise",
+   "amt": 271200.0
+  },
+  {
+   "date": "2026-03-12",
+   "month": "Mar-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - SMB",
+   "amt": 82265.0
+  },
+  {
+   "date": "2026-03-19",
+   "month": "Mar-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "Annual prepay",
+   "amt": 98535.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - Enterprise",
+   "amt": 280800.0
+  },
+  {
+   "date": "2026-04-10",
+   "month": "Apr-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - SMB",
+   "amt": 83237.0
+  },
+  {
+   "date": "2026-04-17",
+   "month": "Apr-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "Annual prepay",
+   "amt": 103963.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - Enterprise",
+   "amt": 291000.0
+  },
+  {
+   "date": "2026-05-11",
+   "month": "May-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - SMB",
+   "amt": 106175.0
+  },
+  {
+   "date": "2026-05-18",
+   "month": "May-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "Annual prepay",
+   "amt": 87825.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - Enterprise",
+   "amt": 301800.0
+  },
+  {
+   "date": "2026-06-12",
+   "month": "Jun-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "MRR - SMB",
+   "amt": 107710.0
+  },
+  {
+   "date": "2026-06-19",
+   "month": "Jun-26",
+   "line": "Subscription Revenue",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 1,
+   "dept": "Revenue",
+   "vendor": "Annual prepay",
+   "amt": 93490.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Implementation",
+   "amt": 39000.0
+  },
+  {
+   "date": "2026-01-10",
+   "month": "Jan-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Training",
+   "amt": 26000.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Implementation",
+   "amt": 34800.0
+  },
+  {
+   "date": "2026-02-11",
+   "month": "Feb-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Training",
+   "amt": 23200.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Implementation",
+   "amt": 43200.0
+  },
+  {
+   "date": "2026-03-12",
+   "month": "Mar-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Training",
+   "amt": 28800.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Implementation",
+   "amt": 36600.0
+  },
+  {
+   "date": "2026-04-10",
+   "month": "Apr-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Training",
+   "amt": 24400.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Implementation",
+   "amt": 41400.0
+  },
+  {
+   "date": "2026-05-11",
+   "month": "May-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Training",
+   "amt": 27600.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Implementation",
+   "amt": 45000.0
+  },
+  {
+   "date": "2026-06-12",
+   "month": "Jun-26",
+   "line": "Professional Services Rev",
+   "section": "Revenue",
+   "secOrder": 1,
+   "lineOrder": 2,
+   "dept": "Services",
+   "vendor": "Training",
+   "amt": 30000.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "AWS",
+   "amt": 28800.0
+  },
+  {
+   "date": "2026-01-10",
+   "month": "Jan-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "Datadog / monitoring",
+   "amt": 19200.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "AWS",
+   "amt": 29700.0
+  },
+  {
+   "date": "2026-02-11",
+   "month": "Feb-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "Datadog / monitoring",
+   "amt": 19800.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "AWS",
+   "amt": 30600.0
+  },
+  {
+   "date": "2026-03-12",
+   "month": "Mar-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "Datadog / monitoring",
+   "amt": 20400.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "AWS",
+   "amt": 31500.0
+  },
+  {
+   "date": "2026-04-10",
+   "month": "Apr-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "Datadog / monitoring",
+   "amt": 21000.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "AWS",
+   "amt": 32400.0
+  },
+  {
+   "date": "2026-05-11",
+   "month": "May-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "Datadog / monitoring",
+   "amt": 21600.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "AWS",
+   "amt": 33300.0
+  },
+  {
+   "date": "2026-06-12",
+   "month": "Jun-26",
+   "line": "Hosting & Infrastructure",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 3,
+   "dept": "Engineering",
+   "vendor": "Datadog / monitoring",
+   "amt": 22200.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Support payroll",
+   "amt": 19200.0
+  },
+  {
+   "date": "2026-01-10",
+   "month": "Jan-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Zendesk / tooling",
+   "amt": 12800.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Support payroll",
+   "amt": 19500.0
+  },
+  {
+   "date": "2026-02-11",
+   "month": "Feb-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Zendesk / tooling",
+   "amt": 13000.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Support payroll",
+   "amt": 19800.0
+  },
+  {
+   "date": "2026-03-12",
+   "month": "Mar-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Zendesk / tooling",
+   "amt": 13200.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Support payroll",
+   "amt": 20400.0
+  },
+  {
+   "date": "2026-04-10",
+   "month": "Apr-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Zendesk / tooling",
+   "amt": 13600.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Support payroll",
+   "amt": 20700.0
+  },
+  {
+   "date": "2026-05-11",
+   "month": "May-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Zendesk / tooling",
+   "amt": 13800.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Support payroll",
+   "amt": 21000.0
+  },
+  {
+   "date": "2026-06-12",
+   "month": "Jun-26",
+   "line": "Customer Support",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 4,
+   "dept": "Support",
+   "vendor": "Zendesk / tooling",
+   "amt": 14000.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Delivery payroll",
+   "amt": 22800.0
+  },
+  {
+   "date": "2026-01-10",
+   "month": "Jan-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Contractor",
+   "amt": 15200.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Delivery payroll",
+   "amt": 21000.0
+  },
+  {
+   "date": "2026-02-11",
+   "month": "Feb-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Contractor",
+   "amt": 14000.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Delivery payroll",
+   "amt": 25200.0
+  },
+  {
+   "date": "2026-03-12",
+   "month": "Mar-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Contractor",
+   "amt": 16800.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Delivery payroll",
+   "amt": 22200.0
+  },
+  {
+   "date": "2026-04-10",
+   "month": "Apr-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Contractor",
+   "amt": 14800.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Delivery payroll",
+   "amt": 24000.0
+  },
+  {
+   "date": "2026-05-11",
+   "month": "May-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Contractor",
+   "amt": 16000.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Delivery payroll",
+   "amt": 26400.0
+  },
+  {
+   "date": "2026-06-12",
+   "month": "Jun-26",
+   "line": "Prof. Services Delivery",
+   "section": "Cost of Revenue",
+   "secOrder": 2,
+   "lineOrder": 5,
+   "dept": "Services",
+   "vendor": "Contractor",
+   "amt": 17600.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Payroll",
+   "amt": 87000.0
+  },
+  {
+   "date": "2026-01-10",
+   "month": "Jan-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Paid media",
+   "amt": 33549.0
+  },
+  {
+   "date": "2026-01-17",
+   "month": "Jan-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Events",
+   "amt": 24451.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Payroll",
+   "amt": 90000.0
+  },
+  {
+   "date": "2026-02-11",
+   "month": "Feb-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Paid media",
+   "amt": 25043.0
+  },
+  {
+   "date": "2026-02-18",
+   "month": "Feb-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Events",
+   "amt": 34957.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Payroll",
+   "amt": 88800.0
+  },
+  {
+   "date": "2026-03-12",
+   "month": "Mar-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Paid media",
+   "amt": 28676.0
+  },
+  {
+   "date": "2026-03-19",
+   "month": "Mar-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Events",
+   "amt": 30524.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Payroll",
+   "amt": 96000.0
+  },
+  {
+   "date": "2026-04-10",
+   "month": "Apr-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Paid media",
+   "amt": 25981.0
+  },
+  {
+   "date": "2026-04-17",
+   "month": "Apr-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Events",
+   "amt": 38019.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Payroll",
+   "amt": 93000.0
+  },
+  {
+   "date": "2026-05-11",
+   "month": "May-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Paid media",
+   "amt": 27511.0
+  },
+  {
+   "date": "2026-05-18",
+   "month": "May-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Events",
+   "amt": 34489.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Payroll",
+   "amt": 97200.0
+  },
+  {
+   "date": "2026-06-12",
+   "month": "Jun-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Paid media",
+   "amt": 32469.0
+  },
+  {
+   "date": "2026-06-19",
+   "month": "Jun-26",
+   "line": "Sales & Marketing",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 6,
+   "dept": "Sales",
+   "vendor": "Events",
+   "amt": 32331.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Eng payroll",
+   "amt": 105000.0
+  },
+  {
+   "date": "2026-01-10",
+   "month": "Jan-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Cloud dev / tooling",
+   "amt": 70000.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Eng payroll",
+   "amt": 106800.0
+  },
+  {
+   "date": "2026-02-11",
+   "month": "Feb-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Cloud dev / tooling",
+   "amt": 71200.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Eng payroll",
+   "amt": 108000.0
+  },
+  {
+   "date": "2026-03-12",
+   "month": "Mar-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Cloud dev / tooling",
+   "amt": 72000.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Eng payroll",
+   "amt": 109800.0
+  },
+  {
+   "date": "2026-04-10",
+   "month": "Apr-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Cloud dev / tooling",
+   "amt": 73200.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Eng payroll",
+   "amt": 111000.0
+  },
+  {
+   "date": "2026-05-11",
+   "month": "May-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Cloud dev / tooling",
+   "amt": 74000.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Eng payroll",
+   "amt": 112800.0
+  },
+  {
+   "date": "2026-06-12",
+   "month": "Jun-26",
+   "line": "Research & Development",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 7,
+   "dept": "Engineering",
+   "vendor": "Cloud dev / tooling",
+   "amt": 75200.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Payroll",
+   "amt": 52800.0
+  },
+  {
+   "date": "2026-01-10",
+   "month": "Jan-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Rent & facilities",
+   "amt": 14267.0
+  },
+  {
+   "date": "2026-01-17",
+   "month": "Jan-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "SaaS / software",
+   "amt": 20933.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Payroll",
+   "amt": 53400.0
+  },
+  {
+   "date": "2026-02-11",
+   "month": "Feb-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Rent & facilities",
+   "amt": 15656.0
+  },
+  {
+   "date": "2026-02-18",
+   "month": "Feb-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "SaaS / software",
+   "amt": 19944.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Payroll",
+   "amt": 54000.0
+  },
+  {
+   "date": "2026-03-12",
+   "month": "Mar-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Rent & facilities",
+   "amt": 19079.0
+  },
+  {
+   "date": "2026-03-19",
+   "month": "Mar-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "SaaS / software",
+   "amt": 16921.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Payroll",
+   "amt": 54600.0
+  },
+  {
+   "date": "2026-04-10",
+   "month": "Apr-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Rent & facilities",
+   "amt": 18527.0
+  },
+  {
+   "date": "2026-04-17",
+   "month": "Apr-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "SaaS / software",
+   "amt": 17873.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Payroll",
+   "amt": 55200.0
+  },
+  {
+   "date": "2026-05-11",
+   "month": "May-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Rent & facilities",
+   "amt": 16342.0
+  },
+  {
+   "date": "2026-05-18",
+   "month": "May-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "SaaS / software",
+   "amt": 20458.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Payroll",
+   "amt": 55800.0
+  },
+  {
+   "date": "2026-06-12",
+   "month": "Jun-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "Rent & facilities",
+   "amt": 19264.0
+  },
+  {
+   "date": "2026-06-19",
+   "month": "Jun-26",
+   "line": "General & Administrative",
+   "section": "Operating Expenses",
+   "secOrder": 3,
+   "lineOrder": 8,
+   "dept": "Corporate",
+   "vendor": "SaaS / software",
+   "amt": 17936.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Depreciation & Amort.",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 9,
+   "dept": "Corporate",
+   "vendor": "Monthly depreciation",
+   "amt": 12000.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Depreciation & Amort.",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 9,
+   "dept": "Corporate",
+   "vendor": "Monthly depreciation",
+   "amt": 12000.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Depreciation & Amort.",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 9,
+   "dept": "Corporate",
+   "vendor": "Monthly depreciation",
+   "amt": 12000.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Depreciation & Amort.",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 9,
+   "dept": "Corporate",
+   "vendor": "Monthly depreciation",
+   "amt": 12000.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Depreciation & Amort.",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 9,
+   "dept": "Corporate",
+   "vendor": "Monthly depreciation",
+   "amt": 12000.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Depreciation & Amort.",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 9,
+   "dept": "Corporate",
+   "vendor": "Monthly depreciation",
+   "amt": 12000.0
+  },
+  {
+   "date": "2026-01-03",
+   "month": "Jan-26",
+   "line": "Interest Expense",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 10,
+   "dept": "Finance",
+   "vendor": "Term loan interest",
+   "amt": 4500.0
+  },
+  {
+   "date": "2026-02-04",
+   "month": "Feb-26",
+   "line": "Interest Expense",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 10,
+   "dept": "Finance",
+   "vendor": "Term loan interest",
+   "amt": 4500.0
+  },
+  {
+   "date": "2026-03-05",
+   "month": "Mar-26",
+   "line": "Interest Expense",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 10,
+   "dept": "Finance",
+   "vendor": "Term loan interest",
+   "amt": 4500.0
+  },
+  {
+   "date": "2026-04-03",
+   "month": "Apr-26",
+   "line": "Interest Expense",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 10,
+   "dept": "Finance",
+   "vendor": "Term loan interest",
+   "amt": 4500.0
+  },
+  {
+   "date": "2026-05-04",
+   "month": "May-26",
+   "line": "Interest Expense",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 10,
+   "dept": "Finance",
+   "vendor": "Term loan interest",
+   "amt": 4500.0
+  },
+  {
+   "date": "2026-06-05",
+   "month": "Jun-26",
+   "line": "Interest Expense",
+   "section": "Below the Line",
+   "secOrder": 4,
+   "lineOrder": 10,
+   "dept": "Finance",
+   "vendor": "Term loan interest",
+   "amt": 4500.0
+  }
+ ]
+}

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/xlsx-discover.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/xlsx-discover.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Phase 0 — discover an .xlsx workbook.
+
+Inventories formal Tables (the migration's Rosetta Stone), pivots/charts, and a
+formula census (flagging untranslatable / report-style sheets). Prints a summary
+and, for each formal Table, its columns + inferred grain.
+
+Usage:
+    python xlsx-discover.py "Sample Forecast.xlsx"
+"""
+import sys
+import re
+from collections import Counter
+from openpyxl import load_workbook
+
+# functions we translate today (see refs/excel-translation.md)
+TRANSLATABLE = {
+    "IF", "IFS", "SWITCH", "IFERROR", "AND", "OR", "NOT",
+    "SUM", "SUMIF", "SUMIFS", "COUNT", "COUNTA", "COUNTIF", "COUNTIFS",
+    "AVERAGE", "AVERAGEIF", "AVERAGEIFS", "MIN", "MAX", "MEDIAN",
+    "VLOOKUP", "XLOOKUP", "HLOOKUP", "INDEX", "MATCH", "LOOKUP",
+    "LEFT", "RIGHT", "MID", "LEN", "CONCAT", "CONCATENATE", "TRIM",
+    "UPPER", "LOWER", "SUBSTITUTE", "FIND", "TEXT",
+    "TODAY", "NOW", "YEAR", "MONTH", "DAY", "DATEDIF", "EDATE",
+    "EOMONTH", "WEEKDAY", "DATE",
+    "ROUND", "ROUNDUP", "ROUNDDOWN", "CEILING", "FLOOR", "ABS", "POWER", "MOD",
+    "SUMPRODUCT",
+}
+# fail-loud: these usually mark a "report drawn in cells" needing manual rebuild
+VOLATILE = {"OFFSET", "INDIRECT", "INDEX_VOLATILE"}
+
+FUNC_RE = re.compile(r"\b([A-Z][A-Z0-9_.]+)\s*\(")
+PK_RE = re.compile(r"(^id|_id|id|code|key|num)$", re.I)
+# headers that look like a spread dimension (a wide cross-tab axis)
+WIDE_HDR_RE = re.compile(
+    r"^(\d{4}([-_/ ]?\d{1,2})?|\d{1,2}[-_/ ]\d{2,4}|"
+    r"jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec|q[1-4]|fy\d+|\d+)$", re.I)
+
+
+def classify(headers, body_rows, nrows, referenced_by_others):
+    """Return (route, why) — entered → input table; derived → read-only DM;
+    reference → maintained-list (input table if users maintain it)."""
+    # formula ratio over non-empty body cells
+    filled = formulas = 0
+    for r in body_rows:
+        for c in r:
+            v = c.value
+            if v is None or v == "":
+                continue
+            filled += 1
+            if isinstance(v, str) and v.startswith("="):
+                formulas += 1
+    fr = (formulas / filled) if filled else 0.0
+    pk = any(PK_RE.search(str(h).strip()) for h in headers if h)
+    # wide cross-tab: many headers that look like a spread axis
+    wide = sum(1 for h in headers if h and WIDE_HDR_RE.match(str(h).strip()))
+    wide_flag = wide >= 4
+
+    if fr >= 0.3:
+        return "DERIVED", f"{fr:.0%} of cells are formulas → read-only DM element + metrics", wide_flag
+    if nrows <= 30 and pk and referenced_by_others:
+        return "REFERENCE", "small + PK + referenced by other sheets → dim (input table only if users maintain it; else read-only)", wide_flag
+    return "ENTERED", "typed values, no inbound formulas → input table (editable)", wide_flag
+
+
+SHEET_REF_RE = re.compile(r"(?:'([^']+)'|([A-Za-z0-9_]+))!\$?[A-Z]+\$?\d+")
+GROWTH_RE = re.compile(r"^=\s*\$?[A-Z]+\$?\d+\s*\*\s*\(\s*1\s*[+\-]", re.I)   # prior*(1±rate)
+FLAT_RE   = re.compile(r"^=\s*\$?[A-Z]+\$?\d+\s*$")                          # =single cell
+SUMIFS_RE = re.compile(r"\bSUMIFS?\b|\bSUMPRODUCT\b", re.I)
+ARITH_RE  = re.compile(r"[A-Z]+\$?\d+\s*[-+*/]\s*\$?[A-Z]+\$?\d+|^=IF\(", re.I)
+
+def classify_report_cells(wb):
+    """Cell-level model map for 'report drawn in cells' sheets (no formal Table).
+    Returns per-sheet counts by class + the detected source/driver sheets."""
+    table_sheets = {ws.title for ws in wb.worksheets if len(ws.tables)}
+    sheetmap = {}          # sheet -> Counter of classes
+    source_sheets = Counter()   # tabs feeding SUMIFS (actuals source)
+    driver_sheets = Counter()   # tabs referenced by growth (1+rate) formulas
+    for ws in wb.worksheets:
+        if ws.title in table_sheets:
+            continue
+        counts = Counter()
+        # which rows contain a formula (to spot manual literals sitting among formulas)
+        rows_with_formula = set()
+        numeric_cells = []
+        for row in ws.iter_rows():
+            for c in row:
+                v = c.value
+                if isinstance(v, str) and v.startswith("="):
+                    rows_with_formula.add(c.row)
+                elif isinstance(v, (int, float)) and c.column > 1:
+                    numeric_cells.append(c)
+        for row in ws.iter_rows():
+            for c in row:
+                v = c.value
+                if not (isinstance(v, str) and v.startswith("=")):
+                    continue
+                if SUMIFS_RE.search(v):
+                    counts["ACTUAL"] += 1
+                    for m in SHEET_REF_RE.finditer(v):
+                        source_sheets[m.group(1) or m.group(2)] += 1
+                elif GROWTH_RE.match(v):
+                    counts["DRIVER_GROWTH"] += 1
+                    for m in SHEET_REF_RE.finditer(v):
+                        driver_sheets[m.group(1) or m.group(2)] += 1
+                elif FLAT_RE.match(v):
+                    counts["FLAT"] += 1
+                elif ARITH_RE.search(v):
+                    counts["DERIVED"] += 1
+                else:
+                    counts["OTHER_FORMULA"] += 1
+        # manual inputs = numeric literals sitting in rows that are otherwise formula-driven
+        manual = sum(1 for c in numeric_cells if c.row in rows_with_formula)
+        if manual:
+            counts["MANUAL"] = manual
+        if counts:
+            sheetmap[ws.title] = counts
+    return sheetmap, source_sheets, driver_sheets
+
+
+def main(path):
+    wb = load_workbook(path, data_only=False)
+    print(f"# Discovery: {path}\n")
+    print(f"Sheets ({len(wb.sheetnames)}): {', '.join(wb.sheetnames)}\n")
+
+    # all formula strings (with their sheet) — for cross-sheet reference detection
+    all_formulas = []
+    for ws in wb.worksheets:
+        for row in ws.iter_rows():
+            for c in row:
+                if isinstance(c.value, str) and c.value.startswith("="):
+                    all_formulas.append((ws.title, c.value))
+
+    # ---- formal Tables + routing ----
+    tables = []
+    for ws in wb.worksheets:
+        for name in ws.tables:
+            ref = ws.tables[name].ref
+            cells = ws[ref]
+            headers = [c.value for c in cells[0]] if cells else []
+            body = cells[1:] if cells else []
+            nrows = len(body)
+            referenced = any(s != ws.title and (ws.title in f or name in f)
+                             for s, f in all_formulas)
+            route, why, wide = classify(headers, body, nrows, referenced)
+            tables.append((name, ws.title, ref, headers, nrows, route, why, wide))
+
+    print(f"## Formal Tables ({len(tables)}) — with routing")
+    routes = Counter()
+    for name, sheet, ref, headers, nrows, route, why, wide in tables:
+        routes[route] += 1
+        tag = {"ENTERED": "✏️  ENTERED", "DERIVED": "🔒 DERIVED", "REFERENCE": "📒 REFERENCE"}[route]
+        print(f"\n  • {name}  (sheet '{sheet}', {ref}, ~{nrows} rows)  →  {tag}")
+        print(f"    columns: {', '.join(str(h) for h in headers)}")
+        print(f"    routing: {why}")
+        if wide:
+            print(f"    ⚠️ wide cross-tab detected → UNPIVOT (Sigma transpose / SQL unpivot) to a tidy grain first")
+    if not tables:
+        print("  (none — workbook is likely 'report drawn in cells'; expect manual rebuild)")
+    else:
+        print(f"\n  routing summary: " + ", ".join(f"{n} {r.lower()}" for r, n in routes.items()))
+        print("  → ENTERED/REFERENCE-maintained tables become input tables (preserve data entry);")
+        print("    DERIVED tables become read-only DM elements + metrics. See SKILL.md 'Preserve the inputs'.")
+
+    # ---- pivots / charts ----
+    n_charts = sum(len(getattr(ws, "_charts", [])) for ws in wb.worksheets)
+    n_pivots = sum(len(getattr(ws, "_pivots", [])) for ws in wb.worksheets)
+    print(f"\n## Visuals: {n_charts} chart(s), {n_pivots} pivot table(s)")
+
+    # ---- formula census ----
+    func_counts = Counter()
+    formula_cells = 0
+    report_sheets = Counter()
+    for ws in wb.worksheets:
+        for row in ws.iter_rows():
+            for c in row:
+                if isinstance(c.value, str) and c.value.startswith("="):
+                    formula_cells += 1
+                    for m in FUNC_RE.findall(c.value):
+                        func_counts[m] += 1
+                        if m in VOLATILE:
+                            report_sheets[ws.title] += 1
+    print(f"\n## Formula census: {formula_cells} formula cells, "
+          f"{len(func_counts)} distinct functions")
+    untranslatable = {f: n for f, n in func_counts.items()
+                      if f not in TRANSLATABLE and f in VOLATILE}
+    unknown = {f: n for f, n in func_counts.items()
+               if f not in TRANSLATABLE and f not in VOLATILE}
+    top = func_counts.most_common(15)
+    print("  top functions:", ", ".join(f"{f}×{n}" for f, n in top))
+    if untranslatable:
+        print(f"  ⚠️ volatile/untranslatable (manual rebuild): "
+              + ", ".join(f"{f}×{n}" for f, n in untranslatable.items()))
+        print(f"     report-style sheets: {', '.join(report_sheets)}")
+    if unknown:
+        print(f"  ❓ not yet in the rules table (verify): "
+              + ", ".join(f"{f}×{n}" for f, n in sorted(unknown.items())))
+
+    # ---- derived report sheets (formula-driven, no formal table) ----
+    table_sheets = {ws.title for ws in wb.worksheets if len(ws.tables)}
+    per_sheet = Counter(s for s, _ in all_formulas)
+    derived = [s for s, n in per_sheet.items() if n and s not in table_sheets]
+    if derived:
+        print(f"\n## Derived report sheets (formula-driven, no formal table): "
+              f"{', '.join(derived)}")
+        print("  🔒 read-only — rebuild as DM metrics + workbook elements (the SUMIFS/"
+              "rollups become grouped aggregates), not input tables.")
+
+    # ---- cell-level MODEL MAP (for report-drawn-in-cells models; see refs/model-taxonomy.md) ----
+    sheetmap, source_sheets, driver_sheets = classify_report_cells(wb)
+    if sheetmap:
+        print("\n## Model map (cell-level) — for report sheets drawn in cells")
+        ICON = {"ACTUAL": "📥 ACTUAL (live source)", "DRIVER_GROWTH": "📈 DRIVER-grown",
+                "MANUAL": "✏️  MANUAL input", "DERIVED": "🧮 DERIVED", "FLAT": "➡️  FLAT (carry)",
+                "OTHER_FORMULA": "· other"}
+        for sheet, counts in sheetmap.items():
+            parts = [f"{ICON.get(k,k)}={v}" for k, v in counts.most_common()]
+            print(f"  • {sheet}: " + ", ".join(parts))
+        if source_sheets:
+            print(f"  → actuals source (SUMIFS targets): {', '.join(source_sheets)}  "
+                  f"= live read-only DM element")
+        if driver_sheets:
+            print(f"  → driver/assumptions sheet (1±rate refs): {', '.join(driver_sheets)}  "
+                  f"= editable rates table / controls")
+        print("  Architecture: union [live ACTUAL] + [forecast]; forecast = DRIVER-grown "
+              "(base×(1+rate)^n, rate from drivers) + MANUAL (editable input table) + FLAT. "
+              "Subtotals/margins = DERIVED workbook calcs. See refs/forecast-recipes.md.")
+        print("  ASK INTENT before building (read-only report / editable plan / live what-if) "
+              "→ determines static vs input-table vs driver-override. See refs/model-taxonomy.md.")
+
+    print("\nNext: classify intent → build per refs/forecast-recipes.md; ENTERED → input-table "
+          "builder; DERIVED → read-only DM; wide → unpivot first; macros → macro-classify.py.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("usage: xlsx-discover.py <file.xlsx>")
+    main(sys.argv[1])

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/xlsx-to-input-csv.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/scripts/xlsx-to-input-csv.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Phase 1 — extract a formal Table to a paste-ready input-table CSV.
+
+Emits ONLY the data-entry columns with UPPER_SNAKE_CASE headers (so a clipboard
+paste into the Sigma input table aligns 1:1), excludes any system-style columns,
+and writes Excel dates as ISO yyyy-mm-dd. Also prints suggested input-table column
+specs (name:type) for build-input-table-wb.py.
+
+Usage:
+    python xlsx-to-input-csv.py "Sample Forecast.xlsx" --table tblForecast --out forecast_input_paste.csv
+"""
+import argparse
+import csv
+import datetime as dt
+import re
+from openpyxl import load_workbook
+
+SYSTEM_COLS = {"ID", "ROW_ID", "CREATED_AT", "CREATED_BY",
+               "UPDATED_AT", "UPDATED_BY", "LAST_UPDATED_AT", "LAST_UPDATED_BY"}
+
+
+def snake(name):
+    s = str(name)
+    # split camelCase / PascalCase boundaries: SubBranch -> Sub_Branch
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", s)
+    s = re.sub(r"[^0-9A-Za-z]+", "_", s).strip("_").upper()
+    return s
+
+
+def infer_type(values):
+    seen = set()
+    for v in values:
+        if v is None or v == "":
+            continue
+        if isinstance(v, bool):
+            seen.add("checkbox")
+        elif isinstance(v, (dt.datetime, dt.date)):
+            seen.add("datetime")
+        elif isinstance(v, (int, float)):
+            seen.add("number")
+        else:
+            seen.add("text")
+    if not seen:
+        return "text"
+    if seen == {"number"}:
+        return "number"
+    if seen <= {"datetime"}:
+        return "datetime"
+    if seen == {"checkbox"}:
+        return "checkbox"
+    return "text"
+
+
+def find_table(wb, table_name):
+    for ws in wb.worksheets:
+        if table_name in ws.tables:
+            return ws, ws.tables[table_name]
+    raise SystemExit(f"table '{table_name}' not found. "
+                     f"available: {[n for ws in wb.worksheets for n in ws.tables]}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("xlsx")
+    ap.add_argument("--table", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    wb = load_workbook(args.xlsx, data_only=True)
+    ws, tbl = find_table(wb, args.table)
+    cells = ws[tbl.ref]
+    raw_headers = [c.value for c in cells[0]]
+    body = cells[1:]
+
+    keep_idx, out_headers, col_values = [], [], []
+    for i, h in enumerate(raw_headers):
+        hsnake = snake(h)
+        if hsnake in SYSTEM_COLS:
+            continue
+        keep_idx.append(i)
+        out_headers.append(hsnake)
+        col_values.append([row[i].value for row in body])
+
+    def fmt(v):
+        if isinstance(v, (dt.datetime, dt.date)):
+            return v.strftime("%Y-%m-%d")
+        return v
+
+    with open(args.out, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(out_headers)
+        for row in body:
+            w.writerow([fmt(row[i].value) for i in keep_idx])
+
+    print(f"wrote {args.out}: {len(body)} rows, {len(out_headers)} entry columns")
+    print(f"  headers: {','.join(out_headers)}")
+    specs = [f"{h}:{infer_type(col_values[j])}" for j, h in enumerate(out_headers)]
+    print("\nsuggested --columns for build-input-table-wb.py:")
+    print("  " + ",".join(specs))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/excel-to-sigma/skills/excel-to-sigma/tests/test_workbook_wire.py
+++ b/plugins/excel-to-sigma/skills/excel-to-sigma/tests/test_workbook_wire.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Offline smoke: workbook builders must emit the released code_rep wire shape."""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB = ROOT / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+import code_rep  # noqa: E402
+import workbook_wire  # noqa: E402
+
+
+class TestWorkbookWire(unittest.TestCase):
+    def test_wire_wraps_document_and_flattens_elements(self):
+        draft = {
+            "name": "Forecast Entry",
+            "folderId": "00000000-0000-0000-0000-000000000001",
+            "description": "test",
+            "schemaVersion": 1,
+            "pages": [{
+                "id": "entryPage",
+                "name": "Entry",
+                "elements": [
+                    {"id": "inputTable", "kind": "input-table", "name": "Entry"},
+                    {"id": "spine", "kind": "table", "name": "Spine"},
+                ],
+            }],
+        }
+        body = workbook_wire.wire_workbook(draft)
+
+        self.assertIn("document", body)
+        self.assertNotIn("pages", body)
+        self.assertNotIn("elements", body)
+        self.assertNotIn("layout", body)
+        self.assertEqual(body["name"], "Forecast Entry")
+        self.assertEqual(body["folderId"], draft["folderId"])
+
+        doc = body["document"]
+        self.assertEqual(doc["schemaVersion"], 1)
+        self.assertEqual(doc["kind"], "workbook")
+        self.assertEqual([p["id"] for p in doc["pages"]], ["entryPage"])
+        self.assertNotIn("elements", doc["pages"][0])
+        self.assertEqual([e["id"] for e in doc["elements"]], ["inputTable", "spine"])
+        self.assertIn("<Page", doc["layout"])
+        self.assertIn('id="entryPage"', doc["layout"])
+        self.assertIn('elementId="inputTable"', doc["layout"])
+        self.assertIn("<Element", doc["layout"])
+        self.assertNotIn("<LayoutElement", doc["layout"])
+
+        # Round-trip through the shared adapter stays nested.
+        again = code_rep.wrap(code_rep.document(body), extra=code_rep.metadata(body))
+        self.assertEqual(again["document"]["elements"][0]["id"], "inputTable")
+
+    def test_already_wrapped_is_idempotent_enough(self):
+        draft = {
+            "name": "X",
+            "document": {
+                "schemaVersion": 1,
+                "kind": "workbook",
+                "pages": [{"id": "p1", "name": "P"}],
+                "elements": [{"id": "e1", "kind": "table"}],
+                "layout": '<Page id="p1"><Element elementId="e1"/></Page>',
+            },
+        }
+        body = workbook_wire.wire_workbook(draft)
+        self.assertEqual(body["document"]["elements"][0]["id"], "e1")
+        self.assertIn("<Element", body["document"]["layout"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -114,19 +114,20 @@
       "canonical": "shared/lib/code_rep.py",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py",
+        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py",
+        "plugins/excel-to-sigma/skills/excel-to-sigma/scripts/lib/code_rep.py",
         "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py",
+        "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py",
         "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py",
         "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py",
         "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py",
-        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py",
-        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py",
+        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py",
         "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py",
-        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py",
-        "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py",
-        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py"
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py"
       ]
     },
     {
@@ -207,7 +208,7 @@
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/degradation_ledger.rb",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/degradation_ledger.rb"
       ],
-      "note": "W2.23's STANDING EXEMPTION for domo/hex was DISCHARGED 2026-08-05: this is the deliberate early-Wave-3 fan-out it called for — BOTH ledger sibs (this file + evidence_ledger.rb) added to domo and hex together, in one atomic commit, with domo's suites run — not a sync-tooling accident. Motivation: assert-phase6-ran.rb is vendored to 8 plugins but this lib was vendored to only 6, so on domo and hex the gate fell through to its legacy uncapped path (\"all gates pass — conversion may declare GREEN\") with no PR-14 verdict derivation — a GREEN there was strictly weaker than the same string from the 6 synced converters. Found while driving domo's 48-card cold run to a defensible gold verdict."
+      "note": "W2.23's STANDING EXEMPTION for domo/hex was DISCHARGED 2026-08-05: this is the deliberate early-Wave-3 fan-out it called for \u2014 BOTH ledger sibs (this file + evidence_ledger.rb) added to domo and hex together, in one atomic commit, with domo's suites run \u2014 not a sync-tooling accident. Motivation: assert-phase6-ran.rb is vendored to 8 plugins but this lib was vendored to only 6, so on domo and hex the gate fell through to its legacy uncapped path (\"all gates pass \u2014 conversion may declare GREEN\") with no PR-14 verdict derivation \u2014 a GREEN there was strictly weaker than the same string from the 6 synced converters. Found while driving domo's 48-card cold run to a defensible gold verdict."
     },
     {
       "canonical": "shared/lib/control_lint.rb",
@@ -883,7 +884,7 @@
         "plugins/tableau-to-sigma/skills/tableau-assessment/refs/environment.md",
         {
           "path": "plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/environment.md",
-          "exception": "Intentional fork: carries Tableau-specific Windows guidance — in-process Sigma + Tableau PAT token minting by migrate-tableau.rb (#310), the get-tableau-token.py twin, and BOM-tolerant spec reads — that does not apply to the other plugins' orchestrators."
+          "exception": "Intentional fork: carries Tableau-specific Windows guidance \u2014 in-process Sigma + Tableau PAT token minting by migrate-tableau.rb (#310), the get-tableau-token.py twin, and BOM-tolerant spec reads \u2014 that does not apply to the other plugins' orchestrators."
         },
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/environment.md",
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/environment.md"
@@ -939,7 +940,7 @@
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/evidence_ledger.rb",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/evidence_ledger.rb"
       ],
-      "note": "W2.23's STANDING EXEMPTION (adjudicated R7/§3-A4) was DISCHARGED 2026-08-05 — this is the scheduled early-Wave-3 two-sibling fan-out it described: this file AND degradation_ledger.rb added to domo and hex together, one atomic commit, domo suites run. It is a deliberate runtime behavior change: domo's assert-phase6-ran.rb previously used its guarded inline ev_append fallback and now writes the real ledger."
+      "note": "W2.23's STANDING EXEMPTION (adjudicated R7/\u00a73-A4) was DISCHARGED 2026-08-05 \u2014 this is the scheduled early-Wave-3 two-sibling fan-out it described: this file AND degradation_ledger.rb added to domo and hex together, one atomic commit, domo suites run. It is a deliberate runtime behavior change: domo's assert-phase6-ran.rb previously used its guarded inline ev_append fallback and now writes the real ledger."
     },
     {
       "canonical": "shared/lib/export_pool.rb",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Graduate [`twells89/excel-to-sigma`](https://github.com/twells89/excel-to-sigma) into `plugins/excel-to-sigma/` and bring it onto the same released workbook **code_rep** wire contract as the other converters (document envelope, flat `elements`, layout last). The staging repo itself isn’t writable from this agent (403), so the update lands in the monorepo — the path the staging README already pointed at.

## Scope

- Plugin(s) touched: `excel-to-sigma` (+ marketplace / AGENTS / phase-schema / `shared/manifest.json` registration)
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both) — one new plugin + its registry wiring

## Changes

- Import staging skill content into `plugins/excel-to-sigma/`
- Vendor `shared/lib/code_rep.py` → `scripts/lib/code_rep.py`
- Add `scripts/lib/workbook_wire.py` (stack layout + `code_rep.wrap`) and route every workbook POST/dry-run through it:
  - `build-input-table-wb.py`
  - `build-forecast-model.py`
  - `build-research-model.py`
  - `batch-convert.py`
- Document the wire contract in `refs/sigma-build-gotchas.md` + SKILL gates (reuse / readback / layout-last / parity / RLS)
- Wire marketplace, AGENTS.md, README, `docs/phase-schema.md`, `shared/manifest.json`
- Offline smoke: `tests/test_workbook_wire.py`

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] `ruby tools/lint-skills.rb` — green
- [x] `ruby tools/lint-skill-paths.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (27/27; no new corpus case yet — foundation skill)
- [x] Phase numbers unchanged; new skill added to `docs/phase-schema.md`
- [x] Bumped plugin version to `0.2.0`

## Notes

- Data-model POSTs remain unwrapped (DM code-rep unchanged).
- Staging repo open PR #3 (fleet detection generalization) was **not** pulled in — this PR is `main` @ a83d42d + code_rep only. Follow-up can port #3 if desired.
- No push access to `twells89/excel-to-sigma` from this environment; consider marking that staging repo as superseded by this plugin once merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af8e515a-9f9c-4d12-94af-5e711404ba2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af8e515a-9f9c-4d12-94af-5e711404ba2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

