### PR TITLE
Document workbook references to data-model metrics

### DIFF
--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-api (authentication), sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter \u2014 the converters assume it is present.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sigma-authoring/skills/sigma-data-models/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/SKILL.md
@@ -71,7 +71,12 @@ Call out any of these before presenting the final spec:
 
 ## Cross-Skill References
 
-- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Building a workbook on top of this model** → load the `sigma-workbooks`
+  skill. Its `sources.md` documents the
+  `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }`
+  source shape. Governed metrics flow through that source as
+  `[Metrics/<metric name>]` (name, not ID); do not treat them as
+  `[<element>/<column>]` references.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
 - **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/cline/sigma-data-models.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/cline/sigma-data-models.md
@@ -62,7 +62,12 @@ Call out any of these before presenting the final spec:
 
 ## Cross-Skill References
 
-- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Building a workbook on top of this model** → load the `sigma-workbooks`
+  skill. Its `sources.md` documents the
+  `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }`
+  source shape. Governed metrics flow through that source as
+  `[Metrics/<metric name>]` (name, not ID); do not treat them as
+  `[<element>/<column>]` references.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
 - **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/codex/AGENTS.md
@@ -62,7 +62,12 @@ Call out any of these before presenting the final spec:
 
 ## Cross-Skill References
 
-- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Building a workbook on top of this model** → load the `sigma-workbooks`
+  skill. Its `sources.md` documents the
+  `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }`
+  source shape. Governed metrics flow through that source as
+  `[Metrics/<metric name>]` (name, not ID); do not treat them as
+  `[<element>/<column>]` references.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
 - **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/continue/sigma-data-models.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/continue/sigma-data-models.md
@@ -62,7 +62,12 @@ Call out any of these before presenting the final spec:
 
 ## Cross-Skill References
 
-- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Building a workbook on top of this model** → load the `sigma-workbooks`
+  skill. Its `sources.md` documents the
+  `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }`
+  source shape. Governed metrics flow through that source as
+  `[Metrics/<metric name>]` (name, not ID); do not treat them as
+  `[<element>/<column>]` references.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
 - **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
@@ -67,7 +67,12 @@ Call out any of these before presenting the final spec:
 
 ## Cross-Skill References
 
-- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Building a workbook on top of this model** → load the `sigma-workbooks`
+  skill. Its `sources.md` documents the
+  `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }`
+  source shape. Governed metrics flow through that source as
+  `[Metrics/<metric name>]` (name, not ID); do not treat them as
+  `[<element>/<column>]` references.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
 - **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/metrics.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/metrics.md
@@ -2,6 +2,33 @@
 
 Metrics are aggregate measures defined in the `metrics` array of a table element. They standardize common calculations so workbook authors don't need to rewrite them.
 
+## Referencing a data-model metric from a workbook
+
+Data-model metrics do flow into workbook elements that source the corresponding
+data-model element. The formula reference uses Sigma's reserved metric namespace:
+
+```yaml
+source:
+  kind: data-model
+  dataModelId: <data-model-id>
+  elementId: <element-id-that-exposes-the-metric>
+columns:
+  - id: total-revenue
+    name: Total Revenue
+    formula: "[Metrics/Total Revenue]"
+```
+
+Use the metric's **name**, not its ID. `[Base/Total Revenue]`,
+`[Base/metric-revenue]`, and `[<data-model-element-name>/Total Revenue]` are
+column references, not metric references, and fail with `Dependency not found`
+when no such column exists.
+
+After creating or updating the data model, GET the model spec and confirm the
+metric is still present before authoring workbook references. A table element
+that gives a metric the exact same name as one of its columns can be accepted
+on write but return without its metrics on readback; rename the metric (preferred)
+or keep the workbook aggregation inline until readback confirms it.
+
 ## Metric
 
 ```json

--- a/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
@@ -319,6 +319,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -312,6 +312,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
@@ -312,6 +312,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -312,6 +312,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -317,6 +317,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/formulas.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/formulas.md
@@ -122,6 +122,34 @@ The prefix depends on the source type:
 
 - Column names must match exactly what the describe endpoint returns. **Never invent column names.**
 
+### Data-model metrics — use `[Metrics/<metric name>]`
+
+A metric in a data-model table's `metrics[]` is not a normal source column.
+Workbook elements sourcing that data-model element reference it through the
+reserved `Metrics` namespace:
+
+```yaml
+source:
+  kind: data-model
+  dataModelId: <data-model-id>
+  elementId: <element-id>
+columns:
+  - id: c-total-revenue
+    name: Total Revenue
+    formula: "[Metrics/Total Revenue]"
+```
+
+The segment after `Metrics/` is the metric's display `name`, not its `id`.
+`[Base/Total Revenue]`, `[Base/<metric-id>]`, and
+`[<data-model-element-name>/Total Revenue]` try to resolve columns and can
+return `400 Dependency not found`; that does not mean data-model metrics are
+unavailable to workbooks.
+
+GET the data-model spec after its write and bind only metrics present in the
+readback. If a metric and column on the same data-model element have identical
+names, rename the metric or use the inline aggregate: Sigma can accept that
+collision-shaped model and omit its metrics from readback.
+
 ## Control references
 
 `controlId` is the formula handle (distinct from the element `id`). Reference a

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/sources.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/sources.md
@@ -38,6 +38,15 @@ elementId: <element-uuid within that model>
 
 Optionally add `groupingId` to apply one of the model element's groupings.
 
+Columns exposed by the data-model element use the element's name as their
+formula prefix, for example `[Order Fact/Revenue]`. Governed metrics are
+different: reference them through the reserved namespace
+`[Metrics/<metric name>]`, for example `[Metrics/Total Revenue]`. Do not use
+the data-model element name or metric ID as the prefix. Confirm the metric is
+present in the data-model GET readback before binding a workbook formula; a
+successful model write alone does not prove that the metric survived
+normalization.
+
 ## join
 
 Joins multiple sources into one logical source via an array of `joins`. Each leg (`primarySource`, `left`, `right`) can be any source kind, so warehouse tables, other elements, and data-model elements can be joined interchangeably.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Document the reserved `[Metrics/<metric name>]` namespace so agents do not misinterpret failed `[Base/<metric>]` column references as proof that data-model metrics cannot flow into workbooks. Include readback and column/metric collision safeguards.

## Scope

- Plugin(s) touched: `sigma-authoring`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [ ] `ruby tools/check-shared.rb` — unavailable locally because this cloud image has no Ruby runtime; CI will run it
- [ ] `ruby tools/lint-skills.rb` — unavailable locally because this cloud image has no Ruby runtime; CI will run it
- [ ] `./corpus/run-corpus.sh --check` — unavailable locally because this cloud image has no Ruby runtime; documentation-only change
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in
- [x] Bumped `sigma-authoring` from 1.12.2 to 1.12.3
- [x] Regenerated non-Claude variants from the canonical skills
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07c9c018-6d3b-468b-859c-50a7e9e1dae0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07c9c018-6d3b-468b-859c-50a7e9e1dae0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

