### PR TITLE
Prefer proven table-based models for Tableau Custom SQL

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -91,6 +91,14 @@ formatting), defer to the companion **`sigma-workbooks`** skill
 (**`sigma-authoring`** plugin — install it alongside; this converter assumes
 it); this skill restates only Tableau-conversion-specific patterns.
 
+**Data-model source policy:** model physical warehouse tables as
+`warehouse-table` elements by default. Tableau Custom SQL is source logic to
+preserve, not an automatic instruction to embed that text in Sigma: decompose
+it into table elements + relationships/calculated columns when the same
+semantics can be represented and proven. Keep `source.kind: sql` only for logic
+that cannot be expressed faithfully in the model (or while establishing the
+parity baseline). See `refs/phase-3-datamodel.md`.
+
 ---
 
 ## Step −1 — Mission intake (MANDATORY — before anything else)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -91,14 +91,6 @@ formatting), defer to the companion **`sigma-workbooks`** skill
 (**`sigma-authoring`** plugin — install it alongside; this converter assumes
 it); this skill restates only Tableau-conversion-specific patterns.
 
-**Data-model source policy:** model physical warehouse tables as
-`warehouse-table` elements by default. Tableau Custom SQL is source logic to
-preserve, not an automatic instruction to embed that text in Sigma: decompose
-it into table elements + relationships/calculated columns when the same
-semantics can be represented and proven. Keep `source.kind: sql` only for logic
-that cannot be expressed faithfully in the model (or while establishing the
-parity baseline). See `refs/phase-3-datamodel.md`.
-
 ---
 
 ## Step −1 — Mission intake (MANDATORY — before anything else)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/data-model-spec.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/data-model-spec.md
@@ -57,7 +57,12 @@ The prefix in a column formula is the **last segment of the `path` array**, exac
 
 ## Element shape (Custom SQL)
 
-Use a Custom SQL element whenever the source data is a SQL query — including any Tableau workbook that uses Custom SQL **and** any DM that needs window aggregates (`SUM() OVER`, `RANK()`, `RUNNING_SUM`, etc.) which Sigma's calc-column functions cannot express.
+Use a Custom SQL element when preserving the source semantics requires a SQL
+query—for example, a vendor-specific operation or a manual window residue that
+Sigma's model cannot express. A Tableau Custom SQL block is not by itself a
+reason to embed the SQL in the target model: prefer physical
+`warehouse-table` elements plus relationships/calc columns when they can
+represent the query exactly and an equivalence probe confirms the rewrite.
 
 ```json
 {
@@ -93,14 +98,27 @@ Use a Custom SQL element whenever the source data is a SQL query — including a
 ### When to use a Custom SQL element vs a warehouse-table element
 
 Use a Custom SQL element when:
-- The Tableau source workbook uses Custom SQL (detected by `extract-custom-sql.rb` in Phase 1f).
-- The DM needs **window aggregates** (`SUM() OVER`, `RANK()`, `ROW_NUMBER()`, `LAG/LEAD`, etc.). Sigma's calc-column window functions (`SumOver`, `RankOver`, `CumulativeSum`, etc.) silently produce `error` type columns and the chart that references them renders blank. The validator hard-fails on these — see `scripts/validate-spec.rb`.
+- Tableau Custom SQL contains semantics that cannot be represented faithfully
+  with warehouse tables, relationships, filters, and Sigma calc columns.
+- The migration has a **manual window residue** that the chart-formula
+  translator cannot express and therefore needs warehouse SQL (`SUM() OVER`,
+  `RANK()`, `ROW_NUMBER()`, `LAG/LEAD`, etc.). Do not put window functions in
+  DM calc columns; see `refs/window-functions.md` for the mainstream family
+  emitted directly on charts.
 - The DM needs **LOD-equivalent pre-aggregation**. Tableau `{FIXED [Dim] : SUM([X])}` becomes `SUM(X) OVER (PARTITION BY Dim)` in the Custom SQL or a pre-aggregated subquery joined back.
 - The customer's data model is already SQL-shaped in Tableau (CTEs, joins, derived columns) and breaking it apart into raw warehouse tables would lose semantics.
 
-Use a `warehouse-table` element when the source is a single physical table and all derived columns can be expressed as Sigma calc columns (scalar `If`/`Case`/`Lookup`/etc. — no window aggregates).
+Use `warehouse-table` elements when the source tables are discoverable and the
+SQL's joins, predicates, projections, and scalar derivations can be reproduced
+without changing row grain or values. This is the maintainable default, not a
+license to drop SQL behavior. Rewriting Custom SQL into tables is a structural
+semantic edit: record both forms and pass `scripts/probe-equivalence.rb` before
+shipping. A failed or unavailable proof means preserve the SQL for parity.
 
-You can mix both kinds of elements in the same DM. A common pattern: warehouse-table elements for the dimension tables (Customer Dim, Product Dim, Date Dim), Custom SQL element for the fact table when it needs window aggregates.
+You can mix both kinds of elements in the same DM. A common pattern is
+warehouse-table elements for dimensions and the ordinary fact, plus a narrowly
+scoped Custom SQL helper only for a manual residue that cannot run as a native
+chart formula.
 
 ### Tableau Custom SQL → Sigma SQL — common rewrites
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-3-datamodel.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-3-datamodel.md
@@ -29,6 +29,30 @@ Write the spec to `<WORK>/dm-spec.json`. Full schema is in
 4. **Element name = formula prefix**. The `name` field on a DM element (e.g. `"Orders"`) becomes the prefix in all workbook formulas that reference it: `[Orders/Sales]`. Choose clean, stable names.
 5. **Relationships go on the source element**, not the target. See `refs/data-model-spec.md`.
 6. **Column formulas use the warehouse table name as prefix**: path `["DEMO_DB", "Tableau Test", "ORDERS"]` → formula `"[ORDERS/Column Name]"`.
+7. **Tables first; Custom SQL only with a reason.** A Tableau
+   `<relation type="text">` proves that the source used SQL, but does not make
+   embedded SQL the preferred Sigma model. When its tables, joins, filters,
+   and scalar derivations can be represented exactly as `warehouse-table`
+   elements + relationships/calc columns, use that maintainable model and
+   record an equivalence proof in `semantic-edits.json`. Preserve
+   `source.kind: "sql"` when decomposition would change grain, filtering,
+   aggregation, window behavior, vendor-specific semantics, or cannot yet be
+   proven. Never discard SQL clauses merely to get a table-shaped model.
+
+### Data-model metrics in workbook formulas
+
+Metrics defined in a data-model element's `metrics[]` **do flow into workbook
+elements** that source that model element. Reference them through the reserved
+namespace `[Metrics/<metric name>]` (name, not ID). `[Base/<metricName>]`,
+`[Base/<metricId>]`, and `[<element name>/<metric name>]` are column lookups;
+their `400 Dependency not found` response does not establish that metrics are
+unavailable.
+
+The orchestrator already writes the readback-confirmed metric census to
+`<WORK>/metrics.json` and binds equivalent chart/KPI measures through
+`[Metrics/<name>]`. If a metric has the exact same name as a column on its
+element, Sigma can omit that element's metrics from readback; the binder
+intentionally keeps those measures inline. Do not override that safeguard.
 
 ### When to use a Custom SQL element instead of a calc column
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -3591,15 +3591,19 @@ calcs.select { |c| c['requires_custom_sql'] }.each do |c|
   }
 end
 
-# (b) custom-SQL datasource blocks — DM must source via kind:sql, not warehouse-table.
+# (b) custom-SQL datasource blocks — preserve the semantics, but do not mistake
+#     source SQL for a mandate to embed SQL in the target model. Tables are the
+#     maintainable default when decomposition is exact + equivalence-proven.
 custom_sql.each do |b|
   q = (b['query'] || b['sql'] || '').to_s.gsub(/\s+/, ' ').strip[0, 120]
   questions << {
     'id' => 'custom_sql_datasource', 'severity' => 'review',
-    'detail' => "Datasource is backed by Custom SQL; the DM element must use source.kind=sql: #{q}",
-    'options' => ['source the DM element via Custom SQL (kind: sql)',
+    'detail' => "Datasource is backed by Tableau Custom SQL. Prefer warehouse-table elements + relationships/calcs " \
+                "when they preserve every join/filter/grain rule and pass the equivalence probe; otherwise retain source.kind=sql: #{q}",
+    'options' => ['normalize to warehouse-table elements (only with a passing semantic equivalence proof)',
+                  'preserve the Custom SQL in source.kind=sql for exact parity',
                   'abort and refactor the source in the warehouse first'],
-    'default' => 'source the DM element via Custom SQL (kind: sql)'
+    'default' => 'normalize to warehouse-table elements when equivalence is provable; otherwise preserve source.kind=sql'
   }
 end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Correct the Tableau migration guidance that treated any Tableau Custom SQL block as a mandate to embed that SQL in Sigma. The phase-scoped guidance now prefers maintainable warehouse-table elements and relationships when the full SQL semantics can be represented and proven equivalent, while retaining Custom SQL when decomposition would change grain, filters, aggregation, or vendor-specific behavior. It also documents the existing `[Metrics/<name>]` workbook binding contract.

## Scope

- Plugin(s) touched: `tableau-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] Ruby syntax parsed successfully with tree-sitter locally
- [x] `git diff --check` — green
- [x] Corpus golden check — green in CI on the feature revision
- [x] Shared-lib drift gate — green in CI on the feature revision
- [x] Skill conformance / byte budget — green after phase-scoping the policy
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in
- [x] Bumped `tableau-to-sigma` from 1.9.11 to 1.9.12
- [x] Follow-up prose-only correction carries a documented version-bump exemption
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07c9c018-6d3b-468b-859c-50a7e9e1dae0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07c9c018-6d3b-468b-859c-50a7e9e1dae0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

