### PR TITLE
fix(shared): stop flagging supported data-model metrics

### DIFF
--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.28",
+  "version": "1.8.29",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-scan.rb
@@ -36,10 +36,8 @@
 #      month/date axis canonicalization (MakeDate), stale-source freshness
 #      note (time-boxed wording), title corrections from source captions.
 #   DESCOPED (trial-proven spec-unsupported; emitted as propose-in-UI NOTES,
-#   never spec changes): DM-metric promotion (metric refs don't resolve
-#   through a workbook table layer), chart-as-filter (useAsFilter silently
-#   dropped on readback), pie percent labels (valueFormat:'percent' silently
-#   dropped).
+#   never spec changes): chart-as-filter (useAsFilter silently dropped on
+#   readback), pie percent labels (valueFormat:'percent' silently dropped).
 #
 # Usage:
 #   ruby scripts/enhance-scan.rb --workbook-id <parityWorkbookId> \
@@ -668,19 +666,6 @@ if viz.any? { |(_p, e)| e['kind'] == 'pie-chart' }
               'readback (trial-proven, same class as trellis/tooltip). Value labels persist; percent ' \
               'style must be set in the Sigma UI.',
     'evidence' => "#{viz.count { |(_p, e)| e['kind'] == 'pie-chart' }} pie-chart element(s) present."
-  }
-end
-dm_sourced = masters.any? { |m| m.dig('source', 'kind') == 'data-model' } ||
-             viz.any? { |(_p, e)| e.dig('source', 'kind') == 'data-model' }
-inline_aggs = viz.count { |(_p, e)| (y_col(e) || {})['formula'].to_s =~ /\A(Sum|Avg|Count|CountDistinct|Min|Max)\(/ }
-if dm_sourced && inline_aggs.positive?
-  descoped << {
-    'id' => 'descoped-dm-metric-promotion',
-    'note' => 'DM metric promotion: charts re-implement aggregate formulas inline, but DM metrics are ' \
-              'NOT referenceable from a chart through an intermediate workbook table ([Master/Metric] -> ' \
-              '"Dependency not found"; bare [Metric] compiles to a silent error column — trial-proven). ' \
-              'Promote in the DM and rebind in the Sigma UI if governance requires it.',
-    'evidence' => "#{inline_aggs} chart(s) carry inline aggregate formulas over a data-model source."
   }
 end
 shared_masters = viz.group_by { |(_p, e)| e.dig('source', 'elementId') }.select { |_k, v| v.size >= 2 }

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-scan.rb
@@ -36,10 +36,8 @@
 #      month/date axis canonicalization (MakeDate), stale-source freshness
 #      note (time-boxed wording), title corrections from source captions.
 #   DESCOPED (trial-proven spec-unsupported; emitted as propose-in-UI NOTES,
-#   never spec changes): DM-metric promotion (metric refs don't resolve
-#   through a workbook table layer), chart-as-filter (useAsFilter silently
-#   dropped on readback), pie percent labels (valueFormat:'percent' silently
-#   dropped).
+#   never spec changes): chart-as-filter (useAsFilter silently dropped on
+#   readback), pie percent labels (valueFormat:'percent' silently dropped).
 #
 # Usage:
 #   ruby scripts/enhance-scan.rb --workbook-id <parityWorkbookId> \
@@ -668,19 +666,6 @@ if viz.any? { |(_p, e)| e['kind'] == 'pie-chart' }
               'readback (trial-proven, same class as trellis/tooltip). Value labels persist; percent ' \
               'style must be set in the Sigma UI.',
     'evidence' => "#{viz.count { |(_p, e)| e['kind'] == 'pie-chart' }} pie-chart element(s) present."
-  }
-end
-dm_sourced = masters.any? { |m| m.dig('source', 'kind') == 'data-model' } ||
-             viz.any? { |(_p, e)| e.dig('source', 'kind') == 'data-model' }
-inline_aggs = viz.count { |(_p, e)| (y_col(e) || {})['formula'].to_s =~ /\A(Sum|Avg|Count|CountDistinct|Min|Max)\(/ }
-if dm_sourced && inline_aggs.positive?
-  descoped << {
-    'id' => 'descoped-dm-metric-promotion',
-    'note' => 'DM metric promotion: charts re-implement aggregate formulas inline, but DM metrics are ' \
-              'NOT referenceable from a chart through an intermediate workbook table ([Master/Metric] -> ' \
-              '"Dependency not found"; bare [Metric] compiles to a silent error column — trial-proven). ' \
-              'Promote in the DM and rebind in the Sigma UI if governance requires it.',
-    'evidence' => "#{inline_aggs} chart(s) carry inline aggregate formulas over a data-model source."
   }
 end
 shared_masters = viz.group_by { |(_p, e)| e.dig('source', 'elementId') }.select { |_k, v| v.size >= 2 }

--- a/shared/scripts/enhance-scan.rb
+++ b/shared/scripts/enhance-scan.rb
@@ -36,10 +36,8 @@
 #      month/date axis canonicalization (MakeDate), stale-source freshness
 #      note (time-boxed wording), title corrections from source captions.
 #   DESCOPED (trial-proven spec-unsupported; emitted as propose-in-UI NOTES,
-#   never spec changes): DM-metric promotion (metric refs don't resolve
-#   through a workbook table layer), chart-as-filter (useAsFilter silently
-#   dropped on readback), pie percent labels (valueFormat:'percent' silently
-#   dropped).
+#   never spec changes): chart-as-filter (useAsFilter silently dropped on
+#   readback), pie percent labels (valueFormat:'percent' silently dropped).
 #
 # Usage:
 #   ruby scripts/enhance-scan.rb --workbook-id <parityWorkbookId> \
@@ -668,19 +666,6 @@ if viz.any? { |(_p, e)| e['kind'] == 'pie-chart' }
               'readback (trial-proven, same class as trellis/tooltip). Value labels persist; percent ' \
               'style must be set in the Sigma UI.',
     'evidence' => "#{viz.count { |(_p, e)| e['kind'] == 'pie-chart' }} pie-chart element(s) present."
-  }
-end
-dm_sourced = masters.any? { |m| m.dig('source', 'kind') == 'data-model' } ||
-             viz.any? { |(_p, e)| e.dig('source', 'kind') == 'data-model' }
-inline_aggs = viz.count { |(_p, e)| (y_col(e) || {})['formula'].to_s =~ /\A(Sum|Avg|Count|CountDistinct|Min|Max)\(/ }
-if dm_sourced && inline_aggs.positive?
-  descoped << {
-    'id' => 'descoped-dm-metric-promotion',
-    'note' => 'DM metric promotion: charts re-implement aggregate formulas inline, but DM metrics are ' \
-              'NOT referenceable from a chart through an intermediate workbook table ([Master/Metric] -> ' \
-              '"Dependency not found"; bare [Metric] compiles to a silent error column — trial-proven). ' \
-              'Promote in the DM and rebind in the Sigma UI if governance requires it.',
-    'evidence' => "#{inline_aggs} chart(s) carry inline aggregate formulas over a data-model source."
   }
 end
 shared_masters = viz.group_by { |(_p, e)| e.dig('source', 'elementId') }.select { |_k, v| v.size >= 2 }


### PR DESCRIPTION
## What & why

Remove the obsolete Phase E detector that tells Tableau and Power BI users data-model metrics cannot be referenced from workbook charts. Both builders already bind formula-equivalent, readback-confirmed metrics through `[Metrics/<name>]`, so the detector emitted incorrect UI-only remediation after successful governed binding was available.

## Scope

- Shared canonical `enhance-scan.rb` plus its Tableau and Power BI vendored copies
- [x] This is an isolated shared-lib change with no plugin-specific feature work

## Checklist

- [x] Edited `shared/scripts/enhance-scan.rb` and ran `ruby tools/sync-shared.rb`
- [x] `ruby tools/check-shared.rb`
- [x] `ruby tools/lint-skills.rb`
- [x] Ruby syntax checks for the canonical script and both copies
- [x] Tableau governed-metric regression suite
- [x] Hygiene sweep and `git diff --check`
- [x] Bumped Tableau to 1.9.13 and Power BI to 1.8.29
- [ ] Full local corpus: 26/28; the remaining existing cases require Node or Ruby newer than the system Ruby 2.6. CI runs the supported runtimes.