### PR TITLE
Fix Tableau control and title-token handling across the workbook/data-model boundary

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-5-workbook.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-5-workbook.md
@@ -73,6 +73,15 @@ reference to the data-model control. Workbook calculations may reference the
 workbook control as `[<workbook controlId>]`; data-model calculations reference
 their local data-model control, and `parameters[]` is the bridge between them.
 
+The same document boundary applies to **dynamic text in a title**. Tableau
+serializes a displayed parameter in a worksheet title as
+`<[Parameters].[Parameter 1 3]>`; Sigma renders that literally, so it must be
+translated to `{{[<controlId>]}}` — and only against a control the **workbook**
+carries. Dynamic text cannot reach a data-model control, so when a parameter was
+converted into a data-model control only, `build-charts-from-signals.rb`
+substitutes the parameter's current value instead and records why. `validate-spec.rb`
+fails the spec if any raw Tableau token would reach POST.
+
 ### Migration coverage — WARN vs NOTE (read this before reacting to log volume)
 The build prints two prefixes (bead beads-sigma-59mk). **`NOTE`** = a success
 confirmation or a verify-nudge — NOT a gap (`translated inline:` / `decomposed:` /

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-5-workbook.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-5-workbook.md
@@ -50,6 +50,29 @@ A very common Tableau idiom: a **parameter** (e.g. "Select Metric": Sales / Prof
 3. **`SUM(CASE …)` (CASE inside the aggregate)** and **per-branch `SUM()`** both translate; the outer aggregate comes from the chart shelf, so don't hand-wrap a second time.
 4. If the calc doesn't auto-translate (compound/inequality condition, LOD-wrapped branch, branch referencing another calc), the build emits a manual note — hand-author the control + `Switch` measure per the shape above, then re-verify with #1 and #2.
 
+### Workbook controls that drive data-model calculations
+
+Control formula scope is document-local. A workbook control named
+`ctl-param-region` does **not** drive a data-model calculation that references a
+data-model control merely because the IDs or captions match. The workbook
+control must target the data-model control explicitly:
+
+```json
+"parameters": [
+  {
+    "kind": "data-model",
+    "dataModelId": "<posted-data-model-id>",
+    "controlId": "<readback data-model controlId>"
+  }
+]
+```
+
+The orchestrator adds this binding after the data-model readback and records
+`<WORK>/dm-control-bindings.json`. Never replace it with a workbook formula
+reference to the data-model control. Workbook calculations may reference the
+workbook control as `[<workbook controlId>]`; data-model calculations reference
+their local data-model control, and `parameters[]` is the bridge between them.
+
 ### Migration coverage — WARN vs NOTE (read this before reacting to log volume)
 The build prints two prefixes (bead beads-sigma-59mk). **`NOTE`** = a success
 confirmation or a verify-nudge — NOT a gap (`translated inline:` / `decomposed:` /

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -276,7 +276,12 @@ def tile_title(zone, fallback)
   t = zone && zone['display_title']
   return fallback unless t && !t.to_s.strip.empty?
 
-  TableauDynamicTitle.translate(t.to_s.strip, zone['calculations'])
+  # `<Sheet Name>` resolves here (the worksheet is known). Parameter tokens are
+  # deliberately left for the post-pass below: a Sigma dynamic-text reference
+  # only renders against a control the WORKBOOK carries, and no control has been
+  # built yet at tile-build time.
+  TableauDynamicTitle.translate(t.to_s.strip, zone['calculations'],
+                                sheet_name: fallback, control_ids: [])
 end
 
 # Carry an explicitly-authored Tableau color-legend zone into Sigma's native
@@ -7912,6 +7917,38 @@ end
 
 all_extras = extras + param_controls + auto_controls
 
+# ---- Tableau title tokens → Sigma dynamic text (post-pass) ------------------
+# Runs AFTER every control is built, because workbook dynamic text renders only
+# against a control the WORKBOOK carries. A Tableau parameter is commonly
+# converted into a DATA-MODEL control, which workbook dynamic text cannot
+# reference; for those the parameter's current value is substituted so the title
+# reads the way the source displayed it. Without this pass the raw Tableau token
+# ships into the element name and Sigma renders it literally, e.g.
+# "Sales Orders - Last <[Parameters].[Parameter 1 3]> weeks" (field-caught).
+begin
+  title_control_ids = all_extras.map { |c| c['controlId'] }.compact
+  title_parameters = meta['parameters'] || []
+  title_calculations = (meta['worksheets'] || {}).values.flat_map { |w| w['calculations'] || [] }
+  title_notes = []
+  (elements + all_extras).each do |el|
+    next unless el.is_a?(Hash)
+
+    %w[name body].each do |field|
+      next unless el[field].is_a?(String)
+
+      translated = TableauDynamicTitle.translate(
+        el[field], title_calculations,
+        parameters: title_parameters, control_ids: title_control_ids, notes: title_notes
+      )
+      el[field] = translated
+    end
+  end
+  title_notes.uniq.each { |note| warnings << note }
+rescue StandardError => e
+  warnings << "title-token translation skipped (#{e.class}: #{e.message}) — raw Tableau parameter " \
+              'tokens may remain in element names; the pre-POST lint (N2) will name them'
+end
+
 # ---- Control-coverage reconciliation — "never miss a .twb parameter/filter" ----
 # Enumerate EVERY extracted parameter + quick-filter and confirm each is
 # accounted for (emitted / needs-wiring / needs-materialization / dropped-with-
@@ -8680,6 +8717,14 @@ if opts[:pages_mode] == :worksheet
         end
         col['formula'] = f
       end
+      # Dynamic text in a title/body references a control the same way a formula
+      # does, so it has to follow the per-page controlId suffix or it points at
+      # an id this page no longer carries and renders nothing.
+      %w[name body].each do |field|
+        next unless el[field].is_a?(String)
+
+        ctl_rewrites.each { |from, to| el[field] = el[field].gsub("{{[#{from}]}}", "{{[#{to}]}}") }
+      end
       # A set-control-value effect's `control` names a param/auto controlId —
       # the SAME id this page just suffixed above. Without this, an emitted
       # action (parameter-action emission is currently gated off in
@@ -8794,6 +8839,13 @@ elsif opts[:pages_mode] == :dashboard
         f = col['formula'].to_s
         ctl_rewrites.each { |from, to| f = f.gsub("[#{from}]", "[#{to}]") }
         col['formula'] = f
+      end
+      # Dynamic text in a title/body follows the same per-page controlId suffix
+      # as a formula reference (see the page-per-worksheet branch above).
+      %w[name body].each do |field|
+        next unless el[field].is_a?(String)
+
+        ctl_rewrites.each { |from, to| el[field] = el[field].gsub("{{[#{from}]}}", "{{[#{to}]}}") }
       end
       # A parameter-action's set-control-value effect names a param/auto
       # controlId — the SAME id this dashboard page just suffixed above via

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/dm_control_binding.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/dm_control_binding.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+#
+# Bind workbook controls to controls in a sourced Sigma data model.
+#
+# A workbook formula can reference only a WORKBOOK control by [controlId].
+# Reusing the same text as a data-model controlId does not cross the document
+# boundary. Sigma's explicit bridge is the workbook control's `parameters[]`:
+#   {kind:"data-model", dataModelId:"...", controlId:"<DM control id>"}
+#
+# The Tableau converter emits parameter controls into the DM, while the chart
+# builder emits the interactive workbook controls. This helper joins those two
+# artifacts by stable Tableau caption/controlId and adds the bridge.
+
+module DmControlBinding
+  module_function
+
+  PREFIX_RE = /\Actl-(?:param|parameter)-/i
+
+  def norm(value)
+    value.to_s.downcase.gsub(/[^a-z0-9]/, '')
+  end
+
+  def keys(control, workbook: false)
+    values = [control['controlId'], control['name']]
+    values << control['controlId'].to_s.sub(PREFIX_RE, '') if workbook
+    values.map { |value| norm(value) }.reject(&:empty?).uniq
+  end
+
+  def workbook_controls(spec)
+    document = spec.is_a?(Hash) && spec['document'].is_a?(Hash) ? spec['document'] : spec
+    elements = if document.is_a?(Hash) && document['elements'].is_a?(Array)
+                 document['elements']
+               else
+                 Array(document && document['pages']).flat_map { |page| Array(page['elements']) }
+               end
+    elements.select { |element| element.is_a?(Hash) && element['kind'] == 'control' }
+  end
+
+  # Mutates `spec`. DM controls must come from the POST/GET readback census, not
+  # the authored request, so a stripped/rejected control can never be targeted.
+  # Returns an audit hash with bound, unmatched, and ambiguous workbook controls.
+  def bind!(spec, data_model_id:, data_model_elements:)
+    dm_controls = Array(data_model_elements).select do |element|
+      element.is_a?(Hash) && element['kind'] == 'control' &&
+        !element['controlId'].to_s.empty?
+    end
+    index = Hash.new { |hash, key| hash[key] = [] }
+    dm_controls.each { |control| keys(control).each { |key| index[key] << control } }
+
+    result = { bound: [], unmatched: [], ambiguous: [] }
+    workbook_controls(spec).each do |control|
+      candidates = keys(control, workbook: true).flat_map { |key| index[key] }.uniq
+      label = control['name'] || control['controlId'] || control['id']
+      if candidates.empty?
+        result[:unmatched] << label
+        next
+      end
+      if candidates.length > 1
+        result[:ambiguous] << {
+          'workbook_control' => label,
+          'data_model_controls' => candidates.map { |candidate| candidate['controlId'] }
+        }
+        next
+      end
+
+      target = {
+        'kind' => 'data-model',
+        'dataModelId' => data_model_id,
+        'controlId' => candidates.first['controlId']
+      }
+      control['parameters'] ||= []
+      unless control['parameters'].any? do |parameter|
+               parameter.is_a?(Hash) &&
+                 parameter['kind'] == target['kind'] &&
+                 parameter['dataModelId'] == target['dataModelId'] &&
+                 parameter['controlId'] == target['controlId']
+             end
+        control['parameters'] << target
+      end
+      result[:bound] << {
+        'workbook_control' => label,
+        'workbook_control_id' => control['controlId'],
+        'data_model_control_id' => target['controlId']
+      }
+    end
+    result
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_dynamic_title.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_dynamic_title.rb
@@ -1,28 +1,102 @@
 # frozen_string_literal: true
 
-# Converts Tableau's parameter-token title syntax into Sigma dynamic text.
-# Tableau serializes a displayed parameter as:
-#   <[Parameters].[Parameter 1 1]>
-# Sigma element titles use:
-#   {{[ctl-param-metric_switch_parameter]}}
+# Converts Tableau's title tokens into Sigma dynamic text.
+#
+# Tableau serializes a displayed parameter inside a worksheet title as
+#   <[Parameters].[Parameter 1 3]>
+# and the worksheet's own name as
+#   <Sheet Name>
+#
+# Sigma element titles reference a WORKBOOK control through dynamic text:
+#   {{[ctl-param-how-many-weeks]}}
+#
+# Two rules keep a translated title honest:
+#
+#   * A Tableau parameter is NOT a worksheet calculated field, so it is resolved
+#     against the workbook's `parameters` list. Resolving against calculations
+#     alone leaves the raw token in the element name, which Sigma renders
+#     literally ("Sales Orders - Last <[Parameters].[Parameter 1 3]> weeks").
+#
+#   * Workbook dynamic text can only reference a control that exists in the
+#     WORKBOOK. It cannot reach a control in a data model, and the converter
+#     frequently emits a Tableau parameter as a data-model control only. When
+#     the workbook control is absent, the parameter's current value is
+#     substituted instead — the value the source title displayed — so the title
+#     reads correctly rather than referencing a control that renders nothing.
 module TableauDynamicTitle
   PARAMETER_TOKEN = /<\[Parameters?\]\s*\.\s*\[([^\]]+)\]>/i
+  SHEET_NAME_TOKEN = /<(Sheet|Page|Workbook|Story|Dashboard)\s+Name>/i
+  # Residual Tableau title tokens, for the pre-POST lint. Deliberately narrow:
+  # a bracketed token or one of Tableau's title keywords, never bare comparison
+  # text such as "A > B".
+  RESIDUAL_TOKEN = /<\[[^\]<>]+\](?:\s*\.\s*\[[^\]<>]+\])?>|<(?:Sheet|Page|Workbook|Story|Dashboard)\s+Name>/i
 
   module_function
 
-  def translate(title, calculations)
-    title.to_s.gsub(PARAMETER_TOKEN) do |original|
-      token = Regexp.last_match(1).to_s.strip
-      parameter = Array(calculations).find do |calculation|
-        name = calculation['name'].to_s.gsub(/^\[|\]$/, '').strip
-        caption = calculation['caption'].to_s.strip
-        name.casecmp?(token) || caption.casecmp?(token)
-      end
-      caption = parameter && parameter['caption'].to_s.strip
-      next original if caption.nil? || caption.empty?
+  def slug(caption)
+    caption.to_s.downcase.gsub(/\W+/, '-').sub(/-\z/, '')
+  end
 
-      slug = caption.downcase.gsub(/\W+/, '-').sub(/-$/, '')
-      "{{[ctl-param-#{slug}]}}"
+  def control_id(caption)
+    "ctl-param-#{slug(caption)}"
+  end
+
+  # Tableau writes numeric parameter values as "12" or "0." depending on type;
+  # render the trailing-dot form the way the source displayed it.
+  def display_value(value)
+    text = value.to_s.strip
+    return text if text.empty?
+
+    text.sub(/\.0*\z/, '')
+  end
+
+  def find_parameter(token, parameters, calculations)
+    candidates = Array(parameters) + Array(calculations)
+    candidates.find do |candidate|
+      next false unless candidate.is_a?(Hash)
+
+      name = candidate['name'].to_s.gsub(/\A\[|\]\z/, '').strip
+      caption = candidate['caption'].to_s.strip
+      name.casecmp?(token) || caption.casecmp?(token)
     end
+  end
+
+  # `control_ids` is the set of controlIds the workbook will actually carry.
+  # Passing nil keeps the reference unconditionally (callers that have no
+  # control census yet); passing a collection gates the reference on it.
+  def translate(title, calculations, parameters: [], control_ids: nil, sheet_name: nil, notes: nil)
+    known = control_ids.nil? ? nil : Array(control_ids).map(&:to_s)
+    out = title.to_s.gsub(PARAMETER_TOKEN) do |original|
+      token = Regexp.last_match(1).to_s.strip
+      parameter = find_parameter(token, parameters, calculations)
+      caption = parameter && parameter['caption'].to_s.strip
+      if caption.nil? || caption.empty?
+        Array(notes) << "title parameter token <[Parameters].[#{token}]> matches no known parameter — " \
+                        'left in the title for migration review'
+        next original
+      end
+
+      cid = control_id(caption)
+      next "{{[#{cid}]}}" if known.nil? || known.include?(cid)
+
+      value = display_value(parameter['default_value'])
+      if value.empty?
+        Array(notes) << "title parameter '#{caption}' has no workbook control and no current value — " \
+                        'token left in the title for migration review'
+        next original
+      end
+      Array(notes) << "title parameter '#{caption}' resolved to its current value #{value.inspect} — " \
+                      'the workbook has no control for it (the converter emits it as a data-model ' \
+                      'control, which workbook dynamic text cannot reference); add a workbook control ' \
+                      'bound to the data-model control to make the title dynamic again'
+      value
+    end
+    out = out.gsub(SHEET_NAME_TOKEN) { sheet_name.to_s } if sheet_name && !sheet_name.to_s.strip.empty?
+    out
+  end
+
+  # Residual raw tokens in a built string (the pre-POST lint's input).
+  def residual_tokens(text)
+    text.to_s.scan(RESIDUAL_TOKEN).map { |match| match.is_a?(Array) ? match.first : match }
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -4215,6 +4215,10 @@ if reuse_dm_id
       { 'id' => p['id'], 'name' => p['name'],
         'elements' => (p['elements'] || []).map do |e|
           el = { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] }
+          if e['kind'] == 'control'
+            el['controlId'] = e['controlId']
+            el['controlType'] = e['controlType']
+          end
           el['columnLabels'] = labels_by_el[e['id']] if labels_by_el.key?(e['id'])
           el
         end }
@@ -4994,6 +4998,26 @@ else
   spec['name'] = display_wb_name if opts[:name]
   spec['folderId'] = opts[:folder] if opts[:folder]
   layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
+end
+# A control in the workbook cannot reference a control in the data model by
+# merely reusing `[controlId]`: formula control scope is document-local. Bridge
+# every matching Tableau parameter control through the released parameters[]
+# target shape, using ONLY the post/GET readback census in dm_els.
+require File.join(HERE, 'lib', 'dm_control_binding')
+dm_control_bindings = DmControlBinding.bind!(
+  spec, data_model_id: dm_id, data_model_elements: dm_els
+)
+File.write(
+  File.join(WORK, 'dm-control-bindings.json'),
+  JSON.pretty_generate(dm_control_bindings)
+)
+if dm_control_bindings[:bound].any?
+  line "DM control binding: #{dm_control_bindings[:bound].size} workbook control instance(s) " \
+       'target readback-confirmed data-model controls through parameters[]'
+end
+dm_control_bindings[:ambiguous].each do |ambiguity|
+  line "WARN: workbook control '#{ambiguity['workbook_control']}' matches multiple data-model controls " \
+       "(#{ambiguity['data_model_controls'].join(', ')}) — no parameters[] target emitted; disambiguate the control IDs"
 end
 # ---- PR-17: thin per-page master instances (default ON) ---------------------
 # Final structural pass over the assembled spec — runs AFTER the multi-metric

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -761,6 +761,15 @@ else
         'visibility' => p['visibility'],
         'elements' => (p['elements'] || []).map do |e|
           el = { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] }
+          # Workbook controls can target a data-model control only through an
+          # explicit parameters[] binding. Preserve the READBACK control handle
+          # (and type for audit/debugging) in dm-ids.json so the workbook builder
+          # never guesses from the authored request or tries a cross-document
+          # [controlId] formula reference.
+          if e['kind'] == 'control'
+            el['controlId'] = e['controlId']
+            el['controlType'] = e['controlType']
+          end
           el['columnLabels'] = labels_by_el[e['id']] if labels_by_el.key?(e['id'])
           if e.key?('metrics')
             el['metrics'] = Array(e['metrics']).map do |metric|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-control-binding.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-control-binding.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'lib/dm_control_binding'
+
+failures = []
+check = lambda do |condition, message|
+  failures << message unless condition
+end
+
+dm_elements = [
+  { 'id' => 'dm-ctl-region', 'kind' => 'control', 'controlId' => 'Region-Pick' },
+  { 'id' => 'dm-ctl-metric', 'kind' => 'control',
+    'controlId' => 'ctl-parameter-17', 'name' => 'Metric Picker' },
+  { 'id' => 'dm-table', 'kind' => 'table', 'name' => 'Orders' }
+]
+spec = {
+  'pages' => [
+    {
+      'id' => 'page-dashboard',
+      'elements' => [
+        { 'id' => 'wb-region', 'kind' => 'control',
+          'controlId' => 'ctl-param-region-pick-dashboard', 'name' => 'Region Pick' },
+        { 'id' => 'wb-metric', 'kind' => 'control',
+          'controlId' => 'ctl-parameter-17', 'name' => 'Metric Picker' },
+        { 'id' => 'wb-filter', 'kind' => 'control',
+          'controlId' => 'ctl-category', 'name' => 'Category' }
+      ]
+    }
+  ]
+}
+
+result = DmControlBinding.bind!(
+  spec, data_model_id: 'dm-123', data_model_elements: dm_elements
+)
+controls = spec['pages'][0]['elements']
+region_target = controls[0]['parameters']&.first
+metric_target = controls[1]['parameters']&.first
+
+check.call(region_target == {
+             'kind' => 'data-model',
+             'dataModelId' => 'dm-123',
+             'controlId' => 'Region-Pick'
+           }, 'caption match binds a page-suffixed workbook control to the DM control')
+check.call(metric_target && metric_target['controlId'] == 'ctl-parameter-17',
+           'exact converter controlId match binds to the DM control')
+check.call(!controls[2].key?('parameters'),
+           'ordinary workbook filters do not gain a data-model parameter target')
+check.call(result[:bound].length == 2 && result[:unmatched] == ['Category'],
+           'audit distinguishes bound parameter controls from unmatched filters')
+
+DmControlBinding.bind!(spec, data_model_id: 'dm-123', data_model_elements: dm_elements)
+check.call(controls[0]['parameters'].length == 1,
+           'binding is idempotent and does not duplicate parameters')
+
+canonical = {
+  'document' => {
+    'elements' => [
+      { 'id' => 'wb-region-2', 'kind' => 'control',
+        'controlId' => 'ctl-param-region-pick', 'name' => 'Region Pick' }
+    ]
+  }
+}
+DmControlBinding.bind!(
+  canonical, data_model_id: 'dm-123', data_model_elements: dm_elements
+)
+check.call(canonical.dig('document', 'elements', 0, 'parameters', 0, 'controlId') == 'Region-Pick',
+           'canonical flat document.elements shape is supported')
+
+if failures.empty?
+  puts 'ALL PASS — workbook controls target matching data-model controls'
+else
+  warn failures.map { |failure| "FAIL: #{failure}" }.join("\n")
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-tableau-dynamic-title.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-tableau-dynamic-title.rb
@@ -4,10 +4,7 @@
 require_relative 'lib/tableau_dynamic_title'
 
 failures = []
-check = lambda do |condition, message|
-  failures << message unless condition
-  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
-end
+check = ->(condition, message) { failures << message unless condition }
 
 calculations = [
   {
@@ -42,6 +39,71 @@ plain = 'Sales Order $ at Risk'
 check.call(
   TableauDynamicTitle.translate(plain, calculations) == plain,
   'static titles remain byte-identical'
+)
+
+# A Tableau PARAMETER is not a worksheet calculated field. Resolving a title
+# against calculations alone shipped "Sales Orders - Last
+# <[Parameters].[Parameter 1 3]> weeks" into a live element name.
+parameters = [
+  { 'name' => '[Parameter 1 3]', 'caption' => 'How Many Weeks',
+    'datatype' => 'integer', 'default_value' => '12' }
+]
+weeks = 'Sales Orders - Last <[Parameters].[Parameter 1 3]> weeks'
+check.call(
+  TableauDynamicTitle.translate(weeks, [], parameters: parameters) ==
+    'Sales Orders - Last {{[ctl-param-how-many-weeks]}} weeks',
+  'a parameter resolves from the parameter list, not only from calculations'
+)
+
+# Dynamic text renders only against a control the WORKBOOK carries. The
+# converter emits Tableau parameters as DATA-MODEL controls, which workbook
+# dynamic text cannot reference.
+notes = []
+check.call(
+  TableauDynamicTitle.translate(
+    weeks, [], parameters: parameters, control_ids: [], notes: notes
+  ) == 'Sales Orders - Last 12 weeks',
+  'without a workbook control the parameter value is substituted'
+)
+check.call(
+  notes.any? { |note| note.include?('How Many Weeks') && note.include?('data-model') },
+  'the value substitution is reported rather than applied silently'
+)
+check.call(
+  TableauDynamicTitle.translate(
+    weeks, [], parameters: parameters, control_ids: ['ctl-param-how-many-weeks']
+  ) == 'Sales Orders - Last {{[ctl-param-how-many-weeks]}} weeks',
+  'a present workbook control keeps the title dynamic'
+)
+
+valueless = [{ 'name' => '[Parameter 9]', 'caption' => 'No Value' }]
+token = 'Bottom <[Parameters].[Parameter 9]> stores'
+check.call(
+  TableauDynamicTitle.translate(token, [], parameters: valueless, control_ids: []) == token,
+  'a parameter with no control and no value keeps its token for review'
+)
+
+check.call(
+  TableauDynamicTitle.translate('<Sheet Name> detail', [], sheet_name: 'KPIs by Manager') ==
+    'KPIs by Manager detail',
+  'the sheet-name token resolves to the worksheet name'
+)
+
+check.call(
+  TableauDynamicTitle.residual_tokens(weeks) == ['<[Parameters].[Parameter 1 3]>'],
+  'residual_tokens finds a raw parameter token'
+)
+check.call(
+  TableauDynamicTitle.residual_tokens('<Sheet Name> detail').length == 1,
+  'residual_tokens finds a raw sheet-name token'
+)
+check.call(
+  TableauDynamicTitle.residual_tokens('Revenue > Plan and Cost < Budget').empty?,
+  'residual_tokens ignores ordinary comparison text'
+)
+check.call(
+  TableauDynamicTitle.residual_tokens('Last {{[ctl-param-how-many-weeks]}} weeks').empty?,
+  'residual_tokens ignores a translated Sigma dynamic reference'
 )
 
 puts

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-spec.rb
@@ -29,6 +29,7 @@ require 'sigma_functions'
 require 'formula_normalize'
 require 'metric_binding' # F4: column/metric collision shape — census admissibility
 require 'workbook_code'
+require 'tableau_dynamic_title' # raw Tableau title tokens must never reach POST
 
 opts = { type: nil, dm_context: nil }
 op = OptionParser.new do |p|
@@ -250,6 +251,30 @@ spec.fetch('pages', []).each do |page|
 end
 
 errors << 'spec contains rgb(...) color strings (Cloudflare WAF blocks)' if JSON.generate(spec).include?('rgb(')
+
+# Raw Tableau title tokens ("<[Parameters].[Parameter 1 3]>", "<Sheet Name>")
+# that survived translation. Sigma has no such syntax and renders the token
+# LITERALLY in the tile header, so the dashboard ships with it visible
+# (field-caught on a live migration). Translate to Sigma dynamic text
+# {{[<controlId>]}} against a control the WORKBOOK carries — workbook dynamic
+# text cannot reference a data-model control — or substitute the parameter's
+# current value. build-charts-from-signals.rb does both automatically; a hit
+# here means a hand-authored or stale spec.
+spec.fetch('pages', []).each do |page|
+  page.fetch('elements', []).each do |el|
+    %w[name body].each do |field|
+      next unless el[field].is_a?(String)
+
+      tokens = TableauDynamicTitle.residual_tokens(el[field]).uniq
+      next if tokens.empty?
+
+      errors << "element \"#{el['name'] || el['id']}\": #{field} carries raw Tableau title token(s) " \
+                "#{tokens.join(', ')} — Sigma renders them literally in the tile header. Use Sigma " \
+                'dynamic text {{[<controlId>]}} bound to a control this WORKBOOK carries (workbook ' \
+                "dynamic text cannot reach a data-model control), or substitute the parameter's value."
+    end
+  end
+end
 
 # ENVELOPE checks (field-caught round 2): a hand-authored spec missing these
 # passed "0 errors" locally and then burned one live 400 per defect, one


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Two defects with one root cause: the converter treats a workbook and its data model as one document, but Sigma scopes controls per document. Both were confirmed against a live migrated workbook.

**1. Workbook controls never targeted the data-model controls.** Tableau parameters become controls in the data model (driving model calculations) and separate controls in the workbook, with nothing connecting them. Matching IDs do not bridge documents. The orchestrator now emits the released target shape using readback-confirmed data-model control IDs and writes `dm-control-bindings.json`:

```json
"parameters": [{ "kind": "data-model", "dataModelId": "...", "controlId": "..." }]
```

**2. Raw Tableau title tokens shipped into element names.** A live tile was named `Sales Orders - Last <[Parameters].[Parameter 1 3]> weeks`. `TableauDynamicTitle` resolved tokens only against worksheet *calculations*, but a Tableau parameter is not a calculated field, so resolution essentially always failed and left the token in place. Fixes:

- resolve against the parameter list (and `<Sheet Name>`);
- emit `{{[controlId]}}` only when the **workbook** carries that control, because workbook dynamic text cannot reference a data-model control — otherwise substitute the parameter's current value and record why;
- carry dynamic text through the per-page controlId suffixing that formulas already got, so the reference does not go stale;
- `validate-spec.rb` now fails pre-POST on any residual token.

## Scope

- Plugin(s) touched: `tableau-to-sigma`
- [x] This PR touches exactly one plugin

`preflight_lint.rb` is shared infrastructure, so the new gate went into the tableau-owned `validate-spec.rb` instead of forking a vendored copy.

## Verification

Ran locally against a Ruby 3.2 runtime, plus a live org for the diagnosis.

- Full Tableau suite: 265/266 pass. The one failure (`test-calc-discovery.rb`) needs Tableau credentials and a fixture absent from this sandbox, and fails identically on the base commit.
- Corpus 28/28; shared-lib drift, skill conformance, agent variants, path lint, hygiene sweep all clean.
- End-to-end through the real builder on a synthetic fixture reproducing the defect:
  - before: `Sales Orders - Last <[Parameters].[Parameter 1 3]> weeks`
  - after, workbook control present: `Sales Orders - Last {{[ctl-param-how-many-weeks-metric-partner-closed]}} weeks`, verified to resolve against a control on that page
  - after, data-model-only parameter: `Sales Orders - Last 12 weeks` plus a recorded note
- The new validator gate flags all four leaked tokens in the live workbook that prompted this.

## Checklist

- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in
- [x] Bumped `tableau-to-sigma` from 1.9.12 to 1.9.14
- [x] Shared libraries untouched (no vendored-copy edits)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07c9c018-6d3b-468b-859c-50a7e9e1dae0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07c9c018-6d3b-468b-859c-50a7e9e1dae0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

