### PR TITLE
fix(qlik): preserve expanded dashboard fidelity

### DIFF
--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -318,6 +318,7 @@ QLIK_MSCHEME = {
     "sc": ["#ffffcc", "#fd8d3c", "#bd0026"],
 }
 QLIK_PRIMARY = "#4477AA"
+QLIK_SINGLE = {3: "#BDBDBD"}
 
 def qlik_color(color, dim_ids, mids, el):
     """Map a Qlik chart color encoding to a Sigma `color` channel, or None.
@@ -338,8 +339,18 @@ def qlik_color(color, dim_ids, mids, el):
         if base.get("format"): dup["format"] = base["format"]
         el["columns"].append(dup)
         return {"by": "scale", "column": cid, "scheme": scheme}
-    if mode in ("byDimension", "byExpression") and dim_ids:
-        return {"by": "category", "column": dim_ids[0]}
+    if mode == "byDimension" and dim_ids:
+        base = next((col for col in el["columns"] if col["id"] == dim_ids[0]), None)
+        if not base: return None
+        cid = nid("clr")
+        el["columns"].append({"id": cid, "formula": base["formula"],
+                              "name": base["name"] + " (color)"})
+        return {"by": "category", "column": cid}
+    if mode == "byExpression":
+        literal = c.get("singleColor")
+        if isinstance(literal, str) and literal.startswith("#"):
+            return {"by": "single", "value": literal}
+        return {"by": "single", "value": QLIK_SINGLE.get(literal, "#BDBDBD")}
     return None
 
 def qlik_refmarks(c):
@@ -357,9 +368,11 @@ def qlik_refmarks(c):
             formula = str(val) if isinstance(val, (int, float)) else (r.get("expr") or "")
             if not formula:
                 continue
+            raw_color = r.get("color")
+            line_color = raw_color if isinstance(raw_color, str) else ({2: "#46C646"}.get(raw_color))
             rm = {"type": "line", "axis": axis,
                   "value": {"type": "formula", "formula": formula},
-                  "line": {"color": r.get("color") or "#ef4444", "width": 2}}
+                  "line": {"color": line_color or "#EF4444", "width": 2}}
             if r.get("label"):
                 rm["label"] = {"visibility": "shown", "text": r["label"]}
             out.append(rm)
@@ -374,26 +387,27 @@ def apply_presentation(el, c):
     }
     if chart_kind and isinstance(legend, dict):
         out = {}
-        if legend.get("show") is not None:
-            out["visibility"] = "shown" if legend.get("show") else "hidden"
+        show = legend.get("show")
+        if show is False:
+            out["visibility"] = "hidden"
         dock = str(legend.get("dock") or "").lower()
-        if dock in ("top", "bottom", "left", "right"):
+        if show is not False and dock in ("top", "bottom", "left", "right"):
             out["position"] = dock
+        elif show is True:
+            out["visibility"] = "shown"
         if out:
             el["legend"] = out
 
     presentation = c.get("presentation") or {}
-    if el.get("kind") == "bar-chart":
-        orientation = str(presentation.get("orientation") or "").lower()
-        if orientation in ("horizontal", "vertical"):
-            el["orientation"] = orientation
     if el.get("kind") == "bar-chart":
         grouping = str(presentation.get("grouping") or "").lower()
         if grouping in ("stacked", "stack"):
             el["stacking"] = "stacked"
         elif grouping in ("normalized", "stacked100", "100%"):
             el["stacking"] = "normalized"
-        elif grouping in ("grouped", "clustered"):
+        elif grouping in ("grouped", "clustered") and len(el.get("yAxis", {}).get("columnIds", [])) > 1:
+            # The live API accepts "none" only when there are multiple series;
+            # single-series grouped bars are represented by omitting stacking.
             el["stacking"] = "none"
     if presentation.get("showLabels") is not None and el.get("kind", "").endswith("-chart"):
         el["dataLabel"] = {
@@ -550,6 +564,22 @@ def build_element(c, resolve, warnings, metrics=None):
         elif mapping.get("approximation"):
             warnings.append(f"'{title}' ({vt}) EXPLICIT APPROXIMATION: {mapping.get('notes')}")
 
+    presentation = c.get("presentation") or {}
+    if vt == "piechart" and presentation.get("showAsDonut"):
+        kind = "donut-chart"
+    elif vt == "linechart" and presentation.get("lineType") == "area":
+        kind = "area-chart"
+    elif vt == "combochart" and c.get("seriesTypes") and set(c["seriesTypes"]) == {"bar"}:
+        # Sigma normalizes an all-bar combo back to bar+line on readback.
+        # A multi-series bar chart preserves the Qlik rendering exactly.
+        kind = "bar-chart"
+    elif vt == "combochart" and c.get("seriesTypes") and set(c["seriesTypes"]) == {"line"}:
+        kind = "line-chart"
+    if kind == "bar-chart" and presentation.get("orientation") == "horizontal":
+        warnings.append(
+            f"'{title}' (barchart) HORIZONTAL ORIENTATION GAP: current Sigma workbook "
+            "spec rejects bar-chart.orientation; emitted the valid default vertical orientation")
+
     if dims_raw and any(d is None for d in dim_disp):
         warnings.append(f"skip '{title}': dim(s) {dims_raw} not on the denorm element"); return None
 
@@ -617,7 +647,7 @@ def build_element(c, resolve, warnings, metrics=None):
     if filters: el["filters"] = filters
 
     sort = qlik_sort(c, dim_ids, mids)
-    if sort is None and kind in ("table", "bar-chart") and mids:
+    if sort is None and kind in ("table", "bar-chart", "line-chart", "area-chart", "combo-chart") and mids:
         sort = (mids[0], "descending")   # Qlik auto-chart default: by measure, desc
 
     if kind == "table":
@@ -644,13 +674,16 @@ def build_element(c, resolve, warnings, metrics=None):
         if len(dim_ids) > 1:
             el["columnsBy"] = [{"id": d} for d in dim_ids[1:]]
         return apply_presentation(el, c)
-    if kind == "pie-chart":
+    if kind in ("pie-chart", "donut-chart"):
         el["value"] = {"id": mids[0]}; el["color"] = {"id": dim_ids[0]}
         el["dataLabel"] = {"labels": "shown"}
         return apply_presentation(el, c)
     if kind == "combo-chart":
-        y = [mids[0]] + [{"columnId": m, "type": "line"} for m in mids[1:]]
+        series = c.get("seriesTypes") or ["bar"] * len(mids)
+        y = [{"columnId": m, "type": series[i] if i < len(series) else "bar"}
+             for i, m in enumerate(mids)]
         el["xAxis"] = {"columnId": dim_ids[0]}; el["yAxis"] = {"columnIds": y}
+        if sort: el["xAxis"]["sort"] = {"by": sort[0], "direction": sort[1]}
         return apply_presentation(el, c)
     if kind == "box-chart":
         el["xAxis"] = {"columnId": dim_ids[0]}
@@ -718,6 +751,19 @@ def build_element(c, resolve, warnings, metrics=None):
     rm = qlik_refmarks(c)
     if rm: el["refMarks"] = rm
     return apply_presentation(el, c)
+
+
+def build_content_element(c):
+    """One source-less Qlik content object -> one source-less Sigma element."""
+    if c.get("vizType") != "text-image":
+        return None
+    title = c.get("title") or "Text"
+    markdown = str(c.get("markdown") or "").strip()
+    body = f"### {title}"
+    if markdown:
+        body += "\n\n" + markdown
+    return {"id": "el-" + re.sub(r"[^a-z0-9]", "", str(c["id"]).lower()),
+            "kind": "text", "name": title, "body": body}
 
 
 def build_tabbed_container(c, charts, resolve, warnings, metrics=None):
@@ -906,6 +952,9 @@ def banded_page(page_id, items, title, id_prefix=None, navigation_id=None):
     if items:
         offset += 1 - min(i[3] for i in items)  # first band starts under the header
     for n, band in enumerate(_decollide_bands(_cluster_bands(items)), 1):
+        if len(band) == 1 and (band[0][2] - band[0][1]) / 24 < 0.60:
+            item = band[0]
+            band = [[item[0], 1, 25, *item[3:]]]
         cid = f"{pfx}-{n}"
         extra.append({"id": cid, "kind": "container"})
         r0 = min(i[3] for i in band); r1 = max(i[4] for i in band)
@@ -1122,6 +1171,10 @@ def main():
                         placed.append((control_subcell(cell, i, len(ctls)), ctl))
                     n_controls += len(ctls)
                     continue
+                if c["vizType"] == "text-image":
+                    el = build_content_element(c)
+                    elems.append(el); placed.append((cell, el))
+                    continue
                 if c["vizType"] == "container":
                     tc, tc_layout, children, sources = build_tabbed_container(
                         c, charts, resolve, warnings, metrics)
@@ -1173,6 +1226,11 @@ def main():
                 elems.extend(ctls)
                 layout_elems.extend(ctls)
                 n_controls += len(ctls)
+                continue
+            if c["vizType"] == "text-image":
+                el = build_content_element(c)
+                elems.append(el)
+                layout_elems.append(el)
                 continue
             if c["vizType"] == "container":
                 tc, tc_layout, children, sources = build_tabbed_container(

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-denorm-sql.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-denorm-sql.py
@@ -93,6 +93,11 @@ def main():
             if f["realColumn"] == "*": continue
             if f["qlikField"].upper().endswith("_KEY"): continue
             value = projection(d, f, al)
+            if value is not None and f.get("isExpression") and jk:
+                # The expression belongs to the Qlik dimension table. A missing
+                # LEFT JOIN has no dimension row, so its calculated fields must
+                # remain null rather than evaluating an ELSE branch on SQL nulls.
+                value = f"CASE WHEN {al}.{real(d, jk)} IS NULL THEN NULL ELSE {value} END"
             if value is not None:
                 select.append(f'{value} AS {f["qlikField"]}')
     if unsupported:

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -181,7 +181,31 @@ def _presentation(props):
         out["grouping"] = str(grouping).lower()
     if show_labels is not None:
         out["showLabels"] = bool(show_labels)
+    line_type = props.get("lineType")
+    if line_type:
+        out["lineType"] = str(line_type).lower()
+    donut = props.get("donut") or {}
+    if isinstance(donut, dict) and donut.get("showAsDonut") is not None:
+        out["showAsDonut"] = bool(donut["showAsDonut"])
     return out or None
+
+
+def _combo_series(measure):
+    """Return the authored Qlik combo-series type; absent means Qlik's bar default."""
+    qdef = measure.get("qDef") or {}
+    raw = measure.get("series") or qdef.get("series")
+    if isinstance(raw, dict):
+        raw = raw.get("type")
+    raw = raw or measure.get("representation") or qdef.get("representation") or "bar"
+    return "line" if str(raw).lower() == "line" else "bar"
+
+
+def _content_fields(props, qtype):
+    """Static Qlik content that must survive even though it has no hypercube."""
+    if qtype != "text-image":
+        return {}
+    markdown = props.get("markdown")
+    return {"markdown": markdown} if isinstance(markdown, str) and markdown.strip() else {}
 
 
 def _gauge(props):
@@ -718,6 +742,9 @@ def main():
         presentation = _presentation(effective)
         if presentation:
             rec["presentation"] = presentation
+        if effective_type == "combochart":
+            rec["seriesTypes"] = [_combo_series(measure) for measure in qmeas]
+        rec.update(_content_fields(effective, effective_type))
         drills = _drill_groups(qdims)
         if drills:
             rec["drillGroups"] = drills

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/golden/retail_orders_workbook.spec.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/golden/retail_orders_workbook.spec.json
@@ -563,7 +563,11 @@
           }
         ],
         "xAxis": {
-          "columnId": "x2"
+          "columnId": "x2",
+          "sort": {
+            "by": "y5",
+            "direction": "descending"
+          }
         },
         "yAxis": {
           "columnIds": [
@@ -2081,7 +2085,11 @@
           }
         ],
         "xAxis": {
-          "columnId": "x21"
+          "columnId": "x21",
+          "sort": {
+            "by": "y37",
+            "direction": "descending"
+          }
         },
         "yAxis": {
           "columnIds": [

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_chart_mappings.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_chart_mappings.py
@@ -12,12 +12,16 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 SKILL = os.path.dirname(HERE)
 SCRIPTS = os.path.join(SKILL, "scripts")
 BUILDER = os.path.join(SCRIPTS, "build-sigma-workbook.py")
+DISCOVERY = os.path.join(SCRIPTS, "qlik-discover.py")
 CATALOG = os.path.join(SKILL, "refs", "catalogs", "viz-kind.json")
 
 sys.path.insert(0, os.path.join(SCRIPTS, "lib"))
 spec = importlib.util.spec_from_file_location("qlik_workbook_builder", BUILDER)
 builder = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(builder)
+discovery_spec = importlib.util.spec_from_file_location("qlik_discovery", DISCOVERY)
+discovery = importlib.util.module_from_spec(discovery_spec)
+discovery_spec.loader.exec_module(discovery)
 
 
 EXPECTED = {
@@ -66,7 +70,7 @@ def chart(viz_type):
         measures = ["Sum(REVENUE)", "Sum(COST)"]
     elif viz_type == "histogram":
         dims, measures = [["SCORE"]], []
-    return {
+    record = {
         "id": viz_type,
         "vizType": viz_type,
         "title": viz_type,
@@ -79,6 +83,9 @@ def chart(viz_type):
         "sort": {"interColumnSortOrder": [], "dimensions": [[]] * len(dims), "measures": [{}] * len(measures)},
         "gauge": {"min": 0, "max": 100, "shape": "bar"},
     }
+    if viz_type == "combochart":
+        record["seriesTypes"] = ["bar", "line"]
+    return record
 
 
 def test_catalog_is_complete():
@@ -135,7 +142,10 @@ def test_full_catalog_builds_one_workbook():
         charts_path = os.path.join(directory, "charts.json")
         denorm_path = os.path.join(directory, "denorm.json")
         spec_path = os.path.join(directory, "spec.json")
-        json.dump([chart(source) for source in EXPECTED], open(charts_path, "w", encoding="utf-8"))
+        source_charts = [chart(source) for source in EXPECTED]
+        source_charts.append({"id": "about", "vizType": "text-image", "title": "About",
+                              "markdown": "Authored source narrative."})
+        json.dump(source_charts, open(charts_path, "w", encoding="utf-8"))
         json.dump({"element": {"columns": [
             {"name": name, "formula": f"[Custom SQL/{raw}]"}
             for name, raw in [
@@ -163,6 +173,8 @@ def test_full_catalog_builds_one_workbook():
         for source, target in EXPECTED.items():
             element_id = "el-" + source.replace("-", "")
             assert elements[element_id]["kind"] == target, (source, elements.get(element_id))
+        assert elements["el-about"]["kind"] == "text"
+        assert "Authored source narrative." in elements["el-about"]["body"]
         coverage = json.load(open(os.path.join(directory, "workbook-coverage.json"), encoding="utf-8"))
         assert coverage["status"] == "PASS"
         assert coverage["sourceVisuals"] == len(EXPECTED)
@@ -193,6 +205,81 @@ def test_auto_chart_shape_mapping():
         builder._ids.clear()
         element = builder.build_element(record, auto_resolve, [])
         assert element["kind"] == expected, (dimensions, element["kind"], expected)
+
+
+def test_live_presentation_subtypes_and_content():
+    presentation = discovery._presentation({
+        "lineType": "area", "donut": {"showAsDonut": True},
+    })
+    assert presentation == {"lineType": "area", "showAsDonut": True}
+    assert discovery._combo_series({"qDef": {}}) == "bar"
+    assert discovery._combo_series({"qDef": {"series": {"type": "line"}}}) == "line"
+    assert discovery._content_fields({"markdown": "Source text"}, "text-image") == {
+        "markdown": "Source text"
+    }
+
+    area = chart("linechart")
+    area["presentation"] = {"lineType": "area"}
+    assert builder.build_element(area, RESOLVE, [])["kind"] == "area-chart"
+
+    donut = chart("piechart")
+    donut["presentation"] = {"showAsDonut": True}
+    assert builder.build_element(donut, RESOLVE, [])["kind"] == "donut-chart"
+
+    bars = chart("combochart")
+    bars["seriesTypes"] = ["bar", "bar"]
+    bars["presentation"] = {"grouping": "grouped"}
+    assert bars["seriesTypes"] == ["bar", "bar"]
+    combo = builder.build_element(bars, RESOLVE, [])
+    measure_ids = [column["id"] for column in combo["columns"] if column["id"].startswith("y")]
+    assert combo["kind"] == "bar-chart"
+    assert combo["yAxis"]["columnIds"] == measure_ids
+    assert combo["stacking"] == "none"
+    assert combo["xAxis"]["sort"] == {"by": measure_ids[0], "direction": "descending"}
+
+    mixed = chart("combochart")
+    mixed["seriesTypes"] = ["bar", "line"]
+    mixed_element = builder.build_element(mixed, RESOLVE, [])
+    assert mixed_element["kind"] == "combo-chart"
+    assert mixed_element["yAxis"]["columnIds"][1]["type"] == "line"
+
+    auto_sorted_area = chart("linechart")
+    auto_sorted_area["presentation"] = {"lineType": "area"}
+    area_element = builder.build_element(auto_sorted_area, RESOLVE, [])
+    assert area_element["xAxis"]["sort"]["direction"] == "descending"
+
+    grouped = chart("barchart")
+    grouped["presentation"] = {"grouping": "grouped"}
+    assert "stacking" not in builder.build_element(grouped, RESOLVE, [])
+
+    horizontal = chart("barchart")
+    horizontal["presentation"] = {"orientation": "horizontal"}
+    horizontal_warnings = []
+    assert "orientation" not in builder.build_element(horizontal, RESOLVE, horizontal_warnings)
+    assert any("HORIZONTAL ORIENTATION GAP" in warning for warning in horizontal_warnings)
+
+    colored = chart("barchart")
+    colored["color"] = {"mode": "byDimension"}
+    colored_element = builder.build_element(colored, RESOLVE, [])
+    assert colored_element["color"]["column"] != colored_element["xAxis"]["columnId"]
+
+    expression_colored = chart("linechart")
+    expression_colored["color"] = {"mode": "byExpression", "singleColor": "#4477aa"}
+    assert builder.build_element(expression_colored, RESOLVE, [])["color"] == {
+        "by": "single", "value": "#4477aa"
+    }
+
+    refmarks = builder.qlik_refmarks({
+        "refLines": {"x": [], "y": [{"value": 0.85, "color": 2}]}
+    })
+    assert refmarks[0]["line"]["color"] == "#46C646"
+
+
+def test_sparse_singleton_band_expands_to_full_width():
+    layout, _ = builder.banded_page(
+        "page", [["pivot", 1, 13, 1, 11, {"kind": "pivot-table"}]], "Charts"
+    )
+    assert 'elementId="pivot" gridColumn="1 / 25"' in layout
 
 
 if __name__ == "__main__":

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_corectl_unbuild.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_corectl_unbuild.py
@@ -77,6 +77,39 @@ def test_unsupported_load_expression_blocks_instead_of_dropping():
         assert not os.path.exists(denorm)
 
 
+def test_dimension_calculation_stays_null_when_left_join_misses():
+    with tempfile.TemporaryDirectory() as output:
+        reconcile = os.path.join(output, "reconcile.json")
+        denorm = os.path.join(output, "denorm.json")
+        json.dump([
+            {
+                "qlikTable": "Customers", "sourceTable": "CUSTOMERS",
+                "fields": [
+                    {"qlikField": "CUSTOMER_KEY", "realColumn": "CUSTOMER_KEY", "isExpression": False},
+                    {"qlikField": "REGION", "realColumn": "REGION", "isExpression": False},
+                    {"qlikField": "REGION_GROUP", "realColumn": "If(REGION='West','West','Other')",
+                     "loadExpression": "If(REGION='West','West','Other')", "isExpression": True},
+                ],
+            },
+            {
+                "qlikTable": "OrderFact", "sourceTable": "ORDER_FACT",
+                "fields": [
+                    {"qlikField": "ORDER_ID", "realColumn": "ORDER_ID", "isExpression": False},
+                    {"qlikField": "CUSTOMER_KEY", "realColumn": "CUSTOMER_KEY", "isExpression": False},
+                    {"qlikField": "NET_REVENUE", "realColumn": "NET_REVENUE", "isExpression": False},
+                ],
+            },
+        ], open(reconcile, "w"))
+        run(sys.executable, os.path.join(SCRIPTS, "gen-denorm-sql.py"),
+            "--reconcile", reconcile, "--database", "ANALYTICS", "--schema", "PUBLIC",
+            "--connection", "conn-offline", "--out", denorm)
+        sql = json.load(open(denorm))["sql"]
+        assert (
+            "CASE WHEN a.CUSTOMER_KEY IS NULL THEN NULL ELSE CASE WHEN a.REGION = 'West' "
+            "THEN 'West' ELSE 'Other' END END AS REGION_GROUP"
+        ) in sql
+
+
 def test_load_expression_helpers_compose_with_arithmetic_and_concat():
     from qlik_load_expr import translate
     columns = {"COUNTRY": "COUNTRY", "SALES": "SALES"}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_workbook_release.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_workbook_release.py
@@ -118,8 +118,9 @@ def main():
     assert box["xAxis"]["columnId"] and box["yAxis"]["columnIds"]
 
     styled = elements["el-styled"]
-    assert styled["legend"] == {"visibility": "hidden", "position": "right"}
-    assert styled["orientation"] == "horizontal" and styled["stacking"] == "normalized"
+    assert styled["legend"] == {"visibility": "hidden"}
+    assert "orientation" not in styled and styled["stacking"] == "normalized"
+    assert "HORIZONTAL ORIENTATION GAP" in run.stderr
     assert styled["dataLabel"]["labels"] == "hidden"
     assert "MANUAL GAP" in run.stderr and "REGION > CITY" in run.stderr
 


### PR DESCRIPTION
## Summary
- preserve Qlik markdown, donut, area, combo-series, sorting, color, legend, reference-line, and sparse-layout presentation in Sigma workbook specs
- keep calculated left-joined dimension fields null when the dimension row is missing
- bump qlik-to-sigma to 1.4.2 and add regression coverage

Follow-up to #711; the final fidelity commit landed on its branch after that PR was squash-merged.

## Validation
- `python3 plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_chart_mappings.py`
- `python3 plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_corectl_unbuild.py`
- `python3 plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_workbook_release.py`
- `git diff --check origin/main...HEAD`
- live Sigma verify: 32/32 elements compile, 67 columns with zero error-typed columns, clean layout/control lint
- live parity: KPI 147611.87, 3 regions, 5 categories, 15 visible region/category rows