### PR TITLE
Fix Tableau calculated-filter and title fidelity

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -772,6 +772,30 @@ def translate_dim_calc(formula, mmap, columns_by_guid = {})
   nil
 end
 
+# A selected Tableau filter bound to a calculated dimension must evaluate the
+# Tableau formula even when the reused DM exposes a same-named physical column.
+# The physical column is not semantic proof and may be entirely NULL. Replace
+# it only when the calculation translates and all dependencies resolve.
+def master_calc_filter_override(caption, formula, mmap, columns_by_guid = {})
+  target = map_column(caption, mmap)
+  return nil unless target
+
+  translated = translate_dim_calc(formula, mmap, columns_by_guid) ||
+               translate_row_level_calc(formula, mmap, columns_by_guid)
+  return nil unless translated
+
+  mapped_names = mmap.values.filter_map { |entry| entry['name'] if entry.is_a?(Hash) }
+  refs = translated.scan(/\[Master\/([^\]]+)\]/).flatten
+  return nil if refs.empty? || refs.any? { |name| !mapped_names.include?(name) }
+  return nil if refs.any? { |name| name.casecmp?(target['name'].to_s) }
+
+  {
+    'id' => target['id'],
+    'name' => target['name'],
+    'formula' => translated.gsub(/\[Master\/([^\]]+)\]/, '[\1]')
+  }
+end
+
 # ---- FIXED-LOD / grain-aware two-stage aggregation --------------------------
 # Tableau `{FIXED [dims] : AGG([m])}` (and Avg-of-a-dim-table-measure, which
 # Tableau evaluates at the dim table's native grain under relationship
@@ -7029,6 +7053,25 @@ norm_cap = ->(s) { s.to_s.strip.downcase.gsub(/[^a-z0-9]+/, '') }
 # filter propagates to every chart sourcing from it). Rides the output JSON as
 # `master_decode_columns` (only when non-empty — additive/byte-identical).
 master_decode_columns = []
+# Source-calculated filters with explicit selections override same-named DM
+# passthroughs on the master. The orchestrator applies these after chart build.
+master_calc_columns = []
+(meta['worksheets'] || {}).each_value do |worksheet|
+  (Array(worksheet['filters']) + Array(worksheet['hidden_filters'])).each do |filter|
+    next if Array(filter['members']).empty?
+    caption = (filter['column_caption'] || filter['caption']).to_s.strip
+    formula = calc_formula_by_caption[caption]
+    next if caption.empty? || formula.to_s.empty?
+
+    override = master_calc_filter_override(caption, formula, mmap, meta['columns_by_guid'] || {})
+    next unless override
+    next if master_calc_columns.any? { |column| column['id'] == override['id'] }
+
+    master_calc_columns << override
+    warnings << "selected calculated filter '#{caption}' overrides the same-named master passthrough " \
+                "with its translated Tableau formula (#{override['formula'][0, 120]})"
+  end
+end
 
 # PR-18 — route an integer-coded discrete-dimension LIST control through a
 # Text() decode helper. A Sigma list/dropdown control sources STRING option
@@ -8752,6 +8795,7 @@ if opts[:pages_mode] == :worksheet
   # PR-18: decode columns the orchestrator injects into the master element (only
   # when a master-rooted integer-dim control was routed — additive/byte-identical).
   _out['master_decode_columns'] = master_decode_columns if master_decode_columns.any?
+  _out['master_calc_columns'] = master_calc_columns if master_calc_columns.any?
   File.write(opts[:out], JSON.pretty_generate(_out))
   warn "wrote #{opts[:out]} (page-per-worksheet: #{pages.size} pages, #{auto_controls.size} auto-controls per page" \
        "#{data_elements.any? ? ", #{data_elements.size} hidden data element(s)" : ''})"
@@ -8989,6 +9033,7 @@ elsif opts[:pages_mode] == :dashboard
   # PR-18: decode columns the orchestrator injects into the master element (only
   # when a master-rooted integer-dim control was routed — additive/byte-identical).
   _out['master_decode_columns'] = master_decode_columns if master_decode_columns.any?
+  _out['master_calc_columns'] = master_calc_columns if master_calc_columns.any?
   File.write(opts[:out], JSON.pretty_generate(_out))
   warn "wrote #{opts[:out]} (page-per-dashboard: #{pages.size} page(s), #{data_elements.size} hidden data element(s), #{(param_controls + auto_controls).size} controls per page)"
 else

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -4780,6 +4780,21 @@ if mechanical
     master_columns << dc
     line "integer-dim decode: added master column '#{dc['name']}' (#{dc['formula']}) — list control filters STRING values (raw numeric list-filter targets are silently stripped by Sigma)"
   end
+  # A Tableau calculated filter's formula wins over a same-named DM physical
+  # passthrough. The builder emits only confidently translated, fully resolved
+  # replacements; preserving the passthrough can make a saved selection blank
+  # every dashboard tile when that physical column is NULL.
+  Array(raw_charts.is_a?(Hash) ? raw_charts['master_calc_columns'] : nil).each do |cc|
+    next unless cc.is_a?(Hash) && cc['id'] && cc['name'] && cc['formula']
+    existing = master_columns.find { |column| column['id'] == cc['id'] } ||
+               master_columns.find { |column| column['name'].to_s.casecmp?(cc['name'].to_s) }
+    if existing
+      existing['formula'] = cc['formula']
+    else
+      master_columns << cc
+    end
+    line "calculated-filter fidelity: master '#{cc['name']}' uses the translated Tableau formula, not a same-named passthrough"
+  end
   # Dim-grain helper placeholder resolution: build-charts runs before it knows
   # the live DM element ids, so grain helpers carry source.elementId =
   # "__DM_ELEMENT__:<name>". Resolve against the readback (dm_els) NOW — an

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -675,7 +675,9 @@ def worksheet_display_title(ws)
   return nil unless ft
   # .elements.to_a('run') / .text — supported by BOTH backends of twb_xml
   # (the Nokogiri shim and the REXML fallback); get_elements is REXML-only.
-  txt = ft.elements.to_a('run').map { |r| r.text.to_s }.join.strip
+  # Tableau writes line breaks as an Æ sentinel plus the actual newline. Keep
+  # the newline but do not leak the sentinel into the Sigma element title.
+  txt = ft.elements.to_a('run').map { |r| r.text.to_s.gsub("Æ", '') }.join.strip
   return nil if txt.empty?
   return nil if txt =~ /\A<[^<>]+>\z/ # "<Sheet Name>" / field-token default
   txt

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calculated-filter-override.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calculated-filter-override.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# A selected calculated filter must not bind to a same-named physical/DM
+# passthrough. That passthrough may be NULL or carry different semantics.
+
+DIR = __dir__
+SOURCE = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+%w[map_column translate_row_level_calc translate_dim_calc master_calc_filter_override].each do |name|
+  match = SOURCE.match(/^def #{name}\b.*?\n^end$/m) or abort("could not extract #{name}")
+  eval(match[0]) # rubocop:disable Security/Eval -- test-only first-party helper extraction
+end
+
+fails = []
+def check(condition, message, fails)
+  fails << message unless condition
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+end
+
+map = %w[Acceptance Heritage Unique\ Deal\ Id Accepted\ Status Status].to_h do |name|
+  plain = name.tr('\\', '')
+  ["(?i)^#{Regexp.escape(plain)}$", { 'id' => "m-#{plain.downcase.gsub(/\W+/, '-')}", 'name' => plain }]
+end
+
+formula = <<~TABLEAU.strip
+  IF [Heritage] = "Mitel"
+  OR ([Heritage] = "Unify"
+  AND (LEFT([Unique Deal Id],1) = "M" OR LEFT([Unique Deal Id],1) = "R"))
+  THEN [Accepted Status]
+  ELSEIF ([Status] = "Active" OR [Status] = "Preferred Supplier")
+  THEN "Qualified"
+  ELSE [Status] END
+TABLEAU
+
+override = master_calc_filter_override('Acceptance', formula, map)
+check(override && override['id'] == 'm-acceptance',
+      "same-named passthrough is replaced in place (got #{override.inspect})", fails)
+check(override && override['formula'].match?(/Left\(\[Unique Deal Id\],1\)/i),
+      'Tableau string logic survives translation', fails)
+check(override && override['formula'].include?('"Qualified"'),
+      'Tableau selected-domain branch survives translation', fails)
+check(override && !override['formula'].include?('[Master/'),
+      'override uses sibling refs because it runs on the master itself', fails)
+
+unmapped = map.reject { |_pattern, entry| entry['name'] == 'Accepted Status' }
+check(master_calc_filter_override('Acceptance', formula, unmapped).nil?,
+      'an unresolved dependency refuses the override instead of guessing', fails)
+check(master_calc_filter_override('Acceptance', 'IF [Acceptance] = "x" THEN "y" END', map).nil?,
+      'a self-referential replacement is refused', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS - selected calculated filters override unsafe same-name passthroughs'
+  exit 0
+end
+
+puts "FAILURES (#{fails.length}):"
+fails.each { |failure| puts "  - #{failure}" }
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-pivot-marks-pcto.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-pivot-marks-pcto.rb
@@ -1,0 +1,147 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# A percent-of-total quick calc can live on the Tableau Marks card while the
+# shelves expose only the raw measure. Preserve its axis scope and formatting.
+
+require 'json'
+require 'rbconfig'
+require 'tmpdir'
+
+DIR = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD = File.join(DIR, 'build-charts-from-signals.rb')
+RUBY = RbConfig.ruby
+
+fails = []
+def check(condition, message, fails)
+  fails << message unless condition
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+end
+
+twb = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Fact' name='federated.primary'>
+        <column caption='Partner Name' datatype='string' name='[Partner Name]' role='dimension' type='nominal' />
+        <column caption='Created FYQQ' datatype='string' name='[Created FYQQ]' role='dimension' type='nominal' />
+        <column caption='Seed' datatype='string' name='[Seed]' role='measure' type='quantitative' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Partner Share Matrix'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.primary'>
+              <column caption='Partner Name' datatype='string' name='[Partner Name]' role='dimension' type='nominal' />
+              <column caption='Created FYQQ' datatype='string' name='[Created FYQQ]' role='dimension' type='nominal' />
+              <column caption='Seed' datatype='string' name='[Seed]' role='measure' type='quantitative' />
+              <column-instance column='[Partner Name]' derivation='None' name='[none:Partner Name:nk]' pivot='key' type='nominal' />
+              <column-instance column='[Created FYQQ]' derivation='None' name='[none:Created FYQQ:nk]' pivot='key' type='nominal' />
+              <column-instance column='[Seed]' derivation='CountD' name='[ctd:Seed:qk]' pivot='key' type='quantitative' />
+              <column-instance column='[Seed]' derivation='CountD' name='[pcto:ctd:Seed:qk:2]' pivot='key' type='quantitative'>
+                <table-calc ordering-field='[federated.primary].[none:Partner Name:nk]' type='PctTotal' />
+              </column-instance>
+            </datasource-dependencies>
+          </view>
+          <style>
+            <style-rule element='cell'>
+              <format attr='text-format' field='[federated.primary].[pcto:ctd:Seed:qk:2]' value='p0.0%' />
+            </style-rule>
+          </style>
+          <rows>[federated.primary].[none:Partner Name:nk]</rows>
+          <cols>[federated.primary].[none:Created FYQQ:nk]</cols>
+          <panes>
+            <pane>
+              <mark class='Square' />
+              <encodings><text column='[federated.primary].[pcto:ctd:Seed:qk:2]' /></encodings>
+            </pane>
+          </panes>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Partner Share'>
+        <zones><zone h='100000' id='1' name='Partner Share Matrix' w='100000' x='0' y='0' /></zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+master_map = {
+  '(?i)^Partner Name$' => { 'id' => 'm-partner', 'name' => 'Partner Name' },
+  '(?i)^Created FYQQ$' => { 'id' => 'm-fyqq', 'name' => 'Created FYQQ' },
+  '(?i)^Seed$' => { 'id' => 'm-seed', 'name' => 'Seed' }
+}
+
+meta = nil
+layout = nil
+build_out = nil
+build_log = ''
+
+Dir.mktmpdir do |dir|
+  twb_path = File.join(dir, 'workbook-content.twb')
+  layout_path = File.join(dir, 'dashboard-layout.json')
+  meta_path = layout_path.sub(/\.json\z/, '-meta.json')
+  map_path = File.join(dir, 'master-columns.json')
+  out_path = File.join(dir, 'chart-specs.json')
+
+  File.write(twb_path, twb)
+  File.write(map_path, JSON.generate(master_map))
+  File.write(File.join(dir, 'get-workbook.json'), JSON.generate('views' => { 'view' => [] }))
+
+  parsed = system(RUBY, PARSER, twb_path, layout_path, out: File::NULL, err: File::NULL)
+  check(parsed, 'parser completed', fails)
+  if parsed
+    meta = JSON.parse(File.read(meta_path))
+    layout = JSON.parse(File.read(layout_path))
+    build_log = IO.popen(
+      [RUBY, BUILD, '--tableau-dir', dir, '--layout', layout_path,
+       '--meta', meta_path, '--master-map', map_path,
+       '--master-element-id', 'master', '--skip-dashboard-read', 'unit-test',
+       '--title', 'Partner Share', '--out', out_path],
+      err: %i[child out], &:read
+    )
+    build_out = JSON.parse(File.read(out_path)) if File.exist?(out_path)
+  end
+end
+
+ws = meta && meta.dig('worksheets', 'Partner Share Matrix')
+qc = ws && Array(ws['quick_calc_pcto']).first
+check(qc == {
+        'agg' => 'ctd', 'col' => 'Seed', 'addressing' => 'Partner Name',
+        'token' => '[pcto:ctd:Seed:qk:2]'
+      }, "parser captures the pcto pill, numeric suffix, and addressing (got #{qc.inspect})", fails)
+
+zone = layout && layout.flat_map { |d| d['zones'] || [] }.find { |z| z['caption'] == 'Partner Share Matrix' }
+check(zone && zone['chart_kind'] == 'pivot-table',
+      "two-dimensional Square-mark crosstab stays a pivot-table (got #{zone && zone['chart_kind'].inspect})", fails)
+
+elements = if build_out.is_a?(Array)
+             build_out
+           else
+             Array(build_out && build_out['elements']) +
+               Array(build_out && build_out['pages']).flat_map { |page| page['elements'] || [] }
+           end
+pivot = elements.find { |element| element['kind'] == 'pivot-table' }
+check(!pivot.nil?, 'builder emits a pivot-table element', fails)
+
+value_col = if pivot
+              Array(pivot['columns']).find { |column| Array(pivot['values']).include?(column['id']) }
+            end
+check(value_col && value_col['formula'] == 'PercentOfTotal(CountDistinct([Master/Seed]), "column")',
+      "Marks-card pcto wraps the CountD value with rows-axis scope (got #{value_col && value_col['formula'].inspect})", fails)
+check(value_col && value_col.dig('format', 'formatString') == ',.1%',
+      "Marks-card pcto keeps the source's one-decimal percent format (got #{value_col && value_col['format'].inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS - pivot Marks-card percent-of-total survives parser and builder'
+  exit 0
+end
+
+puts "FAILURES (#{fails.length}):"
+fails.each { |failure| puts "  - #{failure}" }
+puts "\n--- build log ---\n#{build_log}" unless build_log.empty?
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-worksheet-title.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-worksheet-title.rb
@@ -8,7 +8,8 @@
 # minimal .twb and asserts: (a) a CUSTOM worksheet <title> is extracted to
 # display_title on both the worksheet meta and the dashboard zone; (b) a DEFAULT
 # title (the "<Sheet Name>" field token) is skipped (nil) so the builder falls
-# back to the nickname; (c) build-charts' tile_title consumes display_title.
+# back to the nickname; (c) Tableau's Æ line-break sentinel is stripped; and
+# (d) build-charts' tile_title consumes display_title.
 #
 # Usage: ruby scripts/test-worksheet-title.rb
 
@@ -32,6 +33,10 @@ TWB = <<~XML
         <layout-options><title><formatted-text><run>&lt;Sheet Name&gt;</run></formatted-text></title></layout-options>
         <table><view><datasources/></view></table>
       </worksheet>
+      <worksheet name='Sentinel Sheet'>
+        <layout-options><title><formatted-text><run>CQ DAYS NOT TOUCHED</run><run>Æ&#10;</run><run>Percentage of Total</run></formatted-text></title></layout-options>
+        <table><view><datasources/></view></table>
+      </worksheet>
     </worksheets>
     <dashboards>
       <dashboard name='D'>
@@ -53,6 +58,9 @@ Dir.mktmpdir do |d|
         "custom worksheet <title> extracted (got #{ws.dig('OV KPI Revenue', 'display_title').inspect})", fails)
   check(ws.dig('Plain Sheet', 'display_title').nil?,
         "default '<Sheet Name>' token skipped -> nil (got #{ws.dig('Plain Sheet', 'display_title').inspect})", fails)
+  sentinel_title = ws.dig('Sentinel Sheet', 'display_title')
+  check(sentinel_title == "CQ DAYS NOT TOUCHED\nPercentage of Total" && !sentinel_title.include?('Æ'),
+        "Tableau Æ title sentinel stripped while preserving newline (got #{sentinel_title.inspect})", fails)
 
   doc = JSON.parse(File.read(out))
   dashes = doc.is_a?(Array) ? doc : (doc['dashboards'] || [doc])


### PR DESCRIPTION
## Summary
- replace unsafe same-named DM passthroughs with translated Tableau calculated-filter formulas when dependencies resolve
- strip Tableau's line-break sentinel from worksheet display titles without disturbing the dynamic-title handling added in #710
- add regression coverage for calculated-filter overrides and Marks-card percent-of-total pivots

## Customer impact
- prevents saved calculated-filter selections from blanking dashboards when a reused physical column is NULL or semantically different
- preserves multiline worksheet titles without leaking Tableau serialization characters
- locks in pivot axis scope and percent formatting for crosstabs whose quick calc is encoded on the Marks card

## Verification
- 268/268 offline Tableau Ruby tests passed (credentialed `test-calc-discovery.rb` excluded, matching CI)
- Tableau corpus: 12/12 cases passed
- `ruby tools/check-shared.rb`
- `ruby tools/lint-skills.rb`
- `bash tools/hygiene-sweep.sh`
- `git diff --check`