### PR TITLE
feat(sigma-cross-org-port): Sigma org→org workbook port on the contents endpoints

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "sigma-authoring",
       "source": "./plugins/sigma-authoring",
-      "description": "Canonical Sigma authoring skills every converter defers to: sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models, and custom-sql-to-data-model. Install this ALONGSIDE any converter \u2014 they assume it is present for the current Sigma spec surface.",
+      "description": "Canonical Sigma authoring skills every converter defers to: sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models, custom-sql-to-data-model, and sigma-cross-org-port (Sigma org \u2192 Sigma org workbook copies). Install this ALONGSIDE any converter \u2014 they assume it is present for the current Sigma spec surface.",
       "category": "authoring",
       "keywords": [
         "sigma",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Maturity labels (`gold` / `live` / `foundation` / `scaffold`) are defined in
 | Convert a Mode Report (SQL Queries + Charts) → Sigma | `mode-to-sigma` | foundation | `plugins/mode-to-sigma/skills/mode-to-sigma/` |
 | Author / repair Sigma workbooks (canonical spec) | `sigma-workbooks` | live | `plugins/sigma-authoring/skills/sigma-workbooks/` |
 | Author / repair Sigma data models (canonical spec) | `sigma-data-models` | live | `plugins/sigma-authoring/skills/sigma-data-models/` |
+| Copy a Sigma workbook into another Sigma org that already has the same data | `sigma-cross-org-port` | live | `plugins/sigma-authoring/skills/sigma-cross-org-port/` |
 
 Assessments are read-only (never write to the source or post to Sigma); run one
 to pick what to convert, then hand off to the matching converter.

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.12.3",
-  "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-api (authentication), sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter \u2014 the converters assume it is present.",
+  "version": "1.13.0",
+  "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-api (authentication), sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), custom-sql-to-data-model, and sigma-cross-org-port (copy a workbook between Sigma orgs that already share the underlying data). Install this alongside any converter \u2014 the converters assume it is present.",
   "author": {
     "name": "Thomas Wells"
   },
@@ -16,7 +16,9 @@
     "data-models",
     "authoring",
     "spec",
-    "migration"
+    "migration",
+    "cross-org",
+    "port"
   ],
   "skills": "./skills/"
 }

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: sigma-cross-org-port
+description: >-
+  Copy a Sigma workbook from one Sigma org into another when the underlying data
+  already exists in both (same warehouse tables, same column names) — e.g. moving
+  a demo, template, or sample-data workbook out of a shared org into a personal or
+  customer org. Pulls the source spec, remaps the org-scoped references
+  (connections, image uploads), fixes the GET-to-POST asymmetries, POSTs, and
+  verifies structure + compilation + render. Use when the user says "port/copy
+  this workbook to my org", "move this workbook between orgs", or "recreate this
+  Sigma workbook in another Sigma org". NOT for converting from another BI tool,
+  and NOT a data migration — the target must already have the tables.
+user-invocable: true
+---
+
+# Sigma → Sigma cross-org workbook port
+
+A workbook spec is ~95% org-agnostic. Porting is not a rebuild: it is a
+**reference-remapping** job over a spec you copy verbatim, plus a short list of
+things that genuinely cannot cross an org boundary.
+
+The whole difficulty is that the failures are asymmetric — some are loud 400s on
+create, and some are silent (a `2xx` create whose elements render empty, or an
+image that collapses to a strip). So this skill is audit-first and
+verify-hard-after.
+
+<!-- mandatory-pre-read -->
+Read both before porting anything:
+
+- `refs/non-portable-surface.md` — the complete list of what is org-scoped, what
+  is safely portable (do not "fix" opaque ids), and what has no automated path.
+- `refs/spec-asymmetries.md` — why `GET spec` is not a valid create body, the
+  two silent write-time normalizations, and the error → cause table.
+<!-- /mandatory-pre-read -->
+
+## Scope
+
+**In scope:** Sigma org A → Sigma org B, where the warehouse tables the workbook
+reads already exist in B under the same path and column names.
+
+**Out of scope:** converting from Tableau/Power BI/Looker/etc. (use the matching
+`*-to-sigma` converter); landing data that B does not have; porting data models
+(`/v2/dataModels/spec` is a separate surface — port the model first, then the
+workbook that references it).
+
+**Hard prerequisite — verify, do not assume.** The premise is that both orgs see
+the same data. Prove it in Phase 2 before touching a spec. If the target lacks
+the tables, this is a data migration wearing a port costume: stop and say so.
+
+## Prerequisites
+
+- API credentials for **both** orgs, and the right base URL for each cloud/region
+  — they are frequently different (e.g. source on
+  `https://api.us-a.aws.sigmacomputing.com`, target on
+  `https://aws-api.sigmacomputing.com`). Get tokens via the `sigma-api` skill.
+- `python3` with `pyyaml`. `poppler` (`pdfimages`) only if the workbook has image
+  uploads; `pillow` only if those images need downscaling.
+
+Keep the two tokens in separate shells or separate env files — the single most
+common self-inflicted failure here is POSTing the target spec with the source
+token, which 404s or silently writes to the wrong org.
+
+## Phase 1 — Authenticate both orgs, confirm which is which
+
+`/v2/whoami` returns a bare organization UUID with no name, so it cannot tell you
+*which org* you are in. Use a `lookup` call's returned `url` (Phase 2) — it
+carries the org **slug** — or check the workbook URL slug.
+
+```bash
+for side in src dst; do
+  # exchange client credentials per the sigma-api skill, then:
+  curl -s -H "Authorization: Bearer $TOKEN" "$BASE/v2/whoami" \
+    | jq '{userId, organizationId}'
+done
+```
+
+Record the target's home folder for the create call:
+
+```bash
+USER_ID=$(curl -s -H "Authorization: Bearer $DST_TOKEN" "$DST_BASE/v2/whoami" | jq -r .userId)
+curl -s -H "Authorization: Bearer $DST_TOKEN" "$DST_BASE/v2/members/$USER_ID" | jq -r .homeFolderId
+```
+
+## Phase 2 — Prove data parity (gate)
+
+Pull the source spec, list its warehouse paths, and confirm each one resolves on
+the target — same path **and** same column set.
+
+```bash
+curl -s -H "Authorization: Bearer $SRC_TOKEN" \
+  "$SRC_BASE/v2/workbooks/<SRC_WB_ID>/spec" > src-spec.yaml
+
+grep -o 'connectionId: [0-9a-f-]\{36\}' src-spec.yaml | sort -u
+python3 -c "import yaml,sys
+d=yaml.safe_load(open('src-spec.yaml'))['document']
+seen=set()
+def w(o):
+    if isinstance(o,dict):
+        if o.get('kind')=='warehouse-table': seen.add(tuple(o['path']))
+        [w(v) for v in o.values()]
+    elif isinstance(o,list): [w(v) for v in o]
+w(d); [print(list(p)) for p in sorted(seen)]"
+```
+
+For each path, on **both** orgs:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"path":["DB","SCHEMA","TABLE"]}' "$BASE/v2/connection/<CONN_ID>/lookup"
+# -> {kind, inodeId, url}   ... url confirms the org slug
+
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/v2/connections/tables/<inodeId>/columns?limit=200" \
+  | jq -r '.entries[] | "\(.name)\t\(.dataType // .type)"' | sort
+```
+
+`diff` the two column lists. Identical name+type sets are the green light.
+Differences are not automatically fatal — the workbook may not use the differing
+columns — but they are a decision the user has to make, so surface them.
+
+## Phase 3 — Audit before rewriting
+
+```bash
+python3 scripts/port_workbook.py --src-spec src-spec.yaml \
+  --out /dev/null --report audit.json --audit-only
+```
+
+The report names every unresolved item and the exact flag that fixes it:
+
+- `unmapped_connectionIds` → `--map-connection SRC=DST`
+- `unmapped_image_uploads` → Phase 4
+- `unrepaired_stale_write_columns` → `--map-column TBL:STALE=REAL`, with that
+  table's valid column ids listed so you can choose deliberately
+- `input_tables_needing_data` → Phase 7 (informational; no automated path)
+
+Resolve every one. The tool exits non-zero while any remain, so a clean audit is
+the gate into Phase 5.
+
+## Phase 4 — Recover image uploads (only if the audit lists any)
+
+Upload keys are org-scoped and the spec API cannot create an upload, so the bytes
+must be recovered and re-hosted. A PDF export embeds the originals losslessly.
+
+```bash
+python3 scripts/recover_images.py plan --spec src-spec.yaml
+```
+
+`plan` tells you which pages hold image elements, in export order, and which
+pages a whole-workbook export **omits** — hidden pages and overlay/modal pages.
+Export the workbook, plus each overlay page that holds an image:
+
+```bash
+# whole workbook
+curl -s -X POST -H "Authorization: Bearer $SRC_TOKEN" -H "Content-Type: application/json" \
+  -d '{"format":{"type":"pdf","layout":"portrait"}}' \
+  "$SRC_BASE/v2/workbooks/<SRC_WB_ID>/export"          # -> {queryId}
+
+# an overlay/modal page (this DOES work, and is the only way to reach one)
+curl -s -X POST -H "Authorization: Bearer $SRC_TOKEN" -H "Content-Type: application/json" \
+  -d '{"pageId":"<overlayPageId>","format":{"type":"pdf","layout":"portrait"}}' \
+  "$SRC_BASE/v2/workbooks/<SRC_WB_ID>/export"
+
+# poll until 200 (204 = still running)
+curl -s -o out.pdf -w '%{http_code}\n' -H "Authorization: Bearer $SRC_TOKEN" \
+  "$SRC_BASE/v2/query/<queryId>/download"
+```
+
+Then map, shrink, and **look at the files**:
+
+```bash
+python3 scripts/recover_images.py map --spec src-spec.yaml --pdf out.pdf \
+  --images imgs --out images.tsv
+python3 scripts/recover_images.py shrink --map images.tsv --out-dir web
+```
+
+`map` pairs rasters to upload keys positionally and flags what it cannot
+determine (a page holding both a map and an image, a key it never saw). Charts
+and maps embed their own rasters, so positional pairing is a strong hint, not
+proof — open the images before trusting them. Add overlay-page images to the TSV
+by hand.
+
+`shrink` matters: data URIs inflate ~4/3 in base64. A real case went from 24 MB
+of source PNG to ~2.4 MB of JPEG (~3.3 MB in-spec) with no visible loss at render
+size.
+
+If the user would rather keep native uploads than data URIs, port with the
+images omitted and drag the recovered files onto the elements in the UI.
+
+## Phase 5 — Port and create
+
+```bash
+python3 scripts/port_workbook.py --src-spec src-spec.yaml \
+  --out dst-spec.yaml --report port.json \
+  --folder-id <DST_HOME_FOLDER_ID> --name "<Name>" \
+  --map-connection <SRC_CONN>=<DST_CONN> \
+  --map-column <TBL>:<STALE>=<REAL> \
+  --image-map web/images.tsv
+```
+
+What it rewrites, and why each is necessary, is in `refs/spec-asymmetries.md`:
+`connectionId` remap; `groupingId: base` stripped; uploads inlined as data URIs;
+stale write-columns repaired from your explicit mapping; container row-spans
+pre-expanded with their siblings.
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $DST_TOKEN" \
+  -H "Content-Type: application/yaml" -H "Accept: application/json" \
+  --data-binary @dst-spec.yaml "$DST_BASE/v2/workbooks/spec" | jq .
+```
+
+On a 400, read the message against the error table in
+`refs/spec-asymmetries.md` — every one seen in practice maps to a known cause.
+Fix the spec, re-run, retry. Do not start hand-editing the readback.
+
+Iterate afterwards with `PUT /v2/workbooks/{id}/spec` and a body of
+`{document: …}` **only**.
+
+## Phase 6 — Verify (gate; a 2xx proves nothing)
+
+Three checks, all required.
+
+```bash
+# 1. structure — offline, source vs live readback
+curl -s -H "Authorization: Bearer $DST_TOKEN" \
+  "$DST_BASE/v2/workbooks/<DST_WB_ID>/spec" > dst-readback.yaml
+python3 scripts/verify_port.py structure --src-spec src-spec.yaml --dst-spec dst-readback.yaml
+
+# 2. compile — every data element, live
+python3 scripts/verify_port.py compile --base-url "$DST_BASE" --workbook-id <DST_WB_ID>
+
+# 3. render — export both to PDF and LOOK at them
+```
+
+`structure` compares counts, element ids, kinds, layout placement and settings,
+then field-diffs every element while ignoring the rewrites a port is supposed to
+make. Expect a small number of flagged diffs: your `--map-column` repair, and
+text bodies the API re-normalized. Anything else is a real regression.
+
+`compile` catches the silent class — Sigma accepts unresolvable formulas and
+bakes `'Unknown column "[X]"'` into the SQL as a literal, leaving the element
+blank in the UI. On a failure, run the baseline before blaming the port:
+
+```bash
+python3 scripts/verify_port.py baseline --base-url "$SRC_BASE" --workbook-id <SRC_WB_ID>
+```
+
+Identical failures on identical element ids mean the port is faithful and the
+defect is upstream. Report it as pre-existing; do not quietly repair someone
+else's workbook.
+
+**Render, and actually look.** Structure and compile both pass on a workbook
+whose image collapsed to a strip. Export both workbooks to PDF, rasterize the
+pages, and compare:
+
+```bash
+pdftoppm -r 55 -png src.pdf src_p && pdftoppm -r 55 -png dst.pdf dst_p
+pdfimages -list dst.pdf   # image dimensions/aspect are a fast tell
+```
+
+## Phase 7 — Report the residuals honestly
+
+Some things have no automated path. Name them concretely rather than implying a
+complete port:
+
+- **Input-table data.** Structure ports; rows do not. Say which tables need
+  seed data (and what the source rows were), and which are runtime logs that
+  *should* be empty in a fresh org.
+- **Pre-existing source defects** the baseline confirmed.
+- **Environment-level render diffs** — base theme, control labels. See the
+  caveats in `refs/non-portable-surface.md`.
+- **Version tags** are not spec content; re-tag if it matters.
+
+## Failure modes worth naming
+
+| Symptom | Cause |
+|---|---|
+| 404 on create | target token + source base URL (or vice versa) |
+| Element renders empty, no error anywhere | unresolvable formula; only `compile` finds it |
+| An image is a thin strip | container row-span expansion; a sibling kept the old span |
+| `Grouping not found: 'base'` | you POSTed a GET spec unmodified |
+| Everything works but looks slightly tighter | API collapsed 3+ newlines in text bodies |

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/SKILL.md
@@ -136,6 +136,72 @@ The report names every unresolved item and the exact flag that fixes it:
 Resolve every one. The tool exits non-zero while any remain, so a clean audit is
 the gate into Phase 5.
 
+### `warnings_inherited_from_source` — read this every time
+
+**`GET spec` does not reliably return a workbook's full action surface.** Buttons
+can come back as presentation-only — text, colour, alignment, and no `actions`
+key at all. There is no stub and no marker; the logic is simply absent. Port it
+and you get a workbook that looks perfect and does nothing.
+
+You cannot detect this by diffing source against target — both agree, because
+both are missing it. You detect it by looking for **declared structures nothing
+reaches**, which is what this block reports:
+
+- `overlays_never_opened` — a modal/drawer exists but no `open-overlay` targets
+  it. A modal nothing opens is proof that something is missing.
+- `input_tables_never_written` — an input table with no `insert-rows` /
+  `update-rows` / `delete-rows` writer. Cross-check what *reads* it: a scoring
+  or log table that is joined and aggregated but never written is conclusive.
+- `buttons_with_no_actions` — expected for decorative buttons, suspicious for
+  anything named Submit / Save / Enter.
+- `effect_counts` — sanity-check the shape against the UI. Six question pages
+  with one `insert-rows` between them is not a design choice.
+
+Observed live: a 92-element quiz workbook returned 21 `navigate` + 6
+`select-tab` + 1 `insert-rows`, with all 3 modals unopened, 5 of 6 input tables
+unwritten, and all 6 answer-Submit buttons action-less — while its `Scoring`
+element joined those unwritten tables to compute `Points`.
+
+**This is not a port defect and it is not fixable by porting harder.** Report it
+before the user finds it. The rebuild path is real, though — see below.
+
+### Rebuilding lost actions
+
+Conditional actions **are** authorable, so lost logic can be rewritten in code
+once you know the intended behaviour. `trigger` takes either a bare string or
+`{on, condition}`, with condition `type` of `column`, `constant`, or `formula`:
+
+```yaml
+actions:
+  - id: q1Wrong
+    trigger:
+      on: on-click
+      condition: {type: formula, formula: '[Store-Region] != "West"'}
+    effects:
+      - {effect: open-overlay, overlayId: UwRvau7UH-}
+  - id: q1Right
+    trigger:
+      on: on-click
+      condition: {type: formula, formula: '[Store-Region] = "West"'}
+    effects:
+      - effect: insert-rows
+        table: cNFuPUr6pp
+        values:
+          SC1LNFY0UM: {type: constant, value: {type: number, value: 1}}
+          0Z3GUSDJAC: {type: formula, formula: Now()}
+      - {effect: navigate, target: {type: page, page: kSHcc1l5cg}}
+```
+
+Verified to save and read back. Note a condition references a control by
+**`controlId`** (`[Store-Region]`), not by element id, and Sigma normalizes `<>`
+to `!=` on write. All twelve effects are authorable: `clear-control`,
+`close-overlay`, `delete-rows`, `insert-rows`, `navigate`, `open-document`,
+`open-overlay`, `open-url`, `refresh-element`, `select-tab`, `set-control-value`,
+`update-rows`.
+
+Rebuilding needs the *intended* behaviour, which the spec no longer carries —
+answer keys, thresholds, routing. Ask; do not infer it from the data and hope.
+
 ## Phase 4 — Recover image uploads (only if the audit lists any)
 
 Upload keys are org-scoped and the spec API cannot create an upload, so the bytes
@@ -279,3 +345,4 @@ complete port:
 | An image is a thin strip | container row-span expansion; a sibling kept the old span |
 | `Grouping not found: 'base'` | you POSTed a GET spec unmodified |
 | Everything works but looks slightly tighter | API collapsed 3+ newlines in text bodies |
+| Buttons render but do nothing; modals never appear | `GET spec` omitted the action surface — inherited, not caused. See `warnings_inherited_from_source` |

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/SKILL.md
@@ -199,8 +199,28 @@ to `!=` on write. All twelve effects are authorable: `clear-control`,
 `open-overlay`, `open-url`, `refresh-element`, `select-tab`, `set-control-value`,
 `update-rows`.
 
+Two effects are only partly authorable — check before promising a rebuild:
+
+- **`open-url` cannot carry a destination.** Its schema requires `openTarget`
+  (`_self` / `_blank` / `_parent`) and exposes **no `url` property**. A
+  spec-authored open-url button therefore opens nothing; the destination is
+  UI-only. Sending a `url` key fails the whole element with the unhelpful
+  `document.elements[N]: Invalid kind: "button"`. Leave such buttons unwired and
+  say so.
+- **`open-document`** likewise carries only what its schema lists — verify the
+  fields you need are there rather than assuming parity with the UI.
+
 Rebuilding needs the *intended* behaviour, which the spec no longer carries —
 answer keys, thresholds, routing. Ask; do not infer it from the data and hope.
+
+And when you do reconstruct answers from data, **check them against the
+workbook's own prose.** On the workbook that motivated this skill, the narrative
+had drifted from the dataset: the text cited 148 orders where the data yields
+156, implied three suspects where exactly one qualifies, and named a "nearest"
+store that is neither nearest nor associated with the surviving suspect. Both
+orgs returned byte-identical result sets, so this was upstream staleness, not a
+port artifact — but it makes "correct" ambiguous, and that is the user's call to
+make, not yours.
 
 ## Phase 4 — Recover image uploads (only if the audit lists any)
 

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/refs/non-portable-surface.md
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/refs/non-portable-surface.md
@@ -110,6 +110,25 @@ user:
 - **Accumulated runtime data** (log tables, submissions, leaderboards) → empty
   is correct in a fresh org; say so and move on.
 
+### Action logic the read drops
+Worse than non-portable: **absent from the source spec in the first place**, so
+neither the port nor a source/target diff can see it. `GET spec` can return a
+button as presentation-only — no `actions` key, no stub. Observed on a live
+92-element workbook: all 6 answer-Submit buttons, the registration Enter button,
+and a help button came back with no actions; all 3 modals had no `open-overlay`
+targeting them; 5 of 6 input tables had no writer, including the one the
+`Scoring` element joins to compute points.
+
+Detect it structurally, via `port_workbook.py --audit-only` →
+`warnings_inherited_from_source`: overlays never opened, input tables never
+written, buttons with no actions, and the effect-kind histogram. Declared
+structures that nothing reaches are the tell.
+
+Conditional actions are authorable (`trigger: {on, condition}`; condition `type`
+`column` | `constant` | `formula`; conditions reference a control by
+**`controlId`**), so the logic can be rebuilt in code — but rebuilding needs the
+intended behaviour, which the spec no longer carries. Ask for it.
+
 ### Version tags
 `tags` on the workbook (e.g. a `Public` release tag) are org-local publishing
 state, not spec content. Re-tag in the target if it matters.

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/refs/non-portable-surface.md
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/refs/non-portable-surface.md
@@ -1,0 +1,134 @@
+# What does NOT cross an org boundary
+
+A workbook spec is mostly org-agnostic, but a handful of fields are org-scoped.
+This is the complete list as observed on a live 92-element port (Sigma Public →
+a personal org, AWS US-East → AWS US-West, 2026-08-13). Each entry says how to
+detect it, whether it can be automated, and what the API does if you ignore it.
+
+## Portable — leave alone
+
+These look org-specific and are **not**. Rewriting them is wasted effort at best
+and breakage at worst.
+
+| Field | Why it's fine |
+|---|---|
+| `elements[].id`, `pages[].id`, `panels[].id`, `overlays[].id` | Preserved verbatim on create. `layout` `elementId` refs stay valid. |
+| `columns[].id`, including `inode-<id>/COLUMN` forms | **Opaque strings.** The `inode-` prefix is *not* resolved against the target org's inodes. Verified: a spec carrying `inode-E7qt6FDjryJm6GTEx3liz/ORDER_NUMBER` created cleanly in a different org and compiled to `select ORDER_NUMBER "Order Number" from …`. Do not "fix" these. |
+| `controlId` | A workbook-local name, not an org reference. |
+| Formulas referencing `[SourceName/Column]` | Resolved by **name** against the element's source, not by id. |
+| `settings.theme.overrides` | Copied as-is. Note the *base* theme is the target org's default (see caveats). |
+| `path` on `warehouse-table` sources | Database/schema/table names. Portable **iff** the same path exists on the target connection — verify, don't assume. |
+
+## Must be remapped — automatable
+
+### `connectionId` (every occurrence)
+Appears on `warehouse-table` sources, `input-table` `kind: empty` sources, and
+nested inside control `source.source`. Find them all:
+
+```bash
+grep -o 'connectionId: [0-9a-f-]\{36\}' spec.yaml | sort -u
+```
+
+Resolve the target's equivalent by name, then confirm the table path really
+exists there before porting:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections?limit=100" \
+  | jq -r '.entries[] | "\(.connectionId)  \(.type)  \(.name)"'
+
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"path":["DB","SCHEMA","TABLE"]}' \
+  "$SIGMA_BASE_URL/v2/connection/<DST_CONNECTION_ID>/lookup" | jq .
+```
+
+`lookup` returns `{kind, inodeId, url}` on success. The `url` also confirms the
+**org slug**, which is the only cheap way to be sure you are pointed at the org
+you think you are — `/v2/whoami` returns a bare organization UUID with no name.
+
+If the target connection is missing the path, this is not a port — it is a
+migration that needs the data landed first. Stop and say so.
+
+### Image uploads (`source.kind: upload`)
+The key is `<sourceOrgId>/<uuid>.png`. POSTing a foreign key fails hard:
+
+```
+Image upload does not belong to this organization: '<orgId>/<uuid>.png'
+```
+
+The OpenAPI is explicit that this is reference-only — *"Opaque handle for an
+image uploaded into Sigma (storage key). Emitted by GET and accepted by PUT; not
+a fetchable URL"* and *"the spec cannot upload a new one"*. There is **no public
+endpoint that uploads or serves one**, and guessing app URLs does not work (the
+app serves them behind a session cookie; `/api/…` paths return the SPA shell).
+
+Recovery path that does work — a PDF export embeds the original rasters
+losslessly, so export and extract (`scripts/recover_images.py`), then re-host as
+`kind: url`. A `data:` URI is accepted by the API and renders, which keeps the
+images inside the spec with no external hosting. Caveats:
+
+- Base64 inflates ~4/3. Full-resolution art can push a spec into megabytes;
+  `recover_images.py shrink` downscales first (1400px/q82 took 24 MB of PNG to
+  ~2.4 MB of JPEG, ~3.3 MB in-spec).
+- **Overlay/modal pages are absent from a whole-workbook export.** Export each
+  one separately with `{"pageId": "<overlayPageId>"}` — that does work.
+- Hidden pages are absent too.
+- Charts, point maps and region maps embed their own rasters. `recover_images.py`
+  ignores sub-64px chrome and flags pages where a map and an image coexist, but
+  the pairing is positional: **look at the files** before porting.
+
+If you would rather keep native uploads than data URIs, port with placeholders
+and drag the recovered files onto the image elements in the UI.
+
+## Must be re-created by hand — NOT automatable
+
+### Input-table *data*
+The spec carries an input table's **structure** (columns, types, formulas) and
+nothing else. `kind: empty` accepts only `connectionId`; there is no
+initial-rows field, and no public REST endpoint writes input-table rows. On
+create, the target gets a fresh, empty backing table
+(`…ORG_S_<targetOrgId>."SIGDS_<new-uuid>"`).
+
+Read the source rows so you know exactly what is missing:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"elementId":"<inputTableElementId>","format":{"type":"csv"}}' \
+  "$SIGMA_BASE_URL/v2/workbooks/<SRC_WB>/export"
+# then poll GET /v2/query/<queryId>/download
+```
+
+Then either type them in the UI, or replay the browser's internal
+`POST /api/v2/db/datasheet/edits/apply` with a **browser** JWT (client
+credentials cannot reach it). Distinguish the two cases before you bother the
+user:
+
+- **Seed data** the workbook needs to function (lookup rows, constants,
+  scenario baselines) → must be re-entered or the workbook is broken.
+- **Accumulated runtime data** (log tables, submissions, leaderboards) → empty
+  is correct in a fresh org; say so and move on.
+
+### Version tags
+`tags` on the workbook (e.g. a `Public` release tag) are org-local publishing
+state, not spec content. Re-tag in the target if it matters.
+
+## Caveats — same spec, different render
+
+Copied faithfully, but the target may still not look identical.
+
+- **Base theme.** The spec carries `settings.theme.overrides` but no base theme
+  name, so each org supplies its own default underneath. Observed effect on a
+  real port: control elements rendered their `name` as a visible label in the
+  source org and did not in the target, with the control element **byte-identical**
+  and `settings`/`pages`/`panels`/`overlays` all identical. The control schema
+  exposes no label-visibility field, so this is not spec-expressible — set it in
+  the UI if you need it.
+- **Markdown normalization.** The API collapses runs of 3+ newlines in `text`
+  `body` to 2 on write. Harmless in itself, but it shortens text blocks, which
+  can redistribute auto-sized grid rows around them.
+
+Both are environment/API behaviour, not something the port dropped — prove it
+the same way: diff the element with `verify_port.py structure`, which ignores
+the legitimate rewrites and shows everything else.

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/refs/spec-asymmetries.md
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/refs/spec-asymmetries.md
@@ -1,0 +1,114 @@
+# GET → POST asymmetries, and the error catalog
+
+`GET /v2/workbooks/{id}/spec` is **not** a valid create body. Three classes of
+difference bite, in this order: envelope, emitted-but-rejected fields, and
+normalizations the API applies on write. Then there is a fourth class that has
+nothing to do with the API — latent defects the source org tolerates and
+create-validation does not.
+
+## 1. Envelope
+
+`GET` returns response-only metadata alongside the document:
+
+```
+workbookId, name, url, documentVersion, latestDocumentVersion, ownerId,
+folderId, createdBy, updatedBy, createdAt, updatedAt, description, document
+```
+
+- **CREATE** takes `{name, folderId, description?, document}`. Drop everything
+  else — `ownerId`/`createdBy`/`updatedBy` are source-org user ids and must not
+  be carried over.
+- **UPDATE** takes `{document}` **only**. Sending the outer `name`/`folderId`
+  alongside it 400s.
+
+## 2. Emitted by GET, rejected by POST
+
+### `groupingId: "base"`
+GET writes the implicit ungrouped root explicitly on join legs and
+`primarySource`. Create rejects it:
+
+```
+elements[9].source.primarySource.groupingId: Grouping not found: 'base'
+```
+
+The schema settles it: *"The identifier of a grouping on the source element to
+read data at. **Omit to read ungrouped (base) data.**"* So delete any
+`groupingId` whose value is exactly `base`, at every depth. It reappears on the
+next readback — that is expected, and is why a naive GET → PUT round-trip of an
+unmodified spec can fail.
+
+## 3. Applied by the API on write
+
+Both are silent. Neither is an error; both can change what you see.
+
+### Container row-span expansion
+A `<Container>` whose declared `gridRow` end is **smaller** than its children's
+extent gets expanded to cover them. It is never shrunk when oversized.
+
+```xml
+<!-- POSTed -->
+<Container elementId="c1" gridRow="1 / 3">   <!-- children reach row 11 -->
+<!-- read back -->
+<Container elementId="c1" gridRow="1 / 11">
+```
+
+The failure mode is a **sibling**: an element that shared the container's
+original `1 / 3` now occupies 2 rows of an 11-row page and renders as a strip.
+Observed live: a full-height image next to a text column collapsed to a
+1400×154 sliver (source: 1210×1024).
+
+`port_workbook.py` pre-applies the expansion and carries matching siblings with
+it, so the POSTed layout is already self-consistent and the API changes nothing.
+
+### Text body normalization
+Runs of 3+ newlines in a `text` element's `body` collapse to 2. Cosmetic on its
+own; it shortens text blocks, and auto-sized grid rows around them redistribute.
+Not preventable — document it rather than fighting it.
+
+## 4. Latent source-side defects that create-validation rejects
+
+The source org's runtime tolerates dangling references that a fresh create will
+not. These are **not** port bugs; the port is just the first thing to type-check
+the workbook in years.
+
+```
+sheet: uAThHZWbNF(internal), bad column: TOBPY9LMOJ
+```
+
+An action effect (`insert-rows` / `update-rows`) whose `values` key is not a
+column of its target table. The element id in the message is an internal sheet
+id you will not find in `document.elements` — ignore it and search for the
+**column** id instead. Audit every write action against its table's real column
+ids (`port_workbook.py --audit-only` does this and prints the valid ids), then
+repair explicitly with `--map-column TABLE:STALE=REAL`.
+
+Repair deliberately, not by inference: the tool refuses to guess. In the
+observed case the target table had 3 columns, 2 matched, the stale key carried
+`{type: number, value: 1}`, and the single unmatched column was the numeric
+`Question` — enough to be confident. When it is not that clear-cut, ask.
+
+Similarly, a formula referencing `[Missing node/<id>]` is Sigma's own marker for
+a deleted source element. It survives a port (it is just a string) and keeps
+failing at query time. Confirm with `verify_port.py baseline` that the source
+fails identically, then report it as pre-existing rather than silently fixing
+someone else's workbook.
+
+## Error catalog
+
+| Message | Cause | Fix |
+|---|---|---|
+| `Grouping not found: 'base'` | GET-emitted `groupingId: base` | delete the key |
+| `Image upload does not belong to this organization: '<key>'` | org-scoped upload key | recover bytes, re-host as `kind: url` |
+| `sheet: <id>(internal), bad column: <colId>` | action writes to a non-existent column | `--map-column` |
+| `Dependency not found: '<conn>/<DB>/<SCHEMA>/<TABLE>'` | a control sourced from a warehouse table with no corresponding table element in the workbook, or the path genuinely is not on that connection | verify with `/v2/connection/<id>/lookup`; keep the table element |
+| `'Unknown column "[X]"'` **inside compiled SQL** | formula ref that does not resolve. Not an HTTP error — the create succeeds and the element renders empty | `verify_port.py compile`, then `baseline` to see whether it is pre-existing |
+
+The last row is the one that quietly ruins ports. A `2xx` on create means the
+shape was valid, not that the workbook works. Always run the compile probe.
+
+## Why a naive round-trip "works" in the same org
+
+Within one org, GET → POST usually survives, because `groupingId: base` is the
+only hard blocker and the org's own upload keys and connection ids still
+resolve. That is exactly why cross-org porting surfaces problems nobody has hit
+before — treat same-org success as no evidence at all.

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/port_workbook.py
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/port_workbook.py
@@ -14,6 +14,7 @@ Stdlib only. No network. Portable (no shelling out).
 
 import argparse
 import base64
+import collections
 import json
 import mimetypes
 import os
@@ -180,6 +181,43 @@ def normalize_layout(doc, counts):
 # --------------------------------------------------------------------------
 # audit
 # --------------------------------------------------------------------------
+def orphaned_interactivity(doc):
+    """Interactivity the spec DECLARES but never wires up.
+
+    `GET /v2/workbooks/{id}/spec` does not always return a workbook's full
+    action surface — buttons can come back as presentation-only, with their
+    conditional logic omitted entirely (no stub, no marker). A port then
+    faithfully reproduces a workbook that looks right and does nothing.
+
+    Nothing here is a port defect: it is a read-side gap you inherit. But it is
+    invisible unless you look for structures with no reachable writer/opener,
+    so flag the three that give it away."""
+    elements = [e for e in doc.get("elements", []) if isinstance(e, dict)]
+    effects = []
+
+    def collect(d):
+        if d.get("effect"):
+            effects.append(d)
+    walk(doc, collect)
+
+    opened = {e.get("overlayId") for e in effects if e.get("effect") == "open-overlay"}
+    written = {e.get("table") for e in effects
+               if e.get("effect") in ("insert-rows", "update-rows", "delete-rows")}
+
+    overlays = [o.get("id") for o in doc.get("overlays", []) if isinstance(o, dict)]
+    return {
+        "overlays_never_opened": sorted(o for o in overlays if o not in opened),
+        "input_tables_never_written": sorted(
+            e["id"] for e in elements
+            if e.get("kind") == "input-table" and e["id"] not in written),
+        "buttons_with_no_actions": sorted(
+            e["id"] for e in elements
+            if e.get("kind") == "button" and not e.get("actions")),
+        "effect_counts": dict(sorted(collections.Counter(
+            e["effect"] for e in effects).items())),
+    }
+
+
 def audit(doc, cmap, imap):
     """Everything org-scoped that still needs an operator decision."""
     conns, uploads, input_tables = set(), set(), []
@@ -279,6 +317,7 @@ def main():
 
     blockers = audit(doc, cmap, imap)
     blockers["unrepaired_stale_write_columns"] = stale_findings
+    warnings = orphaned_interactivity(doc)
 
     report = {
         "source": {"workbookId": src.get("workbookId"), "name": src.get("name"),
@@ -286,6 +325,7 @@ def main():
         "rewrites": counts,
         "connection_map": cmap,
         "blockers": blockers,
+        "warnings_inherited_from_source": warnings,
         "totals": {"elements": len(doc.get("elements", [])),
                    "pages": len(doc.get("pages", []))},
     }

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/port_workbook.py
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/port_workbook.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Rewrite a Sigma workbook spec so it can be created in a DIFFERENT org.
+
+Input  : a spec exactly as returned by GET /v2/workbooks/{id}/spec (YAML or JSON).
+Output : a create body {name, folderId, description?, document} for
+         POST /v2/workbooks/spec, plus a JSON report.
+
+Run with no --map-* flags first (audit mode): the report lists every org-scoped
+reference that needs a decision, and the tool exits non-zero if any remain
+unmapped. Supply the mappings, re-run, then POST.
+
+Stdlib only. No network. Portable (no shelling out).
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.exit("PyYAML required: python3 -m pip install pyyaml")
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+def walk(node, fn):
+    """Depth-first visit of every dict in the tree, parents before children."""
+    if isinstance(node, dict):
+        fn(node)
+        for v in list(node.values()):
+            walk(v, fn)
+    elif isinstance(node, list):
+        for v in node:
+            walk(v, fn)
+
+
+def load_spec(path):
+    with open(path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def parse_pairs(items, sep="="):
+    out = {}
+    for raw in items:
+        if sep not in raw:
+            sys.exit(f"bad mapping {raw!r}: expected LEFT{sep}RIGHT")
+        left, right = raw.split(sep, 1)
+        out[left.strip()] = right.strip()
+    return out
+
+
+# --------------------------------------------------------------------------
+# rewrite steps
+# --------------------------------------------------------------------------
+def remap_connections(doc, cmap, counts):
+    """Repoint every connectionId at the target org's connection."""
+    def visit(d):
+        cid = d.get("connectionId")
+        if isinstance(cid, str) and cid in cmap:
+            d["connectionId"] = cmap[cid]
+            counts["connectionId"] += 1
+    walk(doc, visit)
+
+
+def strip_base_grouping(doc, counts):
+    """GET emits the implicit ungrouped root as groupingId: "base"; create
+    rejects it ("Grouping not found: 'base'"). The schema is explicit: omit
+    groupingId to read ungrouped (base) data."""
+    def visit(d):
+        if d.get("groupingId") == "base":
+            del d["groupingId"]
+            counts["groupingId_base_stripped"] += 1
+    walk(doc, visit)
+
+
+def inline_images(doc, imap, counts):
+    """source.kind 'upload' is a reference to an image already uploaded into the
+    SOURCE org. The key is org-scoped, so POSTing it cross-org hard-fails with
+    'Image upload does not belong to this organization', and the spec API cannot
+    create a new upload. Rehost as kind 'url' — a data URI travels in-spec."""
+    def visit(d):
+        if d.get("kind") == "upload" and d.get("key") in imap:
+            url = imap[d["key"]]
+            d.clear()
+            d["kind"] = "url"
+            d["url"] = url
+            counts["images_inlined"] += 1
+    walk(doc, visit)
+
+
+def repair_write_columns(doc, repairs, counts, findings):
+    """A source org can carry dangling action->column references that its own
+    runtime tolerates. Create-validation rejects them:
+    'sheet: <elementId>(internal), bad column: <columnId>'."""
+    colmap = {e["id"]: {c["id"]: c.get("name") for c in (e.get("columns") or [])}
+              for e in doc.get("elements", []) if isinstance(e, dict) and "id" in e}
+
+    def visit(d):
+        if d.get("effect") not in ("insert-rows", "update-rows"):
+            return
+        values = d.get("values")
+        if not isinstance(values, dict):
+            return
+        table = d.get("table")
+        known = colmap.get(table, {})
+        for key in list(values.keys()):
+            if key in known:
+                continue
+            real = repairs.get((table, key))
+            if real and real in known:
+                values[real] = values.pop(key)
+                counts["stale_write_columns_repaired"] += 1
+            else:
+                findings.append({
+                    "table": table,
+                    "staleColumn": key,
+                    "validColumns": known,
+                    "fix": f"--map-column {table}:{key}=<REAL_COLUMN_ID>",
+                })
+    walk(doc, visit)
+
+
+ROW_RE = re.compile(r'gridRow="(\d+) / (\d+)"')
+CONTAINER_RE = re.compile(r"<Container\b([^>]*)>(.*?)</Container>", re.S)
+PAGE_RE = re.compile(r"(<Page\b[^>]*>)(.*?)(</Page>)", re.S)
+ELEMENT_RE = re.compile(r'<Element\s[^>]*gridRow="([^"]+)"[^>]*/>')
+
+
+def normalize_layout(doc, counts):
+    """On create, Sigma EXPANDS a <Container> whose declared gridRow end is
+    smaller than its children's extent (it never shrinks an oversized one).
+    A sibling <Element> that shared the container's ORIGINAL span then no longer
+    matches the expanded container and renders collapsed — a full-height image
+    becomes a thin strip. Pre-apply the expansion so what we POST is already
+    self-consistent, and carry the siblings with it."""
+    layout = doc.get("layout")
+    if not layout:
+        return
+
+    def fix_page(page_match):
+        body = page_match.group(2)
+        for cont in list(CONTAINER_RE.finditer(body)):
+            attrs, inner = cont.group(1), cont.group(2)
+            declared = ROW_RE.search(attrs)
+            if not declared:
+                continue
+            start, end = int(declared.group(1)), int(declared.group(2))
+            child_ends = [int(m.group(2)) for m in ROW_RE.finditer(inner)]
+            if not child_ends or max(child_ends) <= end:
+                continue
+            old_span = f"{start} / {end}"
+            new_span = f"{start} / {max(child_ends)}"
+            new_attrs = attrs.replace(f'gridRow="{old_span}"',
+                                      f'gridRow="{new_span}"', 1)
+            new_cont = f"<Container{new_attrs}>{inner}</Container>"
+            body = body.replace(cont.group(0), new_cont, 1)
+            counts["layout_containers_expanded"] += 1
+
+            def realign(m):
+                if m.group(1) != old_span:
+                    return m.group(0)
+                counts["layout_siblings_realigned"] += 1
+                return m.group(0).replace(f'gridRow="{old_span}"',
+                                          f'gridRow="{new_span}"', 1)
+
+            head, _, tail = body.partition(new_cont)
+            body = (ELEMENT_RE.sub(realign, head) + new_cont
+                    + ELEMENT_RE.sub(realign, tail))
+        return page_match.group(1) + body + page_match.group(3)
+
+    doc["layout"] = PAGE_RE.sub(fix_page, layout)
+
+
+# --------------------------------------------------------------------------
+# audit
+# --------------------------------------------------------------------------
+def audit(doc, cmap, imap):
+    """Everything org-scoped that still needs an operator decision."""
+    conns, uploads, input_tables = set(), set(), []
+
+    def visit(d):
+        cid = d.get("connectionId")
+        if isinstance(cid, str):
+            conns.add(cid)
+        if d.get("kind") == "upload" and "key" in d:
+            uploads.add(d["key"])
+    walk(doc, visit)
+
+    for e in doc.get("elements", []):
+        if isinstance(e, dict) and e.get("kind") == "input-table":
+            input_tables.append({
+                "elementId": e.get("id"),
+                "name": e.get("name"),
+                "columns": [c.get("name") for c in (e.get("columns") or [])],
+            })
+
+    target_conns = set(cmap.values())
+    return {
+        "unmapped_connectionIds": sorted(c for c in conns if c not in target_conns),
+        "unmapped_image_uploads": sorted(u for u in uploads if u not in imap),
+        "input_tables_needing_data": input_tables,
+    }
+
+
+# --------------------------------------------------------------------------
+def build_image_map(path):
+    imap = {}
+    base = os.path.dirname(os.path.abspath(path))
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 2:
+                sys.exit(f"image-map needs TAB-separated key<TAB>path: {line!r}")
+            key, img = parts[0].strip(), parts[1].strip()
+            img = img if os.path.isabs(img) else os.path.join(base, img)
+            if not os.path.exists(img):
+                sys.exit(f"image-map: file not found: {img}")
+            mime = mimetypes.guess_type(img)[0] or "image/png"
+            with open(img, "rb") as ifh:
+                b64 = base64.b64encode(ifh.read()).decode("ascii")
+            imap[key] = f"data:{mime};base64,{b64}"
+    return imap
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--src-spec", required=True,
+                    help="spec from GET /v2/workbooks/{id}/spec (YAML or JSON)")
+    ap.add_argument("--out", required=True, help="create body to write (YAML)")
+    ap.add_argument("--report", required=True, help="JSON report to write")
+    ap.add_argument("--folder-id", help="target folder (required unless --audit-only)")
+    ap.add_argument("--name", help="workbook name (default: source name)")
+    ap.add_argument("--map-connection", action="append", default=[],
+                    metavar="SRC=DST", help="repeatable")
+    ap.add_argument("--map-column", action="append", default=[],
+                    metavar="TABLE_ELEMENT_ID:STALE=REAL", help="repeatable")
+    ap.add_argument("--image-map", metavar="TSV",
+                    help="lines of: upload_key<TAB>local_image_path")
+    ap.add_argument("--audit-only", action="store_true",
+                    help="report what needs mapping; write no create body")
+    args = ap.parse_args()
+
+    src = load_spec(args.src_spec)
+    if "document" not in src:
+        sys.exit("spec has no top-level 'document' — is this a workbook spec?")
+    doc = src["document"]
+
+    cmap = parse_pairs(args.map_connection)
+    imap = build_image_map(args.image_map) if args.image_map else {}
+
+    repairs = {}
+    for raw in args.map_column:
+        left, real = raw.split("=", 1)
+        if ":" not in left:
+            sys.exit(f"bad --map-column {raw!r}: expected TABLE:STALE=REAL")
+        table, stale = left.split(":", 1)
+        repairs[(table.strip(), stale.strip())] = real.strip()
+
+    counts = dict(connectionId=0, groupingId_base_stripped=0, images_inlined=0,
+                  stale_write_columns_repaired=0, layout_containers_expanded=0,
+                  layout_siblings_realigned=0)
+    stale_findings = []
+
+    remap_connections(doc, cmap, counts)
+    strip_base_grouping(doc, counts)
+    inline_images(doc, imap, counts)
+    repair_write_columns(doc, repairs, counts, stale_findings)
+    normalize_layout(doc, counts)
+
+    blockers = audit(doc, cmap, imap)
+    blockers["unrepaired_stale_write_columns"] = stale_findings
+
+    report = {
+        "source": {"workbookId": src.get("workbookId"), "name": src.get("name"),
+                   "documentVersion": src.get("documentVersion")},
+        "rewrites": counts,
+        "connection_map": cmap,
+        "blockers": blockers,
+        "totals": {"elements": len(doc.get("elements", [])),
+                   "pages": len(doc.get("pages", []))},
+    }
+
+    hard = (blockers["unmapped_connectionIds"]
+            or blockers["unmapped_image_uploads"]
+            or blockers["unrepaired_stale_write_columns"])
+
+    if not args.audit_only and not hard:
+        if not args.folder_id:
+            sys.exit("--folder-id is required to write a create body")
+        body = {"name": args.name or src.get("name"),
+                "folderId": args.folder_id, "document": doc}
+        if src.get("description"):
+            body["description"] = src["description"]
+        with open(args.out, "w", encoding="utf-8") as fh:
+            yaml.safe_dump(body, fh, sort_keys=False, width=10 ** 6,
+                           default_flow_style=False, allow_unicode=True)
+        report["wrote"] = args.out
+
+    with open(args.report, "w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2)
+    print(json.dumps(report, indent=2))
+
+    if hard:
+        print("\nUNRESOLVED — supply the mappings above and re-run.",
+              file=sys.stderr)
+        return 2
+    if args.audit_only:
+        print("\nAudit clean. Re-run without --audit-only to write the create body.",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/recover_images.py
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/recover_images.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Recover the bytes behind a workbook's org-scoped image uploads.
+
+`source.kind: upload` keys are opaque handles into the SOURCE org's storage —
+the OpenAPI says so outright ("not a fetchable URL") and there is no public
+endpoint that serves them. But a PDF export embeds the original rasters
+losslessly, so exporting the workbook and pulling the images out of the PDF
+recovers them.
+
+    plan  --spec S.yaml
+        Which pages (and overlay pages) hold image elements, in export order.
+        Overlay/modal pages do NOT appear in a whole-workbook export — export
+        each one separately with {"pageId": "<overlayPageId>"}.
+
+    map   --spec S.yaml --pdf W.pdf --images DIR --out map.tsv
+        Pair extracted files with upload keys by (page order, element order).
+        Emits the TSV that port_workbook.py --image-map consumes.
+
+    shrink --map map.tsv --out-dir DIR [--max-px 1400] [--quality 82]
+        Downscale in place-ish (needs Pillow). Data URIs inflate ~4/3 in
+        base64; full-resolution art can push the spec past a POSTable size.
+
+`plan` and `map` are stdlib-only. `map` needs poppler's `pdfimages` on PATH
+(macOS: brew install poppler; Debian/Ubuntu: apt install poppler-utils;
+Windows: choco install poppler). `shrink` needs Pillow.
+
+ALWAYS eyeball the images against the source render before trusting the map:
+charts, point maps and region maps also embed rasters, so a page holding both a
+map and an image element is inherently ambiguous — `map` flags those rows.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.exit("PyYAML required: python3 -m pip install pyyaml")
+
+PAGE_RE = re.compile(r'<Page\b[^>]*id="([^"]+)"[^>]*>(.*?)</Page>', re.S)
+ELEMENT_ID_RE = re.compile(r'elementId="([^"]+)"')
+# raster-embedding element kinds that are NOT image uploads
+RASTER_KINDS = {"point-map", "region-map", "geography-map"}
+
+
+def load(spec_path):
+    with open(spec_path, encoding="utf-8") as fh:
+        spec = yaml.safe_load(fh)
+    return spec["document"] if "document" in spec else spec
+
+
+def page_plan(doc):
+    """[{pageId, name, kind: page|overlay, visible, images:[elementId], rasters:[kind]}]
+    in layout order — which is the order a whole-workbook export paginates in."""
+    pages = {p["id"]: p for p in doc.get("pages", []) if isinstance(p, dict)}
+    overlays = {o["id"] for o in doc.get("overlays", []) if isinstance(o, dict)}
+    elements = {e["id"]: e for e in doc.get("elements", [])
+                if isinstance(e, dict) and "id" in e}
+    uploads = {eid: e["source"]["key"] for eid, e in elements.items()
+               if isinstance(e.get("source"), dict)
+               and e["source"].get("kind") == "upload"}
+
+    out = []
+    for pid, body in PAGE_RE.findall(doc.get("layout") or ""):
+        ids = ELEMENT_ID_RE.findall(body)
+        meta = pages.get(pid)
+        out.append({
+            "pageId": pid,
+            "name": (meta or {}).get("name") or f"(overlay {pid})",
+            "kind": "overlay" if pid in overlays else "page",
+            "visible": bool(meta) and (meta.get("visibility") != "hidden"),
+            "images": [i for i in ids if i in uploads],
+            "keys": [uploads[i] for i in ids if i in uploads],
+            "rasters": sorted({elements[i]["kind"] for i in ids
+                               if i in elements
+                               and elements[i].get("kind") in RASTER_KINDS}),
+        })
+    return out
+
+
+def cmd_plan(args):
+    plan = page_plan(load(args.spec))
+    exported = [p for p in plan if p["kind"] == "page" and p["visible"]]
+    print("Whole-workbook PDF export paginates these pages, in this order:")
+    for i, p in enumerate(exported, 1):
+        extra = f"  [also embeds: {', '.join(p['rasters'])}]" if p["rasters"] else ""
+        print(f"  pdf page {i:>2}  {p['name']!r}  images={len(p['images'])}{extra}")
+    hidden = [p for p in plan if p["kind"] == "page" and not p["visible"]]
+    overlay = [p for p in plan if p["kind"] == "overlay"]
+    if hidden:
+        print("\nHIDDEN pages (absent from the export; export by pageId if they hold images):")
+        for p in hidden:
+            print(f"  {p['name']!r} pageId={p['pageId']} images={len(p['images'])}")
+    if overlay:
+        print("\nOVERLAY pages (absent from a whole-workbook export — export EACH "
+              'separately with {"pageId": "<id>"}):')
+        for p in overlay:
+            print(f"  pageId={p['pageId']} images={len(p['images'])} keys={p['keys']}")
+    total = sum(len(p["images"]) for p in plan)
+    print(f"\n{total} image upload(s) to recover.")
+    return 0
+
+
+def pdfimages_list(pdf):
+    exe = shutil.which("pdfimages")
+    if not exe:
+        sys.exit("pdfimages not found on PATH — install poppler "
+                 "(macOS: brew install poppler; Debian: apt install poppler-utils)")
+    txt = subprocess.run([exe, "-list", pdf], capture_output=True, text=True,
+                         check=True).stdout
+    rows = []
+    for line in txt.splitlines()[2:]:
+        f = line.split()
+        if len(f) < 4 or not f[0].isdigit():
+            continue
+        rows.append({"page": int(f[0]), "num": int(f[1]), "type": f[2],
+                     "width": int(f[3]), "height": int(f[4])})
+    return rows
+
+
+def cmd_map(args):
+    doc = load(args.spec)
+    plan = page_plan(doc)
+    exported = [p for p in plan if p["kind"] == "page" and p["visible"]]
+
+    os.makedirs(args.images, exist_ok=True)
+    exe = shutil.which("pdfimages")
+    if not exe:
+        sys.exit("pdfimages not found on PATH — install poppler")
+    subprocess.run([exe, "-all", "-p", args.pdf, os.path.join(args.images, "img")],
+                   check=True)
+
+    # only real content rasters: drop soft masks and tiny UI chrome
+    rows = [r for r in pdfimages_list(args.pdf)
+            if r["type"] == "image" and r["width"] >= args.min_px
+            and r["height"] >= args.min_px]
+
+    by_page = {}
+    for r in rows:
+        by_page.setdefault(r["page"], []).append(r)
+
+    extracted = {}
+    for name in os.listdir(args.images):
+        m = re.match(r"img-(\d+)-(\d+)\.(\w+)$", name)
+        if m:
+            extracted[(int(m.group(1)), int(m.group(2)))] = name
+
+    lines, notes, unmatched = [], [], []
+    for idx, page in enumerate(exported, 1):
+        if not page["images"]:
+            continue
+        cands = by_page.get(idx, [])
+        if page["rasters"]:
+            notes.append(f"page {idx} {page['name']!r} also has {page['rasters']} — "
+                         "verify visually, the pairing may be off by one")
+        if len(cands) != len(page["images"]):
+            unmatched.append(f"page {idx} {page['name']!r}: {len(page['images'])} "
+                             f"image element(s) but {len(cands)} raster(s) found")
+        for key, cand in zip(page["keys"], cands):
+            fname = extracted.get((cand["page"], cand["num"]))
+            if not fname:
+                unmatched.append(f"page {idx}: no extracted file for raster "
+                                 f"{cand['num']}")
+                continue
+            lines.append(f"{key}\t{fname}\t{page['name']} "
+                         f"({cand['width']}x{cand['height']})")
+
+    covered = {l.split("\t")[0] for l in lines}
+    for page in plan:
+        for key in page["keys"]:
+            if key not in covered:
+                unmatched.append(f"NOT MAPPED: {key} (page {page['name']!r}, "
+                                 f"kind={page['kind']}) — export this page by pageId")
+
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.write("# upload_key\tlocal_file\tprovenance\n")
+        for l in lines:
+            fh.write(l + "\n")
+
+    print(f"wrote {args.out} with {len(lines)} mapping(s)")
+    for n in notes:
+        print("  NOTE:", n)
+    for u in unmatched:
+        print("  GAP :", u)
+    print("\nVERIFY each file against the source render before porting.")
+    return 1 if unmatched else 0
+
+
+def cmd_shrink(args):
+    try:
+        from PIL import Image
+    except ImportError:
+        sys.exit("Pillow required for shrink: python3 -m pip install pillow")
+    os.makedirs(args.out_dir, exist_ok=True)
+    base = os.path.dirname(os.path.abspath(args.map))
+    total = 0
+    out_lines = []
+    with open(args.map, encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            parts = line.rstrip("\n").split("\t")
+            key, fname = parts[0], parts[1]
+            src = fname if os.path.isabs(fname) else os.path.join(base, fname)
+            im = Image.open(src)
+            if im.mode not in ("RGB", "L"):
+                im = im.convert("RGB")
+            im.thumbnail((args.max_px, args.max_px))
+            dest = os.path.join(args.out_dir,
+                                os.path.splitext(os.path.basename(src))[0] + ".jpg")
+            im.save(dest, "JPEG", quality=args.quality, optimize=True)
+            size = os.path.getsize(dest)
+            total += size
+            rel = os.path.relpath(dest, base)
+            out_lines.append("\t".join([key, rel] + parts[2:]))
+            print(f"  {os.path.basename(src)} -> {rel}  {size} bytes")
+    with open(args.map, "w", encoding="utf-8") as fh:
+        fh.write("# upload_key\tlocal_file\tprovenance\n")
+        for l in out_lines:
+            fh.write(l + "\n")
+    print(f"total {total} bytes (~{total * 4 // 3} as base64 in the spec)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("plan"); p.add_argument("--spec", required=True)
+    p.set_defaults(fn=cmd_plan)
+
+    p = sub.add_parser("map")
+    p.add_argument("--spec", required=True)
+    p.add_argument("--pdf", required=True)
+    p.add_argument("--images", required=True, help="dir for extracted files")
+    p.add_argument("--out", required=True, help="TSV to write")
+    p.add_argument("--min-px", type=int, default=64,
+                   help="ignore rasters smaller than this (UI chrome)")
+    p.set_defaults(fn=cmd_map)
+
+    p = sub.add_parser("shrink")
+    p.add_argument("--map", required=True)
+    p.add_argument("--out-dir", required=True)
+    p.add_argument("--max-px", type=int, default=1400)
+    p.add_argument("--quality", type=int, default=82)
+    p.set_defaults(fn=cmd_shrink)
+
+    args = ap.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/verify_port.py
+++ b/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/verify_port.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Verify a cross-org port. A 2xx on create proves nothing: Sigma accepts specs
+whose formulas don't resolve and embeds the failure as a string literal in the
+compiled SQL, so the element renders empty.
+
+    structure --src-spec S.yaml --dst-spec D.yaml
+        Offline. Element ids/kinds, pages, panels, overlays, layout placement,
+        and a field-level diff that ignores the rewrites a port is SUPPOSED to
+        make (connectionId, image source, groupingId: base).
+
+    compile --base-url URL --workbook-id ID [--token T]
+        Live. Queries every data element and fails on an error literal baked
+        into the SQL. Token defaults to $SIGMA_API_TOKEN.
+
+    baseline --base-url URL --workbook-id ID [--token T]
+        Same probe against the SOURCE workbook. Run it whenever `compile`
+        reports a failure: if the source fails identically, the port is
+        faithful and the defect is pre-existing upstream.
+
+Stdlib only.
+"""
+
+import argparse
+import collections
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.exit("PyYAML required: python3 -m pip install pyyaml")
+
+DATA_KINDS = {"table", "pivot-table", "input-table", "bar-chart", "line-chart",
+              "kpi-chart", "point-map", "region-map", "geography-map",
+              "pie-chart", "donut-chart", "scatter-chart", "combo-chart"}
+
+# Errors Sigma bakes into compiled SQL as string literals when a ref won't resolve.
+ERR_RE = re.compile(
+    r"'((?:Unknown column|Circular column reference|Column )[^']{0,160})'")
+
+
+def load_doc(path):
+    with open(path, encoding="utf-8") as fh:
+        spec = yaml.safe_load(fh)
+    return spec["document"] if "document" in spec else spec
+
+
+def scrub(node):
+    """Neutralise the differences a port is SUPPOSED to introduce."""
+    if isinstance(node, dict):
+        if node.get("kind") == "upload":
+            return {"__IMAGE__": True}
+        if node.get("kind") == "url" and str(node.get("url", "")).startswith("data:"):
+            return {"__IMAGE__": True}
+        return {k: scrub(v) for k, v in node.items()
+                if k not in ("connectionId",) and not (k == "groupingId" and v == "base")}
+    if isinstance(node, list):
+        return [scrub(v) for v in node]
+    return node
+
+
+def diff(a, b, path, out):
+    if isinstance(a, dict) and isinstance(b, dict):
+        for k in sorted(set(a) | set(b)):
+            if k not in a:
+                out.append(f"+ {path}.{k} = {json.dumps(b[k])[:90]}")
+            elif k not in b:
+                out.append(f"- {path}.{k} = {json.dumps(a[k])[:90]}")
+            else:
+                diff(a[k], b[k], f"{path}.{k}", out)
+    elif isinstance(a, list) and isinstance(b, list):
+        if len(a) != len(b):
+            out.append(f"~ {path}: length {len(a)} -> {len(b)}")
+        for i, (x, y) in enumerate(zip(a, b)):
+            diff(x, y, f"{path}[{i}]", out)
+    elif a != b:
+        out.append(f"~ {path}: {json.dumps(a)[:70]} -> {json.dumps(b)[:70]}")
+
+
+def cmd_structure(args):
+    s, t = load_doc(args.src_spec), load_doc(args.dst_spec)
+    fails = []
+
+    def kinds(d):
+        return dict(sorted(collections.Counter(
+            e.get("kind") for e in d.get("elements", [])).items()))
+
+    checks = [
+        ("element count", len(s.get("elements", [])), len(t.get("elements", []))),
+        ("page count", len(s.get("pages", [])), len(t.get("pages", []))),
+        ("panel count", len(s.get("panels", [])), len(t.get("panels", []))),
+        ("overlay count", len(s.get("overlays", [])), len(t.get("overlays", []))),
+        ("element kinds", kinds(s), kinds(t)),
+        ("layout <Element> count",
+         len(re.findall(r"<Element\s", s.get("layout") or "")),
+         len(re.findall(r"<Element\s", t.get("layout") or ""))),
+        ("layout <Container> count",
+         len(re.findall(r"<Container\s", s.get("layout") or "")),
+         len(re.findall(r"<Container\s", t.get("layout") or ""))),
+        ("layout <Page> count",
+         len(re.findall(r"<Page\s", s.get("layout") or "")),
+         len(re.findall(r"<Page\s", t.get("layout") or ""))),
+        ("settings", s.get("settings"), t.get("settings")),
+    ]
+    for label, a, b in checks:
+        ok = a == b
+        print(f"  [{'OK  ' if ok else 'FAIL'}] {label}: {a if not isinstance(a, dict) else ''}"
+              f"{'' if ok else f'  src={a} dst={b}'}")
+        if not ok:
+            fails.append(label)
+
+    sid = {e["id"] for e in s.get("elements", []) if "id" in e}
+    tid = {e["id"] for e in t.get("elements", []) if "id" in e}
+    if sid != tid:
+        fails.append("element ids")
+        print(f"  [FAIL] element ids: missing={sorted(sid - tid)} extra={sorted(tid - sid)}")
+    else:
+        print(f"  [OK  ] element ids: all {len(sid)} preserved")
+
+    se = {e["id"]: e for e in s.get("elements", []) if "id" in e}
+    te = {e["id"]: e for e in t.get("elements", []) if "id" in e}
+    unexpected = 0
+    for eid in sorted(sid & tid):
+        out = []
+        diff(scrub(se[eid]), scrub(te[eid]), "", out)
+        if out:
+            unexpected += 1
+            print(f"  [DIFF] {eid} ({se[eid].get('kind')}) {se[eid].get('name')!r}")
+            for line in out[:6]:
+                print(f"           {line}")
+    print(f"  [{'OK  ' if not unexpected else 'WARN'}] "
+          f"{unexpected} element(s) differ beyond the expected port rewrites")
+
+    if fails:
+        print(f"\nSTRUCTURE FAIL: {', '.join(fails)}")
+        return 1
+    print("\nSTRUCTURE OK")
+    return 0
+
+
+def api_get(base, token, path):
+    req = urllib.request.Request(base.rstrip("/") + path,
+                                 headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return r.read().decode("utf-8", "replace")
+
+
+def probe(args, label):
+    token = args.token or os.environ.get("SIGMA_API_TOKEN")
+    if not token:
+        sys.exit("no token: pass --token or export SIGMA_API_TOKEN")
+    spec = yaml.safe_load(api_get(args.base_url, token,
+                                  f"/v2/workbooks/{args.workbook_id}/spec"))
+    doc = spec["document"]
+    results, bad = [], 0
+    for e in doc.get("elements", []):
+        if e.get("kind") not in DATA_KINDS:
+            continue
+        try:
+            body = api_get(args.base_url, token,
+                           f"/v2/workbooks/{args.workbook_id}/elements/{e['id']}/query?limit=1")
+        except urllib.error.HTTPError as ex:
+            print(f"  [FAIL] {e['id']} ({e.get('kind')}) HTTP {ex.code}")
+            bad += 1
+            results.append({"id": e["id"], "error": f"HTTP {ex.code}"})
+            continue
+        errs = sorted(set(ERR_RE.findall(body)))
+        if errs:
+            print(f"  [FAIL] {e['id']} ({e.get('kind')}) {e.get('name')!r}: {errs[0]}")
+            bad += 1
+            results.append({"id": e["id"], "name": e.get("name"), "errors": errs})
+        else:
+            results.append({"id": e["id"], "name": e.get("name"), "ok": True})
+    total = len(results)
+    print(f"\n{label}: {total - bad}/{total} data elements compile clean")
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as fh:
+            json.dump(results, fh, indent=2)
+    return 1 if bad else 0
+
+
+def cmd_compile(args):
+    return probe(args, "PORTED WORKBOOK")
+
+
+def cmd_baseline(args):
+    rc = probe(args, "SOURCE WORKBOOK (baseline)")
+    if rc:
+        print("Source fails too — compare the element ids against the ported run. "
+              "Identical failures mean the port is faithful and the defect is upstream.")
+    return 0  # baseline is informational; never gate on it
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("structure")
+    p.add_argument("--src-spec", required=True)
+    p.add_argument("--dst-spec", required=True)
+    p.set_defaults(fn=cmd_structure)
+
+    for name, fn in (("compile", cmd_compile), ("baseline", cmd_baseline)):
+        p = sub.add_parser(name)
+        p.add_argument("--base-url", required=True)
+        p.add_argument("--workbook-id", required=True)
+        p.add_argument("--token")
+        p.add_argument("--json-out")
+        p.set_defaults(fn=fn)
+
+    args = ap.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `sigma-authoring/skills/sigma-cross-org-port` — copy a Sigma workbook into a
different Sigma org when both orgs already read the same warehouse tables
(demo/template/sample-data workbooks moving out of a shared org) — and cuts the
skill over to the current workbook **contents** endpoints.

## What is the purpose of this PR?

The skill remaps the org-scoped references in a workbook spec (connections, image
uploads), fixes the GET→POST asymmetries, creates the workbook in the target org,
and verifies structure + compilation + render. It is not a converter and not a
data migration — the target must already have the tables.

The latest change is an endpoint cutover. The skill was written against the legacy
`/v2/workbooks/spec` family, where the document sits under a `document` wrapper and
YAML bodies are accepted. Sigma's current, recommended surface reads
[`GET /v2/workbooks/{id}?includeContents=true`](https://github.com/twells89/sigma-migration-skills/blob/74958468cbfddcc0837b28b27344f325fd013cef/plugins/sigma-authoring/skills/sigma-cross-org-port/SKILL.md#L36-L51), creates via
`POST /v2/workbooks` with the doc under `contents`, updates via
`PUT /v2/workbooks/{id}/contents`, and validates via `POST /v2/workbooks` with
`dryRun: true`. These endpoints are **JSON only**. The scripts now write that
surface while still *reading* either envelope, so old saved specs keep working;
the legacy `/spec*` family also remains supported upstream.

## What should reviewers focus on?

The write path is the substance. [`port_workbook.py`](https://github.com/twells89/sigma-migration-skills/blob/74958468cbfddcc0837b28b27344f325fd013cef/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/port_workbook.py#L347-L356)
now emits a JSON create body keyed `contents` (with an optional `--dry-run`), and
[the read side](https://github.com/twells89/sigma-migration-skills/blob/74958468cbfddcc0837b28b27344f325fd013cef/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/port_workbook.py#L297-L303) of all three scripts accepts
a `contents` envelope, a legacy `document` envelope, or a bare document.

Please sanity-check the **dryRun semantics** baked into the Phase 5 examples and the
[envelope reference](https://github.com/twells89/sigma-migration-skills/blob/74958468cbfddcc0837b28b27344f325fd013cef/plugins/sigma-authoring/skills/sigma-cross-org-port/refs/spec-asymmetries.md#L10-L39): a clean dryRun returns
**HTTP 200 with the `valid` key omitted**, while a failing one returns **HTTP 400
with `{valid:false, errors:[…]}`** — so the [curl example](https://github.com/twells89/sigma-migration-skills/blob/74958468cbfddcc0837b28b27344f325fd013cef/plugins/sigma-authoring/skills/sigma-cross-org-port/SKILL.md#L309-L330)
tests the response body, not the status code. dryRun resolves dependencies, so it
catches `Dependency not found` that the old shape-only `/spec/verify` passed; it does
**not** replace the live compile probe, which is still required for the
`'Unknown column "[X]"'` string-literal class. `verify_port.py` also
[gains the native chart kinds](https://github.com/twells89/sigma-migration-skills/blob/74958468cbfddcc0837b28b27344f325fd013cef/plugins/sigma-authoring/skills/sigma-cross-org-port/scripts/verify_port.py#L37-L42) shipped since the
skill was written (treemap/sankey/funnel/gauge/box/waterfall/area) so its compile
probe covers them.

## How is this PR tested?

The cutover was exercised live against `tj-wells-1989` (`aws-api`). The new
`includeContents` GET returns the doc under `contents`; a create body emitted by the
rewritten `port_workbook.py` is accepted by `POST /v2/workbooks` — a workbook with
real dependency errors dry-ran to HTTP 400 `{valid:false, errors:[3]}`, a clean
round-trip dry-ran to HTTP 200 with `valid` omitted, and both persisted **0**
workbooks. `verify_port.py compile` reads a live workbook through the new GET and
probed its data elements clean; `structure` and `recover_images.py plan` both load
the `contents` envelope. All three scripts pass `python3 -m ast`, and the full
pre-commit governance hook (shared-file check, byte budgets, `hygiene-sweep.sh`,
portability lints) is green.

<details><summary>details — original end-to-end validation (unchanged by this cutover)</summary>

The skill's original build was validated against a live 92-element, 12-page
workbook (9 tables, 6 input tables, 29 buttons, 8 image uploads, 3 modals, 1 point
map) across two clouds/regions: 92/92 element ids preserved, layout placement /
settings / pages / panels / overlays identical, 17/18 data elements compile clean —
the 18th failing *identically* in the source org (a pre-existing `[Missing node/…]`
ref), which the bundled `baseline` probe demonstrates rather than asserts. That
two-org run was **not** re-executed this session (source-org credentials were not
available here); the same-org live checks above cover the endpoint cutover itself.

Findings encoded and documented by the skill:

| Finding | Consequence |
|---|---|
| `inode-<id>/COLUMN` column ids are **opaque** — never resolved against target inodes | Do NOT rewrite them (probe-verified) |
| `groupingId: "base"` emitted by GET, rejected by POST | strip it; schema says omit for ungrouped |
| Image upload keys are org-scoped; the API cannot create an upload | recover bytes from a PDF export, re-host as `kind: url` data URI |
| Overlay/modal pages absent from whole-workbook export | export each by `pageId` — that works |
| Create-validation rejects dangling action→column refs the source org tolerates | explicit `--map-column`, never inferred |
| API expands an undersized `<Container>` row span but **not its siblings** | full-height element silently collapses to a strip; porter pre-applies it |
| Input-table **data** has no automated path | structure ports, rows do not — reported, not hidden |

</details>

🏗️ Generated for Sigma by Claude Code
