### PR TITLE
fix(powerbi): support physical-name connections

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -290,6 +290,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-native-query.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-composite-gate.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-convert-model-reprefix.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-warehouse-column-refs.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-materialization-schedules.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.30",
+  "version": "1.8.31",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-model-gotchas.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/pbi-model-gotchas.md
@@ -23,6 +23,7 @@ lowercase, mostly-ungranted multi-schema, 100s of tables, heavy `CALCULATE`.
 | Metadata cluster: `sortByColumn` (alpha sort), KPI measure sub-object (target/status/trend), hierarchies `levels[]`, `column.summarizeBy` default agg, nested `displayFolder` | convert | `beads-sigma-lanq.13` (P3) |
 | Report filters (`filterConfig` Where-tree, In/Not/Between/Comparison, ComparisonKind, TopN, RelativeDate, `howCreated` Auto/Drill noise, inverted selection, Passthrough) never extracted | extract-pbir + build-workbook | Track 3a (extract) + 3b (apply: list/number-range/top-n → element/master filters; measure/multi-col/date-range → coverage) SHIPPED; date-range-control emission is the fast-follow |
 | Friendly table name ≠ physical view: element-name/formula-prefix reconciliation | build-DM | `beads-sigma-2xap` (SHIPPED #401) |
+| Sigma connection `friendlyName:false`: title-cased converter refs (for example `Order Id`) must be grounded to exact catalog names (`ORDER_ID`) while retaining explicit display names | build-DM | SHIPPED 1.8.31; `lib/warehouse_column_refs.rb` reads connection metadata + paginated table columns before validation/POST |
 | Cross-table measure referencing a dim column dropped (should translate via the relationship) | convert | `beads-sigma-lanq.8` (P2) |
 | Time-intel date grain hardcoded to month (ignores active hierarchy level) | dax/build | `beads-sigma-wpoz` (P3) |
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/convert-model.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/convert-model.rb
@@ -37,6 +37,7 @@ require 'json'
 require 'optparse'
 require 'open3'
 require_relative 'dax-restructure-patterns'
+require_relative 'lib/warehouse_column_refs'
 
 opts = {}
 OptionParser.new do |p|
@@ -126,6 +127,26 @@ named = 0
   end
 end
 dm['name'] = opts[:name] if opts[:name]
+
+# Sigma connections can disable "Use friendly names". In that mode a converter
+# formula such as [ORDER_FACT/Order Id] does not resolve; the exact catalog name
+# is [ORDER_FACT/ORDER_ID]. Ground base columns, inode ids, and qualified derived
+# references before local validation or POST. Placeholder/offline specs skip the
+# live check and retain the converter output.
+connection_ids = (dm['pages'] || []).flat_map { |page| page['elements'] || [] }
+                 .select { |element| element.dig('source', 'kind') == 'warehouse-table' }
+                 .map { |element| element.dig('source', 'connectionId').to_s }.uniq
+if connection_ids.any? && connection_ids.all? { |id| id.match?(UUID_RE) }
+  require_relative 'lib/sigma_rest'
+  grounding = WarehouseColumnRefs.apply!(
+    dm,
+    requester: ->(method, path, **kwargs) { Sigma.request(method, path, **kwargs) },
+    lister: ->(path) { Sigma.list_entries(path) }
+  )
+  modes = grounding['connectionModes'].map { |id, friendly| "#{id}=#{friendly ? 'friendly' : 'physical'}" }.join(', ')
+  warn "   [convert-model] connection naming: #{modes}; grounded #{grounding['rewritten']} formula(s), " \
+       "re-keyed #{grounding['rekeyed']} column id(s), re-prefixed #{grounding['reprefixed']} reference(s)"
+end
 
 # Fixup 3b (beads-sigma-<1b>): reconcile a base warehouse-table column's formula
 # PREFIX to its OWN element name. The converter prefixes base columns with the PBI

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/warehouse_column_refs.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/warehouse_column_refs.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Reconcile converter-friendly warehouse references with the target Sigma
+# connection. Connections with `friendlyName: false` require physical catalog
+# names in warehouse-table formulas and inode ids, while downstream derived
+# elements should keep stable human display names.
+module WarehouseColumnRefs
+  module_function
+
+  def normalize(value)
+    value.to_s.downcase.gsub(/[^a-z0-9]/, '')
+  end
+
+  def catalog_match(entries, candidates)
+    names = entries.map { |entry| entry['name'].to_s }.reject(&:empty?)
+    candidates.compact.map(&:to_s).reject(&:empty?).each do |candidate|
+      return candidate if names.include?(candidate)
+      folded = names.select { |name| name.casecmp(candidate).zero? }
+      return folded.first if folded.one?
+      normalized = names.select { |name| normalize(name) == normalize(candidate) }
+      return normalized.first if normalized.one?
+    end
+    nil
+  end
+
+  def apply!(spec, requester:, lister: nil, friendly_overrides: {})
+    connection_modes = {}
+    lookups = {}
+    aliases = {}
+    warehouse_prefixes = {}
+    id_map = {}
+    unresolved = []
+    rewritten = 0
+    rekeyed = 0
+    reprefixed = 0
+
+    elements = (spec['pages'] || []).flat_map { |page| page['elements'] || [] }
+    elements.each do |element|
+      source = element['source'] || {}
+      next unless source['kind'] == 'warehouse-table'
+      connection_id = source['connectionId'].to_s
+      path = source['path']
+      next if connection_id.empty? || !path.is_a?(Array) || path.empty?
+
+      friendly = if friendly_overrides.key?(connection_id)
+                   friendly_overrides[connection_id]
+                 else
+                   connection_modes.fetch(connection_id) do
+                     connection = requester.call(:get, "/v2/connections/#{connection_id}")
+                     connection_modes[connection_id] = connection['friendlyName']
+                   end
+                 end
+      raise "connection #{connection_id} did not report friendlyName" unless friendly == true || friendly == false
+      connection_modes[connection_id] = friendly
+      next if friendly
+
+      element_name = element['name'].to_s
+      physical_name = path.last.to_s
+      if !element_name.empty? && element_name != physical_name
+        existing = aliases[element_name]
+        if existing && existing != physical_name
+          raise "warehouse element name #{element_name.inspect} maps to both #{existing.inspect} and #{physical_name.inspect}"
+        end
+        aliases[element_name] = physical_name
+      end
+      element['name'] = physical_name
+
+      cache_key = [connection_id, path]
+      entries = lookups.fetch(cache_key) do
+        table = requester.call(:post, "/v2/connection/#{connection_id}/lookup",
+                               body: JSON.generate('path' => path))
+        inode = table['inodeId']
+        raise "#{path.join('.')} did not resolve to a table inode" if table['kind'] != 'table' || inode.to_s.empty?
+        columns_path = "/v2/connections/tables/#{inode}/columns"
+        raise 'warehouse column lister is required when friendly names are disabled' unless lister
+        lookups[cache_key] = lister.call(columns_path)
+      end
+      ref_map = {}
+      entries.each { |entry| ref_map[normalize(entry['name'])] = entry['name'].to_s }
+      warehouse_prefixes[physical_name] = true
+      warehouse_prefixes[element_name] = true unless element_name.empty?
+
+      (element['columns'] || []).each do |column|
+        match = column['formula'].to_s.match(%r{\A\[([^\]/]+)/([^\]/]+)\]\z})
+        next unless match
+        prefix, leaf = match.captures
+        id_leaf = column['id'].to_s.split('/', 2)[1]
+        physical = catalog_match(entries, [leaf, column['name'], id_leaf])
+        unless physical
+          unresolved << "#{path.join('.')}: #{prefix}/#{leaf}" if column['id'].to_s.start_with?('inode-')
+          next
+        end
+        column['name'] = leaf if column['name'].to_s.empty?
+        if column['id'].to_s.start_with?('inode-') && id_leaf != physical
+          old_id = column['id']
+          new_id = "#{old_id.split('/', 2)[0]}/#{physical}"
+          id_map[old_id] = new_id
+          column['id'] = new_id
+          rekeyed += 1
+        end
+        grounded = "[#{physical_name}/#{physical}]"
+        next if column['formula'] == grounded
+        column['formula'] = grounded
+        rewritten += 1
+      end
+
+      ground_element = lambda do |node|
+        case node
+        when Hash
+          if node['formula'].is_a?(String)
+            display_name = nil
+            node['formula'] = node['formula'].gsub(/\[([^\]\/]+)(\/[^\]]+)\]/) do
+              prefix = Regexp.last_match(1)
+              original = Regexp.last_match(0)
+              parts = Regexp.last_match(2).sub(%r{\A/}, '').split('/')
+              next original unless parts.one? && [element_name, physical_name].include?(prefix)
+              physical = ref_map[normalize(parts[0])]
+              next original unless physical
+              display_name ||= parts[0]
+              grounded = "[#{physical_name}/#{physical}]"
+              rewritten += 1 if grounded != original
+              grounded
+            end
+            node['name'] = display_name if node['name'].to_s.empty? && display_name
+          end
+          node.each { |key, value| ground_element.call(value) unless key == 'formula' }
+        when Array
+          node.each { |value| ground_element.call(value) }
+        end
+      end
+      ground_element.call(element)
+    end
+
+    unless id_map.empty?
+      replace_ids = lambda do |node|
+        case node
+        when Hash then node.each { |key, value| node[key] = replace_ids.call(value) }
+        when Array then node.map! { |value| replace_ids.call(value) }
+        when String then id_map.fetch(node, node)
+        else node
+        end
+      end
+      replace_ids.call(spec)
+    end
+
+    unless aliases.empty? && warehouse_prefixes.empty?
+      walk = lambda do |node|
+        case node
+        when Hash
+          if node['formula'].is_a?(String)
+            display_name = nil
+            node['formula'] = node['formula'].gsub(/\[([^\]\/]+)(\/[^\]]+)\]/) do
+              prefix = Regexp.last_match(1)
+              parts = Regexp.last_match(2).sub(%r{\A/}, '').split('/')
+              replacement = aliases.fetch(prefix, prefix)
+              reprefixed += 1 if replacement != prefix
+              display_name ||= parts[0] if parts.one? &&
+                                             (warehouse_prefixes[prefix] || warehouse_prefixes[replacement])
+              "[#{replacement}/#{parts.join('/')}]"
+            end
+            node['name'] = display_name if node['name'].to_s.empty? && display_name
+          end
+          node.each { |key, value| walk.call(value) unless key == 'formula' }
+        when Array
+          node.each { |value| walk.call(value) }
+        end
+      end
+      walk.call(spec)
+    end
+
+    unless unresolved.empty?
+      raise "warehouse columns not found in the connection catalog: #{unresolved.uniq.join(', ')}"
+    end
+    { 'rewritten' => rewritten, 'rekeyed' => rekeyed, 'reprefixed' => reprefixed,
+      'connectionModes' => connection_modes }
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-warehouse-column-refs.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-warehouse-column-refs.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'lib/warehouse_column_refs'
+
+fails = []
+check = lambda do |condition, message|
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+  fails << message unless condition
+end
+
+fixture = {
+  'pages' => [{ 'elements' => [{
+    'id' => 'orders', 'name' => 'Order Fact',
+    'source' => { 'kind' => 'warehouse-table', 'connectionId' => 'conn',
+                  'path' => %w[DB SCHEMA ORDER_FACT] },
+    'columns' => [
+      { 'id' => 'inode-random/ORDER_ID', 'formula' => '[ORDER_FACT/Order Id]' },
+      { 'id' => 'inode-guid/NOT_PHYSICAL', 'formula' => '[ORDER_FACT/Net Revenue]',
+        'name' => 'Net Revenue' },
+      { 'id' => 'calc', 'formula' => 'Text([Order Fact/Order Id])', 'name' => 'Order Text' }
+    ],
+    'order' => ['inode-random/ORDER_ID', 'inode-guid/NOT_PHYSICAL', 'calc'],
+    'relationships' => [{ 'keys' => [{ 'sourceColumnId' => 'inode-guid/NOT_PHYSICAL' }] }]
+  }, {
+    'id' => 'view', 'name' => 'Order View', 'source' => { 'kind' => 'table', 'elementId' => 'orders' },
+    'columns' => [{ 'id' => 'pass', 'formula' => '[Order Fact/Order Id]' }]
+  }] }]
+}
+catalog = [{ 'name' => 'ORDER_ID' }, { 'name' => 'NET_REVENUE' }]
+requester = lambda do |method, _path, **_kwargs|
+  method == :get ? { 'friendlyName' => false } : { 'kind' => 'table', 'inodeId' => 'table' }
+end
+
+physical = Marshal.load(Marshal.dump(fixture))
+result = WarehouseColumnRefs.apply!(physical, requester: requester, lister: ->(_path) { catalog })
+orders, view = physical['pages'][0]['elements']
+check.call(result['connectionModes'] == { 'conn' => false }, 'reads physical naming mode from connection metadata')
+check.call(orders['name'] == 'ORDER_FACT', 'warehouse element uses its physical source prefix')
+check.call(orders['columns'][0]['formula'] == '[ORDER_FACT/ORDER_ID]' &&
+           orders['columns'][0]['name'] == 'Order Id', 'base formula is physical while display name stays friendly')
+check.call(orders['columns'][1]['id'] == 'inode-guid/NET_REVENUE', 'inode suffix is grounded from the catalog')
+check.call(orders['order'][1] == 'inode-guid/NET_REVENUE' &&
+           orders['relationships'][0]['keys'][0]['sourceColumnId'] == 'inode-guid/NET_REVENUE',
+           'column-id cross-references follow the re-key')
+check.call(orders['columns'][2]['formula'] == 'Text([ORDER_FACT/ORDER_ID])',
+           'qualified calculated-column input is grounded')
+check.call(view['columns'][0]['formula'] == '[ORDER_FACT/Order Id]' &&
+           view['columns'][0]['name'] == 'Order Id', 'derived passthrough is grounded and keeps a friendly name')
+
+friendly = Marshal.load(Marshal.dump(fixture))
+friendly_requester = ->(_method, _path, **_kwargs) { { 'friendlyName' => true } }
+friendly_result = WarehouseColumnRefs.apply!(friendly, requester: friendly_requester, lister: ->(_path) { catalog })
+check.call(friendly_result['rewritten'].zero? && friendly == fixture,
+           'friendly-name connections preserve converter output')
+
+puts "\n#{fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)"}"
+fails.each { |failure| puts "  - #{failure}" }
+exit(fails.empty? ? 0 : 1)


### PR DESCRIPTION
## What & why

Sigma connections expose a `friendlyName` boolean. When it is disabled, warehouse-table formulas must use exact catalog names such as `ORDER_ID`; the Power BI converter currently emits friendly references such as `Order Id`, so otherwise-valid models fail during the data-model POST. This change reads the connection setting and paginated table catalog before validation, grounds warehouse-source formulas and inode suffixes only when required, and preserves explicit friendly display names for downstream elements.

## Scope

- Plugin(s) touched: `powerbi-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)
- Registers the new plugin test in the repository CI workflow.

## Verification

- All Power BI Ruby suites passed (`scripts/test-*.rb` plus `tests/*.rb`).
- All Power BI Python suites passed.
- Full corpus: 29/29 cases passed.
- `ruby tools/check-shared.rb` passed.
- `ruby tools/lint-skills.rb` passed (existing tracked size warnings only).
- `ruby tools/check-agent-variants.rb` passed.
- Governance and hygiene sweeps passed.
- Plugin version gate passed: `1.8.30 -> 1.8.31`.
- Live Snowflake test with friendly names disabled: 32 formulas grounded, fresh data model posted with 67 clean columns, fresh workbook posted with 87 clean columns, 10/10 visuals and 19/19 bindings carried over, populated KPI/chart/table render.
- Live Snowflake control test with friendly names enabled: zero rewrites, fresh data model/workbook posted, populated render unchanged.

No source-snapshot value-parity claim is made; the live tests verify connection-mode compatibility, formula resolution, bindings, and rendered live values.

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in
- [x] Bumped the touched plugin version

## If this changes a shared lib

- [x] Not applicable; this is a one-plugin change.

## If this adds a converter

- [x] Not applicable.