### PR TITLE
fix(looker): support physical-name connections

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -417,6 +417,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py
             plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_scout_ledger_integrity.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_warehouse_column_refs.py
             plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_metric_reference.py

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/post_dm.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/post_dm.py
@@ -13,6 +13,7 @@ Usage:
   SIGMA_CONNECTION_ID=<full-uuid> python3 post_dm.py <spec.json> [--folder-id <id>]
 """
 import argparse, json, os, re, sys, urllib.request, urllib.error
+from warehouse_column_refs import apply as ground_warehouse_refs
 
 BASE = os.environ["SIGMA_BASE_URL"]
 TOK = os.environ["SIGMA_API_TOKEN"]
@@ -205,6 +206,13 @@ def main():
     print("folderId:", folder, file=sys.stderr)
     if folder:
         spec["folderId"] = folder
+
+    grounding = ground_warehouse_refs(spec, api)
+    modes = ", ".join(f"{cid}={'friendly' if value else 'physical'}"
+                      for cid, value in grounding["connectionModes"].items())
+    print(f"connection naming: {modes}; grounded {grounding['rewritten']} formula(s), "
+          f"re-keyed {grounding['rekeyed']} id(s), re-prefixed {grounding['reprefixed']} ref(s)",
+          file=sys.stderr)
 
     res = post_dm_with_sync(spec)
     print(json.dumps(res, indent=2)[:600] if isinstance(res, dict) else str(res)[:600])

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_warehouse_column_refs.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_warehouse_column_refs.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import copy
+from warehouse_column_refs import apply
+
+spec = {"pages": [{"elements": [{
+    "name": "Order Fact", "source": {"kind": "warehouse-table", "connectionId": "conn",
+    "path": ["DB", "S", "ORDER_FACT"]},
+    "columns": [
+        {"id": "inode-a/ORDER_ID", "formula": "[ORDER_FACT/Order Id]"},
+        {"id": "calc", "formula": "Text([Order Fact/Order Id])", "name": "Order Text"}],
+    "order": ["inode-a/ORDER_ID", "calc"]
+}, {"name": "Order View", "source": {"kind": "table", "elementId": "fact"},
+    "columns": [{"id": "pass", "formula": "[Order Fact/Order Id]"}]}]}]}
+
+def api(method, path, body=None):
+    if method == "GET" and path.startswith("/v2/connections/") and "/tables/" not in path:
+        return {"friendlyName": False}
+    if method == "POST":
+        return {"kind": "table", "inodeId": "table"}
+    return {"entries": [{"name": "ORDER_ID"}]}
+
+result = apply(spec, api)
+fact, view = spec["pages"][0]["elements"]
+assert fact["name"] == "ORDER_FACT"
+assert fact["columns"][0] == {"id": "inode-a/ORDER_ID", "formula": "[ORDER_FACT/ORDER_ID]", "name": "Order Id"}
+assert fact["columns"][1]["formula"] == "Text([ORDER_FACT/ORDER_ID])"
+assert view["columns"][0] == {"id": "pass", "formula": "[ORDER_FACT/Order Id]", "name": "Order Id"}
+assert result["connectionModes"] == {"conn": False}
+
+friendly = copy.deepcopy(spec)
+original = copy.deepcopy(friendly)
+apply(friendly, lambda *_args: {"friendlyName": True})
+assert friendly == original
+print("test_warehouse_column_refs: PASS")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/warehouse_column_refs.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/warehouse_column_refs.py
@@ -1,0 +1,168 @@
+"""Ground warehouse-table references for Sigma connections without friendly names."""
+import copy
+import json
+import re
+import urllib.parse
+
+
+def _norm(value):
+    return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
+
+
+def _catalog_match(entries, candidates):
+    names = [str(entry.get("name") or "") for entry in entries if entry.get("name")]
+    for candidate in [str(value) for value in candidates if value]:
+        if candidate in names:
+            return candidate
+        folded = [name for name in names if name.lower() == candidate.lower()]
+        if len(folded) == 1:
+            return folded[0]
+        normalized = [name for name in names if _norm(name) == _norm(candidate)]
+        if len(normalized) == 1:
+            return normalized[0]
+    return None
+
+
+def _list_entries(api, path):
+    out, token = [], None
+    while True:
+        query = {"pageSize": 500}
+        if token:
+            query["pageToken"] = token
+        page = api("GET", path + "?" + urllib.parse.urlencode(query))
+        out.extend(page.get("entries") or [])
+        token = page.get("nextPageToken")
+        if not token:
+            return out
+
+
+def apply(spec, api):
+    modes, lookups, aliases, prefixes, id_map, unresolved = {}, {}, {}, set(), {}, []
+    rewritten = rekeyed = reprefixed = 0
+    elements = [element for page in (spec.get("pages") or []) for element in (page.get("elements") or [])]
+
+    for element in elements:
+        source = element.get("source") or {}
+        if source.get("kind") != "warehouse-table":
+            continue
+        connection_id, path = str(source.get("connectionId") or ""), source.get("path")
+        if not connection_id or not isinstance(path, list) or not path:
+            continue
+        if connection_id not in modes:
+            modes[connection_id] = api("GET", f"/v2/connections/{connection_id}").get("friendlyName")
+        friendly = modes[connection_id]
+        if friendly not in (True, False):
+            raise RuntimeError(f"connection {connection_id} did not report friendlyName")
+        if friendly:
+            continue
+
+        old_name, physical_name = str(element.get("name") or ""), str(path[-1])
+        if old_name and old_name != physical_name:
+            prior = aliases.get(old_name)
+            if prior and prior != physical_name:
+                raise RuntimeError(f"element {old_name!r} maps to both {prior!r} and {physical_name!r}")
+            aliases[old_name] = physical_name
+        element["name"] = physical_name
+        key = (connection_id, tuple(path))
+        if key not in lookups:
+            table = api("POST", f"/v2/connection/{connection_id}/lookup", {"path": path})
+            inode = table.get("inodeId")
+            if table.get("kind") != "table" or not inode:
+                raise RuntimeError(f"{'.'.join(path)} did not resolve to a table inode")
+            lookups[key] = _list_entries(api, f"/v2/connections/tables/{inode}/columns")
+        entries = lookups[key]
+        refs = {_norm(entry.get("name")): str(entry.get("name")) for entry in entries if entry.get("name")}
+        prefixes.update(filter(None, (old_name, physical_name)))
+
+        for column in element.get("columns") or []:
+            match = re.fullmatch(r"\[([^\]/]+)/([^\]/]+)\]", str(column.get("formula") or ""))
+            if not match:
+                continue
+            prefix, leaf = match.groups()
+            col_id = str(column.get("id") or "")
+            id_leaf = col_id.split("/", 1)[1] if "/" in col_id else None
+            physical = _catalog_match(entries, (leaf, column.get("name"), id_leaf))
+            if not physical:
+                if col_id.startswith("inode-"):
+                    unresolved.append(f"{'.'.join(path)}: {prefix}/{leaf}")
+                continue
+            column.setdefault("name", leaf)
+            if col_id.startswith("inode-") and id_leaf != physical:
+                new_id = col_id.split("/", 1)[0] + "/" + physical
+                id_map[col_id] = new_id
+                column["id"] = new_id
+                rekeyed += 1
+            grounded = f"[{physical_name}/{physical}]"
+            if column.get("formula") != grounded:
+                column["formula"] = grounded
+                rewritten += 1
+
+        def ground_same(node):
+            nonlocal rewritten
+            if isinstance(node, dict):
+                formula = node.get("formula")
+                display = None
+                if isinstance(formula, str):
+                    def replace(match):
+                        nonlocal display, rewritten
+                        prefix, suffix = match.group(1), match.group(2)[1:]
+                        if "/" in suffix or prefix not in (old_name, physical_name):
+                            return match.group(0)
+                        physical = refs.get(_norm(suffix))
+                        if not physical:
+                            return match.group(0)
+                        display = display or suffix
+                        grounded = f"[{physical_name}/{physical}]"
+                        rewritten += grounded != match.group(0)
+                        return grounded
+                    node["formula"] = re.sub(r"\[([^\]/]+)(/[^\]]+)\]", replace, formula)
+                if display and not node.get("name"):
+                    node["name"] = display
+                for key2, value in node.items():
+                    if key2 != "formula":
+                        ground_same(value)
+            elif isinstance(node, list):
+                for value in node:
+                    ground_same(value)
+        ground_same(element)
+
+    def replace_ids(node):
+        if isinstance(node, dict):
+            for key, value in list(node.items()):
+                node[key] = replace_ids(value)
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                node[index] = replace_ids(value)
+        elif isinstance(node, str):
+            return id_map.get(node, node)
+        return node
+    replace_ids(spec)
+
+    def reprefix(node):
+        nonlocal reprefixed
+        if isinstance(node, dict):
+            formula, display = node.get("formula"), None
+            if isinstance(formula, str):
+                def replace(match):
+                    nonlocal reprefixed, display
+                    prefix, suffix = match.group(1), match.group(2)
+                    replacement = aliases.get(prefix, prefix)
+                    reprefixed += replacement != prefix
+                    if "/" not in suffix[1:] and (prefix in prefixes or replacement in prefixes):
+                        display = display or suffix[1:]
+                    return f"[{replacement}{suffix}]"
+                node["formula"] = re.sub(r"\[([^\]/]+)(/[^\]]+)\]", replace, formula)
+            if display and not node.get("name"):
+                node["name"] = display
+            for key, value in node.items():
+                if key != "formula":
+                    reprefix(value)
+        elif isinstance(node, list):
+            for value in node:
+                reprefix(value)
+    reprefix(spec)
+
+    if unresolved:
+        raise RuntimeError("warehouse columns not found in catalog: " + ", ".join(sorted(set(unresolved))))
+    return {"rewritten": rewritten, "rekeyed": rekeyed, "reprefixed": reprefixed,
+            "connectionModes": modes}


### PR DESCRIPTION
## What & why

Sigma connections can disable `friendlyName`, requiring exact catalog names in warehouse-table formulas and inode suffixes. Ground the completed Looker data-model spec after source/connection rewrites and before its first POST, while preserving friendly derived labels.

## Scope

- Plugin: `looker-to-sigma` only
- Version: `1.2.18 -> 1.2.19`

## Verification

- New Python grounding regression: pass
- Looker corpus: 1/1 pass
- Existing Looker Python suites: pass
- Shared drift, skill lint, agent variants, hygiene: pass
- Live disabled-friendly-name demo evidence: 59/59 columns resolve, populated render, 10/10 strict numeric parity
