### PR TITLE
fix(thoughtspot): support physical-name connections

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -419,6 +419,7 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test_scout_ledger_integrity.py
             plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_scout_ledger_integrity.py
+            plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_warehouse_column_refs.py
             plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_metric_reference.py
             plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_chart_mappings.py
             plugins/gooddata-to-sigma/skills/gooddata-to-sigma/tests/test_metric_reference.py

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -38,6 +38,7 @@ import argparse, json, os, re, ssl, subprocess, sys, time, urllib.request, urlli
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import yaml, ts_common, apply_layouts, scout_gate
+from warehouse_column_refs import apply as ground_warehouse_refs
 import metric_binding as _mb    # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 import code_rep  # workbook code-rep document-wrapper adapter (nested POST shape)
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
@@ -188,6 +189,12 @@ def find_table_elements(dm):
 def build_dm(conv, name, folder):
     """POST the converted Sigma data model. Returns (dmId, denormElemId, denormName)."""
     spec = conv["model"]; spec["name"] = name
+    grounding = ground_warehouse_refs(
+        spec, lambda method, path, body=None: json.loads(sigma(method, path, body)))
+    modes = ", ".join(f"{cid}={'friendly' if value else 'physical'}"
+                      for cid, value in grounding["connectionModes"].items())
+    print(f"  connection naming: {modes}; grounded {grounding['rewritten']} formula(s), "
+          f"re-keyed {grounding['rekeyed']} id(s), re-prefixed {grounding['reprefixed']} ref(s)")
     res = json.loads(sigma("POST", "/v2/dataModels/spec", {"folderId": folder, **spec}))
     dm = res["dataModelId"]
     # discover the denormalized "<root> View" element from the posted DM spec

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_warehouse_column_refs.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test_warehouse_column_refs.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import copy
+from warehouse_column_refs import apply
+
+spec = {"pages": [{"elements": [{
+    "name": "Order Fact", "source": {"kind": "warehouse-table", "connectionId": "conn",
+    "path": ["DB", "S", "ORDER_FACT"]},
+    "columns": [{"id": "inode-x/ORDER_ID", "formula": "[ORDER_FACT/Order Id]"},
+                {"id": "calc", "formula": "Text([Order Fact/Order Id])", "name": "Text Id"}]
+}, {"name": "Order View", "source": {"kind": "table", "elementId": "fact"},
+    "columns": [{"id": "pass", "formula": "[Order Fact/Order Id]"}]}]}]}
+
+def api(method, path, body=None):
+    if method == "POST":
+        return {"kind": "table", "inodeId": "t"}
+    if path.startswith("/v2/connections/tables/"):
+        return {"entries": [{"name": "ORDER_ID"}]}
+    return {"friendlyName": False}
+
+result = apply(spec, api)
+fact, view = spec["pages"][0]["elements"]
+assert fact["name"] == "ORDER_FACT"
+assert fact["columns"][0] == {"id": "inode-x/ORDER_ID", "formula": "[ORDER_FACT/ORDER_ID]", "name": "Order Id"}
+assert fact["columns"][1]["formula"] == "Text([ORDER_FACT/ORDER_ID])"
+assert view["columns"][0] == {"id": "pass", "formula": "[ORDER_FACT/Order Id]", "name": "Order Id"}
+assert result["connectionModes"] == {"conn": False}
+
+friendly = copy.deepcopy(spec); original = copy.deepcopy(friendly)
+apply(friendly, lambda *_args: {"friendlyName": True})
+assert friendly == original
+print("test_warehouse_column_refs: PASS")

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/warehouse_column_refs.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/warehouse_column_refs.py
@@ -1,0 +1,156 @@
+"""Ground warehouse-table references for Sigma connections without friendly names."""
+import re
+import urllib.parse
+
+
+def _norm(value):
+    return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
+
+
+def _match(entries, candidates):
+    names = [str(entry.get("name") or "") for entry in entries if entry.get("name")]
+    for candidate in [str(value) for value in candidates if value]:
+        if candidate in names:
+            return candidate
+        folded = [name for name in names if name.lower() == candidate.lower()]
+        if len(folded) == 1:
+            return folded[0]
+        normalized = [name for name in names if _norm(name) == _norm(candidate)]
+        if len(normalized) == 1:
+            return normalized[0]
+    return None
+
+
+def _columns(api, path):
+    out, token = [], None
+    while True:
+        query = {"pageSize": 500}
+        if token:
+            query["pageToken"] = token
+        page = api("GET", path + "?" + urllib.parse.urlencode(query))
+        out.extend(page.get("entries") or [])
+        token = page.get("nextPageToken")
+        if not token:
+            return out
+
+
+def apply(spec, api):
+    modes, cache, aliases, prefixes, id_map, unresolved = {}, {}, {}, set(), {}, []
+    rewritten = rekeyed = reprefixed = 0
+    elements = [e for p in (spec.get("pages") or []) for e in (p.get("elements") or [])]
+    for element in elements:
+        source = element.get("source") or {}
+        if source.get("kind") != "warehouse-table":
+            continue
+        connection, path = str(source.get("connectionId") or ""), source.get("path")
+        if not connection or not isinstance(path, list) or not path:
+            continue
+        if connection not in modes:
+            modes[connection] = api("GET", f"/v2/connections/{connection}").get("friendlyName")
+        friendly = modes[connection]
+        if friendly not in (True, False):
+            raise RuntimeError(f"connection {connection} did not report friendlyName")
+        if friendly:
+            continue
+        old, physical_name = str(element.get("name") or ""), str(path[-1])
+        if old and old != physical_name:
+            if old in aliases and aliases[old] != physical_name:
+                raise RuntimeError(f"ambiguous warehouse element name {old!r}")
+            aliases[old] = physical_name
+        element["name"] = physical_name
+        key = (connection, tuple(path))
+        if key not in cache:
+            table = api("POST", f"/v2/connection/{connection}/lookup", {"path": path})
+            if table.get("kind") != "table" or not table.get("inodeId"):
+                raise RuntimeError(f"{'.'.join(path)} did not resolve to a table")
+            cache[key] = _columns(api, f"/v2/connections/tables/{table['inodeId']}/columns")
+        entries = cache[key]
+        refs = {_norm(entry.get("name")): str(entry.get("name")) for entry in entries if entry.get("name")}
+        prefixes.update(filter(None, (old, physical_name)))
+        for column in element.get("columns") or []:
+            match = re.fullmatch(r"\[([^\]/]+)/([^\]/]+)\]", str(column.get("formula") or ""))
+            if not match:
+                continue
+            prefix, leaf = match.groups()
+            cid = str(column.get("id") or "")
+            id_leaf = cid.split("/", 1)[1] if "/" in cid else None
+            physical = _match(entries, (leaf, column.get("name"), id_leaf))
+            if not physical:
+                if cid.startswith("inode-"):
+                    unresolved.append(f"{'.'.join(path)}: {prefix}/{leaf}")
+                continue
+            column.setdefault("name", leaf)
+            if cid.startswith("inode-") and id_leaf != physical:
+                new_id = cid.split("/", 1)[0] + "/" + physical
+                id_map[cid] = new_id
+                column["id"] = new_id
+                rekeyed += 1
+            grounded = f"[{physical_name}/{physical}]"
+            if column.get("formula") != grounded:
+                column["formula"] = grounded
+                rewritten += 1
+
+        def same_element(node):
+            nonlocal rewritten
+            if isinstance(node, dict):
+                display = None
+                if isinstance(node.get("formula"), str):
+                    def replace(match):
+                        nonlocal display, rewritten
+                        prefix, leaf = match.group(1), match.group(2)[1:]
+                        if "/" in leaf or prefix not in (old, physical_name) or _norm(leaf) not in refs:
+                            return match.group(0)
+                        display = display or leaf
+                        grounded = f"[{physical_name}/{refs[_norm(leaf)]}]"
+                        rewritten += grounded != match.group(0)
+                        return grounded
+                    node["formula"] = re.sub(r"\[([^\]/]+)(/[^\]]+)\]", replace, node["formula"])
+                if display and not node.get("name"):
+                    node["name"] = display
+                for key2, value in node.items():
+                    if key2 != "formula":
+                        same_element(value)
+            elif isinstance(node, list):
+                for value in node:
+                    same_element(value)
+        same_element(element)
+
+    def replace_ids(node):
+        if isinstance(node, dict):
+            for key, value in list(node.items()):
+                node[key] = replace_ids(value)
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                node[index] = replace_ids(value)
+        elif isinstance(node, str):
+            return id_map.get(node, node)
+        return node
+    replace_ids(spec)
+
+    def derived(node):
+        nonlocal reprefixed
+        if isinstance(node, dict):
+            display = None
+            if isinstance(node.get("formula"), str):
+                def replace(match):
+                    nonlocal display, reprefixed
+                    prefix, suffix = match.group(1), match.group(2)
+                    replacement = aliases.get(prefix, prefix)
+                    reprefixed += replacement != prefix
+                    if "/" not in suffix[1:] and (prefix in prefixes or replacement in prefixes):
+                        display = display or suffix[1:]
+                    return f"[{replacement}{suffix}]"
+                node["formula"] = re.sub(r"\[([^\]/]+)(/[^\]]+)\]", replace, node["formula"])
+            if display and not node.get("name"):
+                node["name"] = display
+            for key, value in node.items():
+                if key != "formula":
+                    derived(value)
+        elif isinstance(node, list):
+            for value in node:
+                derived(value)
+    derived(spec)
+    if unresolved:
+        raise RuntimeError("warehouse columns not found in catalog: " + ", ".join(sorted(set(unresolved))))
+    return {"rewritten": rewritten, "rekeyed": rekeyed, "reprefixed": reprefixed,
+            "connectionModes": modes}


### PR DESCRIPTION
## What & why

Sigma connections can disable `friendlyName`, requiring exact catalog names in warehouse-table formulas and inode suffixes. Ground both vendored-converter and MCP-supplied ThoughtSpot models inside `build_dm`, immediately before the data-model POST, while preserving friendly derived labels.

## Scope

- Plugin: `thoughtspot-to-sigma` only
- Version: `1.2.17 -> 1.2.18`

## Verification

- New Python grounding regression: pass
- ThoughtSpot corpus: 1/1 pass
- Existing ThoughtSpot Python suites: pass
- Shared drift, skill lint, agent variants, hygiene: pass
