### PR TITLE
fix(cognos): support physical-name connections

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -447,6 +447,7 @@ jobs:
           tests=(
             plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-scout-ledger-integrity.mjs
             plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-metric-reference.mjs
+            plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-warehouse-column-refs.mjs
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos \u2192 Sigma",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Migrate IBM Cognos Analytics to Sigma \u2014 Data Module JSON \u2192 Sigma data model, and report-spec XML \u2192 Sigma workbook. Translates the Cognos expression DSL (total..for \u2192 window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/warehouse-column-refs.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/warehouse-column-refs.mjs
@@ -1,0 +1,132 @@
+const norm = (value) => String(value ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function catalogMatch(entries, candidates) {
+  const names = entries.map((entry) => String(entry.name || '')).filter(Boolean);
+  for (const candidate of candidates.filter(Boolean).map(String)) {
+    if (names.includes(candidate)) return candidate;
+    const folded = names.filter((name) => name.toLowerCase() === candidate.toLowerCase());
+    if (folded.length === 1) return folded[0];
+    const normalized = names.filter((name) => norm(name) === norm(candidate));
+    if (normalized.length === 1) return normalized[0];
+  }
+  return null;
+}
+
+async function jsonApi(api, method, path, body) {
+  const response = await api(method, path, body);
+  if (!response.ok || !response.json) throw new Error(`${method} ${path} failed (HTTP ${response.status}): ${response.text.slice(0, 300)}`);
+  return response.json;
+}
+
+async function listColumns(api, tableId) {
+  const entries = [];
+  let token = null;
+  do {
+    const query = new URLSearchParams({ pageSize: '500' });
+    if (token) query.set('pageToken', token);
+    const page = await jsonApi(api, 'GET', `/v2/connections/tables/${tableId}/columns?${query}`);
+    entries.push(...(page.entries || []));
+    token = page.nextPageToken || null;
+  } while (token);
+  return entries;
+}
+
+export async function groundWarehouseRefs(spec, api) {
+  const modes = new Map(), cache = new Map(), aliases = new Map(), prefixes = new Set(), idMap = new Map();
+  const unresolved = [];
+  let rewritten = 0, rekeyed = 0, reprefixed = 0;
+  const elements = (spec.pages || []).flatMap((page) => page.elements || []);
+  for (const element of elements) {
+    const source = element.source || {};
+    if (source.kind !== 'warehouse-table') continue;
+    const connection = String(source.connectionId || ''), path = source.path;
+    if (!connection || !Array.isArray(path) || !path.length) continue;
+    if (!modes.has(connection)) {
+      const details = await jsonApi(api, 'GET', `/v2/connections/${connection}`);
+      modes.set(connection, details.friendlyName);
+    }
+    const friendly = modes.get(connection);
+    if (friendly !== true && friendly !== false) throw new Error(`connection ${connection} did not report friendlyName`);
+    if (friendly) continue;
+
+    const oldName = String(element.name || ''), physicalName = String(path.at(-1));
+    if (oldName && oldName !== physicalName) aliases.set(oldName, physicalName);
+    element.name = physicalName;
+    const cacheKey = `${connection}\0${JSON.stringify(path)}`;
+    if (!cache.has(cacheKey)) {
+      const table = await jsonApi(api, 'POST', `/v2/connection/${connection}/lookup`, { path });
+      if (table.kind !== 'table' || !table.inodeId) throw new Error(`${path.join('.')} did not resolve to a table`);
+      cache.set(cacheKey, await listColumns(api, table.inodeId));
+    }
+    const entries = cache.get(cacheKey);
+    const refs = new Map(entries.filter((entry) => entry.name).map((entry) => [norm(entry.name), String(entry.name)]));
+    prefixes.add(oldName); prefixes.add(physicalName);
+
+    for (const column of element.columns || []) {
+      const match = String(column.formula || '').match(/^\[([^\]/]+)\/([^\]/]+)\]$/);
+      if (!match) continue;
+      const [, prefix, leaf] = match;
+      const cid = String(column.id || ''), idLeaf = cid.includes('/') ? cid.split('/', 2)[1] : null;
+      const physical = catalogMatch(entries, [leaf, column.name, idLeaf]);
+      if (!physical) {
+        if (cid.startsWith('inode-')) unresolved.push(`${path.join('.')}: ${prefix}/${leaf}`);
+        continue;
+      }
+      if (!column.name) column.name = leaf;
+      if (cid.startsWith('inode-') && idLeaf !== physical) {
+        const newId = `${cid.split('/', 1)[0]}/${physical}`;
+        idMap.set(cid, newId); column.id = newId; rekeyed++;
+      }
+      const grounded = `[${physicalName}/${physical}]`;
+      if (column.formula !== grounded) { column.formula = grounded; rewritten++; }
+    }
+
+    const sameElement = (node) => {
+      if (Array.isArray(node)) return node.forEach(sameElement);
+      if (!node || typeof node !== 'object') return;
+      let display = null;
+      if (typeof node.formula === 'string') {
+        node.formula = node.formula.replace(/\[([^\]/]+)(\/[^\]]+)\]/g, (whole, prefix, suffix) => {
+          const leaf = suffix.slice(1);
+          if (leaf.includes('/') || ![oldName, physicalName].includes(prefix) || !refs.has(norm(leaf))) return whole;
+          display ||= leaf;
+          const grounded = `[${physicalName}/${refs.get(norm(leaf))}]`;
+          if (grounded !== whole) rewritten++;
+          return grounded;
+        });
+      }
+      if (display && !node.name) node.name = display;
+      for (const [key, value] of Object.entries(node)) if (key !== 'formula') sameElement(value);
+    };
+    sameElement(element);
+  }
+
+  const replaceIds = (node) => {
+    if (Array.isArray(node)) return node.map(replaceIds);
+    if (node && typeof node === 'object') {
+      for (const [key, value] of Object.entries(node)) node[key] = replaceIds(value);
+      return node;
+    }
+    return typeof node === 'string' ? (idMap.get(node) || node) : node;
+  };
+  replaceIds(spec);
+
+  const derived = (node) => {
+    if (Array.isArray(node)) return node.forEach(derived);
+    if (!node || typeof node !== 'object') return;
+    let display = null;
+    if (typeof node.formula === 'string') {
+      node.formula = node.formula.replace(/\[([^\]/]+)(\/[^\]]+)\]/g, (_whole, prefix, suffix) => {
+        const replacement = aliases.get(prefix) || prefix;
+        if (replacement !== prefix) reprefixed++;
+        if (!suffix.slice(1).includes('/') && (prefixes.has(prefix) || prefixes.has(replacement))) display ||= suffix.slice(1);
+        return `[${replacement}${suffix}]`;
+      });
+    }
+    if (display && !node.name) node.name = display;
+    for (const [key, value] of Object.entries(node)) if (key !== 'formula') derived(value);
+  };
+  derived(spec);
+  if (unresolved.length) throw new Error(`warehouse columns not found in catalog: ${[...new Set(unresolved)].join(', ')}`);
+  return { rewritten, rekeyed, reprefixed, connectionModes: Object.fromEntries(modes) };
+}

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/post-and-readback.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/post-and-readback.mjs
@@ -12,6 +12,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { api, extractId, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
 import * as CodeRep from './lib/code_rep.mjs';
 import { assertWorkbookContract } from './lib/workbook_contract.mjs';
+import { groundWarehouseRefs } from './lib/warehouse-column-refs.mjs';
 
 const a = parseArgs(process.argv.slice(2));
 if (!a.type || !a.spec || !a.folder) { console.error('need --type datamodel|workbook --spec <spec.json> --folder <folderId>'); process.exit(2); }
@@ -20,6 +21,13 @@ const postPath = a.type === 'datamodel' ? '/v2/dataModels/spec' : '/v2/workbooks
 const colsPath = (id) => a.type === 'datamodel' ? `/v2/dataModels/${id}/columns` : `/v2/workbooks/${id}/columns`;
 
 const spec = JSON.parse(readFileSync(a.spec, 'utf8'));
+if (a.type === 'datamodel') {
+  const grounding = await groundWarehouseRefs(spec, api);
+  const modes = Object.entries(grounding.connectionModes)
+    .map(([id, friendly]) => `${id}=${friendly ? 'friendly' : 'physical'}`).join(', ');
+  console.error(`connection naming: ${modes}; grounded ${grounding.rewritten} formula(s), ` +
+    `re-keyed ${grounding.rekeyed} id(s), re-prefixed ${grounding.reprefixed} ref(s)`);
+}
 // name AFTER the spread — `{name, ...spec}` let spec.name silently override --name (beads-sigma-unff).
 const name = a.name || spec.name || `cognos ${a.type} ${Date.now()}`;
 // Workbook code-rep nests non-metadata fields under `document` (verified live

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-warehouse-column-refs.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-warehouse-column-refs.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { groundWarehouseRefs } from './lib/warehouse-column-refs.mjs';
+
+const spec = { pages: [{ elements: [{
+  name: 'Sales Fact', source: { kind: 'warehouse-table', connectionId: 'conn', path: ['DB', 'S', 'SALES_FACT'] },
+  columns: [{ id: 'inode-x/UNIT_COST', formula: '[SALES_FACT/Unit Cost]' },
+    { id: 'calc', formula: 'Text([Sales Fact/Unit Cost])', name: 'Cost Text' }],
+}, { name: 'Sales View', source: { kind: 'table', elementId: 'fact' },
+  columns: [{ id: 'pass', formula: '[Sales Fact/Unit Cost]' }] }] }] };
+const api = async (method, path) => {
+  if (method === 'POST') return { ok: true, status: 200, json: { kind: 'table', inodeId: 't' }, text: '' };
+  if (path.startsWith('/v2/connections/tables/')) return { ok: true, status: 200, json: { entries: [{ name: 'UNIT_COST' }] }, text: '' };
+  return { ok: true, status: 200, json: { friendlyName: false }, text: '' };
+};
+const result = await groundWarehouseRefs(spec, api);
+const [fact, view] = spec.pages[0].elements;
+if (fact.name !== 'SALES_FACT') throw new Error('physical element name not applied');
+if (fact.columns[0].formula !== '[SALES_FACT/UNIT_COST]' || fact.columns[0].name !== 'Unit Cost') throw new Error('base column not grounded');
+if (fact.columns[1].formula !== 'Text([SALES_FACT/UNIT_COST])') throw new Error('qualified calc not grounded');
+if (view.columns[0].formula !== '[SALES_FACT/Unit Cost]' || view.columns[0].name !== 'Unit Cost') throw new Error('derived ref not grounded');
+if (result.connectionModes.conn !== false) throw new Error('connection mode not reported');
+console.log('test-warehouse-column-refs: PASS');


### PR DESCRIPTION
## What & why

Sigma connections can disable `friendlyName`, requiring exact catalog names in warehouse-table formulas and inode suffixes. Ground Cognos data-model specs in the Node post/readback boundary before the create body is assembled; workbook posts are unchanged.

## Scope

- Plugin: `cognos-to-sigma` only
- Version: `1.2.17 -> 1.2.18`

## Verification

- New ESM grounding regression: pass
- Cognos corpus: 2/2 pass
- Existing Cognos ESM suites: pass
- Shared drift, skill lint, agent variants, hygiene: pass
