### PR TITLE
security: quote token output + validate SIGMA_BASE_URL + TLS verify-on; bump cognos deps

### DIFF
--- a/corpus/lib/mcp_convert.py
+++ b/corpus/lib/mcp_convert.py
@@ -15,7 +15,8 @@ try:
     truststore.inject_into_ssl()
     _CTX = None
 except ImportError:
-    _CTX = ssl._create_unverified_context()
+    # No truststore: fall back to a VERIFIED context, never unverified.
+    _CTX = ssl.create_default_context()
 
 URL = "https://sigma-data-model-mcp.onrender.com/mcp"
 

--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos \u2192 Sigma",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "Migrate IBM Cognos Analytics to Sigma \u2014 Data Module JSON \u2192 Sigma data model, and report-spec XML \u2192 Sigma workbook. Translates the Cognos expression DSL (total..for \u2192 window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/PROVENANCE.json
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/PROVENANCE.json
@@ -2,6 +2,7 @@
   "source": "in-skill converter/cli.ts (cli.ts + cognos-report.ts + cognos.ts + metric-binding.ts + sigma-ids.ts + workbook-features.ts)",
   "bundler": "esbuild --bundle --format=esm --platform=node",
   "vendored_modules": "cli.mjs",
+  "runtime_deps": "fast-xml-parser@5.10.1 (MIT) inlined into cli.mjs, with its MIT transitive deps strnum@2.4.2, @nodable/entities@3.0.0, is-unsafe@2.0.0, path-expression-matcher@1.6.2, xml-naming@0.3.0, anynum@1.0.1. Bumped from ^4.5.0 to clear GHSA-gh4j-gqv2-49f6 (XMLBuilder <5.7.0; unused here — only XMLParser).",
   "source_sha256": "8be3266e7b3674cfd64fd411d04f8e078e7b998fd26a7a33db71c49b85b8ab62",
   "sources": [
     "cli.ts",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.mjs
@@ -1,2113 +1,4 @@
 #!/usr/bin/env node
-var __create = Object.create;
-var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getProtoOf = Object.getPrototypeOf;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
-};
-var __copyProps = (to, from, except, desc) => {
-  if (from && typeof from === "object" || typeof from === "function") {
-    for (let key of __getOwnPropNames(from))
-      if (!__hasOwnProp.call(to, key) && key !== except)
-        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
-  }
-  return to;
-};
-var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
-  // If the importer is in node compatibility mode or this is not an ESM
-  // file that has been converted to a CommonJS file using a Babel-
-  // compatible transform (i.e. "__esModule" has not been set), then set
-  // "default" to the CommonJS "module.exports" for node compatibility.
-  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
-  mod
-));
-
-// node_modules/fast-xml-parser/src/util.js
-var require_util = __commonJS({
-  "node_modules/fast-xml-parser/src/util.js"(exports) {
-    "use strict";
-    var nameStartChar = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
-    var nameChar = nameStartChar + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
-    var nameRegexp = "[" + nameStartChar + "][" + nameChar + "]*";
-    var regexName = new RegExp("^" + nameRegexp + "$");
-    var getAllMatches = function(string, regex) {
-      const matches = [];
-      let match = regex.exec(string);
-      while (match) {
-        const allmatches = [];
-        allmatches.startIndex = regex.lastIndex - match[0].length;
-        const len = match.length;
-        for (let index = 0; index < len; index++) {
-          allmatches.push(match[index]);
-        }
-        matches.push(allmatches);
-        match = regex.exec(string);
-      }
-      return matches;
-    };
-    var isName = function(string) {
-      const match = regexName.exec(string);
-      return !(match === null || typeof match === "undefined");
-    };
-    exports.isExist = function(v) {
-      return typeof v !== "undefined";
-    };
-    exports.isEmptyObject = function(obj) {
-      return Object.keys(obj).length === 0;
-    };
-    exports.merge = function(target, a, arrayMode) {
-      if (a) {
-        const keys = Object.keys(a);
-        const len = keys.length;
-        for (let i = 0; i < len; i++) {
-          if (arrayMode === "strict") {
-            target[keys[i]] = [a[keys[i]]];
-          } else {
-            target[keys[i]] = a[keys[i]];
-          }
-        }
-      }
-    };
-    exports.getValue = function(v) {
-      if (exports.isExist(v)) {
-        return v;
-      } else {
-        return "";
-      }
-    };
-    var DANGEROUS_PROPERTY_NAMES = [
-      // '__proto__',
-      // 'constructor',
-      // 'prototype',
-      "hasOwnProperty",
-      "toString",
-      "valueOf",
-      "__defineGetter__",
-      "__defineSetter__",
-      "__lookupGetter__",
-      "__lookupSetter__"
-    ];
-    var criticalProperties = ["__proto__", "constructor", "prototype"];
-    exports.isName = isName;
-    exports.getAllMatches = getAllMatches;
-    exports.nameRegexp = nameRegexp;
-    exports.DANGEROUS_PROPERTY_NAMES = DANGEROUS_PROPERTY_NAMES;
-    exports.criticalProperties = criticalProperties;
-  }
-});
-
-// node_modules/fast-xml-parser/src/validator.js
-var require_validator = __commonJS({
-  "node_modules/fast-xml-parser/src/validator.js"(exports) {
-    "use strict";
-    var util = require_util();
-    var defaultOptions = {
-      allowBooleanAttributes: false,
-      //A tag can have attributes without any value
-      unpairedTags: []
-    };
-    exports.validate = function(xmlData, options) {
-      options = Object.assign({}, defaultOptions, options);
-      const tags = [];
-      let tagFound = false;
-      let reachedRoot = false;
-      if (xmlData[0] === "\uFEFF") {
-        xmlData = xmlData.substr(1);
-      }
-      for (let i = 0; i < xmlData.length; i++) {
-        if (xmlData[i] === "<" && xmlData[i + 1] === "?") {
-          i += 2;
-          i = readPI(xmlData, i);
-          if (i.err) return i;
-        } else if (xmlData[i] === "<") {
-          let tagStartPos = i;
-          i++;
-          if (xmlData[i] === "!") {
-            i = readCommentAndCDATA(xmlData, i);
-            continue;
-          } else {
-            let closingTag = false;
-            if (xmlData[i] === "/") {
-              closingTag = true;
-              i++;
-            }
-            let tagName = "";
-            for (; i < xmlData.length && xmlData[i] !== ">" && xmlData[i] !== " " && xmlData[i] !== "	" && xmlData[i] !== "\n" && xmlData[i] !== "\r"; i++) {
-              tagName += xmlData[i];
-            }
-            tagName = tagName.trim();
-            if (tagName[tagName.length - 1] === "/") {
-              tagName = tagName.substring(0, tagName.length - 1);
-              i--;
-            }
-            if (!validateTagName(tagName)) {
-              let msg;
-              if (tagName.trim().length === 0) {
-                msg = "Invalid space after '<'.";
-              } else {
-                msg = "Tag '" + tagName + "' is an invalid name.";
-              }
-              return getErrorObject("InvalidTag", msg, getLineNumberForPosition(xmlData, i));
-            }
-            const result = readAttributeStr(xmlData, i);
-            if (result === false) {
-              return getErrorObject("InvalidAttr", "Attributes for '" + tagName + "' have open quote.", getLineNumberForPosition(xmlData, i));
-            }
-            let attrStr = result.value;
-            i = result.index;
-            if (attrStr[attrStr.length - 1] === "/") {
-              const attrStrStart = i - attrStr.length;
-              attrStr = attrStr.substring(0, attrStr.length - 1);
-              const isValid = validateAttributeString(attrStr, options);
-              if (isValid === true) {
-                tagFound = true;
-              } else {
-                return getErrorObject(isValid.err.code, isValid.err.msg, getLineNumberForPosition(xmlData, attrStrStart + isValid.err.line));
-              }
-            } else if (closingTag) {
-              if (!result.tagClosed) {
-                return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' doesn't have proper closing.", getLineNumberForPosition(xmlData, i));
-              } else if (attrStr.trim().length > 0) {
-                return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' can't have attributes or invalid starting.", getLineNumberForPosition(xmlData, tagStartPos));
-              } else if (tags.length === 0) {
-                return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' has not been opened.", getLineNumberForPosition(xmlData, tagStartPos));
-              } else {
-                const otg = tags.pop();
-                if (tagName !== otg.tagName) {
-                  let openPos = getLineNumberForPosition(xmlData, otg.tagStartPos);
-                  return getErrorObject(
-                    "InvalidTag",
-                    "Expected closing tag '" + otg.tagName + "' (opened in line " + openPos.line + ", col " + openPos.col + ") instead of closing tag '" + tagName + "'.",
-                    getLineNumberForPosition(xmlData, tagStartPos)
-                  );
-                }
-                if (tags.length == 0) {
-                  reachedRoot = true;
-                }
-              }
-            } else {
-              const isValid = validateAttributeString(attrStr, options);
-              if (isValid !== true) {
-                return getErrorObject(isValid.err.code, isValid.err.msg, getLineNumberForPosition(xmlData, i - attrStr.length + isValid.err.line));
-              }
-              if (reachedRoot === true) {
-                return getErrorObject("InvalidXml", "Multiple possible root nodes found.", getLineNumberForPosition(xmlData, i));
-              } else if (options.unpairedTags.indexOf(tagName) !== -1) {
-              } else {
-                tags.push({ tagName, tagStartPos });
-              }
-              tagFound = true;
-            }
-            for (i++; i < xmlData.length; i++) {
-              if (xmlData[i] === "<") {
-                if (xmlData[i + 1] === "!") {
-                  i++;
-                  i = readCommentAndCDATA(xmlData, i);
-                  continue;
-                } else if (xmlData[i + 1] === "?") {
-                  i = readPI(xmlData, ++i);
-                  if (i.err) return i;
-                } else {
-                  break;
-                }
-              } else if (xmlData[i] === "&") {
-                const afterAmp = validateAmpersand(xmlData, i);
-                if (afterAmp == -1)
-                  return getErrorObject("InvalidChar", "char '&' is not expected.", getLineNumberForPosition(xmlData, i));
-                i = afterAmp;
-              } else {
-                if (reachedRoot === true && !isWhiteSpace(xmlData[i])) {
-                  return getErrorObject("InvalidXml", "Extra text at the end", getLineNumberForPosition(xmlData, i));
-                }
-              }
-            }
-            if (xmlData[i] === "<") {
-              i--;
-            }
-          }
-        } else {
-          if (isWhiteSpace(xmlData[i])) {
-            continue;
-          }
-          return getErrorObject("InvalidChar", "char '" + xmlData[i] + "' is not expected.", getLineNumberForPosition(xmlData, i));
-        }
-      }
-      if (!tagFound) {
-        return getErrorObject("InvalidXml", "Start tag expected.", 1);
-      } else if (tags.length == 1) {
-        return getErrorObject("InvalidTag", "Unclosed tag '" + tags[0].tagName + "'.", getLineNumberForPosition(xmlData, tags[0].tagStartPos));
-      } else if (tags.length > 0) {
-        return getErrorObject("InvalidXml", "Invalid '" + JSON.stringify(tags.map((t) => t.tagName), null, 4).replace(/\r?\n/g, "") + "' found.", { line: 1, col: 1 });
-      }
-      return true;
-    };
-    function isWhiteSpace(char) {
-      return char === " " || char === "	" || char === "\n" || char === "\r";
-    }
-    function readPI(xmlData, i) {
-      const start = i;
-      for (; i < xmlData.length; i++) {
-        if (xmlData[i] == "?" || xmlData[i] == " ") {
-          const tagname = xmlData.substr(start, i - start);
-          if (i > 5 && tagname === "xml") {
-            return getErrorObject("InvalidXml", "XML declaration allowed only at the start of the document.", getLineNumberForPosition(xmlData, i));
-          } else if (xmlData[i] == "?" && xmlData[i + 1] == ">") {
-            i++;
-            break;
-          } else {
-            continue;
-          }
-        }
-      }
-      return i;
-    }
-    function readCommentAndCDATA(xmlData, i) {
-      if (xmlData.length > i + 5 && xmlData[i + 1] === "-" && xmlData[i + 2] === "-") {
-        for (i += 3; i < xmlData.length; i++) {
-          if (xmlData[i] === "-" && xmlData[i + 1] === "-" && xmlData[i + 2] === ">") {
-            i += 2;
-            break;
-          }
-        }
-      } else if (xmlData.length > i + 8 && xmlData[i + 1] === "D" && xmlData[i + 2] === "O" && xmlData[i + 3] === "C" && xmlData[i + 4] === "T" && xmlData[i + 5] === "Y" && xmlData[i + 6] === "P" && xmlData[i + 7] === "E") {
-        let angleBracketsCount = 1;
-        for (i += 8; i < xmlData.length; i++) {
-          if (xmlData[i] === "<") {
-            angleBracketsCount++;
-          } else if (xmlData[i] === ">") {
-            angleBracketsCount--;
-            if (angleBracketsCount === 0) {
-              break;
-            }
-          }
-        }
-      } else if (xmlData.length > i + 9 && xmlData[i + 1] === "[" && xmlData[i + 2] === "C" && xmlData[i + 3] === "D" && xmlData[i + 4] === "A" && xmlData[i + 5] === "T" && xmlData[i + 6] === "A" && xmlData[i + 7] === "[") {
-        for (i += 8; i < xmlData.length; i++) {
-          if (xmlData[i] === "]" && xmlData[i + 1] === "]" && xmlData[i + 2] === ">") {
-            i += 2;
-            break;
-          }
-        }
-      }
-      return i;
-    }
-    var doubleQuote = '"';
-    var singleQuote = "'";
-    function readAttributeStr(xmlData, i) {
-      let attrStr = "";
-      let startChar = "";
-      let tagClosed = false;
-      for (; i < xmlData.length; i++) {
-        if (xmlData[i] === doubleQuote || xmlData[i] === singleQuote) {
-          if (startChar === "") {
-            startChar = xmlData[i];
-          } else if (startChar !== xmlData[i]) {
-          } else {
-            startChar = "";
-          }
-        } else if (xmlData[i] === ">") {
-          if (startChar === "") {
-            tagClosed = true;
-            break;
-          }
-        }
-        attrStr += xmlData[i];
-      }
-      if (startChar !== "") {
-        return false;
-      }
-      return {
-        value: attrStr,
-        index: i,
-        tagClosed
-      };
-    }
-    var validAttrStrRegxp = new RegExp(`(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['"])(([\\s\\S])*?)\\5)?`, "g");
-    function validateAttributeString(attrStr, options) {
-      const matches = util.getAllMatches(attrStr, validAttrStrRegxp);
-      const attrNames = {};
-      for (let i = 0; i < matches.length; i++) {
-        if (matches[i][1].length === 0) {
-          return getErrorObject("InvalidAttr", "Attribute '" + matches[i][2] + "' has no space in starting.", getPositionFromMatch(matches[i]));
-        } else if (matches[i][3] !== void 0 && matches[i][4] === void 0) {
-          return getErrorObject("InvalidAttr", "Attribute '" + matches[i][2] + "' is without value.", getPositionFromMatch(matches[i]));
-        } else if (matches[i][3] === void 0 && !options.allowBooleanAttributes) {
-          return getErrorObject("InvalidAttr", "boolean attribute '" + matches[i][2] + "' is not allowed.", getPositionFromMatch(matches[i]));
-        }
-        const attrName = matches[i][2];
-        if (!validateAttrName(attrName)) {
-          return getErrorObject("InvalidAttr", "Attribute '" + attrName + "' is an invalid name.", getPositionFromMatch(matches[i]));
-        }
-        if (!attrNames.hasOwnProperty(attrName)) {
-          attrNames[attrName] = 1;
-        } else {
-          return getErrorObject("InvalidAttr", "Attribute '" + attrName + "' is repeated.", getPositionFromMatch(matches[i]));
-        }
-      }
-      return true;
-    }
-    function validateNumberAmpersand(xmlData, i) {
-      let re = /\d/;
-      if (xmlData[i] === "x") {
-        i++;
-        re = /[\da-fA-F]/;
-      }
-      for (; i < xmlData.length; i++) {
-        if (xmlData[i] === ";")
-          return i;
-        if (!xmlData[i].match(re))
-          break;
-      }
-      return -1;
-    }
-    function validateAmpersand(xmlData, i) {
-      i++;
-      if (xmlData[i] === ";")
-        return -1;
-      if (xmlData[i] === "#") {
-        i++;
-        return validateNumberAmpersand(xmlData, i);
-      }
-      let count = 0;
-      for (; i < xmlData.length; i++, count++) {
-        if (xmlData[i].match(/\w/) && count < 20)
-          continue;
-        if (xmlData[i] === ";")
-          break;
-        return -1;
-      }
-      return i;
-    }
-    function getErrorObject(code, message, lineNumber) {
-      return {
-        err: {
-          code,
-          msg: message,
-          line: lineNumber.line || lineNumber,
-          col: lineNumber.col
-        }
-      };
-    }
-    function validateAttrName(attrName) {
-      return util.isName(attrName);
-    }
-    function validateTagName(tagname) {
-      return util.isName(tagname);
-    }
-    function getLineNumberForPosition(xmlData, index) {
-      const lines = xmlData.substring(0, index).split(/\r?\n/);
-      return {
-        line: lines.length,
-        // column number is last line's length + 1, because column numbering starts at 1:
-        col: lines[lines.length - 1].length + 1
-      };
-    }
-    function getPositionFromMatch(match) {
-      return match.startIndex + match[1].length;
-    }
-  }
-});
-
-// node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
-var require_OptionsBuilder = __commonJS({
-  "node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
-    var { DANGEROUS_PROPERTY_NAMES, criticalProperties } = require_util();
-    var defaultOnDangerousProperty = (name) => {
-      if (DANGEROUS_PROPERTY_NAMES.includes(name)) {
-        return "__" + name;
-      }
-      return name;
-    };
-    var defaultOptions = {
-      preserveOrder: false,
-      attributeNamePrefix: "@_",
-      attributesGroupName: false,
-      textNodeName: "#text",
-      ignoreAttributes: true,
-      removeNSPrefix: false,
-      // remove NS from tag name or attribute name if true
-      allowBooleanAttributes: false,
-      //a tag can have attributes without any value
-      //ignoreRootElement : false,
-      parseTagValue: true,
-      parseAttributeValue: false,
-      trimValues: true,
-      //Trim string values of tag and attributes
-      cdataPropName: false,
-      numberParseOptions: {
-        hex: true,
-        leadingZeros: true,
-        eNotation: true
-      },
-      tagValueProcessor: function(tagName, val) {
-        return val;
-      },
-      attributeValueProcessor: function(attrName, val) {
-        return val;
-      },
-      stopNodes: [],
-      //nested tags will not be parsed even for errors
-      alwaysCreateTextNode: false,
-      isArray: () => false,
-      commentPropName: false,
-      unpairedTags: [],
-      processEntities: true,
-      htmlEntities: false,
-      ignoreDeclaration: false,
-      ignorePiTags: false,
-      transformTagName: false,
-      transformAttributeName: false,
-      updateTag: function(tagName, jPath, attrs) {
-        return tagName;
-      },
-      // skipEmptyListItem: false
-      captureMetaData: false,
-      maxNestedTags: 100,
-      strictReservedNames: true,
-      onDangerousProperty: defaultOnDangerousProperty
-    };
-    function validatePropertyName(propertyName, optionName) {
-      if (typeof propertyName !== "string") {
-        return;
-      }
-      const normalized = propertyName.toLowerCase();
-      if (DANGEROUS_PROPERTY_NAMES.some((dangerous) => normalized === dangerous.toLowerCase())) {
-        throw new Error(
-          `[SECURITY] Invalid ${optionName}: "${propertyName}" is a reserved JavaScript keyword that could cause prototype pollution`
-        );
-      }
-      if (criticalProperties.some((dangerous) => normalized === dangerous.toLowerCase())) {
-        throw new Error(
-          `[SECURITY] Invalid ${optionName}: "${propertyName}" is a reserved JavaScript keyword that could cause prototype pollution`
-        );
-      }
-    }
-    function normalizeProcessEntities(value) {
-      if (typeof value === "boolean") {
-        return {
-          enabled: value,
-          // true or false
-          maxEntitySize: 1e4,
-          maxExpansionDepth: 10,
-          maxTotalExpansions: 1e3,
-          maxExpandedLength: 1e5,
-          allowedTags: null,
-          tagFilter: null
-        };
-      }
-      if (typeof value === "object" && value !== null) {
-        return {
-          enabled: value.enabled !== false,
-          maxEntitySize: Math.max(1, value.maxEntitySize ?? 1e4),
-          maxExpansionDepth: Math.max(1, value.maxExpansionDepth ?? 1e4),
-          maxTotalExpansions: Math.max(1, value.maxTotalExpansions ?? Infinity),
-          maxExpandedLength: Math.max(1, value.maxExpandedLength ?? 1e5),
-          maxEntityCount: Math.max(1, value.maxEntityCount ?? 1e3),
-          allowedTags: value.allowedTags ?? null,
-          tagFilter: value.tagFilter ?? null
-        };
-      }
-      return normalizeProcessEntities(true);
-    }
-    var buildOptions = function(options) {
-      const built = Object.assign({}, defaultOptions, options);
-      const propertyNameOptions = [
-        { value: built.attributeNamePrefix, name: "attributeNamePrefix" },
-        { value: built.attributesGroupName, name: "attributesGroupName" },
-        { value: built.textNodeName, name: "textNodeName" },
-        { value: built.cdataPropName, name: "cdataPropName" },
-        { value: built.commentPropName, name: "commentPropName" }
-      ];
-      for (const { value, name } of propertyNameOptions) {
-        if (value) {
-          validatePropertyName(value, name);
-        }
-      }
-      if (built.onDangerousProperty === null) {
-        built.onDangerousProperty = defaultOnDangerousProperty;
-      }
-      built.processEntities = normalizeProcessEntities(built.processEntities);
-      return built;
-    };
-    exports.buildOptions = buildOptions;
-    exports.defaultOptions = defaultOptions;
-  }
-});
-
-// node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
-var require_xmlNode = __commonJS({
-  "node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module) {
-    "use strict";
-    var XmlNode = class {
-      constructor(tagname) {
-        this.tagname = tagname;
-        this.child = [];
-        this[":@"] = {};
-      }
-      add(key, val) {
-        if (key === "__proto__") key = "#__proto__";
-        this.child.push({ [key]: val });
-      }
-      addChild(node) {
-        if (node.tagname === "__proto__") node.tagname = "#__proto__";
-        if (node[":@"] && Object.keys(node[":@"]).length > 0) {
-          this.child.push({ [node.tagname]: node.child, [":@"]: node[":@"] });
-        } else {
-          this.child.push({ [node.tagname]: node.child });
-        }
-      }
-    };
-    module.exports = XmlNode;
-  }
-});
-
-// node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
-var require_DocTypeReader = __commonJS({
-  "node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module) {
-    var util = require_util();
-    var DocTypeReader = class {
-      constructor(options) {
-        this.suppressValidationErr = !options;
-        this.options = options || {};
-      }
-      readDocType(xmlData, i) {
-        const entities = /* @__PURE__ */ Object.create(null);
-        let entityCount = 0;
-        if (xmlData[i + 3] === "O" && xmlData[i + 4] === "C" && xmlData[i + 5] === "T" && xmlData[i + 6] === "Y" && xmlData[i + 7] === "P" && xmlData[i + 8] === "E") {
-          i = i + 9;
-          let angleBracketsCount = 1;
-          let hasBody = false, comment = false;
-          let exp = "";
-          for (; i < xmlData.length; i++) {
-            if (xmlData[i] === "<" && !comment) {
-              if (hasBody && hasSeq(xmlData, "!ENTITY", i)) {
-                i += 7;
-                let entityName, val;
-                [entityName, val, i] = this.readEntityExp(xmlData, i + 1, this.suppressValidationErr);
-                if (val.indexOf("&") === -1) {
-                  if (this.options.enabled !== false && this.options.maxEntityCount != null && entityCount >= this.options.maxEntityCount) {
-                    throw new Error(
-                      `Entity count (${entityCount + 1}) exceeds maximum allowed (${this.options.maxEntityCount})`
-                    );
-                  }
-                  const escaped = entityName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                  entities[entityName] = {
-                    regx: RegExp(`&${escaped};`, "g"),
-                    val
-                  };
-                  entityCount++;
-                }
-              } else if (hasBody && hasSeq(xmlData, "!ELEMENT", i)) {
-                i += 8;
-                const { index } = this.readElementExp(xmlData, i + 1);
-                i = index;
-              } else if (hasBody && hasSeq(xmlData, "!ATTLIST", i)) {
-                i += 8;
-              } else if (hasBody && hasSeq(xmlData, "!NOTATION", i)) {
-                i += 9;
-                const { index } = this.readNotationExp(xmlData, i + 1, this.suppressValidationErr);
-                i = index;
-              } else if (hasSeq(xmlData, "!--", i)) {
-                comment = true;
-              } else {
-                throw new Error(`Invalid DOCTYPE`);
-              }
-              angleBracketsCount++;
-              exp = "";
-            } else if (xmlData[i] === ">") {
-              if (comment) {
-                if (xmlData[i - 1] === "-" && xmlData[i - 2] === "-") {
-                  comment = false;
-                  angleBracketsCount--;
-                }
-              } else {
-                angleBracketsCount--;
-              }
-              if (angleBracketsCount === 0) {
-                break;
-              }
-            } else if (xmlData[i] === "[") {
-              hasBody = true;
-            } else {
-              exp += xmlData[i];
-            }
-          }
-          if (angleBracketsCount !== 0) {
-            throw new Error(`Unclosed DOCTYPE`);
-          }
-        } else {
-          throw new Error(`Invalid Tag instead of DOCTYPE`);
-        }
-        return { entities, i };
-      }
-      readEntityExp(xmlData, i) {
-        i = skipWhitespace(xmlData, i);
-        let entityName = "";
-        while (i < xmlData.length && !/\s/.test(xmlData[i]) && xmlData[i] !== '"' && xmlData[i] !== "'") {
-          entityName += xmlData[i];
-          i++;
-        }
-        validateEntityName(entityName);
-        i = skipWhitespace(xmlData, i);
-        if (!this.suppressValidationErr) {
-          if (xmlData.substring(i, i + 6).toUpperCase() === "SYSTEM") {
-            throw new Error("External entities are not supported");
-          } else if (xmlData[i] === "%") {
-            throw new Error("Parameter entities are not supported");
-          }
-        }
-        let entityValue = "";
-        [i, entityValue] = this.readIdentifierVal(xmlData, i, "entity");
-        if (this.options.enabled !== false && this.options.maxEntitySize != null && entityValue.length > this.options.maxEntitySize) {
-          throw new Error(
-            `Entity "${entityName}" size (${entityValue.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`
-          );
-        }
-        i--;
-        return [entityName, entityValue, i];
-      }
-      readNotationExp(xmlData, i) {
-        i = skipWhitespace(xmlData, i);
-        let notationName = "";
-        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
-          notationName += xmlData[i];
-          i++;
-        }
-        !this.suppressValidationErr && validateEntityName(notationName);
-        i = skipWhitespace(xmlData, i);
-        const identifierType = xmlData.substring(i, i + 6).toUpperCase();
-        if (!this.suppressValidationErr && identifierType !== "SYSTEM" && identifierType !== "PUBLIC") {
-          throw new Error(`Expected SYSTEM or PUBLIC, found "${identifierType}"`);
-        }
-        i += identifierType.length;
-        i = skipWhitespace(xmlData, i);
-        let publicIdentifier = null;
-        let systemIdentifier = null;
-        if (identifierType === "PUBLIC") {
-          [i, publicIdentifier] = this.readIdentifierVal(xmlData, i, "publicIdentifier");
-          i = skipWhitespace(xmlData, i);
-          if (xmlData[i] === '"' || xmlData[i] === "'") {
-            [i, systemIdentifier] = this.readIdentifierVal(xmlData, i, "systemIdentifier");
-          }
-        } else if (identifierType === "SYSTEM") {
-          [i, systemIdentifier] = this.readIdentifierVal(xmlData, i, "systemIdentifier");
-          if (!this.suppressValidationErr && !systemIdentifier) {
-            throw new Error("Missing mandatory system identifier for SYSTEM notation");
-          }
-        }
-        return { notationName, publicIdentifier, systemIdentifier, index: --i };
-      }
-      readIdentifierVal(xmlData, i, type) {
-        let identifierVal = "";
-        const startChar = xmlData[i];
-        if (startChar !== '"' && startChar !== "'") {
-          throw new Error(`Expected quoted string, found "${startChar}"`);
-        }
-        i++;
-        while (i < xmlData.length && xmlData[i] !== startChar) {
-          identifierVal += xmlData[i];
-          i++;
-        }
-        if (xmlData[i] !== startChar) {
-          throw new Error(`Unterminated ${type} value`);
-        }
-        i++;
-        return [i, identifierVal];
-      }
-      readElementExp(xmlData, i) {
-        i = skipWhitespace(xmlData, i);
-        let elementName = "";
-        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
-          elementName += xmlData[i];
-          i++;
-        }
-        if (!this.suppressValidationErr && !util.isName(elementName)) {
-          throw new Error(`Invalid element name: "${elementName}"`);
-        }
-        i = skipWhitespace(xmlData, i);
-        let contentModel = "";
-        if (xmlData[i] === "E" && hasSeq(xmlData, "MPTY", i)) {
-          i += 4;
-        } else if (xmlData[i] === "A" && hasSeq(xmlData, "NY", i)) {
-          i += 2;
-        } else if (xmlData[i] === "(") {
-          i++;
-          while (i < xmlData.length && xmlData[i] !== ")") {
-            contentModel += xmlData[i];
-            i++;
-          }
-          if (xmlData[i] !== ")") {
-            throw new Error("Unterminated content model");
-          }
-        } else if (!this.suppressValidationErr) {
-          throw new Error(`Invalid Element Expression, found "${xmlData[i]}"`);
-        }
-        return {
-          elementName,
-          contentModel: contentModel.trim(),
-          index: i
-        };
-      }
-      readAttlistExp(xmlData, i) {
-        i = skipWhitespace(xmlData, i);
-        let elementName = "";
-        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
-          elementName += xmlData[i];
-          i++;
-        }
-        validateEntityName(elementName);
-        i = skipWhitespace(xmlData, i);
-        let attributeName = "";
-        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
-          attributeName += xmlData[i];
-          i++;
-        }
-        if (!validateEntityName(attributeName)) {
-          throw new Error(`Invalid attribute name: "${attributeName}"`);
-        }
-        i = skipWhitespace(xmlData, i);
-        let attributeType = "";
-        if (xmlData.substring(i, i + 8).toUpperCase() === "NOTATION") {
-          attributeType = "NOTATION";
-          i += 8;
-          i = skipWhitespace(xmlData, i);
-          if (xmlData[i] !== "(") {
-            throw new Error(`Expected '(', found "${xmlData[i]}"`);
-          }
-          i++;
-          let allowedNotations = [];
-          while (i < xmlData.length && xmlData[i] !== ")") {
-            let notation = "";
-            while (i < xmlData.length && xmlData[i] !== "|" && xmlData[i] !== ")") {
-              notation += xmlData[i];
-              i++;
-            }
-            notation = notation.trim();
-            if (!validateEntityName(notation)) {
-              throw new Error(`Invalid notation name: "${notation}"`);
-            }
-            allowedNotations.push(notation);
-            if (xmlData[i] === "|") {
-              i++;
-              i = skipWhitespace(xmlData, i);
-            }
-          }
-          if (xmlData[i] !== ")") {
-            throw new Error("Unterminated list of notations");
-          }
-          i++;
-          attributeType += " (" + allowedNotations.join("|") + ")";
-        } else {
-          while (i < xmlData.length && !/\s/.test(xmlData[i])) {
-            attributeType += xmlData[i];
-            i++;
-          }
-          const validTypes = ["CDATA", "ID", "IDREF", "IDREFS", "ENTITY", "ENTITIES", "NMTOKEN", "NMTOKENS"];
-          if (!this.suppressValidationErr && !validTypes.includes(attributeType.toUpperCase())) {
-            throw new Error(`Invalid attribute type: "${attributeType}"`);
-          }
-        }
-        i = skipWhitespace(xmlData, i);
-        let defaultValue = "";
-        if (xmlData.substring(i, i + 8).toUpperCase() === "#REQUIRED") {
-          defaultValue = "#REQUIRED";
-          i += 8;
-        } else if (xmlData.substring(i, i + 7).toUpperCase() === "#IMPLIED") {
-          defaultValue = "#IMPLIED";
-          i += 7;
-        } else {
-          [i, defaultValue] = this.readIdentifierVal(xmlData, i, "ATTLIST");
-        }
-        return {
-          elementName,
-          attributeName,
-          attributeType,
-          defaultValue,
-          index: i
-        };
-      }
-    };
-    var skipWhitespace = (data, index) => {
-      while (index < data.length && /\s/.test(data[index])) {
-        index++;
-      }
-      return index;
-    };
-    function hasSeq(data, seq, i) {
-      for (let j = 0; j < seq.length; j++) {
-        if (seq[j] !== data[i + j + 1]) return false;
-      }
-      return true;
-    }
-    function validateEntityName(name) {
-      if (util.isName(name))
-        return name;
-      else
-        throw new Error(`Invalid entity name ${name}`);
-    }
-    module.exports = DocTypeReader;
-  }
-});
-
-// node_modules/strnum/strnum.js
-var require_strnum = __commonJS({
-  "node_modules/strnum/strnum.js"(exports, module) {
-    var hexRegex = /^[-+]?0x[a-fA-F0-9]+$/;
-    var numRegex = /^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/;
-    var consider = {
-      hex: true,
-      // oct: false,
-      leadingZeros: true,
-      decimalPoint: ".",
-      eNotation: true
-      //skipLike: /regex/
-    };
-    function toNumber(str, options = {}) {
-      options = Object.assign({}, consider, options);
-      if (!str || typeof str !== "string") return str;
-      let trimmedStr = str.trim();
-      if (options.skipLike !== void 0 && options.skipLike.test(trimmedStr)) return str;
-      else if (str === "0") return 0;
-      else if (options.hex && hexRegex.test(trimmedStr)) {
-        return parse_int(trimmedStr, 16);
-      } else if (trimmedStr.search(/[eE]/) !== -1) {
-        const notation = trimmedStr.match(/^([-\+])?(0*)([0-9]*(\.[0-9]*)?[eE][-\+]?[0-9]+)$/);
-        if (notation) {
-          if (options.leadingZeros) {
-            trimmedStr = (notation[1] || "") + notation[3];
-          } else {
-            if (notation[2] === "0" && notation[3][0] === ".") {
-            } else {
-              return str;
-            }
-          }
-          return options.eNotation ? Number(trimmedStr) : str;
-        } else {
-          return str;
-        }
-      } else {
-        const match = numRegex.exec(trimmedStr);
-        if (match) {
-          const sign = match[1];
-          const leadingZeros = match[2];
-          let numTrimmedByZeros = trimZeros(match[3]);
-          if (!options.leadingZeros && leadingZeros.length > 0 && sign && trimmedStr[2] !== ".") return str;
-          else if (!options.leadingZeros && leadingZeros.length > 0 && !sign && trimmedStr[1] !== ".") return str;
-          else if (options.leadingZeros && leadingZeros === str) return 0;
-          else {
-            const num = Number(trimmedStr);
-            const numStr = "" + num;
-            if (numStr.search(/[eE]/) !== -1) {
-              if (options.eNotation) return num;
-              else return str;
-            } else if (trimmedStr.indexOf(".") !== -1) {
-              if (numStr === "0" && numTrimmedByZeros === "") return num;
-              else if (numStr === numTrimmedByZeros) return num;
-              else if (sign && numStr === "-" + numTrimmedByZeros) return num;
-              else return str;
-            }
-            if (leadingZeros) {
-              return numTrimmedByZeros === numStr || sign + numTrimmedByZeros === numStr ? num : str;
-            } else {
-              return trimmedStr === numStr || trimmedStr === sign + numStr ? num : str;
-            }
-          }
-        } else {
-          return str;
-        }
-      }
-    }
-    function trimZeros(numStr) {
-      if (numStr && numStr.indexOf(".") !== -1) {
-        numStr = numStr.replace(/0+$/, "");
-        if (numStr === ".") numStr = "0";
-        else if (numStr[0] === ".") numStr = "0" + numStr;
-        else if (numStr[numStr.length - 1] === ".") numStr = numStr.substr(0, numStr.length - 1);
-        return numStr;
-      }
-      return numStr;
-    }
-    function parse_int(numStr, base) {
-      if (parseInt) return parseInt(numStr, base);
-      else if (Number.parseInt) return Number.parseInt(numStr, base);
-      else if (window && window.parseInt) return window.parseInt(numStr, base);
-      else throw new Error("parseInt, Number.parseInt, window.parseInt are not supported");
-    }
-    module.exports = toNumber;
-  }
-});
-
-// node_modules/fast-xml-parser/src/ignoreAttributes.js
-var require_ignoreAttributes = __commonJS({
-  "node_modules/fast-xml-parser/src/ignoreAttributes.js"(exports, module) {
-    function getIgnoreAttributesFn(ignoreAttributes) {
-      if (typeof ignoreAttributes === "function") {
-        return ignoreAttributes;
-      }
-      if (Array.isArray(ignoreAttributes)) {
-        return (attrName) => {
-          for (const pattern of ignoreAttributes) {
-            if (typeof pattern === "string" && attrName === pattern) {
-              return true;
-            }
-            if (pattern instanceof RegExp && pattern.test(attrName)) {
-              return true;
-            }
-          }
-        };
-      }
-      return () => false;
-    }
-    module.exports = getIgnoreAttributesFn;
-  }
-});
-
-// node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
-var require_OrderedObjParser = __commonJS({
-  "node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module) {
-    "use strict";
-    var util = require_util();
-    var xmlNode = require_xmlNode();
-    var DocTypeReader = require_DocTypeReader();
-    var toNumber = require_strnum();
-    var getIgnoreAttributesFn = require_ignoreAttributes();
-    var OrderedObjParser = class {
-      constructor(options) {
-        this.options = options;
-        this.currentNode = null;
-        this.tagsNodeStack = [];
-        this.docTypeEntities = {};
-        this.lastEntities = {
-          "apos": { regex: /&(apos|#39|#x27);/g, val: "'" },
-          "gt": { regex: /&(gt|#62|#x3E);/g, val: ">" },
-          "lt": { regex: /&(lt|#60|#x3C);/g, val: "<" },
-          "quot": { regex: /&(quot|#34|#x22);/g, val: '"' }
-        };
-        this.ampEntity = { regex: /&(amp|#38|#x26);/g, val: "&" };
-        this.htmlEntities = {
-          "space": { regex: /&(nbsp|#160);/g, val: " " },
-          // "lt" : { regex: /&(lt|#60);/g, val: "<" },
-          // "gt" : { regex: /&(gt|#62);/g, val: ">" },
-          // "amp" : { regex: /&(amp|#38);/g, val: "&" },
-          // "quot" : { regex: /&(quot|#34);/g, val: "\"" },
-          // "apos" : { regex: /&(apos|#39);/g, val: "'" },
-          "cent": { regex: /&(cent|#162);/g, val: "\xA2" },
-          "pound": { regex: /&(pound|#163);/g, val: "\xA3" },
-          "yen": { regex: /&(yen|#165);/g, val: "\xA5" },
-          "euro": { regex: /&(euro|#8364);/g, val: "\u20AC" },
-          "copyright": { regex: /&(copy|#169);/g, val: "\xA9" },
-          "reg": { regex: /&(reg|#174);/g, val: "\xAE" },
-          "inr": { regex: /&(inr|#8377);/g, val: "\u20B9" },
-          "num_dec": { regex: /&#([0-9]{1,7});/g, val: (_, str) => fromCodePoint(str, 10, "&#") },
-          "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val: (_, str) => fromCodePoint(str, 16, "&#x") }
-        };
-        this.addExternalEntities = addExternalEntities;
-        this.parseXml = parseXml;
-        this.parseTextData = parseTextData;
-        this.resolveNameSpace = resolveNameSpace;
-        this.buildAttributesMap = buildAttributesMap;
-        this.isItStopNode = isItStopNode;
-        this.replaceEntitiesValue = replaceEntitiesValue;
-        this.readStopNodeData = readStopNodeData;
-        this.saveTextToParentTag = saveTextToParentTag;
-        this.addChild = addChild;
-        this.ignoreAttributesFn = getIgnoreAttributesFn(this.options.ignoreAttributes);
-        this.entityExpansionCount = 0;
-        this.currentExpandedLength = 0;
-        if (this.options.stopNodes && this.options.stopNodes.length > 0) {
-          this.stopNodesExact = /* @__PURE__ */ new Set();
-          this.stopNodesWildcard = /* @__PURE__ */ new Set();
-          for (let i = 0; i < this.options.stopNodes.length; i++) {
-            const stopNodeExp = this.options.stopNodes[i];
-            if (typeof stopNodeExp !== "string") continue;
-            if (stopNodeExp.startsWith("*.")) {
-              this.stopNodesWildcard.add(stopNodeExp.substring(2));
-            } else {
-              this.stopNodesExact.add(stopNodeExp);
-            }
-          }
-        }
-      }
-    };
-    function addExternalEntities(externalEntities) {
-      const entKeys = Object.keys(externalEntities);
-      for (let i = 0; i < entKeys.length; i++) {
-        const ent = entKeys[i];
-        const escaped = ent.replace(/[.\-+*:]/g, "\\.");
-        this.lastEntities[ent] = {
-          regex: new RegExp("&" + escaped + ";", "g"),
-          val: externalEntities[ent]
-        };
-      }
-    }
-    function parseTextData(val, tagName, jPath, dontTrim, hasAttributes, isLeafNode, escapeEntities) {
-      if (val !== void 0) {
-        if (this.options.trimValues && !dontTrim) {
-          val = val.trim();
-        }
-        if (val.length > 0) {
-          if (!escapeEntities) val = this.replaceEntitiesValue(val, tagName, jPath);
-          const newval = this.options.tagValueProcessor(tagName, val, jPath, hasAttributes, isLeafNode);
-          if (newval === null || newval === void 0) {
-            return val;
-          } else if (typeof newval !== typeof val || newval !== val) {
-            return newval;
-          } else if (this.options.trimValues) {
-            return parseValue(val, this.options.parseTagValue, this.options.numberParseOptions);
-          } else {
-            const trimmedVal = val.trim();
-            if (trimmedVal === val) {
-              return parseValue(val, this.options.parseTagValue, this.options.numberParseOptions);
-            } else {
-              return val;
-            }
-          }
-        }
-      }
-    }
-    function resolveNameSpace(tagname) {
-      if (this.options.removeNSPrefix) {
-        const tags = tagname.split(":");
-        const prefix = tagname.charAt(0) === "/" ? "/" : "";
-        if (tags[0] === "xmlns") {
-          return "";
-        }
-        if (tags.length === 2) {
-          tagname = prefix + tags[1];
-        }
-      }
-      return tagname;
-    }
-    var attrsRegx = new RegExp(`([^\\s=]+)\\s*(=\\s*(['"])([\\s\\S]*?)\\3)?`, "gm");
-    function buildAttributesMap(attrStr, jPath, tagName) {
-      if (this.options.ignoreAttributes !== true && typeof attrStr === "string") {
-        const matches = util.getAllMatches(attrStr, attrsRegx);
-        const len = matches.length;
-        const attrs = {};
-        for (let i = 0; i < len; i++) {
-          const attrName = this.resolveNameSpace(matches[i][1]);
-          if (this.ignoreAttributesFn(attrName, jPath)) {
-            continue;
-          }
-          let oldVal = matches[i][4];
-          let aName = this.options.attributeNamePrefix + attrName;
-          if (attrName.length) {
-            if (this.options.transformAttributeName) {
-              aName = this.options.transformAttributeName(aName);
-            }
-            aName = sanitizeName(aName, this.options);
-            if (oldVal !== void 0) {
-              if (this.options.trimValues) {
-                oldVal = oldVal.trim();
-              }
-              oldVal = this.replaceEntitiesValue(oldVal, tagName, jPath);
-              const newVal = this.options.attributeValueProcessor(attrName, oldVal, jPath);
-              if (newVal === null || newVal === void 0) {
-                attrs[aName] = oldVal;
-              } else if (typeof newVal !== typeof oldVal || newVal !== oldVal) {
-                attrs[aName] = newVal;
-              } else {
-                attrs[aName] = parseValue(
-                  oldVal,
-                  this.options.parseAttributeValue,
-                  this.options.numberParseOptions
-                );
-              }
-            } else if (this.options.allowBooleanAttributes) {
-              attrs[aName] = true;
-            }
-          }
-        }
-        if (!Object.keys(attrs).length) {
-          return;
-        }
-        if (this.options.attributesGroupName) {
-          const attrCollection = {};
-          attrCollection[this.options.attributesGroupName] = attrs;
-          return attrCollection;
-        }
-        return attrs;
-      }
-    }
-    var parseXml = function(xmlData) {
-      xmlData = xmlData.replace(/\r\n?/g, "\n");
-      const xmlObj = new xmlNode("!xml");
-      let currentNode = xmlObj;
-      let textData = "";
-      let jPath = "";
-      this.entityExpansionCount = 0;
-      this.currentExpandedLength = 0;
-      const docTypeReader = new DocTypeReader(this.options.processEntities);
-      for (let i = 0; i < xmlData.length; i++) {
-        const ch = xmlData[i];
-        if (ch === "<") {
-          if (xmlData[i + 1] === "/") {
-            const closeIndex = findClosingIndex(xmlData, ">", i, "Closing Tag is not closed.");
-            let tagName = xmlData.substring(i + 2, closeIndex).trim();
-            if (this.options.removeNSPrefix) {
-              const colonIndex = tagName.indexOf(":");
-              if (colonIndex !== -1) {
-                tagName = tagName.substr(colonIndex + 1);
-              }
-            }
-            if (this.options.transformTagName) {
-              tagName = this.options.transformTagName(tagName);
-            }
-            if (currentNode) {
-              textData = this.saveTextToParentTag(textData, currentNode, jPath);
-            }
-            const lastTagName = jPath.substring(jPath.lastIndexOf(".") + 1);
-            if (tagName && this.options.unpairedTags.indexOf(tagName) !== -1) {
-              throw new Error(`Unpaired tag can not be used as closing tag: </${tagName}>`);
-            }
-            let propIndex = 0;
-            if (lastTagName && this.options.unpairedTags.indexOf(lastTagName) !== -1) {
-              propIndex = jPath.lastIndexOf(".", jPath.lastIndexOf(".") - 1);
-              this.tagsNodeStack.pop();
-            } else {
-              propIndex = jPath.lastIndexOf(".");
-            }
-            jPath = jPath.substring(0, propIndex);
-            currentNode = this.tagsNodeStack.pop();
-            textData = "";
-            i = closeIndex;
-          } else if (xmlData[i + 1] === "?") {
-            let tagData = readTagExp(xmlData, i, false, "?>");
-            if (!tagData) throw new Error("Pi Tag is not closed.");
-            textData = this.saveTextToParentTag(textData, currentNode, jPath);
-            if (this.options.ignoreDeclaration && tagData.tagName === "?xml" || this.options.ignorePiTags) {
-            } else {
-              const childNode = new xmlNode(tagData.tagName);
-              childNode.add(this.options.textNodeName, "");
-              if (tagData.tagName !== tagData.tagExp && tagData.attrExpPresent) {
-                childNode[":@"] = this.buildAttributesMap(tagData.tagExp, jPath, tagData.tagName);
-              }
-              this.addChild(currentNode, childNode, jPath, i);
-            }
-            i = tagData.closeIndex + 1;
-          } else if (xmlData.substr(i + 1, 3) === "!--") {
-            const endIndex = findClosingIndex(xmlData, "-->", i + 4, "Comment is not closed.");
-            if (this.options.commentPropName) {
-              const comment = xmlData.substring(i + 4, endIndex - 2);
-              textData = this.saveTextToParentTag(textData, currentNode, jPath);
-              currentNode.add(this.options.commentPropName, [{ [this.options.textNodeName]: comment }]);
-            }
-            i = endIndex;
-          } else if (xmlData.substr(i + 1, 2) === "!D") {
-            const result = docTypeReader.readDocType(xmlData, i);
-            this.docTypeEntities = result.entities;
-            i = result.i;
-          } else if (xmlData.substr(i + 1, 2) === "![") {
-            const closeIndex = findClosingIndex(xmlData, "]]>", i, "CDATA is not closed.") - 2;
-            const tagExp = xmlData.substring(i + 9, closeIndex);
-            textData = this.saveTextToParentTag(textData, currentNode, jPath);
-            let val = this.parseTextData(tagExp, currentNode.tagname, jPath, true, false, true, true);
-            if (val == void 0) val = "";
-            if (this.options.cdataPropName) {
-              currentNode.add(this.options.cdataPropName, [{ [this.options.textNodeName]: tagExp }]);
-            } else {
-              currentNode.add(this.options.textNodeName, val);
-            }
-            i = closeIndex + 2;
-          } else {
-            let result = readTagExp(xmlData, i, this.options.removeNSPrefix);
-            let tagName = result.tagName;
-            const rawTagName = result.rawTagName;
-            let tagExp = result.tagExp;
-            let attrExpPresent = result.attrExpPresent;
-            let closeIndex = result.closeIndex;
-            if (this.options.transformTagName) {
-              const newTagName = this.options.transformTagName(tagName);
-              if (tagExp === tagName) {
-                tagExp = newTagName;
-              }
-              tagName = newTagName;
-            }
-            if (this.options.strictReservedNames && (tagName === this.options.commentPropName || tagName === this.options.cdataPropName || tagName === this.options.textNodeName || tagName === this.options.attributesGroupName)) {
-              throw new Error(`Invalid tag name: ${tagName}`);
-            }
-            if (currentNode && textData) {
-              if (currentNode.tagname !== "!xml") {
-                textData = this.saveTextToParentTag(textData, currentNode, jPath, false);
-              }
-            }
-            const lastTag = currentNode;
-            if (lastTag && this.options.unpairedTags.indexOf(lastTag.tagname) !== -1) {
-              currentNode = this.tagsNodeStack.pop();
-              jPath = jPath.substring(0, jPath.lastIndexOf("."));
-            }
-            if (tagName !== xmlObj.tagname) {
-              jPath += jPath ? "." + tagName : tagName;
-            }
-            const startIndex = i;
-            if (this.isItStopNode(this.stopNodesExact, this.stopNodesWildcard, jPath, tagName)) {
-              let tagContent = "";
-              if (tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1) {
-                if (tagName[tagName.length - 1] === "/") {
-                  tagName = tagName.substr(0, tagName.length - 1);
-                  jPath = jPath.substr(0, jPath.length - 1);
-                  tagExp = tagName;
-                } else {
-                  tagExp = tagExp.substr(0, tagExp.length - 1);
-                }
-                i = result.closeIndex;
-              } else if (this.options.unpairedTags.indexOf(tagName) !== -1) {
-                i = result.closeIndex;
-              } else {
-                const result2 = this.readStopNodeData(xmlData, rawTagName, closeIndex + 1);
-                if (!result2) throw new Error(`Unexpected end of ${rawTagName}`);
-                i = result2.i;
-                tagContent = result2.tagContent;
-              }
-              const childNode = new xmlNode(tagName);
-              if (tagName !== tagExp && attrExpPresent) {
-                childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
-              }
-              if (tagContent) {
-                tagContent = this.parseTextData(tagContent, tagName, jPath, true, attrExpPresent, true, true);
-              }
-              jPath = jPath.substr(0, jPath.lastIndexOf("."));
-              childNode.add(this.options.textNodeName, tagContent);
-              this.addChild(currentNode, childNode, jPath, startIndex);
-            } else {
-              if (tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1) {
-                if (tagName[tagName.length - 1] === "/") {
-                  tagName = tagName.substr(0, tagName.length - 1);
-                  jPath = jPath.substr(0, jPath.length - 1);
-                  tagExp = tagName;
-                } else {
-                  tagExp = tagExp.substr(0, tagExp.length - 1);
-                }
-                if (this.options.transformTagName) {
-                  const newTagName = this.options.transformTagName(tagName);
-                  if (tagExp === tagName) {
-                    tagExp = newTagName;
-                  }
-                  tagName = newTagName;
-                }
-                const childNode = new xmlNode(tagName);
-                if (tagName !== tagExp && attrExpPresent) {
-                  childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
-                }
-                this.addChild(currentNode, childNode, jPath, startIndex);
-                jPath = jPath.substr(0, jPath.lastIndexOf("."));
-              } else if (this.options.unpairedTags.indexOf(tagName) !== -1) {
-                const childNode = new xmlNode(tagName);
-                if (tagName !== tagExp && attrExpPresent) {
-                  childNode[":@"] = this.buildAttributesMap(tagExp, jPath);
-                }
-                this.addChild(currentNode, childNode, jPath, startIndex);
-                jPath = jPath.substr(0, jPath.lastIndexOf("."));
-                i = result.closeIndex;
-                continue;
-              } else {
-                const childNode = new xmlNode(tagName);
-                if (this.tagsNodeStack.length > this.options.maxNestedTags) {
-                  throw new Error("Maximum nested tags exceeded");
-                }
-                this.tagsNodeStack.push(currentNode);
-                if (tagName !== tagExp && attrExpPresent) {
-                  childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
-                }
-                this.addChild(currentNode, childNode, jPath);
-                currentNode = childNode;
-              }
-              textData = "";
-              i = closeIndex;
-            }
-          }
-        } else {
-          textData += xmlData[i];
-        }
-      }
-      return xmlObj.child;
-    };
-    function addChild(currentNode, childNode, jPath, startIndex) {
-      if (!this.options.captureMetaData) startIndex = void 0;
-      const result = this.options.updateTag(childNode.tagname, jPath, childNode[":@"]);
-      if (result === false) {
-      } else if (typeof result === "string") {
-        childNode.tagname = result;
-        currentNode.addChild(childNode, startIndex);
-      } else {
-        currentNode.addChild(childNode, startIndex);
-      }
-    }
-    var replaceEntitiesValue = function(val, tagName, jPath) {
-      if (val.indexOf("&") === -1) {
-        return val;
-      }
-      const entityConfig = this.options.processEntities;
-      if (!entityConfig.enabled) {
-        return val;
-      }
-      if (entityConfig.allowedTags) {
-        if (!entityConfig.allowedTags.includes(tagName)) {
-          return val;
-        }
-      }
-      if (entityConfig.tagFilter) {
-        if (!entityConfig.tagFilter(tagName, jPath)) {
-          return val;
-        }
-      }
-      for (let entityName in this.docTypeEntities) {
-        const entity = this.docTypeEntities[entityName];
-        const matches = val.match(entity.regx);
-        if (matches) {
-          this.entityExpansionCount += matches.length;
-          if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
-            throw new Error(
-              `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
-            );
-          }
-          const lengthBefore = val.length;
-          val = val.replace(entity.regx, entity.val);
-          if (entityConfig.maxExpandedLength) {
-            this.currentExpandedLength += val.length - lengthBefore;
-            if (this.currentExpandedLength > entityConfig.maxExpandedLength) {
-              throw new Error(
-                `Total expanded content size exceeded: ${this.currentExpandedLength} > ${entityConfig.maxExpandedLength}`
-              );
-            }
-          }
-        }
-      }
-      if (val.indexOf("&") === -1) return val;
-      for (const entityName of Object.keys(this.lastEntities)) {
-        const entity = this.lastEntities[entityName];
-        const matches = val.match(entity.regex);
-        if (matches) {
-          this.entityExpansionCount += matches.length;
-          if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
-            throw new Error(
-              `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
-            );
-          }
-        }
-        val = val.replace(entity.regex, entity.val);
-      }
-      if (val.indexOf("&") === -1) return val;
-      if (this.options.htmlEntities) {
-        for (const entityName of Object.keys(this.htmlEntities)) {
-          const entity = this.htmlEntities[entityName];
-          const matches = val.match(entity.regex);
-          if (matches) {
-            this.entityExpansionCount += matches.length;
-            if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
-              throw new Error(
-                `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
-              );
-            }
-          }
-          val = val.replace(entity.regex, entity.val);
-        }
-      }
-      val = val.replace(this.ampEntity.regex, this.ampEntity.val);
-      return val;
-    };
-    function saveTextToParentTag(textData, parentNode, jPath, isLeafNode) {
-      if (textData) {
-        if (isLeafNode === void 0) isLeafNode = parentNode.child.length === 0;
-        textData = this.parseTextData(
-          textData,
-          parentNode.tagname,
-          jPath,
-          false,
-          parentNode[":@"] ? Object.keys(parentNode[":@"]).length !== 0 : false,
-          isLeafNode
-        );
-        if (textData !== void 0 && textData !== "")
-          parentNode.add(this.options.textNodeName, textData);
-        textData = "";
-      }
-      return textData;
-    }
-    function isItStopNode(stopNodesExact, stopNodesWildcard, jPath, currentTagName) {
-      if (stopNodesWildcard && stopNodesWildcard.has(currentTagName)) return true;
-      if (stopNodesExact && stopNodesExact.has(jPath)) return true;
-      return false;
-    }
-    function tagExpWithClosingIndex(xmlData, i, closingChar = ">") {
-      let attrBoundary;
-      let tagExp = "";
-      for (let index = i; index < xmlData.length; index++) {
-        let ch = xmlData[index];
-        if (attrBoundary) {
-          if (ch === attrBoundary) attrBoundary = "";
-        } else if (ch === '"' || ch === "'") {
-          attrBoundary = ch;
-        } else if (ch === closingChar[0]) {
-          if (closingChar[1]) {
-            if (xmlData[index + 1] === closingChar[1]) {
-              return {
-                data: tagExp,
-                index
-              };
-            }
-          } else {
-            return {
-              data: tagExp,
-              index
-            };
-          }
-        } else if (ch === "	") {
-          ch = " ";
-        }
-        tagExp += ch;
-      }
-    }
-    function findClosingIndex(xmlData, str, i, errMsg) {
-      const closingIndex = xmlData.indexOf(str, i);
-      if (closingIndex === -1) {
-        throw new Error(errMsg);
-      } else {
-        return closingIndex + str.length - 1;
-      }
-    }
-    function readTagExp(xmlData, i, removeNSPrefix, closingChar = ">") {
-      const result = tagExpWithClosingIndex(xmlData, i + 1, closingChar);
-      if (!result) return;
-      let tagExp = result.data;
-      const closeIndex = result.index;
-      const separatorIndex = tagExp.search(/\s/);
-      let tagName = tagExp;
-      let attrExpPresent = true;
-      if (separatorIndex !== -1) {
-        tagName = tagExp.substring(0, separatorIndex);
-        tagExp = tagExp.substring(separatorIndex + 1).trimStart();
-      }
-      const rawTagName = tagName;
-      if (removeNSPrefix) {
-        const colonIndex = tagName.indexOf(":");
-        if (colonIndex !== -1) {
-          tagName = tagName.substr(colonIndex + 1);
-          attrExpPresent = tagName !== result.data.substr(colonIndex + 1);
-        }
-      }
-      return {
-        tagName,
-        tagExp,
-        closeIndex,
-        attrExpPresent,
-        rawTagName
-      };
-    }
-    function readStopNodeData(xmlData, tagName, i) {
-      const startIndex = i;
-      let openTagCount = 1;
-      for (; i < xmlData.length; i++) {
-        if (xmlData[i] === "<") {
-          if (xmlData[i + 1] === "/") {
-            const closeIndex = findClosingIndex(xmlData, ">", i, `${tagName} is not closed`);
-            let closeTagName = xmlData.substring(i + 2, closeIndex).trim();
-            if (closeTagName === tagName) {
-              openTagCount--;
-              if (openTagCount === 0) {
-                return {
-                  tagContent: xmlData.substring(startIndex, i),
-                  i: closeIndex
-                };
-              }
-            }
-            i = closeIndex;
-          } else if (xmlData[i + 1] === "?") {
-            const closeIndex = findClosingIndex(xmlData, "?>", i + 1, "StopNode is not closed.");
-            i = closeIndex;
-          } else if (xmlData.substr(i + 1, 3) === "!--") {
-            const closeIndex = findClosingIndex(xmlData, "-->", i + 3, "StopNode is not closed.");
-            i = closeIndex;
-          } else if (xmlData.substr(i + 1, 2) === "![") {
-            const closeIndex = findClosingIndex(xmlData, "]]>", i, "StopNode is not closed.") - 2;
-            i = closeIndex;
-          } else {
-            const tagData = readTagExp(xmlData, i, ">");
-            if (tagData) {
-              const openTagName = tagData && tagData.tagName;
-              if (openTagName === tagName && tagData.tagExp[tagData.tagExp.length - 1] !== "/") {
-                openTagCount++;
-              }
-              i = tagData.closeIndex;
-            }
-          }
-        }
-      }
-    }
-    function parseValue(val, shouldParse, options) {
-      if (shouldParse && typeof val === "string") {
-        const newval = val.trim();
-        if (newval === "true") return true;
-        else if (newval === "false") return false;
-        else return toNumber(val, options);
-      } else {
-        if (util.isExist(val)) {
-          return val;
-        } else {
-          return "";
-        }
-      }
-    }
-    function fromCodePoint(str, base, prefix) {
-      const codePoint = Number.parseInt(str, base);
-      if (codePoint >= 0 && codePoint <= 1114111) {
-        return String.fromCodePoint(codePoint);
-      } else {
-        return prefix + str + ";";
-      }
-    }
-    function sanitizeName(name, options) {
-      if (util.criticalProperties.includes(name)) {
-        throw new Error(`[SECURITY] Invalid name: "${name}" is a reserved JavaScript keyword that could cause prototype pollution`);
-      } else if (util.DANGEROUS_PROPERTY_NAMES.includes(name)) {
-        return options.onDangerousProperty(name);
-      }
-      return name;
-    }
-    module.exports = OrderedObjParser;
-  }
-});
-
-// node_modules/fast-xml-parser/src/xmlparser/node2json.js
-var require_node2json = __commonJS({
-  "node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
-    "use strict";
-    function prettify(node, options) {
-      return compress(node, options);
-    }
-    function compress(arr3, options, jPath) {
-      let text;
-      const compressedObj = {};
-      for (let i = 0; i < arr3.length; i++) {
-        const tagObj = arr3[i];
-        const property = propName(tagObj);
-        let newJpath = "";
-        if (jPath === void 0) newJpath = property;
-        else newJpath = jPath + "." + property;
-        if (property === options.textNodeName) {
-          if (text === void 0) text = tagObj[property];
-          else text += "" + tagObj[property];
-        } else if (property === void 0) {
-          continue;
-        } else if (tagObj[property]) {
-          let val = compress(tagObj[property], options, newJpath);
-          const isLeaf = isLeafTag(val, options);
-          if (tagObj[":@"]) {
-            assignAttributes(val, tagObj[":@"], newJpath, options);
-          } else if (Object.keys(val).length === 1 && val[options.textNodeName] !== void 0 && !options.alwaysCreateTextNode) {
-            val = val[options.textNodeName];
-          } else if (Object.keys(val).length === 0) {
-            if (options.alwaysCreateTextNode) val[options.textNodeName] = "";
-            else val = "";
-          }
-          if (compressedObj[property] !== void 0 && compressedObj.hasOwnProperty(property)) {
-            if (!Array.isArray(compressedObj[property])) {
-              compressedObj[property] = [compressedObj[property]];
-            }
-            compressedObj[property].push(val);
-          } else {
-            if (options.isArray(property, newJpath, isLeaf)) {
-              compressedObj[property] = [val];
-            } else {
-              compressedObj[property] = val;
-            }
-          }
-        }
-      }
-      if (typeof text === "string") {
-        if (text.length > 0) compressedObj[options.textNodeName] = text;
-      } else if (text !== void 0) compressedObj[options.textNodeName] = text;
-      return compressedObj;
-    }
-    function propName(obj) {
-      const keys = Object.keys(obj);
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
-        if (key !== ":@") return key;
-      }
-    }
-    function assignAttributes(obj, attrMap, jpath, options) {
-      if (attrMap) {
-        const keys = Object.keys(attrMap);
-        const len = keys.length;
-        for (let i = 0; i < len; i++) {
-          const atrrName = keys[i];
-          if (options.isArray(atrrName, jpath + "." + atrrName, true, true)) {
-            obj[atrrName] = [attrMap[atrrName]];
-          } else {
-            obj[atrrName] = attrMap[atrrName];
-          }
-        }
-      }
-    }
-    function isLeafTag(obj, options) {
-      const { textNodeName } = options;
-      const propCount = Object.keys(obj).length;
-      if (propCount === 0) {
-        return true;
-      }
-      if (propCount === 1 && (obj[textNodeName] || typeof obj[textNodeName] === "boolean" || obj[textNodeName] === 0)) {
-        return true;
-      }
-      return false;
-    }
-    exports.prettify = prettify;
-  }
-});
-
-// node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
-var require_XMLParser = __commonJS({
-  "node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module) {
-    var { buildOptions } = require_OptionsBuilder();
-    var OrderedObjParser = require_OrderedObjParser();
-    var { prettify } = require_node2json();
-    var validator = require_validator();
-    var XMLParser2 = class {
-      constructor(options) {
-        this.externalEntities = {};
-        this.options = buildOptions(options);
-      }
-      /**
-       * Parse XML dats to JS object 
-       * @param {string|Buffer} xmlData 
-       * @param {boolean|Object} validationOption 
-       */
-      parse(xmlData, validationOption) {
-        if (typeof xmlData === "string") {
-        } else if (xmlData.toString) {
-          xmlData = xmlData.toString();
-        } else {
-          throw new Error("XML data is accepted in String or Bytes[] form.");
-        }
-        if (validationOption) {
-          if (validationOption === true) validationOption = {};
-          const result = validator.validate(xmlData, validationOption);
-          if (result !== true) {
-            throw Error(`${result.err.msg}:${result.err.line}:${result.err.col}`);
-          }
-        }
-        const orderedObjParser = new OrderedObjParser(this.options);
-        orderedObjParser.addExternalEntities(this.externalEntities);
-        const orderedResult = orderedObjParser.parseXml(xmlData);
-        if (this.options.preserveOrder || orderedResult === void 0) return orderedResult;
-        else return prettify(orderedResult, this.options);
-      }
-      /**
-       * Add Entity which is not by default supported by this library
-       * @param {string} key 
-       * @param {string} value 
-       */
-      addEntity(key, value) {
-        if (value.indexOf("&") !== -1) {
-          throw new Error("Entity value can't have '&'");
-        } else if (key.indexOf("&") !== -1 || key.indexOf(";") !== -1) {
-          throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");
-        } else if (value === "&") {
-          throw new Error("An entity with value '&' is not permitted");
-        } else {
-          this.externalEntities[key] = value;
-        }
-      }
-    };
-    module.exports = XMLParser2;
-  }
-});
-
-// node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
-var require_orderedJs2Xml = __commonJS({
-  "node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module) {
-    var EOL = "\n";
-    function toXml(jArray, options) {
-      let indentation = "";
-      if (options.format && options.indentBy.length > 0) {
-        indentation = EOL;
-      }
-      return arrToStr(jArray, options, "", indentation);
-    }
-    function arrToStr(arr3, options, jPath, indentation) {
-      let xmlStr = "";
-      let isPreviousElementTag = false;
-      if (!Array.isArray(arr3)) {
-        if (arr3 !== void 0 && arr3 !== null) {
-          let text = arr3.toString();
-          text = replaceEntitiesValue(text, options);
-          return text;
-        }
-        return "";
-      }
-      for (let i = 0; i < arr3.length; i++) {
-        const tagObj = arr3[i];
-        const tagName = propName(tagObj);
-        if (tagName === void 0) continue;
-        let newJPath = "";
-        if (jPath.length === 0) newJPath = tagName;
-        else newJPath = `${jPath}.${tagName}`;
-        if (tagName === options.textNodeName) {
-          let tagText = tagObj[tagName];
-          if (!isStopNode(newJPath, options)) {
-            tagText = options.tagValueProcessor(tagName, tagText);
-            tagText = replaceEntitiesValue(tagText, options);
-          }
-          if (isPreviousElementTag) {
-            xmlStr += indentation;
-          }
-          xmlStr += tagText;
-          isPreviousElementTag = false;
-          continue;
-        } else if (tagName === options.cdataPropName) {
-          if (isPreviousElementTag) {
-            xmlStr += indentation;
-          }
-          xmlStr += `<![CDATA[${tagObj[tagName][0][options.textNodeName]}]]>`;
-          isPreviousElementTag = false;
-          continue;
-        } else if (tagName === options.commentPropName) {
-          xmlStr += indentation + `<!--${tagObj[tagName][0][options.textNodeName]}-->`;
-          isPreviousElementTag = true;
-          continue;
-        } else if (tagName[0] === "?") {
-          const attStr2 = attr_to_str(tagObj[":@"], options);
-          const tempInd = tagName === "?xml" ? "" : indentation;
-          let piTextNodeName = tagObj[tagName][0][options.textNodeName];
-          piTextNodeName = piTextNodeName.length !== 0 ? " " + piTextNodeName : "";
-          xmlStr += tempInd + `<${tagName}${piTextNodeName}${attStr2}?>`;
-          isPreviousElementTag = true;
-          continue;
-        }
-        let newIdentation = indentation;
-        if (newIdentation !== "") {
-          newIdentation += options.indentBy;
-        }
-        const attStr = attr_to_str(tagObj[":@"], options);
-        const tagStart = indentation + `<${tagName}${attStr}`;
-        const tagValue = arrToStr(tagObj[tagName], options, newJPath, newIdentation);
-        if (options.unpairedTags.indexOf(tagName) !== -1) {
-          if (options.suppressUnpairedNode) xmlStr += tagStart + ">";
-          else xmlStr += tagStart + "/>";
-        } else if ((!tagValue || tagValue.length === 0) && options.suppressEmptyNode) {
-          xmlStr += tagStart + "/>";
-        } else if (tagValue && tagValue.endsWith(">")) {
-          xmlStr += tagStart + `>${tagValue}${indentation}</${tagName}>`;
-        } else {
-          xmlStr += tagStart + ">";
-          if (tagValue && indentation !== "" && (tagValue.includes("/>") || tagValue.includes("</"))) {
-            xmlStr += indentation + options.indentBy + tagValue + indentation;
-          } else {
-            xmlStr += tagValue;
-          }
-          xmlStr += `</${tagName}>`;
-        }
-        isPreviousElementTag = true;
-      }
-      return xmlStr;
-    }
-    function propName(obj) {
-      const keys = Object.keys(obj);
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
-        if (!Object.prototype.hasOwnProperty.call(obj, key)) continue;
-        if (key !== ":@") return key;
-      }
-    }
-    function attr_to_str(attrMap, options) {
-      let attrStr = "";
-      if (attrMap && !options.ignoreAttributes) {
-        for (let attr in attrMap) {
-          if (!Object.prototype.hasOwnProperty.call(attrMap, attr)) continue;
-          let attrVal = options.attributeValueProcessor(attr, attrMap[attr]);
-          attrVal = replaceEntitiesValue(attrVal, options);
-          if (attrVal === true && options.suppressBooleanAttributes) {
-            attrStr += ` ${attr.substr(options.attributeNamePrefix.length)}`;
-          } else {
-            attrStr += ` ${attr.substr(options.attributeNamePrefix.length)}="${attrVal}"`;
-          }
-        }
-      }
-      return attrStr;
-    }
-    function isStopNode(jPath, options) {
-      jPath = jPath.substr(0, jPath.length - options.textNodeName.length - 1);
-      let tagName = jPath.substr(jPath.lastIndexOf(".") + 1);
-      for (let index in options.stopNodes) {
-        if (options.stopNodes[index] === jPath || options.stopNodes[index] === "*." + tagName) return true;
-      }
-      return false;
-    }
-    function replaceEntitiesValue(textValue, options) {
-      if (textValue && textValue.length > 0 && options.processEntities) {
-        for (let i = 0; i < options.entities.length; i++) {
-          const entity = options.entities[i];
-          textValue = textValue.replace(entity.regex, entity.val);
-        }
-      }
-      return textValue;
-    }
-    module.exports = toXml;
-  }
-});
-
-// node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
-var require_json2xml = __commonJS({
-  "node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module) {
-    "use strict";
-    var buildFromOrderedJs = require_orderedJs2Xml();
-    var getIgnoreAttributesFn = require_ignoreAttributes();
-    var defaultOptions = {
-      attributeNamePrefix: "@_",
-      attributesGroupName: false,
-      textNodeName: "#text",
-      ignoreAttributes: true,
-      cdataPropName: false,
-      format: false,
-      indentBy: "  ",
-      suppressEmptyNode: false,
-      suppressUnpairedNode: true,
-      suppressBooleanAttributes: true,
-      tagValueProcessor: function(key, a) {
-        return a;
-      },
-      attributeValueProcessor: function(attrName, a) {
-        return a;
-      },
-      preserveOrder: false,
-      commentPropName: false,
-      unpairedTags: [],
-      entities: [
-        { regex: new RegExp("&", "g"), val: "&amp;" },
-        //it must be on top
-        { regex: new RegExp(">", "g"), val: "&gt;" },
-        { regex: new RegExp("<", "g"), val: "&lt;" },
-        { regex: new RegExp("'", "g"), val: "&apos;" },
-        { regex: new RegExp('"', "g"), val: "&quot;" }
-      ],
-      processEntities: true,
-      stopNodes: [],
-      // transformTagName: false,
-      // transformAttributeName: false,
-      oneListGroup: false
-    };
-    function Builder(options) {
-      this.options = Object.assign({}, defaultOptions, options);
-      if (this.options.ignoreAttributes === true || this.options.attributesGroupName) {
-        this.isAttribute = function() {
-          return false;
-        };
-      } else {
-        this.ignoreAttributesFn = getIgnoreAttributesFn(this.options.ignoreAttributes);
-        this.attrPrefixLen = this.options.attributeNamePrefix.length;
-        this.isAttribute = isAttribute;
-      }
-      this.processTextOrObjNode = processTextOrObjNode;
-      if (this.options.format) {
-        this.indentate = indentate;
-        this.tagEndChar = ">\n";
-        this.newLine = "\n";
-      } else {
-        this.indentate = function() {
-          return "";
-        };
-        this.tagEndChar = ">";
-        this.newLine = "";
-      }
-    }
-    Builder.prototype.build = function(jObj) {
-      if (this.options.preserveOrder) {
-        return buildFromOrderedJs(jObj, this.options);
-      } else {
-        if (Array.isArray(jObj) && this.options.arrayNodeName && this.options.arrayNodeName.length > 1) {
-          jObj = {
-            [this.options.arrayNodeName]: jObj
-          };
-        }
-        return this.j2x(jObj, 0, []).val;
-      }
-    };
-    Builder.prototype.j2x = function(jObj, level, ajPath) {
-      let attrStr = "";
-      let val = "";
-      const jPath = ajPath.join(".");
-      for (let key in jObj) {
-        if (!Object.prototype.hasOwnProperty.call(jObj, key)) continue;
-        if (typeof jObj[key] === "undefined") {
-          if (this.isAttribute(key)) {
-            val += "";
-          }
-        } else if (jObj[key] === null) {
-          if (this.isAttribute(key)) {
-            val += "";
-          } else if (key === this.options.cdataPropName) {
-            val += "";
-          } else if (key[0] === "?") {
-            val += this.indentate(level) + "<" + key + "?" + this.tagEndChar;
-          } else {
-            val += this.indentate(level) + "<" + key + "/" + this.tagEndChar;
-          }
-        } else if (jObj[key] instanceof Date) {
-          val += this.buildTextValNode(jObj[key], key, "", level);
-        } else if (typeof jObj[key] !== "object") {
-          const attr = this.isAttribute(key);
-          if (attr && !this.ignoreAttributesFn(attr, jPath)) {
-            attrStr += this.buildAttrPairStr(attr, "" + jObj[key]);
-          } else if (!attr) {
-            if (key === this.options.textNodeName) {
-              let newval = this.options.tagValueProcessor(key, "" + jObj[key]);
-              val += this.replaceEntitiesValue(newval);
-            } else {
-              val += this.buildTextValNode(jObj[key], key, "", level);
-            }
-          }
-        } else if (Array.isArray(jObj[key])) {
-          const arrLen = jObj[key].length;
-          let listTagVal = "";
-          let listTagAttr = "";
-          for (let j = 0; j < arrLen; j++) {
-            const item = jObj[key][j];
-            if (typeof item === "undefined") {
-            } else if (item === null) {
-              if (key[0] === "?") val += this.indentate(level) + "<" + key + "?" + this.tagEndChar;
-              else val += this.indentate(level) + "<" + key + "/" + this.tagEndChar;
-            } else if (typeof item === "object") {
-              if (this.options.oneListGroup) {
-                const result = this.j2x(item, level + 1, ajPath.concat(key));
-                listTagVal += result.val;
-                if (this.options.attributesGroupName && item.hasOwnProperty(this.options.attributesGroupName)) {
-                  listTagAttr += result.attrStr;
-                }
-              } else {
-                listTagVal += this.processTextOrObjNode(item, key, level, ajPath);
-              }
-            } else {
-              if (this.options.oneListGroup) {
-                let textValue = this.options.tagValueProcessor(key, item);
-                textValue = this.replaceEntitiesValue(textValue);
-                listTagVal += textValue;
-              } else {
-                listTagVal += this.buildTextValNode(item, key, "", level);
-              }
-            }
-          }
-          if (this.options.oneListGroup) {
-            listTagVal = this.buildObjectNode(listTagVal, key, listTagAttr, level);
-          }
-          val += listTagVal;
-        } else {
-          if (this.options.attributesGroupName && key === this.options.attributesGroupName) {
-            const Ks = Object.keys(jObj[key]);
-            const L = Ks.length;
-            for (let j = 0; j < L; j++) {
-              attrStr += this.buildAttrPairStr(Ks[j], "" + jObj[key][Ks[j]]);
-            }
-          } else {
-            val += this.processTextOrObjNode(jObj[key], key, level, ajPath);
-          }
-        }
-      }
-      return { attrStr, val };
-    };
-    Builder.prototype.buildAttrPairStr = function(attrName, val) {
-      val = this.options.attributeValueProcessor(attrName, "" + val);
-      val = this.replaceEntitiesValue(val);
-      if (this.options.suppressBooleanAttributes && val === "true") {
-        return " " + attrName;
-      } else return " " + attrName + '="' + val + '"';
-    };
-    function processTextOrObjNode(object, key, level, ajPath) {
-      const result = this.j2x(object, level + 1, ajPath.concat(key));
-      if (object[this.options.textNodeName] !== void 0 && Object.keys(object).length === 1) {
-        return this.buildTextValNode(object[this.options.textNodeName], key, result.attrStr, level);
-      } else {
-        return this.buildObjectNode(result.val, key, result.attrStr, level);
-      }
-    }
-    Builder.prototype.buildObjectNode = function(val, key, attrStr, level) {
-      if (val === "") {
-        if (key[0] === "?") return this.indentate(level) + "<" + key + attrStr + "?" + this.tagEndChar;
-        else {
-          return this.indentate(level) + "<" + key + attrStr + this.closeTag(key) + this.tagEndChar;
-        }
-      } else {
-        let tagEndExp = "</" + key + this.tagEndChar;
-        let piClosingChar = "";
-        if (key[0] === "?") {
-          piClosingChar = "?";
-          tagEndExp = "";
-        }
-        if ((attrStr || attrStr === "") && val.indexOf("<") === -1) {
-          return this.indentate(level) + "<" + key + attrStr + piClosingChar + ">" + val + tagEndExp;
-        } else if (this.options.commentPropName !== false && key === this.options.commentPropName && piClosingChar.length === 0) {
-          return this.indentate(level) + `<!--${val}-->` + this.newLine;
-        } else {
-          return this.indentate(level) + "<" + key + attrStr + piClosingChar + this.tagEndChar + val + this.indentate(level) + tagEndExp;
-        }
-      }
-    };
-    Builder.prototype.closeTag = function(key) {
-      let closeTag = "";
-      if (this.options.unpairedTags.indexOf(key) !== -1) {
-        if (!this.options.suppressUnpairedNode) closeTag = "/";
-      } else if (this.options.suppressEmptyNode) {
-        closeTag = "/";
-      } else {
-        closeTag = `></${key}`;
-      }
-      return closeTag;
-    };
-    Builder.prototype.buildTextValNode = function(val, key, attrStr, level) {
-      if (this.options.cdataPropName !== false && key === this.options.cdataPropName) {
-        return this.indentate(level) + `<![CDATA[${val}]]>` + this.newLine;
-      } else if (this.options.commentPropName !== false && key === this.options.commentPropName) {
-        return this.indentate(level) + `<!--${val}-->` + this.newLine;
-      } else if (key[0] === "?") {
-        return this.indentate(level) + "<" + key + attrStr + "?" + this.tagEndChar;
-      } else {
-        let textValue = this.options.tagValueProcessor(key, val);
-        textValue = this.replaceEntitiesValue(textValue);
-        if (textValue === "") {
-          return this.indentate(level) + "<" + key + attrStr + this.closeTag(key) + this.tagEndChar;
-        } else {
-          return this.indentate(level) + "<" + key + attrStr + ">" + textValue + "</" + key + this.tagEndChar;
-        }
-      }
-    };
-    Builder.prototype.replaceEntitiesValue = function(textValue) {
-      if (textValue && textValue.length > 0 && this.options.processEntities) {
-        for (let i = 0; i < this.options.entities.length; i++) {
-          const entity = this.options.entities[i];
-          textValue = textValue.replace(entity.regex, entity.val);
-        }
-      }
-      return textValue;
-    };
-    function indentate(level) {
-      return this.options.indentBy.repeat(level);
-    }
-    function isAttribute(name) {
-      if (name.startsWith(this.options.attributeNamePrefix) && name !== this.options.textNodeName) {
-        return name.substr(this.attrPrefixLen);
-      } else {
-        return false;
-      }
-    }
-    module.exports = Builder;
-  }
-});
-
-// node_modules/fast-xml-parser/src/fxp.js
-var require_fxp = __commonJS({
-  "node_modules/fast-xml-parser/src/fxp.js"(exports, module) {
-    "use strict";
-    var validator = require_validator();
-    var XMLParser2 = require_XMLParser();
-    var XMLBuilder = require_json2xml();
-    module.exports = {
-      XMLParser: XMLParser2,
-      XMLValidator: validator,
-      XMLBuilder
-    };
-  }
-});
 
 // cli.ts
 import { readFileSync, writeFileSync } from "node:fs";
@@ -2655,8 +546,4038 @@ function parseJoinExpr(expr) {
 }
 var trunc = (s, n = 80) => s && s.length > n ? s.slice(0, n) + "\u2026" : s || "";
 
-// cognos-report.ts
-var import_fast_xml_parser = __toESM(require_fxp(), 1);
+// node_modules/fast-xml-parser/src/util.js
+var nameStartChar = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
+var nameChar = nameStartChar + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
+var nameRegexp = "[" + nameStartChar + "][" + nameChar + "]*";
+var regexName = new RegExp("^" + nameRegexp + "$");
+function getAllMatches(string, regex) {
+  const matches = [];
+  let match = regex.exec(string);
+  while (match) {
+    const allmatches = [];
+    allmatches.startIndex = regex.lastIndex - match[0].length;
+    const len = match.length;
+    for (let index = 0; index < len; index++) {
+      allmatches.push(match[index]);
+    }
+    matches.push(allmatches);
+    match = regex.exec(string);
+  }
+  return matches;
+}
+var isName = function(string) {
+  const match = regexName.exec(string);
+  return !(match === null || typeof match === "undefined");
+};
+function isExist(v) {
+  return typeof v !== "undefined";
+}
+var DANGEROUS_PROPERTY_NAMES = [
+  // '__proto__',
+  // 'constructor',
+  // 'prototype',
+  "hasOwnProperty",
+  "toString",
+  "valueOf",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__"
+];
+var criticalProperties = ["__proto__", "constructor", "prototype"];
+
+// node_modules/fast-xml-parser/src/validator.js
+var defaultOptions = {
+  allowBooleanAttributes: false,
+  //A tag can have attributes without any value
+  unpairedTags: []
+};
+function validate(xmlData, options) {
+  options = Object.assign({}, defaultOptions, options);
+  const tags = [];
+  let tagFound = false;
+  let reachedRoot = false;
+  if (xmlData[0] === "\uFEFF") {
+    xmlData = xmlData.substr(1);
+  }
+  for (let i = 0; i < xmlData.length; i++) {
+    if (xmlData[i] === "<" && xmlData[i + 1] === "?") {
+      i += 2;
+      i = readPI(xmlData, i);
+      if (i.err) return i;
+    } else if (xmlData[i] === "<") {
+      let tagStartPos = i;
+      i++;
+      if (xmlData[i] === "!") {
+        i = readCommentAndCDATA(xmlData, i);
+        continue;
+      } else {
+        let closingTag = false;
+        if (xmlData[i] === "/") {
+          closingTag = true;
+          i++;
+        }
+        let tagName = "";
+        for (; i < xmlData.length && xmlData[i] !== ">" && xmlData[i] !== " " && xmlData[i] !== "	" && xmlData[i] !== "\n" && xmlData[i] !== "\r"; i++) {
+          tagName += xmlData[i];
+        }
+        tagName = tagName.trim();
+        if (tagName[tagName.length - 1] === "/") {
+          tagName = tagName.substring(0, tagName.length - 1);
+          i--;
+        }
+        if (!validateTagName(tagName)) {
+          let msg;
+          if (tagName.trim().length === 0) {
+            msg = "Invalid space after '<'.";
+          } else {
+            msg = "Tag '" + tagName + "' is an invalid name.";
+          }
+          return getErrorObject("InvalidTag", msg, getLineNumberForPosition(xmlData, i));
+        }
+        const result = readAttributeStr(xmlData, i);
+        if (result === false) {
+          return getErrorObject("InvalidAttr", "Attributes for '" + tagName + "' have open quote.", getLineNumberForPosition(xmlData, i));
+        }
+        let attrStr = result.value;
+        i = result.index;
+        if (attrStr[attrStr.length - 1] === "/") {
+          const attrStrStart = i - attrStr.length;
+          attrStr = attrStr.substring(0, attrStr.length - 1);
+          const isValid = validateAttributeString(attrStr, options);
+          if (isValid === true) {
+            tagFound = true;
+          } else {
+            return getErrorObject(isValid.err.code, isValid.err.msg, getLineNumberForPosition(xmlData, attrStrStart + isValid.err.line));
+          }
+        } else if (closingTag) {
+          if (!result.tagClosed) {
+            return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' doesn't have proper closing.", getLineNumberForPosition(xmlData, i));
+          } else if (attrStr.trim().length > 0) {
+            return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' can't have attributes or invalid starting.", getLineNumberForPosition(xmlData, tagStartPos));
+          } else if (tags.length === 0) {
+            return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' has not been opened.", getLineNumberForPosition(xmlData, tagStartPos));
+          } else {
+            const otg = tags.pop();
+            if (tagName !== otg.tagName) {
+              let openPos = getLineNumberForPosition(xmlData, otg.tagStartPos);
+              return getErrorObject(
+                "InvalidTag",
+                "Expected closing tag '" + otg.tagName + "' (opened in line " + openPos.line + ", col " + openPos.col + ") instead of closing tag '" + tagName + "'.",
+                getLineNumberForPosition(xmlData, tagStartPos)
+              );
+            }
+            if (tags.length == 0) {
+              reachedRoot = true;
+            }
+          }
+        } else {
+          const isValid = validateAttributeString(attrStr, options);
+          if (isValid !== true) {
+            return getErrorObject(isValid.err.code, isValid.err.msg, getLineNumberForPosition(xmlData, i - attrStr.length + isValid.err.line));
+          }
+          if (reachedRoot === true) {
+            return getErrorObject("InvalidXml", "Multiple possible root nodes found.", getLineNumberForPosition(xmlData, i));
+          } else if (options.unpairedTags.indexOf(tagName) !== -1) {
+          } else {
+            tags.push({ tagName, tagStartPos });
+          }
+          tagFound = true;
+        }
+        for (i++; i < xmlData.length; i++) {
+          if (xmlData[i] === "<") {
+            if (xmlData[i + 1] === "!") {
+              i++;
+              i = readCommentAndCDATA(xmlData, i);
+              continue;
+            } else if (xmlData[i + 1] === "?") {
+              i = readPI(xmlData, ++i);
+              if (i.err) return i;
+            } else {
+              break;
+            }
+          } else if (xmlData[i] === "&") {
+            const afterAmp = validateAmpersand(xmlData, i);
+            if (afterAmp == -1)
+              return getErrorObject("InvalidChar", "char '&' is not expected.", getLineNumberForPosition(xmlData, i));
+            i = afterAmp;
+          } else {
+            if (reachedRoot === true && !isWhiteSpace(xmlData[i])) {
+              return getErrorObject("InvalidXml", "Extra text at the end", getLineNumberForPosition(xmlData, i));
+            }
+          }
+        }
+        if (xmlData[i] === "<") {
+          i--;
+        }
+      }
+    } else {
+      if (isWhiteSpace(xmlData[i])) {
+        continue;
+      }
+      return getErrorObject("InvalidChar", "char '" + xmlData[i] + "' is not expected.", getLineNumberForPosition(xmlData, i));
+    }
+  }
+  if (!tagFound) {
+    return getErrorObject("InvalidXml", "Start tag expected.", 1);
+  } else if (tags.length == 1) {
+    return getErrorObject("InvalidTag", "Unclosed tag '" + tags[0].tagName + "'.", getLineNumberForPosition(xmlData, tags[0].tagStartPos));
+  } else if (tags.length > 0) {
+    return getErrorObject("InvalidXml", "Invalid '" + JSON.stringify(tags.map((t) => t.tagName), null, 4).replace(/\r?\n/g, "") + "' found.", { line: 1, col: 1 });
+  }
+  return true;
+}
+function isWhiteSpace(char) {
+  return char === " " || char === "	" || char === "\n" || char === "\r";
+}
+function readPI(xmlData, i) {
+  const start = i;
+  for (; i < xmlData.length; i++) {
+    if (xmlData[i] == "?" || xmlData[i] == " ") {
+      const tagname = xmlData.substr(start, i - start);
+      if (i > 5 && tagname === "xml") {
+        return getErrorObject("InvalidXml", "XML declaration allowed only at the start of the document.", getLineNumberForPosition(xmlData, i));
+      } else if (xmlData[i] == "?" && xmlData[i + 1] == ">") {
+        i++;
+        break;
+      } else {
+        continue;
+      }
+    }
+  }
+  return i;
+}
+function readCommentAndCDATA(xmlData, i) {
+  if (xmlData.length > i + 5 && xmlData[i + 1] === "-" && xmlData[i + 2] === "-") {
+    for (i += 3; i < xmlData.length; i++) {
+      if (xmlData[i] === "-" && xmlData[i + 1] === "-" && xmlData[i + 2] === ">") {
+        i += 2;
+        break;
+      }
+    }
+  } else if (xmlData.length > i + 8 && xmlData[i + 1] === "D" && xmlData[i + 2] === "O" && xmlData[i + 3] === "C" && xmlData[i + 4] === "T" && xmlData[i + 5] === "Y" && xmlData[i + 6] === "P" && xmlData[i + 7] === "E") {
+    let angleBracketsCount = 1;
+    for (i += 8; i < xmlData.length; i++) {
+      if (xmlData[i] === "<") {
+        angleBracketsCount++;
+      } else if (xmlData[i] === ">") {
+        angleBracketsCount--;
+        if (angleBracketsCount === 0) {
+          break;
+        }
+      }
+    }
+  } else if (xmlData.length > i + 9 && xmlData[i + 1] === "[" && xmlData[i + 2] === "C" && xmlData[i + 3] === "D" && xmlData[i + 4] === "A" && xmlData[i + 5] === "T" && xmlData[i + 6] === "A" && xmlData[i + 7] === "[") {
+    for (i += 8; i < xmlData.length; i++) {
+      if (xmlData[i] === "]" && xmlData[i + 1] === "]" && xmlData[i + 2] === ">") {
+        i += 2;
+        break;
+      }
+    }
+  }
+  return i;
+}
+var doubleQuote = '"';
+var singleQuote = "'";
+function readAttributeStr(xmlData, i) {
+  let attrStr = "";
+  let startChar = "";
+  let tagClosed = false;
+  for (; i < xmlData.length; i++) {
+    if (xmlData[i] === doubleQuote || xmlData[i] === singleQuote) {
+      if (startChar === "") {
+        startChar = xmlData[i];
+      } else if (startChar !== xmlData[i]) {
+      } else {
+        startChar = "";
+      }
+    } else if (xmlData[i] === ">") {
+      if (startChar === "") {
+        tagClosed = true;
+        break;
+      }
+    }
+    attrStr += xmlData[i];
+  }
+  if (startChar !== "") {
+    return false;
+  }
+  return {
+    value: attrStr,
+    index: i,
+    tagClosed
+  };
+}
+var validAttrStrRegxp = new RegExp(`(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['"])(([\\s\\S])*?)\\5)?`, "g");
+function validateAttributeString(attrStr, options) {
+  const matches = getAllMatches(attrStr, validAttrStrRegxp);
+  const attrNames = {};
+  for (let i = 0; i < matches.length; i++) {
+    if (matches[i][1].length === 0) {
+      return getErrorObject("InvalidAttr", "Attribute '" + matches[i][2] + "' has no space in starting.", getPositionFromMatch(matches[i]));
+    } else if (matches[i][3] !== void 0 && matches[i][4] === void 0) {
+      return getErrorObject("InvalidAttr", "Attribute '" + matches[i][2] + "' is without value.", getPositionFromMatch(matches[i]));
+    } else if (matches[i][3] === void 0 && !options.allowBooleanAttributes) {
+      return getErrorObject("InvalidAttr", "boolean attribute '" + matches[i][2] + "' is not allowed.", getPositionFromMatch(matches[i]));
+    }
+    const attrName = matches[i][2];
+    if (!validateAttrName(attrName)) {
+      return getErrorObject("InvalidAttr", "Attribute '" + attrName + "' is an invalid name.", getPositionFromMatch(matches[i]));
+    }
+    if (!Object.prototype.hasOwnProperty.call(attrNames, attrName)) {
+      attrNames[attrName] = 1;
+    } else {
+      return getErrorObject("InvalidAttr", "Attribute '" + attrName + "' is repeated.", getPositionFromMatch(matches[i]));
+    }
+  }
+  return true;
+}
+function validateNumberAmpersand(xmlData, i) {
+  let re = /\d/;
+  if (xmlData[i] === "x") {
+    i++;
+    re = /[\da-fA-F]/;
+  }
+  for (; i < xmlData.length; i++) {
+    if (xmlData[i] === ";")
+      return i;
+    if (!xmlData[i].match(re))
+      break;
+  }
+  return -1;
+}
+function validateAmpersand(xmlData, i) {
+  i++;
+  if (xmlData[i] === ";")
+    return -1;
+  if (xmlData[i] === "#") {
+    i++;
+    return validateNumberAmpersand(xmlData, i);
+  }
+  let count = 0;
+  for (; i < xmlData.length; i++, count++) {
+    if (xmlData[i].match(/\w/) && count < 20)
+      continue;
+    if (xmlData[i] === ";")
+      break;
+    return -1;
+  }
+  return i;
+}
+function getErrorObject(code, message, lineNumber) {
+  return {
+    err: {
+      code,
+      msg: message,
+      line: lineNumber.line || lineNumber,
+      col: lineNumber.col
+    }
+  };
+}
+function validateAttrName(attrName) {
+  return isName(attrName);
+}
+function validateTagName(tagname) {
+  return isName(tagname);
+}
+function getLineNumberForPosition(xmlData, index) {
+  const lines = xmlData.substring(0, index).split(/\r?\n/);
+  return {
+    line: lines.length,
+    // column number is last line's length + 1, because column numbering starts at 1:
+    col: lines[lines.length - 1].length + 1
+  };
+}
+function getPositionFromMatch(match) {
+  return match.startIndex + match[1].length;
+}
+
+// node_modules/@nodable/entities/src/entities.js
+var CURRENCY = {
+  cent: "\xA2",
+  pound: "\xA3",
+  curren: "\xA4",
+  yen: "\xA5",
+  euro: "\u20AC",
+  dollar: "$",
+  fnof: "\u0192",
+  inr: "\u20B9",
+  af: "\u060B",
+  birr: "\u1265\u122D",
+  peso: "\u20B1",
+  rub: "\u20BD",
+  won: "\u20A9",
+  yuan: "\xA5",
+  cedil: "\xB8"
+};
+var XML = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  quot: '"'
+};
+var COMMON_HTML = {
+  nbsp: "\xA0",
+  copy: "\xA9",
+  reg: "\xAE",
+  trade: "\u2122",
+  mdash: "\u2014",
+  ndash: "\u2013",
+  hellip: "\u2026",
+  laquo: "\xAB",
+  raquo: "\xBB",
+  lsquo: "\u2018",
+  rsquo: "\u2019",
+  ldquo: "\u201C",
+  rdquo: "\u201D",
+  bull: "\u2022",
+  para: "\xB6",
+  sect: "\xA7",
+  deg: "\xB0",
+  frac12: "\xBD",
+  frac14: "\xBC",
+  frac34: "\xBE"
+};
+
+// node_modules/@nodable/entities/src/EntityDecoder.js
+var ENTITY_ACTION = Object.freeze({
+  /** Resolve and expand the entity normally. */
+  ALLOW: "allow",
+  /** Silently skip this entity — it will not be registered. */
+  BLOCK: "block",
+  /** Throw an error, aborting entity registration entirely. */
+  THROW: "throw"
+});
+var SPECIAL_CHARS = new Set("!?\\\\/[]$%{}^&*()<>|+");
+function validateEntityName(name) {
+  if (name[0] === "#") {
+    throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${name}"`);
+  }
+  for (const ch of name) {
+    if (SPECIAL_CHARS.has(ch)) {
+      throw new Error(`[EntityReplacer] Invalid character '${ch}' in entity name: "${name}"`);
+    }
+  }
+  return name;
+}
+function mergeEntityMaps(...maps) {
+  const out = /* @__PURE__ */ Object.create(null);
+  for (const map of maps) {
+    if (!map) continue;
+    for (const key of Object.keys(map)) {
+      const raw = map[key];
+      if (typeof raw === "string") {
+        out[key] = raw;
+      } else if (raw && typeof raw === "object" && raw.val !== void 0) {
+        const val = raw.val;
+        if (typeof val === "string") {
+          out[key] = val;
+        }
+      }
+    }
+  }
+  return out;
+}
+var LIMIT_TIER_EXTERNAL = "external";
+var LIMIT_TIER_BASE = "base";
+var LIMIT_TIER_ALL = "all";
+function parseLimitTiers(raw) {
+  if (!raw || raw === LIMIT_TIER_EXTERNAL) return /* @__PURE__ */ new Set([LIMIT_TIER_EXTERNAL]);
+  if (raw === LIMIT_TIER_ALL) return /* @__PURE__ */ new Set([LIMIT_TIER_ALL]);
+  if (raw === LIMIT_TIER_BASE) return /* @__PURE__ */ new Set([LIMIT_TIER_BASE]);
+  if (Array.isArray(raw)) return new Set(raw);
+  return /* @__PURE__ */ new Set([LIMIT_TIER_EXTERNAL]);
+}
+var NCR_LEVEL = Object.freeze({ allow: 0, leave: 1, remove: 2, throw: 3 });
+var XML10_ALLOWED_C0 = /* @__PURE__ */ new Set([9, 10, 13]);
+function parseNCRConfig(ncr) {
+  if (!ncr) {
+    return { xmlVersion: 1, onLevel: NCR_LEVEL.allow, nullLevel: NCR_LEVEL.remove };
+  }
+  const xmlVersion = ncr.xmlVersion === 1.1 ? 1.1 : 1;
+  const onLevel = NCR_LEVEL[ncr.onNCR] ?? NCR_LEVEL.allow;
+  const nullLevel = NCR_LEVEL[ncr.nullNCR] ?? NCR_LEVEL.remove;
+  const clampedNull = Math.max(nullLevel, NCR_LEVEL.remove);
+  return { xmlVersion, onLevel, nullLevel: clampedNull };
+}
+var EntityDecoder = class {
+  /**
+   * @param {object} [options]
+   * @param {object|null}  [options.namedEntities]        — extra named entities merged into base map
+   * @param {object}  [options.limit]                 — security limits
+   * @param {number}       [options.limit.maxTotalExpansions=0]  — 0 = unlimited
+   * @param {number}       [options.limit.maxExpandedLength=0]   — 0 = unlimited
+   * @param {'external'|'base'|'all'|string[]} [options.limit.applyLimitsTo='external']
+   *   Which entity tiers count against the security limits:
+   *   - 'external' (default) — only input/runtime + persistent external entities
+   *   - 'base'               — only DEFAULT_XML_ENTITIES + namedEntities
+   *   - 'all'                — every entity regardless of tier
+   *   - string[]             — explicit combination, e.g. ['external', 'base']
+   * @param {((resolved: string, original: string) => string)|null} [options.postCheck=null]
+   * @param {string[]} [options.remove=[]] — entity names (e.g. ['nbsp', '#13']) to delete (replace with empty string)
+   * @param {string[]} [options.leave=[]]  — entity names to keep as literal (unchanged in output)
+   * @param {object}   [options.ncr]       — Numeric Character Reference controls
+   * @param {1.0|1.1}  [options.ncr.xmlVersion=1.0]
+   *   XML version governing which codepoint ranges are restricted:
+   *   - 1.0 — C0 controls U+0001–U+001F (except U+0009/000A/000D) are prohibited
+   *   - 1.1 — C0 controls are allowed when written as NCRs; C1 (U+007F–U+009F) decoded as-is
+   * @param {'allow'|'leave'|'remove'|'throw'} [options.ncr.onNCR='allow']
+   *   Base action for numeric references. Severity order: allow < leave < remove < throw.
+   *   For codepoint ranges that carry a minimum level (surrogates → remove, XML 1.0 C0 → remove),
+   *   the effective action is max(onNCR, rangeMinimum).
+   * @param {'remove'|'throw'} [options.ncr.nullNCR='remove']
+   *   Action for U+0000 (null). 'allow' and 'leave' are clamped to 'remove' since null is never safe.
+   * @param {((name: string, value: string) => 'allow'|'block'|'throw')|null} [options.onExternalEntity=null]
+   *   Hook called when an external entity is registered via `setExternalEntities()` or
+   *   `addExternalEntity()`. Return `ENTITY_ACTION.ALLOW` to accept the entity,
+   *   `ENTITY_ACTION.BLOCK` to silently skip it, or `ENTITY_ACTION.THROW` to abort with an error.
+   * @param {((name: string, value: string) => 'allow'|'block'|'throw')|null} [options.onInputEntity=null]
+   *   Hook called when an input entity is registered via `addInputEntities()`. Return
+   *   `ENTITY_ACTION.ALLOW` to accept, `ENTITY_ACTION.BLOCK` to silently skip, or
+   *   `ENTITY_ACTION.THROW` to abort with an error.
+   */
+  constructor(options = {}) {
+    this._limit = options.limit || {};
+    this._maxTotalExpansions = this._limit.maxTotalExpansions || 0;
+    this._maxExpandedLength = this._limit.maxExpandedLength || 0;
+    this._postCheck = typeof options.postCheck === "function" ? options.postCheck : (r) => r;
+    this._limitTiers = parseLimitTiers(this._limit.applyLimitsTo ?? LIMIT_TIER_EXTERNAL);
+    this._numericAllowed = options.numericAllowed ?? true;
+    this._baseMap = mergeEntityMaps(XML, options.namedEntities || null);
+    this._externalMap = /* @__PURE__ */ Object.create(null);
+    this._inputMap = /* @__PURE__ */ Object.create(null);
+    this._totalExpansions = 0;
+    this._expandedLength = 0;
+    this._removeSet = new Set(options.remove && Array.isArray(options.remove) ? options.remove : []);
+    this._leaveSet = new Set(options.leave && Array.isArray(options.leave) ? options.leave : []);
+    const ncrCfg = parseNCRConfig(options.ncr);
+    this._ncrXmlVersion = ncrCfg.xmlVersion;
+    this._ncrOnLevel = ncrCfg.onLevel;
+    this._ncrNullLevel = ncrCfg.nullLevel;
+    this._onExternalEntity = typeof options.onExternalEntity === "function" ? options.onExternalEntity : null;
+    this._onInputEntity = typeof options.onInputEntity === "function" ? options.onInputEntity : null;
+  }
+  // -------------------------------------------------------------------------
+  // Private: registration hook dispatch
+  // -------------------------------------------------------------------------
+  /**
+   * Invoke a registration hook for a single entity name/value pair.
+   * Returns true when the entity should be accepted, false when it should be
+   * silently skipped (BLOCK), and throws when the hook returns THROW.
+   *
+   * @param {((name: string, value: string) => 'allow'|'block'|'throw')|null} hook
+   * @param {string} name
+   * @param {string} value
+   * @param {string} context  — used in error messages ('external' | 'input')
+   * @returns {boolean}  true = accept, false = skip
+   */
+  _applyRegistrationHook(hook, name, value, context) {
+    if (!hook) return true;
+    const action = hook(name, value);
+    if (action === ENTITY_ACTION.BLOCK) return false;
+    if (action === ENTITY_ACTION.THROW) {
+      throw new Error(
+        `[EntityDecoder] Registration of ${context} entity "&${name};" was rejected by hook`
+      );
+    }
+    return true;
+  }
+  // -------------------------------------------------------------------------
+  // Persistent external entity registration
+  // -------------------------------------------------------------------------
+  /**
+   * Replace the full set of persistent external entities.
+   * All keys are validated — throws on invalid characters.
+   * If `onExternalEntity` is set, it is called once per entry; entries that
+   * return `ENTITY_ACTION.BLOCK` are silently omitted, `ENTITY_ACTION.THROW`
+   * aborts the whole call.
+   * @param {Record<string, string | { regex?: RegExp, val: string }>} map
+   */
+  setExternalEntities(map) {
+    if (map) {
+      for (const key of Object.keys(map)) {
+        validateEntityName(key);
+      }
+    }
+    if (!this._onExternalEntity) {
+      this._externalMap = mergeEntityMaps(map);
+      return;
+    }
+    const flat = mergeEntityMaps(map);
+    const filtered = /* @__PURE__ */ Object.create(null);
+    for (const [name, value] of Object.entries(flat)) {
+      if (this._applyRegistrationHook(this._onExternalEntity, name, value, "external")) {
+        filtered[name] = value;
+      }
+    }
+    this._externalMap = filtered;
+  }
+  /**
+   * Add a single persistent external entity.
+   * If `onExternalEntity` is set it is called before the entity is stored;
+   * `ENTITY_ACTION.BLOCK` silently skips storage, `ENTITY_ACTION.THROW` raises.
+   * @param {string} key
+   * @param {string} value
+   */
+  addExternalEntity(key, value) {
+    validateEntityName(key);
+    if (typeof value === "string" && value.indexOf("&") === -1) {
+      if (this._applyRegistrationHook(this._onExternalEntity, key, value, "external")) {
+        this._externalMap[key] = value;
+      }
+    }
+  }
+  // -------------------------------------------------------------------------
+  // Input / runtime entity registration (per document)
+  // -------------------------------------------------------------------------
+  /**
+   * Inject DOCTYPE entities for the current document.
+   * Also resets per-document expansion counters.
+   * If `onInputEntity` is set it is called once per entry; entries returning
+   * `ENTITY_ACTION.BLOCK` are silently omitted, `ENTITY_ACTION.THROW` aborts.
+   * @param {Record<string, string | { regx?: RegExp, regex?: RegExp, val: string }>} map
+   */
+  addInputEntities(map) {
+    this._totalExpansions = 0;
+    this._expandedLength = 0;
+    if (!this._onInputEntity) {
+      this._inputMap = mergeEntityMaps(map);
+      return;
+    }
+    const flat = mergeEntityMaps(map);
+    const filtered = /* @__PURE__ */ Object.create(null);
+    for (const [name, value] of Object.entries(flat)) {
+      if (this._applyRegistrationHook(this._onInputEntity, name, value, "input")) {
+        filtered[name] = value;
+      }
+    }
+    this._inputMap = filtered;
+  }
+  // -------------------------------------------------------------------------
+  // Per-document reset
+  // -------------------------------------------------------------------------
+  /**
+   * Wipe input/runtime entities and reset counters.
+   * Call this before processing each new document.
+   * @returns {this}
+   */
+  reset() {
+    this._inputMap = /* @__PURE__ */ Object.create(null);
+    this._totalExpansions = 0;
+    this._expandedLength = 0;
+    return this;
+  }
+  // -------------------------------------------------------------------------
+  // XML version (can be set after construction, e.g. once parser reads <?xml?>)
+  // -------------------------------------------------------------------------
+  /**
+   * Update the XML version used for NCR classification.
+   * Call this as soon as the document's `<?xml version="...">` declaration is parsed.
+   * @param {1.0|1.1|number} version
+   */
+  setXmlVersion(version) {
+    this._ncrXmlVersion = version === 1.1 ? 1.1 : 1;
+  }
+  // -------------------------------------------------------------------------
+  // Primary API
+  // -------------------------------------------------------------------------
+  /**
+   * Replace all entity references in `str` in a single pass.
+   *
+   * @param {string} str
+   * @returns {string}
+   */
+  decode(str) {
+    if (typeof str !== "string" || str.length === 0) return str;
+    if (str.indexOf("&") === -1) return str;
+    const original = str;
+    const chunks = [];
+    const len = str.length;
+    let last = 0;
+    let i = 0;
+    const limitExpansions = this._maxTotalExpansions > 0;
+    const limitLength = this._maxExpandedLength > 0;
+    const checkLimits = limitExpansions || limitLength;
+    while (i < len) {
+      if (str.charCodeAt(i) !== 38) {
+        i++;
+        continue;
+      }
+      let j = i + 1;
+      while (j < len && str.charCodeAt(j) !== 59 && j - i <= 32) j++;
+      if (j >= len || str.charCodeAt(j) !== 59) {
+        i++;
+        continue;
+      }
+      const token = str.slice(i + 1, j);
+      if (token.length === 0) {
+        i++;
+        continue;
+      }
+      let replacement;
+      let tier;
+      if (this._removeSet.has(token)) {
+        replacement = "";
+        if (tier === void 0) {
+          tier = LIMIT_TIER_EXTERNAL;
+        }
+      } else if (this._leaveSet.has(token)) {
+        i++;
+        continue;
+      } else if (token.charCodeAt(0) === 35) {
+        const ncrResult = this._resolveNCR(token);
+        if (ncrResult === void 0) {
+          i++;
+          continue;
+        }
+        replacement = ncrResult;
+        tier = LIMIT_TIER_BASE;
+      } else {
+        const resolved = this._resolveName(token);
+        replacement = resolved?.value;
+        tier = resolved?.tier;
+      }
+      if (replacement === void 0) {
+        i++;
+        continue;
+      }
+      if (i > last) chunks.push(str.slice(last, i));
+      chunks.push(replacement);
+      last = j + 1;
+      i = last;
+      if (checkLimits && this._tierCounts(tier)) {
+        if (limitExpansions) {
+          this._totalExpansions++;
+          if (this._totalExpansions > this._maxTotalExpansions) {
+            throw new Error(
+              `[EntityReplacer] Entity expansion count limit exceeded: ${this._totalExpansions} > ${this._maxTotalExpansions}`
+            );
+          }
+        }
+        if (limitLength) {
+          const delta = replacement.length - (token.length + 2);
+          if (delta > 0) {
+            this._expandedLength += delta;
+            if (this._expandedLength > this._maxExpandedLength) {
+              throw new Error(
+                `[EntityReplacer] Expanded content length limit exceeded: ${this._expandedLength} > ${this._maxExpandedLength}`
+              );
+            }
+          }
+        }
+      }
+    }
+    if (last < len) chunks.push(str.slice(last));
+    const result = chunks.length === 0 ? str : chunks.join("");
+    return this._postCheck(result, original);
+  }
+  // -------------------------------------------------------------------------
+  // Private: limit tier check
+  // -------------------------------------------------------------------------
+  /**
+   * Returns true if a resolved entity of the given tier should count
+   * against the expansion/length limits.
+   * @param {string} tier  — LIMIT_TIER_EXTERNAL | LIMIT_TIER_BASE
+   * @returns {boolean}
+   */
+  _tierCounts(tier) {
+    if (this._limitTiers.has(LIMIT_TIER_ALL)) return true;
+    return this._limitTiers.has(tier);
+  }
+  // -------------------------------------------------------------------------
+  // Private: entity resolution
+  // -------------------------------------------------------------------------
+  /**
+   * Resolve a named entity token (without & and ;).
+   * Priority: inputMap > externalMap > baseMap
+   * Returns the resolved value tagged with its limit tier.
+   *
+   * @param {string} name
+   * @returns {{ value: string, tier: string }|undefined}
+   */
+  _resolveName(name) {
+    if (name in this._inputMap) return { value: this._inputMap[name], tier: LIMIT_TIER_EXTERNAL };
+    if (name in this._externalMap) return { value: this._externalMap[name], tier: LIMIT_TIER_EXTERNAL };
+    if (name in this._baseMap) return { value: this._baseMap[name], tier: LIMIT_TIER_BASE };
+    return void 0;
+  }
+  /**
+   * Classify a codepoint and return the minimum action level that must be applied.
+   * Returns -1 when no minimum is imposed (normal allow path).
+   *
+   * Ranges checked (in priority order):
+   *   1. U+0000            — null, governed by nullNCR (always ≥ remove)
+   *   2. U+D800–U+DFFF     — surrogates, always prohibited (min: remove)
+   *   3. U+0001–U+001F \ {0x09,0x0A,0x0D}  — XML 1.0 restricted C0 (min: remove)
+   *      (skipped in XML 1.1 — C0 controls are allowed when written as NCRs)
+   *
+   * @param {number} cp  — codepoint
+   * @returns {number}   — minimum NCR_LEVEL value, or -1 for no restriction
+   */
+  _classifyNCR(cp) {
+    if (cp === 0) return this._ncrNullLevel;
+    if (cp >= 55296 && cp <= 57343) return NCR_LEVEL.remove;
+    if (this._ncrXmlVersion === 1) {
+      if (cp >= 1 && cp <= 31 && !XML10_ALLOWED_C0.has(cp)) return NCR_LEVEL.remove;
+    }
+    return -1;
+  }
+  /**
+   * Execute a resolved NCR action.
+   *
+   * @param {number} action   — NCR_LEVEL value
+   * @param {string} token    — raw token (e.g. '#38') for error messages
+   * @param {number} cp       — codepoint, used only for error messages
+   * @returns {string|undefined}
+   *   - decoded character string  → 'allow'
+   *   - ''                        → 'remove'
+   *   - undefined                 → 'leave' (caller must skip past '&' only)
+   *   - throws Error              → 'throw'
+   */
+  _applyNCRAction(action, token, cp) {
+    switch (action) {
+      case NCR_LEVEL.allow:
+        return String.fromCodePoint(cp);
+      case NCR_LEVEL.remove:
+        return "";
+      case NCR_LEVEL.leave:
+        return void 0;
+      // signal: keep literal
+      case NCR_LEVEL.throw:
+        throw new Error(
+          `[EntityDecoder] Prohibited numeric character reference &${token}; (U+${cp.toString(16).toUpperCase().padStart(4, "0")})`
+        );
+      default:
+        return String.fromCodePoint(cp);
+    }
+  }
+  /**
+   * Full NCR resolution pipeline for a numeric token.
+   *
+   * Steps:
+   *   1. Parse the codepoint (decimal or hex).
+   *   2. Validate the raw codepoint range (NaN, <0, >0x10FFFF).
+   *   3. If numericAllowed is false and no minimum restriction applies → leave as-is.
+   *   4. Classify the codepoint to find the minimum required action level.
+   *   5. Resolve effective action = max(onNCR, minimum).
+   *   6. Apply and return.
+   *
+   * @param {string} token  — e.g. '#38', '#x26', '#X26'
+   * @returns {string|undefined}
+   *   - string (incl. '')  — replacement ('' = remove)
+   *   - undefined          — leave original &token; as-is
+   */
+  _resolveNCR(token) {
+    const second = token.charCodeAt(1);
+    let cp;
+    if (second === 120 || second === 88) {
+      cp = parseInt(token.slice(2), 16);
+    } else {
+      cp = parseInt(token.slice(1), 10);
+    }
+    if (Number.isNaN(cp) || cp < 0 || cp > 1114111) return void 0;
+    const minimum = this._classifyNCR(cp);
+    if (!this._numericAllowed && minimum < NCR_LEVEL.remove) return void 0;
+    const effective = minimum === -1 ? this._ncrOnLevel : Math.max(this._ncrOnLevel, minimum);
+    return this._applyNCRAction(effective, token, cp);
+  }
+};
+
+// node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
+var defaultOnDangerousProperty = (name) => {
+  if (DANGEROUS_PROPERTY_NAMES.includes(name)) {
+    return "__" + name;
+  }
+  return name;
+};
+var defaultOptions2 = {
+  preserveOrder: false,
+  attributeNamePrefix: "@_",
+  attributesGroupName: false,
+  textNodeName: "#text",
+  ignoreAttributes: true,
+  removeNSPrefix: false,
+  // remove NS from tag name or attribute name if true
+  allowBooleanAttributes: false,
+  //a tag can have attributes without any value
+  //ignoreRootElement : false,
+  parseTagValue: true,
+  parseAttributeValue: false,
+  trimValues: true,
+  //Trim string values of tag and attributes
+  cdataPropName: false,
+  numberParseOptions: {
+    hex: true,
+    leadingZeros: true,
+    eNotation: true,
+    unicode: false
+  },
+  tagValueProcessor: function(tagName, val) {
+    return val;
+  },
+  attributeValueProcessor: function(attrName, val) {
+    return val;
+  },
+  stopNodes: [],
+  //nested tags will not be parsed even for errors
+  alwaysCreateTextNode: false,
+  isArray: () => false,
+  commentPropName: false,
+  unpairedTags: [],
+  processEntities: true,
+  htmlEntities: false,
+  entityDecoder: null,
+  ignoreDeclaration: false,
+  ignorePiTags: false,
+  transformTagName: false,
+  transformAttributeName: false,
+  updateTag: function(tagName, jPath, attrs) {
+    return tagName;
+  },
+  // skipEmptyListItem: false
+  captureMetaData: false,
+  maxNestedTags: 100,
+  strictReservedNames: true,
+  jPath: true,
+  // if true, pass jPath string to callbacks; if false, pass matcher instance
+  onDangerousProperty: defaultOnDangerousProperty
+};
+function validatePropertyName(propertyName, optionName) {
+  if (typeof propertyName !== "string") {
+    return;
+  }
+  const normalized = propertyName.toLowerCase();
+  if (DANGEROUS_PROPERTY_NAMES.some((dangerous) => normalized === dangerous.toLowerCase())) {
+    throw new Error(
+      `[SECURITY] Invalid ${optionName}: "${propertyName}" is a reserved JavaScript keyword that could cause prototype pollution`
+    );
+  }
+  if (criticalProperties.some((dangerous) => normalized === dangerous.toLowerCase())) {
+    throw new Error(
+      `[SECURITY] Invalid ${optionName}: "${propertyName}" is a reserved JavaScript keyword that could cause prototype pollution`
+    );
+  }
+}
+function normalizeProcessEntities(value, htmlEntities) {
+  if (typeof value === "boolean") {
+    return {
+      enabled: value,
+      // true or false
+      maxEntitySize: 1e4,
+      maxExpansionDepth: 1e4,
+      maxTotalExpansions: Infinity,
+      maxExpandedLength: 1e5,
+      maxEntityCount: 1e3,
+      allowedTags: null,
+      tagFilter: null,
+      appliesTo: "all"
+    };
+  }
+  if (typeof value === "object" && value !== null) {
+    return {
+      enabled: value.enabled !== false,
+      maxEntitySize: Math.max(1, value.maxEntitySize ?? 1e4),
+      maxExpansionDepth: Math.max(1, value.maxExpansionDepth ?? 1e4),
+      maxTotalExpansions: Math.max(1, value.maxTotalExpansions ?? Infinity),
+      maxExpandedLength: Math.max(1, value.maxExpandedLength ?? 1e5),
+      maxEntityCount: Math.max(1, value.maxEntityCount ?? 1e3),
+      allowedTags: value.allowedTags ?? null,
+      tagFilter: value.tagFilter ?? null,
+      appliesTo: value.appliesTo ?? "all"
+    };
+  }
+  return normalizeProcessEntities(true);
+}
+var buildOptions = function(options) {
+  const built = Object.assign({}, defaultOptions2, options);
+  const propertyNameOptions = [
+    { value: built.attributeNamePrefix, name: "attributeNamePrefix" },
+    { value: built.attributesGroupName, name: "attributesGroupName" },
+    { value: built.textNodeName, name: "textNodeName" },
+    { value: built.cdataPropName, name: "cdataPropName" },
+    { value: built.commentPropName, name: "commentPropName" }
+  ];
+  for (const { value, name } of propertyNameOptions) {
+    if (value) {
+      validatePropertyName(value, name);
+    }
+  }
+  if (built.onDangerousProperty === null) {
+    built.onDangerousProperty = defaultOnDangerousProperty;
+  }
+  built.processEntities = normalizeProcessEntities(built.processEntities, built.htmlEntities);
+  built.unpairedTagsSet = new Set(built.unpairedTags);
+  if (built.stopNodes && Array.isArray(built.stopNodes)) {
+    built.stopNodes = built.stopNodes.map((node) => {
+      if (typeof node === "string" && node.startsWith("*.")) {
+        return ".." + node.substring(2);
+      }
+      return node;
+    });
+  }
+  return built;
+};
+
+// node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
+var METADATA_SYMBOL;
+if (typeof Symbol !== "function") {
+  METADATA_SYMBOL = "@@xmlMetadata";
+} else {
+  METADATA_SYMBOL = /* @__PURE__ */ Symbol("XML Node Metadata");
+}
+var XmlNode = class {
+  constructor(tagname) {
+    this.tagname = tagname;
+    this.child = [];
+    this[":@"] = /* @__PURE__ */ Object.create(null);
+  }
+  add(key, val) {
+    if (key === "__proto__") key = "#__proto__";
+    this.child.push({ [key]: val });
+  }
+  addChild(node, startIndex) {
+    if (node.tagname === "__proto__") node.tagname = "#__proto__";
+    if (node[":@"] && Object.keys(node[":@"]).length > 0) {
+      this.child.push({ [node.tagname]: node.child, [":@"]: node[":@"] });
+    } else {
+      this.child.push({ [node.tagname]: node.child });
+    }
+    if (startIndex !== void 0) {
+      this.child[this.child.length - 1][METADATA_SYMBOL] = { startIndex };
+    }
+  }
+  /** symbol used for metadata */
+  static getMetaDataSymbol() {
+    return METADATA_SYMBOL;
+  }
+};
+
+// node_modules/xml-naming/src/index.js
+var nameStartChar10 = ":A-Za-z_\xC0-\xD6\xD8-\xF6\xF8-\u02FF\u0370-\u037D\u037F-\u0486\u0488-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD";
+var nameChar10 = nameStartChar10 + "\\-\\.\\d\xB7\u0300-\u036F\u203F-\u2040";
+var nameStartChar11 = ":A-Za-z_\xC0-\u02FF\u0370-\u037D\u037F-\u0486\u0488-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u{10000}-\u{EFFFF}";
+var nameChar11 = nameStartChar11 + "\\-\\.\\d\xB7\u0300-\u036F\u0487\u203F-\u2040";
+var buildRegexes = (startChar, char, flags = "") => {
+  const ncStart = startChar.replace(":", "");
+  const ncChar = char.replace(":", "");
+  const ncNamePat = `[${ncStart}][${ncChar}]*`;
+  return {
+    name: new RegExp(`^[${startChar}][${char}]*$`, flags),
+    ncName: new RegExp(`^${ncNamePat}$`, flags),
+    qName: new RegExp(`^${ncNamePat}(?::${ncNamePat})?$`, flags),
+    nmToken: new RegExp(`^[${char}]+$`, flags),
+    nmTokens: new RegExp(`^[${char}]+(?:\\s+[${char}]+)*$`, flags)
+  };
+};
+var regexes10 = buildRegexes(nameStartChar10, nameChar10);
+var regexes11 = buildRegexes(nameStartChar11, nameChar11, "u");
+var nameStartCharAscii = ":A-Za-z_";
+var nameCharAscii = nameStartCharAscii + "\\-\\.\\d";
+var regexesAscii = buildRegexes(nameStartCharAscii, nameCharAscii);
+var getRegexes = (xmlVersion = "1.0", asciiOnly = false) => {
+  if (asciiOnly) return regexesAscii;
+  return xmlVersion === "1.1" ? regexes11 : regexes10;
+};
+var qName = (str, { xmlVersion = "1.0", asciiOnly = false } = {}) => getRegexes(xmlVersion, asciiOnly).qName.test(str);
+
+// node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
+var DocTypeReader = class {
+  constructor(options, xmlVersion) {
+    this.suppressValidationErr = !options;
+    this.options = options;
+    this.xmlVersion = xmlVersion || 1;
+  }
+  setXmlVersion(xmlVersion = 1) {
+    this.xmlVersion = xmlVersion;
+  }
+  readDocType(xmlData, i) {
+    const entities = /* @__PURE__ */ Object.create(null);
+    let entityCount = 0;
+    if (xmlData[i + 3] === "O" && xmlData[i + 4] === "C" && xmlData[i + 5] === "T" && xmlData[i + 6] === "Y" && xmlData[i + 7] === "P" && xmlData[i + 8] === "E") {
+      i = i + 9;
+      let angleBracketsCount = 1;
+      let hasBody = false, comment = false;
+      let exp = "";
+      for (; i < xmlData.length; i++) {
+        if (xmlData[i] === "<" && !comment) {
+          if (hasBody && hasSeq(xmlData, "!ENTITY", i)) {
+            i += 7;
+            let entityName, val;
+            [entityName, val, i] = this.readEntityExp(xmlData, i + 1, this.suppressValidationErr);
+            if (val.indexOf("&") === -1) {
+              if (this.options.enabled !== false && this.options.maxEntityCount != null && entityCount >= this.options.maxEntityCount) {
+                throw new Error(
+                  `Entity count (${entityCount + 1}) exceeds maximum allowed (${this.options.maxEntityCount})`
+                );
+              }
+              entities[entityName] = val;
+              entityCount++;
+            }
+          } else if (hasBody && hasSeq(xmlData, "!ELEMENT", i)) {
+            i += 8;
+            const { index } = this.readElementExp(xmlData, i + 1);
+            i = index;
+          } else if (hasBody && hasSeq(xmlData, "!ATTLIST", i)) {
+            i += 8;
+          } else if (hasBody && hasSeq(xmlData, "!NOTATION", i)) {
+            i += 9;
+            const { index } = this.readNotationExp(xmlData, i + 1, this.suppressValidationErr);
+            i = index;
+          } else if (hasSeq(xmlData, "!--", i)) comment = true;
+          else throw new Error(`Invalid DOCTYPE`);
+          angleBracketsCount++;
+          exp = "";
+        } else if (xmlData[i] === ">") {
+          if (comment) {
+            if (xmlData[i - 1] === "-" && xmlData[i - 2] === "-") {
+              comment = false;
+              angleBracketsCount--;
+            }
+          } else {
+            angleBracketsCount--;
+          }
+          if (angleBracketsCount === 0) {
+            break;
+          }
+        } else if (xmlData[i] === "[") {
+          hasBody = true;
+        } else {
+          exp += xmlData[i];
+        }
+      }
+      if (angleBracketsCount !== 0) {
+        throw new Error(`Unclosed DOCTYPE`);
+      }
+    } else {
+      throw new Error(`Invalid Tag instead of DOCTYPE`);
+    }
+    return { entities, i };
+  }
+  readEntityExp(xmlData, i) {
+    i = skipWhitespace(xmlData, i);
+    const startIndex = i;
+    while (i < xmlData.length && !/\s/.test(xmlData[i]) && xmlData[i] !== '"' && xmlData[i] !== "'") {
+      i++;
+    }
+    let entityName = xmlData.substring(startIndex, i);
+    validateEntityName2(entityName, { xmlVersion: this.xmlVersion });
+    i = skipWhitespace(xmlData, i);
+    if (!this.suppressValidationErr) {
+      if (xmlData.substring(i, i + 6).toUpperCase() === "SYSTEM") {
+        throw new Error("External entities are not supported");
+      } else if (xmlData[i] === "%") {
+        throw new Error("Parameter entities are not supported");
+      }
+    }
+    let entityValue = "";
+    [i, entityValue] = this.readIdentifierVal(xmlData, i, "entity");
+    if (this.options.enabled !== false && this.options.maxEntitySize != null && entityValue.length > this.options.maxEntitySize) {
+      throw new Error(
+        `Entity "${entityName}" size (${entityValue.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`
+      );
+    }
+    i--;
+    return [entityName, entityValue, i];
+  }
+  readNotationExp(xmlData, i) {
+    i = skipWhitespace(xmlData, i);
+    const startIndex = i;
+    while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+      i++;
+    }
+    let notationName = xmlData.substring(startIndex, i);
+    !this.suppressValidationErr && validateEntityName2(notationName, { xmlVersion: this.xmlVersion });
+    i = skipWhitespace(xmlData, i);
+    const identifierType = xmlData.substring(i, i + 6).toUpperCase();
+    if (!this.suppressValidationErr && identifierType !== "SYSTEM" && identifierType !== "PUBLIC") {
+      throw new Error(`Expected SYSTEM or PUBLIC, found "${identifierType}"`);
+    }
+    i += identifierType.length;
+    i = skipWhitespace(xmlData, i);
+    let publicIdentifier = null;
+    let systemIdentifier = null;
+    if (identifierType === "PUBLIC") {
+      [i, publicIdentifier] = this.readIdentifierVal(xmlData, i, "publicIdentifier");
+      i = skipWhitespace(xmlData, i);
+      if (xmlData[i] === '"' || xmlData[i] === "'") {
+        [i, systemIdentifier] = this.readIdentifierVal(xmlData, i, "systemIdentifier");
+      }
+    } else if (identifierType === "SYSTEM") {
+      [i, systemIdentifier] = this.readIdentifierVal(xmlData, i, "systemIdentifier");
+      if (!this.suppressValidationErr && !systemIdentifier) {
+        throw new Error("Missing mandatory system identifier for SYSTEM notation");
+      }
+    }
+    return { notationName, publicIdentifier, systemIdentifier, index: --i };
+  }
+  readIdentifierVal(xmlData, i, type) {
+    let identifierVal = "";
+    const startChar = xmlData[i];
+    if (startChar !== '"' && startChar !== "'") {
+      throw new Error(`Expected quoted string, found "${startChar}"`);
+    }
+    i++;
+    const startIndex = i;
+    while (i < xmlData.length && xmlData[i] !== startChar) {
+      i++;
+    }
+    identifierVal = xmlData.substring(startIndex, i);
+    if (xmlData[i] !== startChar) {
+      throw new Error(`Unterminated ${type} value`);
+    }
+    i++;
+    return [i, identifierVal];
+  }
+  readElementExp(xmlData, i) {
+    i = skipWhitespace(xmlData, i);
+    const startIndex = i;
+    while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+      i++;
+    }
+    let elementName = xmlData.substring(startIndex, i);
+    if (!this.suppressValidationErr && !qName(elementName, { xmlVersion: this.xmlVersion })) {
+      throw new Error(`Invalid element name: "${elementName}"`);
+    }
+    i = skipWhitespace(xmlData, i);
+    let contentModel = "";
+    if (xmlData[i] === "E" && hasSeq(xmlData, "MPTY", i)) i += 4;
+    else if (xmlData[i] === "A" && hasSeq(xmlData, "NY", i)) i += 2;
+    else if (xmlData[i] === "(") {
+      i++;
+      const startIndex2 = i;
+      while (i < xmlData.length && xmlData[i] !== ")") {
+        i++;
+      }
+      contentModel = xmlData.substring(startIndex2, i);
+      if (xmlData[i] !== ")") {
+        throw new Error("Unterminated content model");
+      }
+    } else if (!this.suppressValidationErr) {
+      throw new Error(`Invalid Element Expression, found "${xmlData[i]}"`);
+    }
+    return {
+      elementName,
+      contentModel: contentModel.trim(),
+      index: i
+    };
+  }
+  readAttlistExp(xmlData, i) {
+    i = skipWhitespace(xmlData, i);
+    let startIndex = i;
+    while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+      i++;
+    }
+    let elementName = xmlData.substring(startIndex, i);
+    validateEntityName2(elementName, { xmlVersion: this.xmlVersion });
+    i = skipWhitespace(xmlData, i);
+    startIndex = i;
+    while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+      i++;
+    }
+    let attributeName = xmlData.substring(startIndex, i);
+    if (!validateEntityName2(attributeName, { xmlVersion: this.xmlVersion })) {
+      throw new Error(`Invalid attribute name: "${attributeName}"`);
+    }
+    i = skipWhitespace(xmlData, i);
+    let attributeType = "";
+    if (xmlData.substring(i, i + 8).toUpperCase() === "NOTATION") {
+      attributeType = "NOTATION";
+      i += 8;
+      i = skipWhitespace(xmlData, i);
+      if (xmlData[i] !== "(") {
+        throw new Error(`Expected '(', found "${xmlData[i]}"`);
+      }
+      i++;
+      let allowedNotations = [];
+      while (i < xmlData.length && xmlData[i] !== ")") {
+        const startIndex2 = i;
+        while (i < xmlData.length && xmlData[i] !== "|" && xmlData[i] !== ")") {
+          i++;
+        }
+        let notation = xmlData.substring(startIndex2, i);
+        notation = notation.trim();
+        if (!validateEntityName2(notation, { xmlVersion: this.xmlVersion })) {
+          throw new Error(`Invalid notation name: "${notation}"`);
+        }
+        allowedNotations.push(notation);
+        if (xmlData[i] === "|") {
+          i++;
+          i = skipWhitespace(xmlData, i);
+        }
+      }
+      if (xmlData[i] !== ")") {
+        throw new Error("Unterminated list of notations");
+      }
+      i++;
+      attributeType += " (" + allowedNotations.join("|") + ")";
+    } else {
+      const startIndex2 = i;
+      while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+        i++;
+      }
+      attributeType += xmlData.substring(startIndex2, i);
+      const validTypes = ["CDATA", "ID", "IDREF", "IDREFS", "ENTITY", "ENTITIES", "NMTOKEN", "NMTOKENS"];
+      if (!this.suppressValidationErr && !validTypes.includes(attributeType.toUpperCase())) {
+        throw new Error(`Invalid attribute type: "${attributeType}"`);
+      }
+    }
+    i = skipWhitespace(xmlData, i);
+    let defaultValue = "";
+    if (xmlData.substring(i, i + 8).toUpperCase() === "#REQUIRED") {
+      defaultValue = "#REQUIRED";
+      i += 8;
+    } else if (xmlData.substring(i, i + 7).toUpperCase() === "#IMPLIED") {
+      defaultValue = "#IMPLIED";
+      i += 7;
+    } else {
+      [i, defaultValue] = this.readIdentifierVal(xmlData, i, "ATTLIST");
+    }
+    return {
+      elementName,
+      attributeName,
+      attributeType,
+      defaultValue,
+      index: i
+    };
+  }
+};
+var skipWhitespace = (data, index) => {
+  while (index < data.length && /\s/.test(data[index])) {
+    index++;
+  }
+  return index;
+};
+function hasSeq(data, seq, i) {
+  for (let j = 0; j < seq.length; j++) {
+    if (seq[j] !== data[i + j + 1]) return false;
+  }
+  return true;
+}
+function validateEntityName2(name, xmlVersion) {
+  if (qName(name, { xmlVersion }))
+    return name;
+  else
+    throw new Error(`Invalid entity name ${name}`);
+}
+
+// node_modules/anynum/digitTable.js
+var SCRIPT_ZEROS = [
+  // Basic Latin (ASCII) — included for completeness / pass-through
+  48,
+  // 0-9
+  // Arabic scripts
+  1632,
+  // Arabic-Indic ٠١٢٣٤٥٦٧٨٩
+  1776,
+  // Extended Arabic-Indic (Urdu/Persian/Sindhi) ۰۱۲۳
+  // Indic scripts
+  2406,
+  // Devanagari ०१२३४५६७८९
+  2534,
+  // Bengali ০১২৩৪৫৬৭৮৯
+  2662,
+  // Gurmukhi ੦੧੨੩੪੫੬੭੮੯
+  2790,
+  // Gujarati ૦૧૨૩૪૫૬૭૮૯
+  2918,
+  // Odia ୦୧୨୩୪୫୬୭୮୯
+  3046,
+  // Tamil ௦௧௨௩௪௫௬௭௮௯
+  3174,
+  // Telugu ౦౧౨౩౪౫౬౭౮౯
+  3302,
+  // Kannada ೦೧೨೩೪೫೬೭೮೯
+  3430,
+  // Malayalam ൦൧൨൩൪൫൬൭൮൯
+  3558,
+  // Sinhala Archaic ෦෧෨෩෪෫෬෭෮෯
+  // Southeast Asian scripts
+  3664,
+  // Thai ๐๑๒๓๔๕๖๗๘๙
+  3792,
+  // Lao ໐໑໒໓໔໕໖໗໘໙
+  3872,
+  // Tibetan ༠༡༢༣༤༥༦༧༨༩
+  4160,
+  // Myanmar ၀၁၂၃၄၅၆၇၈၉
+  4240,
+  // Myanmar Shan ႐႑႒႓႔႕႖႗႘႙
+  6112,
+  // Khmer ០១២៣៤៥៦៧៨៩
+  6160,
+  // Mongolian ᠐᠑᠒᠓᠔᠕᠖᠗᠘᠙
+  6470,
+  // Limbu ᥆᥇᥈᥉᥊᥋᥌᥍᥎᥏
+  6608,
+  // New Tai Lue ᧐᧑᧒᧓᧔᧕᧖᧗᧘᧙
+  6784,
+  // Tai Tham Hora ᪀᪁᪂᪃᪄᪅᪆᪇᪈᪉
+  6800,
+  // Tai Tham Tham ᪐᪑᪒᪓᪔᪕᪖᪗᪘᪙
+  6992,
+  // Balinese ᭐᭑᭒᭓᭔᭕᭖᭗᭘᭙
+  7088,
+  // Sundanese ᮰᮱᮲᮳᮴᮵᮶᮷᮸᮹
+  7232,
+  // Lepcha ᱀᱁᱂᱃᱄᱅᱆᱇᱈᱉
+  7248,
+  // Ol Chiki ᱐᱑᱒᱓᱔᱕᱖᱗᱘᱙
+  // Fullwidth (CJK context)
+  65296,
+  // Fullwidth ０１２３４５６７８９
+  // Mathematical digit variants (Unicode math block)
+  120782,
+  // Mathematical Bold
+  120792,
+  // Mathematical Double-Struck
+  120802,
+  // Mathematical Sans-Serif
+  120812,
+  // Mathematical Sans-Serif Bold
+  120822,
+  // Mathematical Monospace
+  // Other scripts
+  66720,
+  // Osmanya 𐒠𐒡𐒢𐒣𐒤𐒥𐒦𐒧𐒨𐒩
+  68912,
+  // Hanifi Rohingya 𐴰𐴱𐴲𐴳𐴴𐴵𐴶𐴷𐴸𐴹
+  69734,
+  // Brahmi 𑁦𑁧𑁨𑁩𑁪𑁫𑁬𑁭𑁮𑁯
+  69872,
+  // Sora Sompeng 𑃰𑃱𑃲𑃳𑃴𑃵𑃶𑃷𑃸𑃹
+  69942,
+  // Chakma 𑄶𑄷𑄸𑄹𑄺𑄻𑄼𑄽𑄾𑄿
+  70096,
+  // Sharada 𑇐𑇑𑇒𑇓𑇔𑇕𑇖𑇗𑇘𑇙
+  70384,
+  // Khudawadi 𑋰𑋱𑋲𑋳𑋴𑋵𑋶𑋷𑋸𑋹
+  70736,
+  // Newa 𑑐𑑑𑑒𑑓𑑔𑑕𑑖𑑗𑑘𑑙
+  70864,
+  // Tirhuta 𑓐𑓑𑓒𑓓𑓔𑓕𑓖𑓗𑓘𑓙
+  71248,
+  // Modi 𑙐𑙑𑙒𑙓𑙔𑙕𑙖𑙗𑙘𑙙
+  71360,
+  // Takri 𑛀𑛁𑛂𑛃𑛄𑛅𑛆𑛇𑛈𑛉
+  71472,
+  // Ahom 𑜰𑜱𑜲𑜳𑜴𑜵𑜶𑜷𑜸𑜹
+  71904,
+  // Warang Citi 𑣠𑣡𑣢𑣣𑣤𑣥𑣦𑣧𑣨𑣩
+  72016,
+  // Dives Akuru 𑥐𑥑𑥒𑥓𑥔𑥕𑥖𑥗𑥘𑥙
+  72688,
+  // Khitan Small Script 𑯰𑯱𑯲𑯳𑯴𑯵𑯶𑯷𑯸𑯹
+  72784,
+  // Bhaiksuki 𑱐𑱑𑱒𑱓𑱔𑱕𑱖𑱗𑱘𑱙
+  73040,
+  // Masaram Gondi 𑵐𑵑𑵒𑵓𑵔𑵕𑵖𑵗𑵘𑵙
+  73120,
+  // Gunjala Gondi 𑶠𑶡𑶢𑶣𑶤𑶥𑶦𑶧𑶨𑶩
+  73552,
+  // Kawi 𑽐𑽑𑽒𑽓𑽔𑽕𑽖𑽗𑽘𑽙
+  92768,
+  // Mro 𖩠𖩡𖩢𖩣𖩤𖩥𖩦𖩧𖩨𖩩
+  92864,
+  // Tangsa 𖫀𖫁𖫂𖫃𖫄𖫅𖫆𖫇𖫈𖫉
+  93008,
+  // Pahawh Hmong 𖭐𖭑𖭒𖭓𖭔𖭕𖭖𖭗𖭘𖭙
+  123200,
+  // Nyiakeng Puachue Hmong 𞅀𞅁𞅂𞅃𞅄𞅅𞅆𞅇𞅈𞅉
+  123632,
+  // Wancho 𞋰𞋱𞋲𞋳𞋴𞋵𞋶𞋷𞋸𞋹
+  124144,
+  // Nag Mundari 𞓰𞓱𞓲𞓳𞓴𞓵𞓶𞓷𞓸𞓹
+  125264,
+  // Adlam 𞥐𞥑𞥒𞥓𞥔𞥕𞥖𞥗𞥘𞥙
+  130032
+  // Segmented digit symbols 🯰🯱🯲🯳🯴🯵🯶🯷🯸🯹
+];
+var NOT_DIGIT = 255;
+var HIGH_MAP = /* @__PURE__ */ new Map();
+var LOW_MAX = 65535;
+var LOW_MIN = 1632;
+var TABLE_OFFSET = LOW_MIN;
+var TABLE_SIZE = LOW_MAX - LOW_MIN + 1;
+var TABLE = new Uint8Array(TABLE_SIZE).fill(NOT_DIGIT);
+for (const zero of SCRIPT_ZEROS) {
+  for (let d = 0; d < 10; d++) {
+    const cp = zero + d;
+    if (cp <= LOW_MAX) {
+      TABLE[cp - TABLE_OFFSET] = d;
+    } else {
+      HIGH_MAP.set(cp, d);
+    }
+  }
+}
+
+// node_modules/anynum/anynum.js
+var CHAR_0 = 48;
+var CHAR_9 = 57;
+var CHAR_MINUS = 45;
+var MINUS_SET = /* @__PURE__ */ new Set([8722, 65293, 65123]);
+function anynum(str) {
+  if (typeof str !== "string") return str;
+  const len = str.length;
+  if (len === 0) return str;
+  let firstHit = -1;
+  for (let i = 0; i < len; i++) {
+    const cc = str.charCodeAt(i);
+    if (cc >= CHAR_0 && cc <= CHAR_9 || cc === CHAR_MINUS) continue;
+    if (cc < TABLE_OFFSET) {
+      if (MINUS_SET.has(cc)) {
+        firstHit = i;
+        break;
+      }
+      continue;
+    }
+    if (cc >= 55296 && cc <= 56319) {
+      if (i + 1 < len) {
+        const low = str.charCodeAt(i + 1);
+        if (low >= 56320 && low <= 57343) {
+          const cp = 65536 + (cc - 55296 << 10) + (low - 56320);
+          if (HIGH_MAP.has(cp)) {
+            firstHit = i;
+            break;
+          }
+        }
+      }
+      continue;
+    }
+    if (TABLE[cc - TABLE_OFFSET] !== NOT_DIGIT || MINUS_SET.has(cc)) {
+      firstHit = i;
+      break;
+    }
+  }
+  if (firstHit === -1) return str;
+  const chars = [];
+  if (firstHit > 0) chars.push(str.slice(0, firstHit));
+  for (let i = firstHit; i < len; i++) {
+    const cc = str.charCodeAt(i);
+    if (cc >= CHAR_0 && cc <= CHAR_9 || cc === CHAR_MINUS) {
+      chars.push(str[i]);
+      continue;
+    }
+    if (cc < TABLE_OFFSET) {
+      chars.push(MINUS_SET.has(cc) ? "-" : str[i]);
+      continue;
+    }
+    if (cc >= 55296 && cc <= 56319) {
+      if (i + 1 < len) {
+        const low = str.charCodeAt(i + 1);
+        if (low >= 56320 && low <= 57343) {
+          const cp = 65536 + (cc - 55296 << 10) + (low - 56320);
+          const d2 = HIGH_MAP.get(cp);
+          if (d2 !== void 0) {
+            chars.push(String.fromCharCode(d2 + 48));
+            i++;
+            continue;
+          }
+        }
+      }
+      chars.push(str[i]);
+      continue;
+    }
+    if (MINUS_SET.has(cc)) {
+      chars.push("-");
+      continue;
+    }
+    const d = TABLE[cc - TABLE_OFFSET];
+    chars.push(d !== NOT_DIGIT ? String.fromCharCode(d + 48) : str[i]);
+  }
+  return chars.join("");
+}
+var anynum_default = anynum;
+
+// node_modules/strnum/strnum.js
+var hexRegex = /^[-+]?0x[a-fA-F0-9]+$/;
+var binRegex = /^0b[01]+$/;
+var octRegex = /^0o[0-7]+$/;
+var numRegex = /^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/;
+var consider = {
+  hex: true,
+  binary: false,
+  octal: false,
+  leadingZeros: true,
+  decimalPoint: ".",
+  eNotation: true,
+  //skipLike: /regex/,
+  infinity: "original",
+  // "null", "infinity" (Infinity type), "string" ("Infinity" (the string literal))
+  unicode: false
+};
+function toNumber(str, options = {}) {
+  options = Object.assign({}, consider, options);
+  if (!str || typeof str !== "string") return str;
+  let trimmedStr = str.trim();
+  if (trimmedStr.length === 0) return str;
+  else if (options.skipLike !== void 0 && options.skipLike.test(trimmedStr)) return str;
+  else if (trimmedStr === "0") return 0;
+  if (options.unicode) {
+    trimmedStr = anynum_default(trimmedStr);
+    if (trimmedStr === "0") return 0;
+  }
+  if (options.hex && hexRegex.test(trimmedStr)) {
+    return parse_int(trimmedStr, 16);
+  } else if (options.binary && binRegex.test(trimmedStr)) {
+    return parse_int(trimmedStr, 2);
+  } else if (options.octal && octRegex.test(trimmedStr)) {
+    return parse_int(trimmedStr, 8);
+  } else if (!isFinite(trimmedStr)) {
+    return handleInfinity(str, Number(trimmedStr), options);
+  } else if (trimmedStr.includes("e") || trimmedStr.includes("E")) {
+    return resolveEnotation(str, trimmedStr, options);
+  } else {
+    const match = numRegex.exec(trimmedStr);
+    if (match) {
+      const sign = match[1] || "";
+      const leadingZeros = match[2];
+      let numTrimmedByZeros = trimZeros(match[3]);
+      const decimalAdjacentToLeadingZeros = sign ? (
+        // 0., -00., 000.
+        str[leadingZeros.length + 1] === "."
+      ) : str[leadingZeros.length] === ".";
+      if (!options.leadingZeros && (leadingZeros.length > 1 || leadingZeros.length === 1 && !decimalAdjacentToLeadingZeros)) {
+        return str;
+      } else {
+        const num = Number(trimmedStr);
+        const parsedStr = String(num);
+        if (num === 0) return num;
+        if (parsedStr.search(/[eE]/) !== -1) {
+          if (options.eNotation) return num;
+          else return str;
+        } else if (trimmedStr.indexOf(".") !== -1) {
+          if (parsedStr === "0") return num;
+          else if (parsedStr === numTrimmedByZeros) return num;
+          else if (parsedStr === `${sign}${numTrimmedByZeros}`) return num;
+          else return str;
+        }
+        let n = leadingZeros ? numTrimmedByZeros : trimmedStr;
+        if (leadingZeros) {
+          return n === parsedStr || sign + n === parsedStr ? num : str;
+        } else {
+          return n === parsedStr || n === sign + parsedStr ? num : str;
+        }
+      }
+    } else {
+      return str;
+    }
+  }
+}
+var eNotationRegx = /^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;
+function resolveEnotation(str, trimmedStr, options) {
+  if (!options.eNotation) return str;
+  const notation = trimmedStr.match(eNotationRegx);
+  if (notation) {
+    let sign = notation[1] || "";
+    const eChar = notation[3].indexOf("e") === -1 ? "E" : "e";
+    const leadingZeros = notation[2];
+    const eAdjacentToLeadingZeros = sign ? (
+      // 0E.
+      str[leadingZeros.length + 1] === eChar
+    ) : str[leadingZeros.length] === eChar;
+    if (leadingZeros.length > 1 && eAdjacentToLeadingZeros) return str;
+    else if (leadingZeros.length === 1 && (notation[3].startsWith(`.${eChar}`) || notation[3][0] === eChar)) {
+      return Number(trimmedStr);
+    } else if (leadingZeros.length > 0) {
+      if (options.leadingZeros && !eAdjacentToLeadingZeros) {
+        trimmedStr = (notation[1] || "") + notation[3];
+        return Number(trimmedStr);
+      } else return str;
+    } else {
+      return Number(trimmedStr);
+    }
+  } else {
+    return str;
+  }
+}
+function trimZeros(numStr) {
+  if (numStr && numStr.indexOf(".") !== -1) {
+    let end = numStr.length;
+    while (end > 0 && numStr.charCodeAt(end - 1) === 48) end--;
+    numStr = numStr.slice(0, end);
+    if (numStr === ".") numStr = "0";
+    else if (numStr[0] === ".") numStr = "0" + numStr;
+    else if (numStr[numStr.length - 1] === ".") numStr = numStr.substring(0, numStr.length - 1);
+    return numStr;
+  }
+  return numStr;
+}
+function parse_int(numStr, base) {
+  const str = numStr.trim();
+  if (base === 2 || base === 8) numStr = str.substring(2);
+  if (parseInt) return parseInt(numStr, base);
+  else if (Number.parseInt) return Number.parseInt(numStr, base);
+  else if (window && window.parseInt) return window.parseInt(numStr, base);
+  else throw new Error("parseInt, Number.parseInt, window.parseInt are not supported");
+}
+function handleInfinity(str, num, options) {
+  const isPositive = num === Infinity;
+  switch (options.infinity.toLowerCase()) {
+    case "null":
+      return null;
+    case "infinity":
+      return num;
+    // Return Infinity or -Infinity
+    case "string":
+      return isPositive ? "Infinity" : "-Infinity";
+    case "original":
+    default:
+      return str;
+  }
+}
+
+// node_modules/fast-xml-parser/src/ignoreAttributes.js
+function getIgnoreAttributesFn(ignoreAttributes) {
+  if (typeof ignoreAttributes === "function") {
+    return ignoreAttributes;
+  }
+  if (Array.isArray(ignoreAttributes)) {
+    return (attrName) => {
+      for (const pattern of ignoreAttributes) {
+        if (typeof pattern === "string" && attrName === pattern) {
+          return true;
+        }
+        if (pattern instanceof RegExp && pattern.test(attrName)) {
+          return true;
+        }
+      }
+    };
+  }
+  return () => false;
+}
+
+// node_modules/path-expression-matcher/src/Expression.js
+var Expression = class {
+  /**
+   * Create a new Expression
+   * @param {string} pattern - Pattern string (e.g., "root.users.user", "..user[id]")
+   * @param {Object} options - Configuration options
+   * @param {string} options.separator - Path separator (default: '.')
+   */
+  constructor(pattern, options = {}, data) {
+    this.pattern = pattern;
+    this.separator = options.separator || ".";
+    this.segments = this._parse(pattern);
+    this.data = data;
+    this._hasDeepWildcard = this.segments.some((seg) => seg.type === "deep-wildcard");
+    this._hasAttributeCondition = this.segments.some((seg) => seg.attrName !== void 0);
+    this._hasPositionSelector = this.segments.some((seg) => seg.position !== void 0);
+  }
+  /**
+   * Parse pattern string into segments
+   * @private
+   * @param {string} pattern - Pattern to parse
+   * @returns {Array} Array of segment objects
+   */
+  _parse(pattern) {
+    const segments = [];
+    let i = 0;
+    let currentPart = "";
+    while (i < pattern.length) {
+      if (pattern[i] === this.separator) {
+        if (i + 1 < pattern.length && pattern[i + 1] === this.separator) {
+          if (currentPart.trim()) {
+            segments.push(this._parseSegment(currentPart.trim()));
+            currentPart = "";
+          }
+          segments.push({ type: "deep-wildcard" });
+          i += 2;
+        } else {
+          if (currentPart.trim()) {
+            segments.push(this._parseSegment(currentPart.trim()));
+          }
+          currentPart = "";
+          i++;
+        }
+      } else {
+        currentPart += pattern[i];
+        i++;
+      }
+    }
+    if (currentPart.trim()) {
+      segments.push(this._parseSegment(currentPart.trim()));
+    }
+    return segments;
+  }
+  /**
+   * Parse a single segment
+   * @private
+   * @param {string} part - Segment string (e.g., "user", "ns::user", "user[id]", "ns::user:first")
+   * @returns {Object} Segment object
+   */
+  _parseSegment(part) {
+    const segment = { type: "tag" };
+    let bracketContent = null;
+    let withoutBrackets = part;
+    const bracketMatch = part.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);
+    if (bracketMatch) {
+      withoutBrackets = bracketMatch[1] + bracketMatch[3];
+      if (bracketMatch[2]) {
+        const content = bracketMatch[2].slice(1, -1);
+        if (content) {
+          bracketContent = content;
+        }
+      }
+    }
+    let namespace = void 0;
+    let tagAndPosition = withoutBrackets;
+    if (withoutBrackets.includes("::")) {
+      const nsIndex = withoutBrackets.indexOf("::");
+      namespace = withoutBrackets.substring(0, nsIndex).trim();
+      tagAndPosition = withoutBrackets.substring(nsIndex + 2).trim();
+      if (!namespace) {
+        throw new Error(`Invalid namespace in pattern: ${part}`);
+      }
+    }
+    let tag = void 0;
+    let positionMatch = null;
+    if (tagAndPosition.includes(":")) {
+      const colonIndex = tagAndPosition.lastIndexOf(":");
+      const tagPart = tagAndPosition.substring(0, colonIndex).trim();
+      const posPart = tagAndPosition.substring(colonIndex + 1).trim();
+      const isPositionKeyword = ["first", "last", "odd", "even"].includes(posPart) || /^nth\(\d+\)$/.test(posPart);
+      if (isPositionKeyword) {
+        tag = tagPart;
+        positionMatch = posPart;
+      } else {
+        tag = tagAndPosition;
+      }
+    } else {
+      tag = tagAndPosition;
+    }
+    if (!tag) {
+      throw new Error(`Invalid segment pattern: ${part}`);
+    }
+    segment.tag = tag;
+    if (namespace) {
+      segment.namespace = namespace;
+    }
+    if (bracketContent) {
+      if (bracketContent.includes("=")) {
+        const eqIndex = bracketContent.indexOf("=");
+        segment.attrName = bracketContent.substring(0, eqIndex).trim();
+        segment.attrValue = bracketContent.substring(eqIndex + 1).trim();
+      } else {
+        segment.attrName = bracketContent.trim();
+      }
+    }
+    if (positionMatch) {
+      const nthMatch = positionMatch.match(/^nth\((\d+)\)$/);
+      if (nthMatch) {
+        segment.position = "nth";
+        segment.positionValue = parseInt(nthMatch[1], 10);
+      } else {
+        segment.position = positionMatch;
+      }
+    }
+    return segment;
+  }
+  /**
+   * Get the number of segments
+   * @returns {number}
+   */
+  get length() {
+    return this.segments.length;
+  }
+  /**
+   * Check if expression contains deep wildcard
+   * @returns {boolean}
+   */
+  hasDeepWildcard() {
+    return this._hasDeepWildcard;
+  }
+  /**
+   * Check if expression has attribute conditions
+   * @returns {boolean}
+   */
+  hasAttributeCondition() {
+    return this._hasAttributeCondition;
+  }
+  /**
+   * Check if expression has position selectors
+   * @returns {boolean}
+   */
+  hasPositionSelector() {
+    return this._hasPositionSelector;
+  }
+  /**
+   * Get string representation
+   * @returns {string}
+   */
+  toString() {
+    return this.pattern;
+  }
+};
+
+// node_modules/path-expression-matcher/src/ExpressionSet.js
+var ExpressionSet = class {
+  constructor() {
+    this._byDepthAndTag = /* @__PURE__ */ new Map();
+    this._wildcardByDepth = /* @__PURE__ */ new Map();
+    this._deepWildcards = [];
+    this._deepByTerminalTag = /* @__PURE__ */ new Map();
+    this._patterns = /* @__PURE__ */ new Set();
+    this._sealed = false;
+  }
+  /**
+   * Add an Expression to the set.
+   * Duplicate patterns (same pattern string) are silently ignored.
+   *
+   * @param {import('./Expression.js').default} expression - A pre-constructed Expression instance
+   * @returns {this} for chaining
+   * @throws {TypeError} if called after seal()
+   *
+   * @example
+   * set.add(new Expression('root.users.user'));
+   * set.add(new Expression('..script'));
+   */
+  add(expression) {
+    if (this._sealed) {
+      throw new TypeError(
+        "ExpressionSet is sealed. Create a new ExpressionSet to add more expressions."
+      );
+    }
+    if (this._patterns.has(expression.pattern)) return this;
+    this._patterns.add(expression.pattern);
+    if (expression.hasDeepWildcard()) {
+      const lastSeg2 = expression.segments[expression.segments.length - 1];
+      if (lastSeg2 && lastSeg2.type !== "deep-wildcard" && lastSeg2.tag !== "*") {
+        const tag2 = lastSeg2.tag;
+        if (!this._deepByTerminalTag.has(tag2)) this._deepByTerminalTag.set(tag2, []);
+        this._deepByTerminalTag.get(tag2).push(expression);
+      } else {
+        this._deepWildcards.push(expression);
+      }
+      return this;
+    }
+    const depth = expression.length;
+    const lastSeg = expression.segments[expression.segments.length - 1];
+    const tag = lastSeg?.tag;
+    if (!tag || tag === "*") {
+      if (!this._wildcardByDepth.has(depth)) this._wildcardByDepth.set(depth, []);
+      this._wildcardByDepth.get(depth).push(expression);
+    } else {
+      const key = `${depth}:${tag}`;
+      if (!this._byDepthAndTag.has(key)) this._byDepthAndTag.set(key, []);
+      this._byDepthAndTag.get(key).push(expression);
+    }
+    return this;
+  }
+  /**
+   * Add multiple expressions at once.
+   *
+   * @param {import('./Expression.js').default[]} expressions - Array of Expression instances
+   * @returns {this} for chaining
+   *
+   * @example
+   * set.addAll([
+   *   new Expression('root.users.user'),
+   *   new Expression('root.config.setting'),
+   * ]);
+   */
+  addAll(expressions) {
+    for (const expr of expressions) this.add(expr);
+    return this;
+  }
+  /**
+   * Check whether a pattern string is already present in the set.
+   *
+   * @param {import('./Expression.js').default} expression
+   * @returns {boolean}
+   */
+  has(expression) {
+    return this._patterns.has(expression.pattern);
+  }
+  /**
+   * Number of expressions in the set.
+   * @type {number}
+   */
+  get size() {
+    return this._patterns.size;
+  }
+  /**
+   * Seal the set against further modifications.
+   * Useful to prevent accidental mutations after config is built.
+   * Calling add() or addAll() on a sealed set throws a TypeError.
+   *
+   * @returns {this}
+   */
+  seal() {
+    this._sealed = true;
+    return this;
+  }
+  /**
+   * Whether the set has been sealed.
+   * @type {boolean}
+   */
+  get isSealed() {
+    return this._sealed;
+  }
+  /**
+   * Test whether the matcher's current path matches any expression in the set.
+   *
+   * Evaluation order (cheapest → most expensive):
+   *  1. Exact depth + tag bucket  — O(1) lookup, typically 0–2 expressions
+   *  2. Depth-only wildcard bucket — O(1) lookup, rare
+   *  3. Deep-wildcard list         — always checked, but usually small
+   *
+   * @param {import('./Matcher.js').default} matcher - Matcher instance (or readOnly view)
+   * @returns {boolean} true if any expression matches the current path
+   *
+   * @example
+   * if (stopNodes.matchesAny(matcher)) {
+   *   // handle stop node
+   * }
+   */
+  matchesAny(matcher) {
+    return this.findMatch(matcher) !== null;
+  }
+  /**
+  * Find and return the first Expression that matches the matcher's current path.
+  *
+  * Uses the same evaluation order as matchesAny (cheapest → most expensive):
+  *  1. Exact depth + tag bucket
+  *  2. Depth-only wildcard bucket
+  *  3. Deep-wildcard list
+  *
+  * @param {import('./Matcher.js').default} matcher - Matcher instance (or readOnly view)
+  * @returns {import('./Expression.js').default | null} the first matching Expression, or null
+  *
+  * @example
+  * const expr = stopNodes.findMatch(matcher);
+  * if (expr) {
+  *   // access expr.config, expr.pattern, etc.
+  * }
+  */
+  findMatch(matcher) {
+    const depth = matcher.getDepth();
+    const tag = matcher.getCurrentTag();
+    const exactKey = `${depth}:${tag}`;
+    const exactBucket = this._byDepthAndTag.get(exactKey);
+    if (exactBucket) {
+      for (let i = 0; i < exactBucket.length; i++) {
+        if (matcher.matches(exactBucket[i])) return exactBucket[i];
+      }
+    }
+    const wildcardBucket = this._wildcardByDepth.get(depth);
+    if (wildcardBucket) {
+      for (let i = 0; i < wildcardBucket.length; i++) {
+        if (matcher.matches(wildcardBucket[i])) return wildcardBucket[i];
+      }
+    }
+    const deepBucket = this._deepByTerminalTag.get(tag);
+    if (deepBucket) {
+      for (let i = 0; i < deepBucket.length; i++) {
+        if (matcher.matches(deepBucket[i])) return deepBucket[i];
+      }
+    }
+    for (let i = 0; i < this._deepWildcards.length; i++) {
+      if (matcher.matches(this._deepWildcards[i])) return this._deepWildcards[i];
+    }
+    return null;
+  }
+};
+
+// node_modules/path-expression-matcher/src/Matcher.js
+var MatcherView = class {
+  /**
+   * @param {Matcher} matcher - The parent Matcher instance to read from.
+   */
+  constructor(matcher) {
+    this._matcher = matcher;
+  }
+  /**
+   * Get the path separator used by the parent matcher.
+   * @returns {string}
+   */
+  get separator() {
+    return this._matcher.separator;
+  }
+  /**
+   * Get current tag name.
+   * @returns {string|undefined}
+   */
+  getCurrentTag() {
+    const path = this._matcher.path;
+    return path.length > 0 ? path[path.length - 1].tag : void 0;
+  }
+  /**
+   * Get current namespace.
+   * @returns {string|undefined}
+   */
+  getCurrentNamespace() {
+    const path = this._matcher.path;
+    return path.length > 0 ? path[path.length - 1].namespace : void 0;
+  }
+  /**
+   * Get current node's attribute value.
+   * @param {string} attrName
+   * @returns {*}
+   */
+  getAttrValue(attrName) {
+    const path = this._matcher.path;
+    if (path.length === 0) return void 0;
+    return path[path.length - 1].values?.[attrName];
+  }
+  /**
+   * Check if current node has an attribute.
+   * @param {string} attrName
+   * @returns {boolean}
+   */
+  hasAttr(attrName) {
+    const path = this._matcher.path;
+    if (path.length === 0) return false;
+    const current = path[path.length - 1];
+    return current.values !== void 0 && attrName in current.values;
+  }
+  /**
+   * Get the value of a "kept" attribute from the nearest ancestor (or
+   * current node) that declared it via `push(tag, attrs, ns, { keep: [...] })`.
+   * @param {string} attrName
+   * @returns {*}
+   */
+  getAnyParentAttr(attrName) {
+    return this._matcher.getAnyParentAttr(attrName);
+  }
+  /**
+   * Check whether any ancestor (or the current node) kept the given
+   * attribute via `push(tag, attrs, ns, { keep: [...] })`.
+   * @param {string} attrName
+   * @returns {boolean}
+   */
+  hasAnyParentAttr(attrName) {
+    return this._matcher.hasAnyParentAttr(attrName);
+  }
+  /**
+   * Get current node's sibling position (child index in parent).
+   * @returns {number}
+   */
+  getPosition() {
+    const path = this._matcher.path;
+    if (path.length === 0) return -1;
+    return path[path.length - 1].position ?? 0;
+  }
+  /**
+   * Get current node's repeat counter (occurrence count of this tag name).
+   * @returns {number}
+   */
+  getCounter() {
+    const path = this._matcher.path;
+    if (path.length === 0) return -1;
+    return path[path.length - 1].counter ?? 0;
+  }
+  /**
+   * Get current node's sibling index (alias for getPosition).
+   * @returns {number}
+   * @deprecated Use getPosition() or getCounter() instead
+   */
+  getIndex() {
+    return this.getPosition();
+  }
+  /**
+   * Get current path depth.
+   * @returns {number}
+   */
+  getDepth() {
+    return this._matcher.path.length;
+  }
+  /**
+   * Get path as string.
+   * @param {string} [separator] - Optional separator (uses default if not provided)
+   * @param {boolean} [includeNamespace=true]
+   * @returns {string}
+   */
+  toString(separator, includeNamespace = true) {
+    return this._matcher.toString(separator, includeNamespace);
+  }
+  /**
+   * Get path as array of tag names.
+   * @returns {string[]}
+   */
+  toArray() {
+    return this._matcher.path.map((n) => n.tag);
+  }
+  /**
+   * Match current path against an Expression.
+   * @param {Expression} expression
+   * @returns {boolean}
+   */
+  matches(expression) {
+    return this._matcher.matches(expression);
+  }
+  /**
+   * Match any expression in the given set against the current path.
+   * @param {ExpressionSet} exprSet
+   * @returns {boolean}
+   */
+  matchesAny(exprSet) {
+    return exprSet.matchesAny(this._matcher);
+  }
+};
+var Matcher = class {
+  /**
+   * Create a new Matcher.
+   * @param {Object} [options={}]
+   * @param {string} [options.separator='.'] - Default path separator
+   */
+  constructor(options = {}) {
+    this.separator = options.separator || ".";
+    this.path = [];
+    this.siblingStacks = [];
+    this._pathStringCache = null;
+    this._view = new MatcherView(this);
+    this._keptAttrs = [];
+  }
+  /**
+   * Push a new tag onto the path.
+   * @param {string} tagName
+   * @param {Object|null} [attrValues=null]
+   * @param {string|null} [namespace=null]
+   * @param {Object|null} [options=null]
+   * @param {string[]} [options.keep] - Names of attributes (from attrValues)
+   */
+  push(tagName, attrValues = null, namespace = null, options = null) {
+    this._pathStringCache = null;
+    if (this.path.length > 0) {
+      this.path[this.path.length - 1].values = void 0;
+    }
+    const currentLevel = this.path.length;
+    let level = this.siblingStacks[currentLevel];
+    if (!level) {
+      level = { counts: /* @__PURE__ */ new Map(), total: 0 };
+      this.siblingStacks[currentLevel] = level;
+    }
+    const siblingKey = namespace ? `${namespace}:${tagName}` : tagName;
+    const counter = level.counts.get(siblingKey) || 0;
+    const position = level.total;
+    level.counts.set(siblingKey, counter + 1);
+    level.total++;
+    const node = {
+      tag: tagName,
+      position,
+      counter
+    };
+    if (namespace !== null && namespace !== void 0) {
+      node.namespace = namespace;
+    }
+    if (attrValues !== null && attrValues !== void 0) {
+      node.values = attrValues;
+    }
+    this.path.push(node);
+    const depth = this.path.length;
+    const keep = options !== null ? options.keep : null;
+    if (keep !== null && keep !== void 0 && keep.length > 0 && attrValues) {
+      for (let i = 0; i < keep.length; i++) {
+        const name = keep[i];
+        if (attrValues[name] !== void 0) {
+          this._keptAttrs.push({ depth, name, value: attrValues[name] });
+        }
+      }
+    }
+  }
+  /**
+   * Pop the last tag from the path.
+   * @returns {Object|undefined} The popped node
+   */
+  pop() {
+    if (this.path.length === 0) return void 0;
+    this._pathStringCache = null;
+    const node = this.path.pop();
+    if (this.siblingStacks.length > this.path.length + 1) {
+      this.siblingStacks.length = this.path.length + 1;
+    }
+    const poppedDepth = this.path.length + 1;
+    while (this._keptAttrs.length > 0 && this._keptAttrs[this._keptAttrs.length - 1].depth >= poppedDepth) {
+      this._keptAttrs.pop();
+    }
+    return node;
+  }
+  /**
+   * Update current node's attribute values.
+   * Useful when attributes are parsed after push.
+   * @param {Object} attrValues
+   */
+  updateCurrent(attrValues) {
+    if (this.path.length > 0) {
+      const current = this.path[this.path.length - 1];
+      if (attrValues !== null && attrValues !== void 0) {
+        current.values = attrValues;
+      }
+    }
+  }
+  /**
+   * Get current tag name.
+   * @returns {string|undefined}
+   */
+  getCurrentTag() {
+    return this.path.length > 0 ? this.path[this.path.length - 1].tag : void 0;
+  }
+  /**
+   * Get current namespace.
+   * @returns {string|undefined}
+   */
+  getCurrentNamespace() {
+    return this.path.length > 0 ? this.path[this.path.length - 1].namespace : void 0;
+  }
+  /**
+   * Get current node's attribute value.
+   * @param {string} attrName
+   * @returns {*}
+   */
+  getAttrValue(attrName) {
+    if (this.path.length === 0) return void 0;
+    return this.path[this.path.length - 1].values?.[attrName];
+  }
+  /**
+   * Check if current node has an attribute.
+   * @param {string} attrName
+   * @returns {boolean}
+   */
+  hasAttr(attrName) {
+    if (this.path.length === 0) return false;
+    const current = this.path[this.path.length - 1];
+    return current.values !== void 0 && attrName in current.values;
+  }
+  /**
+   * Get the value of a "kept" attribute from the nearest ancestor (or
+   * current node) that declared it via `push(tag, attrs, ns, { keep: [...] })`.
+   * Unlike getAttrValue(), this works regardless of how deep the path has
+   * gone since the attribute was pushed — but only for attribute names that
+   * were explicitly marked with `keep` at push time. Cost is proportional to
+   * the number of currently-kept attributes (typically 0-3), not path depth.
+   * @param {string} attrName
+   * @returns {*} the value, or undefined if no ancestor kept this attribute
+   */
+  getAnyParentAttr(attrName) {
+    const kept = this._keptAttrs;
+    for (let i = kept.length - 1; i >= 0; i--) {
+      if (kept[i].name === attrName) return kept[i].value;
+    }
+    return void 0;
+  }
+  /**
+   * Check whether any ancestor (or the current node) kept the given
+   * attribute via `push(tag, attrs, ns, { keep: [...] })`.
+   * @param {string} attrName
+   * @returns {boolean}
+   */
+  hasAnyParentAttr(attrName) {
+    const kept = this._keptAttrs;
+    for (let i = kept.length - 1; i >= 0; i--) {
+      if (kept[i].name === attrName) return true;
+    }
+    return false;
+  }
+  /**
+   * Get current node's sibling position (child index in parent).
+   * @returns {number}
+   */
+  getPosition() {
+    if (this.path.length === 0) return -1;
+    return this.path[this.path.length - 1].position ?? 0;
+  }
+  /**
+   * Get current node's repeat counter (occurrence count of this tag name).
+   * @returns {number}
+   */
+  getCounter() {
+    if (this.path.length === 0) return -1;
+    return this.path[this.path.length - 1].counter ?? 0;
+  }
+  /**
+   * Get current node's sibling index (alias for getPosition).
+   * @returns {number}
+   * @deprecated Use getPosition() or getCounter() instead
+   */
+  getIndex() {
+    return this.getPosition();
+  }
+  /**
+   * Get current path depth.
+   * @returns {number}
+   */
+  getDepth() {
+    return this.path.length;
+  }
+  /**
+   * Get path as string.
+   * @param {string} [separator] - Optional separator (uses default if not provided)
+   * @param {boolean} [includeNamespace=true]
+   * @returns {string}
+   */
+  toString(separator, includeNamespace = true) {
+    const sep2 = separator || this.separator;
+    const isDefault = sep2 === this.separator && includeNamespace === true;
+    if (isDefault) {
+      if (this._pathStringCache !== null) {
+        return this._pathStringCache;
+      }
+      const result = this.path.map(
+        (n) => n.namespace ? `${n.namespace}:${n.tag}` : n.tag
+      ).join(sep2);
+      this._pathStringCache = result;
+      return result;
+    }
+    return this.path.map(
+      (n) => includeNamespace && n.namespace ? `${n.namespace}:${n.tag}` : n.tag
+    ).join(sep2);
+  }
+  /**
+   * Get path as array of tag names.
+   * @returns {string[]}
+   */
+  toArray() {
+    return this.path.map((n) => n.tag);
+  }
+  /**
+   * Reset the path to empty.
+   */
+  reset() {
+    this._pathStringCache = null;
+    this.path = [];
+    this.siblingStacks = [];
+    this._keptAttrs = [];
+  }
+  /**
+   * Match current path against an Expression.
+   * @param {Expression} expression
+   * @returns {boolean}
+   */
+  matches(expression) {
+    const segments = expression.segments;
+    if (segments.length === 0) {
+      return false;
+    }
+    if (expression.hasDeepWildcard()) {
+      return this._matchWithDeepWildcard(segments);
+    }
+    return this._matchSimple(segments);
+  }
+  /**
+   * @private
+   */
+  _matchSimple(segments) {
+    if (this.path.length !== segments.length) {
+      return false;
+    }
+    for (let i = 0; i < segments.length; i++) {
+      if (!this._matchSegment(segments[i], this.path[i], i === this.path.length - 1)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  /**
+   * @private
+   */
+  _matchWithDeepWildcard(segments) {
+    let pathIdx = this.path.length - 1;
+    let segIdx = segments.length - 1;
+    while (segIdx >= 0 && pathIdx >= 0) {
+      const segment = segments[segIdx];
+      if (segment.type === "deep-wildcard") {
+        segIdx--;
+        if (segIdx < 0) {
+          return true;
+        }
+        const nextSeg = segments[segIdx];
+        let found = false;
+        for (let i = pathIdx; i >= 0; i--) {
+          if (this._matchSegment(nextSeg, this.path[i], i === this.path.length - 1)) {
+            pathIdx = i - 1;
+            segIdx--;
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          return false;
+        }
+      } else {
+        if (!this._matchSegment(segment, this.path[pathIdx], pathIdx === this.path.length - 1)) {
+          return false;
+        }
+        pathIdx--;
+        segIdx--;
+      }
+    }
+    return segIdx < 0;
+  }
+  /**
+   * @private
+   */
+  _matchSegment(segment, node, isCurrentNode) {
+    if (segment.tag !== "*" && segment.tag !== node.tag) {
+      return false;
+    }
+    if (segment.namespace !== void 0) {
+      if (segment.namespace !== "*" && segment.namespace !== node.namespace) {
+        return false;
+      }
+    }
+    if (segment.attrName !== void 0) {
+      if (!isCurrentNode) {
+        return false;
+      }
+      if (!node.values || !(segment.attrName in node.values)) {
+        return false;
+      }
+      if (segment.attrValue !== void 0) {
+        if (String(node.values[segment.attrName]) !== String(segment.attrValue)) {
+          return false;
+        }
+      }
+    }
+    if (segment.position !== void 0) {
+      if (!isCurrentNode) {
+        return false;
+      }
+      const counter = node.counter ?? 0;
+      if (segment.position === "first" && counter !== 0) {
+        return false;
+      } else if (segment.position === "odd" && counter % 2 !== 1) {
+        return false;
+      } else if (segment.position === "even" && counter % 2 !== 0) {
+        return false;
+      } else if (segment.position === "nth" && counter !== segment.positionValue) {
+        return false;
+      }
+    }
+    return true;
+  }
+  /**
+   * Match any expression in the given set against the current path.
+   * @param {ExpressionSet} exprSet
+   * @returns {boolean}
+   */
+  matchesAny(exprSet) {
+    return exprSet.matchesAny(this);
+  }
+  /**
+   * Create a snapshot of current state.
+   * @returns {Object}
+   */
+  snapshot() {
+    return {
+      path: this.path.map((node) => ({ ...node })),
+      siblingStacks: this.siblingStacks.map((level) => level ? { counts: new Map(level.counts), total: level.total } : level),
+      keptAttrs: this._keptAttrs.map((entry) => ({ ...entry }))
+    };
+  }
+  /**
+   * Restore state from snapshot.
+   * @param {Object} snapshot
+   */
+  restore(snapshot) {
+    this._pathStringCache = null;
+    this.path = snapshot.path.map((node) => ({ ...node }));
+    this.siblingStacks = snapshot.siblingStacks.map((level) => level ? { counts: new Map(level.counts), total: level.total } : level);
+    this._keptAttrs = (snapshot.keptAttrs || []).map((entry) => ({ ...entry }));
+  }
+  /**
+   * Return the read-only {@link MatcherView} for this matcher.
+   *
+   * The same instance is returned on every call — no allocation occurs.
+   * It always reflects the current parser state and is safe to pass to
+   * user callbacks without risk of accidental mutation.
+   *
+   * @returns {MatcherView}
+   *
+   * @example
+   * const view = matcher.readOnly();
+   * // pass view to callbacks — it stays in sync automatically
+   * view.matches(expr);       // ✓
+   * view.getCurrentTag();     // ✓
+   * // view.push(...)         // ✗ method does not exist — caught by TypeScript
+   */
+  readOnly() {
+    return this._view;
+  }
+};
+
+// node_modules/is-unsafe/src/contexts/html.js
+var HTML_PATTERNS = [
+  {
+    id: "html-script-open",
+    description: "<script opening tag",
+    pattern: /<script[\s>/]/i
+  },
+  {
+    id: "html-script-close",
+    description: "</script closing tag",
+    pattern: /<\/script[\s>]/i
+  },
+  {
+    id: "html-javascript-protocol",
+    description: "javascript: URI scheme (with optional whitespace/encoding)",
+    // Handles j&#x61;vascript:, j\u0061vascript:, and whitespace variants
+    pattern: /j[\t\n\r ]*a[\t\n\r ]*v[\t\n\r ]*a[\t\n\r ]*s[\t\n\r ]*c[\t\n\r ]*r[\t\n\r ]*i[\t\n\r ]*p[\t\n\r ]*t[\t\n\r ]*:/i
+  },
+  {
+    id: "html-vbscript-protocol",
+    description: "vbscript: URI scheme",
+    pattern: /vbscript[\t\n\r ]*:/i
+  },
+  {
+    id: "html-data-html",
+    description: "data:text/html URI \u2014 can execute scripts in browsers",
+    pattern: /data[\t\n\r ]*:[\t\n\r ]*text\/html/i
+  },
+  {
+    id: "html-data-xhtml",
+    description: "data:application/xhtml+xml URI",
+    pattern: /data[\t\n\r ]*:[\t\n\r ]*application\/xhtml/i
+  },
+  {
+    id: "html-data-svg",
+    description: "data:image/svg+xml URI \u2014 can execute scripts",
+    pattern: /data[\t\n\r ]*:[\t\n\r ]*image\/svg\+xml/i
+  },
+  {
+    id: "html-inline-event-handler",
+    description: "Inline event handler attributes: onclick=, onerror=, onload=, etc.",
+    // \bon ensures we match a word boundary so "phonetic=" is not caught
+    pattern: /\bon\w{1,30}\s*=/i
+  },
+  {
+    id: "html-entity-obfuscated-script",
+    description: "HTML-entity-encoded <script (e.g. &#x3C;script or &lt;script)",
+    // Entities include optional trailing semicolon: &#x3C; or &#x3C (both valid in HTML5)
+    pattern: /(?:&#x0*3[Cc];?|&#0*60;?|&lt;)\s*script/i
+  },
+  {
+    id: "html-entity-obfuscated-javascript",
+    description: 'HTML-entity-encoded javascript: (partial \u2014 catches common &#106; or &#x6a; for "j")',
+    pattern: /(?:&#x0*6[Aa];?|&#0*106;?)\s*(?:&#x0*61;?|a)[\s\S]{0,80}script\s*:/i
+  },
+  {
+    id: "html-style-expression",
+    description: "CSS expression() \u2014 IE-era code execution in style attributes",
+    pattern: /style[\s\S]{0,20}expression\s*\(/i
+  },
+  {
+    id: "html-object-embed",
+    description: "<object or <embed tags that can load active content",
+    pattern: /<(?:object|embed)[\s>/]/i
+  },
+  {
+    id: "html-base-tag",
+    description: "<base href= \u2014 can hijack all relative URLs on a page",
+    pattern: /<base[\s>]/i
+  },
+  {
+    id: "html-meta-refresh",
+    description: '<meta http-equiv="refresh" \u2014 can redirect users',
+    pattern: /<meta[\s\S]{0,40}http-equiv[\s\S]{0,20}refresh/i
+  },
+  {
+    id: "html-srcdoc",
+    description: "srcdoc= attribute on iframes \u2014 embeds HTML that can run scripts",
+    pattern: /srcdoc\s*=/i
+  },
+  {
+    id: "html-iframe",
+    description: "<iframe tag",
+    pattern: /<iframe[\s>/]/i
+  },
+  {
+    id: "html-form",
+    description: "<form tag \u2014 can be used for phishing / credential harvesting injection",
+    pattern: /<form[\s>/]/i
+  }
+];
+var html_default = HTML_PATTERNS;
+
+// node_modules/is-unsafe/src/contexts/xml.js
+var XML_PATTERNS = [
+  {
+    id: "xml-cdata-injection",
+    description: "CDATA section injection: <![CDATA[ breaks out of text node context",
+    pattern: /<!\[CDATA\[/i
+  },
+  {
+    id: "xml-cdata-close",
+    description: "CDATA close sequence: ]]> can terminate an enclosing CDATA section",
+    pattern: /\]\]>/
+  },
+  {
+    id: "xml-processing-instruction",
+    description: "XML processing instruction: <?xml-stylesheet or <?php etc.",
+    pattern: /<\?(?:xml[\- ]|php|asp)/i
+  },
+  {
+    id: "xml-doctype-injection",
+    description: "DOCTYPE declaration embedded in content \u2014 can define entities",
+    // Match <!DOCTYPE followed by end-of-string, whitespace, or [ (internal subset)
+    pattern: /<!DOCTYPE(?:[\s[]|$)/i
+  },
+  {
+    id: "xml-entity-system",
+    description: "SYSTEM keyword \u2014 used in external entity declarations (XXE)",
+    pattern: /\bSYSTEM\s+["']/i
+  },
+  {
+    id: "xml-entity-public",
+    description: "PUBLIC keyword \u2014 used in external entity declarations (XXE)",
+    pattern: /\bPUBLIC\s+["']/i
+  },
+  {
+    id: "xml-entity-declaration",
+    description: "<!ENTITY declaration \u2014 defines entities, potential XXE or entity expansion",
+    pattern: /<!ENTITY[\s%]/i
+  },
+  {
+    id: "xml-billion-laughs",
+    description: "Entity reference chaining / billion laughs: repeated &eX; style references",
+    // Heuristic: 3+ consecutive entity refs suggests expansion attack
+    pattern: /(?:&\w{1,20};){3,}/
+  },
+  {
+    id: "xml-namespace-confusion",
+    description: "xmlns: attribute injection \u2014 can redefine namespaces to confuse parsers",
+    pattern: /\bxmlns\s*(?::\w{1,40})?\s*=/i
+  },
+  {
+    id: "xml-comment-injection",
+    description: "<!-- comment injection \u2014 can hide content from some parsers",
+    pattern: /<!--/
+  },
+  {
+    id: "xml-comment-close",
+    description: "--> closes an enclosing XML comment",
+    pattern: /-->/
+  },
+  {
+    id: "xml-pi-close",
+    description: "?> closes an enclosing processing instruction",
+    pattern: /\?>/
+  }
+];
+var xml_default = XML_PATTERNS;
+
+// node_modules/is-unsafe/src/contexts/svg.js
+var SVG_PATTERNS = [
+  {
+    id: "svg-script-element",
+    description: "<script element inside SVG executes JavaScript",
+    pattern: /<script[\s>/]/i
+  },
+  {
+    id: "svg-xlink-href-javascript",
+    description: "xlink:href with javascript: \u2014 classic SVG XSS via <a> or <use>",
+    pattern: /xlink\s*:\s*href\s*=\s*["']?\s*javascript\s*:/i
+  },
+  {
+    id: "svg-href-javascript",
+    description: "href= with javascript: in SVG context (<a>, <animate>, etc.)",
+    pattern: /href\s*=\s*["']?\s*javascript\s*:/i
+  },
+  {
+    id: "svg-foreignobject",
+    description: "<foreignObject embeds HTML inside SVG \u2014 can execute scripts",
+    pattern: /<foreignObject[\s>/]/i
+  },
+  {
+    id: "svg-use-external",
+    description: "<use xlink:href or href pointing to external resource (non-fragment URL)",
+    // Match <use with href= where the value starts with a non-# character (external URL)
+    // [\"'][^#] catches quoted values not starting with #; [^\"'#\s>] catches unquoted
+    pattern: /<use[\s\S]{0,60}(?:xlink\s*:\s*)?href\s*=\s*(?:["'][^#]|[^"'#\s>])/i
+  },
+  {
+    id: "svg-animate-href",
+    description: '<animate attributeName="href" \u2014 can dynamically change href to javascript:',
+    pattern: /<animate[\s\S]{0,80}attributeName\s*=\s*["'][\s]*href["']/i
+  },
+  {
+    id: "svg-animate-xlinkhref",
+    description: '<animate attributeName="xlink:href"',
+    pattern: /<animate[\s\S]{0,80}attributeName\s*=\s*["'][\s]*xlink\s*:\s*href["']/i
+  },
+  {
+    id: "svg-set-javascript",
+    description: '<set to="javascript:..." \u2014 sets an attribute to a javascript: URI',
+    pattern: /<set[\s\S]{0,80}to\s*=\s*["']?\s*javascript\s*:/i
+  },
+  {
+    id: "svg-event-handler",
+    description: "SVG-specific event handler attributes: onload=, onerror=, onactivate=, etc.",
+    pattern: /\bon(?:load|error|activate|begin|end|repeat|focus|blur|click|mouse\w{1,20}|key\w{1,20})\s*=/i
+  },
+  {
+    id: "svg-handler-generic",
+    description: "Generic on* handler catch-all for SVG attributes",
+    pattern: /\bon\w{1,30}\s*=/i
+  },
+  {
+    id: "svg-filter-feimage",
+    description: "<feImage href= \u2014 filter primitive that can load external resources",
+    pattern: /<feImage[\s\S]{0,80}(?:xlink\s*:\s*)?href\s*=/i
+  },
+  {
+    id: "svg-image-external",
+    description: "<image xlink:href with http/https or javascript protocol",
+    pattern: /<image[\s\S]{0,80}(?:xlink\s*:\s*)?href\s*=\s*["']?\s*(?:https?|javascript)\s*:/i
+  },
+  {
+    id: "svg-style-javascript",
+    description: "style= attribute containing javascript: (e.g. background:url(javascript:...))",
+    pattern: /style\s*=[\s\S]{0,60}javascript\s*:/i
+  }
+];
+var svg_default = SVG_PATTERNS;
+
+// node_modules/is-unsafe/src/contexts/sql.js
+var SQL_PATTERNS = [
+  {
+    id: "sql-block-comment-open",
+    description: "SQL block comment open: /* ... */ \u2014 unusual in legitimate user text",
+    pattern: /\/\*/
+  },
+  {
+    id: "sql-union-select",
+    description: "UNION SELECT \u2014 most common SQL injection aggregation attack",
+    pattern: /\bUNION\s{1,20}(?:ALL\s{1,20})?SELECT\b/i
+  },
+  {
+    id: "sql-drop-table",
+    description: "DROP TABLE \u2014 destructive DDL injection",
+    pattern: /\bDROP\s{1,20}TABLE\b/i
+  },
+  {
+    id: "sql-drop-database",
+    description: "DROP DATABASE \u2014 destructive DDL injection",
+    pattern: /\bDROP\s{1,20}DATABASE\b/i
+  },
+  {
+    id: "sql-insert-into",
+    description: "INSERT INTO \u2014 data injection",
+    pattern: /\bINSERT\s{1,20}INTO\b/i
+  },
+  {
+    id: "sql-delete-from",
+    description: "DELETE FROM \u2014 data deletion injection",
+    pattern: /\bDELETE\s{1,20}FROM\b/i
+  },
+  {
+    id: "sql-update-set",
+    description: "UPDATE ... SET \u2014 data modification injection",
+    // Allows arbitrary content between UPDATE and SET (table name, alias, etc.)
+    pattern: /\bUPDATE\b[\s\S]{1,60}\bSET\b/i
+  },
+  {
+    id: "sql-exec-xp",
+    description: "EXEC xp_ \u2014 MSSQL extended stored procedure execution",
+    pattern: /\bEXEC(?:UTE)?\s{1,20}xp_/i
+  },
+  {
+    id: "sql-tautology-string",
+    description: `Classic string tautology: ' OR '1'='1 or " OR "1"="1"`,
+    // Last quote is optional — injection may truncate it: ' OR '1'='1--
+    pattern: /'\s{0,10}OR\s{0,10}'[^']{0,20}'\s*=\s*'[^']{0,20}/i
+  },
+  {
+    id: "sql-tautology-numeric",
+    description: "Numeric tautology: OR 1=1",
+    pattern: /\bOR\s{1,10}1\s*=\s*1\b/i
+  },
+  {
+    id: "sql-always-true-zero",
+    description: "Numeric tautology: OR 0=0",
+    pattern: /\bOR\s{1,10}0\s*=\s*0\b/i
+  },
+  {
+    id: "sql-sleep-benchmark",
+    description: "Time-based blind injection: SLEEP() or BENCHMARK()",
+    pattern: /\b(?:SLEEP|BENCHMARK)\s*\(/i
+  },
+  {
+    id: "sql-waitfor-delay",
+    description: "MSSQL time-based blind injection: WAITFOR DELAY",
+    pattern: /\bWAITFOR\s{1,20}DELAY\b/i
+  },
+  {
+    id: "sql-char-function",
+    description: "CHAR() function \u2014 used to obfuscate injected strings",
+    pattern: /\bCHAR\s*\(\s*\d{1,3}/i
+  },
+  {
+    id: "sql-information-schema",
+    description: "INFORMATION_SCHEMA \u2014 reconnaissance query for table/column enumeration",
+    pattern: /\bINFORMATION_SCHEMA\b/i
+  }
+];
+var sql_default = SQL_PATTERNS;
+
+// node_modules/is-unsafe/src/contexts/shell.js
+var SHELL_PATTERNS = [
+  {
+    id: "shell-path-traversal-unix",
+    description: "Unix path traversal: ../  \u2014 climbing the directory tree",
+    pattern: /\.\.\//
+  },
+  {
+    id: "shell-path-traversal-windows",
+    description: "Windows path traversal: ..\\ \u2014 climbing the directory tree",
+    pattern: /\.\.\\/
+  },
+  {
+    id: "shell-path-traversal-encoded",
+    description: "URL-encoded path traversal: %2e%2e or %2f variants",
+    pattern: /%2e%2e|%2f\.\.|\.\.%2f/i
+  },
+  {
+    id: "shell-null-byte",
+    description: "Null byte injection: \\x00 or %00 \u2014 truncates strings in C-backed functions",
+    pattern: /\x00|%00/
+  },
+  {
+    id: "shell-semicolon",
+    description: "Semicolon command separator: cmd1; cmd2",
+    pattern: /;/
+  },
+  {
+    id: "shell-pipe",
+    description: "Pipe operator: cmd1 | cmd2",
+    pattern: /\|/
+  },
+  {
+    id: "shell-and-operator",
+    description: "AND operator: cmd1 && cmd2",
+    pattern: /&&/
+  },
+  {
+    id: "shell-or-operator",
+    description: "OR operator: cmd1 || cmd2",
+    pattern: /\|\|/
+  },
+  {
+    id: "shell-backtick",
+    description: "Backtick command substitution: `cmd`",
+    pattern: /`/
+  },
+  {
+    id: "shell-dollar-paren",
+    description: "Dollar-paren command substitution: $(cmd)",
+    pattern: /\$\(/
+  },
+  {
+    id: "shell-dollar-brace",
+    description: "Dollar-brace variable expansion: ${var} \u2014 can be abused for injection",
+    pattern: /\$\{/
+  },
+  {
+    id: "shell-redirect-out",
+    description: "Output redirection: cmd > file or cmd >> file",
+    pattern: />{1,2}/
+  },
+  {
+    id: "shell-redirect-in",
+    description: "Input redirection: cmd < file",
+    pattern: /</
+  },
+  {
+    id: "shell-newline-injection",
+    description: "Newline injection: \\n or \\r \u2014 can inject new shell commands",
+    pattern: /[\n\r]/
+  },
+  {
+    id: "shell-glob-star",
+    description: "Glob expansion: * or ? \u2014 can expand to unintended files",
+    // Only flag when combined with path separators to reduce false positives
+    pattern: /[/\\][*?]/
+  },
+  {
+    id: "shell-absolute-root",
+    description: "Absolute root path injection: string starting with / or \\ (Windows UNC)",
+    pattern: /^(?:\/|\\\\)/
+  },
+  {
+    id: "shell-windows-drive",
+    description: "Windows drive letter path injection: C:\\ or D:/",
+    pattern: /^[a-zA-Z]:[/\\]/
+  },
+  {
+    id: "shell-curl-wget",
+    description: "curl/wget with URL or flags \u2014 can exfiltrate data or download payloads",
+    // Require a URL scheme (http/https/ftp) or a flag (-) to reduce false positives
+    // "curl is a tool" won't match; "curl http://..." or "curl -s ..." will
+    pattern: /\b(?:curl|wget)\s+(?:https?:\/\/|ftp:\/\/|-)/i
+  }
+];
+var shell_default = SHELL_PATTERNS;
+
+// node_modules/is-unsafe/src/contexts/redos.js
+var REDOS_PATTERNS = [
+  {
+    id: "redos-nested-quantifier-plus",
+    description: "Nested + quantifier inside a group with outer quantifier: (a+)+, (.+b)*, etc.",
+    // Matches any group containing a + quantifier, with an outer * or + — catches (a+)+, (.+b)*, etc.
+    pattern: /\([^)]*\+[^)]*\)[+*]/
+  },
+  {
+    id: "redos-nested-quantifier-star",
+    description: "Nested * quantifier: (a*)* or (a*)+ \u2014 catastrophic backtracking",
+    pattern: /\([^)]*\*[^)]*\)[*+]/
+  },
+  {
+    id: "redos-nested-groups",
+    description: "Doubly nested quantified groups: ((a+)+) \u2014 guaranteed catastrophic",
+    pattern: /\(\([^)]{0,40}\)[+*]\)[+*]/
+  },
+  {
+    id: "redos-alternation-overlap",
+    description: "Overlapping alternation under quantifier: (a|a)+ \u2014 ambiguous NFA paths",
+    // Detect repeated identical alternatives under a quantifier
+    pattern: /\(([^|()]{1,20})\|(?:\1)(?:\|[^|()]{1,20}){0,5}\)[+*?]{1,2}/
+  },
+  {
+    id: "redos-star-plus-concat",
+    description: "(x*x)+ pattern \u2014 triggers super-linear backtracking",
+    pattern: /\([^)]{0,10}\*[^)]{0,10}\)[+*]/
+  },
+  {
+    id: "redos-dot-star-greedy",
+    description: "(.*){n,} or (.+){n,} \u2014 repeated greedy dot quantifiers",
+    pattern: /\(\.[*+]\)\{?\d/
+  },
+  {
+    id: "redos-large-repetition",
+    description: "Very large fixed or range repetition count {1000,} or {1000,n} \u2014 denial of service via backtracking",
+    // Matches { followed by 4+ digits (≥1000), then optional ,digits }
+    pattern: /\{\d{4,}(?:,\d*)?\}/
+  },
+  {
+    id: "redos-catastrophic-alternation",
+    description: "Long alternation with many similar branches \u2014 polynomial backtracking risk",
+    // Heuristic: 10+ pipe-separated alternatives in a single group
+    pattern: /\([^)]{0,200}(?:\|[^|)]{0,50}){9,}\)/
+  }
+];
+var redos_default = REDOS_PATTERNS;
+
+// node_modules/is-unsafe/src/contexts/nosql.js
+var sep = `["'\\s]*:`;
+var NOSQL_PATTERNS = [
+  // ─── MongoDB $ operator injection ────────────────────────────────────────
+  {
+    id: "nosql-where-operator",
+    description: "$where \u2014 executes arbitrary JavaScript server-side in MongoDB",
+    pattern: new RegExp(`\\$where${sep}`, "i")
+  },
+  {
+    id: "nosql-ne-operator",
+    description: '$ne \u2014 "not equal" operator used to bypass equality checks',
+    pattern: new RegExp(`\\$ne${sep}`, "i")
+  },
+  {
+    id: "nosql-gt-operator",
+    description: '$gt \u2014 "greater than" used to bypass password/value checks',
+    pattern: new RegExp(`\\$gte?${sep}`, "i")
+  },
+  {
+    id: "nosql-lt-operator",
+    description: '$lt / $lte \u2014 "less than" bypass variants',
+    pattern: new RegExp(`\\$lte?${sep}`, "i")
+  },
+  {
+    id: "nosql-regex-operator",
+    description: "$regex \u2014 can be used to extract data character by character (blind injection)",
+    pattern: new RegExp(`\\$regex${sep}`, "i")
+  },
+  {
+    id: "nosql-or-operator",
+    description: "$or \u2014 logical OR; used to create always-true conditions",
+    pattern: new RegExp(`\\$or${sep}\\s*\\[`, "i")
+  },
+  {
+    id: "nosql-and-operator",
+    description: "$and \u2014 logical AND operator injection",
+    pattern: new RegExp(`\\$and${sep}\\s*\\[`, "i")
+  },
+  {
+    id: "nosql-nor-operator",
+    description: "$nor \u2014 logical NOR operator injection",
+    pattern: new RegExp(`\\$nor${sep}\\s*\\[`, "i")
+  },
+  {
+    id: "nosql-exists-operator",
+    description: "$exists \u2014 can enumerate fields to determine schema",
+    pattern: new RegExp(`\\$exists${sep}`, "i")
+  },
+  {
+    id: "nosql-in-operator",
+    description: "$in \u2014 matches any value in a list; can enumerate values",
+    pattern: new RegExp(`\\$in${sep}\\s*\\[`, "i")
+  },
+  {
+    id: "nosql-expr-operator",
+    description: "$expr \u2014 allows aggregation expressions in queries (MongoDB 3.6+)",
+    pattern: new RegExp(`\\$expr${sep}`, "i")
+  },
+  {
+    id: "nosql-function-operator",
+    description: "$function \u2014 executes arbitrary JavaScript in MongoDB 4.4+",
+    pattern: new RegExp(`\\$function${sep}`, "i")
+  },
+  {
+    id: "nosql-accumulator-operator",
+    description: "$accumulator \u2014 custom aggregation with arbitrary JS execution",
+    pattern: new RegExp(`\\$accumulator${sep}`, "i")
+  },
+  // ─── Prototype pollution ─────────────────────────────────────────────────
+  {
+    id: "nosql-proto-pollution",
+    description: "__proto__ \u2014 prototype pollution via object key injection",
+    pattern: /__proto__/
+  },
+  {
+    id: "nosql-constructor-prototype",
+    description: "constructor.prototype \u2014 alternative prototype pollution vector (dot notation or JSON key)",
+    // Matches dot-notation (obj.constructor.prototype) and JSON key adjacency
+    // ("constructor": {"prototype": ...})
+    pattern: /constructor[\s"':.,{\[]*prototype/i
+  },
+  {
+    id: "nosql-proto-bracket",
+    description: '["__proto__"] \u2014 bracket-notation prototype pollution',
+    pattern: /\[["']__proto__["']\]/
+  }
+];
+var nosql_default = NOSQL_PATTERNS;
+
+// node_modules/is-unsafe/src/contexts/log.js
+var LOG_PATTERNS = [
+  // ─── CRLF / newline injection ─────────────────────────────────────────────
+  {
+    id: "log-crlf-injection",
+    description: "CRLF injection: literal \\r or \\n embeds fake log lines",
+    pattern: /[\r\n]/
+  },
+  {
+    id: "log-url-encoded-crlf",
+    description: "URL-encoded CRLF: %0d, %0a, %0D, %0A \u2014 decoded by some log parsers",
+    pattern: /%0[dDaA]/
+  },
+  {
+    id: "log-unicode-newline",
+    description: "Unicode newline variants: U+2028 (line separator), U+2029 (paragraph separator)",
+    pattern: /[\u2028\u2029]/
+  },
+  // ─── Log4Shell / JNDI injection (CVE-2021-44228) ─────────────────────────
+  {
+    id: "log-log4shell-jndi",
+    description: "Log4Shell: ${jndi:...} triggers remote code execution in Apache Log4j",
+    pattern: /\$\{jndi\s*:/i
+  },
+  {
+    id: "log-log4shell-obfuscated",
+    description: "Obfuscated Log4Shell: ${::-j}... lookup-bypass prefix used to evade WAF detection",
+    // ${::- is the Log4j lookup-bypass escape sequence; presence alone is suspicious
+    pattern: /\$\{::-/
+  },
+  {
+    id: "log-log4j-lookup",
+    description: "Log4j lookup syntax: ${env:...}, ${sys:...}, ${ctx:...} \u2014 data exfiltration",
+    pattern: /\$\{(?:env|sys|ctx|main|map|sd|web|docker|k8s|spring)\s*:/i
+  },
+  // ─── Server-Side Template Injection (SSTI) in log messages ───────────────
+  {
+    id: "log-ssti-double-brace",
+    description: "SSTI double-brace: {{expression}} \u2014 Jinja2, Twig, Handlebars, etc.",
+    pattern: /\{\{[\s\S]{0,80}\}\}/
+  },
+  {
+    id: "log-ssti-hash-brace",
+    description: "SSTI hash-brace: #{expression} \u2014 Thymeleaf, Velocity, Ruby ERB",
+    pattern: /#\{[\s\S]{0,80}\}/
+  },
+  {
+    id: "log-ssti-dollar-brace",
+    description: "SSTI/EL injection: ${expression with operators or method calls} \u2014 JSP EL, Freemarker, SpEL",
+    // Require that the ${...} content looks like an expression, not a plain variable name.
+    // Flags if the content contains: . ( * + operators, or known SSTI keywords.
+    // This avoids flagging ${PATH}, ${HOME} etc. (plain shell variables).
+    pattern: /\$\{[^}]*(?:\.|\(|\*|\+|\bclass\b|\bruntime\b|\bprocess\b|\bexec\b)[^}]{0,80}\}/i
+  },
+  {
+    id: "log-ssti-percent-tag",
+    description: "SSTI ERB/ASP tag: <%= expression %> \u2014 Ruby ERB, ASP",
+    pattern: /<%=[\s\S]{0,80}%>/
+  },
+  // ─── Null byte ────────────────────────────────────────────────────────────
+  {
+    id: "log-null-byte",
+    description: "Null byte: \\x00 or %00 \u2014 can truncate log entries in C-backed loggers",
+    pattern: /\x00|%00/
+  },
+  // ─── ANSI escape injection ────────────────────────────────────────────────
+  {
+    id: "log-ansi-escape",
+    description: "ANSI escape sequence: ESC[ \u2014 can manipulate terminal output when logs are tailed",
+    pattern: /\x1b\[/
+  }
+];
+var log_default = LOG_PATTERNS;
+
+// node_modules/is-unsafe/src/contexts/sql-strict.js
+var SQL_STRICT_EXTRA = [
+  {
+    id: "sql-line-comment",
+    description: "SQL line comment: -- followed by whitespace or end of string",
+    pattern: /--(?:\s|$)/
+  },
+  {
+    id: "sql-stacked-query",
+    description: "Stacked queries: semicolon immediately followed by a SQL keyword",
+    pattern: /;\s{0,10}(?:SELECT|INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|EXEC)\b/i
+  },
+  {
+    id: "sql-hex-encoding",
+    description: "Hex-encoded string injection: 0x41414141 style (MySQL)",
+    pattern: /\b0x[0-9a-f]{4,}/i
+  }
+];
+var SQL_STRICT_PATTERNS = [...sql_default, ...SQL_STRICT_EXTRA];
+var sql_strict_default = SQL_STRICT_PATTERNS;
+
+// node_modules/is-unsafe/src/index.js
+html_default.label = "HTML";
+xml_default.label = "XML";
+svg_default.label = "SVG";
+sql_default.label = "SQL";
+sql_strict_default.label = "SQL-STRICT";
+shell_default.label = "SHELL";
+redos_default.label = "REDOS";
+nosql_default.label = "NOSQL";
+log_default.label = "LOG";
+var VALID_CONTEXTS = Object.freeze({
+  HTML: html_default,
+  XML: xml_default,
+  SVG: svg_default,
+  SQL: sql_default,
+  "SQL-STRICT": sql_strict_default,
+  SHELL: shell_default,
+  REDOS: redos_default,
+  NOSQL: nosql_default,
+  LOG: log_default
+});
+function assertString(value) {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `is-unsafe: first argument must be a string, got ${typeof value}`
+    );
+  }
+}
+function assertContext(context) {
+  if (context instanceof RegExp) return;
+  if (Array.isArray(context)) {
+    if (context.length === 0) {
+      throw new TypeError("is-unsafe: context must not be an empty array");
+    }
+    if (Array.isArray(context[0])) {
+      for (const list of context) {
+        if (!Array.isArray(list) || list.length === 0) {
+          throw new TypeError(
+            "is-unsafe: each context in the array must be a non-empty pattern array (PatternList)"
+          );
+        }
+      }
+    }
+    return;
+  }
+  throw new TypeError(
+    `is-unsafe: second argument must be a PatternList (e.g. HTML), an array of PatternLists (e.g. [HTML, XML]), or a RegExp. Got: ${typeof context}`
+  );
+}
+function normalise(context) {
+  if (context instanceof RegExp) return { lists: null, regex: context };
+  if (Array.isArray(context[0])) return { lists: context, regex: null };
+  return { lists: [context], regex: null };
+}
+function matchList(value, list) {
+  const label = list.label ?? "CUSTOM";
+  for (const rule of list) {
+    if (rule.pattern.test(value)) {
+      return { context: label, id: rule.id, description: rule.description, pattern: rule.pattern };
+    }
+  }
+  return null;
+}
+function isUnsafe(value, context) {
+  assertString(value);
+  assertContext(context);
+  const { lists, regex } = normalise(context);
+  if (regex) return regex.test(value);
+  for (const list of lists) {
+    if (matchList(value, list) !== null) return true;
+  }
+  return false;
+}
+
+// node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
+function extractRawAttributes(prefixedAttrs, options) {
+  if (!prefixedAttrs) return {};
+  const attrs = options.attributesGroupName ? prefixedAttrs[options.attributesGroupName] : prefixedAttrs;
+  if (!attrs) return {};
+  const rawAttrs = {};
+  for (const key in attrs) {
+    if (key.startsWith(options.attributeNamePrefix)) {
+      const rawName = key.substring(options.attributeNamePrefix.length);
+      rawAttrs[rawName] = attrs[key];
+    } else {
+      rawAttrs[key] = attrs[key];
+    }
+  }
+  return rawAttrs;
+}
+function extractNamespace(rawTagName) {
+  if (!rawTagName || typeof rawTagName !== "string") return void 0;
+  const colonIndex = rawTagName.indexOf(":");
+  if (colonIndex !== -1 && colonIndex > 0) {
+    const ns = rawTagName.substring(0, colonIndex);
+    if (ns !== "xmlns") {
+      return ns;
+    }
+  }
+  return void 0;
+}
+var OrderedObjParser = class {
+  constructor(options, externalEntities) {
+    this.options = options;
+    this.currentNode = null;
+    this.tagsNodeStack = [];
+    this.parseXml = parseXml;
+    this.parseTextData = parseTextData;
+    this.resolveNameSpace = resolveNameSpace;
+    this.buildAttributesMap = buildAttributesMap;
+    this.isItStopNode = isItStopNode;
+    this.replaceEntitiesValue = replaceEntitiesValue;
+    this.readStopNodeData = readStopNodeData;
+    this.saveTextToParentTag = saveTextToParentTag;
+    this.addChild = addChild;
+    this.ignoreAttributesFn = getIgnoreAttributesFn(this.options.ignoreAttributes);
+    this.entityExpansionCount = 0;
+    this.currentExpandedLength = 0;
+    this.doctypefound = false;
+    let namedEntities = { ...XML };
+    if (this.options.entityDecoder) {
+      this.entityDecoder = this.options.entityDecoder;
+    } else {
+      if (typeof this.options.htmlEntities === "object") namedEntities = this.options.htmlEntities;
+      else if (this.options.htmlEntities === true) namedEntities = { ...COMMON_HTML, ...CURRENCY };
+      this.entityDecoder = new EntityDecoder({
+        namedEntities: { ...namedEntities, ...externalEntities },
+        numericAllowed: this.options.htmlEntities,
+        limit: {
+          maxTotalExpansions: this.options.processEntities.maxTotalExpansions,
+          maxExpandedLength: this.options.processEntities.maxExpandedLength,
+          applyLimitsTo: this.options.processEntities.appliesTo
+        },
+        // onExternalEntity: (name, value) => isUnsafe(value) ? 'block' : 'allow',
+        onInputEntity: (name, value) => (
+          //TODO: VALID_CONTEXTS.HTML should be set only if this.options.htmlEntities
+          isUnsafe(value, [html_default, xml_default]) ? ENTITY_ACTION.BLOCK : ENTITY_ACTION.ALLOW
+        )
+        //postCheck: resolved => resolved
+      });
+    }
+    this.matcher = new Matcher();
+    this.readonlyMatcher = this.matcher.readOnly();
+    this.isCurrentNodeStopNode = false;
+    this.stopNodeExpressionsSet = new ExpressionSet();
+    const stopNodesOpts = this.options.stopNodes;
+    if (stopNodesOpts && stopNodesOpts.length > 0) {
+      for (let i = 0; i < stopNodesOpts.length; i++) {
+        const stopNodeExp = stopNodesOpts[i];
+        if (typeof stopNodeExp === "string") {
+          this.stopNodeExpressionsSet.add(new Expression(stopNodeExp));
+        } else if (stopNodeExp instanceof Expression) {
+          this.stopNodeExpressionsSet.add(stopNodeExp);
+        }
+      }
+      this.stopNodeExpressionsSet.seal();
+    }
+  }
+};
+function parseTextData(val, tagName, jPath, dontTrim, hasAttributes, isLeafNode, escapeEntities) {
+  const options = this.options;
+  if (val !== void 0) {
+    if (options.trimValues && !dontTrim) {
+      val = val.trim();
+    }
+    if (val.length > 0) {
+      if (!escapeEntities) val = this.replaceEntitiesValue(val, tagName, jPath);
+      const jPathOrMatcher = options.jPath ? jPath.toString() : jPath;
+      const newval = options.tagValueProcessor(tagName, val, jPathOrMatcher, hasAttributes, isLeafNode);
+      if (newval === null || newval === void 0) {
+        return val;
+      } else if (typeof newval !== typeof val || newval !== val) {
+        return newval;
+      } else if (options.trimValues) {
+        return parseValue(val, options.parseTagValue, options.numberParseOptions);
+      } else {
+        const trimmedVal = val.trim();
+        if (trimmedVal === val) {
+          return parseValue(val, options.parseTagValue, options.numberParseOptions);
+        } else {
+          return val;
+        }
+      }
+    }
+  }
+}
+function resolveNameSpace(tagname) {
+  if (this.options.removeNSPrefix) {
+    const tags = tagname.split(":");
+    const prefix = tagname.charAt(0) === "/" ? "/" : "";
+    if (tags[0] === "xmlns") {
+      return "";
+    }
+    if (tags.length === 2) {
+      tagname = prefix + tags[1];
+    }
+  }
+  return tagname;
+}
+var attrsRegx = new RegExp(`([^\\s=]+)\\s*(=\\s*(['"])([\\s\\S]*?)\\3)?`, "gm");
+function buildAttributesMap(attrStr, jPath, tagName, force = false) {
+  const options = this.options;
+  if (force === true || options.ignoreAttributes !== true && typeof attrStr === "string") {
+    const matches = getAllMatches(attrStr, attrsRegx);
+    const len = matches.length;
+    const attrs = {};
+    const processedVals = new Array(len);
+    let hasRawAttrs = false;
+    const rawAttrsForMatcher = {};
+    for (let i = 0; i < len; i++) {
+      const attrName = this.resolveNameSpace(matches[i][1]);
+      const oldVal = matches[i][4];
+      if (attrName.length && oldVal !== void 0) {
+        let val = oldVal;
+        if (options.trimValues) val = val.trim();
+        val = this.replaceEntitiesValue(val, tagName, this.readonlyMatcher);
+        processedVals[i] = val;
+        rawAttrsForMatcher[attrName] = val;
+        hasRawAttrs = true;
+      }
+    }
+    if (hasRawAttrs && typeof jPath === "object" && jPath.updateCurrent) {
+      jPath.updateCurrent(rawAttrsForMatcher);
+    }
+    const jPathStr = options.jPath ? jPath.toString() : this.readonlyMatcher;
+    let hasAttrs = false;
+    for (let i = 0; i < len; i++) {
+      const attrName = this.resolveNameSpace(matches[i][1]);
+      if (this.ignoreAttributesFn(attrName, jPathStr)) continue;
+      let aName = options.attributeNamePrefix + attrName;
+      if (attrName.length) {
+        if (options.transformAttributeName) {
+          aName = options.transformAttributeName(aName);
+        }
+        aName = sanitizeName(aName, options);
+        if (matches[i][4] !== void 0) {
+          const oldVal = processedVals[i];
+          const newVal = options.attributeValueProcessor(attrName, oldVal, jPathStr);
+          if (newVal === null || newVal === void 0) {
+            attrs[aName] = oldVal;
+          } else if (typeof newVal !== typeof oldVal || newVal !== oldVal) {
+            attrs[aName] = newVal;
+          } else {
+            attrs[aName] = parseValue(oldVal, options.parseAttributeValue, options.numberParseOptions);
+          }
+          hasAttrs = true;
+        } else if (options.allowBooleanAttributes) {
+          attrs[aName] = true;
+          hasAttrs = true;
+        }
+      }
+    }
+    if (!hasAttrs) return;
+    if (options.attributesGroupName && !options.preserveOrder) {
+      const attrCollection = {};
+      attrCollection[options.attributesGroupName] = attrs;
+      return attrCollection;
+    }
+    return attrs;
+  }
+}
+var parseXml = function(xmlData) {
+  xmlData = xmlData.replace(/\r\n?/g, "\n");
+  const xmlObj = new XmlNode("!xml");
+  let currentNode = xmlObj;
+  let textData = "";
+  this.matcher.reset();
+  this.entityDecoder.reset();
+  this.entityExpansionCount = 0;
+  this.currentExpandedLength = 0;
+  this.doctypefound = false;
+  const options = this.options;
+  const docTypeReader = new DocTypeReader(options.processEntities);
+  const xmlLen = xmlData.length;
+  for (let i = 0; i < xmlLen; i++) {
+    const ch = xmlData[i];
+    if (ch === "<") {
+      const c1 = xmlData.charCodeAt(i + 1);
+      if (c1 === 47) {
+        const closeIndex = findClosingIndex(xmlData, ">", i, "Closing Tag is not closed.");
+        let tagName = xmlData.substring(i + 2, closeIndex).trim();
+        if (options.removeNSPrefix) {
+          const colonIndex = tagName.indexOf(":");
+          if (colonIndex !== -1) {
+            tagName = tagName.substr(colonIndex + 1);
+          }
+        }
+        tagName = transformTagName(options.transformTagName, tagName, "", options).tagName;
+        if (currentNode) {
+          textData = this.saveTextToParentTag(textData, currentNode, this.readonlyMatcher);
+        }
+        const lastTagName = this.matcher.getCurrentTag();
+        if (tagName && options.unpairedTagsSet.has(tagName)) {
+          throw new Error(`Unpaired tag can not be used as closing tag: </${tagName}>`);
+        }
+        if (lastTagName && options.unpairedTagsSet.has(lastTagName)) {
+          this.matcher.pop();
+          this.tagsNodeStack.pop();
+        }
+        this.matcher.pop();
+        this.isCurrentNodeStopNode = false;
+        currentNode = this.tagsNodeStack.pop();
+        textData = "";
+        i = closeIndex;
+      } else if (c1 === 63) {
+        let tagData = readTagExp(xmlData, i, false, "?>");
+        if (!tagData) throw new Error("Pi Tag is not closed.");
+        textData = this.saveTextToParentTag(textData, currentNode, this.readonlyMatcher);
+        const attsMap = this.buildAttributesMap(tagData.tagExp, this.matcher, tagData.tagName, true);
+        if (attsMap) {
+          const ver = attsMap[this.options.attributeNamePrefix + "version"];
+          this.entityDecoder.setXmlVersion(Number(ver) || 1);
+          docTypeReader.setXmlVersion(Number(ver) || 1);
+        }
+        if (options.ignoreDeclaration && tagData.tagName === "?xml" || options.ignorePiTags) {
+        } else {
+          const childNode = new XmlNode(tagData.tagName);
+          childNode.add(options.textNodeName, "");
+          if (tagData.tagName !== tagData.tagExp && tagData.attrExpPresent && options.ignoreAttributes !== true) {
+            childNode[":@"] = attsMap;
+          }
+          this.addChild(currentNode, childNode, this.readonlyMatcher, i);
+        }
+        i = tagData.closeIndex + 1;
+      } else if (c1 === 33 && xmlData.charCodeAt(i + 2) === 45 && xmlData.charCodeAt(i + 3) === 45) {
+        const endIndex = findClosingIndex(xmlData, "-->", i + 4, "Comment is not closed.");
+        if (options.commentPropName) {
+          const comment = xmlData.substring(i + 4, endIndex - 2);
+          textData = this.saveTextToParentTag(textData, currentNode, this.readonlyMatcher);
+          currentNode.add(options.commentPropName, [{ [options.textNodeName]: comment }]);
+        }
+        i = endIndex;
+      } else if (c1 === 33 && xmlData.charCodeAt(i + 2) === 68) {
+        if (this.doctypefound) throw new Error("Multiple DOCTYPE declarations found.");
+        this.doctypefound = true;
+        const result = docTypeReader.readDocType(xmlData, i);
+        this.entityDecoder.addInputEntities(result.entities);
+        i = result.i;
+      } else if (c1 === 33 && xmlData.charCodeAt(i + 2) === 91) {
+        const closeIndex = findClosingIndex(xmlData, "]]>", i, "CDATA is not closed.") - 2;
+        const tagExp = xmlData.substring(i + 9, closeIndex);
+        textData = this.saveTextToParentTag(textData, currentNode, this.readonlyMatcher);
+        let val = this.parseTextData(tagExp, currentNode.tagname, this.readonlyMatcher, true, false, true, true);
+        if (val == void 0) val = "";
+        if (options.cdataPropName) {
+          currentNode.add(options.cdataPropName, [{ [options.textNodeName]: tagExp }]);
+        } else {
+          currentNode.add(options.textNodeName, val);
+        }
+        i = closeIndex + 2;
+      } else {
+        let result = readTagExp(xmlData, i, options.removeNSPrefix);
+        if (!result) {
+          const context = xmlData.substring(Math.max(0, i - 50), Math.min(xmlLen, i + 50));
+          throw new Error(`readTagExp returned undefined at position ${i}. Context: "${context}"`);
+        }
+        let tagName = result.tagName;
+        const rawTagName = result.rawTagName;
+        let tagExp = result.tagExp;
+        let attrExpPresent = result.attrExpPresent;
+        let closeIndex = result.closeIndex;
+        ({ tagName, tagExp } = transformTagName(options.transformTagName, tagName, tagExp, options));
+        if (options.strictReservedNames && (tagName === options.commentPropName || tagName === options.cdataPropName || tagName === options.textNodeName || tagName === options.attributesGroupName)) {
+          throw new Error(`Invalid tag name: ${tagName}`);
+        }
+        if (currentNode && textData) {
+          if (currentNode.tagname !== "!xml") {
+            textData = this.saveTextToParentTag(textData, currentNode, this.readonlyMatcher, false);
+          }
+        }
+        const lastTag = currentNode;
+        if (lastTag && options.unpairedTagsSet.has(lastTag.tagname)) {
+          currentNode = this.tagsNodeStack.pop();
+          this.matcher.pop();
+        }
+        let isSelfClosing = false;
+        if (tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1) {
+          isSelfClosing = true;
+          if (tagName[tagName.length - 1] === "/") {
+            tagName = tagName.substr(0, tagName.length - 1);
+            tagExp = tagName;
+          } else {
+            tagExp = tagExp.substr(0, tagExp.length - 1);
+          }
+          attrExpPresent = tagName !== tagExp;
+        }
+        let prefixedAttrs = null;
+        let rawAttrs = {};
+        let namespace = void 0;
+        namespace = extractNamespace(rawTagName);
+        if (tagName !== xmlObj.tagname) {
+          this.matcher.push(tagName, {}, namespace);
+        }
+        if (tagName !== tagExp && attrExpPresent) {
+          prefixedAttrs = this.buildAttributesMap(tagExp, this.matcher, tagName);
+          if (prefixedAttrs) {
+            rawAttrs = extractRawAttributes(prefixedAttrs, options);
+          }
+        }
+        if (tagName !== xmlObj.tagname) {
+          this.isCurrentNodeStopNode = this.isItStopNode();
+        }
+        const startIndex = i;
+        if (this.isCurrentNodeStopNode) {
+          let tagContent = "";
+          if (isSelfClosing) {
+            i = result.closeIndex;
+          } else if (options.unpairedTagsSet.has(tagName)) {
+            i = result.closeIndex;
+          } else {
+            const result2 = this.readStopNodeData(xmlData, rawTagName, closeIndex + 1);
+            if (!result2) throw new Error(`Unexpected end of ${rawTagName}`);
+            i = result2.i;
+            tagContent = result2.tagContent;
+          }
+          const childNode = new XmlNode(tagName);
+          if (prefixedAttrs) {
+            childNode[":@"] = prefixedAttrs;
+          }
+          childNode.add(options.textNodeName, tagContent);
+          this.matcher.pop();
+          this.isCurrentNodeStopNode = false;
+          this.addChild(currentNode, childNode, this.readonlyMatcher, startIndex);
+        } else {
+          if (isSelfClosing) {
+            ({ tagName, tagExp } = transformTagName(options.transformTagName, tagName, tagExp, options));
+            const childNode = new XmlNode(tagName);
+            if (prefixedAttrs) {
+              childNode[":@"] = prefixedAttrs;
+            }
+            this.addChild(currentNode, childNode, this.readonlyMatcher, startIndex);
+            this.matcher.pop();
+            this.isCurrentNodeStopNode = false;
+          } else if (options.unpairedTagsSet.has(tagName)) {
+            const childNode = new XmlNode(tagName);
+            if (prefixedAttrs) {
+              childNode[":@"] = prefixedAttrs;
+            }
+            this.addChild(currentNode, childNode, this.readonlyMatcher, startIndex);
+            this.matcher.pop();
+            this.isCurrentNodeStopNode = false;
+            i = result.closeIndex;
+            continue;
+          } else {
+            const childNode = new XmlNode(tagName);
+            if (this.tagsNodeStack.length > options.maxNestedTags) {
+              throw new Error("Maximum nested tags exceeded");
+            }
+            this.tagsNodeStack.push(currentNode);
+            if (prefixedAttrs) {
+              childNode[":@"] = prefixedAttrs;
+            }
+            this.addChild(currentNode, childNode, this.readonlyMatcher, startIndex);
+            currentNode = childNode;
+          }
+          textData = "";
+          i = closeIndex;
+        }
+      }
+    } else {
+      textData += xmlData[i];
+    }
+  }
+  return xmlObj.child;
+};
+function addChild(currentNode, childNode, matcher, startIndex) {
+  if (!this.options.captureMetaData) startIndex = void 0;
+  const jPathOrMatcher = this.options.jPath ? matcher.toString() : matcher;
+  const result = this.options.updateTag(childNode.tagname, jPathOrMatcher, childNode[":@"]);
+  if (result === false) {
+  } else if (typeof result === "string") {
+    childNode.tagname = result;
+    currentNode.addChild(childNode, startIndex);
+  } else {
+    currentNode.addChild(childNode, startIndex);
+  }
+}
+function replaceEntitiesValue(val, tagName, jPath) {
+  const entityConfig = this.options.processEntities;
+  if (!entityConfig || !entityConfig.enabled) {
+    return val;
+  }
+  if (entityConfig.allowedTags) {
+    const jPathOrMatcher = this.options.jPath ? jPath.toString() : jPath;
+    const allowed = Array.isArray(entityConfig.allowedTags) ? entityConfig.allowedTags.includes(tagName) : entityConfig.allowedTags(tagName, jPathOrMatcher);
+    if (!allowed) {
+      return val;
+    }
+  }
+  if (entityConfig.tagFilter) {
+    const jPathOrMatcher = this.options.jPath ? jPath.toString() : jPath;
+    if (!entityConfig.tagFilter(tagName, jPathOrMatcher)) {
+      return val;
+    }
+  }
+  return this.entityDecoder.decode(val);
+}
+function saveTextToParentTag(textData, parentNode, matcher, isLeafNode) {
+  if (textData) {
+    if (isLeafNode === void 0) isLeafNode = parentNode.child.length === 0;
+    textData = this.parseTextData(
+      textData,
+      parentNode.tagname,
+      matcher,
+      false,
+      parentNode[":@"] ? Object.keys(parentNode[":@"]).length !== 0 : false,
+      isLeafNode
+    );
+    if (textData !== void 0 && textData !== "")
+      parentNode.add(this.options.textNodeName, textData);
+    textData = "";
+  }
+  return textData;
+}
+function isItStopNode() {
+  if (this.stopNodeExpressionsSet.size === 0) return false;
+  return this.matcher.matchesAny(this.stopNodeExpressionsSet);
+}
+function tagExpWithClosingIndex(xmlData, i, closingChar = ">") {
+  let attrBoundary = 0;
+  const len = xmlData.length;
+  const closeCode0 = closingChar.charCodeAt(0);
+  const closeCode1 = closingChar.length > 1 ? closingChar.charCodeAt(1) : -1;
+  let result = "";
+  let segmentStart = i;
+  for (let index = i; index < len; index++) {
+    const code = xmlData.charCodeAt(index);
+    if (attrBoundary) {
+      if (code === attrBoundary) attrBoundary = 0;
+    } else if (code === 34 || code === 39) {
+      attrBoundary = code;
+    } else if (code === closeCode0) {
+      if (closeCode1 !== -1) {
+        if (xmlData.charCodeAt(index + 1) === closeCode1) {
+          result += xmlData.substring(segmentStart, index);
+          return { data: result, index };
+        }
+      } else {
+        result += xmlData.substring(segmentStart, index);
+        return { data: result, index };
+      }
+    } else if (code === 9 && !attrBoundary) {
+      result += xmlData.substring(segmentStart, index) + " ";
+      segmentStart = index + 1;
+    }
+  }
+}
+function findClosingIndex(xmlData, str, i, errMsg) {
+  const closingIndex = xmlData.indexOf(str, i);
+  if (closingIndex === -1) {
+    throw new Error(errMsg);
+  } else {
+    return closingIndex + str.length - 1;
+  }
+}
+function findClosingChar(xmlData, char, i, errMsg) {
+  const closingIndex = xmlData.indexOf(char, i);
+  if (closingIndex === -1) throw new Error(errMsg);
+  return closingIndex;
+}
+function readTagExp(xmlData, i, removeNSPrefix, closingChar = ">") {
+  const result = tagExpWithClosingIndex(xmlData, i + 1, closingChar);
+  if (!result) return;
+  let tagExp = result.data;
+  const closeIndex = result.index;
+  const separatorIndex = tagExp.search(/\s/);
+  let tagName = tagExp;
+  let attrExpPresent = true;
+  if (separatorIndex !== -1) {
+    tagName = tagExp.substring(0, separatorIndex);
+    tagExp = tagExp.substring(separatorIndex + 1).trimStart();
+  }
+  const rawTagName = tagName;
+  if (removeNSPrefix) {
+    const colonIndex = tagName.indexOf(":");
+    if (colonIndex !== -1) {
+      tagName = tagName.substr(colonIndex + 1);
+      attrExpPresent = tagName !== result.data.substr(colonIndex + 1);
+    }
+  }
+  return {
+    tagName,
+    tagExp,
+    closeIndex,
+    attrExpPresent,
+    rawTagName
+  };
+}
+function readStopNodeData(xmlData, tagName, i) {
+  const startIndex = i;
+  let openTagCount = 1;
+  const xmllen = xmlData.length;
+  for (; i < xmllen; i++) {
+    if (xmlData[i] === "<") {
+      const c1 = xmlData.charCodeAt(i + 1);
+      if (c1 === 47) {
+        const closeIndex = findClosingChar(xmlData, ">", i, `${tagName} is not closed`);
+        let closeTagName = xmlData.substring(i + 2, closeIndex).trim();
+        if (closeTagName === tagName) {
+          openTagCount--;
+          if (openTagCount === 0) {
+            return {
+              tagContent: xmlData.substring(startIndex, i),
+              i: closeIndex
+            };
+          }
+        }
+        i = closeIndex;
+      } else if (c1 === 63) {
+        const closeIndex = findClosingIndex(xmlData, "?>", i + 1, "StopNode is not closed.");
+        i = closeIndex;
+      } else if (c1 === 33 && xmlData.charCodeAt(i + 2) === 45 && xmlData.charCodeAt(i + 3) === 45) {
+        const closeIndex = findClosingIndex(xmlData, "-->", i + 3, "StopNode is not closed.");
+        i = closeIndex;
+      } else if (c1 === 33 && xmlData.charCodeAt(i + 2) === 91) {
+        const closeIndex = findClosingIndex(xmlData, "]]>", i, "StopNode is not closed.") - 2;
+        i = closeIndex;
+      } else {
+        const tagData = readTagExp(xmlData, i, false);
+        if (tagData) {
+          const openTagName = tagData && tagData.tagName;
+          if (openTagName === tagName && tagData.tagExp[tagData.tagExp.length - 1] !== "/") {
+            openTagCount++;
+          }
+          i = tagData.closeIndex;
+        }
+      }
+    }
+  }
+}
+function parseValue(val, shouldParse, options) {
+  if (shouldParse && typeof val === "string") {
+    const newval = val.trim();
+    if (newval === "true") return true;
+    else if (newval === "false") return false;
+    else return toNumber(val, options);
+  } else {
+    if (isExist(val)) {
+      return val;
+    } else {
+      return "";
+    }
+  }
+}
+function transformTagName(fn, tagName, tagExp, options) {
+  if (fn) {
+    const newTagName = fn(tagName);
+    if (tagExp === tagName) {
+      tagExp = newTagName;
+    }
+    tagName = newTagName;
+  }
+  tagName = sanitizeName(tagName, options);
+  return { tagName, tagExp };
+}
+function sanitizeName(name, options) {
+  if (criticalProperties.includes(name)) {
+    throw new Error(`[SECURITY] Invalid name: "${name}" is a reserved JavaScript keyword that could cause prototype pollution`);
+  } else if (DANGEROUS_PROPERTY_NAMES.includes(name)) {
+    return options.onDangerousProperty(name);
+  }
+  return name;
+}
+
+// node_modules/fast-xml-parser/src/xmlparser/node2json.js
+var METADATA_SYMBOL2 = XmlNode.getMetaDataSymbol();
+function stripAttributePrefix(attrs, prefix) {
+  if (!attrs || typeof attrs !== "object") return {};
+  if (!prefix) return attrs;
+  const rawAttrs = {};
+  for (const key in attrs) {
+    if (key.startsWith(prefix)) {
+      const rawName = key.substring(prefix.length);
+      rawAttrs[rawName] = attrs[key];
+    } else {
+      rawAttrs[key] = attrs[key];
+    }
+  }
+  return rawAttrs;
+}
+function prettify(node, options, matcher, readonlyMatcher) {
+  return compress(node, options, matcher, readonlyMatcher);
+}
+function compress(arr3, options, matcher, readonlyMatcher) {
+  let text;
+  const compressedObj = {};
+  for (let i = 0; i < arr3.length; i++) {
+    const tagObj = arr3[i];
+    const property = propName(tagObj);
+    if (property !== void 0 && property !== options.textNodeName) {
+      const rawAttrs = stripAttributePrefix(
+        tagObj[":@"] || {},
+        options.attributeNamePrefix
+      );
+      matcher.push(property, rawAttrs);
+    }
+    if (property === options.textNodeName) {
+      if (text === void 0) text = tagObj[property];
+      else text += "" + tagObj[property];
+    } else if (property === void 0) {
+      continue;
+    } else if (tagObj[property]) {
+      let val = compress(tagObj[property], options, matcher, readonlyMatcher);
+      const isLeaf = isLeafTag(val, options);
+      if (Object.keys(val).length === 0 && options.alwaysCreateTextNode) {
+        val[options.textNodeName] = "";
+      }
+      if (tagObj[":@"]) {
+        assignAttributes(val, tagObj[":@"], readonlyMatcher, options);
+      } else if (Object.keys(val).length === 1 && val[options.textNodeName] !== void 0 && !options.alwaysCreateTextNode) {
+        val = val[options.textNodeName];
+      } else if (Object.keys(val).length === 0) {
+        if (options.alwaysCreateTextNode) val[options.textNodeName] = "";
+        else val = "";
+      }
+      if (tagObj[METADATA_SYMBOL2] !== void 0 && typeof val === "object" && val !== null) {
+        val[METADATA_SYMBOL2] = tagObj[METADATA_SYMBOL2];
+      }
+      if (compressedObj[property] !== void 0 && Object.prototype.hasOwnProperty.call(compressedObj, property)) {
+        if (!Array.isArray(compressedObj[property])) {
+          compressedObj[property] = [compressedObj[property]];
+        }
+        compressedObj[property].push(val);
+      } else {
+        const jPathOrMatcher = options.jPath ? readonlyMatcher.toString() : readonlyMatcher;
+        if (options.isArray(property, jPathOrMatcher, isLeaf)) {
+          compressedObj[property] = [val];
+        } else {
+          compressedObj[property] = val;
+        }
+      }
+      if (property !== void 0 && property !== options.textNodeName) {
+        matcher.pop();
+      }
+    }
+  }
+  if (typeof text === "string") {
+    if (text.length > 0) compressedObj[options.textNodeName] = text;
+  } else if (text !== void 0) compressedObj[options.textNodeName] = text;
+  return compressedObj;
+}
+function propName(obj) {
+  const keys = Object.keys(obj);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (key !== ":@") return key;
+  }
+}
+function assignAttributes(obj, attrMap, readonlyMatcher, options) {
+  if (attrMap) {
+    const keys = Object.keys(attrMap);
+    const len = keys.length;
+    for (let i = 0; i < len; i++) {
+      const atrrName = keys[i];
+      const rawAttrName = atrrName.startsWith(options.attributeNamePrefix) ? atrrName.substring(options.attributeNamePrefix.length) : atrrName;
+      const jPathOrMatcher = options.jPath ? readonlyMatcher.toString() + "." + rawAttrName : readonlyMatcher;
+      if (options.isArray(atrrName, jPathOrMatcher, true, true)) {
+        obj[atrrName] = [attrMap[atrrName]];
+      } else {
+        obj[atrrName] = attrMap[atrrName];
+      }
+    }
+  }
+}
+function isLeafTag(obj, options) {
+  const { textNodeName } = options;
+  const propCount = Object.keys(obj).length;
+  if (propCount === 0) {
+    return true;
+  }
+  if (propCount === 1 && (obj[textNodeName] || typeof obj[textNodeName] === "boolean" || obj[textNodeName] === 0)) {
+    return true;
+  }
+  return false;
+}
+
+// node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
+var XMLParser = class {
+  constructor(options) {
+    this.externalEntities = {};
+    this.options = buildOptions(options);
+  }
+  /**
+   * Parse XML dats to JS object 
+   * @param {string|Uint8Array} xmlData 
+   * @param {boolean|Object} validationOption 
+   */
+  parse(xmlData, validationOption) {
+    if (typeof xmlData !== "string" && xmlData.toString) {
+      xmlData = xmlData.toString();
+    } else if (typeof xmlData !== "string") {
+      throw new Error("XML data is accepted in String or Bytes[] form.");
+    }
+    if (validationOption) {
+      if (validationOption === true) validationOption = {};
+      const result = validate(xmlData, validationOption);
+      if (result !== true) {
+        throw Error(`${result.err.msg}:${result.err.line}:${result.err.col}`);
+      }
+    }
+    const orderedObjParser = new OrderedObjParser(this.options, this.externalEntities);
+    const orderedResult = orderedObjParser.parseXml(xmlData);
+    if (this.options.preserveOrder || orderedResult === void 0) return orderedResult;
+    else return prettify(orderedResult, this.options, orderedObjParser.matcher, orderedObjParser.readonlyMatcher);
+  }
+  /**
+   * Add Entity which is not by default supported by this library
+   * @param {string} key 
+   * @param {string} value 
+   */
+  addEntity(key, value) {
+    if (value.indexOf("&") !== -1) {
+      throw new Error("Entity value can't have '&'");
+    } else if (key.indexOf("&") !== -1 || key.indexOf(";") !== -1) {
+      throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");
+    } else if (value === "&") {
+      throw new Error("An entity with value '&' is not permitted");
+    } else {
+      this.externalEntities[key] = value;
+    }
+  }
+  /**
+   * Returns a Symbol that can be used to access the metadata
+   * property on a node.
+   * 
+   * If Symbol is not available in the environment, an ordinary property is used
+   * and the name of the property is here returned.
+   * 
+   * The XMLMetaData property is only present when `captureMetaData`
+   * is true in the options.
+   */
+  static getMetaDataSymbol() {
+    return XmlNode.getMetaDataSymbol();
+  }
+};
 
 // metric-binding.ts
 var canon = (f) => (f || "").replace(/\s+/g, "");
@@ -2735,7 +4656,7 @@ function wrap(doc, extra = {}) {
 }
 
 // cognos-report.ts
-var xmlParser = new import_fast_xml_parser.XMLParser({
+var xmlParser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: "@_",
   trimValues: true,
@@ -3081,10 +5002,10 @@ function convertCognosReportToSigma(xml2, options = {}) {
     }
   };
   for (const sg of findAll(report, "singleton")) {
-    const qName = sg["@_refQuery"];
-    const q = queries.get(qName);
+    const qName2 = sg["@_refQuery"];
+    const q = queries.get(qName2);
     if (!q) {
-      warnings.push(`<singleton> "${sg["@_name"]}" refQuery="${qName}" has no matching query \u2014 skipped.`);
+      warnings.push(`<singleton> "${sg["@_name"]}" refQuery="${qName2}" has no matching query \u2014 skipped.`);
       continue;
     }
     const ref = findAll(sg, "dataItemValue").map((d) => d["@_refDataItem"]).find(Boolean);
@@ -3103,7 +5024,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
         if (sm[1] !== nm && q.items.has(sm[1])) addKpiCol(sm[1]);
       }
       const { formula, warns } = translate(d.expression, q);
-      warns.forEach((w) => warnings.push(`"${qName}.${nm}": ${w}`));
+      warns.forEach((w) => warnings.push(`"${qName2}.${nm}": ${w}`));
       const referencesSibling = [...q.items.keys()].some((k) => k !== nm && formula.toLowerCase().includes(`[${sigmaDisplayName(k).toLowerCase()}]`));
       const hasAgg = /\b(Sum|Avg|Min|Max|Count|CountDistinct|Median)\s*\(/.test(formula);
       const id = sigmaShortId();
@@ -3130,10 +5051,10 @@ function convertCognosReportToSigma(xml2, options = {}) {
     addElement(sg, el);
   }
   for (const L of lists) {
-    const qName = L["@_refQuery"];
-    const q = queries.get(qName);
+    const qName2 = L["@_refQuery"];
+    const q = queries.get(qName2);
     if (!q) {
-      warnings.push(`<list> refQuery="${qName}" has no matching query \u2014 skipped.`);
+      warnings.push(`<list> refQuery="${qName2}" has no matching query \u2014 skipped.`);
       continue;
     }
     const colRefs = findAll(L, "dataItemValue").map((d) => d["@_refDataItem"]).filter(Boolean);
@@ -3163,15 +5084,15 @@ function convertCognosReportToSigma(xml2, options = {}) {
           columns.push({ id: sigmaShortId(), name: sigmaDisplayName(r), formula: `${AGG[m[1].toLowerCase()]}([${sigmaDisplayName(m[2])}])` });
           continue;
         }
-        warnings.push(`list column "${r}" not found in query "${qName}" \u2014 skipped.`);
+        warnings.push(`list column "${r}" not found in query "${qName2}" \u2014 skipped.`);
         continue;
       }
       const { formula, warns } = translate(di.expression, q);
-      warns.forEach((w) => warnings.push(`"${qName}.${r}": ${w}`));
+      warns.forEach((w) => warnings.push(`"${qName2}.${r}": ${w}`));
       const id = sigmaShortId();
       if (grouped && isMeasureItem(di)) {
         const _aggk = di.aggregate.toLowerCase();
-        if (!AGG[_aggk]) warnings.push(`list measure "${di.name}" (query "${qName}"): unmapped Cognos aggregate '${di.aggregate}' \u2014 defaulted to Sum (degraded); verify parity or add the mapping (refs/cognos-coverage.md).`);
+        if (!AGG[_aggk]) warnings.push(`list measure "${di.name}" (query "${qName2}"): unmapped Cognos aggregate '${di.aggregate}' \u2014 defaulted to Sum (degraded); verify parity or add the mapping (refs/cognos-coverage.md).`);
         const fn = AGG[_aggk] || "Sum";
         columns.push({ id, name: sigmaDisplayName(di.name), formula: bindMeasure(/^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(formula) ? formula : `${fn}(${formula})`, q) });
         measureIds.push(id);
@@ -3181,17 +5102,17 @@ function convertCognosReportToSigma(xml2, options = {}) {
       }
     }
     if (footerRefs.length) {
-      warnings.push(`list "${qName}": footer total(s) ${footerRefs.join(", ")} \u2014 the grouped Sigma table already aggregates per group; add a grand-total via the table's totals UI (a duplicate Sum column would double-aggregate).`);
+      warnings.push(`list "${qName2}": footer total(s) ${footerRefs.join(", ")} \u2014 the grouped Sigma table already aggregates per group; add a grand-total via the table's totals UI (a duplicate Sum column would double-aggregate).`);
     }
     for (const si of findAll(L, "sortItem")) {
-      if (si["@_refDataItem"]) warnings.push(`list "${qName}" sorts by "${si["@_refDataItem"]}" (${si["@_sortOrder"] || "ascending"}) \u2014 table sort isn't part of the Sigma workbook spec; apply the sort in the UI.`);
+      if (si["@_refDataItem"]) warnings.push(`list "${qName2}" sorts by "${si["@_refDataItem"]}" (${si["@_sortOrder"] || "ascending"}) \u2014 table sort isn't part of the Sigma workbook spec; apply the sort in the UI.`);
     }
     const condRefs = [...new Set(findAll(L, "conditionalStyleRef").map((c) => c["@_refConditionalStyle"]).filter(Boolean))];
-    if (condRefs.length) warnings.push(`list "${qName}" uses conditional style(s) ${condRefs.map((r) => `"${r}"`).join(", ")} \u2014 threshold-driven formats/styles aren't portable to the Sigma spec; set a column format (e.g. $,.3s) or conditional formatting in the UI.`);
+    if (condRefs.length) warnings.push(`list "${qName2}" uses conditional style(s) ${condRefs.map((r) => `"${r}"`).join(", ")} \u2014 threshold-driven formats/styles aren't portable to the Sigma spec; set a column format (e.g. $,.3s) or conditional formatting in the UI.`);
     const el = {
       id: sigmaShortId(),
       kind: "table",
-      name: `${q.subject ? sigmaDisplayName(q.subject) + " \u2014 " : ""}${qName}`,
+      name: `${q.subject ? sigmaDisplayName(q.subject) + " \u2014 " : ""}${qName2}`,
       source: dmSource(q),
       columns,
       order: columns.map((c) => c.id)
@@ -3204,10 +5125,10 @@ function convertCognosReportToSigma(xml2, options = {}) {
   }
   const isTotal = (r) => /^(Total|Summary|Aggregate|Average|Count|Maximum|Minimum)\(/i.test(r || "");
   for (const X of findAll(report, "crosstab")) {
-    const qName = X["@_refQuery"];
-    const q = queries.get(qName);
+    const qName2 = X["@_refQuery"];
+    const q = queries.get(qName2);
     if (!q) {
-      warnings.push(`<crosstab> refQuery="${qName}" has no matching query \u2014 skipped.`);
+      warnings.push(`<crosstab> refQuery="${qName2}" has no matching query \u2014 skipped.`);
       continue;
     }
     const edge = (subtree) => [...new Set(findAll(subtree || {}, "crosstabNodeMember").map((m) => m["@_refDataItem"]).filter((r) => r && !isTotal(r)))];
@@ -3219,11 +5140,11 @@ function convertCognosReportToSigma(xml2, options = {}) {
     const mk = (ref, agg) => {
       const di = q.items.get(ref);
       if (!di) {
-        warnings.push(`crosstab "${qName}" member "${ref}" not in query \u2014 skipped.`);
+        warnings.push(`crosstab "${qName2}" member "${ref}" not in query \u2014 skipped.`);
         return null;
       }
       const { formula, warns } = translate(di.expression, q);
-      warns.forEach((w) => warnings.push(`"${qName}.${ref}": ${w}`));
+      warns.forEach((w) => warnings.push(`"${qName2}.${ref}": ${w}`));
       const id = sigmaShortId();
       cols.push({ id, name: sigmaDisplayName(di.name), formula: agg ? bindMeasure(`Sum(${formula})`, q) : formula });
       return { id };
@@ -3231,11 +5152,11 @@ function convertCognosReportToSigma(xml2, options = {}) {
     const rowsBy = rowRefs.map((r) => mk(r, false)).filter(Boolean);
     const columnsBy = colRefs.map((c) => mk(c, false)).filter(Boolean);
     const values = measRefs.map((m) => mk(m, true)).filter(Boolean).map((o) => o.id);
-    if (!values.length || !rowsBy.length && !columnsBy.length) warnings.push(`crosstab "${qName}" missing a measure or both edges \u2014 review the pivot.`);
+    if (!values.length || !rowsBy.length && !columnsBy.length) warnings.push(`crosstab "${qName2}" missing a measure or both edges \u2014 review the pivot.`);
     const el = {
       id: sigmaShortId(),
       kind: "pivot-table",
-      name: `${q.subject ? sigmaDisplayName(q.subject) + " \u2014 " : ""}${qName} (crosstab)`,
+      name: `${q.subject ? sigmaDisplayName(q.subject) + " \u2014 " : ""}${qName2} (crosstab)`,
       source: dmSource(q),
       columns: cols,
       order: cols.map((c) => c.id),
@@ -3359,8 +5280,8 @@ function convertCognosReportToSigma(xml2, options = {}) {
     const vizType = String(V["@_type"] || "").toLowerCase();
     const vizName = V["@_name"] || "Chart";
     const dsName = findAll(V, "vcDataSet").map((d) => d["@_refDataStore"]).find(Boolean);
-    const qName = dsName ? dsToQuery.get(dsName) : void 0;
-    const q = qName ? queries.get(qName) : void 0;
+    const qName2 = dsName ? dsToQuery.get(dsName) : void 0;
+    const q = qName2 ? queries.get(qName2) : void 0;
     if (!q) {
       warnings.push(`<vizControl> "${vizName}" (${vizType}): no resolvable query (dataStore "${dsName}") \u2014 chart skipped.`);
       continue;
@@ -3381,7 +5302,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
       if (!e) return void 0;
       const di = q.items.get(e.ref);
       if (!di) {
-        warnings.push(`chart "${vizName}" column "${e.ref}" not in query "${qName}" \u2014 skipped.`);
+        warnings.push(`chart "${vizName}" column "${e.ref}" not in query "${qName2}" \u2014 skipped.`);
         return void 0;
       }
       const nm = sigmaDisplayName(di.name);
@@ -3643,19 +5564,19 @@ function convertCognosReportToSigma(xml2, options = {}) {
     ));
   }
   for (const repeater of [...findAll(report, "repeater"), ...findAll(report, "repeaterTable")]) {
-    const qName = repeater["@_refQuery"];
-    const q = queries.get(qName);
+    const qName2 = repeater["@_refQuery"];
+    const q = queries.get(qName2);
     if (!q) {
-      warnings.push(workbookGap("repeater", `refQuery="${qName || "(missing)"}" has no matching query; repeater was not emitted.`));
+      warnings.push(workbookGap("repeater", `refQuery="${qName2 || "(missing)"}" has no matching query; repeater was not emitted.`));
       continue;
     }
     const refs = [...new Set(findAll(repeater, "dataItemValue").map((x) => x["@_refDataItem"]).filter(Boolean))];
-    const sourceName = `${repeater["@_name"] || qName} source`;
+    const sourceName = `${repeater["@_name"] || qName2} source`;
     const sourceColumns = refs.flatMap((ref) => {
       const di = q.items.get(ref);
       if (!di) return [];
       const translated = translate(di.expression, q);
-      translated.warns.forEach((w) => warnings.push(`"${qName}.${ref}": ${w}`));
+      translated.warns.forEach((w) => warnings.push(`"${qName2}.${ref}": ${w}`));
       return [{ id: sigmaShortId(), name: sigmaDisplayName(di.name), formula: translated.formula }];
     });
     const source = {
@@ -3671,7 +5592,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
     const rc = {
       id: sigmaShortId(),
       kind: "repeated-container",
-      name: repeater["@_name"] || `${qName} repeater`,
+      name: repeater["@_name"] || `${qName2} repeater`,
       source: { kind: "table", elementId: source.id },
       arrangement: "list",
       cardSize: "small",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/package-lock.json
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "fast-xml-parser": "^4.5.0"
+        "fast-xml-parser": "^5.10.1"
       },
       "bin": {
         "cognos-to-sigma": "cli.ts"
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -225,9 +225,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "cpu": [
         "arm64"
       ],
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -361,9 +361,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "cpu": [
         "arm64"
       ],
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -412,9 +412,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -429,9 +429,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],
@@ -462,6 +462,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
@@ -472,10 +484,22 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -486,38 +510,38 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
-      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
       "funding": [
         {
           "type": "github",
@@ -526,7 +550,28 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -547,10 +592,10 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
       "funding": [
         {
           "type": "github",
@@ -558,6 +603,36 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/tsx": {
       "version": "4.22.4",
@@ -598,6 +673,21 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     }
   }
 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/package.json
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/package.json
@@ -12,7 +12,7 @@
     "test": "node --import tsx/esm test.ts"
   },
   "dependencies": {
-    "fast-xml-parser": "^4.5.0"
+    "fast-xml-parser": "^5.10.1"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get-token.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get_token.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/pick-destination.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/pick-destination.mjs
@@ -30,9 +30,19 @@ function loadNeutralEnv() {
 
 const BASE = () => (process.env.SIGMA_BASE_URL || 'https://aws-api.sigmacomputing.com').replace(/\/$/, '');
 let TOK = null;
+function validateBaseUrl(base) {
+  // Security (A2): only send Sigma client creds to an https:// sigmacomputing.com host.
+  if (process.env.SIGMA_ALLOW_INSECURE_BASE_URL === '1') { console.error(`WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (${base})`); return; }
+  let u; try { u = new URL(base); } catch { console.error(`FATAL: invalid SIGMA_BASE_URL: ${base}`); process.exit(1); }
+  const host = u.hostname.toLowerCase();
+  if (u.protocol !== 'https:' || !(host === 'sigmacomputing.com' || host.endsWith('.sigmacomputing.com'))) {
+    console.error(`FATAL: refusing to send Sigma credentials to ${base} — require https:// on a sigmacomputing.com host (set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override).`); process.exit(1);
+  }
+}
 async function token() {
   if (process.env.SIGMA_API_TOKEN) return process.env.SIGMA_API_TOKEN;
   loadNeutralEnv();
+  validateBaseUrl(BASE());
   const body = new URLSearchParams({ grant_type: 'client_credentials',
     client_id: process.env.SIGMA_CLIENT_ID, client_secret: process.env.SIGMA_CLIENT_SECRET });
   const r = await fetch(BASE() + '/v2/auth/token', { method: 'POST', body });

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/get-token.sh
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/get_token.py
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/setup.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/assess.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/assess.py
@@ -17,9 +17,34 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 "..", "..", "gooddata-to-sigma", "scripts"))
 from maql import translate  # noqa: E402
 
-_CTX = ssl.create_default_context()
-if os.environ.get("GOODDATA_TLS_VERIFY") != "1":
-    _CTX.check_hostname = False; _CTX.verify_mode = ssl.CERT_NONE
+def _ssl_context():
+    """TLS trust resolution. Some GoodData trial/corp endpoints present a CA
+    chain Python rejects ("CA cert does not include key usage extension") that
+    curl/browsers accept. Prefer the OS trust store (truststore), then certifi,
+    then the stock verified context. NEVER silently downgrades: an unverified
+    context is used ONLY when GOODDATA_INSECURE_TLS=1 is explicitly set, and it
+    logs loudly."""
+    if os.environ.get("GOODDATA_INSECURE_TLS") == "1":
+        print("WARNING: GOODDATA_INSECURE_TLS=1 — TLS verification DISABLED for "
+              "gooddata (insecure)", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; matches curl/browser reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
+_CTX = _ssl_context()
 
 AUTO_VIZ = {"local:headline", "local:table", "local:pivot", "local:column", "local:bar",
             "local:line", "local:area", "local:pie", "local:donut", "local:combo",

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/discover.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/discover.py
@@ -18,13 +18,35 @@ live run and adjust the summary extractors.
 """
 import argparse, json, os, ssl, sys, urllib.request, urllib.error
 
-# Some GoodData trial/corp endpoints present a CA chain Python rejects
-# ("CA cert does not include key usage extension"); fall back to an unverified
-# context. Set GOODDATA_TLS_VERIFY=1 to force strict verification.
-_CTX = ssl.create_default_context()
-if os.environ.get("GOODDATA_TLS_VERIFY") != "1":
-    _CTX.check_hostname = False
-    _CTX.verify_mode = ssl.CERT_NONE
+
+def _ssl_context():
+    """TLS trust resolution. Some GoodData trial/corp endpoints present a CA
+    chain Python rejects ("CA cert does not include key usage extension") that
+    curl/browsers accept. Prefer the OS trust store (truststore), then certifi,
+    then the stock verified context. NEVER silently downgrades: an unverified
+    context is used ONLY when GOODDATA_INSECURE_TLS=1 is explicitly set, and it
+    logs loudly."""
+    if os.environ.get("GOODDATA_INSECURE_TLS") == "1":
+        print("WARNING: GOODDATA_INSECURE_TLS=1 — TLS verification DISABLED for "
+              "gooddata (insecure)", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; matches curl/browser reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
+_CTX = _ssl_context()
 
 
 def api(path):

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get_token.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/platform_auth.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/platform_auth.py
@@ -25,7 +25,7 @@ Credentials (env):
   GOODDATA_PLATFORM_USER      login email               ] username/password flow
   GOODDATA_PLATFORM_PASSWORD  password                  ]
   GOODDATA_PLATFORM_SST       pre-obtained SST          ] (alternative to user/pass)
-  GOODDATA_TLS_VERIFY=1       force strict TLS (default: permissive, like discover.py)
+  GOODDATA_INSECURE_TLS=1     disable TLS verification (default: verified, like discover.py)
 
 CLI:
   python3 platform_auth.py --check          # login, print profile + project count
@@ -39,10 +39,35 @@ import json, os, ssl, sys, urllib.request, urllib.error
 
 _UA = "sigma-gooddata-migration/1.0 (+platform)"
 
-_CTX = ssl.create_default_context()
-if os.environ.get("GOODDATA_TLS_VERIFY") != "1":
-    _CTX.check_hostname = False
-    _CTX.verify_mode = ssl.CERT_NONE
+
+def _ssl_context():
+    """TLS trust resolution. Some GoodData trial/corp endpoints present a CA
+    chain Python rejects ("CA cert does not include key usage extension") that
+    curl/browsers accept. Prefer the OS trust store (truststore), then certifi,
+    then the stock verified context. NEVER silently downgrades: an unverified
+    context is used ONLY when GOODDATA_INSECURE_TLS=1 is explicitly set, and it
+    logs loudly."""
+    if os.environ.get("GOODDATA_INSECURE_TLS") == "1":
+        print("WARNING: GOODDATA_INSECURE_TLS=1 — TLS verification DISABLED for "
+              "gooddata (insecure)", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; matches curl/browser reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
+_CTX = _ssl_context()
 
 
 def _host():

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/get-token.sh
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/get_token.py
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get_token.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/pick_destination.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/pick_destination.py
@@ -32,11 +32,20 @@ def _load_neutral_env():
 def _base():
     return os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com").rstrip("/")
 
+def _validate_base_url(base):
+    # Security (A2): only send Sigma client creds to an https:// sigmacomputing.com host.
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr); return
+    p = urllib.parse.urlparse(base or ""); host = (p.hostname or "").lower()
+    if p.scheme != "https" or not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        sys.exit(f"FATAL: refusing to send Sigma credentials to '{base}' — require https:// on a sigmacomputing.com host (set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override).")
+
 def _token():
     tok = os.environ.get("SIGMA_API_TOKEN")
     if tok:
         return tok
     _load_neutral_env()
+    _validate_base_url(_base())
     data = urllib.parse.urlencode({
         "grant_type": "client_credentials",
         "client_id": os.environ["SIGMA_CLIENT_ID"],

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get_token.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/pick_destination.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/pick_destination.py
@@ -32,11 +32,20 @@ def _load_neutral_env():
 def _base():
     return os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com").rstrip("/")
 
+def _validate_base_url(base):
+    # Security (A2): only send Sigma client creds to an https:// sigmacomputing.com host.
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr); return
+    p = urllib.parse.urlparse(base or ""); host = (p.hostname or "").lower()
+    if p.scheme != "https" or not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        sys.exit(f"FATAL: refusing to send Sigma credentials to '{base}' — require https:// on a sigmacomputing.com host (set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override).")
+
 def _token():
     tok = os.environ.get("SIGMA_API_TOKEN")
     if tok:
         return tok
     _load_neutral_env()
+    _validate_base_url(_base())
     data = urllib.parse.urlencode({
         "grant_type": "client_credentials",
         "client_id": os.environ["SIGMA_CLIENT_ID"],

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/get-token.sh
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get-token.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get_token.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-onprem-shim.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-onprem-shim.py
@@ -69,6 +69,10 @@ def env(name, default=None, required=False):
 SERVER = env("QLIK_ONPREM_SERVER", required=True)
 AUTH = env("QLIK_ONPREM_AUTH", "certs")
 INSECURE = env("QLIK_ONPREM_INSECURE") == "1"
+if INSECURE:
+    sys.stderr.write(
+        "WARNING: QLIK_ONPREM_INSECURE=1 — TLS verification DISABLED for qlik "
+        "(insecure)\n")
 
 
 def ssl_ctx(with_client_cert):

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get-token.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get_token.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get_token.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get_token.py
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/detect_rls.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/detect_rls.py
@@ -28,10 +28,36 @@ Usage:
 """
 import argparse, json, os, ssl, sys, urllib.parse, urllib.request, urllib.error
 
+def _ssl_context():
+    """TLS trust resolution. Some Sisense trial/on-prem endpoints present a CA
+    chain Python rejects (trial CA lacks the key-usage extension) that
+    curl/browsers accept. Prefer the OS trust store (truststore), then certifi,
+    then the stock verified context. NEVER silently downgrades: an unverified
+    context is used ONLY when SISENSE_INSECURE_TLS=1 is explicitly set, and it
+    logs loudly."""
+    if os.environ.get("SISENSE_INSECURE_TLS") == "1":
+        print("WARNING: SISENSE_INSECURE_TLS=1 — TLS verification DISABLED for "
+              "sisense (insecure)", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; matches curl/browser reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
 def _get(url):
     req = urllib.request.Request(url)
     req.add_header("Authorization", "Bearer " + os.environ["SISENSE_API_TOKEN"])
-    ctx = ssl._create_unverified_context()           # trial CA lacks key-usage ext
+    ctx = _ssl_context()
     try:
         with urllib.request.urlopen(req, context=ctx, timeout=60) as r:
             return json.loads(r.read() or "null")

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/discover.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/discover.py
@@ -33,10 +33,12 @@ BASE = os.environ.get("SISENSE_BASE_URL", "").rstrip("/")
 TOKEN = os.environ.get("SISENSE_API_TOKEN", "")
 
 # Some Sisense instances (notably trial/self-signed) present a cert chain that
-# Python's verifier rejects even though curl/browsers accept it. Try verified
-# first; on a cert-verification error, fall back to an unverified context (the
-# target is the customer's own instance, reached over their own creds) and warn.
+# Python's verifier rejects even though curl/browsers accept it. Always try
+# verified first. NEVER silently downgrade on a cert-verification error: an
+# unverified context is used ONLY when SISENSE_INSECURE_TLS=1 is explicitly
+# set, and it logs loudly.
 _UNVERIFIED = ssl._create_unverified_context()
+_INSECURE_OK = os.environ.get("SISENSE_INSECURE_TLS") == "1"
 _warned_ssl = False
 
 
@@ -53,9 +55,14 @@ def _get(path):
     except urllib.error.URLError as e:
         if not isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError):
             raise
+        if not _INSECURE_OK:
+            sys.exit(
+                "TLS cert not verifiable (trial/self-signed cert). Refusing to "
+                "silently fall back to an unverified connection. Set "
+                "SISENSE_INSECURE_TLS=1 to explicitly allow this (insecure).")
         if not _warned_ssl:
-            print("  ! TLS cert not verifiable — falling back to unverified "
-                  "context (trial/self-signed cert)", file=sys.stderr)
+            print("WARNING: SISENSE_INSECURE_TLS=1 — TLS verification DISABLED "
+                  "for sisense (insecure)", file=sys.stderr)
             _warned_ssl = True
         with urllib.request.urlopen(req, context=_UNVERIFIED) as r:
             body = r.read().decode("utf-8")

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get_token.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify_parity.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify_parity.py
@@ -21,6 +21,31 @@ checks.json: [{"label","datasource","jaql":[...],"snowflake_sql","tol":0.01}]
 """
 import json, os, ssl, subprocess, sys, urllib.error, urllib.request
 
+def _ssl_context():
+    """TLS trust resolution. On-prem Sisense deployments commonly sit on
+    self-signed certs. Prefer the OS trust store (truststore), then certifi,
+    then the stock verified context. NEVER silently downgrades: an unverified
+    context is used ONLY when SISENSE_INSECURE_TLS=1 is explicitly set, and it
+    logs loudly."""
+    if os.environ.get("SISENSE_INSECURE_TLS") == "1":
+        print("WARNING: SISENSE_INSECURE_TLS=1 — TLS verification DISABLED for "
+              "sisense (insecure)", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; matches curl/browser reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
 def sisense_jaql(datasource, metadata):
     ds = datasource.replace(" ", "%20").replace("(", "%28").replace(")", "%29")
     url = f'{os.environ["SISENSE_BASE_URL"].rstrip("/")}/api/datasources/{ds}/jaql'
@@ -29,14 +54,7 @@ def sisense_jaql(datasource, metadata):
         "Authorization": f'Bearer {os.environ["SISENSE_API_TOKEN"]}',
         "Content-Type": "application/json",
     })
-    # NOTE: the original `curl -sk` skipped TLS verification (-k), which is
-    # commonly needed against on-prem Sisense deployments on self-signed certs.
-    # Preserved here (not tightened) so existing setups don't silently break;
-    # if this ever needs to be strict, gate it behind an env var instead of
-    # flipping the default.
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    ctx = _ssl_context()
     try:
         with urllib.request.urlopen(req, timeout=120, context=ctx) as resp:
             out = resp.read().decode("utf-8")

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/get-tableau-token.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/get-tableau-token.sh
@@ -91,6 +91,6 @@ print(d['credentials']['token'])
 
 SITE_ID=$(printf '%s' "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['credentials']['site']['id'])")
 
-echo "export TABLEAU_AUTH_TOKEN='${TOKEN}'"
-echo "export TABLEAU_SITE_ID='${SITE_ID}'"
-echo "export TABLEAU_API_VERSION='${API_VER}'"
+printf 'export TABLEAU_AUTH_TOKEN=%q\n' "$TOKEN"
+printf 'export TABLEAU_SITE_ID=%q\n' "$SITE_ID"
+printf 'export TABLEAU_API_VERSION=%q\n' "$API_VER"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-tableau-token.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-tableau-token.py
@@ -20,6 +20,7 @@ TABLEAU_SITE_CONTENT_URL) in the env or ~/.sigma-migration/env (setup-tableau.rb
 """
 import argparse
 import os
+import shlex
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
@@ -46,10 +47,10 @@ def main():
         print(token)
         return
     # default + --print-export: bash-eval-compatible exports (matches get-tableau-token.sh)
-    print(f"export TABLEAU_AUTH_TOKEN='{token}'")
-    print(f"export TABLEAU_SITE_ID='{site}'")
-    print(f"export TABLEAU_SERVER_URL='{server}'")
-    print(f"export TABLEAU_API_VERSION='{ver}'")
+    print(f"export TABLEAU_AUTH_TOKEN={shlex.quote(token)}")
+    print(f"export TABLEAU_SITE_ID={shlex.quote(site)}")
+    print(f"export TABLEAU_SERVER_URL={shlex.quote(server)}")
+    print(f"export TABLEAU_API_VERSION={shlex.quote(ver)}")
 
 
 if __name__ == "__main__":

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-tableau-token.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-tableau-token.sh
@@ -91,6 +91,6 @@ print(d['credentials']['token'])
 
 SITE_ID=$(printf '%s' "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['credentials']['site']['id'])")
 
-echo "export TABLEAU_AUTH_TOKEN='${TOKEN}'"
-echo "export TABLEAU_SITE_ID='${SITE_ID}'"
-echo "export TABLEAU_API_VERSION='${API_VER}'"
+printf 'export TABLEAU_AUTH_TOKEN=%q\n' "$TOKEN"
+printf 'export TABLEAU_SITE_ID=%q\n' "$SITE_ID"
+printf 'export TABLEAU_API_VERSION=%q\n' "$API_VER"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-token.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get_token.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/land-extracts.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/land-extracts.py
@@ -426,6 +426,11 @@ def sigma_token(base):
         sys.exit("FATAL: --sigma-connection-id needs SIGMA_API_TOKEN, or "
                  "SIGMA_CLIENT_ID + SIGMA_CLIENT_SECRET (env or ~/.sigma-migration/env).\n"
                  "  Mint one:  eval \"$(scripts/get-token.sh)\"")
+    # Security (A2): only send Sigma client creds to an https:// sigmacomputing.com host.
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") != "1":
+        _p = urllib.parse.urlparse(base or ""); _h = (_p.hostname or "").lower()
+        if _p.scheme != "https" or not (_h == "sigmacomputing.com" or _h.endswith(".sigmacomputing.com")):
+            sys.exit(f"FATAL: refusing to send Sigma credentials to '{base}' — require https:// on a sigmacomputing.com host (set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override).")
     try:
         status, body = _http_json(
             "POST", f"{base}/v2/auth/token",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/mcp_convert.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/mcp_convert.py
@@ -15,7 +15,8 @@ try:
     truststore.inject_into_ssl()
     _CTX = None
 except ImportError:
-    _CTX = ssl._create_unverified_context()
+    # No truststore: fall back to a VERIFIED context, never unverified.
+    _CTX = ssl.create_default_context()
 
 URL = "https://sigma-data-model-mcp.onrender.com/mcp"
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.py
@@ -45,6 +45,7 @@ import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -155,6 +156,22 @@ def base_url():
     return v
 
 
+def validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        raise SystemExit(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        raise SystemExit(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def token_minted_at():
     """Epoch seconds when the current token was minted, if known. The in-memory
     stamp (set by refresh_token in this process) wins; else SIGMA_TOKEN_MINTED_AT
@@ -259,6 +276,7 @@ def refresh_token():
         secret = os.environ.get("SIGMA_CLIENT_SECRET")
         if not secret:
             raise SigmaAuthError("SIGMA_CLIENT_SECRET not set")
+        validate_base_url(base_url())
         creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
         resp = _send(
             "POST",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-setup-noninteractive.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-setup-noninteractive.rb
@@ -52,7 +52,7 @@ Dir.mktmpdir do |home|
 
   # (2) full flags => writes both stores non-interactively.
   code, out, = run_setup(home, ['--client-id', 'id-123', '--client-secret', 'sec-456',
-                                '--base-url', 'https://api.example-sigma.test',
+                                '--base-url', 'https://api.eu.aws.sigmacomputing.com',
                                 '--connection-id', 'conn-789'])
   check(code == 0, "flag mode exits 0 (got #{code})", fails)
   neutral = File.join(home, '.sigma-migration', 'env')
@@ -62,7 +62,7 @@ Dir.mktmpdir do |home|
   body = File.read(neutral)
   check(body.include?("export SIGMA_CLIENT_ID='id-123'") &&
         body.include?("export SIGMA_CLIENT_SECRET='sec-456'") &&
-        body.include?("export SIGMA_BASE_URL='https://api.example-sigma.test'") &&
+        body.include?("export SIGMA_BASE_URL='https://api.eu.aws.sigmacomputing.com'") &&
         body.include?("export SIGMA_CONNECTION_ID='conn-789'"),
         'neutral file carries all four exports', fails)
   check((File.stat(neutral).mode & 0o777) == 0o600, 'neutral file is 0600', fails)
@@ -90,7 +90,7 @@ Dir.mktmpdir do |home|
   secret = 'supersecret-abcdef-123456'
   code, out, hung = run_setup(home, [], env: { 'SIGMA_CLIENT_ID' => 'id-env',
                                                'SIGMA_CLIENT_SECRET' => secret,
-                                               'SIGMA_BASE_URL' => 'https://api.example-sigma.test' })
+                                               'SIGMA_BASE_URL' => 'https://api.eu.aws.sigmacomputing.com' })
   check(!hung, 'no-TTY env path does not hang', fails)
   check(code == 0, "no-TTY with env creds exits 0 (got #{code})", fails)
   check(out.include?('env SIGMA_CLIENT_ID') && out.include?('env SIGMA_CLIENT_SECRET'),

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
@@ -30,12 +30,16 @@ class Base(unittest.TestCase):
     # env keys we mutate — snapshot + restore so cases don't bleed.
     KEYS = ["SIGMA_BASE_URL", "SIGMA_CLIENT_ID", "SIGMA_CLIENT_SECRET",
             "SIGMA_API_TOKEN", "SIGMA_TOKEN_MINTED_AT", "SIGMA_WORKDIR",
-            "SIGMA_INSECURE_TLS"]
+            "SIGMA_INSECURE_TLS", "SIGMA_ALLOW_INSECURE_BASE_URL"]
 
     def setUp(self):
         self._saved = {k: os.environ.get(k) for k in self.KEYS}
         for k in self.KEYS:
             os.environ.pop(k, None)
+        # These are network-mocked unit tests that mint tokens against fake hosts
+        # (https://b, https://x.example); bypass the A2 base-URL host validator so
+        # they exercise the HTTP/auth seam, not the (separately-tested) allowlist.
+        os.environ["SIGMA_ALLOW_INSECURE_BASE_URL"] = "1"
         # reset module state
         sigma_rest._token_override = None
         sigma_rest._minted_at = None

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get_token.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/ts_lib.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/ts_lib.py
@@ -7,13 +7,39 @@ in the browser tab where you're logged in, or via Develop > REST Playground.
 For a service identity, enable Trusted Auth (Develop > Customizations >
 Security Settings) and POST username+secret_key to auth/token/full.
 """
-import json, os, ssl, urllib.request, urllib.error
+import json, os, ssl, sys, urllib.request, urllib.error
 
 HOST = os.environ.get("TS_HOST", "").rstrip("/")
 TOKEN = os.environ.get("TS_TOKEN", "")
-# Trials often sit behind corp TLS interception whose CA Python won't verify
-# (curl uses the system store and works). Use an unverified context.
-_SSL = ssl._create_unverified_context()
+
+
+def ssl_context():
+    """TLS trust resolution. Trials often sit behind corp TLS interception whose
+    CA Python won't verify even though curl/browsers accept it. Prefer the OS
+    trust store (truststore), then certifi, then the stock verified context.
+    NEVER silently downgrades: an unverified context is used ONLY when
+    THOUGHTSPOT_INSECURE_TLS=1 is explicitly set, and it logs loudly."""
+    if os.environ.get("THOUGHTSPOT_INSECURE_TLS") == "1":
+        print("WARNING: THOUGHTSPOT_INSECURE_TLS=1 — TLS verification DISABLED "
+              "for thoughtspot (insecure)", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; matches curl/browser reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
+_SSL = ssl_context()
 
 
 def _req(path, body=None, method="POST"):

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
@@ -20,7 +20,9 @@ Env: SIGMA_BASE_URL, SIGMA_API_TOKEN, TS_WORKDIR (default for --workdir), TS_ROW
 import argparse, json, os, re, ssl, sys, urllib.request, urllib.error
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import code_rep  # workbook code-rep document-wrapper adapter (nested GET/PUT shape)
-_SSL = ssl._create_unverified_context()
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ts_lib
+_SSL = ts_lib.ssl_context()
 
 TS_GRID_COLS = 12                                   # ThoughtSpot Liveboard grid
 COL_SCALE = 24 // TS_GRID_COLS                      # → Sigma's 24-col grid

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/compare.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/compare.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib
 import yaml, ts_lib
 import code_rep  # workbook code-rep document-wrapper adapter (nested GET shape)
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
-SBASE = os.environ["SIGMA_BASE_URL"]; STOK = os.environ["SIGMA_API_TOKEN"]; _SSL = ssl._create_unverified_context()
+SBASE = os.environ["SIGMA_BASE_URL"]; STOK = os.environ["SIGMA_API_TOKEN"]; _SSL = ts_lib.ssl_context()
 
 # TS chart type -> the Sigma element kind the migration produces (for the structural check)
 EXPECTED = {"KPI": "kpi-chart", "COLUMN": "bar-chart", "BAR": "bar-chart", "LINE": "line-chart",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-ts-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-ts-token.sh
@@ -13,7 +13,13 @@ set -euo pipefail
 : "${TS_USERNAME:?set TS_USERNAME (the service/user to mint a token for)}"
 : "${TS_SECRET_KEY:?set TS_SECRET_KEY (Trusted-Auth secret from Security Settings)}"
 
-RESP=$(curl -sf -k -X POST "${TS_HOST%/}/api/rest/2.0/auth/token/full" \
+CURL_TLS_OPT=()
+if [ "${THOUGHTSPOT_INSECURE_TLS:-}" = "1" ]; then
+  echo "WARNING: THOUGHTSPOT_INSECURE_TLS=1 — TLS verification DISABLED for thoughtspot (insecure)" >&2
+  CURL_TLS_OPT=(-k)
+fi
+
+RESP=$(curl -sf "${CURL_TLS_OPT[@]}" -X POST "${TS_HOST%/}/api/rest/2.0/auth/token/full" \
   -H "Content-Type: application/json" \
   -d "{\"username\":\"${TS_USERNAME}\",\"secret_key\":\"${TS_SECRET_KEY}\",\"validity_time_in_sec\":86400}") || {
     echo "token request failed — check TS_HOST / TS_USERNAME / TS_SECRET_KEY and that Trusted Auth is enabled" >&2
@@ -23,4 +29,4 @@ TOKEN=$(echo "$RESP" | python3 -c "import sys,json;print(json.load(sys.stdin)['t
 if [ -z "${TOKEN:-}" ] || [ "$TOKEN" = "null" ]; then
   echo "no token in response: ${RESP:0:200}" >&2; exit 1
 fi
-echo "export TS_TOKEN=${TOKEN}"
+printf 'export TS_TOKEN=%q\n' "$TOKEN"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get_token.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -37,7 +37,7 @@ Env:
 import argparse, json, os, re, ssl, subprocess, sys, time, urllib.request, urllib.error
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
-import yaml, ts_common, apply_layouts, scout_gate
+import yaml, ts_common, ts_lib, apply_layouts, scout_gate
 from warehouse_column_refs import apply as ground_warehouse_refs
 import metric_binding as _mb    # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 import code_rep  # workbook code-rep document-wrapper adapter (nested POST shape)
@@ -50,7 +50,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 _VENDORED_CONV = os.path.join(HERE, "..", "converter", "thoughtspot.mjs")
 if not os.environ.get("CONVERTER_PATH") and os.path.exists(_VENDORED_CONV):
     os.environ["CONVERTER_PATH"] = _VENDORED_CONV
-_SSL = ssl._create_unverified_context()
+_SSL = ts_lib.ssl_context()
 MCP_TOOL = "mcp__sigma-data-model__convert_thoughtspot_to_sigma"
 
 # Unattended mode (set from --yes in main). Regression fix (gap-scout PR #153):

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/pick_destination.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/pick_destination.py
@@ -32,11 +32,20 @@ def _load_neutral_env():
 def _base():
     return os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com").rstrip("/")
 
+def _validate_base_url(base):
+    # Security (A2): only send Sigma client creds to an https:// sigmacomputing.com host.
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr); return
+    p = urllib.parse.urlparse(base or ""); host = (p.hostname or "").lower()
+    if p.scheme != "https" or not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        sys.exit(f"FATAL: refusing to send Sigma credentials to '{base}' — require https:// on a sigmacomputing.com host (set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override).")
+
 def _token():
     tok = os.environ.get("SIGMA_API_TOKEN")
     if tok:
         return tok
     _load_neutral_env()
+    _validate_base_url(_base())
     data = urllib.parse.urlencode({
         "grant_type": "client_credentials",
         "client_id": os.environ["SIGMA_CLIENT_ID"],

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/scout-validate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/scout-validate.py
@@ -27,7 +27,9 @@ import json, os, sys, ssl, urllib.request, argparse, datetime, re, hashlib
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 import scout_gate
 import code_rep
-_SSL = ssl._create_unverified_context()
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ts_lib
+_SSL = ts_lib.ssl_context()
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
 def api(method, path, body=None, accept_json=True):

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/thoughtspot-render-source.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/thoughtspot-render-source.py
@@ -84,7 +84,7 @@ except Exception:  # ts_screenshot imports yaml at module load; guard the dep
             return False, "not a PNG (error body?)"
         return True, "png signature ok"
 
-_SSL = ssl._create_unverified_context()
+_SSL = ts_lib.ssl_context()
 ENDPOINT = "/api/rest/2.0/report/liveboard"
 
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_lib.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_lib.py
@@ -20,13 +20,39 @@ SCALE NOTES (2026-06-11, for 20-40+ liveboard estates):
     keyed (metadata_id, modified-epoch-ms) — re-runs and multi-liveboard
     migrations skip unchanged exports entirely (hit/miss logged).
 """
-import http.client, json, os, ssl, threading, urllib.parse
+import http.client, json, os, ssl, sys, threading, urllib.parse
 
 HOST = os.environ.get("TS_HOST", "").rstrip("/")
 TOKEN = os.environ.get("TS_TOKEN", "")
-# Trials often sit behind corp TLS interception whose CA Python won't verify
-# (curl uses the system store and works). Use an unverified context.
-_SSL = ssl._create_unverified_context()
+
+
+def ssl_context():
+    """TLS trust resolution. Trials often sit behind corp TLS interception whose
+    CA Python won't verify even though curl/browsers accept it. Prefer the OS
+    trust store (truststore), then certifi, then the stock verified context.
+    NEVER silently downgrades: an unverified context is used ONLY when
+    THOUGHTSPOT_INSECURE_TLS=1 is explicitly set, and it logs loudly."""
+    if os.environ.get("THOUGHTSPOT_INSECURE_TLS") == "1":
+        print("WARNING: THOUGHTSPOT_INSECURE_TLS=1 — TLS verification DISABLED "
+              "for thoughtspot (insecure)", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; matches curl/browser reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
+_SSL = ssl_context()
 _TL = threading.local()      # one persistent keep-alive connection per thread
 
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_screenshot.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_screenshot.py
@@ -20,7 +20,7 @@ import os, sys, json, ssl, struct, urllib.request, urllib.error, re, zlib
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import yaml, ts_lib
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
-_SSL = ssl._create_unverified_context()
+_SSL = ts_lib.ssl_context()
 
 def png_health(data):
     """Heuristic blank/placeholder detection without PIL. Returns (ok, reason).

--- a/shared/lib/sigma_rest.py
+++ b/shared/lib/sigma_rest.py
@@ -45,6 +45,7 @@ import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -155,6 +156,22 @@ def base_url():
     return v
 
 
+def validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        raise SystemExit(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        raise SystemExit(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def token_minted_at():
     """Epoch seconds when the current token was minted, if known. The in-memory
     stamp (set by refresh_token in this process) wins; else SIGMA_TOKEN_MINTED_AT
@@ -259,6 +276,7 @@ def refresh_token():
         secret = os.environ.get("SIGMA_CLIENT_SECRET")
         if not secret:
             raise SigmaAuthError("SIGMA_CLIENT_SECRET not set")
+        validate_base_url(base_url())
         creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
         resp = _send(
             "POST",

--- a/shared/lib/sigma_rest.rb
+++ b/shared/lib/sigma_rest.rb
@@ -102,6 +102,19 @@ module Sigma
     ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
   end
 
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
   # Return a token that is safe to use RIGHT NOW.
   #   - No token anywhere → mint one.
   #   - Known mint time (this process minted it, a parent surfaced
@@ -149,6 +162,7 @@ module Sigma
     begin
       cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
       secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
       creds = Base64.strict_encode64("#{cid}:#{secret}")
       uri = URI("#{base_url}/v2/auth/token")
       req = Net::HTTP::Post.new(uri)

--- a/shared/scripts/get-token.sh
+++ b/shared/scripts/get-token.sh
@@ -17,6 +17,23 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
 # Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
 # settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
 # SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
@@ -57,4 +74,13 @@ if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-echo "export SIGMA_API_TOKEN=${TOKEN}"
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/shared/scripts/get_token.py
+++ b/shared/scripts/get_token.py
@@ -28,8 +28,10 @@ import base64
 import json
 import os
 import re
+import shlex
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
@@ -79,6 +81,22 @@ def _die(msg):
     sys.exit(1)
 
 
+def _validate_base_url(base):
+    """Security (A2): only transmit Sigma credentials to an https://
+    sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+    exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+    SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning)."""
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr)
+        return
+    p = urllib.parse.urlparse(base or "")
+    host = (p.hostname or "").lower()
+    if p.scheme != "https":
+        _die(f"FATAL: SIGMA_BASE_URL must use https:// (got '{base}') — refusing to send Sigma credentials.")
+    if not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        _die(f"FATAL: SIGMA_BASE_URL host '{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev).")
+
+
 def mint_token():
     _load_neutral_env()
     base = os.environ.get("SIGMA_BASE_URL")
@@ -90,6 +108,9 @@ def mint_token():
             "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
             "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
         )
+
+    # Security (A2): validate the base URL BEFORE the client id/secret leaves this process.
+    _validate_base_url(base)
 
     # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
     # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
@@ -131,6 +152,10 @@ def mint_token():
     token = payload.get("access_token")
     if not token:
         _die("Token exchange failed — response did not contain access_token")
+    # Security: the token is emitted for `eval "$(... --print-export)"`; reject any
+    # non-token characters so a poisoned/MITM'd endpoint cannot inject shell.
+    if not re.fullmatch(r"[A-Za-z0-9._~+/=-]+", token):
+        _die("access_token contains unexpected characters — refusing (possible poisoned SIGMA_BASE_URL)")
     return base, token
 
 
@@ -161,13 +186,13 @@ def main():
         wrote = True
 
     if args.print_export:
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
     elif args.print_token:
         print(token)
     elif not wrote:
         # Default with no flags: behave like get-token.sh so `eval "$(...)"`
         # keeps working in bash and nobody's muscle memory breaks.
-        print(f"export SIGMA_API_TOKEN={token}")
+        print(f"export SIGMA_API_TOKEN={shlex.quote(token)}")
 
 
 if __name__ == "__main__":

--- a/shared/scripts/harvest-theme-registry.py
+++ b/shared/scripts/harvest-theme-registry.py
@@ -53,7 +53,17 @@ def api(base, tok, path, accept_json=True, retries=5):
             raise
 
 
+def _validate_base_url(base):
+    # Security (A2): only send Sigma client creds to an https:// sigmacomputing.com host.
+    if os.environ.get("SIGMA_ALLOW_INSECURE_BASE_URL") == "1":
+        print(f"WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ({base})", file=sys.stderr); return
+    p = urllib.parse.urlparse(base or ""); host = (p.hostname or "").lower()
+    if p.scheme != "https" or not (host == "sigmacomputing.com" or host.endswith(".sigmacomputing.com")):
+        sys.exit(f"FATAL: refusing to send Sigma credentials to '{base}' — require https:// on a sigmacomputing.com host (set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override).")
+
+
 def get_token(env):
+    _validate_base_url(env["SIGMA_BASE_URL"])
     data = urllib.parse.urlencode({
         "grant_type": "client_credentials",
         "client_id": env["SIGMA_CLIENT_ID"],

--- a/shared/scripts/setup.rb
+++ b/shared/scripts/setup.rb
@@ -25,6 +25,7 @@ require 'io/console'
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'uri'
 begin
   require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
 rescue LoadError
@@ -161,6 +162,18 @@ base = DEFAULT_BASE if base.empty?
 
 if [base, cid, sec].any?(&:empty?)
   abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
 end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need


### PR DESCRIPTION
Mirrors into dev the security + dependency hardening already on the public mirror, so dev is the safe source of truth and future public syncs are clean.

## A1 — token-output injection (Critical)
Callers run `eval "$(get-token.sh)"`; a poisoned `SIGMA_BASE_URL` returning a metachar-laden token executed arbitrary shell. Now emit via `printf '...=%q'` / `shlex.quote` (charset-validated): `get-token.sh`, `get_token.py`, ThoughtSpot `get-ts-token.sh`, tableau `get-tableau-token.{sh,py}`.

## A2 — validate SIGMA_BASE_URL before sending client creds (High)
Require https:// + a `sigmacomputing.com` host (opt-out `SIGMA_ALLOW_INSECURE_BASE_URL=1`, loud warning). Added to `get-token.sh`, `get_token.py`, `sigma_rest.{py,rb}`, `setup.rb`, and the standalone minters (pick_destination.py ×3, pick-destination.mjs, harvest-theme-registry.py, land-extracts.py). Fanned out via `tools/sync-shared.rb`.

## A3 — TLS verification on by default (Medium)
ThoughtSpot/GoodData/Sisense/`mcp_convert.py`/Qlik: verify-on default; unverified only behind an explicit `<TOOL>_INSECURE_TLS` env with a loud stderr warning — no silent downgrade.

## Tests
`test_sigma_rest.py` (39/39) + `test-setup-noninteractive.rb` updated for the A2 validator. Full tableau `scripts/test-*.rb` suite green.

## Deps (cognos converter)
fast-xml-parser 4.5.6→5.10.1 (clears GHSA-gh4j-gqv2-49f6), esbuild→0.28.2, cli.mjs re-bundled, plugin.json 1.2.19→1.2.20, `npm audit` 0.

Verified locally: A1 grep 0, A2 present in all required files, A3 all env-gated, check-shared 800/800, cognos bundle fresh.