### PR TITLE
fix(tableau): keep parameter switches in workbook layer

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.17",
+  "version": "1.9.18",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -878,6 +878,99 @@ module MechanicalSpecs
     pruned.map { |e| e['name'].to_s }
   end
 
+  # Converter parameter output is workbook metadata, not data-model content.
+  # Keep the raw converter artifact unchanged for diagnostics, but normalize the
+  # result consumed by the orchestrator before it writes conv-meta.json / posts
+  # the DM:
+  #   * simple CASE-on-parameter field/measure switches become param-switch
+  #     workbookPatterns (the converter parser currently accepts quoted WHEN
+  #     values only, while Tableau commonly serializes integer members bare);
+  #   * parameter controls not referenced by any DM formula are removed. A
+  #     genuinely DM-bound control such as parameterized Top-N is preserved.
+  PARAM_CASE_VALUE_RE = /(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[-+]?(?:\d+(?:\.\d*)?|\.\d+)|true|false)/i
+
+  def parameter_case_value(raw)
+    s = raw.to_s.strip
+    return s unless (s.start_with?('"') && s.end_with?('"')) || (s.start_with?("'") && s.end_with?("'"))
+    s[1...-1].gsub(/\\(.)/, '\\1')
+  end
+
+  def parameter_switch_pattern(pattern)
+    return nil unless pattern.is_a?(Hash) && pattern['kind'] == 'param-filter'
+    source = pattern['source'].to_s.gsub(%r{//[^\r\n]*}, '').gsub(/\s+/, ' ').strip
+    match = source.match(/\ACASE\s+\[Parameters?\]\s*\.\s*\[([^\]]+)\]\s+(.+)\s+END\z/i)
+    return nil unless match
+
+    param_name, body = match[1], match[2].strip
+    # Nested CASE/IF branches need a real expression parser; never partially
+    # promote them with this deliberately narrow mechanical recovery.
+    return nil if body.match?(/\b(?:CASE|IF|ELSEIF)\b/i)
+
+    pair_re = /\bWHEN\s+(#{PARAM_CASE_VALUE_RE})\s+THEN\s+(.+?)(?=\s+\bWHEN\b|\s+\bELSE\b|\z)/i
+    cases = body.scan(pair_re).map do |when_value, then_expr|
+      { 'when' => parameter_case_value(when_value), 'then' => then_expr.strip }
+    end
+    return nil if cases.empty?
+
+    consumed = body.gsub(pair_re, '').sub(/\bELSE\s+.+\z/i, '').strip
+    return nil unless consumed.empty?
+    else_expr = body[/\bELSE\s+(.+)\z/i, 1]&.strip
+
+    pattern.merge(
+      'kind' => 'param-switch',
+      'paramName' => pattern['paramName'] || param_name,
+      'cases' => cases,
+      'elseExpr' => else_expr,
+      'requires' => 'WORKBOOK element: a single-select control + a Switch formula on the chart/grouping column; not a data-model control or calculated column.',
+      'note' => "Tableau parameter field switch -> Sigma workbook control-driven Switch (#{cases.size} case(s))."
+    )
+  end
+
+  def normalize_converter_parameters!(result)
+    return result unless result.is_a?(Hash) && result['model'].is_a?(Hash)
+
+    promoted = 0
+    result['workbookPatterns'] = Array(result['workbookPatterns']).map do |pattern|
+      replacement = parameter_switch_pattern(pattern)
+      promoted += 1 if replacement
+      replacement || pattern
+    end
+
+    controls = []
+    data_elements = []
+    (result['model']['pages'] || []).each do |page|
+      Array(page['elements']).each do |element|
+        if element['kind'] == 'control'
+          controls << [page, element]
+        else
+          data_elements << element
+        end
+      end
+    end
+
+    dm_text = JSON.generate(data_elements)
+    preserved = controls.select do |_page, control|
+      id = control['controlId'].to_s
+      !id.empty? && dm_text.include?("[#{id}]")
+    end
+    preserved_ids = preserved.map { |_page, control| control.object_id }.to_set
+    (result['model']['pages'] || []).each do |page|
+      page['elements'] = Array(page['elements']).reject do |element|
+        element['kind'] == 'control' && !preserved_ids.include?(element.object_id)
+      end
+    end
+    removed = controls.size - preserved.size
+
+    stats = result['stats'] ||= {}
+    stats['controls'] = preserved.size
+    warnings = result['warnings'] ||= []
+    warnings << "ℹ Promoted #{promoted} bare-value Tableau parameter CASE calc(s) to workbook param-switch patterns; none were emitted as DM fields." if promoted.positive?
+    if removed.positive?
+      warnings << "ℹ Moved #{removed} unreferenced Tableau parameter control(s) out of the data model; the workbook builder materializes them from parameter metadata."
+    end
+    result
+  end
+
   # Run the Tableau→Sigma converter. Two backends, same output contract
   # ({ model, warnings, stats, security }):
   #   - mcp_build present → node shim importing a LOCAL build/tableau.(m)js
@@ -953,7 +1046,9 @@ module MechanicalSpecs
     JS
     o, e, st = Open3.capture3('node', shim)
     raise "converter failed: #{e}#{o}" unless st.success?
-    JSON.parse(File.read(meta_out))
+    result = normalize_converter_parameters!(JSON.parse(File.read(meta_out)))
+    File.write(meta_out, JSON.pretty_generate(result))
+    result
   end
 
   # Hosted backend: POST the .twb to the convert_tableau_to_sigma tool on the
@@ -991,6 +1086,7 @@ module MechanicalSpecs
                'stats' => out['stats'] || {}, 'security' => out['security'] || [],
                'workbookPatterns' => out['workbookPatterns'] || [], 'parameters' => out['parameters'] || [],
                'relationshipCoverage' => out['relationshipCoverage'] || nil }
+    normalize_converter_parameters!(result)
     File.write(meta_out, JSON.pretty_generate(result))
     result
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/param-display-column.twb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/param-display-column.twb
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<workbook source-build='2024.1.0' version='18.1'>
+  <datasources>
+    <datasource caption='Orders' inline='true' name='federated.orders'>
+      <connection class='federated' dbname='TEST_DB' schema='TEST_SCHEMA'>
+        <relation name='ORDERS' table='[TEST_DB].[TEST_SCHEMA].[ORDERS]' type='table'>
+          <columns>
+            <column datatype='string' name='REGION' ordinal='0' />
+            <column datatype='string' name='CUSTOMER_NAME' ordinal='1' />
+          </columns>
+        </relation>
+      </connection>
+      <column caption='Region' datatype='string' name='[REGION]' role='dimension' type='nominal' />
+      <column caption='Customer Name' datatype='string' name='[CUSTOMER_NAME]' role='dimension' type='nominal' />
+      <column caption='Display Column' datatype='string' name='[Calculation_Display]' role='dimension' type='nominal'>
+        <calculation class='tableau' formula='CASE [Parameters].[Parameter 1] WHEN 1 THEN [Region] WHEN 2 THEN [Customer Name] END' />
+      </column>
+    </datasource>
+    <datasource hasconnection='false' inline='true' name='Parameters'>
+      <column caption='Choose Display Column' datatype='integer' name='[Parameter 1]' param-domain-type='list' role='measure' type='quantitative' value='1'>
+        <members>
+          <member value='1' />
+          <member value='2' />
+        </members>
+      </column>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Dynamic Table'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Orders' name='federated.orders' />
+          </datasources>
+          <datasource-dependencies datasource='federated.orders'>
+            <column caption='Display Column' datatype='string' name='[Calculation_Display]' role='dimension' type='nominal'>
+              <calculation class='tableau' formula='CASE [Parameters].[Parameter 1] WHEN 1 THEN [Region] WHEN 2 THEN [Customer Name] END' />
+            </column>
+            <column-instance column='[Calculation_Display]' derivation='None' name='[none:Calculation_Display:nk]' pivot='key' type='nominal' />
+          </datasource-dependencies>
+        </view>
+        <rows>[federated.orders].[none:Calculation_Display:nk]</rows>
+      </table>
+    </worksheet>
+  </worksheets>
+</workbook>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-controlid-charset.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-controlid-charset.rb
@@ -52,18 +52,24 @@ abort "vendored converter missing: #{VENDORED}" unless File.exist?(VENDORED)
 abort "fixture missing: #{FIXTURE}" unless File.exist?(FIXTURE)
 
 model = nil
+raw_model = nil
 Dir.mktmpdir do |dir|
   conv = MechanicalSpecs.run_converter(
     twb_path: FIXTURE, conn: 'conn-test-1', db: 'ANALYTICS', schema: 'SALES',
     mcp_build: VENDORED, workdir: dir)
   model = conv['model']
+  raw_model = JSON.parse(File.read(File.join(dir, 'dm-raw.json')))
 end
 
-els = (model['pages'] || []).flat_map { |p| p['elements'] || [] }
+els = (raw_model['pages'] || []).flat_map { |p| p['elements'] || [] }
 controls = els.select { |e| e['kind'] == 'control' }
 
-puts 'Part A — structure: parameter controls are emitted'
-check(controls.size >= 2, "at least 2 controls emitted (got #{controls.size})", fails)
+puts 'Part A — raw converter emits controls; migration model moves unreferenced controls to the workbook layer'
+check(controls.size >= 2, "raw artifact contains at least 2 controls (got #{controls.size})", fails)
+normalized_controls = (model['pages'] || []).flat_map { |p| p['elements'] || [] }
+                           .select { |e| e['kind'] == 'control' }
+check(normalized_controls.empty?,
+      "normalized migration DM contains no unreferenced parameter controls (got #{normalized_controls.size})", fails)
 exit 1 unless fails.empty?
 
 CHARSET = /\A[a-zA-Z0-9_-]{1,64}\z/

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-display-column-layer.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-display-column-layer.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression for Tableau dynamic display columns. Parameter controls and their
+# CASE field switches belong to the Sigma workbook, not the data model.
+require 'json'
+require 'tmpdir'
+require_relative 'mechanical-specs'
+
+HERE = __dir__
+VENDORED = File.expand_path('../converter/tableau.mjs', HERE)
+FIXTURE = File.join(HERE, 'test-fixtures', 'param-display-column.twb')
+
+fails = []
+def check(condition, message, fails)
+  fails << message unless condition
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+end
+
+result = nil
+persisted = nil
+Dir.mktmpdir do |dir|
+  result = MechanicalSpecs.run_converter(
+    twb_path: FIXTURE, conn: 'conn-test', db: 'TEST_DB', schema: 'TEST_SCHEMA',
+    mcp_build: VENDORED, workdir: dir
+  )
+  persisted = JSON.parse(File.read(File.join(dir, 'conv-meta.json')))
+end
+
+elements = result.dig('model', 'pages').flat_map { |page| page['elements'] || [] }
+fields = elements.flat_map { |element| Array(element['columns']) + Array(element['metrics']) }
+pattern = Array(result['workbookPatterns']).find { |item| item['name'] == 'Display Column' }
+
+check(elements.none? { |element| element['kind'] == 'control' },
+      'unreferenced Tableau parameter control is absent from the migration DM', fails)
+check(fields.none? { |field| field['name'] == 'Display Column' },
+      'parameter-dependent display column is absent from DM columns and metrics', fails)
+check(result.dig('stats', 'controls') == 0,
+      'normalized converter stats report zero DM controls', fails)
+check(Array(result['parameters']).any? { |parameter| parameter['name'] == 'Choose Display Column' },
+      'parameter metadata remains available to the workbook builder', fails)
+check(pattern && pattern['kind'] == 'param-switch',
+      'bare-integer CASE is promoted from param-filter to workbook param-switch', fails)
+check(pattern && pattern['cases'] == [
+        { 'when' => '1', 'then' => '[Region]' },
+        { 'when' => '2', 'then' => '[Customer Name]' }
+      ], 'workbook switch preserves both display-column branches', fails)
+check(persisted == result, 'conv-meta.json persists the normalized workbook-layer handoff', fails)
+
+# Exercise the existing workbook-pattern consumer against the recovered pattern.
+builder_source = File.read(File.join(HERE, 'build-charts-from-signals.rb'))
+%w[map_column coerce_case_literal remap_param_branch load_param_switches
+   param_switch_for param_switch_inline].each do |method_name|
+  method_source = builder_source.match(/^def #{method_name}\b.*?\n^end$/m)
+  abort "test bug: could not extract #{method_name}" unless method_source
+  eval(method_source[0]) # rubocop:disable Security/Eval - first-party helper test
+end
+$param_switches = []
+$param_switch_by_key = {}
+$param_switch_used = []
+Dir.mktmpdir do |dir|
+  path = File.join(dir, 'conv-meta.json')
+  File.write(path, JSON.generate(result))
+  load_param_switches(path, 'columns_by_guid' => {
+                        'Calculation_Display' => { 'caption' => 'Display Column', 'datatype' => 'string' }
+                      })
+end
+master_map = {
+  '(?i)^Region$' => { 'id' => 'm-region', 'name' => 'Region' },
+  '(?i)^Customer Name$' => { 'id' => 'm-customer', 'name' => 'Customer Name' }
+}
+plan = param_switch_inline(param_switch_for('Calculation_Display'), master_map, {})
+check(plan && plan['sibling_form'] == 'Switch([ctl-parameter-1], "1", [Region], "2", [Customer Name])',
+      'workbook builder materializes the dynamic display column as a control-driven Switch', fails)
+check(plan && plan['branch_refs'] == ['Region', 'Customer Name'],
+      'workbook switch requests both source columns as sibling passthroughs', fails)
+
+# Preserve the deliberate exception: a control referenced by a DM formula is
+# still required at that layer (for example, the converter's Top-N helper).
+synthetic = {
+  'model' => {
+    'pages' => [{ 'elements' => [
+      { 'kind' => 'control', 'controlId' => 'top-n', 'id' => 'ctl-top' },
+      { 'kind' => 'control', 'controlId' => 'unused', 'id' => 'ctl-unused' },
+      { 'kind' => 'table', 'id' => 'table', 'columns' => [
+        { 'id' => 'keep', 'formula' => '[Rank] <= [top-n]', 'name' => 'Keep' }
+      ] }
+    ] }]
+  },
+  'stats' => { 'controls' => 2 }
+}
+MechanicalSpecs.normalize_converter_parameters!(synthetic)
+synthetic_controls = synthetic.dig('model', 'pages', 0, 'elements').select { |element| element['kind'] == 'control' }
+check(synthetic_controls.map { |control| control['controlId'] } == ['top-n'],
+      'DM-referenced parameter control is preserved while an unused sibling is removed', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS - parameter display columns stay in the workbook layer'
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |failure| puts "  - #{failure}" }
+  exit 1
+end


### PR DESCRIPTION
## What & why

Tableau parameter-driven display columns were being emitted as data-model controls and misclassified as filters when CASE branches used bare integer values. Normalize converter output at the migration boundary so simple parameter CASE switches become workbook `param-switch` patterns, unreferenced controls stay out of the data model, and controls genuinely referenced by data-model formulas remain intact. The raw converter artifact is preserved for diagnostics.

## Scope

- Plugin(s) touched: `tableau-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)
- Bumps `tableau-to-sigma` from `1.9.17` to `1.9.18`

## Regression coverage

- Adds a neutral Tableau fixture with a bare-integer parameter CASE display switch.
- Verifies the normalized data model excludes unreferenced parameter controls and parameter-dependent display fields.
- Verifies workbook metadata retains the parameter and produces a control-driven Sigma `Switch` with both sibling columns.
- Verifies controls referenced by data-model formulas remain preserved.
- Updates control-ID coverage to distinguish the unchanged raw artifact from normalized migration output.

## Checklist

- [x] `ruby tools/check-shared.rb` - 767 shared copies matched
- [x] `ruby tools/lint-skills.rb` - green
- [x] `bash tools/hygiene-sweep.sh` - green with committed patterns; optional private pattern file was unavailable in the isolated worktree
- [x] `bash corpus/run-corpus.sh --check` - 29/29 cases passed
- [x] Focused Tableau parameter and LOD regression suite - green
- [x] `git diff --check` - green
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes included
- [x] Bumped the Tableau plugin patch version

## Shared libraries

No shared library changes.