### PR TITLE
fix(tableau): preserve wide flat-table columns

### DIFF
--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.18",
+  "version": "1.9.19",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -29,7 +29,7 @@
 #                       in a workbook spec's pages[].elements[]
 #
 # Per chart zone, the script reads the matching view CSV's first two headers
-# (dim + measure). It then:
+# (dim + measure); flat tables retain every header. It then:
 #   - Maps each header to a master column using the regex map.
 #   - Picks the Sigma element `kind` from chart_kind (with `automatic` → bar
 #     fallback + a warning to verify against the PNG). A VERIFIED per-tile kind
@@ -5714,11 +5714,78 @@ layout.each do |dash|
       # roll-up). And on a grouped table the sort MUST nest inside the grouping
       # entry — element-level sort 400s with "Sort column not found" (verified
       # shape, see qlik-to-sigma refs/sigma-build-gotchas.md; bead f972).
+      #
+      # Unlike charts, a flat detail table is not a dim+measure pair. Tableau's
+      # CSV contains every displayed field, often all discrete dimensions. Keep
+      # the first two columns built above (they carry the mature calc/format
+      # translation), then add every remaining header in source order.
+      aggregation_for = lambda do |header, column|
+        found = (z['aggregations'] || {}).find do |col_ref, _deriv|
+          token = strip_brackets(col_ref).to_s.strip
+          caption = (meta['columns_by_guid'] || {}).dig(token, 'caption').to_s.strip
+          names = [token, caption].reject(&:empty?)
+          names.any? do |name|
+            name.casecmp?(column['name'].to_s.strip) || name.casecmp?(header_base(header.to_s))
+          end
+        end
+        found&.last || infer_csv_agg(header)
+      end
+      if headers.length > 2 && chart_source_eid == opts[:master_id]
+        headers.drop(2).each_with_index do |header, offset|
+          header = header.to_s.strip
+          mapped = map_column(header, mmap) ||
+                   { 'id' => "m-#{header.downcase.gsub(/\W+/, '-')}", 'name' => header }
+          aliases = (meta['column_aliases'] || {})[mapped['name']] ||
+                    (meta['column_aliases'] || {})[header]
+          formula = if mapped['formula']
+                      mapped['formula']
+                    elsif aliases && !aliases.empty?
+                      parts = ["[Master/#{mapped['name']}]"]
+                      aliases.each { |a| parts << a['key'].inspect << a['value'].inspect }
+                      parts << "[Master/#{mapped['name']}]"
+                      "Switch(#{parts.join(', ')})"
+                    else
+                      "[Master/#{mapped['name']}]"
+                    end
+          agg = aggregation_for.call(header, mapped)
+          if DATE_TRUNC.key?(agg)
+            formula = %(DateTrunc("#{DATE_TRUNC[agg]}", #{formula}))
+          elsif agg && agg != 'None' && agg != 'User'
+            formula = render_agg(SIGMA_AGG[agg], formula)
+          end
+          column = {
+            'id' => "t#{offset + 2}-#{el_id}",
+            'name' => mapped['name'],
+            'formula' => formula
+          }
+          fmt = pick_tableau_format(z['formats'], header) ||
+                pick_column_default_format(mapped['name']) ||
+                (mapped['format'].is_a?(Hash) ? mapped['format'] : nil)
+          column['format'] = fmt if fmt
+          element['columns'] << column
+        end
+        warnings << "'#{cap}' flat table retained all #{headers.length} Tableau CSV columns (the chart-oriented path previously kept only two)"
+      elsif headers.length > 2
+        warnings << "'#{cap}' flat table has #{headers.length} Tableau CSV columns but sources a helper element; " \
+                    'only the first two were emitted because the remaining master refs are not reachable from that helper — rebuild the helper with every displayed column'
+      end
+
+      group_by = []
+      calculations = []
+      element['columns'].each_with_index do |column, index|
+        agg = aggregation_for.call(headers[index], column)
+        if agg.nil? || agg == 'None' || DATE_TRUNC.key?(agg)
+          column.delete('format') unless column['format'].is_a?(Hash) && column['format']['kind'] == 'datetime'
+          group_by << column['id']
+        else
+          calculations << column['id']
+        end
+      end
       grouping = {
         'id'           => "g-#{el_id}",
-        'groupBy'      => [dim_col_obj['id']],
-        'calculations' => [meas_col_obj['id']]
+        'groupBy'      => group_by
       }
+      grouping['calculations'] = calculations unless calculations.empty?
       if z['sort']
         dir = z.dig('sort', 'direction').to_s
         grouping['sort'] = [{

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wide-flat-table.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wide-flat-table.rb
@@ -1,0 +1,107 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# A Tableau detail list can place many discrete fields on one shelf. Every CSV
+# header must become a visible Sigma table column; the chart-oriented two-column
+# path is not sufficient for this element kind.
+require 'csv'
+require 'json'
+require 'open3'
+require 'rbconfig'
+require 'tmpdir'
+
+DIR = __dir__
+BUILD = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(condition, message, fails)
+  fails << message unless condition
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+end
+
+dimensions = ['Record ID', 'Owner', 'Category', 'Region', 'Status', 'Updated At']
+headers = dimensions + ['Amount']
+zone = {
+  'id' => 'detail-zone', 'kind' => 'chart', 'caption' => 'Record Detail',
+  'chart_kind' => 'table', 'x_pct' => 0.0, 'y_pct' => 0.0,
+  'w_pct' => 100.0, 'h_pct' => 100.0,
+  'aggregations' => dimensions.to_h { |header| ["[#{header}]", 'None'] }
+                              .merge('[AMOUNT_INTERNAL]' => 'Sum'),
+  'rows_shelf' => {
+    'raw' => headers.map { |header| "[none:#{header}:nk]" }.join(' / '),
+    'fields' => dimensions.map { |header| { 'guid' => header, 'role' => 'dim', 'derivation' => 'none' } } +
+                [{ 'guid' => 'AMOUNT_INTERNAL', 'role' => 'measure', 'derivation' => 'sum' }]
+  },
+  'cols_shelf' => { 'raw' => '', 'fields' => [] },
+  'channels' => {}, 'calculations' => [], 'filters' => []
+}
+layout = [{ 'dashboard' => 'Operations', 'is_story' => false, 'zones' => [zone] }]
+meta = {
+  'worksheets' => {}, 'stories' => [], 'shared_filters' => [],
+  'column_aliases' => {}, 'parameters' => [],
+  'columns_by_guid' => dimensions.to_h do |header|
+    [header, { 'caption' => header,
+               'datatype' => (header == 'Updated At' ? 'datetime' : 'string'),
+               'role' => 'dimension' }]
+  end.merge('AMOUNT_INTERNAL' => { 'caption' => 'Amount', 'datatype' => 'real', 'role' => 'measure' })
+}
+mmap = headers.to_h do |header|
+  ["(?i)^#{Regexp.escape(header)}$",
+   { 'id' => "m-#{header.downcase.gsub(/\W+/, '-')}", 'name' => header }]
+end
+
+result = {}
+log = ''
+Dir.mktmpdir do |dir|
+  views = File.join(dir, 'views')
+  Dir.mkdir(views)
+  File.write(File.join(dir, 'layout.json'), JSON.pretty_generate(layout))
+  File.write(File.join(dir, 'layout-meta.json'), JSON.pretty_generate(meta))
+  File.write(File.join(dir, 'master-map.json'), JSON.pretty_generate(mmap))
+  File.write(File.join(dir, 'get-workbook.json'), JSON.pretty_generate(
+               'workbook' => { 'views' => { 'view' => [{ 'id' => 'view-wide', 'name' => 'Record Detail' }] } }
+             ))
+  CSV.open(File.join(views, 'view-wide.csv'), 'w') do |csv|
+    csv << headers
+    csv << ['R-001', 'A. User', 'Standard', 'West', 'Open', '2026-08-19 09:00:00', '125.50']
+  end
+
+  out = File.join(dir, 'chart-specs.json')
+  stdout, stderr, status = Open3.capture3(
+    RbConfig.ruby, BUILD,
+    '--tableau-dir', dir,
+    '--layout', File.join(dir, 'layout.json'),
+    '--meta', File.join(dir, 'layout-meta.json'),
+    '--master-map', File.join(dir, 'master-map.json'),
+    '--skip-dashboard-read', 'unit-test',
+    '--page-per-dashboard',
+    '--out', out
+  )
+  log = stdout + stderr
+  check(status.success?, "builder exits 0 (got #{status.exitstatus})", fails)
+  result = JSON.parse(File.read(out)) if status.success? && File.exist?(out)
+end
+
+table = Array(result['pages']).flat_map { |page| Array(page['elements']) }
+              .find { |element| element['kind'] == 'table' && element['name'] == 'Record Detail' }
+columns = Array(table && table['columns'])
+grouping = Array(table && table['groupings']).first || {}
+
+check(!table.nil?, 'detail table is emitted', fails)
+check(columns.map { |column| column['name'] } == headers,
+      'all CSV headers are emitted in source order', fails)
+check(grouping['groupBy'] == columns.first(dimensions.length).map { |column| column['id'] },
+      'all non-aggregated detail columns participate in grouping', fails)
+check(grouping['calculations'] == [columns.last && columns.last['id']],
+      'caption-resolved aggregate is the only calculation', fails)
+check(columns.last && columns.last['formula'] == 'Sum([Master/Amount])',
+      'aggregate formula survives beyond the first two CSV headers', fails)
+check(!log.include?('ZONE DROPPED'), 'wide detail table is not dropped', fails)
+
+if fails.empty?
+  puts 'test-wide-flat-table: ALL PASS'
+else
+  puts "test-wide-flat-table: #{fails.size} FAILURE(S)"
+  fails.each { |failure| puts "  - #{failure}" }
+  exit 1
+end


### PR DESCRIPTION
## Summary
- retain every Tableau CSV header when emitting flat Sigma tables
- classify non-aggregated fields as grouping dimensions and caption-resolved aggregates as calculations
- add a hermetic wide-detail-table regression with neutral synthetic data

## Testing
- `ruby scripts/test-wide-flat-table.rb`
- `ruby scripts/test-param-display-column-layer.rb`
- `ruby scripts/test-signal-quality-floor.rb`
- `ruby scripts/test-zone-honesty.rb`
- `ruby scripts/test-build-charts-kind-census.rb`
- `ruby scripts/test-layout-synthesis.rb`
- `ruby scripts/test-arrangement-lint.rb`
- `ruby tools/lint-skills.rb`
- `ruby tools/check-shared.rb`
- `bash corpus/run-corpus.sh --check` (29/29 cases pass)