### PR TITLE
Pin CI Ruby so json gem drift stops breaking corpus goldens

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -5,15 +5,18 @@
 # fallback), and the syntax job only parses files. No secrets are used or
 # needed anywhere in this workflow — keep it that way.
 #
-# Runner deps (verified): ubuntu-24.04 ships python3 (3.12) and bash
+# Runner deps (verified): ubuntu-24.04 ships python3 (3.12), ruby and bash
 # preinstalled. Pinned to ubuntu-24.04 (not -latest) so a runner-image
 # rollover can't silently change the interpreters — but note that pinning the
 # IMAGE does not pin the image's Ruby: ubuntu-24.04 image 20260816.277.1
 # shipped a Ruby whose bundled json gem is >= 2.8, which pretty-prints empty
 # containers as `[]` instead of the historical `[\n\n]`. Every byte-compared
-# corpus golden was generated with the older form, so the jobs that RUN Ruby
-# generators pin Ruby explicitly via setup-ruby. Whole workflow budget:
-# < 2 minutes (locally ~1 s + ~5 s).
+# corpus golden was generated with the older form, so the `corpus` job pins
+# Ruby explicitly via setup-ruby. The pin is deliberately NOT applied to the
+# test-*.rb jobs: those run fine on whatever Ruby the image ships, and
+# setup-ruby's Ruby lacks gems the distro build bundles (webrick, which
+# test-put-layout-prune.rb requires). Whole workflow budget: < 2 minutes
+# (locally ~1 s + ~5 s).
 name: corpus-check
 
 on:
@@ -228,11 +231,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        # Same json-gem pin as the corpus job — several of these suites compare
-        # generated JSON against committed fixtures.
-        with:
-          ruby-version: '3.3'
       - name: Run offline test-*.rb suites
         # EXPLICIT allow-list — only tests that need NO Tableau/Sigma creds or
         # network. Do NOT add test-calc-discovery.rb (needs a Tableau token);
@@ -497,11 +495,6 @@ jobs:
       LC_ALL: en_US.UTF-8
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        # Same json-gem pin as the corpus job — this glob includes suites that
-        # compare generated JSON against committed fixtures.
-        with:
-          ruby-version: '3.3'
       - name: Run EVERY offline test-*.rb (glob, per-file timeout)
         run: |
           set -uo pipefail

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -5,10 +5,15 @@
 # fallback), and the syntax job only parses files. No secrets are used or
 # needed anywhere in this workflow — keep it that way.
 #
-# Runner deps (verified): ubuntu-24.04 ships python3 (3.12), ruby (3.x) and
-# bash preinstalled — no setup-* actions required. Pinned to ubuntu-24.04
-# (not -latest) so a runner-image rollover can't silently change the
-# interpreters. Whole workflow budget: < 2 minutes (locally ~1 s + ~5 s).
+# Runner deps (verified): ubuntu-24.04 ships python3 (3.12) and bash
+# preinstalled. Pinned to ubuntu-24.04 (not -latest) so a runner-image
+# rollover can't silently change the interpreters — but note that pinning the
+# IMAGE does not pin the image's Ruby: ubuntu-24.04 image 20260816.277.1
+# shipped a Ruby whose bundled json gem is >= 2.8, which pretty-prints empty
+# containers as `[]` instead of the historical `[\n\n]`. Every byte-compared
+# corpus golden was generated with the older form, so the jobs that RUN Ruby
+# generators pin Ruby explicitly via setup-ruby. Whole workflow budget:
+# < 2 minutes (locally ~1 s + ~5 s).
 name: corpus-check
 
 on:
@@ -23,6 +28,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        # Pin Ruby (same version the windows-smoke job already pins) so the
+        # bundled json gem keeps the empty-container pretty-print form the
+        # goldens were generated with. Without this, a runner-image Ruby bump
+        # fails every `cmp` golden as an opaque byte offset.
+        with:
+          ruby-version: '3.3'
       - name: Validate every corpus case against its golden
         run: ./corpus/run-corpus.sh --check
       - name: Converter-default regression (issue #227 — vendored default, no silent dev-checkout)
@@ -216,6 +228,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        # Same json-gem pin as the corpus job — several of these suites compare
+        # generated JSON against committed fixtures.
+        with:
+          ruby-version: '3.3'
       - name: Run offline test-*.rb suites
         # EXPLICIT allow-list — only tests that need NO Tableau/Sigma creds or
         # network. Do NOT add test-calc-discovery.rb (needs a Tableau token);
@@ -480,6 +497,11 @@ jobs:
       LC_ALL: en_US.UTF-8
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        # Same json-gem pin as the corpus job — this glob includes suites that
+        # compare generated JSON against committed fixtures.
+        with:
+          ruby-version: '3.3'
       - name: Run EVERY offline test-*.rb (glob, per-file timeout)
         run: |
           set -uo pipefail

--- a/corpus/run-corpus.sh
+++ b/corpus/run-corpus.sh
@@ -32,6 +32,18 @@ cases() {
 }
 
 if [ "$MODE" = "--check" ]; then
+  # json >= 2.8 pretty-prints empty containers as `[]` / `{}` where earlier
+  # versions emitted `[\n\n]` / `{\n\n}`. Every byte-compared golden here was
+  # generated with the older form, so a newer json turns each `cmp` into an
+  # opaque "differ: byte N" with no hint at the cause. Warn up front instead.
+  if command -v ruby >/dev/null 2>&1 &&
+     [ "$(ruby -rjson -e 'print JSON.pretty_generate([]) == "[]"' 2>/dev/null)" = "true" ]; then
+    echo "WARNING: ruby json $(ruby -rjson -e 'print JSON::VERSION') pretty-prints empty containers"
+    echo "         compactly ([] not [<newline><newline>]); goldens were generated with the older"
+    echo "         form, so JSON cmp checks will report byte-level differences. CI pins ruby 3.3"
+    echo "         (.github/workflows/corpus-check.yml) — use the same locally to reproduce."
+  fi
+
   fail=0; total=0
   for c in $(cases); do
     total=$((total + 1))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
`corpus --check` started failing on PRs with an opaque byte offset:

```
corpus/powerbi/workbook-code-release/golden/workbook.json /tmp/.../workbook.json differ: byte 5303, line 219
corpus: 28/29 cases pass
```

Not caused by any PR content. The `ubuntu-24.04` runner image rolled from `20260810.271.1` (last green run on `main`) to `20260816.277.1`, which bumped Ruby to a **json gem >= 2.8**. That release pretty-prints empty containers compactly:

| json | `JSON.pretty_generate({"values"=>[]})` |
|---|---|
| 2.6.3 / 2.7.x | `"values": [\n\n]` |
| >= 2.8 | `"values": []` |

Byte 5303 in the golden is exactly the newline after `"values": [`. Reproduced locally by forcing json 2.9.1 against the same builder — same byte, same line.

The workflow header already pinned the *image* so interpreters couldn't drift; pinning the image turned out not to pin the image's Ruby.

## Fix
- Pin `ruby-version: '3.3'` via `ruby/setup-ruby@v1` on the `corpus` job. The `windows-smoke` job already pinned 3.3 and stayed green through the rollover, which is what isolated the cause.
- The pin is scoped to `corpus` only. Pinning the `test-*.rb` jobs was tried and reverted: `setup-ruby`'s Ruby does not bundle `webrick`, which `test-put-layout-prune.rb` requires, so it traded one failure for another. Those jobs don't byte-compare goldens and are fine on the image Ruby. The rationale is recorded in the workflow header.
- `corpus/run-corpus.sh --check` now warns up front when the local json gem would produce the same mismatch, so the next occurrence reads as a version note rather than a byte offset.
- Goldens are unchanged.

## Test plan
- [x] Reproduced the exact byte/line locally with json 2.9.1
- [x] `./corpus/run-corpus.sh --check` → 29/29 with json 2.6.3, no spurious warning
- [x] Warning path exercised with a stubbed newer json
- [x] `ruby tools/check-shared.rb`, `bash -n corpus/run-corpus.sh`, workflow YAML parses
- [x] CI: `corpus --check` green on the pinned job

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

