### PR TITLE
Fix Power BI extraction, visual bindings, and parity semantics

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -423,6 +423,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-extract-viz-signals.py
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-filters.py
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-viz-kind-parity.py
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-fabric-resolve.py
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/tests/test-extract-model-pbix.py
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/tests/test-extract-report-classic.py
             shared/lib/test_plugin_embed.py

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -300,6 +300,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-phase6-parity-pbi.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-element-match.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-native-query.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-composite-gate.rb

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.37",
+  "version": "1.8.38",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.36",
+  "version": "1.8.37",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.35",
+  "version": "1.8.36",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.34",
+  "version": "1.8.35",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.33",
+  "version": "1.8.34",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -1158,7 +1158,21 @@ def resolve_map_kind(rec, name)
                     action: 'Supply a region-typed column (country/state/county/zip/place) via --bim dataCategory, ' \
                             'or lat+long bindings, to render a real Sigma map — or accept the bar approximation.')
   series = (b['Series'] || b['Legend'] || []).first
-  b['Category'] = [series] if series  # old downgrade kept the legend as the bar category
+  # Native maps use Size for magnitude; the bar fallback reads Y/Values. Carry
+  # the same measure across the downgrade instead of emitting an empty yAxis.
+  if Array(b['Y']).empty? && Array(b['Values']).empty? && !Array(b['Size']).empty?
+    b['Y'] = Array(b.delete('Size')).compact
+  end
+  # A non-geocodable Location still makes a useful bar category.
+  b['Category'] = Array(b['Location']).compact if Array(b['Category']).empty? && !Array(b['Location']).empty?
+  if Array(b['Category']).empty? && series
+    # The old downgrade uses the legend/series as the bar category. Consume the
+    # role: leaving it behind colors by the same column and emits a redundant
+    # interactive legend control targeting a chart that may not be queryable.
+    b['Category'] = [series]
+    b.delete('Series')
+    b.delete('Legend')
+  end
   'bar-chart'
 end
 
@@ -1437,6 +1451,13 @@ def prepare_legend_control!(el, rec, fields, masters, master, legend_qr, target_
   # waterfall charts. Waterfall splitBy keeps its chart-local legend instead.
   return unless %w[bar-chart line-chart area-chart combo-chart scatter-chart
                    pie-chart donut-chart].include?(el['kind'])
+  # A cartesian target without a measure is not queryable and may be stripped
+  # during spec readback. Never emit a dependent control until the target has a
+  # real series; otherwise the control becomes a ghost/dead legend.
+  if %w[bar-chart line-chart area-chart combo-chart scatter-chart].include?(el['kind']) &&
+     Array(el.dig('yAxis', 'columnIds')).empty?
+    return
+  end
 
   # Pie/donut legends are presentation-first and already render in-panel in
   # Sigma. A separate legend control consumes chart canvas height and shrinks the

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-extract-batch.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-extract-batch.py
@@ -110,13 +110,18 @@ def main():
                     "report": {"id": r["id"], "name": r["name"]}, "model": None}
         ds = tm.timed(f"bind:{sl}", lambda w=w, r=r: fab.report_dataset_id(w["id"], r["id"]))
         model = None
+        model_ws = None
         if ds:
-            model = next((m for m in w["models"] if m["id"] == ds), None)
+            model, model_ws = fab.locate_semantic_model(
+                tok, ds, estate=estate, use_cache=not ARGS.no_cache,
+                timings=tm, log=lambda message: print(f"  [{r['name']}] {message}", flush=True))
         if not model:  # fallback: display-name match within the workspace
             model = fab._match(w["models"], r["name"])
+            model_ws = w if model else None
         if model:
-            meta[sl]["model"] = model
-            jobs.append({"name": f"model:{sl}", "ws": w["id"], "kind": "semanticModels",
+            meta[sl]["model"] = dict(model, workspace_id=model_ws["id"],
+                                     workspace_name=model_ws.get("name"))
+            jobs.append({"name": f"model:{sl}", "ws": model_ws["id"], "kind": "semanticModels",
                          "id": model["id"], "fmt": "TMSL"})
         else:
             print(f"  WARN [{r['name']}] no bound semantic model resolved — report-only", flush=True)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_stale_parity.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_stale_parity.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Shape-aware classifier for a stale Power BI Import snapshot versus Sigma's
+# live warehouse. Staleness can explain changed measures or additional buckets;
+# it must never excuse a different dimension representation/schema.
+module PbiStaleParity
+  module_function
+
+  ISO_DATE = /\A\d{4}-\d{2}-\d{2}(?:[T ].*)?\z/.freeze
+  NUMBER = /\A-?\d+(?:\.\d+)?\z/.freeze
+
+  def dimension_key(value)
+    case value
+    when Numeric
+      [:number, value.to_f]
+    else
+      text = value.to_s.strip
+      if text.match?(ISO_DATE)
+        [:date, text[0, 10]]
+      elsif text.match?(NUMBER)
+        [:number, text.to_f]
+      else
+        [:text, text]
+      end
+    end
+  end
+
+  def dimension_keys(rows)
+    Array(rows).map { |row| dimension_key(Array(row)[0]) }
+  end
+
+  # True only when every source bucket still exists at the SAME canonical
+  # dimension type/grain. Values may change in either direction because a stale
+  # snapshot can include rows later corrected/deleted as well as new rows.
+  # Additional Sigma buckets are acceptable; missing source buckets are not.
+  def value_only_stale?(expected_rows, actual_rows)
+    expected = dimension_keys(expected_rows)
+    actual = dimension_keys(actual_rows)
+    return false if expected.empty? || actual.empty?
+    return false unless expected.all? { |key| actual.include?(key) }
+
+    true
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_fabric.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_fabric.py
@@ -349,6 +349,42 @@ def _match(items, needle):
     return next((it for it in items if n in (it.get("name") or "").lower()), None)
 
 
+def _model_owner(estate, model_id):
+    """Return (model, workspace) for a semantic-model id in an estate map."""
+    if not estate or not model_id:
+        return None, None
+    for ws in estate.get("workspaces", []):
+        model = next((m for m in ws.get("models", []) if m.get("id") == model_id), None)
+        if model:
+            return model, ws
+    return None, None
+
+
+def locate_semantic_model(tok, model_id, estate=None, *, use_cache=True,
+                          timings=None, log=lambda s: None):
+    """Locate a semantic model's owning workspace, independent of report scope.
+
+    Shared semantic models can live in a different workspace from the report.
+    Fabric getDefinition requires the MODEL workspace GUID; guessing the report
+    workspace produces a misleading EntityNotFound 404.
+    """
+    model, workspace = _model_owner(estate, model_id)
+    if model:
+        return model, workspace
+
+    if use_cache:
+        cached = load_estate_cache()
+        model, workspace = _model_owner(cached, model_id)
+        if model:
+            return model, workspace
+
+    log(f"[model] semantic model {model_id} is outside the report workspace; "
+        "enumerating accessible workspaces to locate its owner")
+    full_estate = enumerate_estate(tok, timings=timings)
+    save_estate_cache(full_estate)
+    return _model_owner(full_estate, model_id)
+
+
 def resolve_targets(tok, model_name=None, workspace=None, report=None,
                     use_cache=True, timings=None, log=lambda s: None):
     """Resolve (workspace, model, report) using the session estate cache,
@@ -388,13 +424,16 @@ def resolve_targets(tok, model_name=None, workspace=None, report=None,
             # Bind the report's own semantic model (GET reports/{id} -> datasetId).
             dsid = report_dataset_id((r_ws or {}).get("id"), rep["id"])
             if dsid:
-                for w in scope:
-                    m = next((mm for mm in w["models"] if mm.get("id") == dsid), None)
-                    if m:
-                        model, m_ws = m, w
-                        break
-                if not model:  # dataset not in the enumerated estate — use its id directly
-                    model, m_ws = {"id": dsid, "name": None}, r_ws
+                model, m_ws = locate_semantic_model(
+                    tok, dsid, estate=estate, use_cache=use_cache,
+                    timings=timings, log=log)
+                if not model:
+                    raise LookupError(
+                        f"report '{rep.get('name')}' binds semantic model {dsid}, "
+                        "but that model was not found in any accessible workspace")
+                if r_ws and m_ws and r_ws.get("id") != m_ws.get("id"):
+                    log(f"[model] report workspace '{r_ws.get('name')}' uses semantic model "
+                        f"'{model.get('name') or dsid}' from workspace '{m_ws.get('name')}'")
             if not model and scope and scope[0]["models"]:
                 log("[model] WARNING: could not bind the report to its dataset (datasetId "
                     "unavailable) — falling back to the workspace's FIRST model. Pass "
@@ -402,7 +441,8 @@ def resolve_targets(tok, model_name=None, workspace=None, report=None,
                 model, m_ws = scope[0]["models"][0], scope[0]
         elif scope and scope[0]["models"]:
             model, m_ws = scope[0]["models"][0], scope[0]
-        return {"workspace": m_ws or r_ws, "model": model,
+        return {"workspace": m_ws or r_ws, "model_workspace": m_ws,
+                "model": model,
                 "report": rep, "report_workspace": r_ws}
 
     if use_cache:

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
@@ -46,6 +46,7 @@ require 'optparse'
 require 'open3'
 require 'time'
 require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
+require_relative 'lib/pbi_stale_parity'
 
 opts = { extract: false, tol: 0.02 }
 OptionParser.new do |p|
@@ -65,7 +66,8 @@ OptionParser.new do |p|
   p.on('--extract-tol F', Float){ |v| opts[:tol] = v }
   # bead fmte — freshness.json from pbi-freshness.py. When present, the
   # SOURCE-FRESHNESS banner leads both passes, and finalize classifies each
-  # chart MATCH / STALE-EXPLAINED / DIVERGENT (only DIVERGENT blocks).
+  # chart MATCH / STALE-EXPLAINED / DIVERGENT. STALE is reported honestly but
+  # stays non-GREEN until the source model refreshes and strict parity can run.
   p.on('--freshness PATH')      { |v| opts[:fresh] = v }
 end.parse!
 
@@ -232,21 +234,6 @@ if opts[:emit]
   exit 0
 end
 
-# bead fmte — does this chart's delta look like "Sigma shows MORE/newer data"?
-# (extra Sigma-only buckets with none missing, or a larger Sigma total) — the
-# shape a stale import snapshot produces, as opposed to a conversion error.
-def sigma_shows_more?(exp_rows, act_rows)
-  numify = ->(v) { v.is_a?(Numeric) ? v.to_f : (v.to_s.gsub(/[$,%\s]/, '') =~ /\A-?\d+(\.\d+)?\z/ ? v.to_s.gsub(/[$,%\s]/, '').to_f : nil) }
-  exp = exp_rows || []
-  act = act_rows || []
-  exp_dims = exp.map { |r| r[0] }
-  act_dims = act.map { |r| r[0] }
-  return true if (act_dims - exp_dims).any? && (exp_dims - act_dims).empty?
-  exp_sum = exp.map { |r| numify.call(r[1]) }.compact.sum
-  act_sum = act.map { |r| numify.call(r[1]) }.compact.sum
-  act.size >= exp.size && act_sum > exp_sum
-end
-
 if opts[:finalize]
   %i[plan actuals outdir].each { |k| abort("missing --#{k}") unless opts[k] }
   plan = JSON.parse(File.read(opts[:plan]))
@@ -267,14 +254,15 @@ if opts[:finalize]
   failed = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+)$/).flatten
 
   # bead fmte — classify every chart MATCH / STALE-EXPLAINED / DIVERGENT.
-  # A DIVERGE whose delta is "Sigma shows more/newer data" while the source is
-  # stale (or its refresh is failing) is EXPLAINED, not a conversion error.
-  # Only DIVERGENT blocks. Without --freshness, DIVERGE stays DIVERGENT.
+  # A stale explanation is allowed only when every source dimension bucket is
+  # still present at the SAME canonical type/grain. It never excuses schema
+  # drift such as integer Year vs ISO date. Even shape-safe stale deltas remain
+  # non-GREEN: refresh the source and rerun strict parity.
   classes = plan['charts'].map do |c|
     name = c['chart']
     cls = if passed.include?(name)
             'MATCH'
-          elsif fresh_stale? && sigma_shows_more?(c['expected'], c.dig('actual', 'rows'))
+          elsif fresh_stale? && PbiStaleParity.value_only_stale?(c['expected'], c.dig('actual', 'rows'))
             'STALE-EXPLAINED'
           else
             'DIVERGENT'
@@ -285,15 +273,22 @@ if opts[:finalize]
   divergent  = classes.values.count('DIVERGENT')
   if FRESH.any? || stale_expl.positive?
     puts
-    puts 'classification (only DIVERGENT blocks):'
+    puts 'classification (STALE-EXPLAINED is shape-safe but remains non-GREEN):'
     classes.each { |name, cls| puts format('  %-15s %s', cls, name) }
     if stale_expl.positive?
-      puts "  → #{stale_expl} delta(s) are EXPLAINED by the stale PBI snapshot" \
-           "#{FRESH['credsSuspect'] ? ' (refresh failing — creds)' : ''}, not a conversion error."
+      puts "  → #{stale_expl} delta(s) have matching dimension shape and are explained by the stale PBI snapshot" \
+           "#{FRESH['credsSuspect'] ? ' (refresh failing — creds)' : ''}; refresh PBI before claiming exact parity."
     end
   end
 
-  status = total.positive? && divergent.zero? && (passed.size + stale_expl) == total ? 'PASS' : 'FAIL'
+  status =
+    if total.positive? && passed.size == total
+      'PASS'
+    elsif total.positive? && divergent.zero? && (passed.size + stale_expl) == total
+      'STALE'
+    else
+      'FAIL'
+    end
   summary = {
     'workbook_id' => plan.dig('charts', 0, 'workbook_id'),
     'ran_at' => Time.now.utc.iso8601,
@@ -301,7 +296,10 @@ if opts[:finalize]
     'mode' => opts[:extract] ? 'extract' : 'strict',
     'charts_total' => total, 'charts_pass' => passed.size, 'charts_fail' => divergent,
     'charts_stale_explained' => stale_expl,
-    'pass_names' => passed, 'fail_names' => failed,
+    'charts_verified' => passed.size,
+    'pass_names' => passed,
+    'stale_explained_names' => classes.select { |_name, cls| cls == 'STALE-EXPLAINED' }.keys,
+    'fail_names' => classes.select { |_name, cls| cls == 'DIVERGENT' }.keys,
     'classifications' => classes,
     'freshness' => FRESH.empty? ? nil : {
       'lastSuccessfulRefresh' => FRESH.dig('lastSuccessfulRefresh', 'endTime'),

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
@@ -90,7 +90,8 @@ def freshness_banner
   end
   if sd && sd >= 1
     puts "⚠ source is ~#{sd.ceil} day(s) stale — Sigma reads the LIVE warehouse and is"
-    puts '  EXPECTED to show more data; staleness-shaped deltas classify as STALE-EXPLAINED.'
+    puts '  EXPECTED to show different data. Shape-safe deltas may report STALE-EXPLAINED,'
+    puts '  but the run stays non-GREEN until Power BI refreshes and strict parity passes.'
   end
   puts
 end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-fabric-resolve.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-fabric-resolve.py
@@ -2,8 +2,19 @@
 """Offline regressions for report -> semantic-model workspace resolution."""
 
 import copy
+import sys
+import types
 import unittest
 from unittest import mock
+
+# This suite exercises pure estate-resolution logic. CI intentionally does not
+# install the live auth stack, so provide inert import shims before loading the
+# module; no test calls authentication or HTTP.
+truststore = types.ModuleType("truststore")
+truststore.inject_into_ssl = lambda: None
+sys.modules.setdefault("truststore", truststore)
+sys.modules.setdefault("msal", types.ModuleType("msal"))
+sys.modules.setdefault("requests", types.ModuleType("requests"))
 
 import pbi_fabric as fab
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-fabric-resolve.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-fabric-resolve.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Offline regressions for report -> semantic-model workspace resolution."""
+
+import copy
+import unittest
+from unittest import mock
+
+import pbi_fabric as fab
+
+
+REPORT_WS = {
+    "id": "11111111-1111-4111-8111-111111111111",
+    "name": "Reports",
+    "models": [],
+    "reports": [{"id": "report-1", "name": "Employee Dashboard"}],
+}
+MODEL_WS = {
+    "id": "22222222-2222-4222-8222-222222222222",
+    "name": "Shared Models",
+    "models": [{"id": "model-1", "name": "Workforce"}],
+    "reports": [],
+}
+ESTATE = {"fetchedAt": "fixture", "workspaces": [REPORT_WS, MODEL_WS]}
+
+
+class CrossWorkspaceResolutionTest(unittest.TestCase):
+    def test_locate_model_owner_in_full_estate(self):
+        model, workspace = fab.locate_semantic_model(
+            "token", "model-1", estate=copy.deepcopy(ESTATE), use_cache=False)
+        self.assertEqual("Workforce", model["name"])
+        self.assertEqual(MODEL_WS["id"], workspace["id"])
+
+    def test_scoped_report_resolves_remote_model_workspace(self):
+        messages = []
+        with mock.patch.object(fab, "load_estate_cache", return_value=copy.deepcopy(ESTATE)), \
+             mock.patch.object(fab, "report_dataset_id", return_value="model-1"):
+            hit = fab.resolve_targets(
+                "token", workspace=REPORT_WS["id"], report="Employee Dashboard",
+                log=messages.append)
+        self.assertEqual(MODEL_WS["id"], hit["workspace"]["id"])
+        self.assertEqual(MODEL_WS["id"], hit["model_workspace"]["id"])
+        self.assertEqual(REPORT_WS["id"], hit["report_workspace"]["id"])
+        self.assertTrue(any("uses semantic model" in message for message in messages))
+
+    def test_same_workspace_binding_is_unchanged(self):
+        same = copy.deepcopy(ESTATE)
+        same["workspaces"][0]["models"] = [{"id": "model-1", "name": "Workforce"}]
+        with mock.patch.object(fab, "load_estate_cache", return_value=same), \
+             mock.patch.object(fab, "report_dataset_id", return_value="model-1"):
+            hit = fab.resolve_targets(
+                "token", workspace=REPORT_WS["id"], report="Employee Dashboard")
+        self.assertEqual(REPORT_WS["id"], hit["workspace"]["id"])
+        self.assertEqual(REPORT_WS["id"], hit["report_workspace"]["id"])
+
+    def test_inaccessible_bound_model_fails_before_get_definition(self):
+        partial = {"fetchedAt": "fixture", "workspaces": [copy.deepcopy(REPORT_WS)]}
+        with mock.patch.object(fab, "load_estate_cache", return_value=partial), \
+             mock.patch.object(fab, "enumerate_estate", return_value=partial), \
+             mock.patch.object(fab, "save_estate_cache"), \
+             mock.patch.object(fab, "report_dataset_id", return_value="missing-model"):
+            with self.assertRaisesRegex(LookupError, "not found in any accessible workspace"):
+                fab.resolve_targets(
+                    "token", workspace=REPORT_WS["id"], report="Employee Dashboard")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-phase6-parity-pbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-phase6-parity-pbi.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Contract tests for strict Power BI parity versus stale Import snapshots.
+# Shape-safe stale deltas are diagnostic STALE, never PASS; dimension/type
+# mismatches stay DIVERGENT even when refresh is old.
+
+require 'json'
+require 'open3'
+require 'tmpdir'
+
+SCRIPT = File.join(__dir__, 'phase6-parity-pbi.rb')
+fails = []
+def check(condition, message, fails)
+  fails << message unless condition
+  puts "  #{condition ? 'PASS' : 'FAIL'}  #{message}"
+end
+
+def run_case(expected:, actual:, freshness: nil)
+  Dir.mktmpdir do |dir|
+    plan = {
+      'source' => 'powerbi-executequeries',
+      'extract' => false,
+      'charts' => [{ 'chart' => 'Chart A', 'expected' => expected, 'workbook_id' => 'wb-1' }]
+    }
+    plan_path = File.join(dir, 'plan.json')
+    actuals_path = File.join(dir, 'actuals.json')
+    File.write(plan_path, JSON.generate(plan))
+    File.write(actuals_path, JSON.generate('Chart A' => actual))
+    args = ['ruby', SCRIPT, '--finalize', '--plan', plan_path,
+            '--actuals', actuals_path, '--out-dir', dir]
+    if freshness
+      freshness_path = File.join(dir, 'freshness.json')
+      File.write(freshness_path, JSON.generate(freshness))
+      args += ['--freshness', freshness_path]
+    end
+    out, err, status = Open3.capture3(*args)
+    summary = JSON.parse(File.read(File.join(dir, 'parity-final.json')))
+    [status.exitstatus, summary, out + err]
+  end
+end
+
+puts 'strict match'
+code, summary, = run_case(expected: [['East', 10]], actual: [['East', 10]])
+check(code.zero? && summary['status'] == 'PASS' && summary['charts_pass'] == 1,
+      '1/1 strict match is the only PASS path', fails)
+
+puts 'shape-safe stale value delta'
+stale = { 'staleDays' => 82, 'credsSuspect' => true, 'failures' => [{ 'errorCode' => 'refresh' }] }
+code, summary, output = run_case(expected: [['East', 10]], actual: [['East', 12]], freshness: stale)
+check(code == 2 && summary['status'] == 'STALE' &&
+      summary['charts_stale_explained'] == 1 && summary['charts_fail'].zero?,
+      'same dimension shape + stale values reports STALE, not PASS', fails)
+check(output.include?('refresh PBI before claiming exact parity'),
+      'stale result prints the remediation instead of a green claim', fails)
+
+puts 'additional live bucket on stale source'
+code, summary, = run_case(
+  expected: [['East', 10]],
+  actual: [['East', 12], ['West', 3]],
+  freshness: stale
+)
+check(code == 2 && summary['status'] == 'STALE' &&
+      summary['classifications']['Chart A'] == 'STALE-EXPLAINED',
+      'Sigma-only bucket extension remains shape-safe STALE', fails)
+
+puts 'dimension type/grain mismatch on stale source'
+code, summary, = run_case(
+  expected: [[2024, 10]],
+  actual: [['2024-01-01T00:00:00.000Z', 12]],
+  freshness: stale
+)
+check(code == 2 && summary['status'] == 'FAIL' &&
+      summary['charts_stale_explained'].zero? && summary['charts_fail'] == 1,
+      'integer Year versus ISO date is DIVERGENT, never stale-explained', fails)
+check(summary['fail_names'] == ['Chart A'],
+      'shape-divergent chart is named in fail_names', fails)
+
+if fails.empty?
+  puts 'ALL PASS'
+  exit 0
+end
+
+warn "#{fails.size} FAILURE(S):"
+fails.each { |failure| warn "  - #{failure}" }
+exit 1

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-complete.rb
@@ -29,33 +29,51 @@ Dir.mktmpdir do |wd|
   check(out.include?('NOT DONE') && out.include?('never hand-author'),
         'empty-workdir message warns against hand-authoring', fails)
 
-  # 2) success marker with real charts → DONE (0)
+  # 2) resolution marker alone is not value parity → NOT DONE (5)
   File.write(File.join(wd, 'phase6-success.json'),
-             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'parity-pass',
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'resolution-pass',
                            'generatedAt' => '2026-07-10T00:00:00Z'))
   code, out = run_vc(VC, wd)
-  check(code == 0, "success + charts => exit 0 (got #{code})", fails)
-  check(out.include?('DONE') && out.include?('wb-1'), 'done message names the workbook', fails)
+  check(code == 5, "success marker without value parity => exit 5 (got #{code})", fails)
+  check(out.include?('value parity was not run'), 'missing parity message names the required gate', fails)
 
-  # 3) marker present but 0 charts → NOT DONE (3) (empty workbook)
+  # 3) strict parity for every chart → DONE (0)
+  File.write(File.join(wd, 'parity-final.json'),
+             JSON.generate('status' => 'PASS', 'charts_total' => 9,
+                           'charts_pass' => 9, 'charts_fail' => 0))
+  code, out = run_vc(VC, wd)
+  check(code == 0, "success + charts => exit 0 (got #{code})", fails)
+  check(out.include?('DONE') && out.include?('wb-1') && out.include?('9/9 strict matches'),
+        'done message names workbook + strict parity evidence', fails)
+
+  # 4) stale-only parity never claims DONE, even if its writer says PASS.
+  File.write(File.join(wd, 'parity-final.json'),
+             JSON.generate('status' => 'PASS', 'charts_total' => 4,
+                           'charts_pass' => 0, 'charts_fail' => 0,
+                           'charts_stale_explained' => 4))
+  code, out = run_vc(VC, wd)
+  check(code == 5 && out.include?('stale-explained'),
+        'status PASS with 0 strict matches is rejected as stale/inconsistent', fails)
+
+  # 5) marker present but 0 charts → NOT DONE (3) (empty workbook)
   File.write(File.join(wd, 'phase6-success.json'),
              JSON.generate('workbookId' => 'wb-1', 'chartCount' => 0))
   code, = run_vc(VC, wd)
   check(code == 3, "0-chart marker => exit 3 empty (got #{code})", fails)
 
-  # 4) workbook mismatch → exit 4
+  # 6) workbook mismatch → exit 4
   File.write(File.join(wd, 'phase6-success.json'),
              JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9))
   code, = run_vc(VC, wd, wb: 'wb-OTHER')
   check(code == 4, "workbook mismatch => exit 4 (got #{code})", fails)
 end
 
-# 5) the orchestrator wires the empty-workbook guard + success stamp.
+# 7) the orchestrator wires the empty-workbook guard + success stamp.
 mt = File.read(File.join(DIR, 'migrate-powerbi.rb'))
 check(mt.include?('built_ok = parity_ok && chart_els.size.positive?'),
       'orchestrator requires real elements for a green (no vacuous empty pass)', fails)
 check(mt.include?('phase6-success.json'), 'orchestrator stamps the success sentinel', fails)
-# 6) missing-input aborts point at the device-code connect, not a bare "missing".
+# 8) missing-input aborts point at the device-code connect, not a bare "missing".
 check(mt.include?('fabric-extract.py') && mt.include?('microsoft.com/devicelogin'),
       'missing --tmsl/--pbir abort prompts device-code Power BI connect', fails)
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-viz-role-routing.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-viz-role-routing.rb
@@ -273,6 +273,39 @@ check(Array(cov5['unresolved']).none? { |u| %w[Coordinate\ Map Sized\ Coordinate
 check(cov5.dig('summary', 'sourceBindings') == 7 && cov5.dig('summary', 'resolvedBindings') == 7,
       'all seven source coordinate/size/series bindings are honestly resolved', fails)
 
+# =============================================================================
+# Scenario 6: Azure Map without coordinates/geocodable metadata downgrades to a
+# DATA-PRESERVING bar. Series becomes the category and Size becomes Y; the
+# consumed Series must not also emit a color legend/control.
+# =============================================================================
+fallback_signals = {
+  'source' => 'powerbi', 'pages' => [{
+    'page_id' => 'p0', 'page_title' => 'Fallback Map', 'page_w' => 1280, 'page_h' => 720,
+    'interactions' => [], 'visuals' => [
+      azure_visual.call('map-fallback', 'Group Magnitude', {
+                          'Series' => ['G.Group'], 'Size' => ['G.Metric']
+                        })
+    ]
+  }]
+}
+out6, cov6 = run_builder(sig: fallback_signals, mmap: geo_mmap)
+els6 = out6.dig('document', 'elements')
+fallback = els6.find { |e| e['name'] == 'Group Magnitude' }
+check(fallback && fallback['kind'] == 'bar-chart',
+      'coordinate-less Azure Map uses the documented bar fallback', fails)
+fallback_y = fallback && fallback['columns'].find { |c| Array(fallback.dig('yAxis', 'columnIds')).include?(c['id']) }
+check(fallback_y && fallback_y['formula'] == 'Sum([master-geo/Metric])',
+      "Azure Size survives downgrade as the bar measure (got #{fallback_y && fallback_y['formula']})", fails)
+fallback_x = fallback && fallback['columns'].find { |c| c['id'] == fallback.dig('xAxis', 'columnId') }
+check(fallback_x && fallback_x['formula'] == '[master-geo/Group]' && !fallback.key?('color'),
+      'Azure Series is consumed as the bar category, not duplicated as color', fails)
+check(els6.none? { |e| e['kind'] == 'control' && e['controlType'] == 'legend' },
+      'no dependent legend control is emitted for the consumed Series role', fails)
+fallback_cov = Array(cov6['unresolved']).find { |u| u['visual'] == 'Group Magnitude' }
+check(fallback_cov && fallback_cov['severity'] == 'approximated' &&
+      Array(cov6['unresolved']).none? { |u| u['visual'] == 'Group Magnitude' && u['detail'].to_s.include?('no measure') },
+      'coverage records only the honest map→bar approximation, not a missing-measure defect', fails)
+
 puts
 puts(fails.empty? ? 'ALL PASS' : "#{fails.size} FAILURE(S)")
 fails.each { |f| puts "  - #{f}" }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-complete.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-complete.rb
@@ -10,23 +10,20 @@
 # a shell) never gets that marker, because the orchestrator refuses to green a
 # 0-element build. So "built" is a fact on disk, not "the pages look right".
 #
-# IMPORTANT — what the marker does and does NOT prove: the one-shot orchestrator's
-# gate is a RESOLUTION check (every column resolves + warehouse freshness matches),
-# recorded as gates:'resolution-pass'. It does NOT diff the built aggregates against
-# the source's DAX/SQL results. VALUE PARITY is a separate gate — assert-phase6-ran.rb
-# / phase6-parity-pbi.rb, which writes parity-final.json — and this script reports its
-# status separately so a green here is never mistaken for "numbers verified vs source".
-# (Aligning powerbi/qlik to the assert-phase6-ran-stamped marker the other plugins use
-# is tracked under the runtime-contract completion seam, bead p5y2.)
+# IMPORTANT: the one-shot orchestrator's marker proves resolution/non-empty
+# structure only. This verifier additionally requires parity-final.json with
+# every chart strict-PASS. A stale Import snapshot is useful diagnostic evidence
+# but not completion; refresh Power BI and rerun parity before handoff.
 #
 # Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
 #
 # Exit codes:
-#   0  DONE   — phase6-success.json present with chartCount > 0 (built + resolution-verified;
-#              value-parity status reported separately from parity-final.json)
+#   0  DONE   — non-empty build marker + parity-final.json proving every chart
+#              strict-PASS against the source
 #   2  NOT DONE — no success marker (conversion didn't complete / was hand-built)
 #   3  NOT DONE — marker present but 0 chart elements (empty workbook)
 #   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
+#   5  NOT DONE — value parity missing, stale-only, divergent, or internally inconsistent
 
 require 'json'
 require 'optparse'
@@ -66,23 +63,32 @@ end
 # (assert-phase6-ran.rb / phase6-parity-pbi.rb) writes parity-final.json; surface its
 # status honestly rather than implying the one-shot build already value-verified.
 pf = File.join(opts[:wd], 'parity-final.json')
-vparity = begin
-  st = File.exist?(pf) ? JSON.parse(File.read(pf))['status'].to_s.upcase : nil
-  st && (st == 'PASS' ? 'CONFIRMED (parity-final.json)' : "#{st} (parity-final.json)")
+pf_doc = begin
+  File.exist?(pf) ? JSON.parse(File.read(pf)) : nil
 rescue StandardError
   nil
+end
+unless pf_doc
+  warn '⛔ NOT DONE — value parity was not run (parity-final.json missing/unreadable).'
+  warn '   Run phase6-parity-pbi.rb and assert-phase6-ran.rb before handoff.'
+  exit 5
+end
+status = pf_doc['status'].to_s.upcase
+total = pf_doc['charts_total'].to_i
+passed = pf_doc['charts_pass'].to_i
+failed = pf_doc['charts_fail'].to_i
+unless status == 'PASS' && total.positive? && passed == total && failed.zero?
+  warn "⛔ NOT DONE — value parity is #{status.empty? ? 'UNKNOWN' : status}: " \
+       "#{passed}/#{total} strict chart matches, #{failed} divergent."
+  stale = pf_doc['charts_stale_explained'].to_i
+  warn "   #{stale} chart(s) are stale-explained; refresh Power BI and rerun strict parity." if stale.positive?
+  exit 5
 end
 
 puts '✅ DONE — migrate-powerbi.rb built a resolution-verified workbook for this run.'
 puts "   workbook     : #{sj['workbookId']}"
 puts "   charts       : #{sj['chartCount']}"
 puts "   gates        : #{sj['gates']} (columns resolve + freshness match)"
-if vparity
-  puts "   value parity : #{vparity}"
-else
-  puts '   value parity : NOT RUN in this path — the build resolved but its aggregates were'
-  puts '                  NOT diffed vs the source. Run assert-phase6-ran.rb / phase6-parity-pbi.rb'
-  puts '                  before reporting numeric parity with Power BI.'
-end
+puts "   value parity : CONFIRMED — #{passed}/#{total} strict matches (parity-final.json)"
 puts "   stamped      : #{sj['generatedAt']}"
 exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Live Power BI baseline testing found three correctness defects:
1. A report bound to a semantic model in another workspace queried `getDefinition` in the report workspace and 404ed.
2. An Azure Map fallback dropped its Size measure, emitted an empty y-axis, and then emitted a dead legend targeting the broken chart.
3. An 82-day stale Import snapshot allowed an integer-Year vs ISO-date shape mismatch to be labeled `STALE-EXPLAINED`; `parity-final.json` said PASS while `assert-phase6-ran` rejected 0/4 strict matches.

## Changes

- Resolve semantic model ownership across all accessible Fabric workspaces; batch extraction uses the model workspace too and fails clearly when inaccessible.
- On map→bar downgrade, promote `Size` to Y, consume Series as Category, and emit a dependent legend only for a queryable chart.
- Add shape-aware stale classification: every source dimension bucket must exist at the same canonical type/grain.
- Stale-explained runs remain non-GREEN (`STALE`); only strict all-chart equality writes `PASS`.
- `verify-complete.rb` now requires a non-empty build marker plus strict `parity-final.json` evidence and agrees with the final gate.

## Scope

- Plugin: `powerbi-to-sigma`
- CI registration for new plugin tests
- Phase numbers unchanged
- Plugin version 1.8.33 → 1.8.38

## Verification

- [x] Cross-workspace resolver tests
- [x] Azure Map fallback/legend role-routing tests
- [x] Shape-aware stale/strict finalizer tests
- [x] Completion-marker consistency tests
- [x] Every Power BI Ruby and Python suite
- [x] `./corpus/run-corpus.sh --check powerbi` — **4/4**
- [x] shared/skill/variant/provenance governance
- [x] Live cross-workspace extraction: report from `Test`, model TMSL from `My workspace`, no 404
- [x] Live map fallback: grounded `CountDistinct(Employee Id)` y-axis, no ghost legend, 100% source bindings resolved
- [x] Live parity contract: 3 shape-safe stale charts + 1 Year/date shape divergence → `status=FAIL`; `assert-phase6-ran` exit 2 and `verify-complete` exit 5 agree

Exact value parity remains intentionally blocked until the Power BI model's Snowflake credentials are repaired and its Import snapshot refreshes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

