### PR TITLE
Allow accounted Sisense gaps as YELLOW

### DIFF
--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense \u2192 Sigma",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma \u2014 data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sisense-to-sigma/README.md
+++ b/plugins/sisense-to-sigma/README.md
@@ -20,8 +20,8 @@ workbook, layout, and parity.
 2. **(opt-in) RLS scan** — `detect_rls.py`: Sisense data-security → Sigma row-level security (zero-overhead when none).
 3. **Convert model** — `convert.py model`: warehouse-table elements + relationships (cardinality-resolved), ElastiCube custom-SQL → Sigma SQL (verbatim + flagged). POST + read back real ids.
 4. **Convert dashboards** — `convert.py dashboard`: current `{name, document}` workbook request with flat elements, metadata-only pages, and required authoritative layout; indicator→KPI (bounded gauge→progress), waterfall/chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; Sisense columnar layout → Sigma 24-col grid. Unsupported/release-gated features are loud gaps.
-5. **Verify parity** — `verify_parity.py` (data: Sisense JAQL == warehouse) + `verify_layout.py` (structural layout) + render visual-QA (`sigma-export-png.py` + `refs/layout-visual-qa.md`).
-6. **Gap scout** — `scan_gaps.py` measures coverage, records gaps to a `learned-rules.json` ledger; `escalate-gap.py` files a tracking issue (opt-in).
+5. **Verify parity** — `verify_parity.py` proves every emitted widget (including approximations) matches Sisense JAQL; explicitly skipped/not-applicable omissions stay in the source census but are excluded from required chart parity. `verify_layout.py` and render visual-QA cover the emitted workbook.
+6. **Account and report** — `scan_gaps.py` inventories the full source, then census-backed accounting turns explicit manual gaps into an honest YELLOW handoff. Missing/contradictory objects or emitted divergence remain RED.
 
 ## Status
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
@@ -48,10 +48,13 @@ widgets) — never emit confidently-wrong logic.
 >   empty "placeholder" pages.** Post only the specs `convert.py` produces. If you
 >   can't reach Sisense (no host/token), **STOP and tell the user to
 >   authenticate** — do not build a shell.
-> - **Both verify gates must be GREEN with REAL elements before you're done.**
+> - **Both verify gates must pass with REAL emitted elements before a terminal
+>   handoff.**
 >   `verify_parity.py` and `verify_layout.py` now **refuse a vacuous pass** — a
 >   workbook with zero widgets/checks is RED, not "0/0 GREEN". A migration with
->   nothing to verify is not done.
+>   nothing to verify is not done. Final reporting is GREEN only for a fully
+>   faithful run, YELLOW/exit 0 for a usable but explicitly degraded handoff,
+>   and RED for failed gates or missing/contradictory accounting.
 >
 > **READ FIRST — `refs/operating-contract.md`**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
 > **Modeling strategy — `refs/modeling-strategy.md`**: faithful reproduction of the source model is the DEFAULT (parity is the gate); an upstream OBT or Sigma-native materialization is an OPT-IN optimization for hot, join-heavy dashboards, re-verified against the same parity oracle. The converter never auto-flattens.
@@ -106,9 +109,11 @@ python3 scripts/migrate-sisense.py --from-discovery <dir> \
 ```
 
 It retains every phase artifact, requires explicit RLS and visual-waiver
-decisions, and declares completion only after strict JAQL parity, readback,
-render health, shared hard gates, and the census-backed migration report are
-GREEN. Exit 10 is an unresolved RLS decision; exit 2 is a failed migration.
+decisions, and declares completion only after emitted-scope JAQL parity,
+readback, render health, shared hard gates, and census-backed accounting
+reconcile. GREEN and YELLOW are complete exit-0 handoffs; RED is blocked.
+Exit 10 means an unresolved RLS or waiver-budget decision; exit 2 is a failed
+migration.
 
 ### Core scripts
 
@@ -119,8 +124,8 @@ GREEN. Exit 10 is an unresolved RLS decision; exit 2 is a failed migration.
 | `scan_gaps.py` | Human coverage report plus deterministic structured object/gap census. |
 | `convert.py` | Convert model (`model`) and dashboards (`dashboard`). |
 | `post-sisense-spec.py` | Idempotent Sigma DM/workbook POST-or-readback helper; writes authoritative IDs/readbacks and tracks posted workbooks. |
-| `build-sisense-parity.py` | Build grounded JAQL/warehouse checks and normalize `verify_parity.py` output into `parity-final.json`; zero executable checks is RED. |
-| `build-sisense-accounting.py` / `build-sisense-control-scope.py` | Reconcile every model/dashboard object and source filter into the census, coverage, control census, and static control-scope contracts. |
+| `build-sisense-parity.py` | Build grounded JAQL/warehouse checks for every emitted widget and normalize `verify_parity.py` output into `parity-final.json`; zero executable checks, an emitted widget without parity, or proven divergence is RED. Explicitly skipped/not-applicable omissions remain in the source census but are excluded from required chart parity. |
+| `build-sisense-accounting.py` / `check-accounted-gaps.py` / `build-sisense-control-scope.py` | Reconcile every model/dashboard object and source filter into the census, accept only explicit terminal gap dispositions, and build control census/scope contracts. |
 | `finalize-sisense-report.py` / `verify-complete.rb` | All-page PNG health + tile-aware similarity, degradation/report freshness, and final all-pass completion verification. |
 | `verify_parity.py` | Data-value parity gate. |
 | `verify_layout.py` | Structural layout parity gate. |
@@ -136,9 +141,13 @@ every source model table/column/relation/transformation plus every
 dashboard/widget/filter. The deterministic report contains stable object ids,
 status, evidence, provenance, summary counts, and unresolved gaps; the existing
 human stdout and `learned-rules.json` append ledger remain available. It is the
-**flag-never-fake gate**: run it at convert time and again at the shared
-done-gate (`--strict` exits non-zero while any MANUAL/UNHANDLED/flagged gap is
-unresolved). For a gap with no clean Sigma translation, `escalate-gap.py`
+**flag-never-fake census**: run it before conversion. `--strict` is a raw
+pre-accounting diagnostic and therefore still exits non-zero for every
+MANUAL/UNHANDLED/flagged source gap. The orchestrated done-gate instead runs
+`build-sisense-accounting.py` followed by `check-accounted-gaps.py`: a fully
+accounted `approximated`, `needs-review`, or `skipped` disposition is a YELLOW
+handoff, while missing, unaccounted, contradictory, or failed emitted parity is
+RED. For a gap with no clean Sigma translation, `escalate-gap.py`
 (opt-in, dry-run by default) drafts a tracking issue — file it only on `--yes`.
 Durable support boundaries and evidence requirements live in
 `refs/open-items.md`.
@@ -237,10 +246,13 @@ arrangement (no separate post-hoc layout PUT needed; CREATE preserves the ids
 the layout references). See `refs/design-notes.md` ("Layout").
 
 ## Phase 4 — Verify parity  ✅ live-validated
-Two gates, both must be **GREEN** before claiming done:
+Both hard gates must pass before a GREEN or YELLOW terminal handoff:
 - **Data** — `verify_parity.py` runs each widget's JAQL (`POST
   /api/datasources/{ds}/jaql`) and compares to the warehouse SQL Sigma compiles
-  to (+ a Sigma `query` spot-check). Proves the numbers match.
+  to (+ a Sigma `query` spot-check). Every emitted widget—including an
+  approximation—must pass. Explicitly skipped/not-applicable omitted widgets
+  are excluded from required chart parity but remain in `gap-report.json`,
+  `source-object-census.json`, and the final report. Proven divergence is RED.
 - **Layout** — `verify_layout.py <dashboards.json> <sigma_workbook_spec.json>`
   proves the arrangement came over: every mapped widget placed exactly once, no
   orphan refs, inside the 24-col grid, no overlaps, reading order preserved,
@@ -249,11 +261,16 @@ Two gates, both must be **GREEN** before claiming done:
 - **Visual QA** — structural-green is not visually-correct. Render each page with
   `sigma-export-png.py` and read it against `refs/layout-visual-qa.md` (compare
   to the Sisense source PNG). Declare done on a clean render, not an HTTP 200.
-- **Gap scout** — re-run `scan_gaps.py <dashboards.json> --model <model.json>
-  --out gap-report.json --strict`; no unresolved MANUAL/UNHANDLED/flagged gap
-  may remain unaccounted-for. Preserve `gap-report.json` and the other phase
-  artifacts; the forthcoming one-command wrapper must use the same shared
-  hard-gate completion contract rather than a parallel success path.
+- **Accounted-gap gate** — after parity, run source accounting and
+  `check-accounted-gaps.py`. Every source object must have exactly one terminal
+  status. Manual/unhandled/flagged objects may produce an honest YELLOW
+  disposition; omissions or contradictions remain RED.
+
+The orchestrator order is gap census → conversion/POST → emitted-scope parity →
+accounting → accounted-gap gate → shared assert → final report/verification.
+`--accept-waiver-budget-exceeded REASON` passes the named decision to the shared
+assert only after all prior gates pass. Without acceptance, shared exit 19
+becomes decision-required exit 10; accepted overflow is YELLOW/exit 0.
 
 ## Phase 5 — Repoint + enhance
 Wire workbook → DM. Layout is already ported by `convert.py dashboard` (Phase 3)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/operating-contract.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/operating-contract.md
@@ -21,7 +21,10 @@
   Apply the source's dashboard/widget filters so aggregates run over the same
   **population** — otherwise ratios/averages drift even when formulas are "right."
 - **Rebuild every source viz** (indicators, trends, pivots). If a viz has no standalone
-  data export, reconstruct it from the model. **Never silently drop a tile.**
+  data export, reconstruct it from the model. **Never silently drop a tile.** A
+  capability-gap omission must stay in the source census with an explicit
+  `skipped`/`not-applicable` terminal disposition; that is a YELLOW handoff,
+  not faithful GREEN.
 
 ## Verify — don't assume (this is what keeps you on the rails)
 - After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
@@ -40,6 +43,10 @@
 - If you've retried the same failing step ~2×, change approach or surface it — never grind.
 
 ## Done means
-- 0 error columns; every page rendered and visually matching the source; every KPI's
-  number matching the source (or the delta explained); controls present and wired; no
-  silently dropped tiles. Anything short of that is **reported, not hidden.**
+- 0 error columns; every emitted page rendered; every emitted KPI/chart value
+  matching the source; controls present and wired; and every source object
+  accounted exactly once. GREEN means faithful reproduction. YELLOW is a
+  complete, usable handoff with explicit approximated/needs-review/skipped
+  rows or named waivers. Missing/contradictory accounting, emitted divergence,
+  or any failed hard gate is RED. Anything short of GREEN is **reported, not
+  hidden.**

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/build-sisense-accounting.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/build-sisense-accounting.py
@@ -95,6 +95,13 @@ class Accountant:
         if not self.parity_pass:
             self.parity_pass = {folded(name) for name in parity.get("pass_names") or []}
         self.mapping_text = folded(json.dumps(docs.get("jaql") or {}, sort_keys=True))
+        self.gap_categories = {}
+        for row in (docs.get("gap") or {}).get("gaps") or []:
+            if isinstance(row, dict):
+                self.gap_categories.setdefault(
+                    (str(row.get("object_type") or ""), str(row.get("object_id") or "")),
+                    set(),
+                ).add(str(row.get("category") or ""))
 
     def validate_scan(self):
         scan = self.docs["gap"]
@@ -267,15 +274,30 @@ class Accountant:
         if scan_status == "not-applicable":
             return "not-applicable"
         if scan_status == "unhandled":
-            return "skipped" if kind == "widget" else "needs-review"
+            return "needs-review" if built else ("skipped" if kind == "widget" else "needs-review")
         if scan_status == "manual":
-            return "needs-review"
+            return "skipped" if kind == "widget" and not built else "needs-review"
         if scan_status == "hint":
+            categories = self.gap_categories.get(
+                (str(kind), str(source.get("id") or "")), set()
+            )
+            if kind == "widget" and not built and categories.intersection(
+                    {"manual", "unhandled", "flagged"}):
+                return "skipped"
             if built and (kind not in ("widget", "filter") or self.parity_for(source)):
                 return "approximated"
             return "needs-review"
         if scan_status == "auto":
             if not built:
+                # Static/widget-local filter rows are source logic evidence, not
+                # necessarily standalone controls. Their terminal needs-review
+                # disposition is honest accounting; emitted widget scope is
+                # policed separately by build-sisense-parity.py.
+                if kind != "filter":
+                    self.errors.append(
+                        "%s:%s is in scope but no matching target object was found" %
+                        (kind, source.get("id"))
+                    )
                 return "needs-review"
             if kind == "widget" and not self.parity_for(source):
                 return "needs-review"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/build-sisense-parity.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/build-sisense-parity.py
@@ -59,6 +59,67 @@ def datasource_name(widget, dashboard, fallback):
     return fallback
 
 
+def folded(value):
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def workbook_elements(workbook):
+    root = workbook.get("document", workbook) if isinstance(workbook, dict) else {}
+    rows = [row for row in root.get("elements") or [] if isinstance(row, dict)]
+    for page in root.get("pages") or []:
+        if isinstance(page, dict):
+            rows.extend(row for row in page.get("elements") or [] if isinstance(row, dict))
+    return rows
+
+
+def emitted_widget_keys(workbook):
+    """Return a one-use name census for emitted visualization elements."""
+    result = {}
+    for element in workbook_elements(workbook):
+        if element.get("visibleAsSource") is False:
+            continue
+        if element.get("kind") in ("control", "container", "divider", "image", "text"):
+            continue
+        if element.get("controlType") or element.get("id") == "master":
+            continue
+        key = folded(element.get("name") or element.get("title"))
+        if key:
+            result[key] = result.get(key, 0) + 1
+    return result
+
+
+def gap_widget_policy(gap):
+    """Map source widget ids to explicit pre-conversion gap dispositions."""
+    policies = {}
+    if not isinstance(gap, dict):
+        return policies
+    categories = {}
+    for row in gap.get("gaps") or []:
+        if isinstance(row, dict) and row.get("object_type") == "widget":
+            categories.setdefault(str(row.get("object_id")), set()).add(
+                str(row.get("category") or "")
+            )
+    for row in gap.get("objects") or []:
+        if not isinstance(row, dict) or row.get("type") != "widget":
+            continue
+        widget_id = str(row.get("id"))
+        scan_status = str(row.get("status") or "")
+        row_categories = categories.get(widget_id, set())
+        if scan_status == "not-applicable":
+            disposition = "not-applicable"
+        elif scan_status in ("manual", "unhandled") or row_categories.intersection(
+                {"manual", "unhandled", "flagged"}):
+            disposition = "skipped"
+        else:
+            disposition = None
+        policies[widget_id] = {
+            "scan_status": scan_status,
+            "gap_categories": sorted(row_categories),
+            "omitted_disposition": disposition,
+        }
+    return policies
+
+
 def model_tables(model):
     result = {}
     for dataset in model.get("datasets") or []:
@@ -130,11 +191,11 @@ def simple_check(widget, dashboard, model, cube, database, schema):
     }, None
 
 
-def tile_census(widgets, checks):
-    """Reconcile checks to source widgets without counting an override blindly."""
+def tile_census(source_widgets, required_widgets, omitted_widgets, checks):
+    """Reconcile checks to emitted scope while retaining the full source census."""
     remaining = list(checks)
     unmatched = []
-    for widget in widgets:
+    for widget in required_widgets:
         matched_index = None
         for index, check in enumerate(remaining):
             widget_id = str(widget.get("id") or "")
@@ -150,17 +211,24 @@ def tile_census(widgets, checks):
             remaining.pop(matched_index)
     return {
         # Canonical shared assert-phase6-ran.rb contract.
-        "zones_total": len(widgets),
-        "charts_built": len(widgets) - len(unmatched),
+        "zones_total": len(required_widgets),
+        "charts_built": len(required_widgets) - len(unmatched),
         "zones_unmatched": len(unmatched),
         "unmatched_zone_names": [row["name"] for row in unmatched],
         # Sisense-specific detail retained for accounting/report consumers.
-        "source_tiles": len(widgets),
+        "source_tiles": len(source_widgets),
+        "emitted_tiles": len(required_widgets),
+        "omitted_tiles": len(omitted_widgets),
+        "unexpected_omissions": sum(
+            row.get("disposition") == "missing" for row in omitted_widgets
+        ),
         "planned_tiles": len(checks),
         "needs_review_tiles": len(unmatched),
         "extra_checks": len(remaining),
         "unmatched_tiles": unmatched,
-        "source": widgets,
+        "source": source_widgets,
+        "required": required_widgets,
+        "omitted": omitted_widgets,
     }
 
 
@@ -168,13 +236,46 @@ def build(args):
     dashboards = read_json(args.dashboards)
     dashboards = dashboards if isinstance(dashboards, list) else [dashboards]
     model = read_json(args.model)
-    checks, review, widgets = [], [], []
+    workbook = read_json(args.workbook) if args.workbook else None
+    gap = read_json(args.gap_report) if args.gap_report else None
+    emitted_names = emitted_widget_keys(workbook) if workbook is not None else None
+    policies = gap_widget_policy(gap)
+    checks, review, widgets, required, omitted = [], [], [], [], []
     for dashboard in dashboards:
         for widget in dashboard.get("widgets") or []:
             widget_id = widget.get("_id") or widget.get("oid") or widget.get("title")
             name = widget.get("title") or str(widget_id)
-            widgets.append({"id": widget_id, "name": name,
-                            "dashboard": dashboard.get("title")})
+            source_row = {
+                "id": widget_id, "name": name,
+                "dashboard": dashboard.get("title"),
+            }
+            widgets.append(source_row)
+            emitted = True
+            if emitted_names is not None:
+                key = folded(name)
+                emitted = emitted_names.get(key, 0) > 0
+                if emitted:
+                    emitted_names[key] -= 1
+            policy = policies.get(str(widget_id), {})
+            if not emitted:
+                disposition = policy.get("omitted_disposition")
+                omitted_row = {
+                    **source_row,
+                    "disposition": disposition or "missing",
+                    "scan_status": policy.get("scan_status"),
+                    "gap_categories": policy.get("gap_categories") or [],
+                }
+                omitted.append(omitted_row)
+                if disposition in ("skipped", "not-applicable"):
+                    continue
+                review.append({
+                    "widget_id": widget_id, "name": name,
+                    "status": "missing",
+                    "reason": "in-scope widget was not emitted and has no explicit skip/not-applicable disposition",
+                    "sql_generated": False,
+                })
+                continue
+            required.append(source_row)
             check, reason = simple_check(
                 widget, dashboard, model, args.cube,
                 args.database, args.schema,
@@ -194,9 +295,12 @@ def build(args):
         if not isinstance(override, list):
             raise ValueError("--parity-checks must be a JSON array")
         checks = override
-    census = tile_census(widgets, checks)
+    census = tile_census(widgets, required, omitted, checks)
     unmatched_ids = {str(row.get("id")) for row in census["unmatched_tiles"]}
-    review = [row for row in review if str(row.get("widget_id")) in unmatched_ids]
+    review = [
+        row for row in review
+        if str(row.get("widget_id")) in unmatched_ids
+    ]
     plan = {
         "schema_version": 1,
         "source": "sisense",
@@ -208,13 +312,34 @@ def build(args):
         ],
         "needs_review": review,
         "tile_census": census,
+        "scope_policy": {
+            "source_widgets": len(widgets),
+            "required_emitted_widgets": len(required),
+            "explicitly_omitted_widgets": len(omitted) - sum(
+                row["disposition"] == "missing" for row in omitted
+            ),
+            "unexpected_omissions": sum(
+                row["disposition"] == "missing" for row in omitted
+            ),
+        },
     }
     write_json(args.checks_out, checks)
     write_json(args.plan_out, plan)
-    print("Sisense parity plan: %d check(s), %d needs-review widget(s)" %
-          (len(checks), len(review)))
-    if not checks:
-        print("RED: zero executable parity checks", file=sys.stderr)
+    print(
+        "Sisense parity plan: %d/%d emitted widget check(s), "
+        "%d explicitly omitted, %d needs-review" %
+        (len(checks), len(required),
+         plan["scope_policy"]["explicitly_omitted_widgets"], len(review))
+    )
+    if (not checks or census["zones_unmatched"] or census["extra_checks"] or
+            plan["scope_policy"]["unexpected_omissions"]):
+        print(
+            "RED: emitted parity scope is incomplete "
+            "(required=%d checks=%d unmatched=%d extra=%d)" %
+            (len(required), len(checks), census["zones_unmatched"],
+             census["extra_checks"]),
+            file=sys.stderr,
+        )
         return 1
     return 0
 
@@ -253,6 +378,7 @@ def normalize(args):
         int(census.get("zones_total") or 0) > 0
         and int(census.get("zones_unmatched") or 0) == 0
         and int(census.get("extra_checks") or 0) == 0
+        and int(census.get("unexpected_omissions") or 0) == 0
     )
     status = (
         "PASS"
@@ -289,6 +415,10 @@ def main(argv=None):
     make.add_argument("--database", required=True)
     make.add_argument("--schema", required=True)
     make.add_argument("--parity-checks")
+    make.add_argument("--workbook",
+                      help="converted/read-back workbook used to define emitted scope")
+    make.add_argument("--gap-report",
+                      help="structured source census with explicit omitted gaps")
     make.add_argument("--checks-out", required=True)
     make.add_argument("--plan-out", required=True)
     finish = sub.add_parser("normalize")

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/check-accounted-gaps.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/check-accounted-gaps.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Require every structured Sisense gap to have one honest terminal disposition."""
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+TERMINAL = {"migrated", "approximated", "needs-review", "skipped", "not-applicable"}
+YELLOW_GAP_TERMINAL = {"approximated", "needs-review", "skipped"}
+
+
+def read_json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8-sig"))
+
+
+def write_json(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp.%d" % os.getpid())
+    temporary.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def identity(row, source=False):
+    if source:
+        return str(row.get("type") or ""), str(row.get("id") or "")
+    return (
+        str(row.get("type") or row.get("object_type") or ""),
+        str(row.get("id") or row.get("source_object_id") or row.get("object_id") or ""),
+    )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gap-report", required=True)
+    parser.add_argument("--census", required=True)
+    parser.add_argument("--parity")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args(argv)
+
+    gap = read_json(args.gap_report)
+    census = read_json(args.census)
+    parity = read_json(args.parity) if args.parity else None
+    source_rows = gap.get("objects") if isinstance(gap, dict) else None
+    census_rows = census.get("objects") if isinstance(census, dict) else None
+    errors = []
+    if not isinstance(source_rows, list):
+        errors.append("gap report has no objects array")
+        source_rows = []
+    if not isinstance(census_rows, list):
+        errors.append("source census has no objects array")
+        census_rows = []
+
+    source_counts = Counter(identity(row, True) for row in source_rows if isinstance(row, dict))
+    census_counts = Counter(identity(row) for row in census_rows if isinstance(row, dict))
+    duplicate_source = sorted(key for key, count in source_counts.items() if count != 1)
+    duplicate_census = sorted(key for key, count in census_counts.items() if count != 1)
+    if duplicate_source:
+        errors.append("duplicate source identities: %s" % duplicate_source)
+    if duplicate_census:
+        errors.append("duplicate census identities: %s" % duplicate_census)
+    missing = sorted(set(source_counts) - set(census_counts))
+    extra = sorted(set(census_counts) - set(source_counts))
+    if missing:
+        errors.append("source objects missing from accounting: %s" % missing)
+    if extra:
+        errors.append("accounting rows absent from source census: %s" % extra)
+
+    by_identity = {
+        identity(row): row for row in census_rows
+        if isinstance(row, dict) and census_counts[identity(row)] == 1
+    }
+    nonterminal = sorted(
+        "%s:%s=%s" % (*identity(row), row.get("status"))
+        for row in census_rows
+        if isinstance(row, dict) and str(row.get("status") or "") not in TERMINAL
+    )
+    if nonterminal:
+        errors.append("non-terminal accounting rows: %s" % nonterminal)
+    summary = census.get("summary") if isinstance(census, dict) else {}
+    if not isinstance(summary, dict) or summary.get("complete") is not True:
+        errors.append("source census summary is not complete")
+    if int((summary or {}).get("total") or -1) != len(source_rows):
+        errors.append("source census total does not match structured gap census")
+    if int((summary or {}).get("accounted") or -1) != len(source_rows):
+        errors.append("source census is not fully accounted")
+
+    gap_results = []
+    for row in gap.get("gaps") or []:
+        if not isinstance(row, dict):
+            errors.append("gap detail is not an object")
+            continue
+        key = identity(row)
+        accounted = by_identity.get(key)
+        status = str((accounted or {}).get("status") or "missing")
+        category = str(row.get("category") or "")
+        allowed = status in YELLOW_GAP_TERMINAL
+        if not allowed:
+            errors.append(
+                "%s gap %s:%s has disposition %s; expected one of %s" %
+                (category or "structured", key[0], key[1], status,
+                 sorted(YELLOW_GAP_TERMINAL))
+            )
+        gap_results.append({
+            "category": category,
+            "type": key[0],
+            "id": key[1],
+            "name": row.get("object_name"),
+            "terminal_status": status,
+            "accounted": allowed,
+        })
+
+    if isinstance(parity, dict):
+        parity_status = str(parity.get("status") or "").upper()
+        if parity_status not in ("PASS", "GREEN") or parity.get("strict_complete") is not True:
+            errors.append("emitted-scope parity is not strict PASS")
+        omitted = ((parity.get("tile_census") or {}).get("omitted") or [])
+        for row in omitted:
+            if not isinstance(row, dict):
+                continue
+            accounted = by_identity.get(("widget", str(row.get("id") or "")))
+            expected = str(row.get("disposition") or "")
+            actual = str((accounted or {}).get("status") or "missing")
+            if expected not in ("skipped", "not-applicable") or actual != expected:
+                errors.append(
+                    "omitted widget %s parity/accounting disposition mismatch (%s != %s)" %
+                    (row.get("id"), expected, actual)
+                )
+
+    result = {
+        "schema_version": 1,
+        "status": "PASS" if not errors else "FAIL",
+        "source_objects": len(source_rows),
+        "accounted_objects": len(census_rows),
+        "gaps": gap_results,
+        "errors": errors,
+    }
+    write_json(args.out, result)
+    if errors:
+        print("RED: accounted-gap gate failed", file=sys.stderr)
+        for error in errors:
+            print("  - " + error, file=sys.stderr)
+        return 1
+    print(
+        "Accounted-gap gate: PASS (%d/%d objects; %d terminal YELLOW gap disposition(s))" %
+        (len(census_rows), len(source_rows), len(gap_results))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print("check-accounted-gaps: %s" % error, file=sys.stderr)
+        sys.exit(2)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/migrate-sisense.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/migrate-sisense.py
@@ -197,6 +197,38 @@ def run_accounting(workdir, gap, model, dashboards, provenance, parity=None):
     return run(command, check=False)[0]
 
 
+def run_accounted_gap_check(workdir, gap, parity=None):
+    command = [
+        sys.executable, HERE / "check-accounted-gaps.py",
+        "--gap-report", gap,
+        "--census", workdir / "source-object-census.json",
+        "--out", workdir / "accounted-gap-result.json",
+    ]
+    if parity and Path(parity).is_file():
+        command += ["--parity", parity]
+    return run(command, check=False)[0]
+
+
+def reconcile_terminal_marker(workdir):
+    """Make the shared all-pass marker quote the plugin's TerminalOutcome verdict."""
+    report = read_json(workdir / "migration-result.json")
+    marker_path = workdir / "phase6-success.json"
+    marker = read_json(marker_path)
+    verdict = str(report.get("verdict") or "RED").upper()
+    if report.get("completion_status") != "complete" or verdict not in ("GREEN", "YELLOW"):
+        raise MigrationError(
+            "final report is not a complete TerminalOutcome handoff: %s/%s" %
+            (verdict, report.get("completion_status"))
+        )
+    previous = marker.get("verdict")
+    if previous and str(previous).upper() != verdict:
+        marker["shared_verdict"] = previous
+    marker["verdict"] = verdict
+    marker["completion_status"] = "complete"
+    write_json(marker_path, marker)
+    return verdict
+
+
 def tile_boxes(workbook, page_id, output):
     """Derive render-side tile boxes from the authoritative inline layout."""
     root = workbook.get("document", workbook)
@@ -300,6 +332,15 @@ def visual_gate_options(args):
     return []
 
 
+def shared_gate_outcome(returncode, acceptance_reason=None):
+    """Map the shared gate's process contract to Sisense terminal policy."""
+    if returncode == 0:
+        return 0
+    if returncode == 19 and not str(acceptance_reason or "").strip():
+        return 10
+    return 2
+
+
 def main(argv=None):
     # Resolve neutral-file environment overrides before argparse captures its
     # defaults. This is read-only and occurs before any live API operation.
@@ -342,6 +383,10 @@ def main(argv=None):
                         metavar="PAGE=REASON")
     parser.add_argument("--skip-visual-comparison", metavar="REASON")
     parser.add_argument("--blind-grade", metavar="PATH")
+    parser.add_argument(
+        "--accept-waiver-budget-exceeded", metavar="REASON",
+        help="accept shared-gate exit 19 as a named terminal YELLOW decision",
+    )
     args = parser.parse_args(argv)
     if args.dry_run and args.reuse_dm:
         parser.error("--dry-run cannot use a live --reuse-dm")
@@ -349,6 +394,9 @@ def main(argv=None):
         parser.error("--skip-visual-comparison requires a non-empty reason")
     if args.blind_grade and args.skip_visual_comparison:
         parser.error("--blind-grade and --skip-visual-comparison are mutually exclusive")
+    if (args.accept_waiver_budget_exceeded is not None and
+            not args.accept_waiver_budget_exceeded.strip()):
+        parser.error("--accept-waiver-budget-exceeded requires a non-empty reason")
     if not args.dry_run and args.from_discovery is None and not args.cube:
         parser.error("live discovery requires --cube")
     if args.dry_run:
@@ -578,44 +626,40 @@ def main(argv=None):
                              (lint_rc, layout_rc))
     record("workbook-convert-layout")
 
-    parity_plan = workdir / "parity-plan.json"
-    parity_checks = workdir / "parity-checks.json"
-    parity_build = [
-        sys.executable, HERE / "build-sisense-parity.py", "build",
-        "--dashboards", dashboards_path, "--model", model_path,
-        "--cube", cube, "--database", args.database, "--schema", args.schema,
-        "--checks-out", parity_checks, "--plan-out", parity_plan,
-    ]
-    if args.parity_checks:
-        parity_build += ["--parity-checks", args.parity_checks]
-    parity_plan_rc, _ = run(parity_build, check=False)
-
     if args.dry_run:
-        phase("6", "offline dry-run accounting (no POST/parity/render)")
-        strict_rc, _ = run([
-            sys.executable, HERE / "scan_gaps.py", dashboards_path,
-            "--model", model_path, "--out", gap_path,
-            "--rules", workdir / "learned-rules.json", "--strict",
-        ], cwd=workdir, check=False)
+        phase("6", "offline emitted-scope parity planning and accounting")
+        parity_plan = workdir / "parity-plan.json"
+        parity_checks = workdir / "parity-checks.json"
+        parity_build = [
+            sys.executable, HERE / "build-sisense-parity.py", "build",
+            "--dashboards", dashboards_path, "--model", model_path,
+            "--cube", cube, "--database", args.database, "--schema", args.schema,
+            "--workbook", wb_spec, "--gap-report", gap_path,
+            "--checks-out", parity_checks, "--plan-out", parity_plan,
+        ]
+        if args.parity_checks:
+            parity_build += ["--parity-checks", args.parity_checks]
+        parity_plan_rc, _ = run(parity_build, check=False)
         accounting_rc = run_accounting(
             workdir, gap_path, model_path, dashboards_path, provenance
+        )
+        accounted_gap_rc = (
+            run_accounted_gap_check(workdir, gap_path)
+            if accounting_rc == 0 else 1
         )
         record(
             "dry-run-finished", "incomplete",
             complete=False, post_complete=False, parity_complete=False,
             render_complete=False, success_stamped=False,
-            strict_gap_complete=(strict_rc == 0),
             parity_plan_complete=(parity_plan_rc == 0),
             accounting_complete=(accounting_rc == 0),
+            accounted_gap_complete=(accounted_gap_rc == 0),
         )
         print("\nDRY RUN COMPLETE: discovery, scans, model/workbook conversion, "
               "blank-risk lint, layout, parity planning, and accounting exercised.")
         print("POST/parity/render are explicitly NOT complete; no success marker was stamped.")
         print("artifacts: %s" % workdir)
         return 0
-
-    if parity_plan_rc:
-        raise MigrationError("parity planning produced zero executable checks")
 
     phase("5c", "POST/readback workbook")
     post_wb = [
@@ -628,7 +672,25 @@ def main(argv=None):
     wb_id = read_json(workdir / "wb-ids.json")["workbookId"]
     record("workbook-post-readback", post_complete=True)
 
-    phase("6", "JAQL parity and normalized final contract")
+    phase("6", "build parity scope from emitted workbook")
+    parity_plan = workdir / "parity-plan.json"
+    parity_checks = workdir / "parity-checks.json"
+    parity_build = [
+        sys.executable, HERE / "build-sisense-parity.py", "build",
+        "--dashboards", dashboards_path, "--model", model_path,
+        "--cube", cube, "--database", args.database, "--schema", args.schema,
+        "--workbook", workdir / "wb-readback.json", "--gap-report", gap_path,
+        "--checks-out", parity_checks, "--plan-out", parity_plan,
+    ]
+    if args.parity_checks:
+        parity_build += ["--parity-checks", args.parity_checks]
+    parity_plan_rc, _ = run(parity_build, check=False)
+    if parity_plan_rc:
+        record("parity-scope", "failed")
+        return 2
+    record("parity-scope")
+
+    phase("6b", "JAQL parity and normalized final contract")
     verify_rc, _ = run([
         sys.executable, HERE / "verify_parity.py", parity_checks,
         "--snow-conn", args.snow_conn,
@@ -671,9 +733,6 @@ def main(argv=None):
                 "%s=%s" % (name, by_stem[name])
                 for name in target_names if name in by_stem
             ]
-    source_dashboards = read_json(dashboards_path)
-    source_dashboards = source_dashboards if isinstance(source_dashboards, list) else [source_dashboards]
-    source_widget_count = sum(len(row.get("widgets") or []) for row in source_dashboards)
     tiles = []
     layout_pages = []
     for page in pages:
@@ -682,7 +741,9 @@ def main(argv=None):
         tiles.append("%s=%s" % (page["id"], tile_path))
         layout_pages.append({
             "page": page.get("name") or page["id"],
-            "zones": source_widget_count if len(pages) == 1 else len(page_tiles),
+            # Layout scope follows emitted elements. Explicit source omissions
+            # remain in source-object-census.json, not as phantom layout zones.
+            "zones": len(page_tiles),
             "placed": len(page_tiles),
             "grid_fill_pct": round(grid_fill, 6),
             "unplaced_elements": unplaced,
@@ -703,7 +764,7 @@ def main(argv=None):
     run(visual_command)
     record("visual", render_complete=True)
 
-    phase("8", "control probe, orphan cleanup, strict gap gate")
+    phase("8", "control probe, cleanup, and source accounting")
     controls = [row for row in (read_json(wb_spec).get("document") or {}).get("elements") or []
                 if row.get("kind") == "control" or row.get("controlType")]
     if controls:
@@ -721,26 +782,22 @@ def main(argv=None):
         "ruby", HERE / "cleanup-orphan-workbooks.rb",
         "--workdir", workdir, "--keep", wb_id,
     ])
-    strict_rc, _ = run([
-        sys.executable, HERE / "scan_gaps.py", dashboards_path,
-        "--model", model_path, "--out", gap_path,
-        "--rules", workdir / "learned-rules.json", "--strict",
-    ], cwd=workdir, check=False)
-    if strict_rc:
-        record("strict-gap", "failed")
-        return 2
-
-    # The shared gate consumes source-vs-built control scope. Build a
-    # preliminary census now, then refresh the same accounting after the gate
-    # so the final report is post-gate evidence.
-    preliminary_accounting_rc = run_accounting(
+    accounting_rc = run_accounting(
         workdir, gap_path, model_path, dashboards_path, provenance,
         workdir / "parity-final.json",
     )
-    if preliminary_accounting_rc:
-        record("preliminary-accounting", "failed")
+    if accounting_rc:
+        record("accounting", "failed")
         return 2
-    record("preliminary-accounting")
+    record("accounting")
+
+    accounted_gap_rc = run_accounted_gap_check(
+        workdir, gap_path, workdir / "parity-final.json"
+    )
+    if accounted_gap_rc:
+        record("accounted-gap", "failed")
+        return 2
+    record("accounted-gap")
 
     control_scope = workdir / "control-scope.json"
     control_scope_rc, _ = run([
@@ -789,19 +846,29 @@ def main(argv=None):
     if targets:
         gate += ["--sigma-render", targets[0].split("=", 1)[1]]
     gate += visual_gate_options(args)
+    if args.accept_waiver_budget_exceeded:
+        gate += [
+            "--accept-waiver-budget-exceeded",
+            args.accept_waiver_budget_exceeded,
+        ]
     gate_rc, _ = run(gate, check=False)
     if gate_rc:
+        outcome = shared_gate_outcome(
+            gate_rc, args.accept_waiver_budget_exceeded
+        )
+        if outcome == 10:
+            record("shared-assert", "decision-required")
+            print(
+                "DECISION REQUIRED: shared waiver budget exceeded. "
+                "Resolve waivers or rerun with "
+                "--accept-waiver-budget-exceeded REASON for a YELLOW handoff.",
+                file=sys.stderr,
+            )
+            return 10
         record("shared-assert", "failed")
-        return 2
+        return outcome
 
-    phase("10", "post-gate accounting and final report")
-    accounting_rc = run_accounting(
-        workdir, gap_path, model_path, dashboards_path, provenance,
-        workdir / "parity-final.json",
-    )
-    if accounting_rc:
-        record("accounting", "failed")
-        return 2
+    phase("10", "final report from reconciled accounting")
     final_command = [
         sys.executable, HERE / "finalize-sisense-report.py",
         "--workdir", workdir,
@@ -817,6 +884,7 @@ def main(argv=None):
     if run(final_command, check=False)[0]:
         record("report", "failed")
         return 2
+    reconcile_terminal_marker(workdir)
     record("report")
 
     phase("11", "verify complete")
@@ -827,8 +895,15 @@ def main(argv=None):
     if verify_complete_rc:
         record("verify-complete", "failed", complete=False)
         return 2
-    record("verify-complete", complete=True, success_stamped=True)
-    print("\nSisense migration COMPLETE: DM %s, workbook %s, %.1fs" %
+    migration_result = read_json(workdir / "migration-result.json")
+    verdict = str(migration_result.get("verdict") or "RED").upper()
+    completion_status = migration_result.get("completion_status")
+    record(
+        "verify-complete", complete=True, success_stamped=True,
+        terminal_verdict=verdict, completion_status=completion_status,
+    )
+    print("\nSisense migration COMPLETE — VERDICT: %s" % verdict)
+    print("DM %s, workbook %s, %.1fs" %
           (dm_id, wb_id, time.time() - started))
     return 0
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-complete.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-complete.rb
@@ -8,8 +8,9 @@
 require 'json'
 require 'optparse'
 require_relative 'lib/degradation_ledger'
+require_relative 'lib/terminal_outcome'
 
-TERMINAL = %w[migrated approximated needs-review skipped not-applicable].freeze
+TERMINAL = TerminalOutcome::TERMINAL_STATUSES
 
 opts = {}
 OptionParser.new do |parser|
@@ -79,6 +80,7 @@ report_rows = rows(report)
 unless census.dig('summary', 'complete') == true && !census_rows.empty? &&
        census_rows.all? { |row| TERMINAL.include?(status(row)) } &&
        report.dig('summary', 'complete') == true &&
+       report['completion_status'].to_s == 'complete' &&
        report.dig('summary', 'accounted').to_i == report.dig('summary', 'total').to_i
   warn 'NOT DONE: accounting/report is incomplete or has a non-terminal object'
   exit 4
@@ -130,12 +132,20 @@ end
 if report['degradations'].is_a?(Array) && report['degradations'] != derived
   contradictions << 'migration-result degradation ledger differs from fresh derivation'
 end
-accounting_yellow = report_rows.any? do |row|
-  %w[approximated needs-review skipped].include?(status(row))
-end
-expected_report_verdict = derived.empty? && !accounting_yellow ? 'GREEN' : 'YELLOW'
+expected_report_verdict = TerminalOutcome.report_verdict(
+  terminal_rows: report_rows.map { |row| status(row) },
+  degradation_entries: derived,
+  waiver_entries: Array(report['waivers'])
+)
 unless report['verdict'].to_s.upcase == expected_report_verdict
   contradictions << "migration-result verdict #{report['verdict'].inspect} contradicts #{expected_report_verdict}"
+end
+unless TerminalOutcome.completion_status(expected_report_verdict) == 'complete'
+  contradictions << "derived terminal verdict #{expected_report_verdict} is not a complete handoff"
+end
+marker_verdict = marker['verdict'].to_s.upcase
+if !marker_verdict.empty? && marker_verdict != expected_report_verdict
+  contradictions << "shared marker verdict #{marker['verdict'].inspect} contradicts terminal #{expected_report_verdict}"
 end
 state = read_json(File.join(workdir, 'run-state.json')) || {}
 contradictions << 'dry-run state cannot be complete' if state['mode'] == 'dry-run' && state['complete'] == true
@@ -147,7 +157,8 @@ unless contradictions.empty?
   exit 7
 end
 
-puts "DONE: Sisense hard gates, strict parity, accounting, render, ledger, and report reconcile"
+puts "DONE: Sisense hard gates, emitted-scope parity, accounting, render, ledger, and report reconcile"
+puts "  VERDICT: #{expected_report_verdict} (#{report['completion_status']})"
 puts "  workbook: #{marker['workbookId']}"
 puts "  charts: #{passed}/#{total}"
 puts "  objects: #{census_rows.length}/#{census_rows.length}"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_uplift_orchestrator.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_uplift_orchestrator.py
@@ -468,7 +468,7 @@ class UpliftContracts(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             rows = json.loads((Path(td) / "source-object-census.json").read_text())["objects"]
             self.assertEqual({row["id"]: row["status"] for row in rows},
-                             {"t": "migrated", "w": "needs-review",
+                             {"t": "migrated", "w": "skipped",
                               "d": "not-applicable"})
             bad = json.loads(gap.read_text())
             bad["objects"][0]["evidence"] = []
@@ -534,9 +534,248 @@ class UpliftContracts(unittest.TestCase):
         self.assertIn('HERE / "record-visual-check.rb"', source)
         self.assertLess(
             source.index('HERE / "assert-phase6-ran.rb"'),
-            source.index('phase("10", "post-gate accounting and final report")'),
+            source.index('phase("10", "final report from reconciled accounting")'),
         )
         self.assertEqual(len(list(SCRIPTS.glob("assert-phase6-ran.rb"))), 1)
+
+    def test_budget_overflow_requires_decision_and_accepted_path_requires_assert_zero(self):
+        module = load_orchestrator()
+        self.assertEqual(module.shared_gate_outcome(19), 10)
+        self.assertEqual(module.shared_gate_outcome(19, "risk accepted"), 2)
+        self.assertEqual(module.shared_gate_outcome(0, "risk accepted"), 0)
+        help_result = command(SCRIPTS / "migrate-sisense.py", "--help")
+        self.assertIn("--accept-waiver-budget-exceeded REASON", help_result.stdout)
+        source = (SCRIPTS / "migrate-sisense.py").read_text()
+        self.assertIn("DECISION REQUIRED: shared waiver budget exceeded", source)
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            dump(root / "source-object-census.json", {
+                "summary": {"total": 1, "accounted": 1, "complete": True},
+                "objects": [{"type": "widget", "id": "w", "name": "W",
+                             "status": "migrated"}],
+            })
+            dump(root / "parity-final.json", {
+                "status": "PASS", "strict_complete": True,
+                "charts_total": 1, "charts_pass": 1, "charts_fail": 0,
+            })
+            dump(root / "render-health.json", {"status": "PASS"})
+            dump(root / "waivers.json", [{
+                "flag": "--accept-waiver-budget-exceeded",
+                "reason": "operator accepted cumulative risk",
+            }])
+            accepted = command(
+                SCRIPTS / "build-migration-report.rb",
+                "--workdir", root, "--inventory", root / "source-object-census.json",
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            report = json.loads((root / "migration-result.json").read_text())
+            self.assertEqual(report["verdict"], "YELLOW")
+            self.assertEqual(report["completion_status"], "complete")
+
+    def test_emitted_parity_scope_excludes_explicit_omission_but_divergence_is_red(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            dashboards = root / "dashboards.json"
+            model = root / "model.json"
+            workbook = root / "workbook.json"
+            gap = root / "gap.json"
+            override = root / "checks-override.json"
+            checks = root / "checks.json"
+            plan = root / "plan.json"
+            results = root / "results.json"
+            final = root / "parity-final.json"
+            widgets = []
+            for widget_id, title in (("auto", "Auto"), ("approx", "Approx"), ("manual", "Manual")):
+                widgets.append({
+                    "_id": widget_id, "title": title, "type": "indicator",
+                    "metadata": {"panels": [{"name": "value", "items": [{
+                        "jaql": {"dim": "[Fact.Value]", "agg": "sum", "title": title}
+                    }]}]},
+                })
+            dump(dashboards, [{"title": "D", "widgets": widgets, "filters": []}])
+            dump(model, {"datasets": [{"schema": {"tables": [{
+                "name": "Fact", "columns": [{"name": "Value"}]
+            }]}}]})
+            dump(workbook, {"document": {"elements": [
+                {"id": "master", "name": "Master", "kind": "table"},
+                {"id": "a", "name": "Auto", "kind": "kpi"},
+                {"id": "b", "name": "Approx", "kind": "kpi"},
+            ]}})
+            gap_objects = [
+                {"type": "widget", "id": "auto", "name": "Auto", "status": "auto"},
+                {"type": "widget", "id": "approx", "name": "Approx", "status": "hint"},
+                {"type": "widget", "id": "manual", "name": "Manual", "status": "manual"},
+            ]
+            dump(gap, {
+                "objects": gap_objects,
+                "gaps": [{
+                    "object_type": "widget", "object_id": "manual",
+                    "category": "manual",
+                }],
+            })
+            dump(override, [
+                {"label": "Auto", "widget_id": "auto"},
+                {"label": "Approx", "widget_id": "approx"},
+            ])
+            built = command(
+                SCRIPTS / "build-sisense-parity.py", "build",
+                "--dashboards", dashboards, "--model", model, "--cube", "Cube",
+                "--database", "DB", "--schema", "SCHEMA",
+                "--workbook", workbook, "--gap-report", gap,
+                "--parity-checks", override, "--checks-out", checks,
+                "--plan-out", plan,
+            )
+            self.assertEqual(built.returncode, 0, built.stdout + built.stderr)
+            census = json.loads(plan.read_text())["tile_census"]
+            self.assertEqual(census["source_tiles"], 3)
+            self.assertEqual(census["emitted_tiles"], 2)
+            self.assertEqual(census["omitted"][0]["disposition"], "skipped")
+            dump(results, [
+                {"label": "Auto", "verdict": "GREEN"},
+                {"label": "Approx", "verdict": "RED"},
+            ])
+            normalized = command(
+                SCRIPTS / "build-sisense-parity.py", "normalize",
+                "--plan", plan, "--results", results, "--out", final,
+            )
+            self.assertEqual(normalized.returncode, 1)
+            self.assertEqual(json.loads(final.read_text())["status"], "FAIL")
+
+            missing_workbook = json.loads(workbook.read_text())
+            missing_workbook["document"]["elements"] = missing_workbook["document"]["elements"][:1]
+            dump(workbook, missing_workbook)
+            omitted_auto = command(
+                SCRIPTS / "build-sisense-parity.py", "build",
+                "--dashboards", dashboards, "--model", model, "--cube", "Cube",
+                "--database", "DB", "--schema", "SCHEMA",
+                "--workbook", workbook, "--gap-report", gap,
+                "--parity-checks", override, "--checks-out", checks,
+                "--plan-out", plan,
+            )
+            self.assertNotEqual(omitted_auto.returncode, 0)
+            self.assertIn("RED:", omitted_auto.stderr)
+
+    def test_complete_56_object_fixture_is_yellow_usable_handoff(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            scan = command(
+                SCRIPTS / "scan_gaps.py", FIXTURES / "dashboards.json",
+                "--model", FIXTURES / "model_ecommerce.json",
+                "--out", root / "gap-report.json",
+                "--rules", root / "learned-rules.json",
+            )
+            self.assertEqual(scan.returncode, 0, scan.stderr)
+            converted_model = command(
+                SCRIPTS / "convert.py", "model", FIXTURES / "model_ecommerce.json",
+                "connection", "SCHEMA", "DB", "--dashboards", FIXTURES / "dashboards.json",
+                cwd=root,
+            )
+            self.assertEqual(converted_model.returncode, 0, converted_model.stderr)
+            converted_wb = command(
+                SCRIPTS / "convert.py", "dashboard", FIXTURES / "dashboards.json",
+                FIXTURES / "model_ecommerce.json", "dm", "fact", "Commerce",
+                "--dm-spec", root / "sigma_dm_spec.json",
+                cwd=root,
+            )
+            self.assertEqual(converted_wb.returncode, 0, converted_wb.stderr)
+            source = json.loads((FIXTURES / "dashboards.json").read_text())
+            source_by_name = {
+                widget["title"]: widget
+                for dashboard in source for widget in dashboard.get("widgets") or []
+            }
+            workbook = json.loads((root / "sigma_workbook_spec.json").read_text())
+            elements = (workbook.get("document") or {}).get("elements") or []
+            emitted_names = [
+                row["name"] for row in elements
+                if row.get("id") != "master" and row.get("kind") != "control"
+            ]
+            overrides = [{
+                "label": name,
+                "widget_id": source_by_name[name].get("_id") or source_by_name[name].get("oid"),
+            } for name in emitted_names]
+            dump(root / "override.json", overrides)
+            planned = command(
+                SCRIPTS / "build-sisense-parity.py", "build",
+                "--dashboards", FIXTURES / "dashboards.json",
+                "--model", FIXTURES / "model_ecommerce.json",
+                "--cube", "Sample ECommerce", "--database", "DB", "--schema", "SCHEMA",
+                "--workbook", root / "sigma_workbook_spec.json",
+                "--gap-report", root / "gap-report.json",
+                "--parity-checks", root / "override.json",
+                "--checks-out", root / "parity-checks.json",
+                "--plan-out", root / "parity-plan.json",
+            )
+            self.assertEqual(planned.returncode, 0, planned.stdout + planned.stderr)
+            plan = json.loads((root / "parity-plan.json").read_text())
+            dump(root / "parity_keys.json", [
+                {"label": row["chart"], "verdict": "GREEN"}
+                for row in plan["charts"]
+            ])
+            normalized = command(
+                SCRIPTS / "build-sisense-parity.py", "normalize",
+                "--plan", root / "parity-plan.json",
+                "--results", root / "parity_keys.json",
+                "--out", root / "parity-final.json",
+            )
+            self.assertEqual(normalized.returncode, 0, normalized.stderr)
+            accounted = command(
+                SCRIPTS / "build-sisense-accounting.py",
+                "--workdir", root, "--gap-report", root / "gap-report.json",
+                "--model", FIXTURES / "model_ecommerce.json",
+                "--dashboards", FIXTURES / "dashboards.json",
+                "--dm-spec", root / "sigma_dm_spec.json",
+                "--wb-spec", root / "sigma_workbook_spec.json",
+                "--parity-final", root / "parity-final.json",
+                "--jaql-mapping", root / "parity-plan.json",
+            )
+            self.assertEqual(accounted.returncode, 0, accounted.stdout + accounted.stderr)
+            gap_gate = command(
+                SCRIPTS / "check-accounted-gaps.py",
+                "--gap-report", root / "gap-report.json",
+                "--census", root / "source-object-census.json",
+                "--parity", root / "parity-final.json",
+                "--out", root / "accounted-gap-result.json",
+            )
+            self.assertEqual(gap_gate.returncode, 0, gap_gate.stdout + gap_gate.stderr)
+            census = json.loads((root / "source-object-census.json").read_text())
+            self.assertEqual(census["summary"]["total"], 56)
+            self.assertTrue(census["summary"]["complete"])
+
+            time.sleep(0.01)
+            dump(root / "render-health.json", {"status": "PASS", "images": []})
+            dump(root / "blank-risk.json", {"status": "PASS"})
+            ledger = subprocess.run([
+                "ruby", "-I", str(SCRIPTS / "lib"), "-rdegradation_ledger", "-e",
+                "e=DegradationLedger.derive(ARGV[0]); DegradationLedger.write(ARGV[0],e)",
+                str(root),
+            ], capture_output=True, text=True)
+            self.assertEqual(ledger.returncode, 0, ledger.stderr)
+            time.sleep(0.01)
+            report_result = command(
+                SCRIPTS / "build-migration-report.rb",
+                "--workdir", root, "--inventory", root / "source-object-census.json",
+            )
+            self.assertEqual(report_result.returncode, 0, report_result.stderr)
+            report = json.loads((root / "migration-result.json").read_text())
+            self.assertEqual(report["verdict"], "YELLOW")
+            self.assertEqual(report["completion_status"], "complete")
+            self.assertIn("migration report: YELLOW", report_result.stdout)
+            dump(root / "run-state.json", {
+                "mode": "live", "complete": True, "post_complete": True,
+                "parity_complete": True, "render_complete": True,
+            })
+            time.sleep(0.01)
+            dump(root / "sisense-report-finalization.json", {"status": "PASS"})
+            dump(root / "phase6-success.json", {
+                "gates": "all-pass", "workbookId": "wb", "chartCount": len(plan["charts"]),
+                "verdict": "YELLOW", "completion_status": "complete",
+            })
+            verified = command(
+                SCRIPTS / "verify-complete.rb",
+                "--workdir", root, "--workbook-id", "wb",
+            )
+            self.assertEqual(verified.returncode, 0, verified.stdout + verified.stderr)
+            self.assertIn("VERDICT: YELLOW (complete)", verified.stdout)
 
     def test_complete_fixture_passes_terminal_verifier(self):
         with tempfile.TemporaryDirectory() as td:
@@ -561,6 +800,7 @@ class UpliftContracts(unittest.TestCase):
             time.sleep(0.01)
             dump(root / "migration-result.json", {
                 "verdict": "GREEN",
+                "completion_status": "complete",
                 "summary": {"total": 1, "accounted": 1, "complete": True},
                 "source_objects": [obj],
             })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Replaces Sisense’s raw “any gap means failure” rule with complete source accounting and emitted-scope parity.

## Behavior

- Manual/unhandled/flagged omissions may complete YELLOW only with an exact terminal census disposition
- Every emitted widget remains in strict parity scope
- Unexpected omissions, emitted divergence, contradictions, broken output, and incomplete accounting remain RED/nonzero
- Waiver overflow is decision-required unless named and accepted
- Terminal report and marker verdicts are reconciled

Focused tests and the ECommerce corpus are green locally. Plugin version 1.1.17.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

