### PR TITLE
Report Looker degraded handoffs as YELLOW

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -427,6 +427,7 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_metric_reference.py
             plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_build_looker_accounting.py
+            plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_migrate_looker_terminal.py
             plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_migrate_looker_post_workbook_coderep.py
             plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_grounding.py
             plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_completion_contract.py

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -118,8 +118,10 @@ with evidence.
 ## ONE COMMAND (preferred): migrate-looker.py
 
 > ## ⛔ THE ONE PATH (do not improvise a workbook)
-> `migrate-looker.py` is the single entry point; it only reaches GREEN when the
-> `assert-phase6-ran` hard gate passes with real charts. Rules:
+> `migrate-looker.py` is the single entry point; it only reaches a complete
+> GREEN or YELLOW handoff when `assert-phase6-ran` passes with real charts and
+> `verify-complete.rb` reconciles the workbook, report, census, ledger, and
+> completion marker. Rules:
 > - **NEVER hand-drive the per-phase scripts, hand-author a DM/workbook JSON, or
 >   `curl`-POST to `/v2/workbooks` / lay out empty "placeholder" pages** — that
 >   bypasses parity + the gate and ships an EMPTY workbook (the #1 failure mode).
@@ -127,7 +129,8 @@ with evidence.
 >   tell the user to authenticate** — do not build a shell.
 > - **"Done" is a file on disk, not "pages exist."** Complete only when
 >   `ruby scripts/verify-complete.rb --workdir <WORK>` prints ✅ DONE (the gate
->   stamped `phase6-success.json`). An empty workbook is never done. Before
+>   stamped `phase6-success.json`). The orchestrator runs this reconciliation
+>   on every terminal path. An empty workbook is never done. Before
 >   that check, run `ruby scripts/build-migration-report.rb --workdir <WORK>`
 >   and its `--check` mode: every source object and field/formula finding must
 >   have one terminal disposition in `MIGRATION_REPORT.md`,
@@ -137,8 +140,9 @@ The whole pipeline — parse → **RLS gate** → convert → **DM-reuse check**
 POST + readback → workbook build (layout inline) → **source-freshness
 preflight** → **scripted parity + hard gate** — as a single command (mirrors
 qlik-to-sigma's `migrate-qlik.rb` / thoughtspot's `migrate-thoughtspot.py`).
-Gates are never bypassed: the command exits non-zero if parity or
-`assert-phase6-ran.rb` fails.
+Gates are never silently bypassed. The command prints one honest
+`PARITY/VERDICT: GREEN|YELLOW|RED` banner: GREEN and YELLOW are complete exit-0
+handoffs; RED is blocked/nonzero.
 
 ```bash
 # env: SIGMA_CONNECTION_ID = the FULL warehouse-connection UUID (NOT a short
@@ -212,8 +216,20 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
   pool** (measured 24.3s → 5.8s on the 5-chart fixture); set
   `LOOKER_PARITY_WORKERS=1` to serialize on a loaded warehouse (max is clamped
   to 4 — warehouse-friendly bursts only).
-- Exit codes: `0` GREEN · `3` MCP convert request emitted · `10` RLS decision
-  needed · `2` built but a gate FAILED. `--dry-run` = no Sigma POSTs.
+- **Terminal policy:** exact, fully accounted, waiver-free output is GREEN.
+  Fully accounted `approximated` / `needs-review` / `skipped` objects and named
+  source-visual waivers are complete YELLOW when all hard gates and
+  reconciliation pass. Use `--skip-visual-comparison REASON` only when the
+  Looker source image is genuinely unavailable; the Sigma render must still be
+  healthy. Numeric divergence, broken/blank renders, contradictory or
+  incomplete accounting, ERROR columns, and unported RLS remain RED/nonzero.
+  `--accept-waiver-budget-exceeded REASON` passes the named decision to the
+  shared assert. Without acceptance, assert exit 19 becomes orchestrator exit
+  10 (decision required); after every other gate passes, acceptance records the
+  overflow and completes YELLOW exit 0.
+- Exit codes: `0` complete GREEN/YELLOW · `3` MCP convert request emitted ·
+  `10` RLS/waiver-budget decision needed · `12` readiness blocked · `2` built
+  but RED. `--dry-run` = no Sigma POSTs.
 
 ---
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -67,10 +67,11 @@ Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (or SIGMA_CLIENT_ID/SECRET via
 optional CONVERTER_SRC (src/lookml.ts, run via tsx) or CONVERTER_PATH
 (build/lookml.js) — both auto-located.
 
-Exit codes: 0 = done, all gates GREEN; 3 = MCP convert request emitted (resume
-with --converted); 10 = RLS found, decision needed (nothing posted);
-12 = LookML readiness blocked (nothing posted); 2 = built but a parity,
-accounting, report, or hard gate FAILED; other = error.
+Exit codes: 0 = complete GREEN or YELLOW handoff; 3 = MCP convert request
+emitted (resume with --converted); 10 = a security or waiver-budget decision
+is required; 12 = LookML readiness blocked (nothing posted); 2 = built but a
+parity, render, accounting, report, security, reconciliation, or hard gate
+FAILED; other = error.
 """
 import argparse, csv, glob, io, json, os, re, statistics, subprocess, sys, time
 import urllib.request, urllib.error
@@ -87,6 +88,7 @@ MCP_TOOL = "mcp__sigma-data-model__convert_lookml_to_sigma"
 VENDORED_CONVERTER = os.path.join(HERE, "..", "converter", "lookml.mjs")
 READINESS_BLOCKED_EXIT = 12
 SIGMA_POSTS_ALLOWED = False
+COMPLETE_VERDICTS = {"GREEN", "YELLOW"}
 
 
 def resolve_converter():
@@ -275,6 +277,28 @@ def refresh_degradation_ledger(workdir):
         "-rdegradation_ledger", "-e", ruby, workdir,
     ], check=False)
     return rc
+
+
+def resolve_terminal_outcome(*, gates_pass, report_verdict, completion_status,
+                             budget_decision_required=False):
+    """Return the public GREEN/YELLOW/RED verdict and process exit.
+
+    The migration report owns fidelity classification through the shared
+    TerminalOutcome policy.  This adapter only combines that report verdict
+    with independently evaluated hard gates and the completion reconciliation;
+    it deliberately does not re-derive object-status policy in Python.
+    """
+    verdict = str(report_verdict or "").upper()
+    complete = str(completion_status or "").lower() == "complete"
+    if budget_decision_required and complete and verdict in COMPLETE_VERDICTS:
+        return "YELLOW", 10
+    if not gates_pass or not complete or verdict not in COMPLETE_VERDICTS:
+        return "RED", 2
+    return verdict, 0
+
+
+def terminal_banner(verdict):
+    return f"PARITY/VERDICT: {verdict}"
 
 
 def ensure_sigma_env(workdir=None):
@@ -614,6 +638,17 @@ def main():
                          "Default OFF: candidates are printed and the safe default is "
                          "build-new (reuse only via explicit --reuse-dm).")
     ap.add_argument("--yes", action="store_true")
+    ap.add_argument(
+        "--skip-visual-comparison", metavar="REASON",
+        help="named source-visual waiver passed to the hard gate when a Looker "
+             "source image is genuinely unavailable; the Sigma render must "
+             "still be healthy and the terminal verdict is at most YELLOW",
+    )
+    ap.add_argument(
+        "--accept-waiver-budget-exceeded", metavar="REASON",
+        help="explicitly accept hard-gate waiver-budget overflow after every "
+             "other gate passes; records REASON and permits a YELLOW exit-0 handoff",
+    )
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--materialize-derived", choices=["off", "auto", "all"], default="off",
                     help="Phase 2b always SCANS for expensive derived tables (informational). "
@@ -1428,8 +1463,11 @@ console.error('stats:', JSON.stringify(res.stats));
           f"{workers}-wide in {time.time() - t_par:.1f}s")
     json.dump(expected, open(os.path.join(wd, "parity-expected.json"), "w"), indent=2)
     json.dump(actuals, open(os.path.join(wd, "parity-actuals.json"), "w"), indent=2)
-    rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-looker.rb"),
-                 "--workdir", wd, "--finalize"], check=False)
+    parity_finalize_rc, _ = run(
+        ["ruby", os.path.join(HERE, "phase6-parity-looker.rb"),
+         "--workdir", wd, "--finalize"],
+        check=False,
+    )
     # Refresh canonical accounting after parity has supplied terminal evidence
     # and before the hard gate derives/stamps its degradation verdict.
     pre_gate_accounting_rc = run_looker_accounting(
@@ -1451,6 +1489,13 @@ console.error('stats:', JSON.stringify(res.stats));
     # every migration fails gate 8 despite a clean render.
     if render_png and os.path.exists(render_png):
         gate_cmd += ["--sigma-render", render_png]
+    if a.skip_visual_comparison:
+        gate_cmd += ["--skip-visual-comparison", a.skip_visual_comparison]
+    if a.accept_waiver_budget_exceeded:
+        gate_cmd += [
+            "--accept-waiver-budget-exceeded",
+            a.accept_waiver_budget_exceeded,
+        ]
     grc, _ = run(gate_cmd, check=False)
     summary = json.load(open(os.path.join(wd, "parity-final.json")))
 
@@ -1519,15 +1564,49 @@ console.error('stats:', JSON.stringify(res.stats));
     except Exception:
         pass
     report_verdict = str(report.get("verdict") or "MISSING").upper()
+    completion_status = str(report.get("completion_status") or "missing").lower()
     print(f"   migration report: {report_verdict} "
           f"({report.get('summary', {}).get('accounted', 0)}/"
-          f"{report.get('summary', {}).get('total', 0)} accounted)")
+          f"{report.get('summary', {}).get('total', 0)} accounted; "
+          f"completion_status={completion_status})")
+
+    # Always run the final offline reconciliation, including RED and
+    # decision-required paths.  It proves the workbook, report, census,
+    # degradation ledger, waiver census, and phase-6 sentinel agree.  An
+    # unaccepted waiver-budget overflow intentionally has no success sentinel,
+    # so verify-complete remains nonzero until the named decision is accepted.
+    completion_rc, _ = run(
+        ["ruby", os.path.join(HERE, "verify-complete.rb"),
+         "--workdir", wd, "--workbook-id", wb],
+        check=False,
+    )
 
     # ── Summary ────────────────────────────────────────────────────────────────
-    green = (grc == 0 and not errs and pre_gate_accounting_rc == 0 and
-             final_accounting_rc == 0 and ledger_rc == 0 and
-             report_rc == 0 and report_verdict != "RED" and
-             str(render_health.get("status") or "").upper() == "PASS")
+    # Keep gate execution independent from the report's fidelity verdict.
+    # Approximations/waivers can therefore be a complete YELLOW handoff, while
+    # divergence, broken renders, incomplete accounting, contradictions,
+    # ERROR-typed columns, and deliberately unported RLS remain RED/nonzero.
+    non_assert_checks_pass = (
+        parity_finalize_rc == 0 and not errs and
+        pre_gate_accounting_rc == 0 and final_accounting_rc == 0 and
+        ledger_rc == 0 and report_rc == 0 and
+        completion_status == "complete" and
+        str(render_health.get("status") or "").upper() == "PASS" and
+        not findings
+    )
+    budget_decision_required = (
+        grc == 19 and not a.accept_waiver_budget_exceeded and
+        non_assert_checks_pass and report_verdict in COMPLETE_VERDICTS
+    )
+    gates_pass = (
+        grc == 0 and non_assert_checks_pass and completion_rc == 0
+    )
+    terminal_verdict, terminal_exit = resolve_terminal_outcome(
+        gates_pass=gates_pass,
+        report_verdict=report_verdict,
+        completion_status=completion_status,
+        budget_decision_required=budget_decision_required,
+    )
     print("\n================ RESULT ================")
     print(f"dataModelId : {dm}{'  (REUSED)' if a.reuse_dm else ''}")
     print(f"workbookId  : {wb}  '{wspec['name']}'")
@@ -1537,11 +1616,17 @@ console.error('stats:', JSON.stringify(res.stats));
     print(f"ledger      : {'PASS' if ledger_rc == 0 else f'FAIL (exit {ledger_rc})'}")
     print(f"report      : {report_verdict}"
           + ("" if report_rc == 0 else f" · FAIL (exit {report_rc})"))
+    print(f"completion  : {'PASS' if completion_rc == 0 else f'FAIL (exit {completion_rc})'}")
     if findings:
-        print(f"RLS         : {len(findings)} finding(s) NOT ported (recorded in rls-findings.json)")
-    print(f"PARITY      : {'GREEN' if green else 'RED'}  ·  wall-clock {time.time() - T0:.1f}s")
+        print(f"RLS         : RED · {len(findings)} finding(s) NOT ported "
+              "(recorded in rls-findings.json)")
+    print(f"{terminal_banner(terminal_verdict)}  ·  wall-clock {time.time() - T0:.1f}s")
+    if budget_decision_required:
+        print("DECISION REQUIRED: waiver budget exceeded after all other gates passed.")
+        print("Re-run with --accept-waiver-budget-exceeded REASON to record the "
+              "decision and complete a YELLOW handoff.")
     print("========================================")
-    return 0 if green else 2
+    return terminal_exit
 
 
 if __name__ == "__main__":

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-verify-complete.rb
@@ -29,7 +29,7 @@ end
 
 def write_contract(wd, status: 'migrated', verdict: 'GREEN', complete: true,
                    report_status: nil, report_id: 'dash-1', census_id: 'dash-1',
-                   degradations: [])
+                   degradations: [], waivers: [])
   census_row = { 'type' => 'dashboard', 'id' => census_id, 'name' => 'Sales',
                  'status' => status }
   report_row = { 'type' => 'dashboard', 'id' => report_id, 'name' => 'Sales',
@@ -39,12 +39,16 @@ def write_contract(wd, status: 'migrated', verdict: 'GREEN', complete: true,
              'objects' => [census_row])
   write_json(File.join(wd, 'migration-result.json'),
              'verdict' => verdict,
+             'completion_status' => verdict == 'RED' ? 'blocked' : 'complete',
              'summary' => { 'complete' => complete, 'total' => 1,
                             'accounted' => (complete ? 1 : 0) },
              'source_objects' => [report_row], 'degradations' => degradations,
-             'waivers' => [])
+             'waivers' => waivers)
   write_json(File.join(wd, 'parity-final.json'),
-             'status' => 'PASS', 'verdict' => 'GREEN', 'waivers' => [], 'waiver_count' => 0)
+             'status' => 'PASS', 'verdict' => verdict,
+             'waivers' => waivers.map { |entry| entry['flag'] },
+             'waiver_reasons' => waivers.to_h { |entry| [entry['flag'], entry['reason']] },
+             'waiver_count' => waivers.length)
   write_json(File.join(wd, 'degradation-ledger.json'),
              'version' => 1, 'counts' => {}, 'entries' => degradations)
 end
@@ -112,11 +116,58 @@ end
 
 # An honestly-accounted approximation is complete but caps the report at YELLOW.
 Dir.mktmpdir do |wd|
-  success_marker(wd)
-  write_contract(wd, status: 'approximated', verdict: 'YELLOW')
+  waiver = {
+    'flag' => '--skip-visual-comparison',
+    'gate' => 'gate 8b',
+    'reason' => 'source visual unavailable'
+  }
+  degradation = {
+    'class' => 'quality-waiver',
+    'item' => '--skip-visual-comparison',
+    'reason' => 'source visual unavailable',
+    'source_artifact' => 'parity-final.json waivers'
+  }
+  success_marker(wd, 'verdict' => 'YELLOW', 'waivers' => [waiver['flag']])
+  write_contract(wd, status: 'approximated', verdict: 'YELLOW',
+                 degradations: [degradation], waivers: [waiver])
   code, out = run_vc(VC, wd)
-  check(code == 0, "complete approximated accounting => exit 0 (got #{code})", fails)
-  check(out.include?('VERDICT: YELLOW'), 'accounting-derived YELLOW is surfaced', fails)
+  check(code == 0, "accounted approximation + source-visual waiver => exit 0 (got #{code})", fails)
+  check(out.include?('VERDICT: YELLOW'), 'waived approximation surfaces YELLOW, never GREEN', fails)
+end
+
+# A shared-ledger PARTIAL scope-cut spelling reconciles to plugin-local YELLOW.
+Dir.mktmpdir do |wd|
+  degradation = {
+    'class' => 'scope-cut',
+    'item' => 'dropped visual: Unsupported Map',
+    'reason' => 'unsupported source visual',
+    'source_artifact' => 'coverage.json'
+  }
+  success_marker(wd, 'verdict' => 'PARTIAL')
+  write_contract(wd, status: 'skipped', verdict: 'YELLOW',
+                 degradations: [degradation])
+  parity = JSON.parse(File.read(File.join(wd, 'parity-final.json')))
+  parity['verdict'] = 'PARTIAL'
+  write_json(File.join(wd, 'parity-final.json'), parity)
+  write_json(File.join(wd, 'coverage.json'),
+             'unresolved' => [{ 'visual' => 'Unsupported Map',
+                                'severity' => 'dropped',
+                                'detail' => 'unsupported source visual' }])
+  code, out = run_vc(VC, wd)
+  check(code == 0, "fully accounted skipped visual => YELLOW exit 0 (got #{code})", fails)
+  check(out.include?('VERDICT: YELLOW'), 'legacy PARTIAL claim is surfaced as plugin-local YELLOW', fails)
+end
+
+# completion_status is part of the report contract, not inferred from verdict.
+Dir.mktmpdir do |wd|
+  success_marker(wd)
+  write_contract(wd)
+  report = JSON.parse(File.read(File.join(wd, 'migration-result.json')))
+  report.delete('completion_status')
+  write_json(File.join(wd, 'migration-result.json'), report)
+  code, out = run_vc(VC, wd)
+  check(code == 6, "missing completion_status => exit 6 (got #{code})", fails)
+  check(out.include?('completion_status'), 'missing completion_status is named', fails)
 end
 
 # Re-derivation catches a report and stored ledger that hide a scope cut.
@@ -150,6 +201,7 @@ mt = File.read(File.join(DIR, 'migrate-looker.py'))
 check(mt.include?('assert-phase6-ran.rb'), 'orchestrator invokes the assert-phase6-ran hard gate', fails)
 check(mt.include?('build-migration-report.rb'), 'orchestrator invokes the final migration report', fails)
 check(mt.include?('build-looker-accounting.py'), 'orchestrator invokes Looker source accounting', fails)
+check(mt.include?('verify-complete.rb'), 'orchestrator invokes final completion reconciliation', fails)
 asrt = File.read(File.join(DIR, 'assert-phase6-ran.rb'))
 check(asrt.include?('phase6-success.json') && asrt.include?("'chartCount'"),
       'shared gate stamps phase6-success.json with chartCount', fails)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_migrate_looker_post_workbook_coderep.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_migrate_looker_post_workbook_coderep.py
@@ -87,8 +87,16 @@ check(0 <= prelim_idx < gate_idx < final_idx < report_idx < result_idx,
 check('"visual-similarity.json"' in SRC and '"render-health.json"' in SRC and
       '"png_health.py"' in SRC,
       "render health derives from similarity evidence or a Sigma PNG")
-check("report_rc == 0" in main_src and 'report_verdict != "RED"' in main_src,
-      "failed or RED completion report prevents migration success")
+check(
+    all(contract in main_src for contract in (
+        "final_accounting_rc == 0",
+        "report_rc == 0",
+        'completion_status == "complete"',
+        "report_verdict in COMPLETE_VERDICTS",
+    )) and
+    "if not gates_pass or not complete or verdict not in COMPLETE_VERDICTS" in SRC,
+    "failed or RED completion report prevents migration success",
+)
 check("args.yes" not in SRC and "not a.yes" in SRC,
       "gap-scout gate uses parsed namespace a.yes")
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_migrate_looker_terminal.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test_migrate_looker_terminal.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Focused regression tests for migrate-looker's terminal handoff policy."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "migrate_looker", HERE / "migrate-looker.py"
+)
+MIGRATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MIGRATE)
+
+
+class TerminalOutcomeTest(unittest.TestCase):
+    def outcome(self, **overrides):
+        values = {
+            "gates_pass": True,
+            "report_verdict": "GREEN",
+            "completion_status": "complete",
+            "budget_decision_required": False,
+        }
+        values.update(overrides)
+        return MIGRATE.resolve_terminal_outcome(**values)
+
+    def test_accounted_approximation_and_waiver_finish_yellow(self):
+        verdict, code = self.outcome(report_verdict="YELLOW")
+        self.assertEqual((verdict, code), ("YELLOW", 0))
+        banner = MIGRATE.terminal_banner(verdict)
+        self.assertEqual(banner, "PARITY/VERDICT: YELLOW")
+        self.assertNotIn("GREEN", banner)
+
+    def test_true_divergence_or_broken_gate_is_red(self):
+        self.assertEqual(
+            self.outcome(gates_pass=False, report_verdict="YELLOW"),
+            ("RED", 2),
+        )
+        self.assertEqual(
+            self.outcome(report_verdict="RED", completion_status="blocked"),
+            ("RED", 2),
+        )
+        self.assertEqual(MIGRATE.terminal_banner("RED"), "PARITY/VERDICT: RED")
+
+    def test_unported_rls_hard_gate_is_red(self):
+        # migrate-looker includes `not findings` in gates_pass, independently
+        # of the shared report's object-accounting verdict.
+        source = (HERE / "migrate-looker.py").read_text(encoding="utf-8")
+        self.assertIn("not findings", source)
+        self.assertEqual(
+            self.outcome(gates_pass=False, report_verdict="YELLOW"),
+            ("RED", 2),
+        )
+
+    def test_unaccepted_budget_overflow_requires_decision(self):
+        self.assertEqual(
+            self.outcome(
+                report_verdict="YELLOW",
+                budget_decision_required=True,
+                gates_pass=False,
+            ),
+            ("YELLOW", 10),
+        )
+
+    def test_accepted_budget_overflow_is_terminal_yellow(self):
+        self.assertEqual(self.outcome(report_verdict="YELLOW"), ("YELLOW", 0))
+
+    def test_completion_status_must_be_complete(self):
+        self.assertEqual(
+            self.outcome(completion_status="blocked"),
+            ("RED", 2),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-complete.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-complete.rb
@@ -26,8 +26,9 @@
 require 'json'
 require 'optparse'
 require_relative 'lib/degradation_ledger'
+require_relative 'lib/terminal_outcome'
 
-TERMINAL_STATUSES = %w[migrated approximated needs-review skipped not-applicable].freeze
+TERMINAL_STATUSES = TerminalOutcome::TERMINAL_STATUSES
 
 opts = {}
 OptionParser.new do |p|
@@ -134,7 +135,8 @@ end
 
 report_rows = object_rows(report)
 census_rows = object_rows(census)
-report_complete = report.dig('summary', 'complete') == true &&
+report_complete = report['completion_status'].to_s == 'complete' &&
+                  report.dig('summary', 'complete') == true &&
                   report.dig('summary', 'accounted').to_i == report.dig('summary', 'total').to_i
 census_complete = census.dig('summary', 'complete') != false &&
                   !census_rows.empty? &&
@@ -143,7 +145,8 @@ if report['verdict'].to_s.upcase == 'RED' || census['verdict'].to_s.upcase == 'R
    !report_complete || !census_complete ||
    report_rows.any? { |row| !TERMINAL_STATUSES.include?(object_status(row)) }
   warn '⛔ NOT DONE — migration report/source census is RED or incomplete.'
-  warn "   report: verdict=#{report['verdict'].inspect} complete=#{report.dig('summary', 'complete').inspect} " \
+  warn "   report: verdict=#{report['verdict'].inspect} completion_status=#{report['completion_status'].inspect} " \
+       "complete=#{report.dig('summary', 'complete').inspect} " \
        "accounted=#{report.dig('summary', 'accounted').inspect}/#{report.dig('summary', 'total').inspect}"
   warn "   census: objects=#{census_rows.length} complete=#{census.dig('summary', 'complete').inspect}"
   exit 6
@@ -170,7 +173,16 @@ contradictions = []
 run_state = load_json(File.join(wd, 'migrate-state.json')) || {}
 factory_labeled = derived_verdict == 'GREEN' && run_state['tier'].to_s == 'S' &&
                   parity['verdict_by'].to_s == 'builder-self-attested'
-expected_phase6_verdict = factory_labeled ? 'GREEN (factory, self-attested)' : derived_verdict
+expected_phase6_verdict =
+  if factory_labeled
+    'GREEN (factory, self-attested)'
+  else
+    # The shared degradation ledger predates the canonical three-state terminal
+    # policy and may spell a scope-cut handoff PARTIAL/PARTIAL+YELLOW.  For this
+    # plugin's reconciliation those are YELLOW: complete-but-degraded, never
+    # GREEN.  Keep phase-6 compatibility below while comparing canonical claims.
+    TerminalOutcome.expected_report_verdict(['migrated'], derived)
+  end
 
 if stored_ledger.is_a?(Hash) && stored_ledger['entries'].is_a?(Array) &&
    stored_ledger['entries'] != derived
@@ -180,17 +192,20 @@ if report['degradations'].is_a?(Array) && report['degradations'] != derived
   contradictions << "migration-result.json degradation ledger has #{report['degradations'].length} entries but fresh derivation has #{derived.length}"
 end
 
-accounting_yellow = report_rows.any? do |row|
-  %w[approximated needs-review skipped].include?(object_status(row))
-end
-expected_report_verdict = derived.empty? && !accounting_yellow ? 'GREEN' : 'YELLOW'
+expected_report_verdict = TerminalOutcome.report_verdict(
+  terminal_rows: report_rows.map { |row| object_status(row) },
+  degradation_entries: derived,
+  waiver_entries: Array(report['waivers']),
+  hard_failure: Array(report['checks']).any? { |check| check.is_a?(Hash) && check['status'] == 'FAIL' }
+)
 if report['verdict'].to_s.upcase != expected_report_verdict
   contradictions << "migration-result.json claims #{report['verdict'].inspect} but the ledger requires #{expected_report_verdict}"
 end
 
 { 'phase6-success.json' => sj, 'parity-final.json' => parity }.each do |name, doc|
   claim = doc['verdict'].to_s
-  next if claim.empty? || claim == expected_phase6_verdict
+  canonical_claim = claim.start_with?('PARTIAL') ? 'YELLOW' : claim
+  next if claim.empty? || canonical_claim == expected_phase6_verdict
   contradictions << "#{name} claims verdict #{claim.inspect} but the artifacts require #{expected_phase6_verdict}"
 end
 
@@ -229,8 +244,7 @@ unless contradictions.empty?
   exit 8
 end
 
-completion_verdict = report['verdict'].to_s.upcase == 'YELLOW' &&
-                     derived_verdict == 'GREEN' ? 'YELLOW' : expected_phase6_verdict
+completion_verdict = report['verdict'].to_s.upcase
 puts "✅ DONE — hard gates and completion accounting reconcile. VERDICT: #{completion_verdict}"
 puts "   workbook : #{sj['workbookId']}"
 puts "   charts   : #{sj['chartCount']}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Lets fully accounted Looker approximations, skips, and named waivers finish as usable YELLOW handoffs instead of being presented as GREEN or failed wholesale.

## Behavior

- GREEN/YELLOW exit 0; RED remains nonzero
- Honest terminal verdict banner
- Final `verify-complete` reconciliation is mandatory
- Waiver overflow is decision-required unless explicitly accepted
- Divergence, broken render, RLS, contradictions, and incomplete accounting remain hard failures

Focused terminal/accounting/verifier tests are green locally. Plugin version 1.2.22.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

