### PR TITLE
Separate Power BI pending and YELLOW handoffs

### DIFF
--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.43",
+  "version": "1.8.44",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -81,14 +81,19 @@ directories is also registered in CI, so a new suite cannot be added and silentl
 >   connect to Power BI (device-code) or that the report must be published** — do
 >   not fall back to a hand-built shell.
 > - **"Done" is not "pages exist."** The migration is complete only when
->   `ruby scripts/verify-complete.rb --workdir <WORK>` prints ✅ DONE — i.e. the
->   `assert-phase6-ran` parity gate passed with real chart elements. An empty or
+>   `ruby scripts/verify-complete.rb --workdir <WORK>` prints a terminal
+>   **GREEN** or **YELLOW** handoff — i.e. `assert-powerbi-terminal.rb` ran the
+>   shared `assert-phase6-ran` gate and Power BI finalizer with real
+>   chart elements, strict parity, complete source accounting, and fresh
+>   report/census/ledger artifacts. An empty or
 >   placeholder workbook is never done, no matter how it looks. Before that
 >   check, Phase 6 automatically refreshes `<WORK>/source-object-census.json`
 >   and runs `finalize-powerbi-report.rb` plus the migration-report freshness
 >   check; every source table, column, measure, security role, page, visual, and
 >   control must have one terminal disposition in `MIGRATION_REPORT.md` and
->   `migration-result.json`.
+>   `migration-result.json`. The one-shot mechanical path deliberately writes
+>   `parity-pending.json` and exits **10** after a usable resolution-verified
+>   build; it never mints terminal GREEN before strict source parity.
 > - Small/older models (e.g. running on Haiku): if the report is large or complex,
 >   say so and confirm scope with the user before building — don't silently
 >   degrade to a partial shell.
@@ -225,7 +230,10 @@ resume with `--converter-out`. The hosted MCP is a fallback, not the default pat
   `scripts/route-pbi-time-intelligence.rb` with the model, DM spec/readback, and
   master map; write `$WORK/time-intelligence-routing.json` plus the patched
   master map. A GREEN run has zero `needs-review` routes, routes only to a
-  same-fact synthesized element, and parity evidence for every routed record.
+  same-fact synthesized element, and parity evidence for every routed/emitted
+  record. A `needs-review`/`skipped` route may be a terminal **YELLOW**
+  disposition only when it is explicitly accounted and not emitted as a proven
+  route; any emitted route still requires strict chart parity.
   The router never fabricates a DM element. Unresolved, ambiguous, cross-fact,
   or iterator routes stay unmapped and must be recorded as `needs-review` in
   `source-object-census.json`; see `refs/open-items.md`.
@@ -396,7 +404,7 @@ A workbook that POSTs 200 and passes numeric parity can still be visually broken
   - **Online DAX (high-fidelity / import-only models):** PBI `POST /v1.0/myorg/groups/{ws}/datasets/{id}/executeQueries` (DAX) via `--emit-dax`, vs the same Sigma aggregation. DAX-only; breaks under service-principal if RLS; needs the workspace/dataset (auto-wired from `freshness.json`).
     - **XMLA fallback (when `executeQueries` REST is blocked but the model is on capacity):** run the same measure through the Power BI Modeling MCP — `dax_query_operations Execute` on an `Initial Catalog`-bound connection — and diff against the Sigma actuals identically. Recipe in `refs/pbi-modeling-mcp.md`. This also catches **silently mis-modeled source measures** (e.g. time-intel over an inactive date relationship returns a flat total in Power BI) that a SQL oracle wouldn't flag.
 - **Finalize (both paths):** `ruby scripts/phase6-parity-pbi.rb --finalize --plan plan.json --actuals parity-actuals.json --out-dir <dir>` → writes `parity-final.json` (`source` records which oracle was used).
-- Hard gate: `ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>` — incl. layout lint (6), **control lint (7**: dead controls / ghost targets / partial same-page reach / `control-scope.json` coverage; `--skip-control-lint` escape; see `refs/control-parity.md`**)**, and the MEASURED bars wired in Phase 5e: **gate 13 (source-anchor values** — arms when a source PNG is on disk; needs `source-anchors.json` ≥5 + a passing `anchors-verdict.json`; `--skip-anchors-gate "<reason>"`**)** and **gate 14 (visual-similarity floor** — `visual-similarity.json`; `--skip-visual-similarity "<reason>"`**)**. No source PNG on disk → both self-SKIP (stated), never a silent pass.
+- Hard gate: `ruby scripts/assert-powerbi-terminal.rb --workdir <dir> --workbook-id <wb>` — the plugin-local wrapper runs the byte-identical shared `assert-phase6-ran.rb`, then refreshes and verifies Power BI's strict-parity census, report, ledger, and canonical marker (`refs/terminal-handoff.md`). Shared gates include layout lint (6), **control lint (7**: dead controls / ghost targets / partial same-page reach / `control-scope.json` coverage; `--skip-control-lint` escape; see `refs/control-parity.md`**)**, and the MEASURED bars wired in Phase 5e: **gate 13 (source-anchor values** — arms when a source PNG is on disk; needs `source-anchors.json` ≥5 + a passing `anchors-verdict.json`; `--skip-anchors-gate "<reason>"`**)** and **gate 14 (visual-similarity floor** — `visual-similarity.json`; `--skip-visual-similarity "<reason>"`**)**. No source PNG on disk → both self-SKIP (stated), never a silent pass. Waiver-budget overflow exits 19 unless explicitly accepted with `--accept-waiver-budget-exceeded "<reason>"`; acceptance is recorded and can produce only a terminal YELLOW after every other gate passes.
 - Optional flip test when the report has slicers→controls: `ruby scripts/probe-controls.rb --workbook-id <wb> --check-out-of-closure` — runtime proof a control actually filters (in-closure export changes under a non-default `parameters` value, out-of-closure doesn't). MCP query can NOT flip controls (defaults only) — export API `parameters` is the only mechanism.
 
 ## Phase 7 — Bookmarks → per-bookmark workbooks (optional)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/terminal-handoff.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/terminal-handoff.md
@@ -1,0 +1,33 @@
+# Power BI terminal handoff
+
+Run the plugin-local terminal wrapper after strict parity:
+
+```bash
+ruby scripts/assert-powerbi-terminal.rb \
+  --workdir <WORK> --workbook-id <WORKBOOK_ID>
+```
+
+The wrapper delegates all common gates to the shared, byte-identical
+`assert-phase6-ran.rb`, preserving its exit codes and
+`--accept-waiver-budget-exceeded REASON` option. After shared gates pass, it
+refreshes Power BI's source census, degradation ledger, and migration report,
+normalizes the success marker to the canonical `TerminalOutcome` verdict, and
+runs `verify-complete.rb`.
+
+Terminal rules:
+
+- The one-shot mechanical builder writes `parity-pending.json` and exits 10.
+  Resolution-only output is usable but is not GREEN or YELLOW.
+- Every emitted/in-scope chart must have strict PASS parity. An emitted
+  time-intelligence route without PASS evidence is nonterminal.
+- A `needs-review` or `skipped` time-intelligence route can complete as YELLOW
+  only when it is terminal-accounted, non-emitted, and claims no parity proof.
+- Proven divergence is RED/nonzero.
+- Terminal GREEN/YELLOW requires `completion_status: complete` and fresh
+  `MIGRATION_REPORT.md`, `source-object-census.json`, and
+  `degradation-ledger.json`.
+- Unaccepted waiver-budget overflow remains exit 19. Named acceptance is
+  considered only after other gates pass and yields YELLOW exit 0.
+
+On any Power BI-specific finalization or verification failure, the wrapper
+removes `phase6-success.json`, writes a routing marker, and exits nonzero.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-powerbi-terminal.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-powerbi-terminal.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Power BI terminal wrapper around the shared assert-phase6-ran.rb gate.
+# The shared script remains byte-identical across plugins; this wrapper adds the
+# Power BI-specific accounting/report finalization and canonical marker check.
+
+require 'json'
+require 'open3'
+require 'rbconfig'
+require 'time'
+require_relative 'lib/terminal_outcome'
+
+def option_value(argv, *names)
+  argv.each_with_index do |argument, index|
+    names.each do |name|
+      return argv[index + 1] if argument == name
+      return argument.delete_prefix("#{name}=") if argument.start_with?("#{name}=")
+    end
+  end
+  nil
+end
+
+def write_json(path, value)
+  temporary = "#{path}.tmp.#{Process.pid}"
+  File.binwrite(temporary, JSON.pretty_generate(value) + "\n")
+  File.rename(temporary, path)
+ensure
+  File.delete(temporary) if defined?(temporary) && File.exist?(temporary)
+end
+
+def clear_terminal_marker(workdir, reason)
+  success = File.join(workdir, 'phase6-success.json')
+  File.delete(success) if File.file?(success)
+  write_json(
+    File.join(workdir, 'parity-pending.json'),
+    'status' => 'terminal-validation-failed',
+    'routing' => reason,
+    'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+  )
+end
+
+workdir = option_value(ARGV, '--workdir', '--tableau')
+workbook_id = option_value(ARGV, '--workbook-id')
+
+gate_out, gate_err, gate_status = Open3.capture3(
+  RbConfig.ruby, File.join(__dir__, 'assert-phase6-ran.rb'), *ARGV
+)
+unless gate_status.success?
+  $stdout.write(gate_out)
+  $stderr.write(gate_err)
+  exit gate_status.exitstatus
+end
+
+# The shared gate owns common PASS/FAIL checks, but its generic degradation
+# headline is not Power BI's terminal verdict. Suppress only that trailing
+# generic terminal block; the wrapper prints the canonical report verdict after
+# plugin finalization.
+gate_lines = gate_out.lines.take_while { |line| !line.start_with?('[OK] all gates pass') }
+$stdout.write(gate_lines.join)
+$stderr.write(gate_err)
+puts '[OK] shared gates pass — Power BI terminal report validation pending.'
+
+unless workdir && File.directory?(workdir)
+  warn 'assert-powerbi-terminal: shared gate passed but --workdir/--tableau is unavailable'
+  exit 8
+end
+
+begin
+  marker_path = File.join(workdir, 'phase6-success.json')
+  shared_marker = JSON.parse(File.read(marker_path))
+  File.delete(marker_path)
+  write_json(
+    File.join(workdir, 'parity-pending.json'),
+    'status' => 'terminal-finalization-running',
+    'routing' => 'Power BI report/census/ledger validation must finish',
+    'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+  )
+rescue StandardError => e
+  clear_terminal_marker(workdir, "shared gate did not produce a readable provisional marker: #{e.message}")
+  warn "assert-powerbi-terminal: #{e.message}"
+  exit 8
+end
+
+system(RbConfig.ruby, File.join(__dir__, 'finalize-powerbi-report.rb'), '--workdir', workdir)
+finalize_exit = $?.exitstatus
+unless finalize_exit.zero?
+  clear_terminal_marker(workdir, "fix Power BI terminal report/fidelity validation (exit #{finalize_exit})")
+  warn 'assert-powerbi-terminal: finalization failed; terminal success marker removed'
+  exit finalize_exit
+end
+
+begin
+  result = JSON.parse(File.read(File.join(workdir, 'migration-result.json')))
+  expected = TerminalOutcome.expected_report_verdict(
+    Array(result['source_objects']),
+    Array(result['degradations']) + Array(result['waivers'])
+  )
+  raise "report verdict #{result['verdict'] || 'missing'} != expected #{expected}" unless result['verdict'].to_s == expected
+  raise "completion_status #{result['completion_status'] || 'missing'} != complete" unless result['completion_status'].to_s == 'complete'
+
+  marker = shared_marker
+  marker['gates'] = 'all-pass'
+  marker['verdict'] = expected
+  write_json(marker_path, marker)
+  pending_path = File.join(workdir, 'parity-pending.json')
+  File.delete(pending_path) if File.file?(pending_path)
+rescue StandardError => e
+  clear_terminal_marker(workdir, "repair canonical terminal marker/report agreement: #{e.message}")
+  warn "assert-powerbi-terminal: #{e.message}"
+  exit 8
+end
+
+verify_args = [RbConfig.ruby, File.join(__dir__, 'verify-complete.rb'), '--workdir', workdir]
+verify_args.concat(['--workbook-id', workbook_id]) unless workbook_id.to_s.empty?
+system(*verify_args)
+verify_exit = $?.exitstatus
+unless verify_exit.zero?
+  clear_terminal_marker(workdir, "repair final Power BI completion verification (exit #{verify_exit})")
+  warn 'assert-powerbi-terminal: completion verification failed; terminal success marker removed'
+end
+exit verify_exit

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-powerbi-accounting.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-powerbi-accounting.rb
@@ -333,17 +333,29 @@ begin
         bound_visuals = source_visuals.select do |_page, visual|
           Array(visual.fetch('bindings', {}).values).flatten.compact.map(&:to_s).include?(query_ref)
         end
+        route_emitted = %w[routed emitted].include?(route['status'].to_s)
         proven_visual = bound_visuals.find do |_page, visual|
           built = built_visual(visual, spec_wb_elements)
           built && readback_present?(built, readback_wb_elements) && visual_parity_pass?(visual, built, parity)
         end
-        parity_proven = route['status'] == 'routed' && strict_parity?(parity) && !proven_visual.nil?
-        status = parity_proven ? 'migrated' : 'needs-review'
+        parity_proven = route_emitted && strict_parity?(parity) && !proven_visual.nil?
+        status = if parity_proven
+                   'migrated'
+                 elsif route['status'].to_s == 'skipped'
+                   'skipped'
+                 else
+                   'needs-review'
+                 end
         measure_evidence << evidence('time-intelligence-routing.json',
                                      "route status=#{route['status']}; reason=#{route['reason']}")
-        measure_evidence << evidence('workbook readback + parity-final.json',
-                                     parity_proven ? "routed chart #{visual_name(proven_visual.last)} is present and strict-PASS" :
-                                                     'routed measure has no present strict-PASS chart')
+        if route_emitted
+          measure_evidence << evidence('workbook readback + parity-final.json',
+                                       parity_proven ? "routed chart #{visual_name(proven_visual.last)} is present and strict-PASS" :
+                                                       'emitted route has no present strict-PASS chart')
+        else
+          measure_evidence << evidence('time-intelligence-routing.json',
+                                       'terminal route is explicitly not emitted as a proven route')
+        end
       elsif time_intel_shape
         status = 'needs-review'
         measure_evidence << evidence('model + time-intelligence-routing.json',
@@ -407,17 +419,18 @@ begin
       end
       built = built_visual(visual, spec_wb_elements)
       in_readback = readback_present?(built, readback_wb_elements)
-      status = severity_status(rows)
-      if status.nil?
-        status = if !built
-                   'skipped'
-                 elsif !in_readback
-                   'needs-review'
-                 elsif data_visual?(visual)
-                   visual_parity_pass?(visual, built, parity) && strict_parity?(parity) ? 'migrated' : 'needs-review'
-                 else
-                   'migrated'
-                 end
+      emitted = !built.nil? && in_readback
+      parity_in_scope = data_visual?(visual)
+      parity_proven = emitted && parity_in_scope &&
+                      strict_parity?(parity) && visual_parity_pass?(visual, built, parity)
+      status = if !built
+                 'skipped'
+               elsif !in_readback
+                 'needs-review'
+               elsif parity_in_scope && !parity_proven
+                 'needs-review'
+               else
+                 severity_status(rows) || 'migrated'
       end
       visual_statuses[visual_id.to_s] = status
       details = []
@@ -431,7 +444,11 @@ begin
                               'visual is named in strict parity PASS evidence' :
                               'visual is not proven by strict parity PASS evidence')
       end
-      objects << object('visual', visual_id, name, status, details, 'parent_id' => page_id)
+      objects << object('visual', visual_id, name, status, details,
+                        'parent_id' => page_id,
+                        'emitted' => emitted,
+                        'parity_in_scope' => parity_in_scope,
+                        'parity_proven' => parity_proven)
     end
   end
 
@@ -480,6 +497,8 @@ begin
   # completion verifier can require freshness via this builder's --check mode.
   route_proofs = Array(routing['routes']).map do |route|
     query_ref = route.dig('source_measure', 'query_ref').to_s
+    route_status = route['status'].to_s
+    emitted = %w[routed emitted].include?(route_status)
     matching = source_visuals.select do |_page, visual|
       Array(visual.fetch('bindings', {}).values).flatten.compact.map(&:to_s).include?(query_ref)
     end
@@ -490,10 +509,12 @@ begin
     end
     {
       'query_ref' => query_ref,
-      'route_status' => route['status'],
-      'parity_required' => route['parity_required'] == true,
-      'parity_proven' => route['status'] == 'routed' && strict_parity?(parity) && !passed.empty?,
-      'pass_charts' => passed.sort,
+      'route_status' => route_status,
+      'terminal_accounted' => %w[routed emitted needs-review skipped].include?(route_status),
+      'emitted' => emitted,
+      'parity_required' => emitted,
+      'parity_proven' => emitted && strict_parity?(parity) && !passed.empty?,
+      'pass_charts' => emitted ? passed.sort : [],
       'reason' => route['reason']
     }
   end
@@ -508,7 +529,9 @@ begin
     route_proofs << {
       'query_ref' => query_ref,
       'route_status' => 'missing',
-      'parity_required' => true,
+      'terminal_accounted' => false,
+      'emitted' => false,
+      'parity_required' => false,
       'parity_proven' => false,
       'pass_charts' => [],
       'reason' => 'time-intelligence measure absent from routing artifact'
@@ -522,6 +545,9 @@ begin
   raise AccountingError, "duplicate source identities: #{duplicates.inspect}" unless duplicates.empty?
 
   counts = TERMINAL.to_h { |status| [status, objects.count { |row| row['terminal_status'] == status }] }
+  emitted_visuals = objects.select do |row|
+    row['type'] == 'visual' && row['emitted'] == true && row['parity_in_scope'] == true
+  end
   census = {
     'schema_version' => 1,
     'source' => 'powerbi',
@@ -529,7 +555,10 @@ begin
       'total' => objects.length,
       'accounted' => objects.length,
       'complete' => true,
-      'counts' => counts
+      'counts' => counts,
+      'emitted_charts' => emitted_visuals.length,
+      'emitted_charts_parity_proven' => emitted_visuals.count { |row| row['parity_proven'] == true },
+      'strict_parity_complete' => emitted_visuals.all? { |row| row['parity_proven'] == true }
     },
     'source_objects' => objects,
     'time_intelligence' => {

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/finalize-powerbi-report.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/finalize-powerbi-report.rb
@@ -14,6 +14,7 @@ require 'pathname'
 require 'rbconfig'
 require_relative 'lib/degradation_ledger'
 require_relative 'lib/py_resolve'
+require_relative 'lib/terminal_outcome'
 
 class FinalizeError < StandardError; end
 
@@ -179,6 +180,27 @@ def aggregate_health(kind, records)
   }
 end
 
+def validate_powerbi_strict_parity!(workdir)
+  parity = read_json(File.join(workdir, 'parity-final.json')) || {}
+  census = read_json(File.join(workdir, 'source-object-census.json')) || {}
+  total = parity['charts_total'].to_i
+  errors = []
+  errors << "parity status is #{parity['status'] || 'missing'}" unless parity['status'].to_s.upcase == 'PASS'
+  errors << "parity mode is #{parity['mode'] || 'missing'}, expected strict" unless parity['mode'].to_s == 'strict'
+  errors << 'charts_total is zero' unless total.positive?
+  errors << "charts_pass #{parity['charts_pass']} != charts_total #{total}" unless parity['charts_pass'].to_i == total
+  errors << "charts_fail is #{parity['charts_fail'] || 'missing'}, expected 0" unless parity.key?('charts_fail') && parity['charts_fail'].to_i.zero?
+
+  emitted = Array(census['source_objects']).select do |row|
+    row['type'].to_s == 'visual' && row['emitted'] == true && row['parity_in_scope'] == true
+  end
+  unproven = emitted.reject { |row| row['parity_proven'] == true }
+  errors << "emitted/in-scope charts lack strict parity: #{unproven.map { |row| row['name'] }.join(', ')}" unless unproven.empty?
+  errors << 'source census does not declare strict_parity_complete=true' unless census.dig('summary', 'strict_parity_complete') == true
+
+  raise FinalizeError, errors.join('; ') unless errors.empty?
+end
+
 options = {}
 parser = OptionParser.new do |opts|
   opts.banner = 'Usage: finalize-powerbi-report.rb --workdir DIR [--preliminary]'
@@ -254,7 +276,19 @@ begin
   raise FinalizeError, "migration report freshness check failed (exit #{check_status.exitstatus})" unless check_status.success?
 
   result = read_json(File.join(workdir, 'migration-result.json')) || {}
-  raise FinalizeError, 'migration-result.json is RED' if result['verdict'].to_s == 'RED'
+  validate_powerbi_strict_parity!(workdir)
+  expected_verdict = TerminalOutcome.expected_report_verdict(
+    Array(result['source_objects']),
+    Array(result['degradations']) + Array(result['waivers'])
+  )
+  unless result['verdict'].to_s == expected_verdict
+    raise FinalizeError,
+          "migration-result.json verdict #{result['verdict'] || 'missing'} != expected #{expected_verdict}"
+  end
+  unless result['completion_status'].to_s == 'complete'
+    raise FinalizeError,
+          "migration-result.json completion_status is #{result['completion_status'] || 'missing'}, expected complete"
+  end
   puts "powerbi finalization: #{result['verdict']} — accounting/report/ledger/PNG health refreshed"
   exit 0
 rescue FinalizeError, OptionParser::ParseError => e

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -2004,8 +2004,16 @@ run!(['ruby', File.join(HERE, 'finalize-powerbi-report.rb'),
 # see enhance-scan.rb + enhance-apply.rb (the shared Phase-E engine).
 # ---------------------------------------------------------------------------
 enhance_line = nil
-if opts[:enhance] && !parity_ok
-  enhance_line = 'SKIPPED — parity not green (Phase E only clones a parity-verified workbook)'
+strict_parity = begin
+  doc = JSON.parse(File.read(File.join(WORK, 'parity-final.json')))
+  total = doc['charts_total'].to_i
+  doc['status'].to_s.upcase == 'PASS' && doc['mode'].to_s == 'strict' &&
+    total.positive? && doc['charts_pass'].to_i == total && doc['charts_fail'].to_i.zero?
+rescue StandardError
+  false
+end
+if opts[:enhance] && !strict_parity
+  enhance_line = 'SKIPPED — strict value parity pending (Phase E only clones a parity-verified workbook)'
 elsif opts[:enhance]
   puts
   puts '── Phase E (opt-in) · Enhance ──'
@@ -2086,13 +2094,15 @@ if fresh_ok
 end
 puts "ENHANCE     : #{enhance_line}" if enhance_line
 puts "CONTROL-FLIP: #{flip_line}" if flip_line
-# Empty-workbook guard + completion sentinel. parity_ok is VACUOUSLY true when no
+# Empty-workbook guard + routing marker. parity_ok is VACUOUSLY true when no
 # chart elements were built (0 cols, 0 divergent) — an empty/placeholder workbook
 # would otherwise exit 0 and look "done" (the exact PBI failure: pages, no
-# elements). Require real elements, and stamp a run-scoped success marker only on
-# a genuine pass so verify-complete.rb (the done-check the SKILL points at) can't
-# green an empty result.
-built_ok = parity_ok && chart_els.size.positive?
+# elements). A real resolution pass is still not terminal: this one-shot path
+# does not collect strict source parity, so it writes parity-pending.json and
+# exits with the established decision/routing code 10. Only the plugin-local
+# assert-powerbi-terminal.rb wrapper may retain phase6-success.json after the
+# shared gate and Power BI report checks pass.
+resolution_ready = parity_ok && chart_els.size.positive?
 if chart_els.size.zero?
   puts 'ELEMENTS    : 0 chart elements built — EMPTY workbook, NOT a complete migration.'
   puts '              Parity is vacuous with no elements. Do NOT report success: re-extract the'
@@ -2101,18 +2111,27 @@ if chart_els.size.zero?
 end
 begin
   succ = File.join(WORK, 'phase6-success.json')
-  if built_ok
-    # 'resolution-pass' (not 'parity-pass'): this marker records that the build
-    # resolved + freshness-matched, NOT that values were diffed against source.
-    # verify-complete.rb reports value parity separately (parity-final.json).
-    File.write(succ, JSON.pretty_generate('workbookId' => wb_id, 'chartCount' => chart_els.size,
-                                          'gates' => 'resolution-pass',
-                                          'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
-  elsif File.exist?(succ)
-    File.delete(succ) # a prior success marker is stale if this run isn't green
+  pending = File.join(WORK, 'parity-pending.json')
+  File.delete(succ) if File.exist?(succ)
+  if resolution_ready
+    File.write(pending, JSON.pretty_generate(
+      'workbookId' => wb_id,
+      'chartCount' => chart_els.size,
+      'status' => 'parity-pending',
+      'routing' => 'run strict parity, then assert-powerbi-terminal.rb',
+      'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+    ))
+  elsif File.exist?(pending)
+    File.delete(pending)
   end
 rescue StandardError
   nil # sentinel bookkeeping never fails the run
 end
+if resolution_ready
+  puts 'HANDOFF     : ROUTING REQUIRED — workbook is usable, but strict value parity is pending.'
+  puts '              This is not GREEN or YELLOW. Run Phase 6 parity and assert-powerbi-terminal.rb.'
+else
+  puts 'HANDOFF     : RED — resolution/build correctness failed.'
+end
 puts '======================================='
-exit(built_ok ? 0 : 3)
+exit(resolution_ready ? 10 : 3)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/run.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/run.sh
@@ -27,6 +27,7 @@
 #     --ref-dm <referenceDataModelId> \
 #     --master-map /tmp/pbir/master-map.json \
 #     --name "My Report (from Power BI)" \
+#     [--accept-waiver-budget-exceeded "reviewed exception"] \
 #     [--from extract|convert|post-dm|build|post-wb|layout|parity]
 #
 # All artifacts land in --work-dir; each stage is idempotent.
@@ -36,6 +37,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 WORK=/tmp/pbir; FROM=extract
 WS=""; REPORT=""; DATASET=""; BIM=""; CONN=""; DB=""; SCHEMA=""
 REF_DM=""; MMAP=""; NAME=""; CVT_OUT=""; FOLDER=""
+WAIVER_BUDGET_REASON=""
 while [[ $# -gt 0 ]]; do case "$1" in
   --work-dir) WORK="$2"; shift 2;;
   --workspace) WS="$2"; shift 2;;
@@ -50,11 +52,16 @@ while [[ $# -gt 0 ]]; do case "$1" in
   --name) NAME="$2"; shift 2;;
   --folder-id) FOLDER="$2"; shift 2;;
   --converter-out) CVT_OUT="$2"; shift 2;;
+  --accept-waiver-budget-exceeded) WAIVER_BUDGET_REASON="$2"; shift 2;;
   --from) FROM="$2"; shift 2;;
   *) echo "unknown arg $1" >&2; exit 1;;
 esac; done
 mkdir -p "$WORK"
 CVT_OUT="${CVT_OUT:-$WORK/dm-raw.json}"
+ASSERT_BUDGET_ARGS=()
+if [[ -n "$WAIVER_BUDGET_REASON" ]]; then
+  ASSERT_BUDGET_ARGS=(--accept-waiver-budget-exceeded "$WAIVER_BUDGET_REASON")
+fi
 
 # ---- Python resolution + venv bootstrap (bead 7o01) -------------------------
 # The extract/auth scripts need msal + requests + truststore (scripts/
@@ -180,8 +187,8 @@ if [[ $START -le 6 ]]; then
   if [[ -n "$WB_ID" && -f "$WORK/layout.xml" ]]; then
     ruby "$HERE/put-layout.rb" --workbook "$WB_ID" --layout "$WORK/layout.xml"
     # Re-assert the layout actually stuck (catches a silent wipe).
-    if ruby "$HERE/assert-phase6-ran.rb" --tableau "$WORK" --workbook-id "$WB_ID" \
-         --skip-orphan-check --skip-column-check 2>/dev/null \
+    if ruby "$HERE/assert-powerbi-terminal.rb" --tableau "$WORK" --workbook-id "$WB_ID" \
+         --skip-orphan-check --skip-column-check "${ASSERT_BUDGET_ARGS[@]}" 2>/dev/null \
        | grep -q 'gate 4/4: layout XML applied'; then
       echo "  layout-survives check: OK"
     else
@@ -218,20 +225,26 @@ if [[ $START -le 7 ]]; then
   fi
 fi
 
-# ---- FINAL GATE: assert-phase6-ran (bead 148 flags: --tableau + --workbook-id) ----
-# The shared hard gate proves Phase 6 ran, no orphan workbooks, no type=error
-# columns, AND the layout survived (gate 4/4 — bead 16i). It needs the
-# per-conversion dir via --tableau (NOT --workdir) and --workbook-id.
+# ---- FINAL GATE: Power BI wrapper around shared assert-phase6-ran ----
+# The wrapper preserves the shared gate byte-for-byte, then refreshes and checks
+# Power BI's report/census/ledger and canonical terminal marker.
 WB_ID=$(grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$WORK/wb-post.txt" 2>/dev/null | head -1 || true)
 if [[ -f "$WORK/parity-final.json" && -n "$WB_ID" ]]; then
-  echo "== FINAL GATE: assert-phase6-ran =="
-  ruby "$HERE/assert-phase6-ran.rb" --tableau "$WORK" --workbook-id "$WB_ID" || {
-    echo "  >>> GATE FAILED — fix the reported issue before declaring done."; exit 1;
-  }
+  echo "== FINAL GATE: assert-powerbi-terminal =="
+  set +e
+  ruby "$HERE/assert-powerbi-terminal.rb" --tableau "$WORK" --workbook-id "$WB_ID" \
+    "${ASSERT_BUDGET_ARGS[@]}"
+  GATE_RC=$?
+  set -e
+  if [[ $GATE_RC -ne 0 ]]; then
+    echo "  >>> GATE STOPPED (exit $GATE_RC) — preserve the decision/failure code; do not declare done."
+    exit "$GATE_RC"
+  fi
 elif [[ -n "$WB_ID" ]]; then
-  echo "== FINAL GATE (layout + columns only; parity-final.json not yet present) =="
-  ruby "$HERE/assert-phase6-ran.rb" --tableau "$WORK" --workbook-id "$WB_ID" \
-    --skip-orphan-check 2>&1 | grep -E 'gate [34]/4' || true
-  echo "  (run the parity --finalize MCP gate to complete gate 1/4)"
+  echo "== ROUTING REQUIRED (layout + columns only; strict parity pending) =="
+  ruby "$HERE/assert-powerbi-terminal.rb" --tableau "$WORK" --workbook-id "$WB_ID" \
+    --skip-orphan-check "${ASSERT_BUDGET_ARGS[@]}" 2>&1 | grep -E 'gate [34]/4' || true
+  echo "  (run the parity --finalize MCP gate, then resume; this is not terminal GREEN/YELLOW)"
+  exit 10
 fi
-echo "== run.sh done (resume any stage with --from <stage>) =="
+echo "== run.sh terminal gate complete (resume any stage with --from <stage>) =="

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-powerbi-accounting.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-powerbi-accounting.rb
@@ -75,7 +75,8 @@ def command(*args)
   [status.exitstatus, out + err]
 end
 
-def seed_workdir(dir, route_pass: true)
+def seed_workdir(dir, route_status: 'routed', emit_route: true, route_parity: true,
+                 divergence: false, marker_gates: 'all-pass')
   raw = JSON.parse(File.read(MODEL_FIXTURE))
   source_table = raw.dig('model', 'tables').find { |table| table['name'] == 'ABSENCE_RECORDS' }
   source_table = JSON.parse(JSON.generate(source_table))
@@ -126,7 +127,10 @@ def seed_workdir(dir, route_pass: true)
              'pages' => [{ 'id' => 'dm-page', 'elements' => [dm_element] }])
   write_json(File.join(dir, 'conv-meta.json'), 'model' => dm_spec, 'warnings' => [], 'stats' => {})
 
-  elements = signals['pages'][0]['visuals'].map do |visual|
+  emitted_visuals = signals['pages'][0]['visuals'].reject do |visual|
+    visual['visual_id'] == 'ti-route' && !emit_route
+  end
+  elements = emitted_visuals.map do |visual|
     {
       'id' => "el-#{short_id(visual['visual_id'])}",
       'name' => visual_name(visual),
@@ -165,30 +169,42 @@ def seed_workdir(dir, route_pass: true)
              'unbound' => [])
   write_json(File.join(dir, 'time-intelligence-routing.json'),
              'schema_version' => 1,
-             'summary' => { 'routed' => 1, 'needs_review' => 0, 'parity_required' => true },
+             'summary' => {
+               'routed' => %w[routed emitted].include?(route_status) ? 1 : 0,
+               'needs_review' => route_status == 'needs-review' ? 1 : 0,
+               'parity_required' => %w[routed emitted].include?(route_status)
+             },
              'routes' => [{
                'source_measure' => {
                  'table' => 'ABSENCE_RECORDS', 'name' => 'YTD Absence Hours',
                  'query_ref' => 'ABSENCE_RECORDS.YTD Absence Hours'
                },
-               'dax_shape' => 'ytd', 'status' => 'routed',
-               'reason' => 'same-fact-supported-shape', 'parity_required' => true,
+               'dax_shape' => 'ytd', 'status' => route_status,
+               'reason' => route_status == 'needs-review' ? 'explicit-review-disposition' : 'same-fact-supported-shape',
+               'parity_required' => %w[routed emitted].include?(route_status),
                'target_element' => { 'id' => 'dm-absence', 'name' => 'ABSENCE_RECORDS' },
                'target_column' => { 'id' => 'metric-ytdabsencehours', 'name' => 'YTD Absence Hours' }
              }])
 
-  data_names = signals['pages'][0]['visuals'].select do |visual|
+  data_names = emitted_visuals.select do |visual|
     visual['sigma_kind'] != 'control' && visual['sigma_kind'] != 'navigation'
   end.map { |visual| visual_name(visual) }
-  data_names.delete('YTD Absence Trend') unless route_pass
+  data_names.delete('YTD Absence Trend') unless route_parity
+  failed = divergence ? 1 : 0
+  passed = [data_names.length - failed, 0].max
+  classifications = data_names.to_h { |name| [name, 'MATCH'] }
+  classifications[data_names.first] = 'DIVERGENT' if divergence && data_names.first
   write_json(File.join(dir, 'parity-final.json'),
-             'workbook_id' => 'wb-fixture', 'mode' => 'strict', 'status' => 'PASS',
-             'charts_total' => data_names.length, 'charts_pass' => data_names.length,
-             'charts_fail' => 0, 'pass_names' => data_names,
-             'classifications' => data_names.to_h { |name| [name, 'MATCH'] })
+             'workbook_id' => 'wb-fixture', 'mode' => 'strict',
+             'status' => divergence ? 'FAIL' : 'PASS',
+             'charts_total' => data_names.length, 'charts_pass' => passed,
+             'charts_fail' => failed, 'pass_names' => data_names.drop(failed),
+             'classifications' => classifications)
   write_json(File.join(dir, 'phase6-success.json'),
-             'workbookId' => 'wb-fixture', 'chartCount' => data_names.length,
-             'gates' => 'resolution-pass', 'generatedAt' => '2026-08-20T00:00:00Z')
+             'workbookId' => 'wb-fixture', 'chartCount' => [data_names.length, 1].max,
+             'gates' => marker_gates,
+             'verdict' => route_status == 'routed' ? 'GREEN' : 'YELLOW',
+             'generatedAt' => '2026-08-20T00:00:00Z')
   write_json(File.join(dir, 'visual-similarity.json'),
              'status' => 'PASS',
              'source_health' => { 'path' => 'source.png', 'status' => 'PASS', 'reasons' => [] },
@@ -228,6 +244,14 @@ Dir.mktmpdir('pbi-accounting-success') do |dir|
   check(condition, "verify-complete accepts complete non-RED fresh report" \
                    "#{condition ? '' : " [exit=#{code}; #{output.strip}]"}")
 
+  marker = JSON.parse(File.read(File.join(dir, 'phase6-success.json')))
+  marker['verdict'] = 'YELLOW'
+  write_json(File.join(dir, 'phase6-success.json'), marker)
+  code, = command(RbConfig.ruby, VERIFY, '--workdir', dir)
+  check(code == 6, 'terminal marker verdict must exactly match the canonical report verdict')
+  marker['verdict'] = 'GREEN'
+  write_json(File.join(dir, 'phase6-success.json'), marker)
+
   census['summary']['complete'] = false
   write_json(File.join(dir, 'source-object-census.json'), census)
   code, = command(RbConfig.ruby, VERIFY, '--workdir', dir)
@@ -242,15 +266,52 @@ Dir.mktmpdir('pbi-accounting-success') do |dir|
   check(code == 6, 'unaccounted visual is rejected with accounting exit 6')
 end
 
-puts 'missing route parity'
-Dir.mktmpdir('pbi-accounting-route') do |dir|
-  seed_workdir(dir, route_pass: false)
+puts 'terminal-accounted non-emitted time-intelligence route'
+Dir.mktmpdir('pbi-accounting-route-yellow') do |dir|
+  seed_workdir(dir, route_status: 'needs-review', emit_route: false)
   code, = command(RbConfig.ruby, FINALIZER, '--workdir', dir)
-  check(code.zero?, 'needs-review route produces a non-RED diagnostic report')
+  result = JSON.parse(File.read(File.join(dir, 'migration-result.json')))
+  check(code.zero? && result['verdict'] == 'YELLOW' &&
+        result['completion_status'] == 'complete',
+        'terminal-accounted needs-review route produces complete YELLOW')
   code, output = command(RbConfig.ruby, VERIFY, '--workdir', dir)
-  condition = code == 7 && output.include?('time-intelligence')
-  check(condition, "missing route chart PASS is rejected with exit 7" \
+  condition = code.zero? && output.include?('COMPLETE - YELLOW') && !output.include?('GREEN')
+  check(condition, "non-emitted needs-review route is a YELLOW exit-0 handoff" \
                    "#{condition ? '' : " [exit=#{code}; #{output.strip}]"}")
+  check(%w[MIGRATION_REPORT.md source-object-census.json degradation-ledger.json].all? do |name|
+          File.file?(File.join(dir, name))
+        end,
+        'YELLOW handoff includes report, census, and degradation ledger')
+  proof = JSON.parse(File.read(File.join(dir, 'source-object-census.json')))
+              .dig('time_intelligence', 'routes').first
+  check(proof['terminal_accounted'] == true && proof['emitted'] == false &&
+        proof['parity_required'] == false && proof['parity_proven'] == false &&
+        proof['pass_charts'] == [],
+        'needs-review route is terminal-accounted but never emitted as a proven route')
+end
+
+puts 'emitted time-intelligence route missing parity'
+Dir.mktmpdir('pbi-accounting-route-red') do |dir|
+  seed_workdir(dir, route_status: 'routed', emit_route: true, route_parity: false)
+  code, output = command(RbConfig.ruby, FINALIZER, '--workdir', dir)
+  result = JSON.parse(File.read(File.join(dir, 'migration-result.json')))
+  check(code.nonzero? && result['verdict'] != 'GREEN' &&
+        output.include?('emitted/in-scope charts lack strict parity'),
+        'emitted route without strict chart parity is nonterminal/nonzero')
+  code, = command(RbConfig.ruby, VERIFY, '--workdir', dir)
+  check(code.nonzero?, 'verify-complete rejects emitted route missing parity')
+end
+
+puts 'proven parity divergence'
+Dir.mktmpdir('pbi-accounting-divergence') do |dir|
+  seed_workdir(dir, divergence: true)
+  code, = command(RbConfig.ruby, FINALIZER, '--workdir', dir)
+  result = JSON.parse(File.read(File.join(dir, 'migration-result.json')))
+  check(code.nonzero? && result['verdict'] == 'RED' &&
+        result['completion_status'] == 'blocked',
+        'proven divergence remains RED/nonzero')
+  code, = command(RbConfig.ruby, VERIFY, '--workdir', dir)
+  check(code.nonzero?, 'verify-complete rejects proven divergence')
 end
 
 puts 'unaccounted measure and report contradiction'

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-complete.rb
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 # Regression test for the Power BI completion sentinel (2026-07-10).
 #
-# "Done" is a fact on disk: migrate-powerbi.rb stamps phase6-success.json
-# (workbookId + chartCount + parity-pass) only on a real, non-empty, parity-
-# passing build; verify-complete.rb greens ONLY on that. Guards the exact PBI
+# "Done" is a fact on disk: only assert-phase6-ran.rb stamps
+# phase6-success.json with gates=all-pass. The one-shot builder routes to parity
+# with parity-pending.json and exit 10. Guards the exact PBI
 # failure where a blocked agent ships empty placeholder pages and calls it done.
 #
 # Usage: ruby scripts/test-verify-complete.rb
@@ -29,13 +29,18 @@ Dir.mktmpdir do |wd|
   check(out.include?('NOT DONE') && out.include?('never hand-author'),
         'empty-workdir message warns against hand-authoring', fails)
 
-  # 2) resolution marker alone is not value parity → NOT DONE (5)
+  # 2) resolution marker alone is not a terminal marker → NOT DONE (5)
   File.write(File.join(wd, 'phase6-success.json'),
              JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'resolution-pass',
                            'generatedAt' => '2026-07-10T00:00:00Z'))
   code, out = run_vc(VC, wd)
-  check(code == 5, "success marker without value parity => exit 5 (got #{code})", fails)
-  check(out.include?('value parity was not run'), 'missing parity message names the required gate', fails)
+  check(code == 5, "resolution-only marker => exit 5 (got #{code})", fails)
+  check(out.include?('NOT DONE - phase6-success.json is resolution-only') &&
+        !out.include?('terminal handoff'),
+        'resolution-only marker is never called DONE', fails)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'all-pass',
+                           'generatedAt' => '2026-07-10T00:00:00Z'))
 
   # 3) strict parity alone no longer proves completion: whole-source accounting
   # and the generated migration report are part of the final contract.
@@ -58,22 +63,42 @@ Dir.mktmpdir do |wd|
 
   # 5) marker present but 0 charts → NOT DONE (3) (empty workbook)
   File.write(File.join(wd, 'phase6-success.json'),
-             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 0))
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 0, 'gates' => 'all-pass'))
   code, = run_vc(VC, wd)
   check(code == 3, "0-chart marker => exit 3 empty (got #{code})", fails)
 
   # 6) workbook mismatch → exit 4
   File.write(File.join(wd, 'phase6-success.json'),
-             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9))
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'all-pass'))
   code, = run_vc(VC, wd, wb: 'wb-OTHER')
   check(code == 4, "workbook mismatch => exit 4 (got #{code})", fails)
 end
 
-# 7) the orchestrator wires the empty-workbook guard + success stamp.
+# 7) the orchestrator wires the empty-workbook guard + nonterminal routing stamp.
 mt = File.read(File.join(DIR, 'migrate-powerbi.rb'))
-check(mt.include?('built_ok = parity_ok && chart_els.size.positive?'),
-      'orchestrator requires real elements for a green (no vacuous empty pass)', fails)
-check(mt.include?('phase6-success.json'), 'orchestrator stamps the success sentinel', fails)
+check(mt.include?('resolution_ready = parity_ok && chart_els.size.positive?'),
+      'orchestrator requires real elements before routing to parity', fails)
+check(mt.include?('parity-pending.json') && mt.include?('exit(resolution_ready ? 10 : 3)'),
+      'orchestrator stamps parity-pending and exits with routing code 10', fails)
+check(!mt.match?(/File\.write\(succ/),
+      'orchestrator never writes the terminal success sentinel', fails)
+run_sh = File.read(File.join(DIR, 'run.sh'))
+assert_src = File.read(File.join(DIR, 'assert-phase6-ran.rb'))
+wrapper_src = File.read(File.join(DIR, 'assert-powerbi-terminal.rb'))
+check(run_sh.include?('--accept-waiver-budget-exceeded') &&
+      run_sh.include?('"${ASSERT_BUDGET_ARGS[@]}"') &&
+      run_sh.scan('assert-powerbi-terminal.rb').length == 3 &&
+      run_sh.include?('exit "$GATE_RC"'),
+      'run.sh plumbs waiver-budget acceptance and preserves assert exit 19/10', fails)
+check(assert_src.include?("p.on('--accept-waiver-budget-exceeded REASON'") &&
+      assert_src.include?("final_verdict = 'YELLOW' if budget_exceeded_accepted"),
+      'assert exposes named budget acceptance as YELLOW only', fails)
+check(wrapper_src.include?('assert-phase6-ran.rb') &&
+      wrapper_src.include?('finalize-powerbi-report.rb') &&
+      wrapper_src.include?('completion_status') &&
+      wrapper_src.include?('TerminalOutcome.expected_report_verdict') &&
+      wrapper_src.include?('clear_terminal_marker'),
+      'plugin wrapper requires complete report/census/ledger and removes stale success', fails)
 # 8) missing-input aborts point at the device-code connect, not a bare "missing".
 check(mt.include?('fabric-extract.py') && mt.include?('microsoft.com/devicelogin'),
       'missing --tmsl/--pbir abort prompts device-code Power BI connect', fails)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-complete.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-complete.rb
@@ -3,9 +3,10 @@
 #
 # verify-complete.rb — the single offline "is this migration actually done?" check.
 #
-# A Power BI→Sigma conversion produced a real, non-empty workbook ONLY when
-# migrate-powerbi.rb finished and stamped <workdir>/phase6-success.json
-# (workbookId + chartCount + gates) at exit 0. An EMPTY / placeholder workbook
+# A Power BI→Sigma conversion is terminal ONLY when assert-phase6-ran.rb stamped
+# <workdir>/phase6-success.json with gates=all-pass after strict parity. The
+# one-shot builder writes parity-pending.json and exits 10 instead. An EMPTY /
+# placeholder workbook
 # (pages but no elements — the classic failure where a blocked agent hand-builds
 # a shell) never gets that marker, because the orchestrator refuses to green a
 # 0-element build. So "built" is a fact on disk, not "the pages look right".
@@ -18,14 +19,16 @@
 # Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
 #
 # Exit codes:
-#   0  DONE   — non-empty build marker + parity-final.json proving every chart
-#              strict-PASS against the source
+#   0  COMPLETE — terminal GREEN or YELLOW report + all-pass marker +
+#                 strict-PASS evidence for every emitted/in-scope chart
 #   2  NOT DONE — no success marker (conversion didn't complete / was hand-built)
 #   3  NOT DONE — marker present but 0 chart elements (empty workbook)
 #   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
 #   5  NOT DONE — value parity missing, stale-only, divergent, or internally inconsistent
-#   6  NOT DONE — source accounting/report result missing, stale, RED, or mismatched
-#   7  NOT DONE — a parity-required time-intelligence route lacks chart PASS proof
+#   6  NOT DONE — source accounting/report result missing, stale, blocked,
+#                 verdict-mismatched, or emitted-chart parity incomplete
+#   7  NOT DONE — a routed/emitted time-intelligence route lacks chart PASS
+#                 proof, or a review/skipped route is not terminal/non-emitted
 #   8  NOT DONE — degradation ledger or migration report is stale/contradictory
 
 require 'json'
@@ -33,6 +36,7 @@ require 'open3'
 require 'optparse'
 require 'rbconfig'
 require_relative 'lib/degradation_ledger'
+require_relative 'lib/terminal_outcome'
 
 TERMINAL = %w[migrated approximated needs-review skipped not-applicable].freeze
 
@@ -44,12 +48,17 @@ end.parse!(ARGV)
 abort 'FATAL: --workdir required' unless opts[:wd]
 
 succ = File.join(opts[:wd], 'phase6-success.json')
+pending = File.join(opts[:wd], 'parity-pending.json')
 unless File.exist?(succ)
   warn 'NOT DONE - no phase6-success.json in the workdir.'
   warn '   The conversion did not complete a resolution-verified build. If pages exist but are empty,'
   warn '   they were NOT produced by a real migrate-powerbi.rb run - re-run the orchestrator'
   warn "   (never hand-author a workbook). Workdir checked: #{opts[:wd]}"
   exit 2
+end
+if File.exist?(pending)
+  warn 'NOT DONE - parity-pending.json is present; the one-shot build is routing to strict parity.'
+  exit 5
 end
 
 sj = begin
@@ -61,6 +70,10 @@ end
 if sj['chartCount'].to_i <= 0
   warn 'NOT DONE - success marker present but 0 chart elements (empty workbook).'
   exit 3
+end
+unless sj['gates'].to_s == 'all-pass'
+  warn "NOT DONE - phase6-success.json is resolution-only (gates=#{sj['gates'] || 'missing'}), not a terminal gate marker."
+  exit 5
 end
 if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
   warn "DONE marker is for a DIFFERENT workbook (#{sj['workbookId']}) than --workbook-id #{opts[:wb]}."
@@ -129,16 +142,30 @@ accounted = census.dig('summary', 'accounted').to_i
 declared_total = census.dig('summary', 'total').to_i
 result_complete = result.dig('summary', 'complete') == true &&
                   result.dig('summary', 'accounted').to_i == result.dig('summary', 'total').to_i
+expected_verdict = TerminalOutcome.expected_report_verdict(
+  result_rows,
+  Array(result['degradations']) + Array(result['waivers'])
+)
+emitted_charts = census_rows.select do |row|
+  row['type'].to_s == 'visual' && row['emitted'] == true && row['parity_in_scope'] == true
+end
+unproven_emitted = emitted_charts.reject { |row| row['parity_proven'] == true }
 accounting_valid = !census_rows.empty? && accounted == census_rows.length &&
                    declared_total == census_rows.length &&
                    census.dig('summary', 'complete') == true &&
                    census_rows.all? { |row| TERMINAL.include?(row['terminal_status'].to_s) } &&
                    canonical_census == canonical_result && result_complete &&
-                   result['verdict'].to_s != 'RED'
+                   result['verdict'].to_s == expected_verdict &&
+                   result['completion_status'].to_s == 'complete' &&
+                   sj['verdict'].to_s == expected_verdict &&
+                   census.dig('summary', 'strict_parity_complete') == true &&
+                   unproven_emitted.empty?
 unless accounting_valid
-  warn 'NOT DONE - source census and migration result are incomplete, RED, or disagree on exact identity/status.'
+  warn 'NOT DONE - source census/report are incomplete, verdict-inconsistent, or lack strict parity for every emitted chart.'
   warn "   census=#{census_rows.length} objects (declared #{accounted}/#{declared_total}); " \
-       "report=#{result_rows.length}, verdict=#{result['verdict'] || 'missing'}"
+       "report=#{result_rows.length}, verdict=#{result['verdict'] || 'missing'} " \
+       "(expected #{expected_verdict}), completion_status=#{result['completion_status'] || 'missing'}, " \
+       "marker_verdict=#{sj['verdict'] || 'missing'}, unproven_emitted=#{unproven_emitted.length}"
   exit 6
 end
 
@@ -148,19 +175,33 @@ unless routing.is_a?(Hash)
   warn 'NOT DONE - time-intelligence-routing.json is required for the final route census.'
   exit 7
 end
-routes = Array(routing['routes']).select { |route| route['parity_required'] == true }
+routes = Array(routing['routes'])
 proof_by_ref = proofs.to_h { |proof| [proof['query_ref'].to_s, proof] }
 route_failures = routes.filter_map do |route|
   query_ref = route.dig('source_measure', 'query_ref').to_s
   proof = proof_by_ref[query_ref]
-  next if route['status'] == 'routed' && proof &&
-          proof['route_status'] == 'routed' && proof['parity_required'] == true &&
-          proof['parity_proven'] == true && Array(proof['pass_charts']).any?
-  "#{query_ref}: route=#{route['status']}, parity_proven=#{proof && proof['parity_proven']}"
+  route_status = route['status'].to_s
+  emitted = %w[routed emitted].include?(route_status)
+  terminal_only = %w[needs-review skipped].include?(route_status)
+  valid = if emitted
+            proof && proof['terminal_accounted'] == true && proof['emitted'] == true &&
+              proof['parity_required'] == true && proof['parity_proven'] == true &&
+              Array(proof['pass_charts']).any?
+          elsif terminal_only
+            proof && proof['terminal_accounted'] == true && proof['emitted'] == false &&
+              proof['parity_required'] == false && proof['parity_proven'] == false &&
+              Array(proof['pass_charts']).empty?
+          else
+            false
+          end
+  next if valid
+
+  "#{query_ref}: route=#{route_status}, emitted=#{proof && proof['emitted']}, " \
+    "parity_required=#{proof && proof['parity_required']}, parity_proven=#{proof && proof['parity_proven']}"
 end
 extra_proofs = proof_by_ref.keys - routes.map { |route| route.dig('source_measure', 'query_ref').to_s }
 unless route_failures.empty? && extra_proofs.empty?
-  warn 'NOT DONE - every parity-required time-intelligence route must be routed to a present strict-PASS chart.'
+  warn 'NOT DONE - emitted time-intelligence routes need strict-PASS proof; review/skipped routes must be terminal and non-emitted.'
   (route_failures + extra_proofs.map { |ref| "#{ref}: accounting proof has no source route" })
     .each { |failure| warn "   - #{failure}" }
   exit 7
@@ -188,10 +229,12 @@ unless report_status.success?
   exit 8
 end
 
-puts 'DONE - migrate-powerbi.rb built a resolution-verified workbook for this run.'
+headline = expected_verdict == 'GREEN' ? 'DONE - GREEN terminal handoff' : 'COMPLETE - YELLOW terminal handoff'
+puts headline
 puts "   workbook     : #{sj['workbookId']}"
 puts "   charts       : #{sj['chartCount']}"
-puts "   gates        : #{sj['gates']} (columns resolve + freshness match)"
+puts "   gates        : #{sj['gates']} (all required gates)"
 puts "   value parity : CONFIRMED - #{passed}/#{total} strict matches (parity-final.json)"
+puts "   report       : #{expected_verdict} / completion_status=complete"
 puts "   stamped      : #{sj['generatedAt']}"
 exit 0

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/test/test-assert-phase6.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/test/test-assert-phase6.rb
@@ -42,6 +42,7 @@
 require 'json'
 require 'tmpdir'
 require 'fileutils'
+require 'open3'
 
 GATE = File.expand_path('../scripts/assert-phase6-ran.rb', __dir__)
 # Self-identifies the adopting converter from this file's own path (e.g. a
@@ -61,6 +62,13 @@ def run_gate(dir, *extra_args)
   env = { 'SIGMA_BASE_URL' => '', 'SIGMA_API_TOKEN' => '' }
   system(env, *cmd, out: File::NULL, err: File::NULL)
   $?.exitstatus
+end
+
+def capture_gate(dir, *extra_args)
+  cmd = ['ruby', GATE, '--workdir', dir] + extra_args
+  env = { 'SIGMA_BASE_URL' => '', 'SIGMA_API_TOKEN' => '' }
+  out, err, status = Open3.capture3(env, *cmd)
+  [status.exitstatus, out + err]
 end
 
 def write_json(dir, name, obj)
@@ -292,6 +300,20 @@ end
 puts '== waiver budget (exit 19; checked LAST, after every other gate passes) =='
 scenario('3 budget-counted waivers (column+layout+orphan), 1 policy-excluded (visual-comparison) -> exit 19', 19,
          HAPPY_FLAGS + ['--skip-orphan-check', 'budget test: deliberately exceed the cap of 2'])
+Dir.mktmpdir('powerbi-p6-budget-accepted') do |dir|
+  write_good_fixtures(dir)
+  code, output = capture_gate(
+    dir,
+    *(HAPPY_FLAGS +
+      ['--skip-orphan-check', 'budget test: deliberately exceed the cap of 2',
+       '--accept-waiver-budget-exceeded', 'reviewed exception for focused test'])
+  )
+  marker = JSON.parse(File.read(File.join(dir, 'phase6-success.json')))
+  eq(code, 0, 'accepted waiver-budget overflow -> exit 0')
+  eq(marker['verdict'], 'YELLOW', 'accepted waiver-budget marker is YELLOW')
+  eq(output.include?('VERDICT: YELLOW') && !output.include?('VERDICT: GREEN'), true,
+     'accepted waiver-budget banner says YELLOW, never GREEN')
+end
 
 puts
 if $failures.zero? then puts 'ALL PASS'; exit 0 else puts "#{$failures} FAILURE(S)"; exit 1 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Separates a usable but parity-pending Power BI build from terminal GREEN, and permits terminal YELLOW only when all emitted charts are strictly proven and every non-emitted review route is explicitly accounted.

## Behavior

- Mechanical build writes `parity-pending.json` and routes onward; it is never false GREEN
- Accounted non-emitted needs-review/skipped routes can complete YELLOW
- Emitted routes still require strict parity
- Divergence, contradiction, incomplete accounting, or resolution failures remain nonzero
- Waiver overflow requires a named acceptance

Focused accounting, routing, completion, gate, and registration tests are green locally. Plugin version 1.8.44.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

