### PR TITLE
Allow accounted Qlik omissions as YELLOW

### DIFF
--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -63,8 +63,8 @@ never guesses.
 
 > ## ⛔ THE ONE PATH (do not improvise a workbook)
 > `migrate-qlik.rb` is the single entry point — it discovers the Qlik app, builds
-> the DM + workbook, and **only exits 0 when parity/layout/control pass with real
-> elements built**. Rules:
+> the DM + workbook, and **only exits 0 for a complete GREEN or YELLOW handoff
+> after parity/layout/control/render pass with real elements built**. Rules:
 > - **NEVER hand-drive the per-phase scripts, hand-author a DM/workbook JSON, or
 >   `curl`-POST to `/v2/workbooks` / lay out empty "placeholder" pages.** That
 >   bypasses parity + the element guard and ships an EMPTY workbook — the #1 way a
@@ -88,7 +88,8 @@ eval "$(scripts/vendor/get-token.sh)"          # SIGMA_BASE_URL + SIGMA_API_TOKE
 ruby scripts/migrate-qlik.rb \
   --app <qlikAppId> --connection <SIGMA_CONNECTION_ID> \
   --database <DB> --schema <SCHEMA> --context <qlik-cli ctx> \
-  [--folder <SIGMA_FOLDER_ID>] [--name '<prefix>'] [--yes]
+  [--folder <SIGMA_FOLDER_ID>] [--name '<prefix>'] [--yes] \
+  [--accept-waiver-budget-exceeded '<named reason>']
 ```
 
 **Offline corectl export:** when a customer cannot grant live Qlik access, accept
@@ -106,9 +107,10 @@ empty app. Inline chart hypercubes still become `charts.json` and workbook tiles
 
 discover → convert → data model → workbook → layout → parity, for ANY app, driven
 entirely by the discovery artifacts (no app-specific edits). Exit 10 = genuine human
-decisions printed as an OPEN QUESTIONS block (re-run with `--yes` or `--answers`);
-exit 0 = PARITY GREEN; exit 3 = built but parity RED. Each phase below is also an
-independently runnable script if you need to intervene mid-pipeline.
+decision required, including an unaccepted waiver-budget overflow (re-run that case
+with `--accept-waiver-budget-exceeded REASON`); exit 0 = complete GREEN or YELLOW;
+exit 3 = RED after build. Each phase below is also an independently runnable script
+if you need to intervene mid-pipeline.
 
 **Offline smoke (no tenant/org/network):** `ruby scripts/migrate-qlik.rb
 --from-discovery fixtures/retail-orders --connection 0000… --dry-run --yes --out /tmp/smoke`
@@ -486,13 +488,36 @@ ruby scripts/build-migration-report.rb --workdir <WORK> --check
 ruby scripts/verify-complete.rb --workdir <WORK> --workbook-id <workbookId>
 ```
 
-All four commands must exit 0. The finalizer refreshes PNG health, visual
+All four commands must exit 0. `migrate-qlik.rb` invokes this sequence itself,
+including `verify-complete.rb` immediately before its terminal banner. The
+finalizer refreshes PNG health, visual
 similarity, full-app accounting, the degradation ledger, `MIGRATION_REPORT.md`,
 and `migration-result.json`. `assert-phase6-ran.rb` is the shared,
 converter-neutral gate over `parity-final.json`, live readback, layout/control,
 render, visual, tile, and waiver evidence. The inline
 `phase6-success.json` marker does not replace either the shared gate or the
 complete census/report.
+
+Terminal policy:
+
+- **GREEN (exit 0):** complete accounting contains only `migrated` /
+  `not-applicable`, with no degradation or waiver.
+- **YELLOW (exit 0):** every object is terminal-accounted and every hard gate
+  passes, but an `approximated`, `needs-review`, or `skipped` object, degradation,
+  or waiver is reported. An explicitly `skipped`/`not-applicable` source visual
+  may leave required build/parity scope; an approximated emitted visual may not
+  and still requires strict measured parity.
+- **RED (nonzero):** true parity divergence, broken layout/control/render,
+  missing or contradictory accounting, stale reports/ledger, or any other hard
+  gate failure.
+
+Waiver-budget exit 19 from the shared assert is a decision-required exit 10 at
+the one-command boundary. Supplying
+`--accept-waiver-budget-exceeded REASON` passes the named reason to the assert;
+only after every other gate passes can it produce a complete YELLOW exit-0
+handoff. The final line is always the report-derived `TERMINAL: GREEN`,
+`TERMINAL: YELLOW`, or `TERMINAL: RED`; it is never inferred from a success
+boolean.
 
 ---
 
@@ -526,7 +551,8 @@ complete census/report.
 | `scripts/build-qlik-accounting.py` | 6 | Reconcile the complete Qlik app inventory, formula mapping, DM/workbook outputs, controls, layout, tiles, and parity into `source-object-census.json`, `coverage.json`, and Qlik control/layout evidence; fails closed on unaccounted objects. |
 | `scripts/finalize-qlik-report.py` | 6 | Read-only completion finalizer: refresh Qlik accounting, source/target PNG health, visual similarity, degradation evidence, `MIGRATION_REPORT.md`, and `migration-result.json`; attempts every producer and exits nonzero if any contract fails. |
 | `scripts/build-migration-report.rb` | 6 | Consume the complete source-object census and gate artifacts; write `MIGRATION_REPORT.md` + `migration-result.json`. `--check` rejects stale or inconsistent output. |
-| `scripts/verify-complete.rb` | 6 | Additional Qlik empty-build/workbook-id sentinel check. It is supporting evidence and does not replace `assert-phase6-ran.rb` or the migration report. |
+| `scripts/check-migration-report.rb` | 6 | Qlik-local UTF-8-safe `--check` adapter around the byte-identical shared report builder; used by the finalizer/verifier for YELLOW reports containing degradation bullets. |
+| `scripts/verify-complete.rb` | 6 | Final offline completion contract: uses shared `TerminalOutcome`, requires `completion_status=complete`, and rechecks strict parity, accounting/report/ledger agreement, render health, and workbook identity before printing `TERMINAL: GREEN\|YELLOW`. |
 | `refs/control-parity.md` | 5 | The control-parity contract: lint + sidecar schema + the MCP/export-API answer (export `parameters` is the only way to set a control value). |
 | `refs/example-converter-input.json` | 1–2 | The exact convert_qlik_to_sigma input from the first migration. |
 | `fixtures/retail-orders/` | — | Complete offline discovery+converter input set (sanitized demo app) — see `fixtures/README.md` for the offline smoke path. |

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/check-migration-report.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/check-migration-report.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Qlik-local adapter for the shared report builder's --check mode.
+#
+# The canonical builder intentionally reads Markdown in binary mode for
+# byte-stable newlines. Ruby labels that string ASCII-8BIT, which compares
+# unequal to the builder's UTF-8 expected string when a YELLOW report contains
+# its em dash separator. Preserve the shared file byte-for-byte and normalize
+# only this check process's binary reads.
+
+abort 'Usage: check-migration-report.rb ... --check' unless ARGV.include?('--check')
+
+class << File
+  alias qlik_binary_report_read binread
+
+  def binread(*args)
+    qlik_binary_report_read(*args).force_encoding(Encoding::UTF_8)
+  end
+end
+
+load File.join(__dir__, 'build-migration-report.rb')

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/finalize-qlik-report.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/finalize-qlik-report.py
@@ -428,7 +428,10 @@ def main(argv=None):
     report_rc = run(report_command)
     if report_rc:
         failures.append("migration report exited %d" % report_rc)
-    report_check_rc = run(report_command + ["--check"])
+    report_check_rc = run([
+        "ruby", HERE / "check-migration-report.rb", "--workdir", workdir,
+        "--inventory", workdir / "source-object-census.json", "--check",
+    ])
     if report_check_rc:
         failures.append("migration report --check exited %d" % report_check_rc)
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -50,8 +50,9 @@
 #     [--dry-run]              # offline: no Sigma POSTs, no qlik-cli needed with --from-discovery;
 #                              # emits dm-spec.json / wb-spec.json / layout.xml and stops
 #
-# Exit codes: 0 = done (PARITY GREEN); 10 = decisions needed (OPEN QUESTIONS printed,
-# no Sigma objects created); 3 = built but PARITY RED; other = error.
+# Exit codes: 0 = complete GREEN or YELLOW handoff; 10 = decisions needed
+# (including an unaccepted waiver-budget overflow); 3 = built but RED; other =
+# an earlier pipeline error.
 require 'json'
 require 'optparse'
 require 'fileutils'
@@ -59,6 +60,7 @@ require 'open3'
 require 'time'
 require_relative 'lib/scout_gate'
 require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
+require_relative 'lib/terminal_outcome'
 begin; require_relative 'lib/modeling_advisory'; rescue LoadError; end # shared, vendor-neutral CDW join-cost advisory (optional; synced from shared/)
 
 $stdout.sync = true # lane/foreground progress lines interleave correctly
@@ -142,10 +144,19 @@ OptionParser.new do |o|
   o.on('--skip-visual-comparison REASON') { |v| opts[:skip_visual_comparison] = v }
   o.on('--skip-visual-similarity REASON') { |v| opts[:skip_visual_similarity] = v }
   o.on('--skip-anchors-gate REASON') { |v| opts[:skip_anchors_gate] = v }
+  o.on('--accept-waiver-budget-exceeded REASON',
+       'accept waiver-budget overflow after every other gate passes; records a named YELLOW handoff') do |v|
+    opts[:accept_waiver_budget_exceeded] = v
+  end
   # Resolve + print which converter would run (vendored vs explicit dev build), then
   # exit 0 — no creds/args needed. Used by the converter-default regression test.
   o.on('--print-converter')   {     opts[:print_converter] = true }
 end.parse!
+
+if opts.key?(:accept_waiver_budget_exceeded) &&
+   opts[:accept_waiver_budget_exceeded].to_s.strip.empty?
+  abort 'FATAL: --accept-waiver-budget-exceeded requires a non-empty REASON'
+end
 
 abort 'FATAL: choose only one of --unbuild, --prj, or --from-discovery' \
   if [opts[:unbuild], opts[:prj], opts[:from]].compact.size > 1
@@ -1221,11 +1232,11 @@ puts "CONTROL-FLIP: #{flip_ok ? 'GREEN' : 'RED'} — gate 7b runtime flip proof#
 puts "freshness   : Qlik last reload #{app_meta['lastReloadTime'] || '?'} (#{stale_days} days ago)" if stale_days
 puts "warnings    : #{conv_warnings.size} converter, #{(wb_res['warnings'] || []).size} workbook-build" if conv_warnings.any? || (wb_res['warnings'] || []).any?
 # Empty-workbook guard. Completion is minted only by the shared hard gate below;
-# the orchestrator must never hand-write phase6-success.json.
+# the orchestrator must never hand-write phase6-success.json. The finalized
+# source census may later exclude explicitly skipped/not-applicable omissions
+# from required build scope; approximated visuals are emitted and stay in parity.
 n_elements = wb_res['elements'].to_i
 n_queryable = wb_res['queryableElements'].to_i
-mechanical_ok = parity_ok && layout_ok && control_ok && flip_ok &&
-                n_queryable.positive? && wb_res['unbuiltSourceVisuals'].to_a.empty?
 puts 'ELEMENTS    : 0 queryable workbook elements built — Data-only workbook, NOT done.' if n_queryable.zero?
 
 run_terminal = lambda do |label, command|
@@ -1234,17 +1245,18 @@ run_terminal = lambda do |label, command|
   output, status = Open3.capture2e(*command)
   output.each_line { |line| puts "   #{line.rstrip}" } unless output.strip.empty?
   puts "   exit=#{status.exitstatus}"
-  status.success?
+  status
 end
 
 # Cleanup is a real gate input, not best-effort bookkeeping. It runs on both
 # GREEN and RED parity paths so a failed migration does not leave retry
 # workbooks behind.
-cleanup_ok = run_terminal.call(
+cleanup_status = run_terminal.call(
   'Orphan workbook cleanup',
   ['ruby', File.join(HERE, 'cleanup-orphan-workbooks.rb'),
    '--workdir', WORK, '--keep', WB_ID]
 )
+cleanup_ok = cleanup_status.success?
 
 finalizer_cmd = [*PyResolve.argv, File.join(HERE, 'finalize-qlik-report.py'),
                  '--workdir', WORK]
@@ -1259,8 +1271,39 @@ finalizer_cmd += ['--skip-visual-similarity', opts[:skip_visual_similarity]] \
 
 # The first pass materializes accounting/coverage/layout/PNG/similarity inputs
 # consumed by the shared assert. It intentionally runs even when parity is RED.
-pre_finalizer_ok = run_terminal.call('Qlik accounting and report finalization (pre-gate)',
-                                     finalizer_cmd)
+pre_finalizer_status = run_terminal.call('Qlik accounting and report finalization (pre-gate)',
+                                         finalizer_cmd)
+pre_finalizer_ok = pre_finalizer_status.success?
+
+# Only terminal-accounted omissions leave required build/parity scope. Match
+# census visual ids against builder ids without accepting name-only guesses:
+# Qlik census ids are `visual:<objectId>`, while wb-result stores `<objectId>`.
+unbuilt_source_visuals = Array(wb_res['unbuiltSourceVisuals']).map(&:to_s).uniq
+census = begin
+  JSON.parse(File.read(File.join(WORK, 'source-object-census.json')))
+rescue StandardError
+  {}
+end
+census_rows = Array(census['objects'] || census['source_objects'])
+accounted_omissions = census_rows.map do |row|
+  next unless row.is_a?(Hash) && row['type'].to_s == 'inline-visual'
+  next unless %w[skipped not-applicable].include?(row['status'].to_s)
+  next unless row['evidence'].is_a?(Array) && !row['evidence'].empty?
+
+  source_id = row['id'].to_s.sub(/\Avisual:/, '')
+  source_id if unbuilt_source_visuals.include?(source_id)
+end.compact.uniq
+required_unbuilt_visuals = unbuilt_source_visuals - accounted_omissions
+mechanical_ok = parity_ok && layout_ok && control_ok && flip_ok &&
+                n_queryable.positive? && required_unbuilt_visuals.empty?
+if accounted_omissions.any?
+  puts "ACCOUNTING  : #{accounted_omissions.length} terminal-accounted visual omission(s) " \
+       "excluded from required build/parity scope: #{accounted_omissions.join(', ')}"
+end
+if required_unbuilt_visuals.any?
+  puts "ELEMENTS    : #{required_unbuilt_visuals.length} unbuilt source visual(s) lack a skipped/" \
+       "not-applicable terminal disposition: #{required_unbuilt_visuals.join(', ')}"
+end
 
 assert_cmd = ['ruby', File.join(HERE, 'assert-phase6-ran.rb'),
               '--workdir', WORK, '--workbook-id', WB_ID,
@@ -1279,22 +1322,59 @@ assert_cmd += ['--skip-visual-similarity', opts[:skip_visual_similarity]] \
   if opts[:skip_visual_similarity]
 assert_cmd += ['--skip-anchors-gate', opts[:skip_anchors_gate]] \
   if opts[:skip_anchors_gate]
+assert_cmd += ['--accept-waiver-budget-exceeded',
+               opts[:accept_waiver_budget_exceeded].to_s.strip] \
+  if opts[:accept_waiver_budget_exceeded]
 
 # This is the only command allowed to stamp phase6-success.json. Its exit code
-# participates directly in built_ok.
-assert_ok = run_terminal.call('Shared Phase 6 hard gate', assert_cmd)
+# participates directly in the terminal hard-gate result.
+assert_status = run_terminal.call('Shared Phase 6 hard gate', assert_cmd)
+assert_ok = assert_status.success?
 
 # assert-phase6-ran stamps the final waiver census, verdict, and degradation
 # ledger. Re-run the accounting/report finalizer after it on BOTH terminal paths
 # so migration-result.json and the report exactly reflect the terminal state.
-post_finalizer_ok = run_terminal.call('Qlik accounting and report finalization (terminal)',
-                                      finalizer_cmd)
+post_finalizer_status = run_terminal.call('Qlik accounting and report finalization (terminal)',
+                                          finalizer_cmd)
+post_finalizer_ok = post_finalizer_status.success?
 
-built_ok = mechanical_ok && cleanup_ok && pre_finalizer_ok && assert_ok &&
-           post_finalizer_ok
-puts "TERMINAL    : #{built_ok ? 'GREEN' : 'RED'} — accounting/report " \
+# The verifier is the final completion contract, never an optional diagnostic.
+# It re-derives strict parity, complete accounting, report freshness, render
+# health, and the degradation ledger before any terminal verdict is printed.
+verify_status = run_terminal.call(
+  'Qlik completion verification',
+  ['ruby', File.join(HERE, 'verify-complete.rb'),
+   '--workdir', WORK, '--workbook-id', WB_ID]
+)
+verify_ok = verify_status.success?
+
+hard_gates_ok = mechanical_ok && cleanup_ok && pre_finalizer_ok && assert_ok &&
+                post_finalizer_ok && verify_ok
+report = begin
+  JSON.parse(File.read(File.join(WORK, 'migration-result.json')))
+rescue StandardError
+  {}
+end
+reported_verdict = report['verdict'].to_s.upcase
+terminal_verdict = if hard_gates_ok &&
+                      report['completion_status'] == 'complete' &&
+                      TerminalOutcome::COMPLETE_VERDICTS.include?(reported_verdict)
+                     reported_verdict
+                   else
+                     'RED'
+                   end
+puts "TERMINAL: #{terminal_verdict} — accounting/report " \
      "#{post_finalizer_ok ? 'current' : 'failed'}, shared assert " \
-     "#{assert_ok ? 'passed' : 'failed'}"
+     "#{assert_ok ? 'passed' : 'failed'}, verify-complete " \
+     "#{verify_ok ? 'passed' : 'failed'}"
 puts '======================================='
 phase_summary
-exit(built_ok ? 0 : 3)
+
+if assert_status.exitstatus == 19 && !opts[:accept_waiver_budget_exceeded]
+  warn 'DECISION REQUIRED: waiver budget exceeded. Re-run with ' \
+       '--accept-waiver-budget-exceeded REASON to accept a YELLOW handoff.'
+  exit 10
+end
+
+exit(TerminalOutcome.report_exit(terminal_verdict)) if hard_gates_ok
+exit 3

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-complete.rb
@@ -50,17 +50,29 @@ Dir.mktmpdir do |wd|
   check(code == 4, "workbook mismatch => exit 4 (got #{code})", fails)
 end
 
-# 5) the orchestrator wires the empty-workbook guard + shared gate.
+# 5) the orchestrator wires the empty-workbook guard, census-scoped omissions,
+# shared gate, and final verifier.
 mt = File.read(File.join(DIR, 'migrate-qlik.rb'))
 check(mt.include?('mechanical_ok = parity_ok && layout_ok && control_ok && flip_ok') &&
-      mt.include?("wb_res['unbuiltSourceVisuals'].to_a.empty?") &&
-      mt.include?('built_ok = mechanical_ok && cleanup_ok && pre_finalizer_ok && assert_ok'),
-      'orchestrator requires queryable elements and complete source coverage for a green', fails)
+      mt.include?('required_unbuilt_visuals.empty?') &&
+      mt.include?('%w[skipped not-applicable]') &&
+      mt.include?('hard_gates_ok = mechanical_ok && cleanup_ok && pre_finalizer_ok && assert_ok'),
+      'orchestrator excludes only terminal-accounted omissions from required build scope', fails)
 check(mt.include?("require 'flip_gate'") && mt.include?('FlipGate.decide'),
       'orchestrator runs gate 7b (runtime control-flip proof) before a green', fails)
 check(mt.include?("'assert-phase6-ran.rb'") &&
       !mt.match?(/File\.write\([^)]*phase6-success\.json/),
       'orchestrator delegates the success sentinel exclusively to the shared gate', fails)
+check(mt.include?("'verify-complete.rb'") &&
+      mt.index('Qlik completion verification') < mt.index('puts "TERMINAL: #{terminal_verdict}'),
+      'orchestrator invokes verify-complete before its honest terminal banner', fails)
+check(mt.include?("'--accept-waiver-budget-exceeded'") &&
+      mt.include?('assert_status.exitstatus == 19') &&
+      mt.include?('exit 10'),
+      'orchestrator passes waiver-budget acceptance and maps unaccepted exit 19 to decision exit 10', fails)
+check(!mt.include?("built_ok ? 'GREEN'") &&
+      mt.include?('TerminalOutcome::COMPLETE_VERDICTS.include?(reported_verdict)'),
+      'orchestrator derives GREEN/YELLOW from the completed report, never a boolean', fails)
 # 6) SKILL carries THE ONE PATH / no-hand-drive directive.
 sk = File.read(File.join(DIR, '..', 'SKILL.md'))
 check(sk.include?('THE ONE PATH') && sk.downcase.include?('never hand-drive'),

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-complete.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-complete.rb
@@ -8,8 +8,9 @@
 require 'json'
 require 'optparse'
 require_relative 'lib/degradation_ledger'
+require_relative 'lib/terminal_outcome'
 
-TERMINAL = %w[migrated approximated needs-review skipped not-applicable].freeze
+TERMINAL = TerminalOutcome::TERMINAL_STATUSES.freeze
 PROVENANCE = %w[live engine-export inferred].freeze
 PASS_STATES = %w[PASS MATCH PASSED GREEN OK].freeze
 
@@ -113,7 +114,8 @@ census_complete = census.dig('summary', 'complete') == true &&
                       PROVENANCE.include?(row['source_provenance'].to_s) &&
                       row['evidence'].is_a?(Array) && !row['evidence'].empty?
                   end
-report_complete = report['verdict'].to_s.upcase != 'RED' &&
+report_complete = TerminalOutcome.report_exit(report['verdict']).zero? &&
+                  report['completion_status'] == 'complete' &&
                   report.dig('summary', 'complete') == true &&
                   report.dig('summary', 'accounted').to_i == report.dig('summary', 'total').to_i &&
                   report.dig('summary', 'total').to_i == report_rows.length &&
@@ -123,7 +125,9 @@ unless census_complete && report_complete
   fail_with(6, 'NOT DONE — source census/report is RED, incomplete, or has a failed check.',
             ["census complete=#{census.dig('summary', 'complete').inspect} " \
              "#{census.dig('summary', 'accounted')}/#{census.dig('summary', 'total')}",
-             "report verdict=#{report['verdict'].inspect} complete=#{report.dig('summary', 'complete').inspect}",
+             "report verdict=#{report['verdict'].inspect} " \
+             "completion_status=#{report['completion_status'].inspect} " \
+             "complete=#{report.dig('summary', 'complete').inspect}",
              "failed checks=#{Array(report['checks']).reject { |check| check['status'] == 'PASS' }.map { |check| check['name'] }.join(', ')}"])
 end
 
@@ -183,7 +187,7 @@ fail_with(8, 'NOT DONE — PNG/finalization contract failed.', png_errors) unles
 
 # Re-run the report's deterministic check so a post-finalization edit to either
 # JSON or Markdown cannot ride through on an old qlik-finalization.json.
-report_check = system('ruby', File.join(__dir__, 'build-migration-report.rb'),
+report_check = system('ruby', File.join(__dir__, 'check-migration-report.rb'),
                       '--workdir', wd, '--inventory', census_path, '--check',
                       out: File::NULL, err: File::NULL)
 fail_with(8, 'REPORT CONTRADICTION — generated migration report is stale.') unless report_check
@@ -210,16 +214,30 @@ end
 contradictions << 'migration report degradation list differs from fresh derivation' unless
   Array(report['degradations']) == derived
 
-accounting_yellow = report_rows.any? { |row| %w[approximated needs-review skipped].include?(status(row)) }
-expected_report_verdict = (derived.empty? && !accounting_yellow && Array(report['waivers']).empty?) ? 'GREEN' : 'YELLOW'
+expected_report_verdict = TerminalOutcome.report_verdict(
+  terminal_rows: report_rows,
+  degradation_entries: derived,
+  waiver_entries: Array(report['waivers'])
+)
 contradictions << "report verdict #{report['verdict'].inspect} != #{expected_report_verdict}" unless
   report['verdict'].to_s.upcase == expected_report_verdict
 
-derived_verdict = DegradationLedger.verdict(derived)
+# The shared assert still carries the older PARTIAL ledger label in its marker.
+# At the public terminal boundary, a fully accounted scope cut is YELLOW under
+# TerminalOutcome; only missing/contradictory accounting or a failed hard gate
+# is RED. Normalize that legacy internal label before checking gate claims.
+normalize_terminal_claim = lambda do |claim|
+  value = claim.to_s.upcase
+  next '' if value.empty?
+  next 'GREEN' if value.start_with?('GREEN')
+  next 'YELLOW' if value == 'YELLOW' || value.start_with?('PARTIAL')
+  value
+end
 { 'phase6-success.json' => success, 'parity-final.json' => parity }.each do |name, doc|
   claim = doc['verdict'].to_s
-  contradictions << "#{name} verdict #{claim.inspect} != #{derived_verdict}" unless
-    claim.empty? || claim == derived_verdict
+  normalized_claim = normalize_terminal_claim.call(claim)
+  contradictions << "#{name} verdict #{claim.inspect} != #{expected_report_verdict}" unless
+    normalized_claim.empty? || normalized_claim == expected_report_verdict
 end
 if parity.key?('waiver_count') && parity['waiver_count'].to_i != Array(parity['waivers']).length
   contradictions << 'parity waiver_count differs from its waiver list'
@@ -230,12 +248,12 @@ if success['waivers'].is_a?(Array) && parity['waivers'].is_a?(Array) &&
 end
 fail_with(9, 'REPORT CONTRADICTION — gate/report/ledger claims disagree.', contradictions) unless contradictions.empty?
 
-completion_verdict = report['verdict'].to_s.upcase == 'YELLOW' &&
-                     derived_verdict == 'GREEN' ? 'YELLOW' : derived_verdict
-puts "✅ DONE — Qlik hard gates, strict parity, PNG health, accounting, and report reconcile. VERDICT: #{completion_verdict}"
+completion_verdict = report['verdict'].to_s.upcase
+puts "✅ DONE — Qlik hard gates, strict parity, PNG health, accounting, and report reconcile."
 puts "   workbook : #{success['workbookId']}"
 puts "   charts   : #{passed}/#{total} strict matches"
 puts "   gates    : #{success['gates']}"
 puts "   objects  : #{census_rows.length}/#{census_rows.length} exactly reconciled"
 puts "   ledger   : #{derived.empty? ? 'empty' : "#{derived.length} degradation(s)"}"
-exit 0
+puts "TERMINAL: #{completion_verdict}"
+exit TerminalOutcome.report_exit(completion_verdict)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_completion_contract.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_completion_contract.py
@@ -151,6 +151,24 @@ class CompletionContractTest(unittest.TestCase):
             "waivers": [], "generatedAt": "2026-08-20T00:00:00Z",
         })
 
+    def add_accounted_skipped_visual(self):
+        charts = json.loads((self.workdir / "charts.json").read_text())
+        charts.append({
+            "id": "chart-skipped", "title": "Unsupported extension",
+            "vizType": "extension", "dimensions": ["Country"],
+            "measures": ["ExtensionValue(Country)"],
+        })
+        write_json(self.workdir / "charts.json", charts)
+        coverage = json.loads((self.workdir / "workbook-coverage.json").read_text())
+        coverage.update({
+            "sourceVisuals": 2,
+            "sourceVisualIds": ["chart-1", "chart-skipped"],
+            "builtSourceVisualIds": ["chart-1"],
+            "unbuiltSourceVisualIds": ["chart-skipped"],
+            "status": "FAIL",
+        })
+        write_json(self.workdir / "workbook-coverage.json", coverage)
+
     def test_unaccounted_source_object_fails_closed(self):
         dm = json.loads((self.workdir / "dm-spec.json").read_text())
         dm["pages"][0]["elements"][0]["columns"] = []
@@ -242,17 +260,88 @@ class CompletionContractTest(unittest.TestCase):
         terminal_report = text.index(
             "Qlik accounting and report finalization (terminal)"
         )
+        verify_complete = text.index("Qlik completion verification")
+        terminal_banner = text.index('puts "TERMINAL: #{terminal_verdict}')
         self.assertLess(normalize, lint)
         self.assertLess(lint, post)
         self.assertLess(post, parity)
         self.assertLess(parity, cleanup)
         self.assertLess(cleanup, shared_assert)
         self.assertLess(shared_assert, terminal_report)
+        self.assertLess(terminal_report, verify_complete)
+        self.assertLess(verify_complete, terminal_banner)
         self.assertNotRegex(
             text, r"File\.write\([^)]*phase6-success\.json"
         )
-        self.assertIn("assert_ok = run_terminal.call", text)
+        self.assertIn("assert_status = run_terminal.call", text)
         self.assertIn("mechanical_ok && cleanup_ok && pre_finalizer_ok && assert_ok", text)
+        self.assertNotIn("built_ok ? 'GREEN'", text)
+
+    def test_accounted_skipped_visual_is_yellow_and_complete(self):
+        self.add_accounted_skipped_visual()
+        final = self.finalize()
+        self.assertEqual(final.returncode, 0, final.stdout + final.stderr)
+        report = json.loads((self.workdir / "migration-result.json").read_text())
+        skipped = [
+            row for row in report["source_objects"]
+            if row["type"] == "inline-visual" and row["id"] == "visual:chart-skipped"
+        ]
+        self.assertEqual([row["status"] for row in skipped], ["skipped"])
+        self.assertEqual(report["verdict"], "YELLOW")
+        self.assertEqual(report["completion_status"], "complete")
+
+        self.stamp_shared_gate_success()
+        result = self.run_script(
+            "verify-complete.rb", "--workdir", self.workdir,
+            "--workbook-id", "wb-1",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("TERMINAL: YELLOW", result.stdout)
+
+    def test_approximated_emitted_visual_divergence_is_red(self):
+        write_json(self.workdir / "formula-mapping.json", {
+            "formulas": [{
+                "objectId": "chart-1", "status": "approximated",
+                "source": "Sum(Sales)", "target": "Sum([Sales])",
+            }],
+        })
+        final = self.finalize()
+        self.assertEqual(final.returncode, 0, final.stdout + final.stderr)
+        report = json.loads((self.workdir / "migration-result.json").read_text())
+        visual = next(
+            row for row in report["source_objects"]
+            if row["type"] == "inline-visual" and row["id"] == "visual:chart-1"
+        )
+        self.assertEqual(visual["status"], "approximated")
+        self.assertEqual(report["verdict"], "YELLOW")
+
+        parity = json.loads((self.workdir / "parity-final.json").read_text())
+        parity.update({
+            "status": "FAIL", "charts_pass": 0, "charts_fail": 1,
+            "fail_names": ["Sales"], "divergent": True,
+            "per_chart": [{
+                "chart": "Sales", "source_object_id": "chart-1",
+                "status": "DIVERGENT", "pass": False,
+            }],
+        })
+        write_json(self.workdir / "parity-final.json", parity)
+        self.stamp_shared_gate_success()
+        result = self.run_script(
+            "verify-complete.rb", "--workdir", self.workdir,
+            "--workbook-id", "wb-1",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("parity is not strict", result.stderr)
+
+    def test_budget_overflow_flag_is_wired_as_decision_or_yellow_acceptance(self):
+        text = (SCRIPTS / "migrate-qlik.rb").read_text(encoding="utf-8")
+        self.assertIn("o.on('--accept-waiver-budget-exceeded REASON'", text)
+        self.assertIn(
+            "assert_cmd += ['--accept-waiver-budget-exceeded'", text
+        )
+        self.assertIn("assert_status.exitstatus == 19", text)
+        self.assertIn("exit 10", text)
+        self.assertIn("TerminalOutcome::COMPLETE_VERDICTS", text)
 
     def test_report_contradiction_fails_completion(self):
         final = self.finalize()
@@ -268,6 +357,20 @@ class CompletionContractTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("CONTRADICTION", result.stderr)
 
+    def test_verify_complete_requires_complete_completion_status(self):
+        final = self.finalize()
+        self.assertEqual(final.returncode, 0, final.stdout + final.stderr)
+        self.stamp_shared_gate_success()
+        report = json.loads((self.workdir / "migration-result.json").read_text())
+        report["completion_status"] = "blocked"
+        write_json(self.workdir / "migration-result.json", report)
+        result = self.run_script(
+            "verify-complete.rb", "--workdir", self.workdir,
+            "--workbook-id", "wb-1",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("completion_status", result.stderr)
+
     def test_complete_success(self):
         final = self.finalize()
         self.assertEqual(final.returncode, 0, final.stdout + final.stderr)
@@ -278,6 +381,7 @@ class CompletionContractTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("strict parity", result.stdout)
+        self.assertIn("TERMINAL: GREEN", result.stdout)
         census = json.loads((self.workdir / "source-object-census.json").read_text())
         self.assertTrue(census["summary"]["complete"])
         self.assertTrue(all(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Stops treating source visuals explicitly accounted as skipped/not-applicable as a total Qlik migration failure.

## Behavior

- Only identity-matched, evidenced terminal omissions leave required build/parity scope
- Emitted approximations still require parity
- GREEN/YELLOW exit 0 with honest banner and mandatory `verify-complete`
- Divergence, broken output, contradictions, and incomplete accounting remain RED/nonzero
- Waiver overflow is decision-required unless named and accepted

Completion and verifier tests are green locally. Plugin version 1.4.6.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

