### PR TITLE
Harden MicroStrategy workbook formula and control contracts

### DIFF
--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -28,7 +28,12 @@ user-invocable: true
 
 ## Preflight the workbook spec before POST (mandatory)
 
-Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.
+Before POSTing any workbook spec, run **both** validators:
+
+1. `ruby scripts/lib/preflight_lint.rb <spec.json>` catches grouping and control grammar failures.
+2. From the companion `sigma-workbooks` skill, run `./scripts/validate-spec.sh <absolute-spec-path>` to reject bare source-column self-references and list/segmented controls without a value-list `source`.
+
+The API accepts a filters-only list control, but the picker is empty: `filters` names what changes; `source` supplies the values a user can select. API acceptance is not a shipping criterion. Date-range controls are different and correctly use `filters` without a separate value-list source. Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.
 
 ## Converter architecture (read if you know the other migration skills)
 
@@ -351,7 +356,11 @@ curl -s -X POST "$SIGMA_BASE_URL/v2/workbooks/spec" \
 # UNSCOUTED error column — spawn a gap-scout per the printed --gap-id (see
 # scripts/gap-scout.md), re-run the gate, and only proceed when it exits 0.
 python3 scripts/scout-gate-readback.py --workbook-id <workbookId> --workdir <out-dir>
-# Read back and confirm document.layout + flat document.elements survived.
+# Read back, validate, and confirm document.layout + flat document.elements survived.
+curl -s "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" > <out-dir>/workbook-readback.yaml
+# Run from the companion sigma-workbooks skill directory:
+./scripts/validate-spec.sh <absolute-out-dir>/workbook-readback.yaml
 # put-layout.rb is now a repair/reapply tool, not the normal create path:
 # ruby scripts/put-layout.rb --workbook <workbookId> --layout layout.xml
 ```

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/phase-e-enhance.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/phase-e-enhance.md
@@ -188,7 +188,8 @@ trial-proven spec-unsupported): chart-as-filter (`useAsFilter` silently dropped
 on readback), pie percent labels (`valueFormat:'percent'` silently dropped).
 DM-metric promotion is not an enhancement candidate: the normal workbook build
 already binds formula-equivalent, readback-confirmed metrics through
-`[Metrics/<metric name>]`. `[Master/<metric>]` is an invalid column lookup, not
+`[Metrics/<metric name>]`. `[Orders/<metric>]` (where `Orders` is the default
+join-element name) is an invalid column lookup, not
 evidence that data-model metrics are unavailable.
 
 ### Prerequisites for apply

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/phase-e-enhance.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/phase-e-enhance.md
@@ -188,8 +188,7 @@ trial-proven spec-unsupported): chart-as-filter (`useAsFilter` silently dropped
 on readback), pie percent labels (`valueFormat:'percent'` silently dropped).
 DM-metric promotion is not an enhancement candidate: the normal workbook build
 already binds formula-equivalent, readback-confirmed metrics through
-`[Metrics/<metric name>]`. `[Orders/<metric>]` (where `Orders` is the default
-join-element name) is an invalid column lookup, not
+`[Metrics/<metric name>]`. `[Master/<metric>]` is an invalid column lookup, not
 evidence that data-model metrics are unavailable.
 
 ### Prerequisites for apply

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/gap-scout.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/gap-scout.md
@@ -21,19 +21,22 @@ metric→SQL for AE-emulation sql elements.
 ## Candidates to scout (MSTR metric function → Sigma)
 | MSTR function | Why it errors | Candidate Sigma translation to validate |
 |---|---|---|
-| `RunningSum / RunningAvg / RunningMax` | window/running calc | `CumulativeSum([Master/Col])` in a date-grouped element |
-| `Rank / RankByValue` | window rank | `Rank([Master/Col])` (grouped-element context) |
-| `Lag / Lead / OffsetValue` | offset | `Lag([Master/Col], n)` in a sorted/date-grouped element |
-| `Median / Percentile / Mode` | distribution | `Median([Master/Col])` / `Percentile([Master/Col], p)` |
-| `StdDev / Variance` | stats | `Stdev([Master/Col])` / `Var([Master/Col])` |
+| `RunningSum / RunningAvg / RunningMax` | window/running calc | `CumulativeSum([Orders/Col])` in a date-grouped element |
+| `Rank / RankByValue` | window rank | `Rank([Orders/Col])` (grouped-element context) |
+| `Lag / Lead / OffsetValue` | offset | `Lag([Orders/Col], n)` in a sorted/date-grouped element |
+| `Median / Percentile / Mode` | distribution | `Median([Orders/Col])` / `Percentile([Orders/Col], p)` |
+| `StdDev / Variance` | stats | `Stdev([Orders/Col])` / `Var([Orders/Col])` |
 | `NTile / Quartile` | bucketing | derived bins or `Rank` + ratio; escalate if no 1:1 |
 | `FirstInRange / LastInRange` | windowed first/last | `First`/`Last` in a sorted grouped element |
 | MSTR-specific (`ApplySimple`, `BannerNumber`, …) | passthrough/raw SQL | translate via the warehouse SQL, else escalate |
 
 Spawn ONE scout per distinct error column; run them in parallel (independent).
 
-**Point the scout at the denormalized join element** (e.g. `Orders`), referencing
-columns as `[Master/<Display Name>]`.
+**Point the scout at the denormalized join element** and qualify columns with
+that element's actual `name`. The converter default is `Orders`, so the default
+form is `[Orders/<Display Name>]`. If conversion used
+`--join-element-name <other-name>`, replace `Orders` in every candidate formula;
+never use an element id or a generic `Master` prefix.
 
 ## How to spawn (Agent tool, subagent_type 'general-purpose')
 ```

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-validate.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-validate.py
@@ -11,11 +11,15 @@ optimistically — a function with no Sigma equivalent surfaces as a type=error 
 when the workbook is read back. Use this to confirm a candidate replacement resolves.
 
     python3 scout-validate.py \
-      --formula 'CumulativeSum([Master/Net Revenue])' \
+      --formula 'CumulativeSum([Orders/Net Revenue])' \
       --data-model-id <dm> --element-id <denorm-elem-id> --folder-id <folder> \
       --feature 'RunningSum' --pattern '\\bRunningSum\\s*\\(' \
-      --template 'CumulativeSum([Master/\\1])' --hint 'date-grouped element' \
+      --template 'CumulativeSum([Orders/\\1])' --hint 'date-grouped element' \
       --description 'MSTR RunningSum -> Sigma CumulativeSum' --home ~/.microstrategy-to-sigma
+
+`Orders` is the converter's default `--join-element-name`. Replace it in both
+formula arguments when the conversion used another join-element name; formula
+prefixes are element names, never ids or a generic `Master` alias.
 
 To feed the run-each-time gap-scout gate (bead beads-sigma-5l5e), also pass the
 error column's gate id and the conversion working dir — the result is appended to

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_metric_reference.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_metric_reference.py
@@ -14,6 +14,7 @@ Run: python3 tests/test_metric_reference.py   (exit 0 = pass)
 """
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -83,8 +84,38 @@ def test_no_false_positive():
     print("[ok] no [Metrics/<name>] ref points at a non-existent metric")
 
 
+def test_workbook_formula_and_control_contract():
+    """Workbook source refs stay qualified and selectable controls stay populated."""
+    wb, _ = _convert()
+    elements = wb["document"]["elements"]
+    for el in elements:
+        for col in el.get("columns", []):
+            refs = re.findall(r"\[([^\]]+)\]", str(col.get("formula") or ""))
+            bare = [ref for ref in refs if "/" not in ref]
+            assert not bare, (
+                f"{el.get('name')}/{col.get('name')} emitted bare workbook "
+                f"reference(s) {bare}: {col.get('formula')}"
+            )
+
+    controls = [el for el in elements
+                if el.get("kind") == "control"
+                and el.get("controlType") in ("list", "segmented")]
+    assert controls, "fixture must exercise list/segmented control wiring"
+    for ctl in controls:
+        src = ctl.get("source")
+        assert isinstance(src, dict), (
+            f"{ctl.get('controlId')} has filters but no value-list source"
+        )
+        assert src.get("kind") == "source" and isinstance(src.get("source"), dict), src
+        assert src["source"].get("kind") == "table", src
+        assert src["source"].get("elementId") and src.get("columnId"), src
+        assert ctl.get("filters"), f"{ctl.get('controlId')} has no filter targets"
+    print("[ok] workbook refs qualified; list controls carry value sources + targets")
+
+
 if __name__ == "__main__":
     test_matched_measures_bind_to_metrics()
     test_ratio_metric_stays_inline()
     test_no_false_positive()
+    test_workbook_formula_and_control_contract()
     print("ALL PASS")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Make the MicroStrategy workflow explicitly reject two workbook shapes that can survive an API write but do not produce a usable workbook: bare source-column self-references and list/segmented controls without a value-list source. Also replace generic `Master` formula examples in the MicroStrategy scout path with the converter's actual join-element name contract.

Depends on the companion validator change in [#748](https://github.com/twells89/sigma-migration-skills/pull/748).

## Scope

- Plugin(s) touched: `microstrategy-to-sigma`
- [x] This PR touches exactly one plugin or is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — 31/31 green
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in
- [x] Bumped `microstrategy-to-sigma` from 0.2.25 to 0.2.26

## Verification

- Extended the existing creds-free converter regression to require qualified workbook references and complete list-control value/target wiring.
- MicroStrategy grounding and metric-reference suites pass.
- Both incremental-push and full-PR plugin-version ranges pass locally.
- Agent-variant, hygiene, shared-file, and skill-governance checks are green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d93b3bfc-f2e4-499a-ac85-d308cd04c938?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d93b3bfc-f2e4-499a-ac85-d308cd04c938&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

