### PR TITLE
qlik-to-sigma: synthesize cross-filter controls (recreate Qlik's associative model)

### DIFF
--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -404,6 +404,23 @@ MANUAL. The builder emits the **`control-scope.json` sidecar** (contract:
 `sourceFilterSignals`, per-control `mustReach` over every chart on every page
 (static proof of global reach), and `unbound` entries with reasons.
 
+**Synthesized cross-filter controls (`--synth-controls`).** Qlik cross-filters on
+*any* field via the global associative model — including sheets with **no**
+filterpane, where a user just clicks a bar. Sigma has **no authorable chart-mark
+"Use as filter"** (UI-only), so `build-sigma-workbook.py` recreates that UX with
+controls: when the source app has **zero** filter widgets (e.g. QlikView `-prj`,
+which carries none, or a filterpane-less Sense sheet), it **synthesizes a compact
+control bar** from the most-used chart **dimension** fields (deduped, `*_KEY`/`*_ID`
+and expression dims excluded, capped by `--synth-controls-max`, default 6), each
+filtering the shared master via the *same* `build_control()` shapes + `control_lint`
+reach enforcement. Modes: `auto` (default — synth only when there are no real filter
+widgets, so apps that already have filterpanes are unchanged/golden-safe), `all`
+(also top up apps that have some filters), `off` (strict port — real widgets only).
+Synth controls are tagged `synthesized:true` in the sidecar (`synthesizedCount`),
+and are **not** counted as `sourceFilterSignals`. **Post-publish note:** true
+in-chart mark-click cross-filtering is a one-time Sigma UI step ("Use as filter"),
+not spec-authorable — call it out to the customer.
+
 **Native trellis (small multiples).** A Qlik **chart-level trellis** (a chart
 whose Appearance>Trellis splits it into a panel grid by a dimension) and the
 native **trellis-container** object both collapse to Sigma's **native element

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -1216,7 +1216,7 @@ def main():
                     f"synthesized {n_synth} cross-filter control(s) from chart dimensions "
                     f"(associative-model approximation; --synth-controls={a.synth_controls}): "
                     + ", ".join(labels[f] for f in ranked)
-                    + " — in-chart mark-click filtering remains a Sigma UI step (not spec-authorable)")
+                    + " - in-chart mark-click filtering remains a Sigma UI step (not spec-authorable)")
 
     # Base children owned by a trellis-container are emitted THROUGH the
     # container (one faceted element), never standalone.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -277,6 +277,7 @@ def build_control(lb, resolve, mcol_id, raw_of, warnings, scope, unbound, seen_f
     # GLOBAL associative reach.
     scope.append({"controlId": ctl_id, "sourceName": sig, "status": "wired",
                   "controlType": el["controlType"], "scope": "page", "mustReach": [],
+                  "synthesized": bool(lb.get("_synth")),
                   "wired": [{"elementId": MASTER_ID, "columnId": cid}]})
     return el
 
@@ -1052,6 +1053,16 @@ def main():
                           "(default: control-scope.json next to --spec-out)")
     ap.add_argument("--coverage-out", default=None,
                     help="source-visual coverage report (default: workbook-coverage.json next to --spec-out)")
+    ap.add_argument("--synth-controls", choices=["auto", "all", "off"], default="auto",
+                    help="Cross-filter controls to approximate Qlik's GLOBAL associative model when the "
+                         "source app lacks filter widgets (Sigma has no authorable chart-mark click-filter, "
+                         "so controls are the mechanism). auto (default): synthesize a control bar from the "
+                         "most-used chart DIMENSION fields ONLY when the app has zero filterpanes/listboxes "
+                         "(no regression to apps that already have them — e.g. fills QlikView -prj + "
+                         "filterpane-less Sense). all: also top up apps that have some filters, to "
+                         "--synth-controls-max. off: strict port (only real Qlik filter widgets).")
+    ap.add_argument("--synth-controls-max", type=int, default=6,
+                    help="Cap on synthesized cross-filter controls (default 6).")
     a = ap.parse_args()
 
     charts = {c["id"]: c for c in json.load(open(a.charts))}
@@ -1146,6 +1157,67 @@ def main():
                                             scope, unbound, seen_fields)
                               for lb in lbs) if el]
 
+    # --- Synthesize cross-filter controls (associative-model approximation) ------
+    # Qlik cross-filters on ANY field via the global associative model; Sigma has
+    # no authorable chart-mark click-filter, so we recreate the "select anywhere,
+    # filter everywhere" UX with controls on the shared master. We fabricate a
+    # filterpane + child listboxes INTO `charts` (from the most-used chart
+    # dimension fields) so the normal controls_for/grid_layout/placement paths and
+    # control_lint handle them unchanged. auto: only when the app has zero real
+    # filter widgets (no regression); all: also top up; off: skip. Chart-mark
+    # click-filter stays a Sigma UI step (documented, not spec-authorable).
+    n_synth = 0
+    if a.synth_controls != "off":
+        real_fields, real_signals = set(), 0
+        for c in charts.values():
+            vt = c.get("vizType")
+            if vt == "listbox":
+                real_signals += 1
+                f = (c.get("listbox") or {}).get("field")
+                if f: real_fields.add(f)
+            elif vt == "filterpane":
+                real_signals += 1
+                for ch in (c.get("children") or []):
+                    f = ((charts.get(ch) or {}).get("listbox") or {}).get("field")
+                    if f: real_fields.add(f)
+        if a.synth_controls == "all" or real_signals == 0:
+            usage, labels = {}, {}
+            for c in charts.values():
+                if c.get("vizType") not in CHARTY:
+                    continue
+                dlabs = c.get("dimLabels") or []
+                for i, grp in enumerate(c.get("dimensions") or []):
+                    f = grp[0] if isinstance(grp, list) else grp
+                    if not f or not re.match(r"^[A-Za-z_][\w ]*$", str(f)):
+                        continue                                   # skip expression dims
+                    if f in real_fields or re.search(r"(^|_)(KEY|ID)$", str(f).upper()):
+                        continue                                   # already filtered / join-key
+                    dn = resolve(f)
+                    if dn is None or dn not in mcol_id:
+                        continue                                   # must resolve to a master column
+                    usage[f] = usage.get(f, 0) + 1
+                    labels.setdefault(f, dlabs[i] if i < len(dlabs) and dlabs[i] else f)
+            ranked = sorted(usage, key=lambda f: (-usage[f], str(f)))[:max(0, a.synth_controls_max)]
+            if ranked:
+                kids = []
+                for f in ranked:
+                    lid = "synth-lb-" + re.sub(r"[^a-z0-9]", "", str(f).lower())
+                    charts[lid] = {"id": lid, "vizType": "listbox", "title": labels[f],
+                                   "_synth": True,
+                                   "listbox": {"field": f, "label": labels[f], "state": None}}
+                    kids.append(lid)
+                charts["synth-fp"] = {"id": "synth-fp", "vizType": "filterpane", "title": "Filters",
+                                      "_synth": True, "children": kids}
+                n_synth = len(kids)
+                if sheets:
+                    sheets[0].setdefault("cells", []).insert(
+                        0, {"objectId": "synth-fp", "col": 0, "row": 0, "colspan": 24, "rowspan": 2})
+                warnings.append(
+                    f"synthesized {n_synth} cross-filter control(s) from chart dimensions "
+                    f"(associative-model approximation; --synth-controls={a.synth_controls}): "
+                    + ", ".join(labels[f] for f in ranked)
+                    + " — in-chart mark-click filtering remains a Sigma UI step (not spec-authorable)")
+
     # Base children owned by a trellis-container are emitted THROUGH the
     # container (one faceted element), never standalone.
     tr_children = trellis_child_ids(charts)
@@ -1164,7 +1236,7 @@ def main():
                 if cell["objectId"] in tr_children: continue   # emitted via its container
                 if cell["objectId"] in container_children: continue  # emitted in its parent's tab
                 if c["vizType"] in ("filterpane", "listbox"):
-                    n_signals += 1
+                    if not c.get("_synth"): n_signals += 1   # synthesized controls aren't source signals
                     ctls = controls_for(c)
                     for i, ctl in enumerate(ctls):
                         elems.append(ctl)
@@ -1221,7 +1293,7 @@ def main():
             if c["id"] in tr_children or c["id"] in container_children:
                 continue   # child emitted through its owning composition object
             if c["vizType"] == "filterpane" or (c["vizType"] == "listbox" and c["id"] not in child_ids):
-                n_signals += 1
+                if not c.get("_synth"): n_signals += 1   # synthesized controls aren't source signals
                 ctls = controls_for(c)
                 elems.extend(ctls)
                 layout_elems.extend(ctls)
@@ -1336,6 +1408,7 @@ def main():
     scope_path = a.control_scope_out or os.path.join(
         os.path.dirname(os.path.abspath(a.spec_out)), "control-scope.json")
     json.dump({"version": 1, "source": "qlik", "sourceFilterSignals": n_signals,
+                "synthesizedCount": sum(1 for sc in scope if sc.get("synthesized")),
                 "controls": scope, "unbound": unbound},
                open(scope_path, "w"), indent=2)
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -242,6 +242,9 @@ end
 
 def run!(cmd, env: {})
   out, st = Open3.capture2e(env, *cmd)
+  # Windows consoles hand back cp1252 bytes (e.g. em-dash -> 0x97) that are invalid
+  # UTF-8; scrub so the strip/each_line below never raise Encoding::CompatibilityError.
+  out = out.force_encoding('UTF-8').scrub
   out.each_line { |l| puts "   #{l.rstrip}" } unless out.strip.empty?
   abort "FATAL: command failed (#{st.exitstatus}): #{cmd.join(' ')}" unless st.success?
   out

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_grounding.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_grounding.py
@@ -326,6 +326,61 @@ def test_retail_count_distinct_golden():
     print("[ok] retail golden: safe CountDistinct normalization is pinned")
 
 
+def _build_scope(charts_path, synth="auto"):
+    """Build with a control-scope sidecar + a --synth-controls mode; return (spec, scope)."""
+    with tempfile.TemporaryDirectory() as d:
+        spec_out = os.path.join(d, "spec.json"); cs = os.path.join(d, "control-scope.json")
+        r = subprocess.run(
+            [sys.executable, BUILDER, "--charts", charts_path, "--layout", os.path.join(FIX, "layout.json"),
+             "--denorm", os.path.join(FIX, "denorm.json"), "--dm-id", "dm-x", "--denorm-element-id", "el-x",
+             "--name", "T", "--dry-run", "--synth-controls", synth,
+             "--spec-out", spec_out, "--out", os.path.join(d, "res.json"),
+             "--element-map", os.path.join(d, "emap.json"), "--layout-out", os.path.join(d, "l.xml"),
+             "--control-scope-out", cs],
+            capture_output=True, text=True)
+        assert r.returncode == 0, "builder failed:\n" + r.stderr
+        return json.load(open(spec_out)), json.load(open(cs))
+
+
+def _filterless_charts(d):
+    """Fixture charts with every filterpane/listbox removed — a Qlik app that
+    relied on pure associative click-filtering (the synth-controls gap)."""
+    kept = [c for c in json.load(open(os.path.join(FIX, "charts.json")))
+            if c.get("vizType") not in ("filterpane", "listbox")]
+    p = os.path.join(d, "charts_nofilter.json"); json.dump(kept, open(p, "w"))
+    return p
+
+
+def test_synth_fills_filterless_app():
+    with tempfile.TemporaryDirectory() as d:
+        spec, scope = _build_scope(_filterless_charts(d), synth="auto")
+    assert scope["sourceFilterSignals"] == 0, "no source filters expected"
+    assert scope["synthesizedCount"] > 0, "auto must synthesize a control bar when the app has no filters"
+    assert any(c.get("synthesized") for c in scope["controls"]), "expected synthesized scope entries"
+    for e in (el for el in spec["document"]["elements"] if el.get("kind") == "control"):
+        tgt = (e.get("filters") or [{}])[0].get("source", {})
+        assert tgt.get("elementId") == "m-master", f"{e.get('controlId')} must filter the shared master"
+    assert not any(c["controlId"].upper().endswith(("KEYFILTER", "IDFILTER"))
+                   for c in scope["controls"] if c.get("synthesized")), "never synthesize a join/id key"
+    print("[ok] synth-controls: filterless app gets a master-filtering control bar")
+
+
+def test_synth_noop_when_filters_present():
+    _, scope = _build_scope(os.path.join(FIX, "charts.json"), synth="auto")
+    assert scope["sourceFilterSignals"] > 0
+    assert scope["synthesizedCount"] == 0, "auto must NOT synthesize when real filters exist (no regression)"
+    print("[ok] synth-controls: auto no-ops when real filters exist (golden safe)")
+
+
+def test_synth_all_tops_up_and_dedupes():
+    _, scope = _build_scope(os.path.join(FIX, "charts.json"), synth="all")
+    assert scope["synthesizedCount"] > 0, "all must top up"
+    ids = [c["controlId"] for c in scope["controls"]]
+    assert len(ids) == len(set(ids)), "controlIds must be unique (synth dedupes against real fields)"
+    assert any(not c.get("synthesized") for c in scope["controls"]), "real controls must remain alongside synth"
+    print("[ok] synth-controls: --all tops up + dedupes against real filters")
+
+
 if __name__ == "__main__":
     test_catalogs_valid()
     test_no_inline_maps()
@@ -335,5 +390,8 @@ if __name__ == "__main__":
     test_coverage_matrix_fresh()
     test_scalar_actual_converter_path()
     test_retail_count_distinct_golden()
+    test_synth_fills_filterless_app()
+    test_synth_noop_when_filters_present()
+    test_synth_all_tops_up_and_dedupes()
     test_golden()
     print("ALL PASS")


### PR DESCRIPTION
## What / why

Qlik cross-filters on **any** field via its global **associative model** — including sheets with no filterpane (click a bar → everything filters). Sigma has **no authorable chart-mark "Use as filter"** (UI-only, confirmed in `sigma-workbooks/reference/workflows/actions.md`, Looker's `looker-dashboard-layout.md:299`, and Gate 11 of every `assert-phase6-ran.rb`). So apps with no explicit filter widgets — notably **QlikView `-prj`** (carries none) and filterpane-less Sense sheets — migrated with **zero controls → static, no cross-filtering.**

Qlik apps *with* filterpanes/listboxes already migrate with working cross-filtering (`build_control()` → one global control on the shared master, gated by `control_lint.rb`). This PR fills the gap for the apps that had nothing.

## How

`build-sigma-workbook.py` synthesizes a compact control bar from the most-used chart **dimension** fields, reusing the *existing* control machinery (controls filter the shared master → propagate to every chart = Qlik's global semantics):

- **`--synth-controls auto|all|off`** (default `auto`: synth **only when the app has zero real filter widgets** → no regression to apps that already have filterpanes) + **`--synth-controls-max`** (default 6).
- Fabricates a synthetic filterpane + child listboxes into `charts`, so the normal `controls_for` / `grid_layout` / placement / `control_lint` paths handle them unchanged (`control_lint.rb` untouched).
- Excludes expression dims + `*_KEY`/`*_ID` join keys; dedupes against real filter fields; every synth control targets `m-master`.
- Tagged `synthesized:true` in `control-scope.json` (+ `synthesizedCount`); **not** counted as `sourceFilterSignals` (gate-7 semantics unchanged).
- SKILL.md documents the flag + the post-publish note that in-chart mark-click filtering stays a Sigma UI step.

## Verification

- **Grounding** (`tests/test_grounding.py`, 3 new): golden **byte-identical** (default `auto` no-ops when real filters exist); synth fills a filterless app (master-wired, keys excluded); `--all` tops up + dedupes.
- **Live** (`migrate-qlik.rb --prj` on the QlikView fixture, 0 source filters): synthesized 3 controls (Category/Brand/Segment), workbook POSTed, **gate 7 control-lint CLEAN**, and the **flip test PASSED** — `CategoryFilter=Electronics` filtered the bar chart **5 → 1 rows** at runtime.

plugin 1.4.5 → 1.5.0. Single-plugin; shared files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)