### PR TITLE
chore(powerbi-to-sigma): bump pip deps (msal/truststore/pypdfium2/Pillow) [v1.8.39]

### DIFF
--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.38",
+  "version": "1.8.39",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/requirements.txt
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/requirements.txt
@@ -1,5 +1,5 @@
 # Power BI / Fabric assessment — Python deps. Same set as powerbi-to-sigma.
 # Pinned to stable, long-released versions (no bleeding-edge).
-msal>=1.28,<1.32
+msal>=1.37.0,<1.38
 requests
-truststore>=0.9,<0.11
+truststore>=0.10.4,<0.11

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/requirements.txt
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/requirements.txt
@@ -1,6 +1,6 @@
-msal>=1.28,<1.32
+msal>=1.37.0,<1.38
 requests
-truststore>=0.9,<0.11
+truststore>=0.10.4,<0.11
 
 # OPTIONAL — LOCAL .pbix model extraction ONLY (extract-model-pbix.py /
 # migrate-powerbi.rb --pbix). Deliberately NOT installed by the default
@@ -17,5 +17,5 @@ truststore>=0.9,<0.11
 # Phase 5e source render: rasterize the ExportToFile PDF -> per-page PNGs in
 # export-pbi-pages.py so the agent's `Read` needs no poppler/pdftoppm. pypdfium2
 # ships portable abi3 wheels (BSD/Apache); Pillow writes the PNGs.
-pypdfium2>=4.30,<5
-Pillow>=10.4,<12
+pypdfium2>=5.13.0,<6
+Pillow>=12.3.0,<13


### PR DESCRIPTION
Mirrors into dev the dependency bumps Dependabot proposed on the public mirror as **#7** and **#8**. Per the SEC-41733 policy (deps are managed in dev → flow to public via the resync; direct lockfile PRs on public can't pass the plugin-version-bump gate), those public bot PRs will be closed as superseded by this dev change.

### Bumps
| file | package | from | to |
|---|---|---|---|
| powerbi-to-sigma/scripts | msal | `>=1.28,<1.32` | `>=1.37.0,<1.38` |
| powerbi-to-sigma/scripts | truststore | `>=0.9,<0.11` | `>=0.10.4,<0.11` |
| powerbi-to-sigma/scripts | pypdfium2 | `>=4.30,<5` | `>=5.13.0,<6` |
| powerbi-to-sigma/scripts | Pillow | `>=10.4,<12` | `>=12.3.0,<13` |
| powerbi-assessment/scripts | msal | `>=1.28,<1.32` | `>=1.37.0,<1.38` |
| powerbi-assessment/scripts | truststore | `>=0.9,<0.11` | `>=0.10.4,<0.11` |

Plugin patch bump **1.8.38 → 1.8.39** (satisfies the version-bump gate). All four targets verified released before the 3-day stability cutoff (newest pypdfium2 5.13.0 @ 2026-08-13).