### PR TITLE
mstr→sigma: deepen Path B (super-cube rehost) + promote validated fidelity recipes

### DIFF
--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -133,10 +133,10 @@ Check what backs the dossier's dataset before extracting. `GET /objects/{dataset
 
   **Decide first (ask the customer):** if the cube has a real upstream system of record, prefer pointing Sigma at that live warehouse source. **Rehosting the cube copies a point-in-time snapshot** into the customer's warehouse — it does not stay fresh unless something re-feeds it. Only rehost when there's no live source (demo/prototype cubes, locked-down trials, managed metrics without formulas).
 
-  **If rehosting**, the cube's *data* still extracts cleanly even though its model doesn't:
-  1. Pull all rows via the cube instance API — `POST /v2/cubes/{id}/instances?offset&limit` for page 1 (returns `instanceId` + `definition.grid` + `data`), then `GET /v2/cubes/{id}/instances/{iid}?offset` to page. Element lists in each response are page-scoped. Flatten attributes-on-rows + metrics-on-columns into one table.
-  2. `COPY` it into the warehouse the Sigma connection reaches (quote identifiers to preserve display names; `DATE_FORMAT`/`FIELD_OPTIONALLY_ENCLOSED_BY` for messy CSV; `GRANT SELECT` to the connection role + schema sync — see `sigma-data-models`).
-  3. **Rejoin the normal flow at Phase 3** with a `warehouse-table` source. Skip Phase 1/2 (no bundle to extract) — build the DM + workbook directly, and lean hard on Phase 1.1's source-PDF capture + execute-instance value truth (a cube's KPIs are often a latest-period stat, and a chapter date filter drives the row subsets).
+  **If rehosting** — full depth, fidelity recipes, and the exact shapes are in **`refs/path-b-rehost.md`** — the cube's *data* still extracts cleanly even though its model doesn't:
+  1. **A multi-sheet import is MANY tables in one cube.** Pulling every attribute + metric at once cross-joins them (`Cartesian Join Governing` abort); the auto `Row Count - <name>` metrics **enumerate the source tables**. Run `python3 scripts/extract-cube.py <cubeId> <outDir>` — one CSV per table, with membership decided by the **grand-total invariant** (an attribute/measure is native to a table only if grouping that table's Row Count by it *preserves the total* — a foreign/conformed dim repeats rows), **page-scoped** label resolution while paging (`POST /v2/cubes/{id}/instances` then `GET …/instances/{iid}?offset`), and a **fan-out guard** (`SUM(row-count)==table total`, `SUM(measure)==grand total`) that fails loudly on cross-join inflation. A single-table cube (no `Row Count -` metrics) is the simple flatten-to-one-table case.
+  2. `COPY` each CSV into the warehouse the Sigma connection reaches (quote identifiers to preserve display names; `DATE_FORMAT`/`FIELD_OPTIONALLY_ENCLOSED_BY` for messy CSV). **The connection reads as a service role, not your loader's role**, so the new tables stay invisible until you `GRANT SELECT … TO ROLE <the connection's role>` **and** schema-level sync: `POST /v2/connections/{connectionId}/sync {"path":["DB","SCHEMA"]}` (table-level sync 404s until the table is already discovered — sync the schema first). See `refs/path-b-rehost.md` / `sigma-data-models`.
+  3. **Rejoin the normal flow at Phase 3.** **Prefer a `sql` DM source over `warehouse-table` for these freshly-loaded tables** — it runs live against the connection and resolves immediately, skipping the catalog-sync dependency (the role still needs `SELECT`; it also lets you alias clean display names). Skip Phase 1/2 (no bundle to extract) — build the DM + workbook directly, and lean hard on Phase 1.1's source capture + execute-instance value truth (a cube's KPIs are often a latest-period stat, and a chapter date filter drives the row subsets).
   4. **Emit REAL charts, not labeled-table stubs.** Path B is the legacy Quick
      Cube hand-build fallback, not evidence that every classic-converter chart
      family is validated. Reuse released Sigma kinds only when the recovered
@@ -147,7 +147,7 @@ Check what backs the dossier's dataset before extracting. `GET /objects/{dataset
      insufficiently grounded type, and you say so.
   5. **Gates:** `assert-phase6-ran.rb` is wired for the classic path — in path B it does not apply, but you still MUST run the **parity gate** and the **source-fidelity Visual QA gate** (compare the render to `source_dossier.pdf`, every page). Don't declare done on HTTP 200.
 
-  > **Known ceiling — be honest in the writeup:** a cube's *derived* metrics (e.g. an "Inventory Performance" ratio, or non-additive aggregations) carry their formula only inside the cube — they do NOT reduce from the rehosted base columns. Recover exact definitions via Workstation export / ODBC, or approximate and **label the approximation**. Never silently ship a guessed metric as exact.
+  > **Derived metrics — recover, then VERIFY across every period:** a dossier's headline metrics (Revenue / Cost / margin %, or non-additive aggregations) are often *dossier-level derived* metrics that are **not** in the cube's `availableObjects`, so they do NOT reduce from the rehosted base columns. Recover them rather than guess: pull their ids from an **executed viz** (`definition.grid.columns[templateMetrics].elements`), reverse-engineer the definition from the statement structure (which base rows they aggregate), and **verify the formula against the executed viz values across EVERY period** — not one — before trusting it. Reproduce as a Sigma DM metric; otherwise (Workstation export / ODBC, or approximate) **label the approximation**. Never silently ship a guessed metric as exact. (`refs/path-b-rehost.md` §3.)
 
 ## Phase 1 — Extract the bundle
 
@@ -181,6 +181,24 @@ python3 scripts/microstrategy-render-source.py <dossierId> --workdir <WORK>   # 
 element arrangement (columns/rows, what sits next to what), each viz's real
 chart KIND (a "microcharts" or "kpi" type is not a bar table), branding/header
 bands, and any controls/selector panels.
+
+> **Read the dossier's own "Dashboard Details" / "About" chapter if it has one —
+> it is a design spec handed to you.** Polished dossiers frequently ship a
+> documentation page describing each chapter's chart kinds, filters, and
+> interactions ("panel stack with a panel selector", "grids with outline mode",
+> "heat map … filters the horizontal stacked bar to the right",
+> "synchronized-axis bar chart", "default dynamic selection filter set to the
+> last 4 quarters", "linked text boxes"). Those phrases map directly to Sigma
+> shapes (tabbed-container, pivot hierarchy, backgroundScale + cross-filter,
+> trellis, last-N filter, navigate buttons) — see `refs/path-b-rehost.md` §5.
+>
+> **PDF-export limits (`export-dossier-pdf.py`):** it tends to render only the
+> *active/default* chapter and **blocks external images** (whitelist) — the
+> branding logo comes back empty and other chapters may be absent. So don't
+> treat the PDF as the whole dashboard: execute every viz (below), and ask the
+> customer for the logo asset (Sigma `image` needs a hosted URL — no upload API).
+> Match the source **theme** too (a dark dossier → `settings.theme.name: Dark`),
+> not the default light canvas.
 
 ```bash
 # (b) Execute the dossier instance and pull each visualization's grid + DISPLAYED values.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/design-notes.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/design-notes.md
@@ -25,6 +25,19 @@ MSTR REST ──extract.py──> bundle.json ──convert.py──> sigma_dm_s
   derived from semantics (count/quantity → integer, pct/margin/ratio →
   percent, money-named facts → currency).
 
+## Path B — super-cube (Quick Cube) rehost is a SEPARATE flow
+
+The pipeline above is the **classic-schema** path (a live warehouse-backed
+dossier). A **super-cube / Quick Cube** (`subtype 779`, a file import) has no
+warehouse semantic model, so `extract.py`/`convert.py` do **not** apply — you
+rehost the cube's data into the warehouse and rebuild by hand. That flow (its
+own extractor `scripts/extract-cube.py`, the multi-table Cartesian trap and the
+grand-total membership/fan-out invariant, `sql`-source-over-`warehouse-table`
+for fresh tables, the connection grant + schema-sync, dossier-level derived-
+metric recovery+verification, and the MSTR-viz → Sigma fidelity recipes proven
+on a live rebuild) lives in **`refs/path-b-rehost.md`**. Keep the two paths
+distinct in any writeup — don't claim `convert.py` drove a super-cube.
+
 ## Validated scope (live trial, exact parity)
 
 - Classic-schema path: star schema (fact + dims, incl. heterogeneous key

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/path-b-rehost.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/path-b-rehost.md
@@ -1,0 +1,185 @@
+# Path B — super-cube (Quick Cube) rehost + faithful rebuild
+
+`SKILL.md` Phase 0.5 branches here when the dossier's dataset is a **super-cube**
+(`subtype 779` — a file / Quick-Cube import, `Row Count - <name>.xlsx` metrics,
+no live warehouse). There is no warehouse semantic model, so `extract.py` /
+`convert.py` do **not** drive it. This ref is the depth behind the Path B steps:
+extract the data correctly, land it so Sigma can see it, recover the derived
+metrics, and rebuild the dossier with real fidelity (not a generic dashboard).
+
+Everything below is live-validated on a real multi-table super-cube dossier
+(4 Excel sheets → Snowflake → Sigma DM + 5-page workbook, row-parity exact).
+
+---
+
+## 1. Extract the data — a multi-sheet cube is MANY tables
+
+A naive "pull the whole cube into one flat table" **fails** on a multi-sheet
+import: requesting every attribute + metric at once cross-joins the sheets and
+MSTR aborts with `Cartesian Join Governing`. The cube's auto-generated
+`Row Count - <name>` metrics **enumerate the source tables** — extract each at
+its own grain.
+
+Use `scripts/extract-cube.py <cubeId> <outDir>` (one CSV per table +
+`cube_manifest.json`). What it encodes, and what to know if hand-driving it:
+
+- **Per-table request:** `POST /v2/cubes/{id}/instances` with
+  `requestedObjects:{attributes:[that table's attrs], metrics:[measures + its Row Count]}`,
+  then `GET /v2/cubes/{id}/instances/{iid}?offset=…` to page.
+- **Membership by probe:** an attribute/measure belongs to a table iff it can be
+  requested alongside that table's Row Count *without* a Cartesian abort.
+  Conformed dims (Year/Quarter/Region/…) match several tables — that's expected.
+- **Element lists are PAGE-SCOPED.** `data.headers.rows[r]` are element
+  *indices* into **that page's own** `definition.grid.rows[i].elements` — resolve
+  labels per page while paging, never carry indices across pages.
+- **Fan-out guard (do not skip).** A conformed dim grouped with the wrong
+  table's measure silently duplicates rows. Pull grand totals with **no
+  attributes** (`requestedObjects.attributes: []`) and assert, after grouping,
+  `SUM(row-count) == table total` and `SUM(measure) == measure grand total`.
+  `extract-cube.py` fails (exit 1) if either mismatches. This is what proves the
+  extracted CSV is the real table, not an inflated cross-join.
+
+> A single-table cube (no `Row Count -` metrics) is the simple case: the whole
+> grid is one table and the classic "flatten attrs-on-rows + metrics-on-columns"
+> holds.
+
+---
+
+## 2. Land it so Sigma can see it
+
+`COPY` the CSVs into the warehouse the Sigma connection reaches (quote
+identifiers to preserve display names). Two gotchas that otherwise block the
+DM/workbook POST:
+
+- **Grant + sync.** The connection reads as a **service role**, not the role
+  your loader (`snow` CLI, etc.) used to create the tables. So the new tables
+  are invisible until you (a) `GRANT SELECT ON <DB>.<SCHEMA>.<TABLE> TO ROLE
+  <the connection's role>` and (b) **schema-level** sync the connection:
+  `POST /v2/connections/{connectionId}/sync {"path":["DB","SCHEMA"]}`.
+  Table-level sync 404s until the table is already discovered, so sync the
+  **schema** first. (Full story + how to find the connection's role:
+  `sigma-data-models`.)
+- **Prefer a `sql` DM source over `warehouse-table` for freshly-loaded tables.**
+  A `warehouse-table` source resolves through Sigma's cached catalog, so a
+  brand-new table often fails to POST (`Source not found`) until the sync above
+  lands. A `sql` source (`{kind:sql, connectionId, statement:"SELECT … FROM
+  DB.SCHEMA.TABLE"}`) runs live against the connection and resolves immediately
+  — the role still needs `SELECT`, but there's no catalog-sync dependency. It
+  also lets you alias columns to clean display names in one place.
+
+Rejoin the normal flow at **Phase 3** (build the DM, then the workbook).
+
+---
+
+## 3. Recover the DERIVED metrics — they aren't in the cube's objects
+
+The dossier's headline metrics (e.g. Revenue / Cost / Operating Income /
+margin %) are frequently **dossier-level derived metrics** — computed *in the
+dossier*, so they do **not** appear in the cube's `availableObjects`. Recover
+them, don't guess:
+
+1. **Find their ids** in an executed viz: `GET …/visualizations/{key}` →
+   `definition.grid.columns[…templateMetrics].elements[]` carries each metric's
+   `name` + `id`.
+2. **Reverse-engineer the definition** from the statement structure — which
+   base rows they aggregate (e.g. Revenue = `Sum(Amount)` where
+   `Category = "Revenues"`; Cost = the `Cost of Revenues` + `Operating Expenses`
+   categories; Operating Income = Revenue + Cost; margin % = the ratio).
+3. **Verify against the executed viz values across ALL periods**, not one.
+   Export/execute the KPI (or trend) and confirm your formula reproduces every
+   period before trusting it. Ship the reverse-engineered metric only once it
+   matches; otherwise label it an approximation. (Cross-period verification is
+   what separates "looks right for Q4" from "correct.")
+
+These become metrics on the Sigma data model (`sigma-data-models`).
+
+---
+
+## 4. Capture the design INTENT before rebuilding
+
+The bundle/vizzes tell you the data; they do **not** tell you the intended
+*design*. Two cheap, high-value captures:
+
+- **Read the dossier's own "Dashboard Details" / "About" chapter if it has one.**
+  Many polished dossiers ship a documentation page that literally describes each
+  chapter's chart kinds, filters, and interactions ("panel stack with a panel
+  selector", "grids with outline mode", "heat map … filters the horizontal
+  stacked bar to the right", "synchronized-axis bar chart", "default dynamic
+  selection filter set to the last 4 quarters", "linked text boxes"). It is a
+  design spec handed to you — read it first.
+- **Execute every viz** (`…/instances/{mid}/chapters/{ck}/visualizations/{vk}`)
+  for the exact attribute↔metric pairings and displayed values (the parity
+  baseline + how derived metrics slice).
+
+**PDF-export limits (`export-dossier-pdf.py`):** it tends to render only the
+*active/default* chapter and **blocks external images** (whitelist) — so the
+branding logo comes back empty and other chapters may be missing. Don't treat
+the PDF as the whole dashboard: execute each viz, and ask the customer for the
+logo asset (Sigma `image` elements need a **hosted URL** — there is no upload
+API). Match the source **theme** too (a dark dossier → `settings.theme.name:
+Dark`), not the default light canvas.
+
+---
+
+## 5. Fidelity recipes — MSTR viz → Sigma element (live-validated on Path B)
+
+These are the shapes that turn "right data, generic look" into a faithful
+rebuild. All authored via `/v2/workbooks/spec`; see the `sigma-workbooks` skill
+for full field reference and always clone shapes from a recent GET-back / the
+compiled OpenAPI (`assets.sigmacomputing.com/openapi/public-rest-api/...`),
+which is ahead of any vendored copy.
+
+- **`multi_metric_kpi` → a row of comparative KPI cards.** Each card is a
+  container holding: a `kpi-chart` with `comparisonColumn:{columnId}` +
+  `comparison:{display:"percentage", colorGood, colorBad}` (the ▲/▼ delta
+  badge), an optional "Previous Quarter: …" subtitle `text`, and — for the
+  sparkline — a **separate borderless `area-chart` stacked BELOW the KPI in the
+  same container** (the KPI's own `trend` field is inert from spec; the
+  composite renders). Give the KPI ~6 grid rows or the comparison badge gets
+  dropped (KPI drops lower items when short).
+- **`grid` with outline mode / consolidations → `pivot-table`** with a
+  `rowsBy` hierarchy (Category ▸ Description, etc.) and `columnsBy` the period.
+  Consolidations are custom subtotal groupings; the hierarchy reproduces the
+  shape (exact custom subtotal *ordering* is only approximated).
+- **`heat_map` → `pivot-table` + `conditionalFormats:{type:backgroundScale}`**
+  (a diverging scheme for signed values). This is a real analog — do **not**
+  fall back to a flagged table. Wire heat-map→bar cross-filtering as a control
+  if the source does.
+- **`comparison_kpi` → `kpi-chart` with `comparisonColumn`** — the comparison is
+  spec-authorable; don't flag it as manual.
+- **synchronized-axis bar chart → `bar-chart` `trellis:{rowsBy:[{columnId}]}`**
+  (one same-scale panel per category). Needs a **long** facet dimension, so if
+  the cube stores the split as wide columns (one metric per category), **unpivot
+  to long** — a `sql` source with `UNION ALL`/`UNPIVOT` (or a `transpose`
+  source) that yields a `Department`-style column. Note: a column can't sit on
+  both `trellis` and `color` — add a **duplicate column** for the color channel.
+- **panel stack + panel selector → `tabbed-container`.** One `<Tab>` per panel
+  (bare `<Element>` children only, no nested `<Container>` inside a `<Tab>`);
+  drive it from a button with the `select-tab` effect if needed.
+- **linked text boxes / chapter navigation → `button` elements with a
+  `navigate` effect** (`effects:[{effect:navigate, target:{type:page, page:…}}]`),
+  or the built-in side sidebar (`settings.navigation.pageSidebar:"enabled"`,
+  `primary:"sidebar"`). **The `button` element has no color field** — its color
+  is the theme primary, so set `settings.theme.overrides.colors.highlight` (else
+  buttons render Sigma-blue). The `navigation` element renders as a horizontal
+  tab bar and its vertical mode clips — stacked `button`s give the boxed look.
+- **dynamic "last N quarters" chapter filter → an element list filter** pinned
+  to the last N period values (MSTR's "default dynamic selection filter").
+- **Theme:** `settings.theme.name:"Dark"` + `overrides.categoricalScheme` (the
+  source's palette) + `overrides.colors.highlight` (accent). Set it once at the
+  document level; per-element `color.scheme` still drives bar/line series.
+
+---
+
+## 6. Gates (same rigor as the classic path)
+
+`assert-phase6-ran.rb` is wired for the classic path and does not apply to a
+Path B hand-build, but you still MUST:
+
+- **Row parity** — expected values come from MSTR (executed viz / report), never
+  invented; money & counts exact.
+- **Source-fidelity Visual QA** — render every page and compare to the source
+  (PDF where it rendered, plus the executed-viz values and any screenshots).
+  Right numbers in the wrong-looking dashboard still fails this gate.
+
+Never declare done on an HTTP 200.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/viz-type-mapping.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/viz-type-mapping.md
@@ -15,6 +15,17 @@ Grid plus bar/line have live source-to-target evidence; waterfall uses the
 released native shape; area is mechanically wired but still unverified. Do not
 collapse those distinct evidence levels into a blanket "chart support" claim.
 
+**Path B hand-build ✓** marks a shape proven on a live super-cube *rehost*
+rebuild (`refs/path-b-rehost.md` §5) — spec-authored, POSTed, and
+render/parity-verified end-to-end — but **not yet wired into the classic
+converter's automated emission**. Treat it as a validated recipe to apply by
+hand on Path B, not an auto-conversion. Also mapped there: a **synchronized-axis
+bar chart** (MSTR's per-category same-scale panels) → `bar-chart`
+`trellis:{rowsBy:[{columnId}]}` (needs a long facet dimension — unpivot wide
+cube columns); **linked text boxes / chapter nav** → `button` + `navigate`
+effect (or the built-in `settings.navigation` sidebar); a **dynamic last-N
+chapter filter** → an element list filter pinned to the last N periods.
+
 Counts below are from a 365-dossier / ~7,400-viz sweep of MicroStrategy's
 public demo environment (Tutorial, MobileDashboards, Embedded Analytics,
 AI Auto projects, 2026-06) — the extractor walker parsed **all** of them,
@@ -23,21 +34,21 @@ so every listed type is extraction-validated. Counts double as gap priority.
 | MSTR `visualizationType` | n | Sigma element kind | Build |
 |---|---|---|---|
 | `grid` | 1893 | `table` (pivot when `crossTab: true`) | **validated (parity-verified)** |
-| `kpi` | 1633 | `kpi-chart` | roadmap (top priority by volume) |
+| `kpi` | 1633 | `kpi-chart` | **Path B hand-build ✓** (roadmap for classic converter) |
 | `bar_chart` | 810 | `bar-chart` | **validated** |
 | `geospatial_service` | 331 | `region-map` / `point-map` (by geo attribute granularity — cognos `tiledmap` precedent) | roadmap |
 | `line_chart` | 252 | `line-chart` | **validated** |
 | `bubble_chart` | 221 | `scatter` (size slot) | roadmap |
-| `heat_map` | 188 | flagged `table` (size+color tile grid has no Sigma analog) | fallback |
+| `heat_map` | 188 | `pivot-table` + `conditionalFormats:{type:backgroundScale}` (diverging scheme for signed values); cross-filter a partner bar via a control | **Path B hand-build ✓** (was: flagged — it DOES have an analog) |
 | `combo_chart` | 182 | `combo` | roadmap |
 | `area_chart` | 170 | `area-chart` | wired, **not live-verified** |
-| `multi_metric_kpi` | 168 | one `kpi-chart` per metric | roadmap |
+| `multi_metric_kpi` | 168 | a KPI-card row: per metric a `kpi-chart` with `comparisonColumn`+`comparison:{display:percentage,colorGood/Bad}` (Δ badge) + a "Previous …" subtitle `text` + a composite `area-chart` sparkline stacked below in the same container | **Path B hand-build ✓** (recipe: `path-b-rehost.md` §5) |
 | `compound_grid` | 155 | `table` | roadmap |
-| `microcharts` | 113 | `table` + flagged sparkline columns | fallback |
+| `microcharts` | 113 | `table` + composite `area-chart` sparklines (a borderless area-chart per row/metric; the KPI's own `trend` field is inert from spec) | **Path B hand-build ✓** (recipe: `path-b-rehost.md` §5) |
 | `ring_chart` | 111 | `pie` (donut variant) | roadmap |
 | `google_map` | 104 | `region-map` / `point-map` | roadmap |
 | `pie_chart` | 90 | `pie` | roadmap |
-| `comparison_kpi` | 67 | `kpi-chart` (comparison value flagged) | roadmap |
+| `comparison_kpi` | 67 | `kpi-chart` + `comparisonColumn`/`comparison` (the Δ badge IS spec-authorable) | **Path B hand-build ✓** |
 | `sankey` | 42 | flagged `table` | fallback |
 | `gauge` | 33 | `progress` when explicit value/range semantics exist; otherwise flagged `table` | **released, grounded-only** |
 | `histogram` | 27 | `bar` (pre-binned) or flagged | fallback |

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/extract-cube.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/extract-cube.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""extract-cube.py — Path B (super-cube / Quick Cube rehost) data extractor.
+
+A MicroStrategy super-cube (subtype 779 — a file/Quick-Cube import) has no
+warehouse semantic model, so the classic ``extract.py`` / ``convert.py`` path
+does not apply (see SKILL.md Phase 0.5 and ``refs/path-b-rehost.md``). This
+pulls the cube's DATA, one CSV per source table, ready to COPY into the
+warehouse the Sigma connection reaches.
+
+It handles three things a naive "pull the whole cube into one table" does NOT:
+
+  1. **A multi-sheet import is MANY tables in one cube.** Requesting every
+     attribute + metric at once cross-joins them and MSTR aborts with
+     ``Cartesian Join Governing``. The auto-generated ``Row Count - <name>``
+     metrics enumerate the source tables; each is extracted at its own grain.
+  2. **Element lists in each instance response are PAGE-SCOPED.** Header rows
+     are element *indices* into that page's own ``definition.grid.rows[i].
+     elements`` — resolve labels per page while paging, never across pages.
+  3. **Fan-out guard.** A conformed dimension grouped with the wrong table's
+     measure silently duplicates rows. After extracting each table we assert
+     ``SUM(row-count) == table total`` and ``SUM(measure) == measure grand
+     total`` (both pulled with NO attributes) so a fan-out fails loudly instead
+     of shipping inflated numbers.
+
+Membership (which attributes / measures belong to a table) is inferred by the
+**grand-total invariant**, not a bare compatibility probe: an object is native
+to a table only when grouping that table's Row Count by it *preserves the
+total*. A conformed dimension from another sheet may not Cartesian-abort but it
+REPEATS rows (the grouped Row Count sums to a multiple of the table total), so
+compatibility alone is not enough — the sum has to match. Attributes and
+measures that inflate the total are excluded (logged), which is what keeps each
+extracted CSV at the table's true grain. Cross-check the kept set against the
+dossier's viz groupings (execute each viz; see ``refs/path-b-rehost.md``).
+
+Usage:
+  python3 scripts/extract-cube.py <cubeId> <outDir> [--limit 1000]
+
+Creds via mstr.py (MSTR_BASE_URL/USERNAME/PASSWORD or ~/.sigma-migration/env).
+Writes <outDir>/<SAFE_TABLE_NAME>.csv per table + <outDir>/cube_manifest.json.
+"""
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+
+import mstr
+
+
+def _instance(s, cube, attr_ids, metric_ids, offset, limit):
+    body = {"requestedObjects": {
+        "attributes": [{"id": a} for a in attr_ids],
+        "metrics": [{"id": m} for m in metric_ids]}}
+    return s.post(f"/v2/cubes/{cube}/instances?offset={offset}&limit={limit}", body)
+
+
+def _page(resp):
+    """(attr names, metric names, rows) for one instance page; labels resolved
+    against THIS page's own (page-scoped) element lists."""
+    grid = resp["definition"]["grid"]
+    data = resp["data"]
+    attr_units = grid.get("rows", []) or []
+    met_names = []
+    for u in grid.get("columns", []) or []:
+        if u.get("type") == "templateMetrics":
+            met_names = [e.get("name") for e in u.get("elements", []) or []]
+    hrows = data["headers"]["rows"]
+    raw = data["metricValues"]["raw"]
+    rows = []
+    for ri, hr in enumerate(hrows):
+        labels = [(attr_units[i]["elements"][idx].get("formValues") or [None])[0]
+                  for i, idx in enumerate(hr)]
+        rows.append(labels + (raw[ri] if ri < len(raw) else []))
+    return [u.get("name") for u in attr_units], met_names, rows
+
+
+def _grand(s, cube, metric_ids):
+    """Metric grand totals with NO attributes (the fan-out oracle)."""
+    r = _instance(s, cube, [], metric_ids, 0, 1)
+    return r["data"]["metricValues"]["raw"][0]
+
+
+def _preserves_total(s, cube, attr_ids, metric_ids, metric_pos, grand, limit=100000):
+    """True iff grouping `metric_ids` by `attr_ids` keeps the metric at
+    `metric_pos` summing to `grand` (i.e. the attribute set partitions the
+    table's rows rather than repeating them). Cartesian abort => False."""
+    try:
+        _, _, rows, _ = _extract(s, cube, attr_ids, metric_ids, limit)
+    except Exception as e:  # noqa: BLE001 — RuntimeError text carries the code
+        if "cartesian" in str(e).lower():
+            return False
+        raise
+    col = len(attr_ids) + metric_pos
+    got = sum(r[col] for r in rows if isinstance(r[col], (int, float)))
+    return abs(got - grand) < max(1e-3, abs(grand) * 1e-9)
+
+
+def _extract(s, cube, attr_ids, metric_ids, limit):
+    r = _instance(s, cube, attr_ids, metric_ids, 0, limit)
+    iid = r["instanceId"]
+    total = r["data"]["paging"]["total"]
+    anames, mnames, rows = _page(r)
+    off = limit
+    while len(rows) < total:
+        r2 = s.get(f"/v2/cubes/{cube}/instances/{iid}?offset={off}&limit={limit}")
+        _, _, more = _page(r2)
+        rows += more
+        off += limit
+    return anames, mnames, rows, total
+
+
+def _safe(name):
+    return re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").upper() or "TABLE"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("cube", help="cube / dataset object id (subtype 779)")
+    ap.add_argument("outDir")
+    ap.add_argument("--limit", type=int, default=1000)
+    a = ap.parse_args()
+    os.makedirs(a.outDir, exist_ok=True)
+    s = mstr.Session()
+
+    ao = s.get(f"/v2/cubes/{a.cube}")["definition"]["availableObjects"]
+    attrs = {x["name"]: x["id"] for x in ao.get("attributes", [])}
+    metrics = {x["name"]: x["id"] for x in ao.get("metrics", [])}
+
+    # Source tables = the auto "Row Count - <name>" metrics. A cube with none is
+    # single-table: the whole grid is one table.
+    rc_by_table = {n.split("Row Count -", 1)[1].strip(): mid
+                   for n, mid in metrics.items() if n.startswith("Row Count -")}
+    if not rc_by_table:
+        rc_by_table = {"cube": None}
+    measures = {n: mid for n, mid in metrics.items() if not n.startswith("Row Count -")}
+    print(f"cube {a.cube}: {len(attrs)} attributes, {len(measures)} measures, "
+          f"{len(rc_by_table)} source table(s): {list(rc_by_table)}")
+
+    manifest = {"cube": a.cube, "tables": {}}
+    for tname, rc in rc_by_table.items():
+        if rc is None:  # single-table cube — no Row Count metric to anchor on
+            member_attrs = list(attrs.items())
+            member_meas = list(measures.items())
+        else:
+            g_rc = _grand(s, a.cube, [rc])[0]
+            # native attributes: grouping this table's Row Count by the attribute
+            # PRESERVES the total (a foreign/joined dim would repeat rows).
+            member_attrs = [(an, aid) for an, aid in attrs.items()
+                            if _preserves_total(s, a.cube, [aid], [rc], 0, g_rc)]
+            attr_ids = [x[1] for x in member_attrs]
+            # native measures: at the native-attr grain, SUM(measure) still equals
+            # its own grand total (foreign measures Cartesian-abort or inflate).
+            member_meas = []
+            for mn, mid in measures.items():
+                g_m = _grand(s, a.cube, [mid])[0]
+                if g_m is None:
+                    continue
+                # anchor the grain to THIS table with its Row Count, so a foreign
+                # measure joined only through a conformed dim is rejected (it will
+                # Cartesian-abort or sum to the wrong total at the table's grain).
+                if _preserves_total(s, a.cube, attr_ids, [mid, rc], 0, g_m):
+                    member_meas.append((mn, mid))
+
+        metric_ids = [m[1] for m in member_meas] + ([rc] if rc else [])
+        anames, mnames, rows, total = _extract(
+            s, a.cube, [x[1] for x in member_attrs], metric_ids, a.limit)
+
+        # fan-out guard (re-assert at the final combined grain)
+        checks = {}
+        if rc is not None:
+            grand = _grand(s, a.cube, metric_ids)
+            rc_idx = len(member_meas)  # rc is last metric
+            got_rc = sum(r[len(anames) + rc_idx] for r in rows
+                         if isinstance(r[len(anames) + rc_idx], (int, float)))
+            checks["row_count"] = {"got": got_rc, "expected": grand[rc_idx],
+                                   "ok": abs(got_rc - grand[rc_idx]) < 1e-6}
+            for mi, (mn, _) in enumerate(member_meas):
+                got = sum(r[len(anames) + mi] for r in rows
+                          if isinstance(r[len(anames) + mi], (int, float)))
+                checks[mn] = {"got": got, "expected": grand[mi],
+                              "ok": abs(got - grand[mi]) < 1e-3}
+
+        header = anames + mnames
+        path = os.path.join(a.outDir, _safe(tname) + ".csv")
+        with open(path, "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(header)
+            w.writerows(rows)
+        manifest["tables"][tname] = {
+            "csv": os.path.basename(path), "rows": len(rows), "paging_total": total,
+            "attributes": anames, "measures": [m[0] for m in member_meas],
+            "verification": checks}
+        bad = [k for k, v in checks.items() if not v.get("ok", True)]
+        status = "FAN-OUT/ MISMATCH: " + ",".join(bad) if bad else "verified"
+        print(f"  [{tname}] {len(rows)} rows -> {os.path.basename(path)}  ({status})")
+
+    json.dump(manifest, open(os.path.join(a.outDir, "cube_manifest.json"), "w"), indent=2)
+    print(f"wrote cube_manifest.json to {a.outDir}")
+    any_bad = any(not v.get("ok", True)
+                  for t in manifest["tables"].values() for v in t["verification"].values())
+    sys.exit(1 if any_bad else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

A production MSTR→Sigma migration this week was a **super-cube (Quick Cube)** dossier, which exposed two gaps: (1) the super-cube "Path B" is hand-driven with **no scripts** and a *one-flat-table* assumption that Cartesian-aborts on a multi-sheet import; (2) most of what makes a migration look faithful (comparative KPIs + sparklines, tabbed statements, heat-map, department trellis, themed dark canvas, nav) was marked **roadmap/fallback** — but it's all buildable today.

Everything here was validated end-to-end on a live 4-sheet super-cube dossier → Snowflake → Sigma data model + 5-page workbook (row-parity exact, render-verified).

## Changes

- **`scripts/extract-cube.py` (new)** — Path B multi-table extractor. The auto `Row Count - <name>` metrics enumerate the source tables; membership is decided by the **grand-total invariant** (an attribute/measure is native only if grouping the table's Row Count by it *preserves the total* — the measure test is Row-Count-anchored so conformed dims don't leak), labels are resolved **per page** (element lists are page-scoped), and a **fan-out guard** (`SUM(row-count)==table total`, `SUM(measure)==grand total`) fails loudly on cross-join inflation. Live run: 4 tables extracted at exact grain, measures correctly partitioned per table.
- **`refs/path-b-rehost.md` (new)** — the full Path B guide: multi-table extraction, landing (grant `SELECT` to the connection's **service role** + **schema-level** `POST /v2/connections/{id}/sync`; prefer a `sql` DM source over `warehouse-table` for freshly-loaded tables), derived-metric recovery + **cross-period** verification, reading the dossier's own "Dashboard Details" chapter as a design spec, and the MSTR-viz → Sigma **fidelity recipes**.
- **`SKILL.md`** — Phase 0.5 Path B rewritten (multi-table, grant/sync, `sql`-source); Phase 1.1 gains design-doc capture + PDF-export limits (single chapter, blocked images); derived-metric note now has a method + a cross-period verify requirement.
- **`refs/viz-type-mapping.md`** — promote `kpi` / `multi_metric_kpi` / `comparison_kpi` / `heat_map` / `microcharts` from roadmap/fallback to **Path-B hand-build ✓** recipes (notably `heat_map` → `pivot-table` + `backgroundScale` is a real analog, not a flag); add synchronized-axis → `trellis`, linked-text-boxes → `navigate` buttons, dynamic last-N chapter filter. Marked distinct from the classic converter's automated emission.
- **`refs/design-notes.md`** — note Path B is a separate flow from `convert.py`.

## Notes
- `viz-type-mapping.md`'s `VIZ_MAPPED` (assessment classifier) is intentionally **not** flipped — these are hand-build recipes for Path B, not automated converter coverage, so the readiness readout stays honest.
- No auto-conversion claims changed for the classic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
