### PR TITLE
fix: F5 encoding crash class — corpus determinism + the 21 real sites (#752)

### DIFF
--- a/.githooks/run-governance-checks.sh
+++ b/.githooks/run-governance-checks.sh
@@ -55,6 +55,7 @@ if [ "${CI:-}" = "true" ]; then
   [ -f tools/test-commit-msg-guard.sh ] && { bash tools/test-commit-msg-guard.sh || fail=1; }
   [ -f tools/test-lint-skill-paths.sh ] && { bash tools/test-lint-skill-paths.sh || fail=1; }
   [ -f tools/test-lint-uplift-contracts.rb ] && { ruby tools/test-lint-uplift-contracts.rb || fail=1; }
+  [ -f tools/test-lint-twb-encoding.rb ] && { ruby tools/test-lint-twb-encoding.rb || fail=1; }
 fi
 if [ "$fail" -ne 0 ]; then
   echo "" >&2

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -407,7 +407,15 @@ jobs:
         # runner (US-ASCII) it raises Encoding::CompatibilityError on any non-ASCII
         # .twb/XML — which has silently crashed migrations 3+ times. Any read of a
         # .twb / xml / layout file MUST pass `encoding: 'UTF-8'`.
+        # RULE 2 (#752) additionally catches a RAW read whose result is later
+        # regexp-matched, whatever the extension — that is how the
+        # assert-phase6-ran.rb dm-spec.json crash slipped past the .twb-token rule.
         run: ruby tools/lint-twb-encoding.rb   # single source of truth (plugins/ + shared/); also run by .githooks/run-governance-checks.sh
+      - name: Self-test — the F5 gate must FAIL on the #752 shape
+        # A gate nobody has watched fail is not a gate. Plants the exact defect
+        # (raw dm-spec.json read + .scan) in a throwaway tree and asserts exit 1,
+        # plus the safe shapes that must stay quiet.
+        run: ruby tools/test-lint-twb-encoding.rb
       - name: Run offline test_*.py suites
         # EXPLICIT allow-list — creds-free, network-free Python tests only.
         # PyYAML is needed by the looker offline dashboard parser

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -29,6 +29,19 @@ jobs:
     name: corpus --check (creds-free goldens)
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    env:
+      # Same pin, same reason as ruby-full-suite and the BSD-smoke job below:
+      # UTF-8-heavy fixtures crash under a US-ASCII default external encoding
+      # (F5 crash class). This job was the one that did NOT pin it, which is how
+      # tableau/preagg-kpi could pass in CI and fail on an unset-LANG laptop
+      # (issue #752). run-corpus.sh self-pins as well, which covers a developer
+      # running it directly; this job-level pin covers the OTHER steps here and
+      # means the runner's default locale is never something we rely on.
+      # (Running a single case's `bash checks.sh` by hand still needs a UTF-8
+      # locale in your own shell -- its inline `ruby -e` assertions cannot
+      # self-pin. corpus/README.md says so.)
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -62,6 +62,27 @@ derivations, fixture-mode probes, and final gates against their synthetic
 `checks.sh` must be listed in the MANIFEST expectations artifacts
 (corpus_check enforces this).
 
+### A UTF-8 locale is required (issue #752)
+
+`run-corpus.sh` exports one for you (`C.UTF-8`, else `en_US.UTF-8`), so the
+corpus gives the same verdict on every machine — it previously reported 11/12
+with `LANG` unset and 12/12 with `LANG=en_US.UTF-8`, which made it an unreliable
+oracle for anything built on top of it. Fixtures are full of em-dashes and under
+a US-ASCII default external encoding ruby dies on them.
+
+If you run a single case's `checks.sh` **directly**, set a UTF-8 locale in your
+own shell first:
+
+```
+LC_ALL=en_US.UTF-8 bash tableau/preagg-kpi/checks.sh
+```
+
+The inline `ruby -e` assertions inside those scripts hold non-ASCII characters in
+their *source text*, and a `-e` script's encoding comes from the locale — so they
+cannot `require_relative 'lib/cli_encoding'`, and `RUBYOPT=-EUTF-8` does not fix
+them either (`-E` sets external/internal encoding, not script encoding). Only the
+locale does.
+
 ## Goldens are id-normalized
 
 The converters generate random element/column ids on every run

--- a/corpus/run-corpus.sh
+++ b/corpus/run-corpus.sh
@@ -10,6 +10,41 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# A UTF-8 locale is NOT optional (issue #752). The corpus is the creds-free
+# oracle -- a differential harness or a bisect built on it needs the same verdict
+# on every machine -- but its verdict used to depend on the developer's shell:
+# LANG unset gave 11/12 (tableau/preagg-kpi FAILed), LANG=en_US.UTF-8 gave 12/12.
+# The fixtures are full of em-dashes, and under a US-ASCII default external
+# encoding ruby dies three different ways on them.
+#
+# This pin fixes the one of those three that NOTHING else can: the inline
+# `ruby -rjson -e '...'` assertions inside tableau/*/checks.sh, whose SOURCE text
+# holds em-dashes. A `-e` script's encoding comes from the locale, so it cannot
+# `require_relative 'lib/cli_encoding'` and -- verified -- RUBYOPT=-EUTF-8 does
+# NOT help either (-E sets external/internal, not the script encoding). The other
+# two mechanisms are fixed at the source in the scripts themselves, deliberately,
+# so this pin can never mask a crash a real migration would hit.
+#
+# C.UTF-8 first: it needs no locale generation and is present on modern glibc and
+# on macOS. en_US.UTF-8 is the fallback (and what corpus-check.yml pins).
+#
+# Capture `locale -a` ONCE into a variable rather than piping it into grep -q:
+# under the `set -o pipefail` above, grep -q exits on its first match, `locale`
+# then dies of SIGPIPE (141), and pipefail promotes that to the pipeline's status
+# -- so a locale that IS present reads as absent and the pin silently no-ops.
+# (Cost me a debugging round: the corpus stayed at 11/12 with the warning firing
+# on a machine that has both locales.)
+_locales="$(locale -a 2>/dev/null || true)"
+case $'\n'"$_locales"$'\n' in
+  *$'\nC.UTF-8\n'*)     export LANG=C.UTF-8 LC_ALL=C.UTF-8 ;;
+  *$'\nen_US.UTF-8\n'*) export LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 ;;
+  *)
+    echo "WARNING: no C.UTF-8 or en_US.UTF-8 locale found; corpus cases with non-ASCII" >&2
+    echo "         fixtures may fail spuriously (issue #752). Install a UTF-8 locale." >&2
+    ;;
+esac
+unset _locales
+
 MODE="--check"
 FILTER=""
 CONVERTED=""

--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos \u2192 Sigma",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "Migrate IBM Cognos Analytics to Sigma \u2014 Data Module JSON \u2192 Sigma data model, and report-spec XML \u2192 Sigma workbook. Translates the Cognos expression DSL (total..for \u2192 window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.83",
+  "version": "0.16.84",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.84",
+  "version": "0.16.85",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-assessment/scripts/render-readout.rb
+++ b/plugins/domo-to-sigma/skills/domo-assessment/scripts/render-readout.rb
@@ -53,7 +53,9 @@ plan      = read_json(File.join(options[:in], 'migration-plan.json'), {})
 audit     = File.exist?(File.join(options[:in], 'usage.json'))
 
 template_path = options[:template] || File.expand_path('../refs/readout-template.md', __dir__)
-tpl = File.read(template_path)
+# encoding: 'UTF-8' — the template is gsub'd below and ships prose (em-dashes,
+# arrows), so a raw read crashes under an unset/C locale. F5 crash class, #752.
+tpl = File.read(template_path, encoding: 'UTF-8')
 
 # ---- helpers (md_table/md_cell/section_block -- same pattern as the other
 # *-assessment renderers, kept vendor-agnostic on purpose) --------------------

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/setup.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData \u2192 Sigma",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma \u2014 the declarative workspace layout (LDM + analytics model) \u2192 Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex \u2192 Sigma",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Migrate Hex projects to Sigma \u2014 SQL cells, single-value/METRIC cells, and EXPLORE charts \u2192 Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/put-layout.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/put-layout.rb
@@ -38,7 +38,11 @@ def http(method, path, body = nil)
   Sigma.request(method, path, body: body, binary: true)
 end
 
-xml = File.read(opts[:layout])
+# encoding: 'UTF-8' is NOT optional — this layout XML is regexp-matched below and
+# carries element titles straight from the source dashboard, so em-dashes and
+# curly quotes are the norm. A raw read inherits the locale's default external
+# encoding and raises `invalid byte sequence in US-ASCII`. F5 crash class, #752.
+xml = File.read(opts[:layout], encoding: 'UTF-8')
 abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 
 raw_spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec"))

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/mode-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/mode-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mode-to-sigma",
   "displayName": "Mode \u2192 Sigma",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Convert a Mode Report (Queries + Charts) into a Sigma data model and matching workbook. Discovery via the Mode REST API (Queries, Charts, Filters, plus a live run to sample each Query's output columns), a reuse check before building a new data model, DM + workbook creation via REST (every Query wraps its raw SQL verbatim as a native-SQL table element \u2014 no formula translation needed, since Mode's SQL already runs in the target warehouse dialect), a notebook-flow layout, and parity verification against the source Mode Query values. Bundles mode-to-sigma (registered, converter-only for this release) + mode-assessment (not yet registered).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.39",
+  "version": "1.8.40",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout.rb
@@ -20,7 +20,9 @@ end.parse!
 abort('--out required') unless opts[:out]
 
 template_path = opts[:template] || File.expand_path('../refs/readout-template.md', __dir__)
-tpl = File.read(template_path)
+# encoding: 'UTF-8' — the template is gsub'd below and ships prose (em-dashes,
+# arrows), so a raw read crashes under an unset/C locale. F5 crash class, #752.
+tpl = File.read(template_path, encoding: 'UTF-8')
 
 inventory  = JSON.parse(File.read(File.join(opts[:out], 'inventory.json')))
 complexity_path = File.join(opts[:out], 'complexity.json')

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/put-layout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/put-layout.rb
@@ -45,7 +45,11 @@ def http(method, path, body = nil)
   Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
 end
 
-xml = File.read(opts[:layout])
+# encoding: 'UTF-8' is NOT optional — this layout XML is regexp-matched below and
+# carries element titles straight from the source dashboard, so em-dashes and
+# curly quotes are the norm. A raw read inherits the locale's default external
+# encoding and raises `invalid byte sequence in US-ASCII`. F5 crash class, #752.
+xml = File.read(opts[:layout], encoding: 'UTF-8')
 abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 
 raw_spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/put-layout.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/put-layout.rb
@@ -46,7 +46,11 @@ def http(method, path, body = nil)
   Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
 end
 
-xml = File.read(opts[:layout])
+# encoding: 'UTF-8' is NOT optional — this layout XML is regexp-matched below and
+# carries element titles straight from the source dashboard, so em-dashes and
+# curly quotes are the norm. A raw read inherits the locale's default external
+# encoding and raises `invalid byte sequence in US-ASCII`. F5 crash class, #752.
+xml = File.read(opts[:layout], encoding: 'UTF-8')
 abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 
 raw_spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight \u2192 Sigma",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma \u2014 analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight \u2192 Sigma",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma \u2014 analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout.rb
@@ -19,7 +19,9 @@ end.parse!
 abort('--out required') unless opts[:out]
 
 template_path = opts[:template] || File.expand_path('../refs/readout-template.md', __dir__)
-tpl = File.read(template_path)
+# encoding: 'UTF-8' — the template is gsub'd below and ships prose (em-dashes,
+# arrows), so a raw read crashes under an unset/C locale. F5 crash class, #752.
+tpl = File.read(template_path, encoding: 'UTF-8')
 
 inventory  = JSON.parse(File.read(File.join(opts[:out], 'inventory.json')))
 complexity_path = File.join(opts[:out], 'complexity.json')

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
@@ -37,7 +37,11 @@ def http(method, path, body = nil)
   Sigma.request(method, path, body: body, binary: true)
 end
 
-xml = File.read(opts[:layout])
+# encoding: 'UTF-8' is NOT optional — this layout XML is regexp-matched below and
+# carries element titles straight from the source dashboard, so em-dashes and
+# curly quotes are the norm. A raw read inherits the locale's default external
+# encoding and raises `invalid byte sequence in US-ASCII`. F5 crash class, #752.
+xml = File.read(opts[:layout], encoding: 'UTF-8')
 abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 
 raw_spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec"))

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense \u2192 Sigma",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma \u2014 data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.23",
+  "version": "1.9.24",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.24",
+  "version": "1.9.25",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/render-readout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/render-readout.rb
@@ -18,7 +18,9 @@ end.parse!
 abort('--out required') unless opts[:out]
 
 template_path = opts[:template] || File.expand_path('../refs/readout-template.md', __dir__)
-tpl = File.read(template_path)
+# encoding: 'UTF-8' — the template is gsub'd below and ships prose (em-dashes,
+# arrows), so a raw read crashes under an unset/C locale. F5 crash class, #752.
+tpl = File.read(template_path, encoding: 'UTF-8')
 
 inv_path        = File.join(opts[:out], 'inventory.json')
 complexity_path = File.join(opts[:out], 'complexity.json')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-agg-semantics.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-agg-semantics.rb
@@ -43,6 +43,13 @@
 #                 printed; gate 19 will refuse GREEN, exit 26).
 
 require 'json'
+# F5 crash class (issue #752). --reason carries agent/operator prose that is
+# echoed into a UTF-8 literal and JSON-written; under an unset/C locale ARGV is
+# tagged ASCII-8BIT, so the first em-dash raises
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` here (ruby 3.3) or
+# Encoding::UndefinedConversionError inside JSON.generate (ruby 2.6).
+# `encoding: 'UTF-8'` on the reads below cannot fix this — only ARGV can.
+require_relative 'lib/cli_encoding'
 require 'optparse'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'agg_semantics_lint'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-lod-calcs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/audit-lod-calcs.rb
@@ -50,6 +50,11 @@
 #                 (FATAL block printed; gate 17 will refuse GREEN, exit 24).
 
 require 'json'
+# F5 crash class (issue #752) — see audit-agg-semantics.rb. --reason prose from
+# ARGV is tagged ASCII-8BIT under an unset/C locale and then interpolated into a
+# UTF-8 literal / JSON-written. Reads here already pass encoding: 'UTF-8'; that
+# does nothing for ARGV, which is what this require fixes.
+require_relative 'lib/cli_encoding'
 require 'optparse'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'lod_audit'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -33,6 +33,12 @@
 # Sigma kinds with the table in refs/workbook-layout.md.
 
 require 'json'
+# F5 crash class (issue #752). The .twb read below already passes
+# encoding: 'UTF-8', but --dashboard / --dashboard-filter / --page-filter names
+# arrive via ARGV, which an unset/C locale tags ASCII-8BIT; those names are
+# JSON-written into the layout, so a curly quote or em-dash in a Tableau caption
+# crashes the emit. Only ARGV re-tagging fixes that.
+require_relative 'lib/cli_encoding'
 # Nokogiri-backed REXML drop-in — REXML is O(n^2) on large .twb files; twb_xml.rb
 # parses a 5 MB / 95-worksheet workbook in well under a second. See lib/twb_xml.rb.
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup-tableau.rb
@@ -44,7 +44,9 @@ end
 # any other vars already there (e.g. Sigma creds from setup.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — body is regexp-matched below; see shared/scripts/setup.rb.
+  # F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/cli_encoding.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/shared/lib/cli_encoding.rb
+++ b/shared/lib/cli_encoding.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 #
-# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points (system Ruby 2.6).
+# cli_encoding.rb — G3: UTF-8 bootstrap for CLI entry points. NOT 2.6-only.
 #
 # Field failure, BOTH field-workbook runs (3 crashes total): under an unset/C
-# locale, Ruby 2.6 tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…)
-# in an agent-authored --notes/--name then raises
-# Encoding::UndefinedConversionError inside JSON.generate (pick-destination.rb
-# cmd_create, record-visual-check.rb) and costs a retry. Any script that
-# round-trips agent-authored prose through JSON must `require_relative
-# 'lib/cli_encoding'` before parsing options.
+# locale Ruby tags ARGV strings ASCII-8BIT; the first em-dash ("—", \xE2…) in an
+# agent-authored --notes/--name/--reason then blows up on the way into JSON —
+# Encoding::UndefinedConversionError inside JSON.generate on 2.6
+# (pick-destination.rb cmd_create, record-visual-check.rb), and
+# `incompatible character encodings: UTF-8 and ASCII-8BIT` on 3.3 the moment the
+# value is interpolated into a UTF-8 literal (audit-agg-semantics.rb, #752).
+# Every supported Ruby is affected; only the exception class moved.
+#
+# Any script that round-trips agent-authored prose through JSON must
+# `require_relative 'lib/cli_encoding'` before parsing options. Note that
+# `File.read(path, encoding: 'UTF-8')` does NOT substitute for this — it fixes
+# reads, not ARGV. Conversely this does not fix an inline `ruby -e` assertion
+# whose SOURCE text holds a non-ASCII byte: -e script encoding comes from the
+# locale, so only a UTF-8 LANG/LC_ALL fixes those (see corpus/run-corpus.sh).
+# Ruby 3.0 FROZE ARGV's strings, so the original in-place force_encoding/scrub!
+# raised `can't modify frozen String (FrozenError)` on exactly the input this
+# guard exists to repair — i.e. the shim was silently broken on every Ruby >= 3.0,
+# including the 3.3 that CI pins (found while fixing issue #752). The ARGV ARRAY
+# is still mutable, so replace the element instead of mutating the string.
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
-ARGV.each do |a|
+ARGV.each_with_index do |a, i|
   next unless a.is_a?(String) && a.encoding == Encoding::ASCII_8BIT
-  a.force_encoding(Encoding::UTF_8)
-  a.scrub!('') unless a.valid_encoding?
+  s = a.dup.force_encoding(Encoding::UTF_8)
+  s.scrub!('') unless s.valid_encoding?
+  ARGV[i] = s
 end

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -3181,7 +3181,14 @@ end
 # ---------------------------------------------------------------------------
 jp_path = File.join(opts[:tab], 'join-plan.json')
 jp_dm = File.join(opts[:tab], 'dm-spec.json')
-jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+# encoding: 'UTF-8' is NOT optional (F5 crash class, issue #752). This is the
+# only RAW File.read in this file — every other read feeds JSON.parse, which
+# tolerates locale-tagged bytes. A raw read inherits the locale's default
+# external encoding, so under an unset/C locale a dm-spec.json carrying one
+# em-dash makes the .scan below raise
+# `invalid byte sequence in US-ASCII (ArgumentError)` and the gate exits 1
+# instead of its real verdict. Reproduced on ruby 3.3.12, not just 2.6.
+jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm, encoding: 'UTF-8') rescue '') : ''
 jp_dm_join_n = jp_dm_src.scan(/"kind"\s*:\s*"join"/).length
 jp_dm_has_emitted_join = jp_dm_join_n.positive?
 jp_resolved = lambda do |e|

--- a/shared/scripts/setup.rb
+++ b/shared/scripts/setup.rb
@@ -70,7 +70,11 @@ end
 # any other vars already there (e.g. Tableau creds from setup-tableau.rb).
 def upsert_neutral_env(pairs)
   FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
   pairs.each do |k, v|
     line = "export #{k}='#{v}'"
     if body =~ /^export #{Regexp.escape(k)}=.*$/

--- a/tools/lint-twb-encoding.rb
+++ b/tools/lint-twb-encoding.rb
@@ -15,13 +15,30 @@
 # inline CI grep only scanned plugins/tableau-to-sigma, so a #388-class unencoded
 # read in shared/ or another plugin was invisible until it hit a non-ASCII file.
 #
-# Exit 0 = clean; exit 1 = at least one unencoded .twb/XML read (prints each site).
-# Faithful port of the former inline grep pipeline:
+# RULE 2 (issue #752) — the .twb-token rule above could not see the crash that
+# actually shipped. assert-phase6-ran.rb did `File.read(jp_dm)` on a dm-spec.JSON
+# and then `.scan`'d the raw string: `jp_dm` matches no .twb token, and RULE 1's
+# EXCLUDE drops `.json` outright, so the site was never even a candidate. Under an
+# unset locale one em-dash in that file made the gate exit 1 instead of its real
+# verdict.
+#
+# What actually distinguishes a crash from a false alarm is NOT the extension —
+# it is whether the raw string gets pattern-matched. `JSON.parse(File.read(x))` is
+# safe at any locale (verified: JSON.parse re-tags and returns UTF-8), which is
+# why RULE 1 was right to exclude it. But a RAW read whose result is later
+# regex'd/`scan`'d raises `invalid byte sequence in US-ASCII (ArgumentError)`.
+# So RULE 2 ignores the path entirely and asks: raw read -> assigned -> matched?
+#
+# Exit 0 = clean; exit 1 = at least one offending read (prints each site).
+# RULE 1 is a faithful port of the former inline grep pipeline:
 #   grep -rnE "File\.read\(([^)]*\b(twb|INP|disc_log)\b[^)]*)\)"  (case-sensitive)
 #     | grep -v "encoding:"                                       (case-sensitive)
 #     | grep -viE "JSON\.parse|\.json|\.rb'|File\.write"          (case-insensitive)
 
-ROOT = File.expand_path('..', __dir__)
+# LINT_ROOT lets tools/test-lint-twb-encoding.rb drive this against throwaway
+# fixture trees offline, the same way check-plugin-version-bump.sh is
+# range-parameterized. Unset in CI and in the hook — they lint the real repo.
+ROOT = ENV['LINT_ROOT'] || File.expand_path('..', __dir__)
 Dir.chdir(ROOT)
 
 # File.read(...) whose argument mentions a .twb-ish path token. Matches `twb` as a
@@ -32,26 +49,83 @@ TOKEN     = /File\.read\(([^)]*(?:\btwb\b|_twb\b|\bINP\b|\bdisc_log\b)[^)]*)\)/
 # Already-safe or not-a-.twb reads to skip (case-insensitive, mirrors grep -vi).
 EXCLUDE   = /JSON\.parse|\.json|\.rb'|File\.write/i
 
+# RULE 2: `<var> = ... File.read(...) ...` with no `encoding:` on that line and no
+# JSON.parse wrapping it. Captures the assigned variable so we can ask whether the
+# raw string is later pattern-matched.
+RAW_ASSIGN = /^\s*(?:@|\$)?([a-z_][a-zA-Z_0-9]*)\s*(?:\|\|)?=\s*(.*File\.read\(.*)$/
+# Operations that run a REGEXP over the string — these are what raise on a
+# locale-tagged string with a high byte. Plain equality, include?, length, and
+# byte-oriented work are all safe, so they are deliberately not listed.
+MATCH_OPS = /\.(?:scan|match\??|gsub!?|sub!?|slice|index|rindex|partition|rpartition|split|start_with\?|end_with\?|count)\(\s*[%\/]|\.(?:scan|match\??|gsub!?|sub!?)\(|=~|!~/
+
+# Reads of SOURCE text rather than migration data. A test asserting on its own
+# script's body, or a renderer slurping a committed .md template, is a far lower
+# risk than a workdir artifact carrying customer prose — and if it does trip, it
+# fails loudly in CI rather than mid-migration. RULE 1 already excludes `.rb'` for
+# exactly this reason; RULE 2 keeps the same scope so the two rules agree.
+SOURCE_READ = /\.(?:rb|mjs|js|py|md|ps1|sh|txt|tpl|erb)['"]|__FILE__|__dir__\s*,\s*['"][^'"]*\.(?:rb|mjs|py|md)/
+# Test files: the gate exists to protect migration RUNS. A locale-fragile
+# assertion helper is a CI problem, not a field crash, and sweeping 75 of them
+# into this gate would bury the one site that actually shipped broken.
+TEST_FILE   = %r{(?:^|/)(?:test[-_][^/]*|[^/]*[-_]test)\.rb$|/tests?/}
+
+def rule2_hits(file, src)
+  return [] if file =~ TEST_FILE
+  out = []
+  lines = src.lines
+  lines.each_with_index do |line, i|
+    next unless (m = line.match(RAW_ASSIGN))
+    var, rhs = m[1], m[2]
+    next if rhs.include?('encoding:')          # already safe
+    next if rhs =~ /JSON\.parse/               # parsed, not pattern-matched — safe
+    next if rhs =~ SOURCE_READ                 # reading source/template text, not migration data
+    # Does anything after this line run a regexp over `var`?
+    used = lines[(i + 1)..]&.each_with_index&.find do |l, _|
+      l =~ /(?<![a-zA-Z_0-9])#{Regexp.escape(var)}\s*(?:\.[a-z_]+\s*)*?#{MATCH_OPS}/ ||
+        l =~ /(?<![a-zA-Z_0-9])#{Regexp.escape(var)}\s*(?:=~|!~)/ ||
+        l =~ /(?<![a-zA-Z_0-9])#{Regexp.escape(var)}\.(?:scan|match\??|gsub!?|sub!?|split)\(/
+    end
+    next unless used
+    out << "#{file}:#{i + 1}: #{line.strip}\n" \
+            "      -> raw string pattern-matched at #{file}:#{i + 2 + used[1]}: #{used[0].strip}"
+  end
+  out
+end
+
 hits = []
+rule2 = []
 %w[plugins shared].each do |dir|
   next unless Dir.exist?(dir)
   Dir.glob(File.join(dir, '**', '*.rb')).sort.each do |f|
-    File.foreach(f, encoding: 'UTF-8').with_index(1) do |line, n|
+    src = File.read(f, encoding: 'UTF-8')
+    src.each_line.with_index(1) do |line, n|
       next unless line =~ TOKEN
       next if line.include?('encoding:')   # already sets an encoding — safe
       next if line =~ EXCLUDE
       hits << "#{f}:#{n}: #{line.strip}"
     end
+    rule2.concat(rule2_hits(f, src))
   end
 end
 
-if hits.empty?
-  puts 'OK: no unencoded .twb/XML File.read sites (plugins/ + shared/).'
+if hits.empty? && rule2.empty?
+  puts 'OK: no unencoded .twb/XML File.read sites, and no raw read feeding a regexp (plugins/ + shared/).'
   exit 0
 end
 
-warn "::error::File.read on a .twb without encoding: 'UTF-8' (F5 crash class):"
-hits.each { |h| warn "  #{h}" }
-warn ''
+unless hits.empty?
+  warn "::error::File.read on a .twb without encoding: 'UTF-8' (F5 crash class):"
+  hits.each { |h| warn "  #{h}" }
+  warn ''
+end
+
+unless rule2.empty?
+  warn '::error::raw File.read whose result is later regexp-matched (F5 crash class, #752).'
+  warn "Under an unset/C locale the string is tagged US-ASCII and the match raises"
+  warn '`invalid byte sequence in US-ASCII (ArgumentError)` on the first non-ASCII byte:'
+  rule2.each { |h| warn "  #{h}" }
+  warn ''
+end
+
 warn "Fix: add `encoding: 'UTF-8'` — e.g. File.read(path, encoding: 'UTF-8')."
 exit 1

--- a/tools/test-lint-twb-encoding.rb
+++ b/tools/test-lint-twb-encoding.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-lint-twb-encoding.rb — self-test for the F5 crash-class gate (#752).
+#
+# A gate nobody has watched FAIL is not a gate. tools/lint-twb-encoding.rb grew a
+# second rule because its first one could not see the crash that actually shipped
+# (assert-phase6-ran.rb read a dm-spec.JSON raw and then .scan'd it: no .twb token
+# in the argument, and RULE 1 excluded `.json` outright, so the site was never
+# even a candidate). This file plants that exact defect — and the false-positive
+# shapes that must NOT trip — in throwaway fixture trees and asserts the exit code
+# each way round.
+#
+# Offline, creds-free, no network. Drives the lint via LINT_ROOT.
+
+require 'fileutils'
+require 'tmpdir'
+
+LINT = File.expand_path('lint-twb-encoding.rb', __dir__)
+fail_count = 0
+
+def check(desc, cond)
+  if cond
+    puts "  ok   #{desc}"
+  else
+    puts "  FAIL #{desc}"
+    $stdout.flush
+    return false
+  end
+  true
+end
+
+# Run the lint against a fixture tree. Returns [exit_status, combined_output].
+def run_lint(files)
+  Dir.mktmpdir('lint-f5-') do |root|
+    files.each do |rel, body|
+      path = File.join(root, rel)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, body)
+    end
+    out = IO.popen({ 'LINT_ROOT' => root }, ['ruby', LINT], err: [:child, :out], &:read)
+    [$?.exitstatus, out]
+  end
+end
+
+def lint(files)
+  run_lint(files)
+end
+
+puts 'test-lint-twb-encoding: F5 crash-class gate'
+
+# ---------------------------------------------------------------------------
+# THE PLANTED DEFECT: the shape that actually shipped broken (#752).
+# ---------------------------------------------------------------------------
+shipped_defect = <<~RUBY
+  jp_dm = File.join(opts[:tab], 'dm-spec.json')
+  jp_dm_src = File.exist?(jp_dm) ? (File.read(jp_dm) rescue '') : ''
+  jp_dm_join_n = jp_dm_src.scan(/"kind"\\s*:\\s*"join"/).length
+RUBY
+code, out = lint('plugins/p/skills/s/scripts/gate.rb' => shipped_defect)
+fail_count += 1 unless check('the #752 shape FAILS the gate (exit 1)', code == 1)
+fail_count += 1 unless check('  ...and the offending read is named', out.include?('scripts/gate.rb:2'))
+fail_count += 1 unless check('  ...and the match site is named', out.include?('gate.rb:3'))
+
+# The fix must clear it — otherwise the gate is unsatisfiable and gets disabled.
+fixed = shipped_defect.sub('File.read(jp_dm)', "File.read(jp_dm, encoding: 'UTF-8')")
+code, = lint('plugins/p/skills/s/scripts/gate.rb' => fixed)
+fail_count += 1 unless check("encoding: 'UTF-8' CLEARS it (exit 0)", code.zero?)
+
+# ---------------------------------------------------------------------------
+# RULE 1 must still work (the .twb-token rule it shipped with).
+# ---------------------------------------------------------------------------
+code, out = lint('plugins/p/skills/s/scripts/parse.rb' => "raw = File.read(twb)\n")
+fail_count += 1 unless check('RULE 1 still catches an unencoded .twb read', code == 1)
+code, = lint('plugins/p/skills/s/scripts/parse.rb' => "raw = File.read(twb, encoding: 'UTF-8')\n")
+fail_count += 1 unless check('RULE 1 still passes an encoded .twb read', code.zero?)
+
+# ---------------------------------------------------------------------------
+# FALSE POSITIVES the gate must NOT trip on. Each of these is a shape that
+# exists in-tree today; a gate that flags them is noise and gets turned off.
+# ---------------------------------------------------------------------------
+safe = {
+  'JSON.parse tolerates locale-tagged bytes' =>
+    "d = JSON.parse(File.read(p))\nd.to_s.scan(/x/)\n",
+  'a read never pattern-matched' =>
+    "body = File.read(p)\nFile.write(other, body)\n",
+  'a read only compared / measured' =>
+    "body = File.read(p)\nputs body.length if body.include?('x')\n",
+  'reading its own source text (.rb literal)' =>
+    "src = File.read(File.join(__dir__, 'other.rb'))\nsrc.scan(/def /)\n",
+  'already encoded' =>
+    "s = File.read(p, encoding: 'UTF-8')\ns.scan(/x/)\n"
+}
+safe.each do |desc, body|
+  code, out = lint('plugins/p/skills/s/scripts/x.rb' => body)
+  fail_count += 1 unless check("no false positive: #{desc}", code.zero?)
+  puts out.lines.grep(/scripts\/x\.rb/).map { |l| "         #{l}" }.join unless code.zero?
+end
+
+# A test file is out of scope by design: the gate protects migration RUNS, and
+# sweeping ~75 locale-fragile assertion helpers in would bury the real site.
+code, = lint('plugins/p/skills/s/scripts/test-thing.rb' => shipped_defect)
+fail_count += 1 unless check('test-*.rb is out of scope (documented narrowing)', code.zero?)
+
+puts
+if fail_count.zero?
+  puts 'ALL PASS — the gate fails on the #752 shape, clears when fixed, and stays quiet on the safe shapes.'
+  exit 0
+end
+puts "#{fail_count} check(s) FAILED"
+exit 1


### PR DESCRIPTION
Closes #752.

@CurtisDeCastro's report is accurate and the root cause is exactly right. Reproduced on `main`, and the mechanism is precisely as described: `assert-phase6-ran.rb:3158` is `jp_dm_src.scan(...)` over `File.read(dm-spec.json)`, which raises `invalid byte sequence in US-ASCII (ArgumentError)` under an unset locale.

Verifying it turned up four things that changed the fix.

### 1. Not Ruby-2.6-specific

Reproduces on **ruby 3.3.12** — the version CI pins. Under `LANG` unset, all three mechanisms fire:

```
assert-phase6-ran.rb:3185:in `scan': invalid byte sequence in US-ASCII (ArgumentError)
audit-agg-semantics.rb:94: incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
-e:8: invalid multibyte char (US-ASCII)
```

The middle one is worth noting: on 3.3 it surfaces as `CompatibilityError` interpolating ARGV into a UTF-8 literal, not `UndefinedConversionError` inside `JSON.generate` as on 2.6. Same root cause, same remedy — only the exception class moved.

### 2. `RUBYOPT=-EUTF-8` does not fix the inline assertions

Tested directly. `-E` sets external/internal encoding but **not** the `-e` script's source encoding, so the inline `ruby -e` assertions still die:

| | raw read + `scan` | inline `ruby -e` em-dash | ARGV tagging |
|---|---|---|---|
| baseline | CRASH | CRASH | ASCII-8BIT |
| `RUBYOPT=-EUTF-8` | OK | **CRASH** | UTF-8 |
| `LANG=en_US.UTF-8` | OK | OK | UTF-8 |

Pinning the locale is the only lever that covers all three.

### 3. Only 1 of 70 unencoded reads could actually crash

`JSON.parse(File.read(x))` is safe at any locale — `JSON.parse` re-tags and returns UTF-8 (verified). Only a **raw** read later fed to a regexp crashes. `assert-phase6-ran.rb` has 70 unencoded `File.read` sites and exactly one is raw: line 3184. So this is a one-line fix, not a sweep — which matters, because "audit the rest of `scripts/*.rb`" is 369 of 373 tableau scripts.

### 4. `lib/cli_encoding.rb` itself was broken

Ruby 3.0 froze ARGV's strings, so the shim's in-place `force_encoding`/`scrub!` raised `can't modify frozen String (FrozenError)` on precisely the input it exists to repair. It has been inert on every ruby >= 3.0, including the 3.3 CI pins. The ARGV array is still mutable, so it now replaces the element instead of mutating the string.

## What's here

**Crash fixes at the source** (kept separate from the locale pin so the pin can never mask a live crash):

- `assert-phase6-ran.rb:3184` — `encoding: 'UTF-8'` on the one raw read
- `audit-agg-semantics.rb`, `audit-lod-calcs.rb`, `parse-twb-layout.rb` — `require_relative 'lib/cli_encoding'`; these already read files with `encoding:`, and their exposure is ARGV, which `encoding:` cannot touch
- `lib/cli_encoding.rb` — the FrozenError fix above

**Gate extended so the class can't return.** RULE 1 couldn't see this crash: `jp_dm` matches no `.twb` token and the `EXCLUDE` dropped `.json`, so the site was never a candidate. RULE 2 ignores the path and asks the question that actually distinguishes a crash — raw read → assigned → regexp-matched?

Measured before narrowing: 95 hits / 76 files, 75 test-shaped. RULE 2 skips `test-*.rb` and source/template-text reads (RULE 1 already excludes `.rb'` for the same reason) — a gate reporting 95 sites to fix the 1 that shipped gets switched off. That left **20 real sites, all fixed here**, including four `put-layout.rb` reads of **layout XML** that are squarely the documented F5 class and slipped RULE 1 only because the variable is `opts[:layout]`.

**Corpus determinism.** `run-corpus.sh` self-pins a UTF-8 locale and the `corpus` CI job gets the `env:` pin the two other ruby jobs already carry — that job being the one *without* it is how this stayed green in CI and failed on a laptop.

One detail worth flagging for anyone writing similar shell: `locale -a | grep -qx C.UTF-8` is wrong under `set -o pipefail`. `grep -q` exits on first match, `locale` dies of SIGPIPE (141), pipefail promotes that to the pipeline status, and an installed locale reads as absent — the pin silently no-ops. Capture once into a variable and `case` on it.

## Verification

```
corpus: 31/31 cases pass     # LANG unset
corpus: 31/31 cases pass     # LANG=en_US.UTF-8
```

Also green on `/bin/bash` 3.2. Gate proven to **fail** before being trusted — `tools/test-lint-twb-encoding.rb` plants the exact #752 shape in a throwaway tree and asserts exit 1 naming both the read and the match site, asserts the fix clears it, and asserts five safe shapes stay quiet. Confirmed non-vacuous by inverting an assertion. Wired into CI and the governance hook.

`check-shared.rb` clean (815 copies), `test_shared_script_closure.rb` ALL PASS, four touched tableau suites pass, plugin versions bumped.

A separate PR follows for #753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)