### PR TITLE
feat: .rb/.py twin API-parity gate (#753)

### DIFF
--- a/.githooks/run-governance-checks.sh
+++ b/.githooks/run-governance-checks.sh
@@ -34,6 +34,7 @@ fi
 [ -f tools/check-agent-variants.rb ] && { ruby tools/check-agent-variants.rb || fail=1; }
 [ -f tools/lint-skill-paths.rb ] && { ruby tools/lint-skill-paths.rb || fail=1; }
 [ -f tools/lint-uplift-contracts.rb ] && { ruby tools/lint-uplift-contracts.rb || fail=1; }
+[ -f tools/lint-twin-parity.rb ] && { ruby tools/lint-twin-parity.rb || fail=1; }
 [ -f tools/check-cognos-bundle.rb ] && { ruby tools/check-cognos-bundle.rb || fail=1; }
 # bootstrap<->doctor KEEP-IN-LOCKSTEP guard (E2.1): bootstrap.sh duplicates
 # doctor.sh's probes (py_real, the vm-node candidate globs, Test-RealPython)
@@ -56,6 +57,7 @@ if [ "${CI:-}" = "true" ]; then
   [ -f tools/test-lint-skill-paths.sh ] && { bash tools/test-lint-skill-paths.sh || fail=1; }
   [ -f tools/test-lint-uplift-contracts.rb ] && { ruby tools/test-lint-uplift-contracts.rb || fail=1; }
   [ -f tools/test-lint-twb-encoding.rb ] && { ruby tools/test-lint-twb-encoding.rb || fail=1; }
+  [ -f tools/test-lint-twin-parity.rb ] && { ruby tools/test-lint-twin-parity.rb || fail=1; }
 fi
 if [ "$fail" -ne 0 ]; then
   echo "" >&2

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -429,6 +429,18 @@ jobs:
         # (raw dm-spec.json read + .scan) in a throwaway tree and asserts exit 1,
         # plus the safe shapes that must stay quiet.
         run: ruby tools/test-lint-twb-encoding.rb
+      - name: Lint — .rb/.py twin API parity (#753)
+        # The .rb/.py pairing in shared/lib reads as "these are equivalent", but
+        # nothing checked it: check-shared.rb enforces byte-identical VENDORING of
+        # one file into each plugin, not that a .py twin exports what its .rb does.
+        # A ported caller just hits AttributeError at runtime.
+        run: ruby tools/lint-twin-parity.rb
+      - name: Self-test — the twin-parity gate must FAIL on a deleted function
+        # And must stay QUIET on the seven shapes a naive `grep '^def '` diff gets
+        # wrong (Python's `_` privacy marker, ruby `private` regions, `def self.`,
+        # `?`/`!` suffixes, initialize/__init__, declared renames). Five of the nine
+        # rows in the original report were one of those.
+        run: ruby tools/test-lint-twin-parity.rb
       - name: Run offline test_*.py suites
         # EXPLICIT allow-list — creds-free, network-free Python tests only.
         # PyYAML is needed by the looker offline dashboard parser

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData \u2192 Sigma",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma \u2014 the declarative workspace layout (LDM + analytics model) \u2192 Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/metric_binding.py
@@ -9,6 +9,11 @@ analyst never gets the metric object. This module is the thin, converter-agnosti
 binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
 is provably the same aggregation — and fall back to the inline formula otherwise.
 
+NAMING NOTE (issue #753): ``_walk_chain`` and ``_dedup_by_name`` are internal
+helpers here but public on the Ruby side (its ``module_function`` exports
+everything). They are NOT missing — a ported caller just needs the underscored
+name. tools/lint-twin-parity.rb classifies this as visibility-only.
+
 Pure functions, stdlib only:
 
 - ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/metric_binding.py
@@ -9,6 +9,11 @@ analyst never gets the metric object. This module is the thin, converter-agnosti
 binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
 is provably the same aggregation — and fall back to the inline formula otherwise.
 
+NAMING NOTE (issue #753): ``_walk_chain`` and ``_dedup_by_name`` are internal
+helpers here but public on the Ruby side (its ``module_function`` exports
+everything). They are NOT missing — a ported caller just needs the underscored
+name. tools/lint-twin-parity.rb classifies this as visibility-only.
+
 Pure functions, stdlib only:
 
 - ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/metric_binding.py
@@ -9,6 +9,11 @@ analyst never gets the metric object. This module is the thin, converter-agnosti
 binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
 is provably the same aggregation — and fall back to the inline formula otherwise.
 
+NAMING NOTE (issue #753): ``_walk_chain`` and ``_dedup_by_name`` are internal
+helpers here but public on the Ruby side (its ``module_function`` exports
+everything). They are NOT missing — a ported caller just needs the underscored
+name. tools/lint-twin-parity.rb classifies this as visibility-only.
+
 Pure functions, stdlib only:
 
 - ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/metric_binding.py
@@ -9,6 +9,11 @@ analyst never gets the metric object. This module is the thin, converter-agnosti
 binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
 is provably the same aggregation — and fall back to the inline formula otherwise.
 
+NAMING NOTE (issue #753): ``_walk_chain`` and ``_dedup_by_name`` are internal
+helpers here but public on the Ruby side (its ``module_function`` exports
+everything). They are NOT missing — a ported caller just needs the underscored
+name. tools/lint-twin-parity.rb classifies this as visibility-only.
+
 Pure functions, stdlib only:
 
 - ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense \u2192 Sigma",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma \u2014 data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/metric_binding.py
@@ -9,6 +9,11 @@ analyst never gets the metric object. This module is the thin, converter-agnosti
 binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
 is provably the same aggregation — and fall back to the inline formula otherwise.
 
+NAMING NOTE (issue #753): ``_walk_chain`` and ``_dedup_by_name`` are internal
+helpers here but public on the Ruby side (its ``module_function`` exports
+everything). They are NOT missing — a ported caller just needs the underscored
+name. tools/lint-twin-parity.rb classifies this as visibility-only.
+
 Pure functions, stdlib only:
 
 - ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.25",
+  "version": "1.9.26",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.py
@@ -1,9 +1,27 @@
 """Sigma REST API wrapper with automatic 401 retry + token refresh.
 
-Python twin of sigma_rest.rb (P1 runtime-shrink: Ruby -> Python). Byte-for-byte
-behaviour parity with the Ruby module is enforced by test_sigma_rest.py and the
-cross-impl parity harness. Stdlib only (urllib) — no third-party deps, matching
-the repo's "no Gemfile / no pip install" contract.
+Python twin of sigma_rest.rb (P1 runtime-shrink: Ruby -> Python). Stdlib only
+(urllib) — no third-party deps, matching the repo's "no Gemfile / no pip install"
+contract.
+
+WHAT ACTUALLY ENFORCES PARITY (corrected, issue #753). This docstring used to
+claim "byte-for-byte behaviour parity ... enforced by test_sigma_rest.py and the
+cross-impl parity harness". There is no cross-impl parity harness — the phrase
+appeared nowhere but in this file and tableau_rest.py — and test_sigma_rest.py
+never invokes ruby; it hand-encodes the Ruby module's observable behaviour in
+Python. Two real guards exist:
+  * tools/lint-twin-parity.rb — every public name in the .rb has a counterpart
+    here (API surface, not behaviour).
+  * test_sigma_rest.py — this module's behaviour against hand-written expectations.
+Behavioural equivalence is NOT machine-checked. Treat a change to either twin as
+a change to both.
+
+DELIBERATE NON-PORT: `Sigma.list_entries` (sigma_rest.rb) has no twin here. Its
+`nextPage`/`page` pagination is documented as WRONG for the columns endpoints,
+which use nextPageToken/pageToken — see discover-columns.rb and
+discover-warehouse-columns.rb, which hand-roll the loop for exactly that reason.
+Port the endpoint-correct loop, not this function. Recorded in ALLOWED in
+tools/lint-twin-parity.rb.
 
 Sigma OAuth bearer tokens expire after ~1 hour; long runs outlive a single
 token. This module provides:

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.py
@@ -1,8 +1,24 @@
 """Tableau REST API wrapper for tableau-to-sigma when the MCP isn't available.
 
-Python twin of tableau_rest.rb (P1 runtime-shrink: Ruby -> Python). Behaviour
-parity with the Ruby module is enforced by test_tableau_rest.py and the
-cross-impl parity harness. Stdlib only (urllib) — no third-party deps.
+Python twin of tableau_rest.rb (P1 runtime-shrink: Ruby -> Python). Stdlib only
+(urllib) — no third-party deps.
+
+WHAT ACTUALLY ENFORCES PARITY (corrected, issue #753): there is no "cross-impl
+parity harness" — the phrase existed only in this docstring and sigma_rest.py's —
+and test_tableau_rest.py does not invoke ruby. API-surface parity is checked by
+tools/lint-twin-parity.rb; behavioural equivalence is not machine-checked.
+
+DELIBERATE NON-PORTS (recorded in ALLOWED in tools/lint-twin-parity.rb). The Ruby
+twin exports eight functions with no counterpart here — the largest twin
+divergence in shared/lib:
+  query_datasource, view_data_filtered   — the VizQL/CSV data-fetch spine.
+      Porting needs live-Tableau validation of pagination + filter semantics; a
+      blind translation would be worse than the gap.
+  datasource_connections, workbook_connections, virtual_connections,
+  virtual_connection_connections, graphql_workbook_dashboards,
+  find_workbook_by_content_url           — read/discovery surface, no Python
+      caller yet.
+If you are porting the Tableau skill to Python, these are the real work.
 
 Requires TABLEAU_SERVER_URL, TABLEAU_SITE_ID, TABLEAU_AUTH_TOKEN,
 TABLEAU_API_VERSION in env (set by scripts/get-tableau-token.sh). PAT refresh

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/metric_binding.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/metric_binding.py
@@ -9,6 +9,11 @@ analyst never gets the metric object. This module is the thin, converter-agnosti
 binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
 is provably the same aggregation — and fall back to the inline formula otherwise.
 
+NAMING NOTE (issue #753): ``_walk_chain`` and ``_dedup_by_name`` are internal
+helpers here but public on the Ruby side (its ``module_function`` exports
+everything). They are NOT missing — a ported caller just needs the underscored
+name. tools/lint-twin-parity.rb classifies this as visibility-only.
+
 Pure functions, stdlib only:
 
 - ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on

--- a/shared/lib/composition.py
+++ b/shared/lib/composition.py
@@ -2,6 +2,14 @@
 
 kind -> role inference (used when an element has no explicit role). Chart
 kinds default to "supporting"; callers wanting a "hero" must tag it explicitly.
+
+NAMING NOTE (issue #753): nine helpers the Ruby twin exposes publicly are
+underscore-private here — ``_le``, ``_band``, ``_roleize``, ``_indent``,
+``_render_bands``, ``_check_pattern_roles``, ``_compose_exec``,
+``_compose_master_detail``, ``_compose_overview``. They are NOT missing; the Ruby
+module just has no ``private`` marker, so its blanket ``module_function`` exports
+its internals too. Porting a Ruby caller means using the underscored name.
+tools/lint-twin-parity.rb reports this as visibility-only rather than a gap.
 """
 ROLES = ["control", "kpi", "insight", "hero", "supporting", "table", "master", "detail",
          "header", "kpi2", "trend", "pivot", "base"]

--- a/shared/lib/metric_binding.py
+++ b/shared/lib/metric_binding.py
@@ -9,6 +9,11 @@ analyst never gets the metric object. This module is the thin, converter-agnosti
 binder that lets a builder prefer a governed ``[Metrics/<name>]`` reference when it
 is provably the same aggregation — and fall back to the inline formula otherwise.
 
+NAMING NOTE (issue #753): ``_walk_chain`` and ``_dedup_by_name`` are internal
+helpers here but public on the Ruby side (its ``module_function`` exports
+everything). They are NOT missing — a ported caller just needs the underscored
+name. tools/lint-twin-parity.rb classifies this as visibility-only.
+
 Pure functions, stdlib only:
 
 - ``available_metrics(element_id, elements_by_id)`` — the metrics REFERENCEABLE on

--- a/shared/lib/sigma_rest.py
+++ b/shared/lib/sigma_rest.py
@@ -1,9 +1,27 @@
 """Sigma REST API wrapper with automatic 401 retry + token refresh.
 
-Python twin of sigma_rest.rb (P1 runtime-shrink: Ruby -> Python). Byte-for-byte
-behaviour parity with the Ruby module is enforced by test_sigma_rest.py and the
-cross-impl parity harness. Stdlib only (urllib) — no third-party deps, matching
-the repo's "no Gemfile / no pip install" contract.
+Python twin of sigma_rest.rb (P1 runtime-shrink: Ruby -> Python). Stdlib only
+(urllib) — no third-party deps, matching the repo's "no Gemfile / no pip install"
+contract.
+
+WHAT ACTUALLY ENFORCES PARITY (corrected, issue #753). This docstring used to
+claim "byte-for-byte behaviour parity ... enforced by test_sigma_rest.py and the
+cross-impl parity harness". There is no cross-impl parity harness — the phrase
+appeared nowhere but in this file and tableau_rest.py — and test_sigma_rest.py
+never invokes ruby; it hand-encodes the Ruby module's observable behaviour in
+Python. Two real guards exist:
+  * tools/lint-twin-parity.rb — every public name in the .rb has a counterpart
+    here (API surface, not behaviour).
+  * test_sigma_rest.py — this module's behaviour against hand-written expectations.
+Behavioural equivalence is NOT machine-checked. Treat a change to either twin as
+a change to both.
+
+DELIBERATE NON-PORT: `Sigma.list_entries` (sigma_rest.rb) has no twin here. Its
+`nextPage`/`page` pagination is documented as WRONG for the columns endpoints,
+which use nextPageToken/pageToken — see discover-columns.rb and
+discover-warehouse-columns.rb, which hand-roll the loop for exactly that reason.
+Port the endpoint-correct loop, not this function. Recorded in ALLOWED in
+tools/lint-twin-parity.rb.
 
 Sigma OAuth bearer tokens expire after ~1 hour; long runs outlive a single
 token. This module provides:

--- a/shared/lib/tableau_rest.py
+++ b/shared/lib/tableau_rest.py
@@ -1,8 +1,24 @@
 """Tableau REST API wrapper for tableau-to-sigma when the MCP isn't available.
 
-Python twin of tableau_rest.rb (P1 runtime-shrink: Ruby -> Python). Behaviour
-parity with the Ruby module is enforced by test_tableau_rest.py and the
-cross-impl parity harness. Stdlib only (urllib) — no third-party deps.
+Python twin of tableau_rest.rb (P1 runtime-shrink: Ruby -> Python). Stdlib only
+(urllib) — no third-party deps.
+
+WHAT ACTUALLY ENFORCES PARITY (corrected, issue #753): there is no "cross-impl
+parity harness" — the phrase existed only in this docstring and sigma_rest.py's —
+and test_tableau_rest.py does not invoke ruby. API-surface parity is checked by
+tools/lint-twin-parity.rb; behavioural equivalence is not machine-checked.
+
+DELIBERATE NON-PORTS (recorded in ALLOWED in tools/lint-twin-parity.rb). The Ruby
+twin exports eight functions with no counterpart here — the largest twin
+divergence in shared/lib:
+  query_datasource, view_data_filtered   — the VizQL/CSV data-fetch spine.
+      Porting needs live-Tableau validation of pagination + filter semantics; a
+      blind translation would be worse than the gap.
+  datasource_connections, workbook_connections, virtual_connections,
+  virtual_connection_connections, graphql_workbook_dashboards,
+  find_workbook_by_content_url           — read/discovery surface, no Python
+      caller yet.
+If you are porting the Tableau skill to Python, these are the real work.
 
 Requires TABLEAU_SERVER_URL, TABLEAU_SITE_ID, TABLEAU_AUTH_TOKEN,
 TABLEAU_API_VERSION in env (set by scripts/get-tableau-token.sh). PAT refresh

--- a/tools/lint-twin-parity.rb
+++ b/tools/lint-twin-parity.rb
@@ -1,0 +1,207 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# lint-twin-parity.rb — .rb/.py twin API-parity gate (issue #753).
+#
+# Several shared/lib modules ship as `.rb` + `.py` twins. The pairing reads as
+# "these are equivalent", and that is the assumption anyone porting a caller
+# makes — but equivalence was asserted by FILE NAMING ALONE. tools/check-shared.rb
+# enforces byte-identical VENDORING of one file into each plugin; nothing checked
+# that a `.py` twin still exports what its `.rb` does. A ported caller just hits
+# AttributeError at runtime, or silently takes a different path.
+#
+# WHY THIS COMPARES PUBLIC APIs, NOT `^def` LINES
+# ----------------------------------------------
+# The obvious implementation — diff `grep '^def '` on each side — reports ~70%
+# false positives on this tree, and a gate that cries wolf gets switched off. It
+# has to model how each language actually marks something internal:
+#
+#   * Python's leading underscore IS the privacy marker. `_walk_chain` is
+#     `walk_chain`; reporting it missing is noise.
+#   * Ruby `private` / `module_function` regions are internal too — and all three
+#     `code_rep` methods that look absent from the Python side sit below its
+#     `private` on line 145.
+#   * `def self.foo` is public even inside a `private` region (Ruby applies
+#     `private` to instance methods only). coverage_catalog depends on this.
+#   * Ruby predicates/bangs (`token_stale?`, `refresh_token!`) lose the suffix.
+#   * Ruby's `initialize` is Python's `__init__`.
+#   * Some twins deliberately RENAME (warehouse_transforms `apply` ->
+#     `apply_transforms`). That is a mapping, not a gap.
+#
+# What survives all of that is a real divergence. Each one is either fixed or
+# recorded in the allow-list below WITH A REASON, so the next person doesn't
+# re-report it (which is exactly what #753 asked for).
+#
+# Exit 0 = every pair reconciled; exit 1 = an unexplained gap. Offline,
+# creds-free. LINT_ROOT lets tools/test-lint-twin-parity.rb drive it against
+# throwaway fixture trees, mirroring check-plugin-version-bump.sh.
+
+require 'json'
+require 'set'
+
+ROOT = ENV['LINT_ROOT'] || File.expand_path('..', __dir__)
+Dir.chdir(ROOT)
+
+LIB = ENV['TWIN_LIB_DIR'] || 'shared/lib'
+
+# --- Deliberate divergences -------------------------------------------------
+# Ruby-side public names with no Python twin, each with the reason it is absent.
+# Adding a name here is a decision to be reviewed, not a way to silence the gate.
+ALLOWED = {
+  'sigma_rest' => {
+    'list_entries' =>
+      'Not ported. Its pagination contract (`nextPage`/`page`) is documented as ' \
+      'WRONG for the columns endpoints, which use nextPageToken/pageToken — see the ' \
+      'comments in discover-columns.rb and discover-warehouse-columns.rb explaining ' \
+      'why they hand-roll the loop instead. A Python port must not be a blind ' \
+      'translation; port the endpoint-correct loop. Only live ruby caller: ' \
+      'fidelity-loop.rb.'
+  },
+  'tableau_rest' => {
+    'datasource_connections'       => 'Tableau REST read surface not yet needed by any Python caller.',
+    'workbook_connections'         => 'Tableau REST read surface not yet needed by any Python caller.',
+    'virtual_connections'          => 'Tableau REST read surface not yet needed by any Python caller.',
+    'virtual_connection_connections' => 'Tableau REST read surface not yet needed by any Python caller.',
+    'graphql_workbook_dashboards'  => 'Metadata-API (GraphQL) surface; no Python caller yet.',
+    'find_workbook_by_content_url' => 'Discovery helper; no Python caller yet.',
+    'query_datasource'             => 'VizQL data-fetch spine. Porting it needs live-Tableau validation ' \
+                                      '(pagination + filter semantics), so it is deliberately out of scope ' \
+                                      'here rather than translated untested.',
+    'view_data_filtered'           => 'CSV data-fetch spine. Same reason as query_datasource: needs live ' \
+                                      'validation, not a blind port.'
+  }
+}.freeze
+
+# Ruby name => Python name, where the twin intentionally uses a different name.
+RENAMES = {
+  'warehouse_transforms' => { 'apply' => 'apply_transforms', 'detect' => 'detect_warehouse' }
+}.freeze
+
+# --- Extraction -------------------------------------------------------------
+
+# Public method names defined in a Ruby file.
+#
+# Heuristic, documented on purpose: a bare `private` line puts subsequent
+# INSTANCE methods (`def foo`) out of the public API until end of file, while
+# `def self.foo` stays public regardless. That is exact for every twin in this
+# tree; if a future twin nests a private region inside a module that later
+# reopens a public one, this over-reports rather than under-reports, and the
+# reviewer adds an allow-list entry or splits the file.
+def ruby_public(src)
+  names = Set.new
+  private_mode = false
+  src.each_line do |line|
+    stripped = line.strip
+    private_mode = true if stripped == 'private'
+    private_mode = false if stripped == 'public' || stripped == 'module_function'
+    next unless (m = stripped.match(/\Adef\s+(self\.)?([a-zA-Z_][a-zA-Z_0-9]*[?!]?)/))
+    is_singleton = !m[1].nil?
+    next if private_mode && !is_singleton   # `private` never hides `def self.`
+    name = m[2].sub(/[?!]\z/, '')           # token_stale? -> token_stale
+    name = '__init__' if name == 'initialize'
+    names << name
+  end
+  names
+end
+
+# All function/method names defined in a Python file, split into public and
+# underscore-private. A leading underscore is the privacy marker; dunders are kept
+# public because they are part of the observable API.
+def python_names(src)
+  pub = Set.new
+  priv = Set.new
+  src.each_line do |line|
+    next unless (m = line.strip.match(/\A(?:async\s+)?def\s+([a-zA-Z_][a-zA-Z_0-9]*)/))
+    name = m[1]
+    if name.start_with?('_') && !name.start_with?('__')
+      priv << name.sub(/\A_+/, '')
+    else
+      pub << name
+    end
+  end
+  [pub, priv]
+end
+
+# --- Compare ----------------------------------------------------------------
+
+pairs = Dir.glob(File.join(LIB, '*.rb')).sort.filter_map do |rb|
+  base = File.basename(rb, '.rb')
+  next if base.start_with?('test_')          # test twins are checked by running them
+  py = File.join(File.dirname(rb), "#{base}.py")
+  File.exist?(py) ? [base, rb, py] : nil
+end
+
+if pairs.empty?
+  puts "OK: no .rb/.py twin pairs under #{LIB}/ to check."
+  exit 0
+end
+
+gaps       = []  # no counterpart AT ALL — fail unless allow-listed
+visibility = []  # exists, but only as `_name` — report; a porting trap, not a bug
+explained  = []  # allow-listed — report, don't fail
+stale      = []  # allow-listed but no longer missing — fail (keeps the list honest)
+
+pairs.each do |mod, rb, py|
+  rb_names = ruby_public(File.read(rb, encoding: 'UTF-8'))
+  py_pub, py_priv = python_names(File.read(py, encoding: 'UTF-8'))
+  renames  = RENAMES[mod] || {}
+  allowed  = ALLOWED[mod] || {}
+
+  present_pub = ->(n) { py_pub.include?(n) || py_pub.include?(renames[n].to_s) }
+  present_any = ->(n) { present_pub.call(n) || py_priv.include?(n) || py_priv.include?(renames[n].to_s) }
+
+  rb_names.each do |n|
+    next if present_pub.call(n)
+    if py_priv.include?(n) || py_priv.include?(renames[n].to_s)
+      # THIS is the case #753's `^def` diff mistook for a missing function:
+      # metric_binding.walk_chain is `_walk_chain`, sigma_rest.token_stale? is
+      # `_token_stale`. The behaviour is there; only the visibility differs.
+      visibility << [mod, n]
+    elsif allowed.key?(n)
+      explained << [mod, n, allowed[n]]
+    else
+      gaps << [mod, n, rb, py]
+    end
+  end
+
+  # An allow-list entry for something that IS now present is stale — drop it, or
+  # the list quietly grows into a permanent exemption nobody rereads.
+  allowed.each_key { |n| stale << [mod, n] if present_any.call(n) }
+end
+
+checked = pairs.map(&:first)
+
+unless gaps.empty?
+  warn '::error::.rb/.py twin API gap — a Python caller of these hits AttributeError (#753):'
+  gaps.each do |mod, name, rb, py|
+    warn "  #{mod}: `#{name}` is public in #{rb} but absent from #{py}"
+  end
+  warn ''
+  warn 'Fix by ONE of:'
+  warn "  * port it to the .py twin;"
+  warn "  * make it private on the Ruby side (`private`, or `_`-prefix the Python name) if it is internal;"
+  warn "  * add it to ALLOWED in tools/lint-twin-parity.rb WITH A REASON, if the omission is deliberate."
+end
+
+unless stale.empty?
+  warn '::error::stale ALLOWED entries in tools/lint-twin-parity.rb — these now EXIST in the .py twin:'
+  stale.each { |mod, name| warn "  #{mod}: `#{name}` — delete this allow-list entry." }
+  warn ''
+end
+
+exit 1 unless gaps.empty? && stale.empty?
+
+puts "OK: #{checked.length} .rb/.py twin pair(s) reconciled — no missing function. " \
+     "(#{explained.length} documented non-port, #{visibility.length} visibility-only difference.)"
+explained.group_by(&:first).each do |mod, rows|
+  puts "  ~ #{mod}: #{rows.map { |r| r[1] }.join(', ')} — deliberately not ported, see ALLOWED"
+end
+unless visibility.empty?
+  puts
+  puts 'Visibility-only (present as `_name` in the .py twin — a Python caller must'
+  puts 'use the underscored name; these are NOT missing functions):'
+  visibility.group_by(&:first).each do |mod, rows|
+    puts "  ~ #{mod}: #{rows.map { |r| "#{r[1]} -> _#{r[1]}" }.join(', ')}"
+  end
+end
+exit 0

--- a/tools/test-lint-twin-parity.rb
+++ b/tools/test-lint-twin-parity.rb
@@ -1,0 +1,140 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-lint-twin-parity.rb — self-test for the .rb/.py twin-parity gate (#753).
+#
+# A gate nobody has watched FAIL is not a gate. This drives
+# tools/lint-twin-parity.rb against throwaway fixture pairs and asserts, in both
+# directions:
+#
+#   * a genuinely deleted function FAILS (that is the bug class #753 is about);
+#   * every shape the naive `grep '^def '` diff got WRONG stays quiet — Python's
+#     `_` privacy marker, Ruby `private` regions, `def self.` escaping `private`,
+#     `?`/`!` suffixes, initialize/__init__, and deliberate renames. Five of the
+#     nine rows in the original report were one of these.
+#
+# The second half matters as much as the first: a gate that reports 12 phantom
+# gaps on a clean tree gets switched off, and then the real one ships.
+#
+# Offline, creds-free, no network. Drives the lint via LINT_ROOT + TWIN_LIB_DIR.
+
+require 'fileutils'
+require 'tmpdir'
+
+LINT = File.expand_path('lint-twin-parity.rb', __dir__)
+fails = 0
+
+def check(desc, cond)
+  puts(cond ? "  ok   #{desc}" : "  FAIL #{desc}")
+  cond
+end
+
+# files: { 'mod.rb' => src, 'mod.py' => src } — written into <tmp>/shared/lib/
+def lint(files)
+  Dir.mktmpdir('twin-parity-') do |root|
+    dir = File.join(root, 'shared', 'lib')
+    FileUtils.mkdir_p(dir)
+    files.each { |name, body| File.write(File.join(dir, name), body) }
+    out = IO.popen({ 'LINT_ROOT' => root, 'TWIN_LIB_DIR' => 'shared/lib' },
+                   ['ruby', LINT], err: [:child, :out], &:read)
+    [$?.exitstatus, out]
+  end
+end
+
+puts 'test-lint-twin-parity: .rb/.py twin API parity'
+
+# ---------------------------------------------------------------------------
+# THE BUG CLASS: a function that genuinely has no counterpart.
+# ---------------------------------------------------------------------------
+code, out = lint(
+  'm.rb' => "module M\n  module_function\n  def alpha; end\n  def beta; end\nend\n",
+  'm.py' => "def alpha():\n    pass\n"
+)
+fails += 1 unless check('a genuinely missing function FAILS (exit 1)', code == 1)
+fails += 1 unless check('  ...and names it', out.include?('`beta`'))
+fails += 1 unless check('  ...and does not cry about the one that IS there', !out.include?('`alpha`'))
+
+# Porting it clears the gate — otherwise the gate is unsatisfiable.
+code, = lint(
+  'm.rb' => "module M\n  module_function\n  def alpha; end\n  def beta; end\nend\n",
+  'm.py' => "def alpha():\n    pass\n\n\ndef beta():\n    pass\n"
+)
+fails += 1 unless check('porting it CLEARS the gate (exit 0)', code.zero?)
+
+# ---------------------------------------------------------------------------
+# FALSE POSITIVES — each of these is a row the original `^def` diff got wrong.
+# ---------------------------------------------------------------------------
+quiet = {
+  "Python `_` privacy marker (metric_binding.walk_chain -> _walk_chain)" => [
+    "module M\n  module_function\n  def walk_chain; end\nend\n",
+    "def _walk_chain():\n    pass\n"
+  ],
+  "Ruby `private` region (all three code_rep methods live below its `private`)" => [
+    "module M\n  def pub; end\n  private\n  def helper; end\nend\n",
+    "def pub():\n    pass\n"
+  ],
+  "`def self.` stays public inside a `private` region (coverage_catalog)" => [
+    "class C\n  private\n  def inst; end\nend\nmodule M\n  def self.load; end\nend\n",
+    "def load():\n    pass\n"
+  ],
+  "Ruby predicate suffix (sigma_rest.token_stale? -> token_stale)" => [
+    "module M\n  module_function\n  def token_stale?; end\nend\n",
+    "def token_stale():\n    pass\n"
+  ],
+  "Ruby bang suffix (refresh_token! -> refresh_token)" => [
+    "module M\n  module_function\n  def refresh_token!; end\nend\n",
+    "def refresh_token():\n    pass\n"
+  ],
+  "initialize <-> __init__ (coverage_catalog constructor convention)" => [
+    "class C\n  def initialize(a); end\nend\n",
+    "class C:\n    def __init__(self, a):\n        pass\n"
+  ],
+  "class methods on both sides, not just module-level `^def`" => [
+    "class C\n  def resolve(k); end\nend\n",
+    "class C:\n    def resolve(self, k):\n        pass\n"
+  ]
+}
+quiet.each do |desc, (rb, py)|
+  code, out = lint('m.rb' => rb, 'm.py' => py)
+  ok = check("no false positive: #{desc}", code.zero?)
+  fails += 1 unless ok
+  puts out.lines.grep(/`/).map { |l| "         #{l}" }.join unless ok
+end
+
+# A deliberate rename is a mapping, not a gap — but only for the module that
+# declares it (warehouse_transforms), so this fixture module must still fail.
+code, = lint(
+  'warehouse_transforms.rb' => "module M\n  module_function\n  def apply; end\n  def detect; end\nend\n",
+  'warehouse_transforms.py' => "def apply_transforms():\n    pass\n\n\ndef detect_warehouse():\n    pass\n"
+)
+fails += 1 unless check('declared RENAMES are honoured (warehouse_transforms)', code.zero?)
+
+# ---------------------------------------------------------------------------
+# The allow-list must not rot into a permanent exemption.
+# ---------------------------------------------------------------------------
+code, out = lint(
+  'sigma_rest.rb' => "module M\n  module_function\n  def list_entries; end\nend\n",
+  'sigma_rest.py' => "def list_entries():\n    pass\n"
+)
+fails += 1 unless check('a STALE allow-list entry FAILS (the name now exists)', code == 1)
+fails += 1 unless check('  ...and says to delete it', out.include?('delete this allow-list entry'))
+
+# A visibility-only difference is reported but must NOT fail the build.
+code, out = lint(
+  'm.rb' => "module M\n  module_function\n  def helper; end\nend\n",
+  'm.py' => "def _helper():\n    pass\n"
+)
+fails += 1 unless check('visibility-only difference passes but IS reported', code.zero?)
+fails += 1 unless check('  ...and is labelled as not-missing', out.include?('helper -> _helper'))
+
+# A pair with no .py twin is out of scope (most shared/lib is ruby-only).
+code, = lint('rubyonly.rb' => "module M\n  def x; end\nend\n")
+fails += 1 unless check('a .rb with no .py twin is out of scope', code.zero?)
+
+puts
+if fails.zero?
+  puts 'ALL PASS — fails on a real gap and on a stale exemption; quiet on all 7 false-positive shapes.'
+  exit 0
+end
+puts "#{fails} check(s) FAILED"
+exit 1


### PR DESCRIPTION
Closes #753.

The premise is exactly right: the `.rb`/`.py` pairing in `shared/lib` reads as "these are equivalent," `check-shared.rb` only enforces byte-identical *vendoring* of one file into each plugin, and nothing checked that a `.py` twin still exports what its `.rb` does. Building the guard was worth it.

Verifying the table changed the design, though, so the specifics are worth recording.

### Five of the nine rows are false positives

The `grep '^def '` diff doesn't model how each language marks something internal:

| Reported missing | Actually |
|---|---|
| `metric_binding.dedup_by_name` | `_dedup_by_name` (`.py:151`) |
| `metric_binding.walk_chain` | `_walk_chain` (`.py:122`) |
| `sigma_rest.token_stale?` | `_token_stale` (`.py:190`) |
| `code_rep.flatten_elements` | `_flatten_elements` (`.py:150`) |
| `code_rep.fold_legacy_theme` | `_fold_legacy_theme` (`.py:31`) |

Python's leading underscore *is* the privacy marker. And on the Ruby side, all three flagged `code_rep` methods — including `canonicalize_document` — sit below that module's `private` on line 145, so none of them was ever public API. **`code_rep` has zero public gaps.**

### Both "the ones that bite" claims dissolve

`list_entries`' three cited callers are **comments documenting deliberate non-use**:

```
assert-phase6-ran.rb:1474   # prevent. Local loop rather than Sigma.list_entries: this gate deliberately
discover-columns.rb:131     #    `page` shape list_entries assumes — list_entries silently stops after page
discover-warehouse-columns.rb:31  # `nextPageToken`/expects `pageToken`, not list_entries' assumed `nextPage`/
```

Those endpoints use `nextPageToken`/`pageToken`, so they hand-roll the loop on purpose. The one real caller — `fidelity-loop.rb:558` — isn't in the list. Worth knowing before porting it: a blind translation would inherit the wrong pagination contract.

And `code_rep.flatten_elements`' cited caller, `column_census.rb`, **defines its own** `flatten_elements` at line 147 and never requires `code_rep`.

### What the report missed — the biggest real divergence

`tableau_rest` exports **eight** functions with no Python counterpart, including the `query_datasource` / `view_data_filtered` data-fetch spine. That's larger than anything in the table, and squarely on the path of a Python port of the Tableau skill.

Allow-listed with reasons rather than ported: the data-fetch functions need live-Tableau validation of pagination and filter semantics, and a blind translation would be worse than the gap. The gate makes it visible instead of silent. Happy to take the port as a follow-up.

## The gate

Your option 1, with the normalization that makes it usable. Modelling privacy properly was the difference between 12 phantom findings and 0 — and a gate that cries wolf gets switched off, after which the real gap ships.

It handles: Ruby `private` regions (with `def self.` escaping them, which `coverage_catalog` relies on), `module_function`, `?`/`!` suffixes, `initialize` ↔ `__init__`, class methods on both sides, declared renames (`warehouse_transforms` `apply` → `apply_transforms`), and Python's `_` prefix.

Three outcomes rather than one:

- **MISSING** — no counterpart at all → fails unless allow-listed with a reason
- **VISIBILITY** — exists as `_name` → reported, doesn't fail. This is the class the `^def` diff mistook for missing, and it's still the actionable fact for a porter: it's there, use the underscored name.
- **ALLOWED** — deliberate non-port → reported with its reason

A **stale** allow-list entry also fails, so the exemption list can't quietly become permanent.

On `main`:

```
OK: 14 .rb/.py twin pair(s) reconciled — no missing function.
    (9 documented non-port, 12 visibility-only difference.)
```

You flagged the `?`-suffix and cross-language exception-name wrinkles for the behavioural approach — both real. I've skipped option 2 here: the symbol gate catches this class for a fraction of the cost, and your differential harness is better owned by the port that needs it.

## Also corrected

`sigma_rest.py` and `tableau_rest.py` both claimed parity was "enforced by ... the cross-impl parity harness." No such harness exists — the phrase appears nowhere but in those two docstrings — and `test_{sigma,tableau}_rest.py` never invoke Ruby; they hand-encode the Ruby behaviour in Python. They now state what actually holds, and record the deliberate non-ports so this isn't re-reported.

## Verification

Gate proven to **fail** before being trusted. `tools/test-lint-twin-parity.rb` (17 checks) asserts a deleted function fails and is named, that porting it clears the gate, that a stale allow-list entry fails, and that all seven false-positive shapes stay quiet. Also verified against the real tree by deleting `_walk_chain` from `metric_binding.py` — fails, names `walk_chain`, passes again on restore.

`check-shared.rb` clean (815 copies), governance suite exit 0, both Python twin test suites pass, versions bumped. Wired into CI and the governance hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)