### PR TITLE
feat(microstrategy-to-sigma): plugin tier for viz types with no native Sigma analog

### DIFF
--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
-  "displayName": "MicroStrategy \u2192 Sigma",
-  "version": "0.2.32",
-  "description": "Migrate MicroStrategy (Strategy One) to Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
+  "displayName": "MicroStrategy → Sigma",
+  "version": "0.2.33",
+  "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"
   },

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/assess.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/assess.py
@@ -43,6 +43,11 @@ VIZ_MAPPED = {
     'pie_chart', 'ring_chart', 'bubble_chart',
     'geospatial_service', 'google_map', 'esri_map',
 }
+# Types with NO native Sigma analog that are reproducible via a bespoke plugin
+# element (refs/plugin-tier.md). Convertible, but each costs a plugin to build,
+# host and register — so they are neither "mapped" nor "needs-review": they
+# carry their own signal so estate sizing reflects the real work.
+VIZ_PLUGIN_TIER = {'heat_map', 'sankey', 'network', 'sequences_sunburst'}
 # MicroStrategy object types (quick-search `type` param)
 TYPE_REPORT = 3
 TYPE_DOCUMENT = 55  # documents AND dossiers
@@ -89,9 +94,13 @@ def assess_dossier(s, doc):
         for pg in ch.get('pages') or []:
             n_pages += 1
             walk_container(pg, hist, flags)
-    unmapped = sorted(t for t in hist if t not in VIZ_MAPPED)
+    unmapped = sorted(t for t in hist
+                      if t not in VIZ_MAPPED and t not in VIZ_PLUGIN_TIER)
+    plugin_tier = sorted(t for t in hist if t in VIZ_PLUGIN_TIER)
     if flags['panel_stacks'] or unmapped:
         tag = 'needs-review'
+    elif plugin_tier:
+        tag = 'plugin-tier'
     elif flags['free_form_fields'] or flags['selectors'] or len(hist) > 2:
         tag = 'moderate'
     else:

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -80,7 +80,9 @@ logic.
 > REST gotcha — changesets, locks, lowercase response headers, session-bound
 > dossier flows), `ae-row-collapse.md` (the one MSTR behavior no clean SQL
 > reproduces, and the pinning workflow), `viz-type-mapping.md` (dossier viz →
-> Sigma element lookup), `design-notes.md` (architecture + modeling gotchas +
+> Sigma element lookup), `plugin-tier.md` (what to do when a source viz has NO
+> native Sigma analog — `heat_map` is a treemap, and Sigma has none: match it
+> with a plugin, never a shaded table), `design-notes.md` (architecture + modeling gotchas +
 > roadmap), `control-parity.md` (shared control-targeting contract: the
 > control lint, the control-scope.json sidecar, and the flip test). For
 > canonical Sigma spec shapes, defer to the companion `sigma-data-models` /
@@ -487,6 +489,12 @@ explicit-value progress gauges; allowlisted styling; and explicit repeaters.
 Every partial panel/repeater/style translation is recorded in
 `feature-gaps.json`. Box plots remain capability-gated and default to a loud
 table fallback.
+
+**Plugin tier:** viz types with **no native Sigma analog** (`heat_map` — a
+treemap — plus `sankey`, `network`, sunburst) are matched with a bespoke plugin
+element, not degraded to a table; see `refs/plugin-tier.md`. If you do ship a
+degraded tile, the visual-QA report must NAME it as an approximation and say
+what encoding was lost — never fold it into "matches".
 
 **Flagged / roadmap:** unmapped or unwired viz types → flagged table fallback
 (`refs/viz-type-mapping.md`); KPI/pie/combo/scatter and other non-axis-generic

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/plugin-tier.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/plugin-tier.md
@@ -1,0 +1,91 @@
+# The plugin tier — matching a viz Sigma has no native analog for
+
+Some source visualizations have **no Sigma element kind that reproduces them**.
+For those, the choice is a bespoke **plugin element** or a lossy fallback. This
+file is the decision rule and the build recipe.
+
+**Rule: native first, plugin when native genuinely can't, fallback last — and
+always label a fallback as an approximation.** Never ship a tile that drops an
+encoding and call it a match.
+
+## When the plugin tier applies
+
+Sigma's complete visual set, enumerated from the compiled OpenAPI (2026-08-25):
+
+`bar-chart · line-chart · area-chart · combo-chart · scatter-chart ·
+donut-chart · pie-chart · kpi-chart · waterfall-chart · pivot-table · table ·
+input-table · geography-map · region-map · point-map · plugin · container ·
+tabbed-container · text · image · button · control · divider`
+
+No treemap, no sankey, no tile-heatmap. So:
+
+| MSTR type | n | Why native fails |
+|---|---|---|
+| `heat_map` | 188 | It is a **treemap**: area encodes the metric and groups nest. A pivot with `backgroundScale` keeps the numbers and loses both. |
+| `sankey` | 42 | Flow/link geometry has no analog. |
+| `network` | 25 | Node-link graph has no analog. |
+| `sequences_sunburst` | ≤12 | Radial hierarchy has no analog. |
+
+A ready treemap plugin: `github.com/twells89/sigma-treemap-plugin` (single
+file, no build step, MIT).
+
+## Recipe
+
+1. **Build/choose the plugin.** Use the `sigma-plugin-authoring` skill.
+2. **Host it persistently and publicly.** Localhost renders only in the
+   builder's own browser — not for other viewers, and not for Sigma's
+   server-side PNG export.
+3. **Register:** `POST /v2/plugins {name, url, devUrl}` → `pluginId`.
+4. **Embed** via the shared emitter (`shared/lib/plugin_embed.rb|py`), bound to
+   a source element on the hidden data page.
+5. **Verify** with a data-parity check on the bound element (always provable)
+   plus a render check (needs the public host).
+
+## Traps that cost a day on the Executive Financial Analysis migration
+
+- ⚠️ **If the plugin loads and configures but never receives data, suspect the
+  column-binding shape.** On this migration the plugin loaded, took its config,
+  resolved its source element, and `subscribeToElementData` accepted the handle
+  and never fired — no error anywhere, and `/verify` reported `valid:true`
+  throughout. It started working once the element was bound **once in the
+  editor UI**, which rewrote the bindings from bare `columnId` strings to
+  `{kind:"column", columnId:…, source:"<element config key>"}`.
+  Two changes landed together there (the object form, and the UI performing the
+  bind), so treat this as **a thing to try, not a settled rule** — the
+  `sigma-plugin-authoring` guidance specifies bare strings and may well be
+  right for the paths it was verified against. **Bind it once in the UI and GET
+  the spec back** — a UI-written config is ground truth for whatever the
+  current API expects.
+- 🚨 **The SDK UMD needs React as a peer global** from v1.2.0 (2026-05-19).
+  Without `window.React` the factory throws and `window.SigmaPlugin` is an
+  empty object → `client` undefined → the plugin silently never binds. Load
+  `react@18.3.1` UMD **before** the SDK, and **pin the SDK** — unpinned
+  `@latest` crosses that boundary on its own.
+- ⚠️ **`devUrl` and `url` are different servers.** Edit mode loads `devUrl`,
+  published view loads `url`. `devUrl=localhost` + `url=<public>` means the two
+  modes run different code — a plugin can work in edit and fail in view for
+  that reason alone. Keep them identical while debugging.
+- ⚠️ **`url` is immutable.** `PATCH /v2/plugins/{id}` accepts only
+  name/description/devUrl. Moving the host, or cache-busting, needs a new
+  `POST` (new `pluginId`) and a repoint. This is why orgs accumulate
+  `…v2/v3/v4` registrations — clean them up when done.
+- ⚠️ **Control filters cannot target a viz element** (hard 400,
+  `Dependency not found`). To reproduce MSTR's `visualization_as_filter`, give
+  the *target* viz its own source table and filter that. Filtering the shared
+  source would filter the plugin too, which the source selector does not do.
+- 🚨 **`POST /v2/workbooks/spec/verify` returns `valid: true` for every one of
+  the above.** It is not a render gate. Only opening the workbook catches them.
+- ⚠️ **A local harness that stubs the SDK tests your rendering and none of the
+  integration.** The React trap survived a full "verified" local pass that way.
+  Prove the data path against a real workbook.
+
+## Reproducing MSTR selectors
+
+A viz whose `definition` carries
+`selector.selectorType: "visualization_as_filter"` filters its `targets` on
+click. Reproduce it with a plugin `variable` binding → a filters-only `list`
+control → the **target's own** source table:
+
+```
+tile click → plugin setVariable(<control>) → list control → filters target's source table
+```

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/viz-type-mapping.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/viz-type-mapping.md
@@ -31,6 +31,29 @@ public demo environment (Tutorial, MobileDashboards, Embedded Analytics,
 AI Auto projects, 2026-06) — the extractor walker parsed **all** of them,
 so every listed type is extraction-validated. Counts double as gap priority.
 
+**Tiers.** *native* — a Sigma element kind reproduces the viz. **plugin tier**
+— Sigma has **no native analog**; match it with a bespoke plugin element rather
+than degrading to a table. *fallback* — flagged `table`, data preserved, loud
+warning: the honest last resort, never presented as a match.
+
+Sigma's complete visual set, enumerated from the compiled OpenAPI (2026-08-25):
+`bar-chart · line-chart · area-chart · combo-chart · scatter-chart ·
+donut-chart · pie-chart · kpi-chart · waterfall-chart · pivot-table · table ·
+input-table · geography-map · region-map · point-map · plugin · container ·
+tabbed-container · text · image · button · control · divider`. There is **no
+treemap, sankey, or tile-heatmap**. (`VizTreemap` does appear in the OpenAPI —
+as an *icon* name beside `Wand` and `Webhooks`. It is not a chart type.)
+
+⚠️ **`heat_map` was mismapped here until 2026-08-25.** MicroStrategy's Heat Map
+is a **treemap** — nested rectangles sized by a metric with a header band per
+group — not a grid heatmap. This table previously claimed a `pivot-table` +
+`backgroundScale` analog and marked it hand-build-✓. Shipped against a live
+dossier it read as a plain table with cell shading: it dropped the size
+encoding, the nesting, and the click-to-filter, and it was **rejected on
+sight** by the reviewer. A tile that preserves the numbers but loses the
+encoding is an *approximation*, not a match — say so, or fix it. See
+`refs/plugin-tier.md`.
+
 | MSTR `visualizationType` | n | Sigma element kind | Build |
 |---|---|---|---|
 | `grid` | 1893 | `table` (pivot when `crossTab: true`) | **validated (parity-verified)** |
@@ -39,7 +62,7 @@ so every listed type is extraction-validated. Counts double as gap priority.
 | `geospatial_service` | 331 | `region-map` / `point-map` (by geo attribute granularity — cognos `tiledmap` precedent) | roadmap |
 | `line_chart` | 252 | `line-chart` | **validated** |
 | `bubble_chart` | 221 | `scatter` (size slot) | roadmap |
-| `heat_map` | 188 | `pivot-table` + `conditionalFormats:{type:backgroundScale}` (diverging scheme for signed values); cross-filter a partner bar via a control | **Path B hand-build ✓** (was: flagged — it DOES have an analog) |
+| `heat_map` | 188 | **`plugin`** — a treemap. Sigma has no native one; `github.com/twells89/sigma-treemap-plugin`. Cross-filter a partner viz via a control (MSTR's `visualization_as_filter`) | **plugin tier** (was: pivot+`backgroundScale` — a LOSSY approximation, see below) |
 | `combo_chart` | 182 | `combo` | roadmap |
 | `area_chart` | 170 | `area-chart` | wired, **not live-verified** |
 | `multi_metric_kpi` | 168 | a KPI-card row: per metric a `kpi-chart` with `comparisonColumn`+`comparison:{display:percentage,colorGood/Bad}` (Δ badge) + a "Previous …" subtitle `text` + a composite `area-chart` sparkline stacked below in the same container | **Path B hand-build ✓** (recipe: `path-b-rehost.md` §5) |


### PR DESCRIPTION
## What happened

A live MSTR migration shipped `Cost/Revenue Mix` as a shaded pivot table. The source viz is `heat_map` — which in MicroStrategy is a **treemap**: nested rectangles sized by a metric, one header band per group. The reproduction kept every number and lost the size encoding, the nesting, and the click-to-filter. It passed every visual-QA dimension and was rejected on sight by the reviewer.

`viz-type-mapping.md` had actively encouraged this, claiming `pivot-table` + `backgroundScale` was an analog and marking it hand-build-✓.

## Why a tier, not a one-off fix

Sigma's element kinds, enumerated from the compiled OpenAPI, contain **no treemap, sankey or tile-heatmap**. For those source types the only choices are a plugin or a lossy fallback. That's a category, so it gets an explicit tier: **native → plugin → *labelled* fallback**. `heat_map` alone is 188 vizzes in the 365-dossier sweep.

## Changes

**New — `refs/plugin-tier.md`:** decision rule, build/register/embed recipe, how to reproduce MSTR's `visualization_as_filter`, and the traps that make a spec-authored plugin silently render nothing.

**`viz-type-mapping.md`:** `heat_map` → plugin tier with the prior mismapping documented; tier definitions; Sigma's full visual set; and the `VizTreemap`-is-an-*icon*-name grep trap.

**Assessment:** new `VIZ_PLUGIN_TIER` set and a `plugin-tier` estate tag — these are convertible, but each costs a plugin to build, host and register, so scoring them as plain "mapped" understates the work and "needs-review" overstates it.

**`shared/lib/plugin_embed.{rb,py}` — a real bug:** the emitter coerced column bindings to bare strings. Sigma's own editor writes the **object** form `{kind:"column", columnId, source}`, confirmed by GET-back of a human-bound workbook. Bare-string bindings bind *nothing*: the plugin loads, takes its config, resolves its source element, and `subscribeToElementData` accepts the handle and never fires — with `POST /v2/workbooks/spec/verify` reporting `valid:true` throughout. Golden updated; **verified to fail on the old shape before the fix**.

**`shared/` visual-QA — new required dimension `approximation_labelled`:** a tile that keeps the numbers but drops an encoding the source had (area, nesting, flow, click-to-filter) is an approximation, not a match — name it with what was lost, or fix it. Enforced in `record-visual-check.rb`.

## Blast radius

The last two land in `shared/`, so they reach **all 12 converters** (24 vendored copies, synced via `tools/sync-shared.rb`; all plugin versions bumped). That's deliberate — shipping a lossy tile as a match is not an MSTR-specific failure. Reviewers of other converters may want to confirm the new required checklist key doesn't invalidate verdicts they have recorded.

## Verification

```
tools/check-shared.rb              OK: 815 shared-file copies match canonical
tools/lint-twin-parity.rb          OK: 14 .rb/.py twin pairs reconciled
tools/lint-skills.rb               OK: 13 converter SKILL.md, budgets clean
tools/check-plugin-version-bump.sh OK (origin/main..HEAD)
shared/lib/test_plugin_embed.py    OK  (FAILED on the old binding shape)
shared/lib/test_plugin_embed.rb    OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)