### PR TITLE
fix(actions): rename action identifier fields to the live *Id shape

### DIFF
--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-api (authentication), sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter \u2014 the converters assume it is present.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/agents.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/agents.md
@@ -118,7 +118,7 @@ agents:
         steps:
           - kind: effect
             effect: insert-rows
-            table: annotations          # an input-table element id (see actions.md)
+            tableElementId: annotations # an input-table element id (see actions.md)
             values:
               an-note:
                 type: agent-input

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/actions.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/actions.md
@@ -4,6 +4,20 @@ Buttons wire a user click to one or more **effects** — insert rows into an
 input table, reset a control, set a control's value, or open/close a modal.
 They live in flat `document.elements[]`; layout places them.
 
+> **Action identifier fields — which ones carry an `Id` suffix.** The
+> 2026-08-26 rename gave identifier properties the referenced resource type
+> plus an `Id` suffix (verified by A/B creates plus `GET .../spec` readback
+> diffs against a live org). The renamed ones are documented per-effect below.
+>
+> **These were deliberately NOT renamed** — the bare name is still the only
+> accepted spelling and the `*Id` form is **rejected**, so don't "regularise"
+> them: `set-control-value.control`, `navigate` `target: {type: page, page:}`,
+> `refresh-element` `target: {type: element, element:}`, and the value source
+> `{type: control, control:}`.
+>
+> `clear-control`'s scope *does* use `controlId` while `set-control-value`
+> keeps a bare `control`. That asymmetry is real, not a documentation slip.
+
 ## Button shape
 
 ```yaml
@@ -16,7 +30,7 @@ actions:
     trigger: on-click
     effects:
       - effect: insert-rows
-        table: annotations
+        tableElementId: annotations
         values:
           an-note: { type: control, control: NoteCtl }
 ```
@@ -43,14 +57,14 @@ build:
 
 ```yaml
 effect: insert-rows
-table: annotations             # an input-table element's id
+tableElementId: annotations             # an input-table element's id
 values:
   an-note: { type: control, control: NoteCtl }
   an-tag:  { type: constant, value: { type: text, value: "manual" } }
 ```
 
 `values` is a map of the input table's **own column ids** to a value descriptor:
-- `{ type: control, control: <controlId> }` — the current value of a control.
+- `{ type: control, controlId: <controlId> }` — the current value of a control.
 - `{ type: constant, value: { type: text, value: <literal> } }` — a hard-coded
   literal.
 
@@ -62,18 +76,19 @@ pattern* below.
 
 ```yaml
 effect: clear-control
-scope: { type: page, page: pg }
+scope: { type: page, pageId: pg }
 usePublishedValue: true
 ```
 
 The OpenAPI's `scope` discriminator actually has **three** shapes —
-`{ type: control, control: <controlId> }` (clear one control), `{ type:
-container, container: <containerElementId> }` (clear every control in a
-container), and `{ type: page, page: <pageId> }` (clear every control on a
-page). **Only `page` scope is live-verified here** — an element/container-scoped
-`clear-control` masked-failed the button in live testing (the button silently
-didn't work; no clear error pointed at the cause). Until `control`/`container`
-scope is independently re-verified, build resets around `page` scope only.
+`{ type: control, controlId: <controlId> }` (clear one control), `{ type:
+container, containerElementId: <containerElementId> }` (clear every control in a
+container), and `{ type: page, pageId: <pageId> }` (clear every control on a
+page). **All three are now live-verified** (2026-08-26). The earlier
+"an element/container-scoped `clear-control` masked-failed the button" finding
+was an artefact of the PRE-RENAME key names: what masked-failed was the rejected
+key (`control` / `container`), not the scope type. All three create and read back
+cleanly with the `*Id` spellings above.
 
 ### `set-control-value` — set a control programmatically
 
@@ -179,7 +194,7 @@ Use this for in-workbook page jumps rather than an `open-url` to a page URL.
 
 ```yaml
 effect: select-tab
-tabbedContainer: tc            # the tabbed-container ELEMENT's id
+tabbedContainerElementId: tc            # the tabbed-container ELEMENT's id
 selectedTab: { type: tab, index: 1 }              # 0-BASED index into tabs[]
 # or:        { type: direction, direction: next } # next | previous
 ```
@@ -205,7 +220,7 @@ selector; `update-rows` also takes the same `values` map as `insert-rows`.
 ```yaml
 # Update every row matching a formula
 effect: update-rows
-table: itbl
+tableElementId: itbl
 whichRows: { type: formula, formula: '[note] = "x"' }
 values:
   amount: { type: constant, value: { type: number, value: 1 } }
@@ -214,7 +229,7 @@ values:
 ```yaml
 # Update exactly one row by primary key
 effect: update-rows
-table: itbl
+tableElementId: itbl
 whichRows:
   type: single-row
   primaryKeys:
@@ -226,7 +241,7 @@ values:
 ```yaml
 # Delete every row matching a formula
 effect: delete-rows
-table: itbl
+tableElementId: itbl
 whichRows: { type: formula, formula: '[note] = "x"' }
 ```
 
@@ -252,7 +267,7 @@ derived table/chart that reads from the input table; Sigma may report those as
 
 ```yaml
 effect: open-document
-document: <inodeId>            # the target workbook/report inode id
+documentId: <inodeId>            # the target workbook/report inode id
 documentType: workbook         # workbook | report  (REQUIRED — selects the route)
 openTarget: _blank             # _self | _blank | _parent  (REQUIRED)
 targetControls:                # optional: seed the target's controls
@@ -293,7 +308,7 @@ to capture what the user types, and a **button** that inserts a row.
       trigger: on-click
       effects:
         - effect: insert-rows
-          table: annotations
+          tableElementId: annotations
           values:
             an-note: { type: control, control: NoteCtl }
 
@@ -327,7 +342,7 @@ listed cause **first** before assuming the element kind itself is unsupported.
 |---|---|---|
 | `Invalid kind: "input-table"` | `inputMode` was omitted. | Always set `inputMode: edit` (or `explore`/`view` — see `input-tables.md`). It's technically documented as required in `tables.md`, but omitting it produces this generic message rather than a field-specific one. |
 | `Invalid kind: "control"` (on a `text`/`text-area` control used for **entry**, not filtering) | One or more of `mode`, `case`, `includeNulls`, `showOperators` was omitted. | Set all four — see `controls.md`'s "Entry (write) text controls" section. |
-| Button silently does nothing on click | An element/container-scoped `clear-control`. | Use `scope: { type: page, page: <id> }` only (see above). |
+| Button silently does nothing on click | A `clear-control` still using the pre-rename `scope: { type: page, page: <id> }`. This is the ONE old name that does **not** 400: Sigma returns 200 and DROPS the key, leaving a bare `scope: {type: page}` that clears nothing. | Use `pageId:`, and assert on the `GET .../spec` readback rather than the status code. |
 | `document.pages[0]: Invalid type: "page"` | An invalid entry in some element's `columns[]` — e.g. trying to author a row-action `kind: button` as an input-table column. The mismatch is reported against the **page** schema, not the offending column. | Check the `columns[]` you last touched, not the page `type`. Row-scoped action hosts aren't spec-authorable (see `delete-rows` / `current-row` above). |
 | `Duplicate layout element id '<id>'` | The layout **XML string**, not the elements — usually an unbounded `replace("</Page>", …)` that spliced the same element into every `<Page>`. | Bound the replacement (`count=1`) or append overlay pages after all element splicing. See the overlay layout gotcha above. |
 | `page-break 'X' must span exactly one grid row (got height N)` | A `page-break` given a multi-row `gridRow`. | Page breaks are fixed at height 1 — use a one-row span, e.g. `gridRow="24 / 25"`. |
@@ -339,8 +354,8 @@ listed cause **first** before assuming the element kind itself is unsupported.
 - `scripts/lib/actions.rb` — `Actions.button(id:, text:, effects:,
   appearance:)`, `Actions.input_table_empty(id:, connection_id:, columns:,
   name:)`, `Actions.input_table_linked(id:, from:, connection_id:, columns:,
-  name:)`, and the three effect builders `Actions.insert_rows_effect(table:,
-  values:)` / `Actions.clear_control_effect(page:)` /
+  name:)`, and the three effect builders `Actions.insert_rows_effect(table_element_id:,
+  values:)` / `Actions.clear_control_effect(page_id:)` /
   `Actions.set_control_value_effect(control:, text:)` build exactly the shapes
   above (`inputMode: "edit"` always emitted; `clear_control_effect` only ever
   emits page scope). Gated behind `Actions::SURFACES`; a NO-GO flip returns

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/actions.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/actions.rb
@@ -7,7 +7,7 @@
 #
 #   require_relative 'lib/actions'
 #   btn = Actions.button(id: 'btn-log', text: 'Log note',
-#                         effects: [Actions.insert_rows_effect(table: 'annotations', values: {...})])
+#                         effects: [Actions.insert_rows_effect(table_element_id: 'annotations', values: {...})])
 #   tbl = Actions.input_table_empty(id: 'annotations', connection_id: WRITE, columns: [...])
 #
 # Live-verified shape facts (verified live against a real Sigma org, building
@@ -35,7 +35,7 @@
 #     entries — this module does not reshape `values`, callers build it),
 #     clear-control (an ELEMENT-scoped clear-control masked-failed the button
 #     live — only page scope is verified, so this builder only emits
-#     scope:{type:"page",page:}), set-control-value (constant text value).
+#     scope:{type:"page",pageId:}), set-control-value (constant text value).
 #
 # All builders are gated through Actions::SURFACES (same discipline as
 # richness.rb/styling.rb): a NO-GO flip on `button`/`input_table_empty`/
@@ -129,29 +129,29 @@ module Actions
     out
   end
 
-  # Returns an `insert-rows` effect Hash: {effect, table, values}. `values`
+  # Returns an `insert-rows` effect Hash: {effect, tableElementId, values}. `values`
   # is a pass-through Hash of colId => {type:"control",control:} |
   # {type:"constant",value:{type:"text",value:}} entries (or any other
   # already-shaped value descriptor) — never reshaped here; system columns
   # (CREATED_AT/CREATED_BY) are never included, Sigma auto-fills them.
   # NO-GO surface -> {} (never a faked effect spliced into a caller's
   # actions: array).
-  def self.insert_rows_effect(table:, values:, surfaces: SURFACES)
-    raise ArgumentError, 'table required' if table.to_s.empty?
+  def self.insert_rows_effect(table_element_id:, values:, surfaces: SURFACES)
+    raise ArgumentError, 'table_element_id required' if table_element_id.to_s.empty?
     return {} unless surfaces[:effects]
 
-    { 'effect' => 'insert-rows', 'table' => table, 'values' => values }
+    { 'effect' => 'insert-rows', 'tableElementId' => table_element_id, 'values' => values }
   end
 
-  # Returns a `clear-control` effect Hash: {effect, scope:{type:"page",page:},
+  # Returns a `clear-control` effect Hash: {effect, scope:{type:"page",pageId:},
   # usePublishedValue:true}. Page scope ONLY — an element-scoped
   # clear-control masked-failed the button live, so this builder never emits
   # any other scope shape. NO-GO surface -> {}.
-  def self.clear_control_effect(page:, surfaces: SURFACES)
-    raise ArgumentError, 'page required' if page.to_s.empty?
+  def self.clear_control_effect(page_id:, surfaces: SURFACES)
+    raise ArgumentError, 'page_id required' if page_id.to_s.empty?
     return {} unless surfaces[:effects]
 
-    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => page }, 'usePublishedValue' => true }
+    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'pageId' => page_id }, 'usePublishedValue' => true }
   end
 
   # Returns a `set-control-value` effect Hash: {effect, control,

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/test_actions.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/test_actions.rb
@@ -23,11 +23,11 @@ end
 
 check('button: default appearance/trigger + default action_id "a-<id>"') do
   el = Actions.button(id: 'btn-log', text: 'Log note',
-                       effects: [{ 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => {} }])
+                       effects: [{ 'effect' => 'insert-rows', 'tableElementId' => 'annotations', 'values' => {} }])
   el == {
     'id' => 'btn-log', 'kind' => 'button', 'text' => 'Log note', 'appearance' => 'filled',
     'actions' => [{ 'id' => 'a-btn-log', 'trigger' => 'on-click',
-                    'effects' => [{ 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => {} }] }]
+                    'effects' => [{ 'effect' => 'insert-rows', 'tableElementId' => 'annotations', 'values' => {} }] }]
   }
 end
 check('button: custom appearance + trigger are honored') do
@@ -39,8 +39,8 @@ check('button: explicit action_id: overrides the "a-<id>" default') do
   el['actions'][0]['id'] == 'a-reset'
 end
 check('button: effects array is passed through verbatim (caller builds via effect builders)') do
-  effects = [{ 'effect' => 'insert-rows', 'table' => 't', 'values' => { 'c' => 1 } },
-             { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'pg' }, 'usePublishedValue' => true }]
+  effects = [{ 'effect' => 'insert-rows', 'tableElementId' => 't', 'values' => { 'c' => 1 } },
+             { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'pageId' => 'pg' }, 'usePublishedValue' => true }]
   el = Actions.button(id: 'btn-log', text: 'Log note', effects: effects)
   el['actions'][0]['effects'] == effects && el['actions'][0]['effects'].length == 2
 end
@@ -148,30 +148,30 @@ end
 
 # --- effect builders -------------------------------------------------------
 
-check('insert_rows_effect: {effect, table, values} — values passed through verbatim') do
+check('insert_rows_effect: {effect, tableElementId, values} — values passed through verbatim') do
   values = { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
-  Actions.insert_rows_effect(table: 'annotations', values: values) ==
-    { 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => values }
+  Actions.insert_rows_effect(table_element_id: 'annotations', values: values) ==
+    { 'effect' => 'insert-rows', 'tableElementId' => 'annotations', 'values' => values }
 end
-check('insert_rows_effect: table required') do
-  begin; Actions.insert_rows_effect(table: '', values: {}); false
+check('insert_rows_effect: table_element_id required') do
+  begin; Actions.insert_rows_effect(table_element_id: '', values: {}); false
   rescue ArgumentError; true; end
 end
 check('insert_rows_effect: NO-GO surface -> {}') do
-  Actions.insert_rows_effect(table: 'annotations', values: {},
+  Actions.insert_rows_effect(table_element_id: 'annotations', values: {},
                               surfaces: Actions::SURFACES.merge(effects: false)) == {}
 end
 
-check('clear_control_effect: {effect, scope:{type:page,page}, usePublishedValue:true}') do
-  Actions.clear_control_effect(page: 'pg') ==
-    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'pg' }, 'usePublishedValue' => true }
+check('clear_control_effect: {effect, scope:{type:page,pageId}, usePublishedValue:true}') do
+  Actions.clear_control_effect(page_id: 'pg') ==
+    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'pageId' => 'pg' }, 'usePublishedValue' => true }
 end
-check('clear_control_effect: page required') do
-  begin; Actions.clear_control_effect(page: ''); false
+check('clear_control_effect: page_id required') do
+  begin; Actions.clear_control_effect(page_id: ''); false
   rescue ArgumentError; true; end
 end
 check('clear_control_effect: NO-GO surface -> {}') do
-  Actions.clear_control_effect(page: 'pg', surfaces: Actions::SURFACES.merge(effects: false)) == {}
+  Actions.clear_control_effect(page_id: 'pg', surfaces: Actions::SURFACES.merge(effects: false)) == {}
 end
 
 check('set_control_value_effect: {effect, control, value:{type:constant,value:{type:text,value}}}') do
@@ -197,9 +197,9 @@ end
 golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'actions_golden.json')))
 check('helpers match actions_golden.json (sorted-key identical)') do
   button_effects = [
-    Actions.insert_rows_effect(table: 'annotations',
+    Actions.insert_rows_effect(table_element_id: 'annotations',
                                 values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }),
-    Actions.clear_control_effect(page: 'pg')
+    Actions.clear_control_effect(page_id: 'pg')
   ]
   actual = {
     'button' => Actions.button(id: 'btn-log', text: 'Log note', appearance: 'filled', effects: button_effects),
@@ -210,9 +210,9 @@ check('helpers match actions_golden.json (sorted-key identical)') do
     'input_table_linked' => Actions.input_table_linked(id: 'targets', from: 'fam-pivot',
                                                         connection_id: 'write-conn-1', columns: TARGET_COLUMNS),
     'insert_rows_effect' => Actions.insert_rows_effect(
-      table: 'annotations', values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
+      table_element_id: 'annotations', values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
     ),
-    'clear_control_effect' => Actions.clear_control_effect(page: 'pg'),
+    'clear_control_effect' => Actions.clear_control_effect(page_id: 'pg'),
     'set_control_value_effect' => Actions.set_control_value_effect(control: 'RegionF', text: 'West')
   }
   JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/test_richness.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/test_richness.rb
@@ -201,7 +201,7 @@ end
 
 AGENT_TOOLS = [
   { 'toolId' => 't-log-note', 'kind' => 'action', 'name' => 'Log note', 'description' => 'Insert a review note.',
-    'steps' => [{ 'kind' => 'effect', 'effect' => 'insert-rows', 'table' => 'annotations',
+    'steps' => [{ 'kind' => 'effect', 'effect' => 'insert-rows', 'tableElementId' => 'annotations',
                   'values' => { 'an-note' => { 'type' => 'agent-input', 'inputName' => 'note' } } }] }
 ].freeze
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/testdata/actions_golden.json
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/testdata/actions_golden.json
@@ -11,7 +11,7 @@
         "effects": [
           {
             "effect": "insert-rows",
-            "table": "annotations",
+            "tableElementId": "annotations",
             "values": {
               "an-note": {
                 "type": "control",
@@ -23,7 +23,7 @@
             "effect": "clear-control",
             "scope": {
               "type": "page",
-              "page": "pg"
+              "pageId": "pg"
             },
             "usePublishedValue": true
           }
@@ -92,7 +92,7 @@
   },
   "insert_rows_effect": {
     "effect": "insert-rows",
-    "table": "annotations",
+    "tableElementId": "annotations",
     "values": {
       "an-note": {
         "type": "control",
@@ -104,7 +104,7 @@
     "effect": "clear-control",
     "scope": {
       "type": "page",
-      "page": "pg"
+      "pageId": "pg"
     },
     "usePublishedValue": true
   },

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/testdata/richness_golden.json
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/testdata/richness_golden.json
@@ -30,7 +30,7 @@
           {
             "kind": "effect",
             "effect": "insert-rows",
-            "table": "annotations",
+            "tableElementId": "annotations",
             "values": {
               "an-note": {
                 "type": "agent-input",

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.26",
+  "version": "1.9.27",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -8288,10 +8288,12 @@ unless opts[:pages_mode] == :worksheet
                       'control' => ctl['controlId'],
                       # The HOST element's columnId (not a bare column name):
                       # the live-probed shape is
-                      # {type: "column", column: <columnId>}. Resolved just
+                      # {type: "column", columnId: <columnId>}. Resolved just
                       # above against host_el['columns'] — see the
                       # HOST-COLUMN BINDING note there.
-                      'value'   => { 'type' => 'column', 'column' => col_id } }]
+                      # Renamed from `column` in the 2026-08-26 action field
+                      # rename; the bare `column` key is now rejected.
+                      'value'   => { 'type' => 'column', 'columnId' => col_id } }]
     }
     errs = ActionLedger.validate_action(action)
     raise "emitted an invalid parameter-action on #{host_el['id']}: #{errs.join('; ')}" if errs.any?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_ledger.rb
@@ -20,6 +20,15 @@ module ActionLedger
   # effect => required property names (beyond "effect" itself).
   # NOTE: open-url's `url` is NOT required by the API — a missing url is
   # schema-valid and does nothing. We require it anyway; that is deliberate.
+  #
+  # ACTION FIELD RENAME (live since 2026-08-26, probe-verified): identifier
+  # properties now carry the referenced resource type and an `Id` suffix. The
+  # names below are the post-rename ones; the pre-rename spellings (`table`,
+  # `tabbedContainer`, `document`) are REJECTED by the API.
+  #
+  # `set-control-value` keeps a bare `control`, and `navigate`/`refresh-element`
+  # keep a bare `target` — those were deliberately NOT renamed (probe-confirmed
+  # that the `*Id` form 400s). Don't "regularise" them.
   EFFECT_REQUIRED = {
     'navigate'          => %w[target],
     'set-control-value' => %w[control value],
@@ -27,12 +36,12 @@ module ActionLedger
     'open-url'          => %w[openTarget url],
     'open-overlay'      => %w[overlayId],
     'close-overlay'     => [],
-    'select-tab'        => %w[tabbedContainer selectedTab],
+    'select-tab'        => %w[tabbedContainerElementId selectedTab],
     'refresh-element'   => %w[target],
-    'insert-rows'       => %w[table values],
-    'update-rows'       => %w[table whichRows values],
-    'delete-rows'       => %w[table whichRows],
-    'open-document'     => %w[document documentType openTarget]
+    'insert-rows'       => %w[tableElementId values],
+    'update-rows'       => %w[tableElementId whichRows values],
+    'delete-rows'       => %w[tableElementId whichRows],
+    'open-document'     => %w[documentId documentType openTarget]
   }.freeze
 
   # Action ids must be unique across the ENTIRE workbook, not per element:

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-ledger.rb
@@ -114,5 +114,36 @@ Dir.mktmpdir do |d|
         'a missing manifest reads as empty, not an exception')
 end
 
+puts 'EFFECT_REQUIRED uses the POST-RENAME identifier field names'
+# The 2026-08-26 action field rename made identifier properties carry the
+# referenced resource type and an `Id` suffix. EFFECT_REQUIRED is a hand-kept
+# mirror of the API contract, and nothing else in this suite reads its VALUES —
+# so before this check, reverting any entry to its pre-rename spelling left the
+# whole suite green while every emitted action 400'd live. These assertions are
+# the canary for that drift.
+{
+  'insert-rows'   => 'tableElementId',
+  'update-rows'   => 'tableElementId',
+  'delete-rows'   => 'tableElementId',
+  'select-tab'    => 'tabbedContainerElementId',
+  'open-document' => 'documentId'
+}.each do |effect, field|
+  check(ActionLedger::EFFECT_REQUIRED.fetch(effect, []).include?(field),
+        "#{effect} requires #{field} (post-rename name)")
+end
+# Pre-rename spellings must NOT come back.
+%w[table tabbedContainer document].each do |dead|
+  hits = ActionLedger::EFFECT_REQUIRED.select { |_, req| req.include?(dead) }.keys
+  check(hits.empty?, "no effect still requires the pre-rename `#{dead}` (found on: #{hits.inspect})")
+end
+# Deliberately NOT renamed — the bare names are still what the API wants, so a
+# well-meaning "regularise these too" edit should fail here.
+check(ActionLedger::EFFECT_REQUIRED['set-control-value'].include?('control'),
+      'set-control-value still requires the BARE `control` (controlId is rejected live)')
+check(ActionLedger::EFFECT_REQUIRED['navigate'].include?('target'),
+      'navigate still requires the BARE `target` (not renamed)')
+check(ActionLedger::EFFECT_REQUIRED['refresh-element'].include?('target'),
+      'refresh-element still requires the BARE `target` (not renamed)')
+
 puts($fails.empty? ? "\nALL PASS" : "\n#{$fails.size} FAILURES")
 exit($fails.empty? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parameter-action-emission.rb
@@ -159,23 +159,24 @@ Dir.mktmpdir do |d|
     check(eff['effect'] == 'set-control-value', 'the effect is set-control-value')
     check(eff.dig('value', 'type') == 'column', 'the value binds to the clicked column')
     # The design's VERIFIED SIGMA SHAPES section pins
-    # `value: {type: "column", column: <columnId>}` — a columnId, NOT a bare
-    # column name. The id is the HOST element's own column id, which is what
+    # `value: {type: "column", columnId: <columnId>}` — a columnId, NOT a bare
+    # column name. (The key itself was `column` before the 2026-08-26 action
+    # field rename; the bare `column` key is now rejected by the API.) The id is the HOST element's own column id, which is what
     # makes the binding real: a name that no column of the clicked element
     # carries would set the control to nothing (or to the wrong thing).
-    check(eff.dig('value', 'column') == 'x-el-metric-buttons',
+    check(eff.dig('value', 'columnId') == 'x-el-metric-buttons',
           "the value binds to the HOST element's columnId, not a bare name " \
-          "(got #{eff.dig('value', 'column').inspect})")
+          "(got #{eff.dig('value', 'columnId').inspect})")
     check(!eff['control'].to_s.empty?, 'the effect names a control')
 
-    puts '== HOST-COLUMN BINDING: value.column is a column OF THE HOST ============'
+    puts '== HOST-COLUMN BINDING: value.columnId is a column OF THE HOST ==========='
     host_el_spec = spec['pages'].flat_map { |p| p['elements'] || [] }
                      .find { |e| e['id'] == pa_entry['hostElementId'] }
     check(!host_el_spec.nil?,
           "the manifest's hostElementId #{pa_entry['hostElementId'].inspect} names a real posted element")
-    host_col = host_el_spec && Array(host_el_spec['columns']).find { |c| c['id'] == eff.dig('value', 'column') }
+    host_col = host_el_spec && Array(host_el_spec['columns']).find { |c| c['id'] == eff.dig('value', 'columnId') }
     check(!host_col.nil?,
-          "value.column #{eff.dig('value', 'column').inspect} is an id carried by the HOST element " \
+          "value.columnId #{eff.dig('value', 'columnId').inspect} is an id carried by the HOST element " \
           "(host columns: #{host_el_spec ? Array(host_el_spec['columns']).map { |c| c['id'] }.inspect : 'n/a'})")
     check(host_col && host_col['name'] == 'Metric Button',
           "that host column is the one the Tableau source-field resolved to, 'Metric Button' " \

--- a/shared/lib/actions.py
+++ b/shared/lib/actions.py
@@ -6,7 +6,7 @@ connect them -- the "Component C" piece of docs/superpowers/specs/
 
     import actions
     btn = actions.button(id="btn-log", text="Log note",
-                          effects=[actions.insert_rows_effect(table="annotations", values={...})])
+                          effects=[actions.insert_rows_effect(table_element_id="annotations", values={...})])
     tbl = actions.input_table_empty(id="annotations", connection_id=WRITE, columns=[...])
 
 Live-verified shape facts (design doc "Live-verified shape facts"; reference
@@ -146,8 +146,8 @@ def input_table_linked(id, from_, connection_id, columns, name=None, surfaces=No
     return out
 
 
-def insert_rows_effect(table, values, surfaces=None):
-    """Returns an `insert-rows` effect dict: {effect, table, values}.
+def insert_rows_effect(table_element_id, values, surfaces=None):
+    """Returns an `insert-rows` effect dict: {effect, tableElementId, values}.
     `values` is a pass-through dict of colId -> {type:"control",control:} |
     {type:"constant",value:{type:"text",value:}} entries (or any other
     already-shaped value descriptor) -- never reshaped here; system columns
@@ -156,26 +156,26 @@ def insert_rows_effect(table, values, surfaces=None):
     actions: array).
     """
     s = SURFACES if surfaces is None else surfaces
-    if not table:
-        raise ValueError("table required")
+    if not table_element_id:
+        raise ValueError("table_element_id required")
     if not s["effects"]:
         return {}
-    return {"effect": "insert-rows", "table": table, "values": values}
+    return {"effect": "insert-rows", "tableElementId": table_element_id, "values": values}
 
 
-def clear_control_effect(page, surfaces=None):
+def clear_control_effect(page_id, surfaces=None):
     """Returns a `clear-control` effect dict: {effect,
-    scope:{type:"page",page:}, usePublishedValue:True}. Page scope ONLY --
+    scope:{type:"page",pageId:}, usePublishedValue:True}. Page scope ONLY --
     an element-scoped clear-control masked-failed the button live (design
     doc), so this builder never emits any other scope shape. NO-GO
     surface -> {}.
     """
     s = SURFACES if surfaces is None else surfaces
-    if not page:
-        raise ValueError("page required")
+    if not page_id:
+        raise ValueError("page_id required")
     if not s["effects"]:
         return {}
-    return {"effect": "clear-control", "scope": {"type": "page", "page": page}, "usePublishedValue": True}
+    return {"effect": "clear-control", "scope": {"type": "page", "pageId": page_id}, "usePublishedValue": True}
 
 
 def set_control_value_effect(control, text, surfaces=None):

--- a/shared/lib/actions.rb
+++ b/shared/lib/actions.rb
@@ -8,7 +8,7 @@
 #
 #   require_relative 'lib/actions'
 #   btn = Actions.button(id: 'btn-log', text: 'Log note',
-#                         effects: [Actions.insert_rows_effect(table: 'annotations', values: {...})])
+#                         effects: [Actions.insert_rows_effect(table_element_id: 'annotations', values: {...})])
 #   tbl = Actions.input_table_empty(id: 'annotations', connection_id: WRITE, columns: [...])
 #
 # Live-verified shape facts (design doc "Live-verified shape facts"; reference
@@ -131,29 +131,29 @@ module Actions
     out
   end
 
-  # Returns an `insert-rows` effect Hash: {effect, table, values}. `values`
+  # Returns an `insert-rows` effect Hash: {effect, tableElementId, values}. `values`
   # is a pass-through Hash of colId => {type:"control",control:} |
   # {type:"constant",value:{type:"text",value:}} entries (or any other
   # already-shaped value descriptor) — never reshaped here; system columns
   # (CREATED_AT/CREATED_BY) are never included, Sigma auto-fills them.
   # NO-GO surface -> {} (never a faked effect spliced into a caller's
   # actions: array).
-  def self.insert_rows_effect(table:, values:, surfaces: SURFACES)
-    raise ArgumentError, 'table required' if table.to_s.empty?
+  def self.insert_rows_effect(table_element_id:, values:, surfaces: SURFACES)
+    raise ArgumentError, 'table_element_id required' if table_element_id.to_s.empty?
     return {} unless surfaces[:effects]
 
-    { 'effect' => 'insert-rows', 'table' => table, 'values' => values }
+    { 'effect' => 'insert-rows', 'tableElementId' => table_element_id, 'values' => values }
   end
 
   # Returns a `clear-control` effect Hash: {effect, scope:{type:"page",page:},
   # usePublishedValue:true}. Page scope ONLY — an element-scoped
   # clear-control masked-failed the button live (design doc), so this
   # builder never emits any other scope shape. NO-GO surface -> {}.
-  def self.clear_control_effect(page:, surfaces: SURFACES)
-    raise ArgumentError, 'page required' if page.to_s.empty?
+  def self.clear_control_effect(page_id:, surfaces: SURFACES)
+    raise ArgumentError, 'page_id required' if page_id.to_s.empty?
     return {} unless surfaces[:effects]
 
-    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => page }, 'usePublishedValue' => true }
+    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'pageId' => page_id }, 'usePublishedValue' => true }
   end
 
   # Returns a `set-control-value` effect Hash: {effect, control,

--- a/shared/lib/test_actions.py
+++ b/shared/lib/test_actions.py
@@ -21,11 +21,11 @@ class SurfacesTest(unittest.TestCase):
 class ButtonTest(unittest.TestCase):
     def test_default_appearance_trigger_and_default_action_id(self):
         el = actions.button(id="btn-log", text="Log note",
-                             effects=[{"effect": "insert-rows", "table": "annotations", "values": {}}])
+                             effects=[{"effect": "insert-rows", "tableElementId": "annotations", "values": {}}])
         self.assertEqual(el, {
             "id": "btn-log", "kind": "button", "text": "Log note", "appearance": "filled",
             "actions": [{"id": "a-btn-log", "trigger": "on-click",
-                         "effects": [{"effect": "insert-rows", "table": "annotations", "values": {}}]}],
+                         "effects": [{"effect": "insert-rows", "tableElementId": "annotations", "values": {}}]}],
         })
 
     def test_custom_appearance_and_trigger_are_honored(self):
@@ -39,8 +39,8 @@ class ButtonTest(unittest.TestCase):
         self.assertEqual(el["actions"][0]["id"], "a-reset")
 
     def test_effects_list_is_passed_through_verbatim(self):
-        effects = [{"effect": "insert-rows", "table": "t", "values": {"c": 1}},
-                   {"effect": "clear-control", "scope": {"type": "page", "page": "pg"}, "usePublishedValue": True}]
+        effects = [{"effect": "insert-rows", "tableElementId": "t", "values": {"c": 1}},
+                   {"effect": "clear-control", "scope": {"type": "page", "pageId": "pg"}, "usePublishedValue": True}]
         el = actions.button(id="btn-log", text="Log note", effects=effects)
         self.assertEqual(el["actions"][0]["effects"], effects)
         self.assertEqual(len(el["actions"][0]["effects"]), 2)
@@ -151,31 +151,31 @@ class InputTableLinkedTest(unittest.TestCase):
 class InsertRowsEffectTest(unittest.TestCase):
     def test_shape_values_passed_through_verbatim(self):
         values = {"an-note": {"type": "control", "control": "NoteCtl"}}
-        self.assertEqual(actions.insert_rows_effect(table="annotations", values=values),
-                          {"effect": "insert-rows", "table": "annotations", "values": values})
+        self.assertEqual(actions.insert_rows_effect(table_element_id="annotations", values=values),
+                          {"effect": "insert-rows", "tableElementId": "annotations", "values": values})
 
     def test_table_required(self):
         with self.assertRaises(ValueError):
-            actions.insert_rows_effect(table="", values={})
+            actions.insert_rows_effect(table_element_id="", values={})
 
     def test_no_go_surface_returns_empty_dict(self):
         surfaces = dict(actions.SURFACES, effects=False)
-        self.assertEqual(actions.insert_rows_effect(table="annotations", values={}, surfaces=surfaces), {})
+        self.assertEqual(actions.insert_rows_effect(table_element_id="annotations", values={}, surfaces=surfaces), {})
 
 
 class ClearControlEffectTest(unittest.TestCase):
     def test_shape(self):
-        self.assertEqual(actions.clear_control_effect(page="pg"),
-                          {"effect": "clear-control", "scope": {"type": "page", "page": "pg"},
+        self.assertEqual(actions.clear_control_effect(page_id="pg"),
+                          {"effect": "clear-control", "scope": {"type": "page", "pageId": "pg"},
                            "usePublishedValue": True})
 
     def test_page_required(self):
         with self.assertRaises(ValueError):
-            actions.clear_control_effect(page="")
+            actions.clear_control_effect(page_id="")
 
     def test_no_go_surface_returns_empty_dict(self):
         surfaces = dict(actions.SURFACES, effects=False)
-        self.assertEqual(actions.clear_control_effect(page="pg", surfaces=surfaces), {})
+        self.assertEqual(actions.clear_control_effect(page_id="pg", surfaces=surfaces), {})
 
 
 class SetControlValueEffectTest(unittest.TestCase):
@@ -205,9 +205,9 @@ class GoldenTest(unittest.TestCase):
 
     def test_helpers_match_actions_golden(self):
         button_effects = [
-            actions.insert_rows_effect(table="annotations",
+            actions.insert_rows_effect(table_element_id="annotations",
                                         values={"an-note": {"type": "control", "control": "NoteCtl"}}),
-            actions.clear_control_effect(page="pg"),
+            actions.clear_control_effect(page_id="pg"),
         ]
         actual = {
             "button": actions.button(id="btn-log", text="Log note", appearance="filled", effects=button_effects),
@@ -217,8 +217,8 @@ class GoldenTest(unittest.TestCase):
             "input_table_linked": actions.input_table_linked(
                 id="targets", from_="fam-pivot", connection_id="write-conn-1", columns=TARGET_COLUMNS),
             "insert_rows_effect": actions.insert_rows_effect(
-                table="annotations", values={"an-note": {"type": "control", "control": "NoteCtl"}}),
-            "clear_control_effect": actions.clear_control_effect(page="pg"),
+                table_element_id="annotations", values={"an-note": {"type": "control", "control": "NoteCtl"}}),
+            "clear_control_effect": actions.clear_control_effect(page_id="pg"),
             "set_control_value_effect": actions.set_control_value_effect(control="RegionF", text="West"),
         }
         self.assertEqual(json.dumps(_sort(actual)), json.dumps(_sort(self.golden)))

--- a/shared/lib/test_actions.rb
+++ b/shared/lib/test_actions.rb
@@ -23,11 +23,11 @@ end
 
 check('button: default appearance/trigger + default action_id "a-<id>"') do
   el = Actions.button(id: 'btn-log', text: 'Log note',
-                       effects: [{ 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => {} }])
+                       effects: [{ 'effect' => 'insert-rows', 'tableElementId' => 'annotations', 'values' => {} }])
   el == {
     'id' => 'btn-log', 'kind' => 'button', 'text' => 'Log note', 'appearance' => 'filled',
     'actions' => [{ 'id' => 'a-btn-log', 'trigger' => 'on-click',
-                    'effects' => [{ 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => {} }] }]
+                    'effects' => [{ 'effect' => 'insert-rows', 'tableElementId' => 'annotations', 'values' => {} }] }]
   }
 end
 check('button: custom appearance + trigger are honored') do
@@ -39,8 +39,8 @@ check('button: explicit action_id: overrides the "a-<id>" default') do
   el['actions'][0]['id'] == 'a-reset'
 end
 check('button: effects array is passed through verbatim (caller builds via effect builders)') do
-  effects = [{ 'effect' => 'insert-rows', 'table' => 't', 'values' => { 'c' => 1 } },
-             { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'pg' }, 'usePublishedValue' => true }]
+  effects = [{ 'effect' => 'insert-rows', 'tableElementId' => 't', 'values' => { 'c' => 1 } },
+             { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'pageId' => 'pg' }, 'usePublishedValue' => true }]
   el = Actions.button(id: 'btn-log', text: 'Log note', effects: effects)
   el['actions'][0]['effects'] == effects && el['actions'][0]['effects'].length == 2
 end
@@ -148,30 +148,30 @@ end
 
 # --- effect builders -------------------------------------------------------
 
-check('insert_rows_effect: {effect, table, values} — values passed through verbatim') do
+check('insert_rows_effect: {effect, tableElementId, values} — values passed through verbatim') do
   values = { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
-  Actions.insert_rows_effect(table: 'annotations', values: values) ==
-    { 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => values }
+  Actions.insert_rows_effect(table_element_id: 'annotations', values: values) ==
+    { 'effect' => 'insert-rows', 'tableElementId' => 'annotations', 'values' => values }
 end
-check('insert_rows_effect: table required') do
-  begin; Actions.insert_rows_effect(table: '', values: {}); false
+check('insert_rows_effect: table_element_id required') do
+  begin; Actions.insert_rows_effect(table_element_id: '', values: {}); false
   rescue ArgumentError; true; end
 end
 check('insert_rows_effect: NO-GO surface -> {}') do
-  Actions.insert_rows_effect(table: 'annotations', values: {},
+  Actions.insert_rows_effect(table_element_id: 'annotations', values: {},
                               surfaces: Actions::SURFACES.merge(effects: false)) == {}
 end
 
-check('clear_control_effect: {effect, scope:{type:page,page}, usePublishedValue:true}') do
-  Actions.clear_control_effect(page: 'pg') ==
-    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'pg' }, 'usePublishedValue' => true }
+check('clear_control_effect: {effect, scope:{type:page,pageId}, usePublishedValue:true}') do
+  Actions.clear_control_effect(page_id: 'pg') ==
+    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'pageId' => 'pg' }, 'usePublishedValue' => true }
 end
-check('clear_control_effect: page required') do
-  begin; Actions.clear_control_effect(page: ''); false
+check('clear_control_effect: page_id required') do
+  begin; Actions.clear_control_effect(page_id: ''); false
   rescue ArgumentError; true; end
 end
 check('clear_control_effect: NO-GO surface -> {}') do
-  Actions.clear_control_effect(page: 'pg', surfaces: Actions::SURFACES.merge(effects: false)) == {}
+  Actions.clear_control_effect(page_id: 'pg', surfaces: Actions::SURFACES.merge(effects: false)) == {}
 end
 
 check('set_control_value_effect: {effect, control, value:{type:constant,value:{type:text,value}}}') do
@@ -197,9 +197,9 @@ end
 golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'actions_golden.json')))
 check('helpers match actions_golden.json (sorted-key identical)') do
   button_effects = [
-    Actions.insert_rows_effect(table: 'annotations',
+    Actions.insert_rows_effect(table_element_id: 'annotations',
                                 values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }),
-    Actions.clear_control_effect(page: 'pg')
+    Actions.clear_control_effect(page_id: 'pg')
   ]
   actual = {
     'button' => Actions.button(id: 'btn-log', text: 'Log note', appearance: 'filled', effects: button_effects),
@@ -210,9 +210,9 @@ check('helpers match actions_golden.json (sorted-key identical)') do
     'input_table_linked' => Actions.input_table_linked(id: 'targets', from: 'fam-pivot',
                                                         connection_id: 'write-conn-1', columns: TARGET_COLUMNS),
     'insert_rows_effect' => Actions.insert_rows_effect(
-      table: 'annotations', values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
+      table_element_id: 'annotations', values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
     ),
-    'clear_control_effect' => Actions.clear_control_effect(page: 'pg'),
+    'clear_control_effect' => Actions.clear_control_effect(page_id: 'pg'),
     'set_control_value_effect' => Actions.set_control_value_effect(control: 'RegionF', text: 'West')
   }
   JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))

--- a/shared/lib/test_richness.py
+++ b/shared/lib/test_richness.py
@@ -209,7 +209,7 @@ class WidePivotTest(unittest.TestCase):
 
 AGENT_TOOLS = [
     {"toolId": "t-log-note", "kind": "action", "name": "Log note", "description": "Insert a review note.",
-     "steps": [{"kind": "effect", "effect": "insert-rows", "table": "annotations",
+     "steps": [{"kind": "effect", "effect": "insert-rows", "tableElementId": "annotations",
                 "values": {"an-note": {"type": "agent-input", "inputName": "note"}}}]},
 ]
 

--- a/shared/lib/test_richness.rb
+++ b/shared/lib/test_richness.rb
@@ -201,7 +201,7 @@ end
 
 AGENT_TOOLS = [
   { 'toolId' => 't-log-note', 'kind' => 'action', 'name' => 'Log note', 'description' => 'Insert a review note.',
-    'steps' => [{ 'kind' => 'effect', 'effect' => 'insert-rows', 'table' => 'annotations',
+    'steps' => [{ 'kind' => 'effect', 'effect' => 'insert-rows', 'tableElementId' => 'annotations',
                   'values' => { 'an-note' => { 'type' => 'agent-input', 'inputName' => 'note' } } }] }
 ].freeze
 

--- a/shared/lib/testdata/actions_golden.json
+++ b/shared/lib/testdata/actions_golden.json
@@ -11,7 +11,7 @@
         "effects": [
           {
             "effect": "insert-rows",
-            "table": "annotations",
+            "tableElementId": "annotations",
             "values": {
               "an-note": {
                 "type": "control",
@@ -23,7 +23,7 @@
             "effect": "clear-control",
             "scope": {
               "type": "page",
-              "page": "pg"
+              "pageId": "pg"
             },
             "usePublishedValue": true
           }
@@ -92,7 +92,7 @@
   },
   "insert_rows_effect": {
     "effect": "insert-rows",
-    "table": "annotations",
+    "tableElementId": "annotations",
     "values": {
       "an-note": {
         "type": "control",
@@ -104,7 +104,7 @@
     "effect": "clear-control",
     "scope": {
       "type": "page",
-      "page": "pg"
+      "pageId": "pg"
     },
     "usePublishedValue": true
   },

--- a/shared/lib/testdata/richness_golden.json
+++ b/shared/lib/testdata/richness_golden.json
@@ -30,7 +30,7 @@
           {
             "kind": "effect",
             "effect": "insert-rows",
-            "table": "annotations",
+            "tableElementId": "annotations",
             "values": {
               "an-note": {
                 "type": "agent-input",

--- a/shared/scripts/verify-ws4-e2e.rb
+++ b/shared/scripts/verify-ws4-e2e.rb
@@ -347,12 +347,12 @@ def build_spec(home, schema_version)
 
   # ==== SURFACE: Actions.button x3, one per verified effect ================
   btn_reset = Actions.button(id: 'btn-reset', text: 'Reset filters', appearance: 'outline',
-                              effects: [Actions.clear_control_effect(page: PG_ACTIONS)])
+                              effects: [Actions.clear_control_effect(page_id: PG_ACTIONS)])
   btn_preset = Actions.button(id: 'btn-preset', text: 'Preset note', appearance: 'outline',
                                effects: [Actions.set_control_value_effect(control: NOTE_CTL_HANDLE,
                                                                            text: 'Reviewed - looks good')])
   btn_log = Actions.button(id: 'btn-log', text: 'Log note', appearance: 'filled',
-                            effects: [Actions.insert_rows_effect(table: 'review-log',
+                            effects: [Actions.insert_rows_effect(table_element_id: 'review-log',
                                                                   values: { 'rl-note' => { 'type' => 'control',
                                                                                             'control' => NOTE_CTL_HANDLE } })])
 


### PR DESCRIPTION
## Context

Sigma standardised action effect field names so identifiers carry the referenced resource type and an `Id` suffix (`element` → `codeElementId`).

**The rename is already live.** The announcement said "No changes are live yet — we expect to ship this week", but a 40-case A/B probe against a real org on 2026-08-26 (each effect POSTed twice, old name vs new, then `GET .../spec` and diff the readback) showed every renamed field is already enforced. The converters have been emitting rejected shapes, not merely deprecated ones — so this is a live break, not preparation.

## The rename

| effect / path | old (dead) | new |
|---|---|---|
| `insert-rows` / `update-rows` / `delete-rows` | `table` | `tableElementId` |
| `clear-control` `scope{type:page}` | `page` | `pageId` |
| `select-tab` | `tabbedContainer` | `tabbedContainerElementId` |
| `open-document` | `document` | `documentId` |
| value union `{type:column}` | `column` | `columnId` |

## The two production sites

**`action_ledger.rb` `EFFECT_REQUIRED`** — a hand-kept mirror of the API contract carrying four pre-rename names. It's fail-closed, so a stale map doesn't just miss bugs, it validates the *wrong* shape and lets a broken spec ship looking clean.

**`build-charts-from-signals.rb`** — emitted parameter actions as `{type: "column", column: <id>}`. The bare `column` key is now rejected.

## Shared twins

`insert_rows_effect(table:)` → `(table_element_id:)` and `clear_control_effect(page:)` → `(page_id:)`, so the language-level keyword matches the wire field. Both `.rb`/`.py` twins move together and stay byte-identical against `actions_golden.json`.

Agent tool `steps[]` share the same effect union (confirmed against the OpenAPI), so the richness fixtures move too.

## ⚠️ One silent failure

`clear-control` with the old `scope: {type: page, page: …}` is the **only** old name that doesn't 400. It returns **200 OK** and Sigma drops the key — the readback is a bare `scope: {type: page}` and the button clears nothing. A generator still emitting `page:` looks completely healthy.

## New gate

Adds an `EFFECT_REQUIRED` canary to `test-action-ledger.rb`. Nothing read that map's **values** before, so reverting any entry to its pre-rename spelling left the whole suite green while every emitted action failed live.

Proven to fail on two planted defects:
1. reverting `insert-rows` to `table` → fails ✅
2. over-eagerly renaming `set-control-value.control` to `controlId` → fails ✅

## Deliberately NOT renamed

Probe-confirmed the `*Id` form is **rejected** and the bare name is still required. The canary guards this direction too, so please don't "regularise" them in review:

- `set-control-value.control`
- `navigate` `target.page`
- `refresh-element` `target.element`
- the `{type: control, control:}` value source

## Note on the vendored copy

`plugins/sigma-authoring/skills/sigma-workbooks` is patched in place rather than re-vendored from `twells89/sigma-skills`. It has drifted well behind upstream (whole workflow files missing), so a re-vendor would import a large unrelated delta. That refresh is worth its own PR. Upstream's matching fixes are in twells89/sigma-skills#50.

## Verification

- All 11 repo gates pass (`check-shared`, `lint-twin-parity`, `check-agent-variants`, hygiene, …).
- Both `.rb`/`.py` twin suites, the vendored suites, and all 7 tableau action tests pass.
- Plugin version-bump gate OK (`sigma-authoring` 1.12.5→1.12.6, `tableau-to-sigma` 1.9.26→1.9.27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)