### PR TITLE
fix(domo): layout emitter still produced legacy <LayoutElement>/<GridContainer>

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -441,6 +441,15 @@ jobs:
         # `?`/`!` suffixes, initialize/__init__, declared renames). Five of the nine
         # rows in the original report were one of those.
         run: ruby tools/test-lint-twin-parity.rb
+      - name: Lint — layout emitters must not produce legacy tags
+        # The 2026-08-07 contract renamed <LayoutElement>/<GridContainer> to
+        # <Element>/<Container>. domo's scripts/lib/layout.rb — a vendored copy
+        # of tableau's, marked "do not diverge" — sat on the old tags for ~2.5
+        # weeks unnoticed, because CodeRep.document()/.wrap() canonicalize on
+        # the way to the wire. That net only covers adapter paths: a script
+        # writing document.layout directly, or a human hand-building a request
+        # from an intermediate artifact, still gets a 400. Pin the emitters.
+        run: ruby tools/lint-layout-tags.rb
       - name: Run offline test_*.py suites
         # EXPLICIT allow-list — creds-free, network-free Python tests only.
         # PyYAML is needed by the looker offline dashboard parser

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.86",
+  "version": "0.16.87",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.85",
+  "version": "0.16.86",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/layout.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/layout.rb
@@ -9,8 +9,8 @@
 # Container-based layouts (layout-playbook.md, verified 2026-06-10):
 #   - spec side: a `kind: container` placeholder element per band
 #     (container_el / header_text_el below build those spec objects)
-#   - layout side: a <GridContainer> (NOT <LayoutElement type="grid">, which
-#     silently drops children) whose child <LayoutElement>s use
+#   - layout side: a <Container> (NOT <Element type="grid">, which silently
+#     drops children) whose child <Element>s use
 #     CONTAINER-RELATIVE coordinates (rows restart at 1).
 require_relative 'zone_census'
 
@@ -45,13 +45,13 @@ module SigmaLayout
   # Default 24 (the page grid); a vertical control rail declares cols: 1 so its
   # children stack full-width (children's gridColumn refs are LOCAL to this).
   def gc(eid, c0, c1, r0, r1, inner, cols: GRID_COLS)
-    "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
+    "<Container elementId=\"#{eid}\" type=\"grid\" " \
     "gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\" " \
-    "gridTemplateColumns=\"repeat(#{cols}, 1fr)\" gridTemplateRows=\"auto\">\n#{inner}\n</GridContainer>"
+    "gridTemplateColumns=\"repeat(#{cols}, 1fr)\" gridTemplateRows=\"auto\">\n#{inner}\n</Container>"
   end
 
   def le(eid, c0, c1, r0, r1)
-    "  <LayoutElement elementId=\"#{eid}\" gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\"/>"
+    "  <Element elementId=\"#{eid}\" gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\"/>"
   end
 
   def page_xml(page_id, *children)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-layout-xml-tags.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-layout-xml-tags.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# Offline: lib/layout.rb's XML emitters must produce the POST-2026-08-07 tag
+# names — <Element> / <Container>, never the legacy <LayoutElement> /
+# <GridContainer>.
+#
+# WHY THIS TEST EXISTS
+# --------------------
+# lib/layout.rb is a copy of tableau-to-sigma's, carrying a "do not diverge
+# this copy" header. When the layout contract renamed the tags, tableau,
+# powerbi and quicksight all moved; this copy did not, and stayed wrong for
+# ~2.5 weeks.
+#
+# It never broke a live run, which is exactly why nothing caught it:
+# Sigma::CodeRep.document() and .wrap() both canonicalize the layout on the way
+# to the wire, so every artifact and every POST came out correct. The emitter
+# was wrong, the output was right, and no test looked at the emitter.
+#
+# That safety net only covers paths that go through the adapter. A script that
+# writes document.layout directly, or a human reading an intermediate artifact
+# and hand-building a request from it, sees <LayoutElement> and gets a 400.
+# So the emitters are pinned here directly, deliberately WITHOUT routing
+# through CodeRep — canonicalizing first would test the net, not the emitter.
+#
+# tools/lint-layout-tags.rb enforces the same rule fleet-wide; this keeps the
+# check inside domo's own suite so it survives running the plugin standalone.
+#
+#   ruby test/test-layout-xml-tags.rb
+
+require_relative '../scripts/lib/layout'
+
+$failures = 0
+def eq(actual, expected, msg)
+  if actual == expected
+    puts "  ok: #{msg}"
+  else
+    $failures += 1
+    puts "  FAIL: #{msg}\n        expected #{expected.inspect}\n        got      #{actual.inspect}"
+  end
+end
+def ok(cond, msg) eq(!!cond, true, msg) end
+
+LEGACY = /<\/?(?:LayoutElement|GridContainer)\b/
+
+puts 'lib/layout.rb XML emitters — tag names'
+
+el = SigmaLayout.le('el-a', 1, 25, 1, 5)
+ok(el.include?('<Element '),  'le() emits <Element>')
+ok(!el.match?(LEGACY),        'le() emits no legacy tag')
+ok(el.include?('elementId="el-a"'), 'le() carries the elementId')
+
+gc = SigmaLayout.gc('c-1', 1, 25, 1, 8, el)
+ok(gc.include?('<Container '),  'gc() opens <Container>')
+ok(gc.include?('</Container>'), 'gc() closes </Container>')
+ok(!gc.match?(LEGACY),          'gc() emits no legacy tag')
+ok(gc.include?(el),             'gc() nests its children verbatim')
+
+page = SigmaLayout.page_xml('pg-1', gc)
+ok(page.start_with?('<Page '), 'page_xml() opens <Page>')
+ok(!page.match?(LEGACY),       'page_xml() output is free of legacy tags end to end')
+
+# The whole point: a document.layout built straight from these emitters must be
+# wire-ready with NO canonicalization step in between.
+ok(!SigmaLayout.assemble(page).match?(LEGACY),
+   'assemble() output is wire-ready without CodeRep canonicalization') if SigmaLayout.respond_to?(:assemble)
+
+puts($failures.zero? ? "\nALL PASS" : "\n#{$failures} FAILURES")
+exit($failures.zero? ? 0 : 1)

--- a/tools/lint-layout-tags.rb
+++ b/tools/lint-layout-tags.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# lint-layout-tags.rb — fleet gate: no layout emitter may produce the legacy
+# `<LayoutElement>` / `<GridContainer>` tags.
+#
+# WHY THIS EXISTS
+# ---------------
+# The 2026-08-07 workbook layout contract renamed the tags: `<LayoutElement>`
+# -> `<Element>` and `<GridContainer>` -> `<Container>`. The converters were
+# migrated, but `domo-to-sigma`'s `scripts/lib/layout.rb` — a VENDORED copy of
+# tableau's, carrying a "do not diverge this copy" header — was left on the old
+# tags for ~2.5 weeks and nothing caught it.
+#
+# It did not break live runs, because `Sigma::CodeRep.document()` and `.wrap()`
+# both canonicalize the layout on the way to the wire. That safety net is
+# exactly what made this invisible: the emitter was wrong, every artifact and
+# every POST was right, and no test looked at the emitter.
+#
+# The net only covers paths that go THROUGH the adapter. A script that writes
+# `document.layout` directly, or a human reading an intermediate artifact and
+# hand-building a request from it, sees the legacy tags and gets a 400. So the
+# emitters are worth pinning independently of the adapter.
+#
+# Checks every `scripts/lib/layout.rb` by LOADING it and calling its emitters,
+# rather than grepping — a grep cannot tell an emitted tag from a comment or,
+# as in `build-dashboard-layout.rb`, from a guard regex that legitimately names
+# the legacy tags in order to reject them.
+
+require 'open3'
+
+LEGACY = /<\/?(?:LayoutElement|GridContainer)\b/
+
+roots = Dir.glob('plugins/*/skills/*/scripts/lib/layout.rb').sort
+abort 'lint-layout-tags: no layout.rb found — wrong cwd?' if roots.empty?
+
+failures = []
+roots.each do |path|
+  dir = File.dirname(File.dirname(path)) # .../scripts
+  probe = <<~RUBY
+    $LOAD_PATH.unshift 'lib'
+    require 'layout'
+    out = []
+    out << SigmaLayout.le('e', 1, 25, 1, 5) if SigmaLayout.respond_to?(:le)
+    out << SigmaLayout.gc('c', 1, 25, 1, 5, 'x') if SigmaLayout.respond_to?(:gc)
+    out << SigmaLayout.page_xml('p', 'x') if SigmaLayout.respond_to?(:page_xml)
+    print out.join("\\n")
+  RUBY
+  stdout, stderr, status = Open3.capture3('ruby', '-e', probe, chdir: dir)
+  unless status.success?
+    puts "  ~ #{path}: could not load (#{stderr.lines.first&.strip}) — skipped"
+    next
+  end
+  if stdout.match?(LEGACY)
+    failures << path
+    puts "  ✗ #{path}: emits legacy layout tags"
+    stdout.lines.grep(LEGACY).each { |l| puts "      #{l.strip}" }
+  else
+    puts "  ✓ #{path}"
+  end
+end
+
+if failures.empty?
+  puts "\nlint-layout-tags OK (#{roots.size} emitters checked)"
+  exit 0
+end
+warn "\nlint-layout-tags FAILED — #{failures.size} emitter(s) still produce " \
+     '<LayoutElement>/<GridContainer>. Use <Element>/<Container>.'
+exit 1


### PR DESCRIPTION
## TL;DR for the reported symptom

The two files named in the report — `post-and-readback.rb` and `build-workbook-spec.rb` — are **already on the new shape** and have been for weeks:

- `post-and-readback.rb` → wraps via `Sigma::CodeRep` since **#609, 2026-08-06**
- domo's `build-workbook-spec.rb` → emits the full `document` shape since **#676, 2026-08-08**

Verified by round-tripping a flat legacy body through the adapter — it comes out as exactly `{ name, folderId, document: { schemaVersion, kind, pages, elements, layout } }`, the shape the live API wants.

So a fresh run does **not** hit the flat-POST rejection. Anyone still seeing it is on a checkout/plugin build older than domo-to-sigma **0.16.4**.

## But the layout-tag half of the report was a real find

`plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/layout.rb` genuinely still emitted `<LayoutElement>` / `<GridContainer>`. It's a **vendored copy of tableau's** carrying a "do not diverge this copy" header, and it was left behind when tableau, powerbi and quicksight all moved to `<Element>` / `<Container>`. Wrong for ~2.5 weeks.

**Why it never broke a run:** `CodeRep.document()` and `.wrap()` both canonicalize the layout on the way to the wire. Every artifact and every POST came out correct. That's exactly why nothing caught it — the emitter was wrong, the output was right, and no test looked at the emitter.

**Why it still matters:** the net only covers paths that go through the adapter. A script writing `document.layout` directly, or a human reading an intermediate artifact and hand-building a request from it, sees `<LayoutElement>` and gets a 400.

## New gate

`tools/lint-layout-tags.rb`, wired into corpus-check. It **loads** each `scripts/lib/layout.rb` and calls its emitters rather than grepping — a grep can't distinguish an emitted tag from a comment, or from `build-dashboard-layout.rb`'s guard regex, which legitimately names the legacy tags in order to reject them.

Proven against the real defect: on the pre-fix tree it reports domo and only domo, and exits non-zero. Post-fix all four emitters pass.

## Scope

Only domo was affected — powerbi, quicksight and tableau all emit `<Element>` correctly (each verified by loading and calling its emitter, not by grep).

`test-migrate-domo.rb` fails identically on clean main; pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)