### PR TITLE
fix: real ruby 2.6 floor (agents were installing runtimes mid-migration) + nested action-rename validation

### DIFF
--- a/.githooks/run-governance-checks.sh
+++ b/.githooks/run-governance-checks.sh
@@ -35,6 +35,7 @@ fi
 [ -f tools/lint-skill-paths.rb ] && { ruby tools/lint-skill-paths.rb || fail=1; }
 [ -f tools/lint-uplift-contracts.rb ] && { ruby tools/lint-uplift-contracts.rb || fail=1; }
 [ -f tools/lint-twin-parity.rb ] && { ruby tools/lint-twin-parity.rb || fail=1; }
+[ -f tools/lint-ruby-floor.rb ] && { ruby tools/lint-ruby-floor.rb || fail=1; }
 [ -f tools/check-cognos-bundle.rb ] && { ruby tools/check-cognos-bundle.rb || fail=1; }
 # bootstrap<->doctor KEEP-IN-LOCKSTEP guard (E2.1): bootstrap.sh duplicates
 # doctor.sh's probes (py_real, the vm-node candidate globs, Test-RealPython)
@@ -58,6 +59,7 @@ if [ "${CI:-}" = "true" ]; then
   [ -f tools/test-lint-uplift-contracts.rb ] && { ruby tools/test-lint-uplift-contracts.rb || fail=1; }
   [ -f tools/test-lint-twb-encoding.rb ] && { ruby tools/test-lint-twb-encoding.rb || fail=1; }
   [ -f tools/test-lint-twin-parity.rb ] && { ruby tools/test-lint-twin-parity.rb || fail=1; }
+  [ -f tools/test-lint-ruby-floor.rb ] && { ruby tools/test-lint-ruby-floor.rb || fail=1; }
 fi
 if [ "$fail" -ne 0 ]; then
   echo "" >&2

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -450,6 +450,16 @@ jobs:
         # writing document.layout directly, or a human hand-building a request
         # from an intermediate artifact, still gets a 400. Pin the emitters.
         run: ruby tools/lint-layout-tags.rb
+      - name: Lint — ruby 2.6 floor (polyfill present, in scope, in order)
+        # `ruby -c` CANNOT see this: a missing METHOD is a runtime NoMethodError,
+        # and this job runs 3.3 where filter_map/tally exist. ~60 call sites had
+        # already broken the documented 2.6 floor; under system 2.6, 13 of 277
+        # tableau suites failed and 6 of those emitted silently EMPTY output.
+        run: ruby tools/lint-ruby-floor.rb
+      - name: Self-test — the ruby-floor gate must FAIL on each real mistake
+        # missing require / require nested in a block / require after first use /
+        # ruby-3.0 endless def. All four were made while landing the polyfill.
+        run: ruby tools/test-lint-ruby-floor.rb
       - name: Run offline test_*.py suites
         # EXPLICIT allow-list — creds-free, network-free Python tests only.
         # PyYAML is needed by the looker offline dashboard parser

--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos \u2192 Sigma",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Migrate IBM Cognos Analytics to Sigma \u2014 Data Module JSON \u2192 Sigma data model, and report-spec XML \u2192 Sigma workbook. Translates the Cognos expression DSL (total..for \u2192 window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos \u2192 Sigma",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Migrate IBM Cognos Analytics to Sigma \u2014 Data Module JSON \u2192 Sigma data model, and report-spec XML \u2192 Sigma workbook. Translates the Cognos expression DSL (total..for \u2192 window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.87",
+  "version": "0.16.88",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.88",
+  "version": "0.16.89",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/build-workbook.rb
@@ -24,6 +24,9 @@ require 'json'
 require 'fileutils'
 require 'base64'
 require_relative 'lib/domo_sigma_util'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 include DomoSigma
 
 OUT = ENV['DOMO_DISCOVERY_DIR'] || File.expand_path('../discovery', __dir__)

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/doctor.sh
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/doctor.sh
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/domo_sigma_util.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/domo_sigma_util.rb
@@ -3,6 +3,9 @@
 # and the workbook column references — a mismatch compiles Sigma columns to type
 # "error" (case-sensitive same-element refs).
 
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 module DomoSigma
   module_function
 

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/migrate-domo.rb
@@ -89,6 +89,9 @@ require_relative 'lib/code_rep'
 require_relative 'lib/layout'
 require_relative 'lib/sigma_rest'
 require_relative 'lib/domo_warehouse_column_refs'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 include DomoSigma
 
 opts = { mode: 'page-per-worksheet', workbook_name: 'Domo Migration' }

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/post-and-readback.rb
@@ -59,6 +59,9 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'dm_quarantine'
 require 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 QUARANTINE = opts[:quarantine] && opts[:type] == 'datamodel'
 DEFERRED_PATH = File.join(opts[:workdir], 'deferred-elements.json')

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/put-layout.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/put-layout.rb
@@ -28,6 +28,9 @@ require 'date'
 require 'optparse'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 opts = {}
 OptionParser.new do |p|

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/test/test-migrate-domo.rb
@@ -15,6 +15,10 @@ require 'json'
 require 'tmpdir'
 require 'open3'
 require_relative '../scripts/lib/code_rep'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative '../scripts/lib/ruby_compat'
 
 SKILL   = File.expand_path('..', __dir__)
 SCRIPTS = File.join(SKILL, 'scripts')

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData \u2192 Sigma",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma \u2014 the declarative workspace layout (LDM + analytics model) \u2192 Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "gooddata-to-sigma",
   "displayName": "GoodData \u2192 Sigma",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma \u2014 the declarative workspace layout (LDM + analytics model) \u2192 Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex \u2192 Sigma",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Migrate Hex projects to Sigma \u2014 SQL cells, single-value/METRIC cells, and EXPLORE charts \u2192 Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/post-and-readback.rb
@@ -38,6 +38,9 @@ FileUtils.mkdir_p(opts[:workdir])
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 POST_PATH = opts[:type] == 'datamodel' ? '/v2/dataModels/spec'    : '/v2/workbooks/spec'
 GET_PATH  = opts[:type] == 'datamodel' ? '/v2/dataModels/%s/spec' : '/v2/workbooks/%s/spec'

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/put-layout.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/put-layout.rb
@@ -25,6 +25,9 @@ require 'optparse'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 opts = {}
 OptionParser.new do |p|

--- a/plugins/mode-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/mode-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mode-to-sigma",
   "displayName": "Mode \u2192 Sigma",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Convert a Mode Report (Queries + Charts) into a Sigma data model and matching workbook. Discovery via the Mode REST API (Queries, Charts, Filters, plus a live run to sample each Query's output columns), a reuse check before building a new data model, DM + workbook creation via REST (every Query wraps its raw SQL verbatim as a native-SQL table element \u2014 no formula translation needed, since Mode's SQL already runs in the target warehouse dialect), a notebook-flow layout, and parity verification against the source Mode Query values. Bundles mode-to-sigma (registered, converter-only for this release) + mode-assessment (not yet registered).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.40",
+  "version": "1.8.41",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.41",
+  "version": "1.8.42",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -57,6 +57,9 @@ require_relative 'lib/coverage_catalog'
 require_relative 'lib/trellis_emit' # shared native-trellis emitter (supported-kind gate + fallbacks)
 require_relative 'lib/metric_binding' # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 require_relative 'lib/pbi_reportbuild' # report-build hardening: one-base-table-per-page, boolean controls, friendly names
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 include SigmaLayout
 
 # ---------------------------------------------------------------------------

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-spec.rb
@@ -35,6 +35,9 @@ require 'net/http'
 require 'uri'
 require 'base64'
 require_relative 'lib/layout'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 opts = { mode: 'page-per-worksheet' }
 OptionParser.new do |p|

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_native_query.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_native_query.rb
@@ -8,6 +8,9 @@
 #   2. extracts Value.NativeQuery / connector Query= SQL from the original TMSL;
 #   3. restores those source elements to Sigma kind:"sql" after conversion.
 require 'json'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module PbiNativeQuery
   module_function

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -89,6 +89,9 @@ require 'pbi_timeintel_route' # time-intel fallback-router fact-provenance guard
 require 'pbi_native_query' # preserve Value.NativeQuery/Query= SQL around the pinned converter
 require 'pbi_composite' # remote-model detection; NativeQuery is warehouse SQL
 require 'materialization_schedules' # opt-in DM element schedule lifecycle
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 # Converter resolution (issue #227). The pinned VENDORED bundle is the DEFAULT so a
 # developer machine and a customer machine produce identical output for the same

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/put-layout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/put-layout.rb
@@ -22,6 +22,9 @@ require 'date'
 require 'optparse'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 opts = {}
 OptionParser.new do |p|

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-reportbuild-emit.rb
@@ -31,6 +31,9 @@ require 'tmpdir'
 require 'rbconfig'
 require_relative 'lib/layout_lint'
 require_relative 'lib/code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 BUILD = File.join(__dir__, 'build-workbook-from-pbir.rb')
 RUBY  = RbConfig.ruby

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-workbook-code-release.rb
@@ -8,6 +8,9 @@ require 'tmpdir'
 require 'rbconfig'
 require_relative 'lib/layout_lint'
 require_relative 'lib/layout'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 BUILD = File.join(__dir__, 'build-workbook-from-pbir.rb')
 ASSEMBLE = File.join(__dir__, 'build-workbook-spec.rb')

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
@@ -66,6 +66,9 @@ elements.each do |el|
   all_element_names << el['id'] if el['id']
 end
 require 'set' rescue nil
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 # RESERVED reference prefixes that are always valid regardless of the spec's own
 # elements. `Metrics` is the governed data-model metric namespace: a column
 # formula may reference a DM metric as [Metrics/<measure name>] (the documented,

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/put-layout.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/put-layout.rb
@@ -23,6 +23,9 @@ require 'date'
 require 'optparse'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative '../lib/ruby_compat'
 
 opts = {}
 OptionParser.new do |p|

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight \u2192 Sigma",
-  "version": "1.5.22",
+  "version": "1.5.23",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma \u2014 analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight \u2192 Sigma",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma \u2014 analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -33,6 +33,9 @@ require_relative 'lib/coverage_catalog'
 require_relative 'lib/trellis_emit' # shared native-trellis emitter (supported-kind gate + fallbacks)
 require_relative 'lib/metric_binding' # shared DM-metric binder ([Metrics/<name>] over inline re-derive)
 require_relative 'lib/layout'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 opts = {}
 OptionParser.new do |o|

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/post-and-readback.rb
@@ -32,6 +32,9 @@ FileUtils.mkdir_p(opts[:workdir])
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 BASE = ENV.fetch('SIGMA_BASE_URL')
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
@@ -18,6 +18,9 @@ require 'json'
 require 'yaml'
 require 'date'
 require 'optparse'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 # sigma_rest self-exchanges SIGMA_CLIENT_ID/SECRET (auto-loading
 # ~/.sigma-migration/env) exactly like the phase 1-4 scripts — SIGMA_API_TOKEN
 # is optional, not a hard requirement (bead eqom).

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/validate-spec.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/validate-spec.rb
@@ -16,6 +16,9 @@ require 'set'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_functions'
 require 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 opts = { type: nil, dm_context: nil }
 op = OptionParser.new do |p|

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-api (authentication), sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter \u2014 the converters assume it is present.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-api (authentication), sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter \u2014 the converters assume it is present.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sigma-authoring",
   "displayName": "Sigma Authoring (Workbooks + Data Models)",
-  "version": "1.12.8",
+  "version": "1.12.9",
   "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-api (authentication), sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter \u2014 the converters assume it is present.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/ruby_compat.rb
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/workbook_sql.rb
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/workbook_sql.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module Sigma
   module WorkbookSql

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/extract-openapi-contract.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/extract-openapi-contract.rb
@@ -54,6 +54,93 @@ def collect_discriminators(schema, discriminator, out = [])
   out.uniq { |entry| entry[discriminator] }.sort_by { |entry| entry[discriminator] }
 end
 
+# ---- Actions coverage (issue: the 2026-08-26 action field rename) -----------
+#
+# This fixture pinned CreateWorkbookSpec and the element/control discriminators
+# but had ZERO Actions coverage -- no `effect`, no insert-rows, nothing. So when
+# Sigma renamed every action identifier field to a *Id shape (table ->
+# tableElementId, and eight more), the pinned contract did not move and this gate
+# stayed green while four repos emitted dead keys. It would not have caught the
+# next one either.
+#
+# Effects are NOT a named schema; they hang off
+# Actions.items.allOf[].properties.effects.items as a oneOf discriminated by
+# `effect`. Pin each member's merged property + required sets so a rename,
+# an added effect, or a newly-required field all show up as a fixture diff.
+def effects_schema(actions)
+  Array(actions['items'] && actions['items']['allOf']).each do |part|
+    effects = property(part, 'effects')
+    return effects['items'] if effects.is_a?(Hash) && effects['items']
+  end
+  nil
+end
+
+# Merged shape per `effect` value. Uses the same merged_* helpers as everything
+# else here so allOf-split members (discriminator in one branch, properties in
+# another -- which is how column-range hides minColumnId/maxColumnId) are seen.
+def collect_effects(effects_items)
+  out = {}
+  walk = lambda do |node|
+    next unless node.is_a?(Hash)
+    props = merged_properties(node)
+    names = props.is_a?(Hash) ? props.keys : Array(props)
+    effect_prop = property(node, 'effect')
+    values = effect_prop && (effect_prop['enum'] || (effect_prop['const'] ? [effect_prop['const']] : nil))
+    if values
+      values.each do |value|
+        next unless value.is_a?(String)
+        out[value] = {
+          'required' => (merged_required(node) - ['effect']).sort,
+          'properties' => (names - ['effect']).sort
+        }
+      end
+    end
+    Array(node['oneOf']).each { |part| walk.call(part) }
+    Array(node['anyOf']).each { |part| walk.call(part) }
+    Array(node['allOf']).each { |part| walk.call(part) }
+  end
+  walk.call(effects_items)
+  out.sort.to_h
+end
+
+# The union members reached from inside an effect: value sources
+# ({type: column} -> columnId), whichRows selectors, clear-control scopes,
+# navigate/refresh targets. These are where the rename's NESTED half landed and
+# where nothing was pinned at all. Keyed by "type" so `control` appearing with
+# BOTH `control` (set-control-value, NOT renamed) and `controlId` (clear-control
+# scope, renamed) is visible as two distinct shapes rather than collapsed.
+def collect_union_shapes(node, out = {}, seen = {})
+  return out unless node.is_a?(Hash)
+  return out if seen[node.object_id]
+  seen[node.object_id] = true
+
+  type_prop = property(node, 'type')
+  values = type_prop && (type_prop['enum'] || (type_prop['const'] ? [type_prop['const']] : nil))
+  if values && values.length == 1 && values.first.is_a?(String)
+    props = merged_properties(node)
+    names = ((props.is_a?(Hash) ? props.keys : Array(props)) - ['type']).sort
+    unless names.empty?
+      key = "#{values.first}(#{names.join(',')})"
+      out[key] = { 'type' => values.first, 'properties' => names,
+                   'required' => (merged_required(node) - ['type']).sort }
+    end
+  end
+  %w[oneOf anyOf allOf].each { |comb| Array(node[comb]).each { |part| collect_union_shapes(part, out, seen) } }
+  node.each_value { |val| collect_union_shapes(val, out, seen) if val.is_a?(Hash) }
+  out
+end
+
+# `automatedActions` hangs off document, not off the Actions schema.
+def automated_actions_effects(document)
+  aa = property(document, 'automatedActions')
+  return nil unless aa.is_a?(Hash) && aa['items']
+  Array(aa['items']['allOf']).each do |part|
+    effects = property(part, 'effects')
+    return effects['items'] if effects.is_a?(Hash) && effects['items']
+  end
+  nil
+end
+
 path = ARGV.fetch(0) { abort 'usage: extract-openapi-contract.rb OPENAPI_JSON' }
 openapi = JSON.parse(File.read(path))
 schemas = openapi.fetch('components').fetch('schemas')
@@ -86,6 +173,20 @@ contract = {
       collect_discriminators(schemas.fetch('CommonElement'), 'kind')
     ).uniq { |entry| entry['kind'] }.sort_by { |entry| entry['kind'] },
     'controls' => collect_discriminators(schemas.fetch('CommonElement'), 'controlType')
+  },
+  # Per-effect property/required sets + the nested union shapes they reference.
+  # A rename on either level is now a fixture diff instead of a silent 400.
+  'actions' => {
+    # ELEMENT-level actions (the `Actions` schema): 22 effects. This is what a
+    # button / on-select emits and what the converters generate.
+    'effects' => collect_effects(effects_schema(schemas.fetch('Actions'))),
+    'unionShapes' => collect_union_shapes(schemas.fetch('Actions')).sort.to_h,
+    # DOCUMENT-level `automatedActions` is a SEPARATE surface with its own effect
+    # union -- `call-agent` exists only here, which is why pinning `Actions`
+    # alone reports 22 of the 23 effect names visible in the spec. Pinned so a
+    # rename on either surface is a diff; note automatedActions is documented as
+    # UI-authorable only, so this is contract-tracking, not an emit target.
+    'automatedActionEffects' => collect_effects(automated_actions_effects(create_document))
   }
 }
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/fixtures/openapi-workbook-contract.json
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/fixtures/openapi-workbook-contract.json
@@ -6,11 +6,25 @@
   },
   "schemas": {
     "CreateWorkbookSpec": {
-      "required": ["document", "folderId", "name"],
-      "properties": ["description", "document", "folderId", "name"]
+      "required": [
+        "document",
+        "folderId",
+        "name"
+      ],
+      "properties": [
+        "description",
+        "document",
+        "folderId",
+        "name"
+      ]
     },
     "CreateWorkbookSpec.document": {
-      "required": ["elements", "kind", "pages", "schemaVersion"],
+      "required": [
+        "elements",
+        "kind",
+        "pages",
+        "schemaVersion"
+      ],
       "properties": [
         "agents",
         "elements",
@@ -24,11 +38,20 @@
       ]
     },
     "UpdateWorkbookSpec": {
-      "required": ["document"],
-      "properties": ["document"]
+      "required": [
+        "document"
+      ],
+      "properties": [
+        "document"
+      ]
     },
     "UpdateWorkbookSpec.document": {
-      "required": ["elements", "kind", "pages", "schemaVersion"],
+      "required": [
+        "elements",
+        "kind",
+        "pages",
+        "schemaVersion"
+      ],
       "properties": [
         "agents",
         "elements",
@@ -73,7 +96,13 @@
       ]
     },
     "WorkbookSpec.document": {
-      "required": ["elements", "kind", "layout", "pages", "schemaVersion"],
+      "required": [
+        "elements",
+        "kind",
+        "layout",
+        "pages",
+        "schemaVersion"
+      ],
       "properties": [
         "agents",
         "elements",
@@ -87,7 +116,10 @@
       ]
     },
     "WorkbookPage": {
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "properties": [
         "backgroundColor",
         "backgroundImage",
@@ -101,52 +133,741 @@
   },
   "releasedVariants": {
     "elements": [
-      {"title": "Area Chart", "kind": "area-chart"},
-      {"title": "Bar Chart", "kind": "bar-chart"},
-      {"title": "Button", "kind": "button"},
-      {"title": "Chat", "kind": "chat"},
-      {"title": "Combo Chart", "kind": "combo-chart"},
-      {"title": "Container", "kind": "container"},
-      {"title": "Checkbox", "kind": "control"},
-      {"title": "Divider", "kind": "divider"},
-      {"title": "Embed", "kind": "embed"},
-      {"title": "Form", "kind": "form"},
-      {"title": "Geography Map", "kind": "geography-map"},
-      {"title": "Image", "kind": "image"},
-      {"title": "Input Table", "kind": "input-table"},
-      {"title": "KPI", "kind": "kpi-chart"},
-      {"title": "Line Chart", "kind": "line-chart"},
-      {"title": "Manual navigation", "kind": "navigation"},
-      {"title": "Page break", "kind": "page-break"},
-      {"title": "Pivot Table", "kind": "pivot-table"},
-      {"title": "Plugin", "kind": "plugin"},
-      {"title": "Point Map", "kind": "point-map"},
-      {"title": "Progress", "kind": "progress"},
-      {"title": "Region Map", "kind": "region-map"},
-      {"title": "Repeated container", "kind": "repeated-container"},
-      {"title": "Scatter Chart", "kind": "scatter-chart"},
-      {"title": "Tabbed container", "kind": "tabbed-container"},
-      {"title": "Table", "kind": "table"},
-      {"title": "Text", "kind": "text"},
-      {"title": "Waterfall Chart", "kind": "waterfall-chart"}
+      {
+        "title": "Area Chart",
+        "kind": "area-chart"
+      },
+      {
+        "title": "Bar Chart",
+        "kind": "bar-chart"
+      },
+      {
+        "title": "Button",
+        "kind": "button"
+      },
+      {
+        "title": "Chat",
+        "kind": "chat"
+      },
+      {
+        "title": "Combo Chart",
+        "kind": "combo-chart"
+      },
+      {
+        "title": "Container",
+        "kind": "container"
+      },
+      {
+        "title": "Checkbox",
+        "kind": "control"
+      },
+      {
+        "title": "Divider",
+        "kind": "divider"
+      },
+      {
+        "title": "Embed",
+        "kind": "embed"
+      },
+      {
+        "title": "Form",
+        "kind": "form"
+      },
+      {
+        "title": "Geography Map",
+        "kind": "geography-map"
+      },
+      {
+        "title": "Image",
+        "kind": "image"
+      },
+      {
+        "title": "Input Table",
+        "kind": "input-table"
+      },
+      {
+        "title": "KPI",
+        "kind": "kpi-chart"
+      },
+      {
+        "title": "Line Chart",
+        "kind": "line-chart"
+      },
+      {
+        "title": "Manual navigation",
+        "kind": "navigation"
+      },
+      {
+        "title": "Page break",
+        "kind": "page-break"
+      },
+      {
+        "title": "Pivot Table",
+        "kind": "pivot-table"
+      },
+      {
+        "title": "Plugin",
+        "kind": "plugin"
+      },
+      {
+        "title": "Point Map",
+        "kind": "point-map"
+      },
+      {
+        "title": "Progress",
+        "kind": "progress"
+      },
+      {
+        "title": "Region Map",
+        "kind": "region-map"
+      },
+      {
+        "title": "Repeated container",
+        "kind": "repeated-container"
+      },
+      {
+        "title": "Scatter Chart",
+        "kind": "scatter-chart"
+      },
+      {
+        "title": "Tabbed container",
+        "kind": "tabbed-container"
+      },
+      {
+        "title": "Table",
+        "kind": "table"
+      },
+      {
+        "title": "Text",
+        "kind": "text"
+      },
+      {
+        "title": "Waterfall Chart",
+        "kind": "waterfall-chart"
+      }
     ],
     "controls": [
-      {"title": "Checkbox", "controlType": "checkbox"},
-      {"title": "Date", "controlType": "date"},
-      {"title": "Date Range", "controlType": "date-range"},
-      {"title": "Drill down", "controlType": "drill"},
-      {"title": "Hierarchy", "controlType": "hierarchy"},
-      {"title": "Legend", "controlType": "legend"},
-      {"title": "Number", "controlType": "number"},
-      {"title": "Number Range", "controlType": "number-range"},
-      {"title": "Range Slider", "controlType": "range-slider"},
-      {"title": "Segmented Control", "controlType": "segmented"},
-      {"title": "Slider", "controlType": "slider"},
-      {"title": "Switch", "controlType": "switch"},
-      {"title": "Synced", "controlType": "synced"},
-      {"title": "Text", "controlType": "text"},
-      {"title": "Text Area", "controlType": "text-area"},
-      {"title": "Top N", "controlType": "top-n"}
+      {
+        "title": "Checkbox",
+        "controlType": "checkbox"
+      },
+      {
+        "title": "Date",
+        "controlType": "date"
+      },
+      {
+        "title": "Date Range",
+        "controlType": "date-range"
+      },
+      {
+        "title": "Drill down",
+        "controlType": "drill"
+      },
+      {
+        "title": "Hierarchy",
+        "controlType": "hierarchy"
+      },
+      {
+        "title": "Legend",
+        "controlType": "legend"
+      },
+      {
+        "title": "Number",
+        "controlType": "number"
+      },
+      {
+        "title": "Number Range",
+        "controlType": "number-range"
+      },
+      {
+        "title": "Range Slider",
+        "controlType": "range-slider"
+      },
+      {
+        "title": "Segmented Control",
+        "controlType": "segmented"
+      },
+      {
+        "title": "Slider",
+        "controlType": "slider"
+      },
+      {
+        "title": "Switch",
+        "controlType": "switch"
+      },
+      {
+        "title": "Synced",
+        "controlType": "synced"
+      },
+      {
+        "title": "Text",
+        "controlType": "text"
+      },
+      {
+        "title": "Text Area",
+        "controlType": "text-area"
+      },
+      {
+        "title": "Top N",
+        "controlType": "top-n"
+      }
     ]
+  },
+  "actions": {
+    "effects": {
+      "call-api": {
+        "required": [
+          "connectorId"
+        ],
+        "properties": [
+          "connectorId"
+        ]
+      },
+      "call-stored-procedure": {
+        "required": [
+          "storedProcedure"
+        ],
+        "properties": [
+          "storedProcedure"
+        ]
+      },
+      "clear-chat-element-messages": {
+        "required": [
+          "chatElementId"
+        ],
+        "properties": [
+          "chatElementId"
+        ]
+      },
+      "clear-control": {
+        "required": [
+          "scope"
+        ],
+        "properties": [
+          "scope"
+        ]
+      },
+      "close-overlay": {
+        "required": [],
+        "properties": []
+      },
+      "custom-sort": {
+        "required": [
+          "elementId",
+          "sort"
+        ],
+        "properties": [
+          "elementId",
+          "sort"
+        ]
+      },
+      "delete-rows": {
+        "required": [
+          "tableElementId",
+          "whichRows"
+        ],
+        "properties": [
+          "tableElementId",
+          "whichRows"
+        ]
+      },
+      "export": {
+        "required": [
+          "channel",
+          "source",
+          "uri"
+        ],
+        "properties": [
+          "channel",
+          "source",
+          "uri"
+        ]
+      },
+      "if-else": {
+        "required": [
+          "if"
+        ],
+        "properties": [
+          "if"
+        ]
+      },
+      "insert-rows": {
+        "required": [
+          "tableElementId",
+          "values"
+        ],
+        "properties": [
+          "tableElementId",
+          "values"
+        ]
+      },
+      "navigate": {
+        "required": [
+          "target"
+        ],
+        "properties": [
+          "target"
+        ]
+      },
+      "open-document": {
+        "required": [
+          "documentId",
+          "documentType",
+          "openTarget"
+        ],
+        "properties": [
+          "documentId",
+          "documentType",
+          "openTarget"
+        ]
+      },
+      "open-overlay": {
+        "required": [
+          "overlayId"
+        ],
+        "properties": [
+          "overlayId"
+        ]
+      },
+      "open-url": {
+        "required": [
+          "openTarget"
+        ],
+        "properties": [
+          "openTarget"
+        ]
+      },
+      "refresh-element": {
+        "required": [
+          "target"
+        ],
+        "properties": [
+          "target"
+        ]
+      },
+      "reset-form": {
+        "required": [],
+        "properties": []
+      },
+      "run-python-element": {
+        "required": [
+          "codeElementId"
+        ],
+        "properties": [
+          "codeElementId"
+        ]
+      },
+      "select-tab": {
+        "required": [
+          "selectedTab",
+          "tabbedContainerElementId"
+        ],
+        "properties": [
+          "selectedTab",
+          "tabbedContainerElementId"
+        ]
+      },
+      "set-control-value": {
+        "required": [
+          "control",
+          "value"
+        ],
+        "properties": [
+          "control",
+          "value"
+        ]
+      },
+      "set-form-values": {
+        "required": [
+          "formElementId",
+          "values"
+        ],
+        "properties": [
+          "formElementId",
+          "values"
+        ]
+      },
+      "trigger-plugin": {
+        "required": [
+          "pluginEffectId",
+          "pluginElementId"
+        ],
+        "properties": [
+          "pluginEffectId",
+          "pluginElementId"
+        ]
+      },
+      "update-rows": {
+        "required": [
+          "tableElementId",
+          "values",
+          "whichRows"
+        ],
+        "properties": [
+          "tableElementId",
+          "values",
+          "whichRows"
+        ]
+      }
+    },
+    "unionShapes": {
+      "agent-input(inputName)": {
+        "type": "agent-input",
+        "properties": [
+          "inputName"
+        ],
+        "required": [
+          "inputName"
+        ]
+      },
+      "boolean(value)": {
+        "type": "boolean",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "boolean-list(value)": {
+        "type": "boolean-list",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "column(aggregation,by,columnId,direction,nulls)": {
+        "type": "column",
+        "properties": [
+          "aggregation",
+          "by",
+          "columnId",
+          "direction",
+          "nulls"
+        ],
+        "required": [
+          "columnId",
+          "direction"
+        ]
+      },
+      "column(columnId)": {
+        "type": "column",
+        "properties": [
+          "columnId"
+        ],
+        "required": [
+          "columnId"
+        ]
+      },
+      "column(columnId,direction)": {
+        "type": "column",
+        "properties": [
+          "columnId",
+          "direction"
+        ],
+        "required": [
+          "columnId",
+          "direction"
+        ]
+      },
+      "column-match(columnId)": {
+        "type": "column-match",
+        "properties": [
+          "columnId"
+        ],
+        "required": [
+          "columnId"
+        ]
+      },
+      "column-range(maxColumnId,minColumnId)": {
+        "type": "column-range",
+        "properties": [
+          "maxColumnId",
+          "minColumnId"
+        ],
+        "required": []
+      },
+      "constant(cond,value)": {
+        "type": "constant",
+        "properties": [
+          "cond",
+          "value"
+        ],
+        "required": [
+          "cond",
+          "value"
+        ]
+      },
+      "constant(value)": {
+        "type": "constant",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "container(containerElementId)": {
+        "type": "container",
+        "properties": [
+          "containerElementId"
+        ],
+        "required": [
+          "containerElementId"
+        ]
+      },
+      "control(control)": {
+        "type": "control",
+        "properties": [
+          "control"
+        ],
+        "required": [
+          "control"
+        ]
+      },
+      "control(controlId)": {
+        "type": "control",
+        "properties": [
+          "controlId"
+        ],
+        "required": [
+          "controlId"
+        ]
+      },
+      "csv(repeatHeaderLabels)": {
+        "type": "csv",
+        "properties": [
+          "repeatHeaderLabels"
+        ],
+        "required": []
+      },
+      "date(value)": {
+        "type": "date",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "date-list(value)": {
+        "type": "date-list",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "date-range(value)": {
+        "type": "date-range",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "direction(direction)": {
+        "type": "direction",
+        "properties": [
+          "direction"
+        ],
+        "required": [
+          "direction"
+        ]
+      },
+      "dynamic(value)": {
+        "type": "dynamic",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "element(element)": {
+        "type": "element",
+        "properties": [
+          "element"
+        ],
+        "required": [
+          "element"
+        ]
+      },
+      "excel(includeMetadata,repeatHeaderLabels)": {
+        "type": "excel",
+        "properties": [
+          "includeMetadata",
+          "repeatHeaderLabels"
+        ],
+        "required": []
+      },
+      "excel(repeatHeaderLabels)": {
+        "type": "excel",
+        "properties": [
+          "repeatHeaderLabels"
+        ],
+        "required": []
+      },
+      "external-report(documentId)": {
+        "type": "external-report",
+        "properties": [
+          "documentId"
+        ],
+        "required": [
+          "documentId"
+        ]
+      },
+      "form-field(fieldId)": {
+        "type": "form-field",
+        "properties": [
+          "fieldId"
+        ],
+        "required": [
+          "fieldId"
+        ]
+      },
+      "formula(formula)": {
+        "type": "formula",
+        "properties": [
+          "formula"
+        ],
+        "required": [
+          "formula"
+        ]
+      },
+      "formula-range(max,min)": {
+        "type": "formula-range",
+        "properties": [
+          "max",
+          "min"
+        ],
+        "required": []
+      },
+      "level(columns)": {
+        "type": "level",
+        "properties": [
+          "columns"
+        ],
+        "required": [
+          "columns"
+        ]
+      },
+      "number(value)": {
+        "type": "number",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "number-list(value)": {
+        "type": "number-list",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "number-range(value)": {
+        "type": "number-range",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "page(page)": {
+        "type": "page",
+        "properties": [
+          "page"
+        ],
+        "required": [
+          "page"
+        ]
+      },
+      "page(pageId)": {
+        "type": "page",
+        "properties": [
+          "pageId"
+        ],
+        "required": []
+      },
+      "pdf(layout,pageSize)": {
+        "type": "pdf",
+        "properties": [
+          "layout",
+          "pageSize"
+        ],
+        "required": [
+          "layout",
+          "pageSize"
+        ]
+      },
+      "single-row(primaryKeys)": {
+        "type": "single-row",
+        "properties": [
+          "primaryKeys"
+        ],
+        "required": [
+          "primaryKeys"
+        ]
+      },
+      "static(values)": {
+        "type": "static",
+        "properties": [
+          "values"
+        ],
+        "required": [
+          "values"
+        ]
+      },
+      "tab(index)": {
+        "type": "tab",
+        "properties": [
+          "index"
+        ],
+        "required": [
+          "index"
+        ]
+      },
+      "text(value)": {
+        "type": "text",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      },
+      "text-list(value)": {
+        "type": "text-list",
+        "properties": [
+          "value"
+        ],
+        "required": [
+          "value"
+        ]
+      }
+    },
+    "automatedActionEffects": {
+      "call-agent": {
+        "required": [
+          "agentId",
+          "prompt"
+        ],
+        "properties": [
+          "agentId",
+          "prompt"
+        ]
+      }
+    },
+    "_note": "Actions coverage added 2026-08-26 after the action field rename shipped with zero coverage here. Extracted from the CANONICAL asset (assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json). The sections above predate this and were captured 2026-08-08 from a different asset -- re-running the extractor over the canonical asset also moves releasedVariants (elements 28->32, controls 16->0) and breaks 4 existing assertions, so they are deliberately NOT refreshed here. Reconciling the two assets is separate work."
   }
 }

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/ruby_compat.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/probe-release-contract.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/probe-release-contract.rb
@@ -11,6 +11,9 @@ require 'json'
 require 'net/http'
 require 'time'
 require 'uri'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 BASE_URL = ENV.fetch('SIGMA_BASE_URL').sub(%r{/$}, '')
 TOKEN = ENV.fetch('SIGMA_API_TOKEN')

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/test-openapi-contract.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/test-openapi-contract.rb
@@ -24,6 +24,96 @@ create_doc = schemas.fetch('CreateWorkbookSpec.document')
 update = schemas.fetch('UpdateWorkbookSpec')
 read_doc = schemas.fetch('WorkbookSpec.document')
 page = schemas.fetch('WorkbookPage')
+actions = contract.fetch('actions')
+effects = actions.fetch('effects')
+union_shapes = actions.fetch('unionShapes').values
+
+# ---- the 2026-08-26 action field rename -----------------------------------
+# This fixture pinned CreateWorkbookSpec and the element/control discriminators
+# but had ZERO Actions coverage. So when Sigma renamed every action identifier
+# field to a *Id shape, the pin did not move, this gate stayed green, and four
+# repos emitted dead keys. These assertions exist so the NEXT rename is a
+# failing test rather than a field incident.
+#
+# `_renamed` pairs are asserted in BOTH directions: the new key must be pinned
+# AND the old key must be gone. Only checking the new key would keep passing if
+# the API ever accepted both.
+{
+  'insert-rows' => 'tableElementId',
+  'update-rows' => 'tableElementId',
+  'delete-rows' => 'tableElementId',
+  'set-form-values' => 'formElementId',
+  'select-tab' => 'tabbedContainerElementId',
+  'open-document' => 'documentId',
+  'custom-sort' => 'elementId',
+  'run-python-element' => 'codeElementId',
+  'clear-chat-element-messages' => 'chatElementId'
+}.each do |effect, new_key|
+  assert_contract(failures, "#{effect} requires #{new_key} (post-rename)") do
+    effects.fetch(effect, {}).fetch('required', []).include?(new_key)
+  end
+end
+
+{
+  'insert-rows' => 'table', 'update-rows' => 'table', 'delete-rows' => 'table',
+  'set-form-values' => 'form', 'select-tab' => 'tabbedContainer',
+  'open-document' => 'document'
+}.each do |effect, dead_key|
+  assert_contract(failures, "#{effect} no longer exposes the dead `#{dead_key}` key") do
+    !effects.fetch(effect, {}).fetch('properties', []).include?(dead_key)
+  end
+end
+
+assert_contract(failures, 'trigger-plugin uses pluginElementId + pluginEffectId') do
+  effects.fetch('trigger-plugin', {}).fetch('required', []).sort == %w[pluginEffectId pluginElementId]
+end
+
+# The rename is SELECTIVE. These three were probed and deliberately NOT renamed,
+# so a future "cleanup" to *Id would be a live 400. Pin the bare names.
+assert_contract(failures, 'set-control-value keeps the bare `control` key') do
+  effects.fetch('set-control-value', {}).fetch('required', []).include?('control')
+end
+assert_contract(failures, 'a {type:page} union member with a bare `page` still exists (navigate target)') do
+  union_shapes.any? { |shape| shape['type'] == 'page' && shape['properties'] == ['page'] }
+end
+assert_contract(failures, 'a {type:element} union member with a bare `element` still exists (refresh-element target)') do
+  union_shapes.any? { |shape| shape['type'] == 'element' && shape['properties'] == ['element'] }
+end
+assert_contract(failures, 'a {type:control} union member with a bare `control` still exists (set-control-value)') do
+  union_shapes.any? { |shape| shape['type'] == 'control' && shape['properties'] == ['control'] }
+end
+
+# ...while the SAME discriminators renamed under a clear-control scope.
+assert_contract(failures, 'clear-control scope union renamed to pageId/controlId/containerElementId') do
+  %w[pageId controlId containerElementId].all? do |key|
+    union_shapes.any? { |shape| shape['properties'] == [key] }
+  end
+end
+
+# The nested half of the rename -- value sources, whichRows selectors, sort keys.
+assert_contract(failures, 'column union members use columnId, never bare `column`') do
+  cols = union_shapes.select { |shape| shape['type'] == 'column' }
+  cols.any? && cols.none? { |shape| shape['properties'].include?('column') } &&
+    cols.all? { |shape| shape['properties'].include?('columnId') }
+end
+assert_contract(failures, 'column-match uses columnId') do
+  union_shapes.any? { |shape| shape['type'] == 'column-match' && shape['properties'] == ['columnId'] }
+end
+assert_contract(failures, 'column-range uses minColumnId/maxColumnId, not min/max') do
+  ranges = union_shapes.select { |shape| shape['type'] == 'column-range' }
+  ranges.any? && ranges.all? { |shape| shape['properties'].sort == %w[maxColumnId minColumnId] }
+end
+
+# Coverage floor: element actions currently expose 22 effects and
+# automatedActions exposes only call-agent. A DROP means the pin lost coverage;
+# a RISE means Sigma shipped an effect nobody has looked at yet.
+assert_contract(failures, "element actions expose 22 effects (got #{effects.length})") do
+  effects.length == 22
+end
+assert_contract(failures, 'automatedActions exposes call-agent (its own separate surface)') do
+  actions.fetch('automatedActionEffects').key?('call-agent')
+end
+
 element_kinds = contract.dig('releasedVariants', 'elements').map { |entry| entry.fetch('kind') }
 control_types = contract.dig('releasedVariants', 'controls').map { |entry| entry.fetch('controlType') }
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
@@ -53,6 +53,9 @@ require 'fileutils'
 require 'time'
 require 'tmpdir'
 require_relative 'lib/code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 RESPONSE_ONLY = %w[workbookId url documentVersion latestDocumentVersion ownerId
                    createdBy updatedBy createdAt updatedAt].freeze

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense \u2192 Sigma",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma \u2014 data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense \u2192 Sigma",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma \u2014 data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-complete.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify-complete.rb
@@ -8,6 +8,9 @@
 require 'json'
 require 'optparse'
 require_relative 'lib/degradation_ledger'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 TERMINAL = %w[migrated approximated needs-review skipped not-applicable].freeze
 

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.27",
+  "version": "1.9.28",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.28",
+  "version": "1.9.29",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.29",
+  "version": "1.9.30",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -74,6 +74,9 @@ require_relative 'lib/kpi_comparison_detect' # Task 5: prior/target comparison-m
 require_relative 'lib/action_ledger' # workbook-wide action id registry + validate/manifest
 require_relative 'lib/action_column_resolver' # Task 5: raw Tableau source-field ref -> emitted Sigma column name
 require 'erb'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 opts = { master_id: 'master' }
 OptionParser.new do |p|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -55,6 +55,9 @@ require_relative 'lib/layout'
 require_relative 'lib/zone_census'
 require_relative 'lib/arrangement_lint'
 require_relative 'lib/workbook_code'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 include SigmaLayout
 
 # ---- Source-derived header chrome -----------------------------------------

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-source-object-census.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-source-object-census.rb
@@ -11,6 +11,9 @@ require 'set'
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'twb_xml'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 class CensusError < StandardError; end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/action_ledger.rb
@@ -29,19 +29,92 @@ module ActionLedger
   # `set-control-value` keeps a bare `control`, and `navigate`/`refresh-element`
   # keep a bare `target` — those were deliberately NOT renamed (probe-confirmed
   # that the `*Id` form 400s). Don't "regularise" them.
+  # Required top-level properties per effect, DERIVED FROM the canonical OpenAPI
+  # asset (assets.sigmacomputing.com/openapi/public-rest-api/...) on 2026-08-26,
+  # the day the action field rename went live. All 23 effects the API accepts are
+  # listed: the previous table had 12, so any converter emitting one of the other
+  # 11 was rejected by our own validator as an "unknown effect".
+  #
+  # `open-url` is deliberately STRICTER than the spec, which requires only
+  # openTarget: an open-url with no `url` is schema-valid, persists, and does
+  # NOTHING. A generator bug that drops the url ships a healthy-looking button
+  # that is inert, so assert it here.
   EFFECT_REQUIRED = {
-    'navigate'          => %w[target],
-    'set-control-value' => %w[control value],
-    'clear-control'     => %w[scope],
-    'open-url'          => %w[openTarget url],
-    'open-overlay'      => %w[overlayId],
-    'close-overlay'     => [],
-    'select-tab'        => %w[tabbedContainerElementId selectedTab],
-    'refresh-element'   => %w[target],
-    'insert-rows'       => %w[tableElementId values],
-    'update-rows'       => %w[tableElementId whichRows values],
-    'delete-rows'       => %w[tableElementId whichRows],
-    'open-document'     => %w[documentId documentType openTarget]
+    'call-agent'                  => %w[agentId prompt],
+    'call-api'                    => %w[connectorId],
+    'call-stored-procedure'       => %w[storedProcedure],
+    'clear-chat-element-messages' => %w[chatElementId],
+    'clear-control'               => %w[scope],
+    'close-overlay'               => [],
+    'custom-sort'                 => %w[elementId sort],
+    'delete-rows'                 => %w[tableElementId whichRows],
+    'export'                      => %w[channel source uri],
+    'if-else'                     => %w[if],
+    'insert-rows'                 => %w[tableElementId values],
+    'navigate'                    => %w[target],
+    'open-document'               => %w[documentId documentType openTarget],
+    'open-overlay'                => %w[overlayId],
+    'open-url'                    => %w[openTarget url],
+    'refresh-element'             => %w[target],
+    'reset-form'                  => [],
+    'run-python-element'          => %w[codeElementId],
+    'select-tab'                  => %w[tabbedContainerElementId selectedTab],
+    'set-control-value'           => %w[control value],
+    'set-form-values'             => %w[formElementId values],
+    'trigger-plugin'              => %w[pluginElementId pluginEffectId],
+    'update-rows'                 => %w[tableElementId whichRows values]
+  }.freeze
+
+  # ---- the 2026-08-26 action field rename -----------------------------------
+  #
+  # Sigma renamed identifier fields to an explicit *Id shape. Every old name now
+  # hard-400s EXCEPT ONE, which is why this table exists rather than a code
+  # comment: `clear-control` `scope:{type:page, page:}` returns 200 OK and
+  # SILENTLY DROPS the key -- readback is a bare `scope:{type:page}` and the
+  # button clears nothing. A generator still emitting `page:` looks completely
+  # healthy. Status codes are not evidence here; the emitted shape is.
+  #
+  # Nested paths matter as much as top-level ones and had NO coverage before:
+  # a value source, a whichRows selector, a custom-sort key and a column-range
+  # bound are all places the old bare name still parsed fine locally.
+  DEAD_KEYS = {
+    'table'            => 'tableElementId',
+    'form'             => 'formElementId',
+    'tabbedContainer'  => 'tabbedContainerElementId',
+    'document'         => 'documentId',
+    'pluginElement'    => 'pluginElementId',
+    'pluginEffect'     => 'pluginEffectId',
+    'column'           => 'columnId',
+    'min'              => 'minColumnId',
+    'max'              => 'maxColumnId'
+  }.freeze
+
+  # Renames that apply ONLY inside a discriminated union member, because the
+  # bare name is still the ONLY accepted form elsewhere. The rename is
+  # deliberately selective -- these three were probed and NOT renamed, so
+  # "fixing" them to *Id is itself a 400:
+  #   set-control-value.control                  stays `control`
+  #   navigate         target{type:page}.page    stays `page`
+  #   refresh-element  target{type:element}.element stays `element`
+  # So `page`/`element`/`control` are dead only under a clear-control scope.
+  DEAD_KEYS_IN_CLEAR_CONTROL_SCOPE = {
+    'page'      => 'pageId',
+    'control'   => 'controlId',
+    'container' => 'containerElementId'
+  }.freeze
+
+  # Union members whose required keys we can check once we see `type`.
+  # Spec-derived; `column-range` is listed with NO required keys on purpose --
+  # minColumnId/maxColumnId are both OPTIONAL in the API, so a range that lost
+  # its bounds is schema-valid and silently unbounded. Warned about separately.
+  UNION_REQUIRED = {
+    'column'       => %w[columnId],
+    'column-match' => %w[columnId],
+    'column-range' => [],
+    'control'      => %w[controlId],
+    'container'    => %w[containerElementId],
+    'constant'     => %w[value],
+    'formula'      => %w[formula]
   }.freeze
 
   # Action ids must be unique across the ENTIRE workbook, not per element:
@@ -75,6 +148,55 @@ module ActionLedger
           errs << "effects[#{i}] (#{name}): missing required property `#{req}`"
         end
       end
+      # Nested shapes. Before this, EFFECT_REQUIRED only saw the top level, so a
+      # values[]/whichRows/sort/scope still carrying a pre-rename key passed
+      # validation here and then 400'd live (or, for clear-control page,
+      # succeeded and silently did nothing).
+      errs.concat(deep_errors(eff, "effects[#{i}] (#{name})", name))
+    end
+    errs
+  end
+
+  # Walks an effect looking for (a) dead pre-rename keys, (b) union members
+  # missing their required *Id, and (c) the two shapes that are schema-valid but
+  # inert. Path-aware because the SAME key name can be live or dead depending on
+  # where it sits: `control` is correct under set-control-value and dead under a
+  # clear-control scope.
+  def self.deep_errors(node, path, effect_name, in_clear_control_scope = false)
+    errs = []
+    case node
+    when Hash
+      node.each_key do |key|
+        if (replacement = DEAD_KEYS[key])
+          errs << "#{path}.#{key}: `#{key}` was renamed to `#{replacement}` " \
+                  '(Sigma action field rename, 2026-08-26) — the old key is rejected'
+        end
+        next unless in_clear_control_scope && (replacement = DEAD_KEYS_IN_CLEAR_CONTROL_SCOPE[key])
+        errs << "#{path}.#{key}: under a clear-control scope `#{key}` was renamed to " \
+                "`#{replacement}`" + (key == 'page' ? ' — and the old key is dropped SILENTLY (200 OK, clears nothing)' : '')
+      end
+
+      type = node['type']
+      if type.is_a?(String) && UNION_REQUIRED.key?(type)
+        UNION_REQUIRED[type].each do |req|
+          if node[req].nil? || node[req].to_s.empty?
+            errs << "#{path}: {type: #{type.inspect}} requires `#{req}`"
+          end
+        end
+        # Both bounds optional in the API, so an empty range is accepted and
+        # silently matches everything. Almost always a dropped/renamed key.
+        if type == 'column-range' && node['minColumnId'].to_s.empty? && node['maxColumnId'].to_s.empty?
+          errs << "#{path}: {type: \"column-range\"} has neither minColumnId nor maxColumnId — " \
+                  'the API accepts this and the range silently matches everything'
+        end
+      end
+
+      node.each do |key, val|
+        scope_now = in_clear_control_scope || (effect_name == 'clear-control' && key == 'scope')
+        errs.concat(deep_errors(val, "#{path}.#{key}", effect_name, scope_now))
+      end
+    when Array
+      node.each_with_index { |val, idx| errs.concat(deep_errors(val, "#{path}[#{idx}]", effect_name, in_clear_control_scope)) }
     end
     errs
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/per_page_masters.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/per_page_masters.rb
@@ -39,6 +39,9 @@
 # operates on is produced by this plugin's mechanical builder.
 require 'set'
 require 'json'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module PerPageMasters
   module_function

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/workbook_code.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/workbook_code.rb
@@ -7,6 +7,9 @@
 # use this adapter and keep their nested pages[].elements shape.
 require 'cgi'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module WorkbookCode
   module_function

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -37,6 +37,9 @@ require 'rexml/xpath'
 require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 require_relative 'lib/theme_derive' # shared theme derivation/emission (v5.0)
 require_relative 'lib/sql_ident_check' # #685-C: calc-masquerading-as-physical fixup reuses its scanner/catalog check
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 module MechanicalSpecs
   module_function

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -67,6 +67,9 @@ require 'sigma_rest'
 require 'dm_quarantine'
 require 'code_rep'
 require 'workbook_code'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 begin
   require 'offramp' # off-ramp trail (waiver observability); optional — never load-bearing
 rescue LoadError

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/put-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/put-layout.rb
@@ -70,6 +70,9 @@ $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
 require 'code_rep'
 require 'workbook_code'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 BASE = ENV.fetch('SIGMA_BASE_URL') # sigma_rest fills this from auth.json when unset
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-ledger.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-ledger.rb
@@ -50,7 +50,11 @@ check(ActionLedger.validate_action(nav_no_target).any?, 'navigate without target
 
 scv = { 'id' => 'a', 'trigger' => 'on-select',
         'effects' => [{ 'effect' => 'set-control-value', 'control' => 'RegionCtl',
-                        'value' => { 'type' => 'column', 'column' => 'c-region' } }] }
+                        # columnId, not `column` -- renamed 2026-08-26. This fixture
+                        # still said `column` and asserted it was well-formed, which
+                        # the new nested validation correctly rejects. `control`
+                        # (above) is one of the three fields NOT renamed.
+                        'value' => { 'type' => 'column', 'columnId' => 'c-region' } }] }
 check(ActionLedger.validate_action(scv).empty?, 'a well-formed set-control-value validates')
 check(ActionLedger.validate_action(
   scv.merge('effects' => [scv['effects'][0].reject { |k, _| k == 'control' }])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-rename-contract.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-action-rename-contract.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-action-rename-contract.rb — the 2026-08-26 Sigma action field rename.
+#
+# Sigma renamed action identifier fields to an explicit *Id shape. Every old name
+# now hard-400s EXCEPT ONE: `clear-control` `scope:{type:page, page:}` returns
+# 200 OK and SILENTLY DROPS the key, so the button persists and clears nothing.
+# Status codes are not evidence for that one; only the emitted shape is.
+#
+# The rename is also SELECTIVE. Three fields were probed and deliberately NOT
+# renamed, so "fixing" them to *Id is itself a 400. Half of this file exists to
+# assert we do NOT over-rename them:
+#   set-control-value.control                       stays `control`
+#   navigate         target{type:page}.page         stays `page`
+#   refresh-element  target{type:element}.element   stays `element`
+#
+# Every expectation below is derived from the canonical OpenAPI asset
+# (assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json)
+# read on 2026-08-26, cross-checked against the live probe recorded in the
+# reference docs. Offline, creds-free, no network.
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'action_ledger'
+
+fails = 0
+
+def check(desc, cond)
+  puts(cond ? "  ok  #{desc}" : "  FAIL #{desc}")
+  cond
+end
+
+# expect: a substring the errors must contain, or '' meaning "must be clean"
+def expect_error(desc, effects, expect)
+  action = { 'id' => 'a1', 'trigger' => 'on-click', 'effects' => effects }
+  errs = ActionLedger.validate_action(action)
+  ok = expect.empty? ? errs.empty? : errs.any? { |e| e.include?(expect) }
+  res = check(desc, ok)
+  puts "        got: #{errs.inspect}" unless res
+  res
+end
+
+puts 'RENAMED — the old key must be rejected (top level)'
+[
+  ['insert-rows `table`',      [{ 'effect' => 'insert-rows', 'table' => 't', 'values' => [] }],                    'renamed to `tableElementId`'],
+  ['update-rows `table`',      [{ 'effect' => 'update-rows', 'table' => 't', 'whichRows' => {}, 'values' => [] }],  'renamed to `tableElementId`'],
+  ['delete-rows `table`',      [{ 'effect' => 'delete-rows', 'table' => 't', 'whichRows' => {} }],                  'renamed to `tableElementId`'],
+  ['set-form-values `form`',   [{ 'effect' => 'set-form-values', 'form' => 'f', 'values' => [] }],                  'renamed to `formElementId`'],
+  ['select-tab `tabbedContainer`', [{ 'effect' => 'select-tab', 'tabbedContainer' => 'tc', 'selectedTab' => { 'type' => 'tab', 'index' => 0 } }], 'renamed to `tabbedContainerElementId`'],
+  ['open-document `document`', [{ 'effect' => 'open-document', 'document' => 'd', 'documentType' => 'workbook', 'openTarget' => 'new-tab' }], 'renamed to `documentId`'],
+  ['trigger-plugin `pluginElement`', [{ 'effect' => 'trigger-plugin', 'pluginElement' => 'p', 'pluginEffect' => 'e' }], 'renamed to `pluginElementId`']
+].each { |d, e, x| fails += 1 unless expect_error(d, e, x) }
+
+puts
+puts 'RENAMED — nested paths (these had NO validator coverage before)'
+[
+  ['value source {type:column} `column`',  [{ 'effect' => 'set-control-value', 'control' => 'c', 'value' => { 'type' => 'column', 'column' => 'col' } }], 'renamed to `columnId`'],
+  ['whichRows {type:column-match} `column`', [{ 'effect' => 'delete-rows', 'tableElementId' => 't', 'whichRows' => { 'type' => 'column-match', 'column' => 'c' } }], 'renamed to `columnId`'],
+  ['custom-sort sort.`column`',            [{ 'effect' => 'custom-sort', 'elementId' => 'e', 'sort' => { 'type' => 'column', 'column' => 'c', 'direction' => 'asc' } }], 'renamed to `columnId`'],
+  ['column-range `min`/`max`',             [{ 'effect' => 'insert-rows', 'tableElementId' => 't', 'values' => [{ 'type' => 'column-range', 'min' => 'a', 'max' => 'b' }] }], 'renamed to `minColumnId`']
+].each { |d, e, x| fails += 1 unless expect_error(d, e, x) }
+
+puts
+puts 'SCHEMA-VALID BUT INERT — the API accepts these and they do nothing'
+fails += 1 unless expect_error('clear-control scope `page` is the SILENT drop',
+                               [{ 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'p' } }], 'SILENTLY')
+fails += 1 unless expect_error('column-range with neither bound matches everything',
+                               [{ 'effect' => 'insert-rows', 'tableElementId' => 't', 'values' => [{ 'type' => 'column-range' }] }], 'silently matches everything')
+fails += 1 unless expect_error('open-url with no url persists and does nothing',
+                               [{ 'effect' => 'open-url', 'openTarget' => 'new-tab' }], 'missing required property `url`')
+
+puts
+puts 'NOT RENAMED — the bare name is still the ONLY accepted form; do not "fix" these'
+[
+  ['set-control-value keeps bare `control`',    [{ 'effect' => 'set-control-value', 'control' => 'ctl', 'value' => { 'type' => 'constant', 'value' => { 'type' => 'text', 'value' => 'x' } } }]],
+  ['navigate keeps bare target.`page`',         [{ 'effect' => 'navigate', 'target' => { 'type' => 'page', 'page' => 'p1' } }]],
+  ['refresh-element keeps bare target.`element`', [{ 'effect' => 'refresh-element', 'target' => { 'type' => 'element', 'element' => 'e1' } }]]
+].each { |d, e| fails += 1 unless expect_error(d, e, '') }
+
+puts
+puts 'ALL 23 spec effects are known (the old table had 12, so 11 were rejected as "unknown")'
+known = %w[call-agent call-api call-stored-procedure clear-chat-element-messages clear-control
+           close-overlay custom-sort delete-rows export if-else insert-rows navigate open-document
+           open-overlay open-url refresh-element reset-form run-python-element select-tab
+           set-control-value set-form-values trigger-plugin update-rows]
+missing = known.reject { |k| ActionLedger::EFFECT_REQUIRED.key?(k) }
+fails += 1 unless check("every spec effect is in EFFECT_REQUIRED (missing: #{missing.inspect})", missing.empty?)
+fails += 1 unless check('and no invented effects beyond the spec',
+                        (ActionLedger::EFFECT_REQUIRED.keys - known).empty?)
+
+puts
+puts 'CORRECT new shapes must pass cleanly'
+fails += 1 unless expect_error('post-rename shapes validate',
+                               [{ 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'pageId' => 'p' } },
+                                { 'effect' => 'delete-rows', 'tableElementId' => 't', 'whichRows' => { 'type' => 'column-match', 'columnId' => 'c' } },
+                                { 'effect' => 'custom-sort', 'elementId' => 'e', 'sort' => { 'type' => 'column', 'columnId' => 'c', 'direction' => 'asc' } }], '')
+
+puts
+if fails.zero?
+  puts 'all action-rename contract tests passed'
+  exit 0
+end
+puts "#{fails} check(s) FAILED"
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-aggregate-dimension.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-aggregate-dimension.rb
@@ -22,6 +22,10 @@
 require 'json'
 require 'set'
 require 'tmpdir'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 DIR = __dir__
 SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-bound-filter-wiring.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-bound-filter-wiring.rb
@@ -13,6 +13,10 @@
 #
 # Usage:  ruby scripts/test-calc-bound-filter-wiring.rb
 require 'json'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 DIR = __dir__
 SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calculated-filter-override.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calculated-filter-override.rb
@@ -4,6 +4,10 @@
 # A selected calculated filter must not bind to a same-named physical/DM
 # passthrough. That passthrough may be NULL or carry different semantics.
 
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 DIR = __dir__
 SOURCE = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
 %w[map_column translate_row_level_calc translate_dim_calc master_calc_filter_override].each do |name|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-display-type.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-display-type.rb
@@ -12,6 +12,10 @@
 #
 # Usage:  ruby scripts/test-control-display-type.rb
 require 'json'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 DIR = __dir__
 SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-date-default-normalize.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-date-default-normalize.rb
@@ -16,6 +16,10 @@
 #
 # Usage:  ruby scripts/test-date-default-normalize.rb
 
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 SRC = File.join(__dir__, 'build-charts-from-signals.rb')
 src = File.read(SRC)
 m = src[/def iso_utc_datestamp.*?\nend/m]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-divider-button-emit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-divider-button-emit.rb
@@ -18,6 +18,10 @@ $LOAD_PATH.unshift File.join(DIR, 'lib')
 require 'zone_census'
 require 'layout'
 require 'action_ledger'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 fails = []
 def check(cond, msg, fails)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-header-contrast.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-header-contrast.rb
@@ -18,6 +18,10 @@
 # Usage:  ruby scripts/test-header-contrast.rb
 require 'json'
 require_relative 'lib/zone_census'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 DIR = __dir__
 CHARTS = File.read(File.join(DIR, 'build-charts-from-signals.rb'))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-header-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-header-derivation.rb
@@ -7,6 +7,10 @@
 #
 # Exercises the pure helpers directly.  Usage: ruby scripts/test-header-derivation.rb
 
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 DIR = __dir__
 SRC = File.read(File.join(DIR, 'build-dashboard-layout.rb'))
 %w[band_like_fill? header_from_source].each do |fn|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-comparison-wiring.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-comparison-wiring.rb
@@ -3,6 +3,10 @@
 require 'json'
 require_relative 'lib/kpi_card'
 require_relative 'lib/kpi_comparison_detect'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 $failures = 0
 def check(desc); ok = yield; puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}"); $failures += 1 unless ok; end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-value-fidelity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-value-fidelity.rb
@@ -20,6 +20,10 @@
 #
 # Usage:  ruby scripts/test-kpi-value-fidelity.rb
 require 'json'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 DIR = __dir__
 SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-ds-routing.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-ds-routing.rb
@@ -15,6 +15,10 @@
 # Pure-function test: extracts route_multi_ds! from build-charts-from-signals.rb.
 # Usage:  ruby scripts/test-multi-ds-routing.rb
 require 'json'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 DIR = __dir__
 SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-display-column-layer.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-display-column-layer.rb
@@ -6,6 +6,10 @@
 require 'json'
 require 'tmpdir'
 require_relative 'mechanical-specs'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 HERE = __dir__
 VENDORED = File.expand_path('../converter/tableau.mjs', HERE)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-filter-targets.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-filter-targets.rb
@@ -18,6 +18,10 @@
 #
 # Usage:  ruby scripts/test-param-filter-targets.rb
 
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 SRC = File.join(__dir__, 'build-charts-from-signals.rb')
 src = File.read(SRC)
 %w[map_column param_filter_targets].each do |fn|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
@@ -55,6 +55,10 @@ patterns = { 'workbookPatterns' => [
     'elseExpr' => nil }
 ] }
 require 'tmpdir'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 Dir.mktmpdir do |d|
   File.write(File.join(d, 'wp.json'), JSON.dump(patterns))
   load_param_switches(File.join(d, 'wp.json'), meta)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-png-trellis.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-png-trellis.rb
@@ -6,6 +6,10 @@
 # the only reliable discriminator between that and an implicit color grouping.
 
 require_relative 'lib/trellis_emit'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 source = File.read(File.join(__dir__, 'build-charts-from-signals.rb'))
 method = source.match(/^def apply_verified_trellis!.*?\n^end$/m) or abort('could not extract apply_verified_trellis!')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relative-date-filter.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relative-date-filter.rb
@@ -23,6 +23,10 @@
 
 require 'date'
 require 'time'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 SRC = File.join(__dir__, 'build-charts-from-signals.rb')
 src = File.read(SRC)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-spec-api-coverage.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-spec-api-coverage.rb
@@ -5,6 +5,10 @@
 # (plain bar/line/KPI). Extracts the function from build-charts-from-signals.rb
 # (it's an inline top-level def, like test-param-measure-picker.rb does).
 require 'json'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 SRC = File.read(File.join(__dir__, 'build-charts-from-signals.rb'))
 fn  = SRC[/^def spec_api_limit_entries.*?^end/m] or abort('could not extract spec_api_limit_entries')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
@@ -10,6 +10,10 @@
 # Usage:  ruby scripts/test-styled-text-body.rb
 
 require 'json'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 DIR = __dir__
 SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-ensure.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-ensure.rb
@@ -14,6 +14,10 @@ SRC = File.read(File.join(DIR, 'post-and-readback.rb'))
 m = SRC.match(/^def ensure_theme!.*?\n^end$/m) or abort('could not extract ensure_theme!')
 require_relative 'lib/theme_derive'
 require_relative 'lib/workbook_code'
+# Ruby 2.6 floor: this test READS a sibling script and eval()s a method out
+# of it, so that script's own require_relative lines never run -- the test
+# must supply the polyfill itself. See shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 # require_relative cannot infer a basepath inside eval — the lib is preloaded.
 eval(m[0].sub(/require_relative\s+'lib\/theme_derive'/, 'nil')) # rubocop:disable Security/Eval
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-workbook-code-release.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-workbook-code-release.rb
@@ -8,6 +8,9 @@ require 'tmpdir'
 require 'rbconfig'
 require_relative 'lib/workbook_code'
 require_relative 'mechanical-specs'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative 'lib/ruby_compat'
 
 RUBY = RbConfig.ruby
 STORIES = File.join(__dir__, 'build-story-pages.rb')

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/blind_grade.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/ruby_compat.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/shared/lib/actions.py
+++ b/shared/lib/actions.py
@@ -35,7 +35,7 @@ command-center workbook on a test org:
     entries -- this module does not reshape `values`, callers build it),
     clear-control (an ELEMENT-scoped clear-control masked-failed the button
     live -- only page scope is verified, so this builder only emits
-    scope={type:"page",page:}), set-control-value (constant text value).
+    scope={type:"page",pageId:}), set-control-value (constant text value).
 
 All builders are gated through SURFACES (same discipline as richness.py/
 styling.py): a NO-GO flip on `button`/`input_table_empty`/`input_table_linked`

--- a/shared/lib/actions.rb
+++ b/shared/lib/actions.rb
@@ -37,7 +37,7 @@
 #     entries — this module does not reshape `values`, callers build it),
 #     clear-control (an ELEMENT-scoped clear-control masked-failed the button
 #     live — only page scope is verified, so this builder only emits
-#     scope:{type:"page",page:}), set-control-value (constant text value).
+#     scope:{type:"page",pageId:}), set-control-value (constant text value).
 #
 # All builders are gated through Actions::SURFACES (same discipline as
 # richness.rb/styling.rb): a NO-GO flip on `button`/`input_table_empty`/
@@ -145,7 +145,7 @@ module Actions
     { 'effect' => 'insert-rows', 'tableElementId' => table_element_id, 'values' => values }
   end
 
-  # Returns a `clear-control` effect Hash: {effect, scope:{type:"page",page:},
+  # Returns a `clear-control` effect Hash: {effect, scope:{type:"page",pageId:},
   # usePublishedValue:true}. Page scope ONLY — an element-scoped
   # clear-control masked-failed the button live (design doc), so this
   # builder never emits any other scope shape. NO-GO surface -> {}.

--- a/shared/lib/blind_grade.rb
+++ b/shared/lib/blind_grade.rb
@@ -26,6 +26,9 @@
 require 'json'
 require 'digest'
 require_relative 'code_rep'
+# Ruby 2.6 floor (macOS system ruby): this file uses Enumerable#tally (2.7+).
+# Polyfilled rather than rewritten -- see shared/lib/ruby_compat.rb.
+require_relative 'ruby_compat'
 
 module BlindGrade
   # The six checklist dimensions a visual verdict attests (kept in lockstep

--- a/shared/lib/ruby_compat.rb
+++ b/shared/lib/ruby_compat.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# ruby_compat.rb — makes the skills' documented Ruby 2.6 floor actually true.
+#
+# WHY THIS EXISTS. Every converter documents a 2.6 floor (macOS system Ruby) so
+# an agent never has to install a runtime mid-migration — 30 comments across the
+# tree say "not filter_map — that's Ruby 2.7+; the skills target 2.6". But 57
+# call sites crept in anyway, and `ruby -c` cannot see them: a missing METHOD is
+# a runtime NoMethodError, not a syntax error, and CI runs 3.x so it never hit
+# one. doctor.sh compounded it by printing the Ruby version without asserting a
+# floor, so 2.6.10 passed green while the code needed 2.7.
+#
+# The field failure mode is worse than a crash. Of 277 tableau test files under
+# system 2.6: 7 died with a clean `undefined method 'filter_map'`, but 6 more
+# reported a SEMANTIC failure instead — e.g. test-layout-px-rows.rb prints
+# "per-dashboard derivation: Fixed=74, Auto=48 (got {})". A sub-script crashed,
+# something rescued it, and the caller carried on with empty data. In a real
+# migration that ships a silently degraded workbook rather than stopping.
+#
+# So: polyfill, don't rewrite 57 call sites. Agents keep working on stock macOS
+# and new code keeps modern idioms. tools/lint-ruby-floor.rb enforces that any
+# file using one of these methods actually requires this file.
+#
+# Additive and idempotent by construction: each polyfill is guarded by a
+# respond_to?/method_defined? check, so on 2.7+ this file defines NOTHING and
+# the real C implementations are used. Safe to require twice, and safe to
+# require from a library (it never changes behaviour on a modern Ruby).
+#
+# Must itself stay 2.6-parseable: no endless method defs, no pattern matching.
+
+# Enumerable#filter_map — Ruby 2.7.
+#
+# NOT `map { … }.compact`: filter_map drops every FALSEY result, so a block
+# returning `false` is dropped too, while compact only removes nil. Using
+# map+compact as the polyfill would keep `false` and silently change results for
+# any predicate-shaped block. `select { |x| x }` reproduces the real semantics.
+unless Enumerable.method_defined?(:filter_map)
+  module Enumerable
+    def filter_map
+      return to_enum(:filter_map) unless block_given?
+      out = []
+      each { |item| (val = yield(item)) && out << val }
+      out
+    end
+  end
+end
+
+# Enumerable#tally — Ruby 2.7. Counts occurrences into a Hash.
+# (Hit live: an agent's migration crashed here inside the workbook validator.)
+unless Enumerable.method_defined?(:tally)
+  module Enumerable
+    def tally
+      each_with_object({}) { |item, acc| acc[item] = (acc[item] || 0) + 1 }
+    end
+  end
+end
+
+# Hash#except — Ruby 3.0. Not currently used in-tree; polyfilled because it is
+# the next idiom likely to be reached for, and a NoMethodError mid-migration is
+# expensive to diagnose.
+unless Hash.method_defined?(:except)
+  class Hash
+    def except(*keys)
+      reject { |k, _| keys.include?(k) }
+    end
+  end
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -1276,6 +1276,25 @@
         "plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/migration-report-format.md",
         "plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/migration-report-format.md"
       ]
+    },
+    {
+      "canonical": "shared/lib/ruby_compat.rb",
+      "targets": [
+        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/ruby_compat.rb",
+        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/ruby_compat.rb",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/ruby_compat.rb",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/ruby_compat.rb"
+      ],
+      "reason": "Ruby 2.6 floor polyfill (filter_map/tally/except). Required by every script that uses a 2.7+ Enumerable method; tools/lint-ruby-floor.rb enforces the require."
     }
   ]
 }

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -49,7 +49,36 @@ echo
 
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
-  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+  # Assert the FLOOR, do not just print the version. This check used to be a
+  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
+  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
+  # NoMethodError mid-migration and started hand-installing runtimes or writing
+  # their own polyfills into the workdir. The floor is now real: 2.6 is
+  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
+  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
+  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
+  RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
+  # NOTE: $HERE is not set until much later in this script, so resolve the
+  # script dir locally rather than reading an empty var (which would make the
+  # polyfill check below always "missing").
+  _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  RUBY_OLD=0
+  case "$RUBY_MAJMIN" in
+    1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
+  esac
+  if [ "$RUBY_OLD" -eq 1 ]; then
+    bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
+    # 2.6 without the polyfill is the exact configuration that failed in the
+    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
+    # EMPTY output rather than crashing.
+    bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
+  elif [ "$RUBY_MAJMIN" = "2.6" ]; then
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+  else
+    ok "ruby — $RUBY_V"
+  fi
 else
   if [ "$OS" = "windows-bash" ]; then
     bad "ruby not found" "Run the bootstrap: bash scripts/bootstrap.sh   — no-admin install/activation; it re-runs this doctor when done."

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -50,32 +50,41 @@ echo
 # --- ruby ------------------------------------------------------------------
 if command -v ruby >/dev/null 2>&1; then
   RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
-  # Assert the FLOOR, do not just print the version. This check used to be a
-  # bare `ok "ruby — $version"`, so system ruby 2.6.10 passed green while ~60
-  # call sites needed 2.7+ (filter_map/tally) -- agents then hit a runtime
-  # NoMethodError mid-migration and started hand-installing runtimes or writing
-  # their own polyfills into the workdir. The floor is now real: 2.6 is
-  # supported because shared/lib/ruby_compat.rb polyfills those methods, and
-  # tools/lint-ruby-floor.rb keeps it that way. So the honest check is
-  # ">= 2.6 AND the polyfill shipped", not ">= 2.7".
   RUBY_MAJMIN="$(printf '%s' "$RUBY_V" | cut -d. -f1,2)"
-  # NOTE: $HERE is not set until much later in this script, so resolve the
-  # script dir locally rather than reading an empty var (which would make the
-  # polyfill check below always "missing").
+  # Assert the FLOOR, do not just print the version. This was a bare
+  # `ok "ruby — $version"`, so system ruby 2.6.10 passed GREEN while ~60 call
+  # sites needed 2.7+ (filter_map/tally): agents hit a runtime NoMethodError
+  # mid-migration and started hand-installing runtimes or writing their own
+  # polyfills into the customer workdir. The floor is real now -- 2.6 works
+  # because ruby_compat.rb polyfills those methods and tools/lint-ruby-floor.rb
+  # keeps it that way -- so the honest check is ">= 2.6 AND the polyfill
+  # shipped", not ">= 2.7".
+  #
+  # $HERE is not set until much later in this script, so resolve the script dir
+  # locally; reading the empty var would make the polyfill always look missing.
   _DOCTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # scripts/lib/ruby_compat.rb in a DEPLOYED plugin; ../lib/ruby_compat.rb
+  # relative to the canonical shared/scripts/ copy. Accept either -- checking
+  # only the first made this doctor fail when invoked from shared/scripts/,
+  # which is how shared/scripts/test-bootstrap.rb drives it (caught in CI's
+  # macOS job, not locally).
+  _RUBY_COMPAT=""
+  for _c in "$_DOCTOR_DIR/lib/ruby_compat.rb" "$_DOCTOR_DIR/../lib/ruby_compat.rb"; do
+    if [ -f "$_c" ]; then _RUBY_COMPAT="$_c"; break; fi
+  done
   RUBY_OLD=0
   case "$RUBY_MAJMIN" in
     1.*|2.0|2.1|2.2|2.3|2.4|2.5) RUBY_OLD=1 ;;
   esac
   if [ "$RUBY_OLD" -eq 1 ]; then
     bad "ruby $RUBY_V is below the 2.6 floor" "Install ruby >= 2.6 (bash scripts/bootstrap.sh), or use the macOS system ruby at /usr/bin/ruby."
-  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ ! -f "$_DOCTOR_DIR/lib/ruby_compat.rb" ]; then
-    # 2.6 without the polyfill is the exact configuration that failed in the
-    # field: 13 of 277 tableau suites broke, and 6 of those emitted silently
-    # EMPTY output rather than crashing.
+  elif [ "$RUBY_MAJMIN" = "2.6" ] && [ -z "$_RUBY_COMPAT" ]; then
+    # 2.6 with no polyfill is the exact configuration that failed in the field:
+    # 13 of 277 tableau suites broke, and 6 of those emitted silently EMPTY
+    # output instead of crashing.
     bad "ruby $RUBY_V needs lib/ruby_compat.rb (2.7+ method polyfill) and it is missing" "Re-install/update the plugin so scripts/lib/ruby_compat.rb ships, or use ruby >= 2.7."
   elif [ "$RUBY_MAJMIN" = "2.6" ]; then
-    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by lib/ruby_compat.rb)"
+    ok "ruby — $RUBY_V (2.6 floor; 2.7+ methods polyfilled by ruby_compat.rb)"
   else
     ok "ruby — $RUBY_V"
   fi

--- a/shared/scripts/verify-layout-contract-e2e.rb
+++ b/shared/scripts/verify-layout-contract-e2e.rb
@@ -29,7 +29,12 @@ require 'json'
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'sigma_rest'
 
-def log(m) = puts("[layout-contract] #{m}")
+# NOT an endless def (`def log(m) = ...`): that is Ruby 3.0+ syntax and a hard
+# SyntaxError on the macOS system ruby 2.6 this repo targets. `ruby -c` under
+# CI's 3.3 parses it happily, which is how it landed. See tools/lint-ruby-floor.rb.
+def log(m)
+  puts("[layout-contract] #{m}")
+end
 def skip!(m)
   puts("SKIP: #{m}")
   exit 0

--- a/tools/lint-ruby-floor.rb
+++ b/tools/lint-ruby-floor.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# lint-ruby-floor.rb — keeps the documented Ruby 2.6 floor actually true.
+#
+# Every converter documents a 2.6 floor (macOS system Ruby) so an agent never
+# has to install a runtime mid-migration; 30 comments across the tree say "not
+# filter_map — that's Ruby 2.7+". 57 call sites landed anyway, because NOTHING
+# could see them:
+#
+#   * `ruby -c` (the script-syntax CI job) cannot: a missing METHOD is a runtime
+#     NoMethodError, not a syntax error.
+#   * CI runs Ruby 3.3, where the methods exist.
+#   * doctor.sh printed the Ruby version without asserting any floor, so 2.6.10
+#     passed green while the code needed 2.7.
+#
+# Measured field impact under system 2.6, 277 tableau test files: 7 died with a
+# clean `undefined method 'filter_map'`, and 6 more reported a SEMANTIC failure
+# instead (e.g. "per-dashboard derivation: Fixed=74, Auto=48 (got {})") because a
+# sub-script crashed, something rescued it, and the caller continued with empty
+# data. Silent degradation is the reason this is a gate and not a style note.
+#
+# The fix is a polyfill (shared/lib/ruby_compat.rb), not 57 rewrites — so what
+# this gate enforces is that the polyfill is actually IN EFFECT wherever it is
+# needed. Three conditions, all three of which a careful manual pass got wrong
+# at least once while landing it:
+#
+#   1. PRESENT  — a file using a 2.7+ method requires ruby_compat at all.
+#   2. TOP-LEVEL— the require is at column 0, not nested inside a def/if/block
+#                 that may never execute (hit once: build-workbook-spec.rb).
+#   3. ORDERED  — the require precedes the first use in the file
+#                 (hit once: validate-spec.rb, require L72 vs use L38).
+#
+# Plus a syntax rule `ruby -c` under 3.x cannot express: no Ruby 3.0+ endless
+# method defs (`def f = expr`), which are a hard SyntaxError on 2.6.
+#
+# Exit 0 = clean; exit 1 = at least one violation. LINT_ROOT for the self-test.
+
+ROOT = ENV['LINT_ROOT'] || File.expand_path('..', __dir__)
+Dir.chdir(ROOT)
+
+# Methods absent from Ruby 2.6 that shared/lib/ruby_compat.rb polyfills.
+# Keep in lockstep with that file: a method polyfilled there but missing here is
+# unenforced, and one here but not there makes the gate unsatisfiable.
+POLYFILLED = /\.(?:filter_map|tally)\b|\.except\(/
+# Ruby 3.0+ endless method definition — SyntaxError on 2.6, parses fine on 3.x,
+# so the script-syntax job is blind to it.
+ENDLESS_DEF = /^\s*def\s+[a-zA-Z_][a-zA-Z_0-9]*[?!]?(?:\([^)]*\))?\s*=\s*[^=]/
+
+SKIP_DIRS = %r{^(?:docs/|\.git/)}
+# A gate's own self-test necessarily EMBEDS violating code as fixture strings
+# (tools/test-lint-ruby-floor.rb heredocs an indented require on purpose to
+# prove the NESTED rule fires). Scanning it flags the fixtures, not real code.
+SKIP_FILES = %r{^tools/test-lint-.*\.rb$}
+
+def strip_comments(line)
+  # Good enough for this gate: drop a whole-line comment. An inline `#` inside a
+  # string would be a false positive, so require the # to start the line.
+  line.lstrip.start_with?('#') ? '' : line
+end
+
+violations = []
+
+Dir.glob('{plugins,shared,tools}/**/*.rb').sort.each do |path|
+  next if path =~ SKIP_DIRS
+  next if path =~ SKIP_FILES
+  next if File.basename(path) == 'ruby_compat.rb'   # the polyfill itself
+  src = File.read(path, encoding: 'UTF-8')
+  lines = src.lines
+
+  lines.each_with_index do |line, i|
+    next if strip_comments(line).empty?
+    next unless line =~ ENDLESS_DEF
+    violations << ["#{path}:#{i + 1}", 'ruby 3.0+ endless method def is a SyntaxError on 2.6', line.strip]
+  end
+
+  use_idx = lines.index { |l| !strip_comments(l).empty? && strip_comments(l) =~ POLYFILLED }
+  next unless use_idx
+
+  req_idx = lines.index do |l|
+    l.start_with?('require_relative', 'require') && l.include?('ruby_compat')
+  end
+  nested  = lines.index { |l| l =~ /\A\s+require(?:_relative)?\b.*ruby_compat/ }
+
+  if req_idx.nil? && nested.nil?
+    violations << ["#{path}:#{use_idx + 1}", 'uses a 2.7+ method but never requires ruby_compat', lines[use_idx].strip]
+  elsif req_idx.nil? && nested
+    violations << ["#{path}:#{nested + 1}", 'requires ruby_compat INSIDE an indented block — may never execute', lines[nested].strip]
+  elsif req_idx > use_idx
+    violations << ["#{path}:#{req_idx + 1}", "requires ruby_compat AFTER first use (line #{use_idx + 1})", lines[req_idx].strip]
+  end
+end
+
+if violations.empty?
+  puts 'OK: ruby 2.6 floor holds (every 2.7+ method use is polyfilled, in scope, and in order; no endless defs).'
+  exit 0
+end
+
+warn '::error::Ruby 2.6 floor violated — an agent on stock macOS ruby will hit this at RUNTIME:'
+violations.each { |loc, why, code| warn "  #{loc}: #{why}\n      #{code}" }
+warn ''
+warn "Fix: require_relative '<path>/lib/ruby_compat' at COLUMN 0, ABOVE the first use."
+warn 'Or, if the file genuinely needs a newer Ruby, say so in the skill docs and raise the floor deliberately.'
+exit 1

--- a/tools/lint-twin-parity.rb
+++ b/tools/lint-twin-parity.rb
@@ -38,6 +38,9 @@
 
 require 'json'
 require 'set'
+# Ruby 2.6 floor (macOS system ruby): this file uses a 2.7+ Enumerable
+# method. Polyfilled rather than rewritten — see shared/lib/ruby_compat.rb.
+require_relative '../shared/lib/ruby_compat'
 
 ROOT = ENV['LINT_ROOT'] || File.expand_path('..', __dir__)
 Dir.chdir(ROOT)

--- a/tools/test-lint-ruby-floor.rb
+++ b/tools/test-lint-ruby-floor.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-lint-ruby-floor.rb — self-test for the Ruby 2.6 floor gate.
+#
+# Each of the four rules below corresponds to a mistake actually made while
+# landing the polyfill, which is why the gate checks placement and not just
+# presence:
+#   * MISSING   — 57 call sites had no polyfill at all (the original bug).
+#   * NESTED    — build-workbook-spec.rb got the require inside an indented
+#                 block, so it never ran and the test still failed.
+#   * ORDERED   — validate-spec.rb got the require at L72 with the use at L38.
+#   * ENDLESS   — verify-layout-contract-e2e.rb shipped a Ruby 3.0 endless def
+#                 that CI's 3.3 `ruby -c` parses happily.
+#
+# Offline, creds-free. Drives the lint via LINT_ROOT.
+
+require 'fileutils'
+require 'tmpdir'
+
+LINT = File.expand_path('lint-ruby-floor.rb', __dir__)
+fails = 0
+
+def check(desc, cond)
+  puts(cond ? "  ok   #{desc}" : "  FAIL #{desc}")
+  cond
+end
+
+# Writes files under <tmp>/plugins/p/skills/s/scripts/ and runs the lint there.
+def lint(files)
+  Dir.mktmpdir('ruby-floor-') do |root|
+    base = File.join(root, 'plugins', 'p', 'skills', 's', 'scripts')
+    FileUtils.mkdir_p(File.join(base, 'lib'))
+    # the polyfill must exist for the "fixed" cases to be satisfiable
+    File.write(File.join(base, 'lib', 'ruby_compat.rb'), "# stub polyfill\n")
+    files.each do |rel, body|
+      path = File.join(base, rel)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, body)
+    end
+    out = IO.popen({ 'LINT_ROOT' => root }, ['ruby', LINT], err: [:child, :out], &:read)
+    [$?.exitstatus, out]
+  end
+end
+
+puts 'test-lint-ruby-floor: ruby 2.6 floor gate'
+
+# --- RULE 1: missing entirely ----------------------------------------------
+code, out = lint('a.rb' => "x = [1].filter_map { |v| v }\n")
+fails += 1 unless check('MISSING: 2.7+ method with no polyfill FAILS', code == 1)
+fails += 1 unless check('  ...names the method line', out.include?('a.rb:1'))
+
+code, = lint('a.rb' => "require_relative 'lib/ruby_compat'\nx = [1].filter_map { |v| v }\n")
+fails += 1 unless check('  ...and a correct require CLEARS it', code.zero?)
+
+# --- RULE 2: nested inside a block -----------------------------------------
+nested = <<~RUBY
+  def go
+    require_relative 'lib/ruby_compat'
+    [1].filter_map { |v| v }
+  end
+RUBY
+code, out = lint('b.rb' => nested)
+fails += 1 unless check('NESTED: require inside an indented block FAILS', code == 1)
+fails += 1 unless check('  ...says it may never execute', out.include?('may never execute'))
+
+# --- RULE 3: require after first use ---------------------------------------
+ordered = <<~RUBY
+  x = [1].filter_map { |v| v }
+  require_relative 'lib/ruby_compat'
+RUBY
+code, out = lint('c.rb' => ordered)
+fails += 1 unless check('ORDERED: require AFTER first use FAILS', code == 1)
+fails += 1 unless check('  ...reports the use line', out.include?('AFTER first use (line 1)'))
+
+# --- RULE 4: ruby 3.0 endless def ------------------------------------------
+code, out = lint('d.rb' => "def log(m) = puts(m)\n")
+fails += 1 unless check('ENDLESS: ruby 3.0 endless def FAILS', code == 1)
+fails += 1 unless check('  ...calls it a 2.6 SyntaxError', out.include?('SyntaxError on 2.6'))
+code, = lint('d.rb' => "def log(m)\n  puts(m)\nend\n")
+fails += 1 unless check('  ...and the classic form is fine', code.zero?)
+
+# --- false positives the gate must NOT trip on -----------------------------
+quiet = {
+  'a comment mentioning filter_map' => "# not filter_map -- that is 2.7+\nx = [1].map { |v| v }.compact\n",
+  'plain 2.6-safe code'             => "x = [1].map { |v| v }.compact\n",
+  'keyword-arg default with ='      => "def f(a: 1)\n  a\nend\n",
+  'assignment to a method result'   => "y = 1\nz = y\n",
+  'the polyfill file itself'        => nil
+}
+quiet.each do |desc, body|
+  next if body.nil?
+  code, out = lint('e.rb' => body)
+  ok = check("no false positive: #{desc}", code.zero?)
+  fails += 1 unless ok
+  puts out.lines.grep(/e\.rb/).map { |l| "         #{l}" }.join unless ok
+end
+
+puts
+if fails.zero?
+  puts 'ALL PASS — gate fails on all four real mistakes and stays quiet on 2.6-safe code.'
+  exit 0
+end
+puts "#{fails} check(s) FAILED"
+exit 1


### PR DESCRIPTION
Two things, from field reports.

## 1. Ruby — agents were installing runtimes mid-migration

Root cause is a **gate/code mismatch**, exactly as diagnosed in the field: `doctor.sh` printed the Ruby version without asserting a floor, so system 2.6.10 passed green while ~60 call sites needed 2.7+. Nothing could see the drift — `ruby -c` can't (a missing *method* is a runtime `NoMethodError`, not syntax), and CI runs 3.3 where the methods exist.

The repo documents a 2.6 floor in **30 comments** ("not filter_map — that's Ruby 2.7+; the skills target 2.6") and violates it in **57 `filter_map` sites** plus `Array#tally` in `blind_grade.rb` (×14) and two `put-layout.rb`.

Measured, not assumed — 277 tableau test files under stock 2.6:

| outcome | count |
|---|---|
| clean `undefined method 'filter_map'` | 7 |
| **semantic failure instead** — sub-script crashed, something rescued it, caller continued with empty data | 6 |

That second row is the important one. `test-layout-px-rows.rb` printed `per-dashboard derivation: Fixed=74, Auto=48 (got {})`. In a real migration that ships a **silently degraded workbook**, not a clean stop.

**Fix: polyfill, not 57 rewrites.** `shared/lib/ruby_compat.rb` provides `filter_map`, `tally`, `Hash#except`, each guarded by `method_defined?` so on 2.7+ it defines nothing. Deliberately **not** `map{}.compact` for `filter_map` — `filter_map` drops every *falsey* result, so a predicate-shaped block returning `false` would be kept by `compact` and silently change results. Verified identical on 2.6.10 and 3.3.12, `false` case included.

`tools/lint-ruby-floor.rb` enforces three placement conditions — each of which my own manual pass got wrong at least once:

- **PRESENT** — the file requires the polyfill at all
- **TOP-LEVEL** — at column 0, not nested in a block that may never run (hit: `build-workbook-spec.rb` — require present, test still failed)
- **ORDERED** — require precedes first use (hit: `validate-spec.rb`, require L72 vs use L38 — also present, also still failed)

Plus a rule `ruby -c` under 3.x can't express: no Ruby 3.0 endless defs. Found one already shipped (`verify-layout-contract-e2e.rb:32`).

`doctor.sh` now **asserts** the floor: fails below 2.6, fails on 2.6 when `lib/ruby_compat.rb` is absent (the exact configuration that broke in the field), otherwise says which case it is. Proven both ways by deleting the polyfill.

**Result: 455 test files under stock 2.6 → zero remaining version gaps** (was 13 failures in tableau alone). The 10 still-failing suites fail identically on pristine `main` under 3.3 — pre-existing, env-dependent fixtures/tokens, confirmed against a stashed tree.

## 2. Action field rename — the nested half

I verified #764 against the live canonical OpenAPI asset. **It's correct and complete for everything the repo emits**, including the part that's easy to get wrong: the three deliberately *not*-renamed survivors weren't over-renamed (`set-control-value.control`, `navigate` target `page`, `refresh-element` target `element` — still bare in the spec, still bare in our emitters).

Two gaps remained.

**Nested shapes had zero validation.** `EFFECT_REQUIRED` only checked top-level keys, so a `values[]`/`whichRows`/`sort`/`scope` still carrying a pre-rename key passed our validator and 400'd live. That's precisely where the nested half of your list lands — value sources → `columnId`, `whichRows` `column-match` → `columnId`, `custom-sort.sort.column` → `columnId`, `column-range` → `minColumnId`/`maxColumnId`.

Two of those fail **silently**, not with a 400:
- `clear-control scope:{type:page, page:}` → 200 OK, key dropped, button clears nothing
- `column-range` has **both bounds optional** in the spec, so a range that lost its keys is schema-valid and silently matches everything

`deep_errors()` is path-aware because the same key is live or dead depending on position — `control` is *correct* under `set-control-value` and *dead* under a `clear-control` scope. A blanket rename would break production.

This immediately caught a **stale fixture**: `test-action-ledger.rb` asserted `{type:'column', column:}` was "a well-formed set-control-value". #764 updated the emitters but missed the test.

**`EFFECT_REQUIRED` listed 12 of 23 effects**, and `validate_action` rejects an unlisted effect as `"unknown effect"` — so emitting `custom-sort`, `trigger-plugin`, `run-python-element`, `set-form-values`, `clear-chat-element-messages`, `call-api`, `call-stored-procedure`, `export`, `if-else` or `reset-form` was blocked by our own validator. Now spec-derived for all 23. `open-url` stays deliberately stricter than the spec (which requires only `openTarget`): an `open-url` with no `url` persists and does nothing.

Also worth noting for your list: **`trigger-plugin`** (`pluginElement`/`pluginEffect` → `pluginElementId`/`pluginEffectId`) is a real rename that wasn't in it — confirmed in the spec, 22 hits each.

**The OpenAPI fixture had zero Actions coverage** — no `effect`, no `insert-rows` — which is why the pin didn't move when the rename shipped and wouldn't have caught the next one. `extract-openapi-contract.rb` now pins per-effect property/required sets plus the nested union shapes, reusing the existing `merged_*` helpers so allOf-split members are seen (that split is how `column-range` hides its bounds). Both surfaces pinned: element-level `Actions` (22 effects) and document-level `automatedActions` (1 — `call-agent` exists only there, which is why pinning `Actions` alone accounts for 22 of the 23 names).

⚠️ **One thing I deliberately did NOT do.** Re-running the extractor over the canonical asset also moves `releasedVariants` (elements 28→32, controls 16→**0**) and breaks 4 existing assertions — the pre-existing sections were captured 2026-08-08 from a *different* asset. I added only the `actions` section and left the rest untouched, recorded in the fixture's `_note`. **Reconciling those two assets is separate work and probably wants your call** — controls going to 0 suggests the old pin came from the stale Fern asset.

## Verification

Both gates proven to **fail** before being trusted:
- reverting the fixture's actions section to pre-rename spellings → 14+ named failures, exit 1; restoring → pass
- `tools/test-lint-ruby-floor.rb` (14 checks) fails on all four real mistakes and stays quiet on 2.6-safe code
- `test-action-rename-contract.rb` (17 checks) asserts the survivors are *not* flagged, so an over-eager future rename fails too

Corpus 31/31 with `LANG` unset. Governance suite exit 0. All action + code-rep suites pass on **both** 2.6.10 and 3.3.12. Versions bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)